### PR TITLE
Add grouped abduction and identifiability guards

### DIFF
--- a/docs/causal4d_identifiability_and_grouped_likelihood.md
+++ b/docs/causal4d_identifiability_and_grouped_likelihood.md
@@ -109,6 +109,37 @@ readout trajectories with the robust grouped likelihood and adds each
 particle's discrepancy variance to the selected coordinate covariance.
 The physical simulator trajectories remain immutable.
 
+## Command-line use
+
+The factual-abduction CLI can construct frame-grouped evidence directly from
+the permitted object tracks:
+
+```bash
+causal4d-abduct-phystwin-intervention \
+  known.bank.npz belief.npz CASE/final_data.pkl \
+  factual.npz factual_eval.json \
+  --grouped-observation-likelihood \
+  --prior-nominal-probability 0.95 \
+  --outlier-scale-multiplier 100
+```
+
+A source-frozen identifiability artifact is a non-pickled NPZ containing
+`intervention_sensitivity` and optional `nuisance_sensitivity` and `covariance`
+arrays. Guarded use is:
+
+```bash
+causal4d-abduct-phystwin-intervention \
+  known.bank.npz belief.npz CASE/final_data.pkl \
+  factual.npz factual_eval.json \
+  --grouped-observation-likelihood \
+  --identifiability-npz source_identifiability.npz \
+  --abstain-when-unidentifiable
+```
+
+The sensitivity artifact must be fitted or generated without the target
+continuation. Threshold flags are explicit CLI inputs so a protocol can freeze
+them before target outcomes are opened.
+
 ## Required protocol usage
 
 1. Build intervention sensitivities from source-only or controlled finite

--- a/docs/causal4d_identifiability_and_grouped_likelihood.md
+++ b/docs/causal4d_identifiability_and_grouped_likelihood.md
@@ -1,0 +1,127 @@
+# Intervention Identifiability and Grouped Observation Likelihood
+
+## Status
+
+This implementation adds an opt-in, backward-compatible inference path. The
+frozen `v0.3.0-causal4d-aip` dense likelihood remains unchanged unless grouped
+evidence or an identifiability result is explicitly supplied.
+
+## Motivation
+
+A response prefix can often be explained by several observationally similar
+causes:
+
+- realized gain, delay, controller-frame bias, contact, or slip;
+- physical-state or parameter error;
+- coherent camera or gauge bias;
+- unresolved readout discrepancy.
+
+Explaining the prefix is therefore insufficient. Causal4D should update the
+realized-intervention posterior only when the intervention response remains
+informative after nuisance response is removed.
+
+## Grouped evidence
+
+`ObservationGroup` selects a vector of scalar rollout coordinates and supplies:
+
+- the complete metric covariance of that vector;
+- a residual-independent prior nominal probability;
+- a broad-component covariance multiplier;
+- a Student-t degrees-of-freedom value;
+- a frozen composite-likelihood weight;
+- source, view, and contributor provenance.
+
+The nominal and broad components use the same covariance orientation. If
+`C_g` is the declared covariance and `nu > 2`, the Student-t scale is
+
+```text
+Psi_g = (nu - 2) / nu * C_g.
+```
+
+The broad component uses `lambda_out * Psi_g`. The residual changes the
+posterior nominal responsibility but never changes the prior nominal
+probability.
+
+`GroupedObservationEvidence` caps repeated contributors automatically. If one
+contributor is used in `m` groups, each affected group receives at most `1/m`
+of its declared composite power. Duplicating an observation while retaining
+its contributor identity therefore leaves the total evidence power unchanged.
+Feeders should still construct scientifically meaningful groups instead of
+relying on this cap as a substitute for covariance modeling.
+
+`GroupedObservationEvidence.from_dense_prefix` is a convenience adapter that
+creates one group per permitted O-plus frame with diagonal covariance. It is
+mainly intended for controlled benchmarks and migration tests. Real feeders
+should export full covariance, contributor identities, and view/source
+provenance directly.
+
+## Conditional identifiability
+
+Let `J_z` contain whitened finite-response sensitivities for the proposed
+intervention variables and let `J_n` contain whitened nuisance sensitivities.
+The implementation projects intervention response onto the orthogonal
+complement of the nuisance span:
+
+```text
+J_z|n = (I - P_n) J_z
+I_z|n = J_z|n.T J_z|n.
+```
+
+`assess_intervention_identifiability` reports:
+
+- the eigenvalues and effective rank of `I_z|n`;
+- its minimum eigenvalue and condition number;
+- the fraction of intervention-response energy remaining after nuisance
+  projection;
+- the largest cosine between the intervention and nuisance subspaces;
+- explicit failure reasons.
+
+Thresholds are supplied through `IdentifiabilityConfig` and must be frozen on
+source or controlled data. They are not estimated from the target future.
+
+`finite_response_sensitivity` converts predeclared simulator perturbations into
+secant columns. It does not claim that the resulting local response is a global
+transition model.
+
+## Guarded factual abduction
+
+`abduct_factual_intervention` now accepts three optional arguments:
+
+```python
+factual = abduct_factual_intervention(
+    bank,
+    belief,
+    observations,
+    prefix_frame_count=7,
+    grouped_evidence=evidence,
+    identifiability=diagnostic,
+    abstain_when_unidentifiable=True,
+)
+```
+
+When the diagnostic fails and guarded abduction is enabled, the returned
+`FactualIntervention` uses the exact original joint prior over physical
+particles and intervention hypotheses. The artifact records the diagnostic and
+failure reasons. No target-future frame is read.
+
+When grouped evidence is supplied, Causal4D scores the particle-specific
+readout trajectories with the robust grouped likelihood and adds each
+particle's discrepancy variance to the selected coordinate covariance.
+The physical simulator trajectories remain immutable.
+
+## Required protocol usage
+
+1. Build intervention sensitivities from source-only or controlled finite
+   responses.
+2. Build nuisance sensitivities for the bias, gauge, state, and discrepancy
+   modes that are admitted by the experiment.
+3. Freeze identifiability thresholds before opening a target continuation.
+4. Construct grouped O-plus evidence using only the declared response prefix.
+5. Abduce with exact-prior abstention enabled.
+6. Report abstention rate, conditional-information diagnostics, posterior
+   entropy reduction, factual continuation, and held-out interventional
+   prediction.
+
+A passed local diagnostic is necessary but not sufficient for a paper claim.
+The same-object multi-action protocol and independent-execution calibration
+remain the required real-evidence gates.

--- a/docs/causal4d_same_object_multi_action_protocol.md
+++ b/docs/causal4d_same_object_multi_action_protocol.md
@@ -223,28 +223,37 @@ profile appears three times; and each realization condition appears twice.
 
 ### D. Cross-action/contact calibration
 
-Twelve folds are fixed in advance, one for every contact/profile cell. In each
-fold:
+Twelve folds are fixed in advance, one for every contact/profile cell. The
+versioned pre-acquisition amendment is authoritative for the fold membership.
+In each fold:
 
 - the target is the three repetitions of one contact/profile cell;
-- no source session contains the held-out contact;
-- no source session contains the held-out profile, even as its paired command;
-- eight source executions fit the model and discrepancy;
-- four disjoint source executions calibrate coverage and any semantic beta;
+- no fitting session contains the held-out contact;
+- no fitting session contains the held-out profile, even as its paired command;
+- six source sessions contribute both executions, giving 12 fitting executions
+  for the model, discrepancy, and source-only hyperparameters;
+- nine disjoint source sessions contribute one preregistered execution each,
+  giving nine independent calibration units;
+- the unused sibling executions in calibration sessions are not substituted;
+- the unused sibling executions in target sessions remain outside fitting and
+  calibration;
 - the three target executions remain untouched.
 
 Across the 12 folds, each execution is an out-of-fold target exactly once.
 Likelihood temperature, discrepancy scales, coverage transforms, and semantic
-beta are refit or selected only from that fold's fit/calibration sets. Target
-results never choose a shared hyperparameter.
+beta are refit or selected only from that fold's fitting and calibration sets.
+Target results never choose a shared hyperparameter.
 
-The four calibration executions in each v1 fold support an exploratory frozen
-transform and an out-of-fold target test. They do not pass the later
-undercoverage audit's ten-independent-execution gate for a real calibration
-claim. Before physical acquisition, a calibration-headline protocol must either
-pre-register a pooled source transform that still excludes every target action
-and contact, or issue a higher-repetition v2. The 36-run v1 remains valid for
-factual, same-grasp, new-contact, and calibration-transfer diagnosis.
+Nine independent calibration sessions give a finite 90% split-conformal
+threshold at rank 9 of 9, so the maximum calibration score sets the interval.
+The report must retain the largest and second-largest scores, the
+maximum-to-median ratio, leave-one-calibration-session-out thresholds, and
+interval width by fold. This is a coarse finite marginal execution-block
+calibration result, not a pooled-coordinate or worst-group guarantee. A
+stronger calibration headline still requires a preregistered pooled source
+transform that excludes every target contact and action or a higher-repetition
+protocol version. The 36-run design remains valid for factual, same-grasp,
+new-contact, and calibration-transfer diagnosis.
 
 ## Counterfactual Language
 

--- a/src/causal4d/__init__.py
+++ b/src/causal4d/__init__.py
@@ -12,6 +12,21 @@ from causal4d.contracts import (
 )
 from causal4d.counterfactual import apply_counterfactual_operator
 from causal4d.evaluation import run_counterfactual_benchmark
+from causal4d.grouped_likelihood import (
+    GroupLikelihoodDiagnostics,
+    grouped_component_log_likelihoods,
+    posterior_weights_from_grouped_evidence,
+)
+from causal4d.identifiability import (
+    IdentifiabilityConfig,
+    InterventionIdentifiabilityResult,
+    assess_intervention_identifiability,
+    finite_response_sensitivity,
+)
+from causal4d.observation_evidence import (
+    GroupedObservationEvidence,
+    ObservationGroup,
+)
 from causal4d.rollout_bank import JointRolloutBank, SparseTrajectoryEvidence
 from causal4d.semantic_freshness import (
     SEMANTIC_TIMING_SCHEMA_VERSION,
@@ -26,8 +41,13 @@ __all__ = [
     "CounterfactualBenchmarkConfig",
     "CounterfactualQuery",
     "FactualIntervention",
+    "GroupLikelihoodDiagnostics",
+    "GroupedObservationEvidence",
+    "IdentifiabilityConfig",
+    "InterventionIdentifiabilityResult",
     "LatentContactConfig",
     "JointRolloutBank",
+    "ObservationGroup",
     "PhysicalPosterior",
     "SEMANTIC_TIMING_SCHEMA_VERSION",
     "SEMANTIC_TIMING_SCOPE",
@@ -39,7 +59,11 @@ __all__ = [
     "TwinBelief",
     "apply_counterfactual_operator",
     "apply_semantic_freshness_gate",
+    "assess_intervention_identifiability",
     "build_protocol",
+    "finite_response_sensitivity",
+    "grouped_component_log_likelihoods",
+    "posterior_weights_from_grouped_evidence",
     "run_counterfactual_benchmark",
     "run_latent_contact_benchmark",
 ]

--- a/src/causal4d/cli/abduct_phystwin_intervention.py
+++ b/src/causal4d/cli/abduct_phystwin_intervention.py
@@ -12,11 +12,17 @@ import numpy as np
 
 from bayesian_phystwin.phystwin_residual_dynamics import _target_validity
 from causal4d.contracts import TwinBelief, load_contract, save_contract
+from causal4d.identifiability import (
+    IdentifiabilityConfig,
+    InterventionIdentifiabilityResult,
+    assess_intervention_identifiability,
+)
 from causal4d.intervention_abduction import (
     FactualAbductionConfig,
     abduct_factual_intervention,
     evaluate_factual_abduction,
 )
+from causal4d.observation_evidence import GroupedObservationEvidence
 from causal4d.phystwin_backend import load_rollout_bank
 
 
@@ -37,13 +43,75 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--likelihood-power", type=float, default=12.0)
     parser.add_argument("--dynamic-likelihood-weight", type=float, default=0.25)
     parser.add_argument("--degrees-of-freedom", type=float, default=4.0)
+    parser.add_argument(
+        "--grouped-observation-likelihood",
+        action="store_true",
+        help=(
+            "Use one robust full-covariance observation group per permitted O+ "
+            "frame instead of the legacy dense generalized likelihood."
+        ),
+    )
+    parser.add_argument("--prior-nominal-probability", type=float, default=0.95)
+    parser.add_argument("--outlier-scale-multiplier", type=float, default=100.0)
+    parser.add_argument(
+        "--identifiability-npz",
+        help=(
+            "Optional NPZ with intervention_sensitivity and optional "
+            "nuisance_sensitivity/covariance arrays, fitted without target future."
+        ),
+    )
+    parser.add_argument("--abstain-when-unidentifiable", action="store_true")
+    parser.add_argument("--identifiability-rank-tolerance", type=float, default=1e-6)
+    parser.add_argument(
+        "--minimum-information-eigenvalue", type=float, default=1e-6
+    )
+    parser.add_argument("--maximum-condition-number", type=float, default=1e8)
+    parser.add_argument(
+        "--minimum-residualized-response-fraction", type=float, default=0.10
+    )
+    parser.add_argument("--maximum-subspace-cosine", type=float, default=0.995)
     return parser
+
+
+def _load_identifiability(
+    path: str | None,
+    *,
+    config: IdentifiabilityConfig,
+) -> InterventionIdentifiabilityResult | None:
+    if path is None:
+        return None
+    with np.load(path, allow_pickle=False) as payload:
+        if "intervention_sensitivity" not in payload:
+            raise ValueError(
+                "identifiability NPZ must contain intervention_sensitivity"
+            )
+        intervention = np.asarray(payload["intervention_sensitivity"], dtype=float)
+        nuisance = (
+            np.asarray(payload["nuisance_sensitivity"], dtype=float)
+            if "nuisance_sensitivity" in payload
+            else None
+        )
+        covariance = (
+            np.asarray(payload["covariance"], dtype=float)
+            if "covariance" in payload
+            else None
+        )
+    return assess_intervention_identifiability(
+        intervention,
+        nuisance,
+        covariance=covariance,
+        config=config,
+    )
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     if args.o_plus_prefix_frames < 1:
         raise ValueError("--o-plus-prefix-frames must be positive")
+    if args.abstain_when_unidentifiable and args.identifiability_npz is None:
+        raise ValueError(
+            "--abstain-when-unidentifiable requires --identifiability-npz"
+        )
     bank, manifest = load_rollout_bank(args.rollout_bank_npz)
     artifact = load_contract(args.twin_belief_npz)
     if not isinstance(artifact, TwinBelief):
@@ -64,6 +132,30 @@ def main(argv: Sequence[str] | None = None) -> int:
         dynamic_likelihood_weight=args.dynamic_likelihood_weight,
         degrees_of_freedom=args.degrees_of_freedom,
     )
+    grouped_evidence = None
+    if args.grouped_observation_likelihood:
+        grouped_evidence = GroupedObservationEvidence.from_dense_prefix(
+            observations_from_endpoint,
+            prefix_frame_count=prefix_frame_count,
+            scale_m=args.observation_scale_m,
+            mask=mask_from_endpoint,
+            prior_nominal_probability=args.prior_nominal_probability,
+            outlier_scale_multiplier=args.outlier_scale_multiplier,
+            degrees_of_freedom=args.degrees_of_freedom,
+            source_id=f"{artifact.context.case_id}:object_points",
+        )
+    identifiability = _load_identifiability(
+        args.identifiability_npz,
+        config=IdentifiabilityConfig(
+            relative_rank_tolerance=args.identifiability_rank_tolerance,
+            minimum_information_eigenvalue=args.minimum_information_eigenvalue,
+            maximum_condition_number=args.maximum_condition_number,
+            minimum_residualized_response_fraction=(
+                args.minimum_residualized_response_fraction
+            ),
+            maximum_subspace_cosine=args.maximum_subspace_cosine,
+        ),
+    )
     factual = abduct_factual_intervention(
         bank,
         artifact,
@@ -71,6 +163,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         prefix_frame_count=prefix_frame_count,
         observation_mask=mask_from_endpoint,
         config=settings,
+        grouped_evidence=grouped_evidence,
+        identifiability=identifiability,
+        abstain_when_unidentifiable=args.abstain_when_unidentifiable,
     )
     evaluation = evaluate_factual_abduction(
         bank,
@@ -80,6 +175,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         observation_mask=mask_from_endpoint,
         prefix_frame_count=prefix_frame_count,
         config=settings,
+        grouped_evidence=grouped_evidence,
     )
     evaluation.update(
         {
@@ -88,6 +184,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             "factual_intervention_id": factual.artifact_id,
             "rollout_bank_manifest": manifest,
             "twin_belief_id": artifact.artifact_id,
+            "grouped_observation_evidence_id": (
+                None if grouped_evidence is None else grouped_evidence.evidence_id
+            ),
+            "intervention_identifiability": (
+                None if identifiability is None else identifiability.as_dict()
+            ),
         }
     )
     save_contract(args.output_factual_npz, factual)
@@ -109,6 +211,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "relative_track_error_improvement": evaluation[
                     "relative_track_error_improvement"
                 ],
+                "abduction_abstained_unidentifiable": factual.metadata.get(
+                    "abduction_abstained_unidentifiable", False
+                ),
             },
             indent=2,
             sort_keys=True,

--- a/src/causal4d/grouped_likelihood.py
+++ b/src/causal4d/grouped_likelihood.py
@@ -1,0 +1,166 @@
+"""Correlation-aware robust likelihoods over grouped observation evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import lgamma
+
+import numpy as np
+
+from causal4d.observation_evidence import GroupedObservationEvidence, ObservationGroup
+
+
+@dataclass(frozen=True)
+class GroupLikelihoodDiagnostics:
+    """Nominal responsibilities and effective powers for one grouped update."""
+
+    group_ids: tuple[str, ...]
+    effective_group_weights: tuple[float, ...]
+    nominal_responsibilities: np.ndarray
+
+
+def _multivariate_student_t_log_density(
+    residual: np.ndarray,
+    covariance_m2: np.ndarray,
+    *,
+    degrees_of_freedom: float,
+    covariance_multiplier: float = 1.0,
+) -> np.ndarray:
+    """Evaluate a conventional multivariate Student-t with declared covariance."""
+
+    values = np.asarray(residual, dtype=float)
+    covariance = np.asarray(covariance_m2, dtype=float) * covariance_multiplier
+    dimension = values.shape[-1]
+    if covariance.shape[-2:] != (dimension, dimension):
+        raise ValueError("covariance_m2 must end in (coordinate, coordinate)")
+    scale = ((degrees_of_freedom - 2.0) / degrees_of_freedom) * covariance
+    sign, log_determinant = np.linalg.slogdet(scale)
+    if np.any(sign <= 0.0):
+        raise ValueError("Student-t scale matrix must be positive definite")
+    solved = np.linalg.solve(scale, values[..., None])[..., 0]
+    mahalanobis = np.einsum("...i,...i->...", values, solved)
+    normalization = (
+        lgamma(0.5 * (degrees_of_freedom + dimension))
+        - lgamma(0.5 * degrees_of_freedom)
+        - 0.5
+        * (
+            dimension * np.log(degrees_of_freedom * np.pi)
+            + log_determinant
+        )
+    )
+    return normalization - 0.5 * (degrees_of_freedom + dimension) * np.log1p(
+        mahalanobis / degrees_of_freedom
+    )
+
+
+def group_log_likelihood(
+    predicted_values_m: np.ndarray,
+    group: ObservationGroup,
+    *,
+    additive_variance_m2: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return robust mixture log likelihood and posterior nominal responsibility."""
+
+    predictions = np.asarray(predicted_values_m, dtype=float)
+    if predictions.shape[-1] != group.coordinate_count:
+        raise ValueError("predicted group coordinates do not match the observation group")
+    residual = predictions - group.values_m
+    covariance = group.covariance_m2
+    if additive_variance_m2 is not None:
+        additive = np.asarray(additive_variance_m2, dtype=float)
+        if additive.shape != predictions.shape:
+            raise ValueError("additive_variance_m2 must match predicted group values")
+        if np.any(~np.isfinite(additive)) or np.any(additive < 0.0):
+            raise ValueError("additive variances must be finite and nonnegative")
+        covariance = covariance + additive[..., :, None] * np.eye(group.coordinate_count)
+    nominal = _multivariate_student_t_log_density(
+        residual,
+        covariance,
+        degrees_of_freedom=group.degrees_of_freedom,
+    )
+    outlier = _multivariate_student_t_log_density(
+        residual,
+        covariance,
+        degrees_of_freedom=group.degrees_of_freedom,
+        covariance_multiplier=group.outlier_scale_multiplier,
+    )
+    log_nominal_component = np.log(group.prior_nominal_probability) + nominal
+    log_outlier_component = np.log1p(-group.prior_nominal_probability) + outlier
+    log_mixture = np.logaddexp(log_nominal_component, log_outlier_component)
+    responsibility = np.exp(log_nominal_component - log_mixture)
+    return log_mixture, responsibility
+
+
+def grouped_component_log_likelihoods(
+    predicted_components_m: np.ndarray,
+    evidence: GroupedObservationEvidence,
+    *,
+    prefix_frame_count: int,
+    component_variance_m2: np.ndarray | None = None,
+) -> tuple[np.ndarray, GroupLikelihoodDiagnostics]:
+    """Score arbitrary leading component dimensions against grouped O-plus evidence."""
+
+    components = np.asarray(predicted_components_m, dtype=float)
+    if components.ndim < 4:
+        raise ValueError("predicted_components_m must end in (frame, node, coordinate)")
+    if not np.all(np.isfinite(components)):
+        raise ValueError("predicted components must be finite")
+    evidence.validate_prefix(
+        prefix_frame_count=prefix_frame_count,
+        rollout_shape=components.shape[-3:],
+    )
+    leading_shape = components.shape[:-3]
+    variance = None
+    if component_variance_m2 is not None:
+        variance = np.broadcast_to(
+            np.asarray(component_variance_m2, dtype=float), components.shape
+        )
+        if np.any(~np.isfinite(variance)) or np.any(variance < 0.0):
+            raise ValueError("component variances must be finite and nonnegative")
+    total = np.zeros(leading_shape, dtype=float)
+    responsibilities = []
+    effective_weights = evidence.effective_group_weights
+    for group, weight in zip(evidence.groups, effective_weights, strict=True):
+        selected = group.selected_predictions(components)
+        selected_variance = (
+            None if variance is None else group.selected_predictions(variance)
+        )
+        log_likelihood, responsibility = group_log_likelihood(
+            selected, group, additive_variance_m2=selected_variance
+        )
+        total += weight * log_likelihood
+        responsibilities.append(responsibility)
+    diagnostics = GroupLikelihoodDiagnostics(
+        group_ids=tuple(group.group_id for group in evidence.groups),
+        effective_group_weights=effective_weights,
+        nominal_responsibilities=np.stack(responsibilities, axis=-1),
+    )
+    return total, diagnostics
+
+
+def posterior_weights_from_grouped_evidence(
+    prior_weights: np.ndarray,
+    predicted_components_m: np.ndarray,
+    evidence: GroupedObservationEvidence,
+    *,
+    prefix_frame_count: int,
+    component_variance_m2: np.ndarray | None = None,
+) -> tuple[np.ndarray, GroupLikelihoodDiagnostics]:
+    """Apply grouped evidence to finite component support in log space."""
+
+    prior = np.asarray(prior_weights, dtype=float)
+    if prior.shape != np.asarray(predicted_components_m).shape[:-3]:
+        raise ValueError("prior_weights must match the component leading dimensions")
+    if np.any(prior < 0.0) or not np.isclose(np.sum(prior), 1.0):
+        raise ValueError("prior_weights must be nonnegative and sum to one")
+    score, diagnostics = grouped_component_log_likelihoods(
+        predicted_components_m,
+        evidence,
+        prefix_frame_count=prefix_frame_count,
+        component_variance_m2=component_variance_m2,
+    )
+    log_posterior = np.log(np.maximum(prior, 1e-300)) + score
+    maximum = float(np.max(log_posterior))
+    posterior = np.exp(log_posterior - maximum)
+    posterior /= np.sum(posterior)
+    return posterior, diagnostics

--- a/src/causal4d/identifiability.py
+++ b/src/causal4d/identifiability.py
@@ -1,0 +1,219 @@
+"""Intervention-versus-nuisance identifiability diagnostics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class IdentifiabilityConfig:
+    """Frozen thresholds for conditional intervention information."""
+
+    relative_rank_tolerance: float = 1e-6
+    minimum_information_eigenvalue: float = 1e-6
+    maximum_condition_number: float = 1e8
+    minimum_residualized_response_fraction: float = 0.10
+    maximum_subspace_cosine: float = 0.995
+
+    def __post_init__(self) -> None:
+        if not 0.0 < self.relative_rank_tolerance < 1.0:
+            raise ValueError("relative_rank_tolerance must lie in (0, 1)")
+        if self.minimum_information_eigenvalue <= 0.0:
+            raise ValueError("minimum_information_eigenvalue must be positive")
+        if self.maximum_condition_number <= 1.0:
+            raise ValueError("maximum_condition_number must exceed one")
+        if not 0.0 <= self.minimum_residualized_response_fraction <= 1.0:
+            raise ValueError("minimum_residualized_response_fraction must lie in [0, 1]")
+        if not 0.0 <= self.maximum_subspace_cosine <= 1.0:
+            raise ValueError("maximum_subspace_cosine must lie in [0, 1]")
+
+
+@dataclass(frozen=True)
+class InterventionIdentifiabilityResult:
+    """Conditional information remaining after projecting out nuisance response."""
+
+    conditional_information: np.ndarray
+    eigenvalues: np.ndarray
+    effective_rank: int
+    parameter_count: int
+    minimum_eigenvalue: float
+    condition_number: float
+    residualized_response_fraction: float
+    maximum_subspace_cosine: float
+    identifiable: bool
+    failure_reasons: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        information = np.asarray(self.conditional_information, dtype=float).copy()
+        eigenvalues = np.asarray(self.eigenvalues, dtype=float).copy()
+        if information.shape != (self.parameter_count, self.parameter_count):
+            raise ValueError("conditional_information must match parameter_count")
+        if eigenvalues.shape != (self.parameter_count,):
+            raise ValueError("eigenvalues must match parameter_count")
+        if not np.all(np.isfinite(information)) or not np.all(np.isfinite(eigenvalues)):
+            raise ValueError("identifiability arrays must be finite")
+        information.setflags(write=False)
+        eigenvalues.setflags(write=False)
+        object.__setattr__(self, "conditional_information", information)
+        object.__setattr__(self, "eigenvalues", eigenvalues)
+        object.__setattr__(self, "failure_reasons", tuple(self.failure_reasons))
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "effective_rank": self.effective_rank,
+            "parameter_count": self.parameter_count,
+            "minimum_eigenvalue": self.minimum_eigenvalue,
+            "condition_number": (
+                self.condition_number if np.isfinite(self.condition_number) else None
+            ),
+            "residualized_response_fraction": self.residualized_response_fraction,
+            "maximum_subspace_cosine": self.maximum_subspace_cosine,
+            "identifiable": self.identifiable,
+            "failure_reasons": list(self.failure_reasons),
+            "eigenvalues": self.eigenvalues.tolist(),
+        }
+
+
+def finite_response_sensitivity(
+    reference_response: np.ndarray,
+    perturbed_responses: np.ndarray,
+    perturbation_steps: Sequence[float],
+    *,
+    valid: np.ndarray | None = None,
+) -> np.ndarray:
+    """Build a flattened secant-sensitivity matrix from finite perturbations.
+
+    ``perturbed_responses`` has shape ``(parameter, ...)`` and each remaining
+    dimension must match ``reference_response``. A boolean ``valid`` mask may
+    select response coordinates before flattening.
+    """
+
+    reference = np.asarray(reference_response, dtype=float)
+    perturbed = np.asarray(perturbed_responses, dtype=float)
+    steps = np.asarray(tuple(perturbation_steps), dtype=float)
+    if perturbed.ndim != reference.ndim + 1 or perturbed.shape[1:] != reference.shape:
+        raise ValueError("perturbed_responses must have shape (parameter, *reference.shape)")
+    if steps.shape != (len(perturbed),) or np.any(~np.isfinite(steps)) or np.any(steps == 0.0):
+        raise ValueError("perturbation_steps must be finite, nonzero, and match parameters")
+    responses = (perturbed - reference[None]) / steps.reshape((-1,) + (1,) * reference.ndim)
+    if valid is None:
+        selected = np.ones(reference.shape, dtype=bool)
+    else:
+        selected = np.asarray(valid, dtype=bool)
+        if selected.shape != reference.shape:
+            raise ValueError("valid must match reference_response")
+    if not np.any(selected):
+        raise ValueError("finite-response sensitivity has no valid coordinates")
+    matrix = responses[:, selected].T
+    if not np.all(np.isfinite(matrix)):
+        raise ValueError("finite-response sensitivities must be finite")
+    return matrix
+
+
+def _whiten(matrix: np.ndarray, covariance: np.ndarray | None) -> np.ndarray:
+    values = np.asarray(matrix, dtype=float)
+    if values.ndim != 2 or values.shape[0] == 0 or values.shape[1] == 0:
+        raise ValueError("sensitivity matrices must be nonempty two-dimensional arrays")
+    if not np.all(np.isfinite(values)):
+        raise ValueError("sensitivity matrices must be finite")
+    if covariance is None:
+        return values
+    noise = np.asarray(covariance, dtype=float)
+    if noise.shape != (values.shape[0], values.shape[0]):
+        raise ValueError("covariance must match the response dimension")
+    if not np.all(np.isfinite(noise)) or not np.allclose(noise, noise.T, atol=1e-12):
+        raise ValueError("covariance must be finite and symmetric")
+    try:
+        factor = np.linalg.cholesky(noise)
+    except np.linalg.LinAlgError as error:
+        raise ValueError("covariance must be positive definite") from error
+    return np.linalg.solve(factor, values)
+
+
+def _orthonormal_basis(matrix: np.ndarray, tolerance: float) -> np.ndarray:
+    if matrix.shape[1] == 0:
+        return np.zeros((matrix.shape[0], 0), dtype=float)
+    left, singular_values, _ = np.linalg.svd(matrix, full_matrices=False)
+    if len(singular_values) == 0 or singular_values[0] == 0.0:
+        return np.zeros((matrix.shape[0], 0), dtype=float)
+    rank = int(np.sum(singular_values > tolerance * singular_values[0]))
+    return left[:, :rank]
+
+
+def assess_intervention_identifiability(
+    intervention_sensitivity: np.ndarray,
+    nuisance_sensitivity: np.ndarray | None = None,
+    *,
+    covariance: np.ndarray | None = None,
+    config: IdentifiabilityConfig | None = None,
+) -> InterventionIdentifiabilityResult:
+    """Assess intervention information conditional on nuisance response.
+
+    The supplied sensitivities are whitened by ``covariance``. Intervention
+    columns are then projected onto the orthogonal complement of the nuisance
+    response. The resulting Gram matrix is the local conditional information.
+    """
+
+    settings = config or IdentifiabilityConfig()
+    intervention = _whiten(intervention_sensitivity, covariance)
+    response_count, parameter_count = intervention.shape
+    if nuisance_sensitivity is None:
+        nuisance = np.zeros((response_count, 0), dtype=float)
+    else:
+        nuisance_raw = np.asarray(nuisance_sensitivity, dtype=float)
+        if nuisance_raw.ndim != 2 or nuisance_raw.shape[0] != response_count:
+            raise ValueError("nuisance_sensitivity must share the response dimension")
+        nuisance = _whiten(nuisance_raw, covariance)
+
+    nuisance_basis = _orthonormal_basis(nuisance, settings.relative_rank_tolerance)
+    intervention_basis = _orthonormal_basis(
+        intervention, settings.relative_rank_tolerance
+    )
+    residualized = intervention - nuisance_basis @ (nuisance_basis.T @ intervention)
+    information = residualized.T @ residualized
+    information = 0.5 * (information + information.T)
+    eigenvalues = np.maximum(np.linalg.eigvalsh(information), 0.0)
+    largest = float(eigenvalues[-1])
+    tolerance = settings.relative_rank_tolerance * max(largest, 1.0)
+    effective_rank = int(np.sum(eigenvalues > tolerance))
+    minimum = float(eigenvalues[0])
+    positive = eigenvalues[eigenvalues > tolerance]
+    condition_number = (
+        float(np.max(positive) / np.min(positive)) if len(positive) else float("inf")
+    )
+    original_energy = float(np.sum(np.square(intervention)))
+    residual_energy = float(np.sum(np.square(residualized)))
+    residual_fraction = residual_energy / original_energy if original_energy > 0.0 else 0.0
+    if nuisance_basis.shape[1] and intervention_basis.shape[1]:
+        maximum_cosine = float(
+            np.max(np.linalg.svd(nuisance_basis.T @ intervention_basis, compute_uv=False))
+        )
+    else:
+        maximum_cosine = 0.0
+
+    reasons = []
+    if effective_rank < parameter_count:
+        reasons.append("rank_deficient_after_nuisance_projection")
+    if minimum < settings.minimum_information_eigenvalue:
+        reasons.append("conditional_information_below_threshold")
+    if condition_number > settings.maximum_condition_number:
+        reasons.append("conditional_information_ill_conditioned")
+    if residual_fraction < settings.minimum_residualized_response_fraction:
+        reasons.append("intervention_response_absorbed_by_nuisance")
+    if maximum_cosine > settings.maximum_subspace_cosine:
+        reasons.append("intervention_and_nuisance_subspaces_nearly_collinear")
+    return InterventionIdentifiabilityResult(
+        conditional_information=information,
+        eigenvalues=eigenvalues,
+        effective_rank=effective_rank,
+        parameter_count=parameter_count,
+        minimum_eigenvalue=minimum,
+        condition_number=condition_number,
+        residualized_response_fraction=float(residual_fraction),
+        maximum_subspace_cosine=maximum_cosine,
+        identifiable=not reasons,
+        failure_reasons=tuple(reasons),
+    )

--- a/src/causal4d/intervention_abduction.py
+++ b/src/causal4d/intervention_abduction.py
@@ -8,6 +8,12 @@ from typing import Any
 import numpy as np
 
 from causal4d.contracts import FactualIntervention, TwinBelief, array_sha256
+from causal4d.grouped_likelihood import (
+    GroupLikelihoodDiagnostics,
+    posterior_weights_from_grouped_evidence,
+)
+from causal4d.identifiability import InterventionIdentifiabilityResult
+from causal4d.observation_evidence import GroupedObservationEvidence
 from causal4d.rollout_bank import JointRolloutBank
 
 
@@ -64,6 +70,65 @@ def physical_readout_components(
     return bank.trajectories.astype(float) + discrepancy[None, :, None]
 
 
+def _grouped_diagnostics_summary(
+    diagnostics: GroupLikelihoodDiagnostics,
+) -> dict[str, Any]:
+    responsibilities = np.asarray(diagnostics.nominal_responsibilities, dtype=float)
+    reduction_axes = tuple(range(responsibilities.ndim - 1))
+    return {
+        "group_ids": list(diagnostics.group_ids),
+        "effective_group_weights": list(diagnostics.effective_group_weights),
+        "mean_nominal_responsibility_by_group": np.mean(
+            responsibilities, axis=reduction_axes
+        ).tolist(),
+        "minimum_nominal_responsibility_by_group": np.min(
+            responsibilities, axis=reduction_axes
+        ).tolist(),
+    }
+
+
+def _update_joint_weights(
+    bank: JointRolloutBank,
+    belief: TwinBelief,
+    observations_from_endpoint_m: np.ndarray,
+    *,
+    prefix_frame_count: int,
+    observation_mask: np.ndarray | None,
+    settings: FactualAbductionConfig,
+    base_weights: np.ndarray | None = None,
+    grouped_evidence: GroupedObservationEvidence | None = None,
+) -> tuple[np.ndarray, GroupLikelihoodDiagnostics | None]:
+    discrepancy, discrepancy_variance = _belief_readout(bank, belief)
+    if grouped_evidence is None:
+        return (
+            bank.update_from_observations(
+                observations_from_endpoint_m,
+                prefix_frame_count=prefix_frame_count,
+                scale_m=settings.observation_scale_m,
+                likelihood_power=settings.likelihood_power,
+                dynamic_likelihood_weight=settings.dynamic_likelihood_weight,
+                degrees_of_freedom=settings.degrees_of_freedom,
+                mask=observation_mask,
+                base_weights=base_weights,
+                particle_discrepancy_m=discrepancy,
+                particle_discrepancy_variance_m2=discrepancy_variance,
+            ),
+            None,
+        )
+    components = physical_readout_components(bank, belief)
+    component_variance = np.broadcast_to(
+        discrepancy_variance[None, :, None], components.shape
+    )
+    prior = bank.prior_joint_weights if base_weights is None else base_weights
+    return posterior_weights_from_grouped_evidence(
+        prior,
+        components,
+        grouped_evidence,
+        prefix_frame_count=prefix_frame_count,
+        component_variance_m2=component_variance,
+    )
+
+
 def abduct_factual_intervention(
     bank: JointRolloutBank,
     belief: TwinBelief,
@@ -72,8 +137,19 @@ def abduct_factual_intervention(
     prefix_frame_count: int,
     observation_mask: np.ndarray | None = None,
     config: FactualAbductionConfig | None = None,
+    grouped_evidence: GroupedObservationEvidence | None = None,
+    identifiability: InterventionIdentifiabilityResult | None = None,
+    abstain_when_unidentifiable: bool = False,
 ) -> FactualIntervention:
-    """Infer persistent ``phi`` and factual event ``kappa_obs`` from O+ only."""
+    """Infer persistent ``phi`` and factual event ``kappa_obs`` from O+ only.
+
+    The legacy dense Student-t score remains the default. Supplying
+    ``grouped_evidence`` activates full-covariance robust groups with fixed prior
+    reliability and contributor-aware composite powers. When
+    ``abstain_when_unidentifiable`` is true, a failed supplied identifiability
+    result returns the unchanged joint prior over physical and intervention
+    support rather than a falsely concentrated posterior.
+    """
 
     settings = config or FactualAbductionConfig()
     if not 2 <= prefix_frame_count < bank.frame_count:
@@ -81,18 +157,26 @@ def abduct_factual_intervention(
     expected_stop = belief.context.o_plus.frame_start + prefix_frame_count - 1
     if expected_stop > belief.context.o_plus.frame_stop:
         raise ValueError("abduction prefix extends beyond O+")
-    discrepancy, discrepancy_variance = _belief_readout(bank, belief)
-    joint_weights = bank.update_from_observations(
-        observations_from_endpoint_m,
-        prefix_frame_count=prefix_frame_count,
-        scale_m=settings.observation_scale_m,
-        likelihood_power=settings.likelihood_power,
-        dynamic_likelihood_weight=settings.dynamic_likelihood_weight,
-        degrees_of_freedom=settings.degrees_of_freedom,
-        mask=observation_mask,
-        particle_discrepancy_m=discrepancy,
-        particle_discrepancy_variance_m2=discrepancy_variance,
+    if abstain_when_unidentifiable and identifiability is None:
+        raise ValueError("an identifiability result is required for guarded abduction")
+    abstained = bool(
+        abstain_when_unidentifiable
+        and identifiability is not None
+        and not identifiability.identifiable
     )
+    if abstained:
+        joint_weights = bank.prior_joint_weights.copy()
+        grouped_diagnostics = None
+    else:
+        joint_weights, grouped_diagnostics = _update_joint_weights(
+            bank,
+            belief,
+            observations_from_endpoint_m,
+            prefix_frame_count=prefix_frame_count,
+            observation_mask=observation_mask,
+            settings=settings,
+            grouped_evidence=grouped_evidence,
+        )
     hand_count = len(bank.hypothesis_metadata[0]["contact"]["attachment_shifts"])
     phi_names = ("gain_multiplier", "delay_steps", "rotation_degrees")
     kappa_names = tuple(
@@ -124,6 +208,29 @@ def abduct_factual_intervention(
             kappa.append(event)
             hypothesis_indices.append(hypothesis_index)
             particle_indices.append(particle_index)
+    metadata: dict[str, Any] = {
+        "abduction_likelihood": asdict(settings),
+        "observation_prefix_frame_count_including_endpoint": prefix_frame_count,
+        "o_plus_frames_used": prefix_frame_count - 1,
+        "future_frames_read_by_abduction": 0,
+        "rollout_bank_trajectories_sha256": array_sha256(bank.trajectories),
+        "discrepancy_scored_as_separate_readout": True,
+        "discrepancy_injected_into_simulator_state": False,
+    }
+    if grouped_evidence is not None:
+        metadata["grouped_observation_evidence"] = {
+            "evidence_id": grouped_evidence.evidence_id,
+            "group_count": len(grouped_evidence.groups),
+            "contributor_multiplicity": grouped_evidence.contributor_multiplicity,
+            "diagnostics": (
+                None
+                if grouped_diagnostics is None
+                else _grouped_diagnostics_summary(grouped_diagnostics)
+            ),
+        }
+    if identifiability is not None:
+        metadata["intervention_identifiability"] = identifiability.as_dict()
+        metadata["abduction_abstained_unidentifiable"] = abstained
     return FactualIntervention(
         context=belief.context,
         component_ids=tuple(component_ids),
@@ -136,15 +243,7 @@ def abduct_factual_intervention(
         weights=joint_weights.reshape(-1),
         evidence_frame_stop=expected_stop,
         source_twin_belief_id=belief.artifact_id,
-        metadata={
-            "abduction_likelihood": asdict(settings),
-            "observation_prefix_frame_count_including_endpoint": prefix_frame_count,
-            "o_plus_frames_used": prefix_frame_count - 1,
-            "future_frames_read_by_abduction": 0,
-            "rollout_bank_trajectories_sha256": array_sha256(bank.trajectories),
-            "discrepancy_scored_as_separate_readout": True,
-            "discrepancy_injected_into_simulator_state": False,
-        },
+        metadata=metadata,
     )
 
 
@@ -222,11 +321,11 @@ def evaluate_factual_abduction(
     observation_mask: np.ndarray,
     prefix_frame_count: int,
     config: FactualAbductionConfig | None = None,
+    grouped_evidence: GroupedObservationEvidence | None = None,
 ) -> dict[str, Any]:
     """Compare BPT+z with a same-evidence BPT posterior fixed to nominal z."""
 
     settings = config or FactualAbductionConfig()
-    discrepancy, discrepancy_variance = _belief_readout(bank, belief)
     z_weights = factual_joint_weights(
         factual,
         hypothesis_count=len(bank.hypothesis_ids),
@@ -237,17 +336,15 @@ def evaluate_factual_abduction(
     action_mass = bank.hypothesis_prior_weights[nominal]
     action_mass = action_mass / np.sum(action_mass)
     nominal_base[nominal] = action_mass[:, None] * bank.parameter_weights[None]
-    nominal_weights = bank.update_from_observations(
+    nominal_weights, _ = _update_joint_weights(
+        bank,
+        belief,
         observations_from_endpoint_m,
         prefix_frame_count=prefix_frame_count,
-        scale_m=settings.observation_scale_m,
-        likelihood_power=settings.likelihood_power,
-        dynamic_likelihood_weight=settings.dynamic_likelihood_weight,
-        degrees_of_freedom=settings.degrees_of_freedom,
-        mask=observation_mask,
+        observation_mask=observation_mask,
+        settings=settings,
         base_weights=nominal_base,
-        particle_discrepancy_m=discrepancy,
-        particle_discrepancy_variance_m2=discrepancy_variance,
+        grouped_evidence=grouped_evidence,
     )
     components = physical_readout_components(bank, belief)
     z_prediction = np.einsum("hp,hptnc->tnc", z_weights, components)
@@ -269,6 +366,9 @@ def evaluate_factual_abduction(
     return {
         "abduction_prefix_frame_count_including_endpoint": prefix_frame_count,
         "held_out_rollout_interval": [prefix_frame_count, bank.frame_count],
+        "evidence_model": (
+            "grouped_robust_composite" if grouped_evidence is not None else "legacy_dense"
+        ),
         "bpt_without_z": nominal_metrics,
         "bpt_plus_causal4d_z": z_metrics,
         "relative_track_error_improvement": float(improvement),

--- a/src/causal4d/observation_evidence.py
+++ b/src/causal4d/observation_evidence.py
@@ -1,0 +1,245 @@
+"""Typed grouped observation evidence for correlation-aware Causal4D updates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+
+def _readonly(values: np.ndarray, *, dtype: Any = float) -> np.ndarray:
+    result = np.asarray(values, dtype=dtype).copy()
+    result.setflags(write=False)
+    return result
+
+
+def _json_metadata(values: Mapping[str, Any]) -> dict[str, Any]:
+    import json
+
+    try:
+        return json.loads(json.dumps(dict(values), sort_keys=True, allow_nan=False))
+    except (TypeError, ValueError) as error:
+        raise ValueError("metadata must contain finite JSON data") from error
+
+
+@dataclass(frozen=True)
+class ObservationGroup:
+    """One jointly scored observation group.
+
+    A group contains scalar coordinates selected from a dense rollout by parallel
+    frame, node, and coordinate index vectors. ``covariance_m2`` is the covariance
+    of the complete selected vector, not a per-coordinate variance shortcut.
+    ``prior_nominal_probability`` is fixed before evaluating the residual.
+    """
+
+    group_id: str
+    values_m: np.ndarray
+    frame_indices: np.ndarray
+    node_indices: np.ndarray
+    coordinate_indices: np.ndarray
+    covariance_m2: np.ndarray
+    contributor_ids: tuple[str, ...]
+    prior_nominal_probability: float = 0.95
+    outlier_scale_multiplier: float = 100.0
+    degrees_of_freedom: float = 4.0
+    composite_weight: float = 1.0
+    source_id: str = "unknown"
+    view_id: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.group_id or not self.source_id:
+            raise ValueError("group_id and source_id must be nonempty")
+        values = _readonly(self.values_m)
+        frames = _readonly(self.frame_indices, dtype=np.int64)
+        nodes = _readonly(self.node_indices, dtype=np.int64)
+        coordinates = _readonly(self.coordinate_indices, dtype=np.int64)
+        covariance = _readonly(self.covariance_m2)
+        count = len(values)
+        if values.ndim != 1 or count == 0:
+            raise ValueError("values_m must be a nonempty vector")
+        if frames.shape != (count,) or nodes.shape != (count,) or coordinates.shape != (count,):
+            raise ValueError("frame, node, and coordinate indices must match values_m")
+        if np.any(frames < 0) or np.any(nodes < 0) or np.any(coordinates < 0):
+            raise ValueError("observation indices must be nonnegative")
+        if not np.all(np.isfinite(values)):
+            raise ValueError("observation values must be finite")
+        if covariance.shape != (count, count):
+            raise ValueError("covariance_m2 must have shape (coordinate, coordinate)")
+        if not np.all(np.isfinite(covariance)) or not np.allclose(
+            covariance, covariance.T, atol=1e-12, rtol=1e-10
+        ):
+            raise ValueError("covariance_m2 must be finite and symmetric")
+        eigenvalues = np.linalg.eigvalsh(covariance)
+        if np.min(eigenvalues) <= 0.0:
+            raise ValueError("covariance_m2 must be positive definite")
+        if not 0.0 < self.prior_nominal_probability < 1.0:
+            raise ValueError("prior_nominal_probability must lie in (0, 1)")
+        if self.outlier_scale_multiplier <= 1.0:
+            raise ValueError("outlier_scale_multiplier must exceed one")
+        if self.degrees_of_freedom <= 2.0:
+            raise ValueError("degrees_of_freedom must exceed two")
+        if not 0.0 < self.composite_weight <= 1.0:
+            raise ValueError("composite_weight must lie in (0, 1]")
+        if not self.contributor_ids or any(not value for value in self.contributor_ids):
+            raise ValueError("contributor_ids must contain nonempty identities")
+        if len(set(self.contributor_ids)) != len(self.contributor_ids):
+            raise ValueError("contributor_ids must be unique within a group")
+        object.__setattr__(self, "values_m", values)
+        object.__setattr__(self, "frame_indices", frames)
+        object.__setattr__(self, "node_indices", nodes)
+        object.__setattr__(self, "coordinate_indices", coordinates)
+        object.__setattr__(self, "covariance_m2", covariance)
+        object.__setattr__(self, "contributor_ids", tuple(self.contributor_ids))
+        object.__setattr__(self, "metadata", _json_metadata(self.metadata))
+
+    @property
+    def coordinate_count(self) -> int:
+        return len(self.values_m)
+
+    def validate_rollout_shape(self, shape: Sequence[int]) -> None:
+        if len(shape) != 3:
+            raise ValueError("rollout shape must be (frame, node, coordinate)")
+        frame_count, node_count, coordinate_count = map(int, shape)
+        if np.any(self.frame_indices >= frame_count):
+            raise ValueError(f"group {self.group_id!r} references an unavailable frame")
+        if np.any(self.node_indices >= node_count):
+            raise ValueError(f"group {self.group_id!r} references an unavailable node")
+        if np.any(self.coordinate_indices >= coordinate_count):
+            raise ValueError(f"group {self.group_id!r} references an unavailable coordinate")
+
+    def selected_predictions(self, trajectories_m: np.ndarray) -> np.ndarray:
+        trajectories = np.asarray(trajectories_m, dtype=float)
+        if trajectories.ndim < 3:
+            raise ValueError("trajectories_m must end in (frame, node, coordinate)")
+        self.validate_rollout_shape(trajectories.shape[-3:])
+        return trajectories[
+            ...,
+            self.frame_indices,
+            self.node_indices,
+            self.coordinate_indices,
+        ]
+
+
+@dataclass(frozen=True)
+class GroupedObservationEvidence:
+    """A collection of observation groups with contributor-aware power caps.
+
+    Reusing a contributor in multiple groups automatically divides each affected
+    group power by that contributor's multiplicity. Exact duplicated evidence with
+    the same contributor identity therefore cannot sharpen the posterior.
+    """
+
+    groups: tuple[ObservationGroup, ...]
+    evidence_id: str = "grouped_observation_evidence"
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        groups = tuple(self.groups)
+        if not groups or not self.evidence_id:
+            raise ValueError("grouped evidence must have an identity and at least one group")
+        identifiers = [group.group_id for group in groups]
+        if len(set(identifiers)) != len(identifiers):
+            raise ValueError("observation group IDs must be unique")
+        object.__setattr__(self, "groups", groups)
+        object.__setattr__(self, "metadata", _json_metadata(self.metadata))
+
+    @property
+    def contributor_multiplicity(self) -> dict[str, int]:
+        result: dict[str, int] = {}
+        for group in self.groups:
+            for contributor in group.contributor_ids:
+                result[contributor] = result.get(contributor, 0) + 1
+        return result
+
+    @property
+    def effective_group_weights(self) -> tuple[float, ...]:
+        multiplicity = self.contributor_multiplicity
+        return tuple(
+            group.composite_weight
+            / max(multiplicity[contributor] for contributor in group.contributor_ids)
+            for group in self.groups
+        )
+
+    def validate_prefix(self, *, prefix_frame_count: int, rollout_shape: Sequence[int]) -> None:
+        if prefix_frame_count < 2:
+            raise ValueError("prefix_frame_count must reveal at least one O-plus frame")
+        for group in self.groups:
+            group.validate_rollout_shape(rollout_shape)
+            if np.any(group.frame_indices <= 0):
+                raise ValueError("grouped O-plus evidence may not reuse the endpoint frame")
+            if np.any(group.frame_indices >= prefix_frame_count):
+                raise ValueError("grouped evidence crosses the declared O-plus prefix")
+
+    @classmethod
+    def from_dense_prefix(
+        cls,
+        observations_m: np.ndarray,
+        *,
+        prefix_frame_count: int,
+        scale_m: float,
+        mask: np.ndarray | None = None,
+        prior_nominal_probability: float = 0.95,
+        outlier_scale_multiplier: float = 100.0,
+        degrees_of_freedom: float = 4.0,
+        source_id: str = "dense_observation",
+    ) -> "GroupedObservationEvidence":
+        """Build one covariance-aware group per O-plus frame.
+
+        This convenience constructor preserves frame-level correlation boundaries.
+        More detailed feeders should construct groups directly and supply their full
+        metric covariance and contributor provenance.
+        """
+
+        observations = np.asarray(observations_m, dtype=float)
+        if observations.ndim != 3 or observations.shape[2] not in {2, 3}:
+            raise ValueError("observations_m must have shape (frame, node, 2|3)")
+        if not 2 <= prefix_frame_count <= len(observations):
+            raise ValueError("prefix_frame_count must reveal O-plus frames")
+        if scale_m <= 0.0 or not np.isfinite(scale_m):
+            raise ValueError("scale_m must be positive and finite")
+        valid = np.all(np.isfinite(observations), axis=2)
+        if mask is not None:
+            supplied = np.asarray(mask, dtype=bool)
+            if supplied.shape == observations.shape:
+                supplied = np.all(supplied, axis=2)
+            if supplied.shape != observations.shape[:2]:
+                raise ValueError("mask must have shape (T, N) or (T, N, C)")
+            valid &= supplied
+        groups = []
+        coordinate_count = observations.shape[2]
+        for frame in range(1, prefix_frame_count):
+            nodes = np.flatnonzero(valid[frame])
+            if len(nodes) == 0:
+                continue
+            frame_indices = np.repeat(frame, len(nodes) * coordinate_count)
+            node_indices = np.repeat(nodes, coordinate_count)
+            coordinate_indices = np.tile(np.arange(coordinate_count), len(nodes))
+            values = observations[frame, nodes].reshape(-1)
+            covariance = np.eye(len(values), dtype=float) * scale_m**2
+            groups.append(
+                ObservationGroup(
+                    group_id=f"{source_id}:frame:{frame}",
+                    values_m=values,
+                    frame_indices=frame_indices,
+                    node_indices=node_indices,
+                    coordinate_indices=coordinate_indices,
+                    covariance_m2=covariance,
+                    contributor_ids=(f"{source_id}:frame:{frame}",),
+                    prior_nominal_probability=prior_nominal_probability,
+                    outlier_scale_multiplier=outlier_scale_multiplier,
+                    degrees_of_freedom=degrees_of_freedom,
+                    source_id=source_id,
+                )
+            )
+        if not groups:
+            raise ValueError("dense prefix contains no valid O-plus observations")
+        return cls(
+            groups=tuple(groups),
+            evidence_id=f"{source_id}:prefix:{prefix_frame_count}",
+            metadata={
+                "constructor": "from_dense_prefix",
+                "prefix_frame_count_including_endpoint": prefix_frame_count,
+            },
+        )

--- a/tests/test_causal4d_grouped_abduction.py
+++ b/tests/test_causal4d_grouped_abduction.py
@@ -1,0 +1,138 @@
+import numpy as np
+
+from causal4d.contracts import TwinBelief, build_causal_context
+from causal4d.identifiability import assess_intervention_identifiability
+from causal4d.intervention_abduction import (
+    FactualAbductionConfig,
+    abduct_factual_intervention,
+    evaluate_factual_abduction,
+    factual_joint_weights,
+)
+from causal4d.observation_evidence import GroupedObservationEvidence
+from causal4d.rollout_bank import JointRolloutBank
+
+
+def _problem():
+    bank_frames = 8
+    trajectories = np.zeros((3, 1, bank_frames, 1, 3), dtype=float)
+    time = np.arange(bank_frames, dtype=float)
+    trajectories[1, 0, :, 0, 0] = 0.01 * time
+    trajectories[2, 0, :, 0, 0] = -0.01 * time
+
+    def metadata(identifier, gain, shift):
+        return {
+            "hypothesis_id": identifier,
+            "action": {
+                "proposal_id": "known",
+                "future_action_observed": True,
+                "provenance": "unit factual action",
+            },
+            "contact": {
+                "attachment_shifts": [shift],
+                "gain_multiplier": gain,
+                "delay_steps": 0,
+                "slip_fraction": 0.0,
+                "rotation_degrees": 0.0,
+            },
+        }
+
+    bank = JointRolloutBank(
+        hypothesis_ids=("nominal", "high_gain", "shifted"),
+        hypothesis_metadata=(
+            metadata("nominal", 1.0, 0),
+            metadata("high_gain", 1.15, 0),
+            metadata("shifted", 1.0, 1),
+        ),
+        hypothesis_prior_weights=np.asarray([0.6, 0.2, 0.2]),
+        parameter_particles=np.asarray([[0.0]]),
+        parameter_weights=np.asarray([1.0]),
+        trajectories=trajectories,
+        variance_floor_m2=1e-8,
+    )
+    full_frames = 11
+    intervention_frame = 4
+    full_observations = np.zeros((full_frames, 1, 3), dtype=float)
+    full_observations[intervention_frame - 1 :] = trajectories[1, 0]
+    actions = np.zeros((full_frames, 1, 3), dtype=float)
+    context = build_causal_context(
+        protocol_id="grouped_abduction_unit",
+        case_id="synthetic",
+        observations=full_observations,
+        observed_actions=actions,
+        counterfactual_actions=actions,
+        intervention_frame=intervention_frame,
+    )
+    belief = TwinBelief(
+        context=context,
+        endpoint_frame=intervention_frame - 1,
+        particle_ids=("p0",),
+        theta_names=("spring",),
+        endpoint_position_m=np.zeros((1, 1, 3)),
+        endpoint_velocity_mps=np.zeros((1, 1, 3)),
+        theta=np.asarray([[0.0]]),
+        discrepancy_mean_m=np.zeros((1, 1, 3)),
+        discrepancy_variance_m2=np.zeros((1, 1, 3)),
+        weights=np.asarray([1.0]),
+    )
+    observations = trajectories[1, 0].copy()
+    mask = np.ones((bank_frames, 1), dtype=bool)
+    config = FactualAbductionConfig(observation_scale_m=0.001)
+    evidence = GroupedObservationEvidence.from_dense_prefix(
+        observations,
+        prefix_frame_count=4,
+        scale_m=0.001,
+        mask=mask,
+        prior_nominal_probability=0.99,
+        source_id="unit_tracks",
+    )
+    return bank, belief, observations, mask, config, evidence
+
+
+def test_grouped_abduction_recovers_matching_intervention() -> None:
+    bank, belief, observations, mask, config, evidence = _problem()
+    factual = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=config,
+        grouped_evidence=evidence,
+    )
+    joint = factual_joint_weights(factual, hypothesis_count=3, particle_count=1)
+    assert np.argmax(joint[:, 0]) == 1
+    assert factual.metadata["grouped_observation_evidence"]["group_count"] == 3
+    result = evaluate_factual_abduction(
+        bank,
+        belief,
+        factual,
+        observations,
+        observation_mask=mask,
+        prefix_frame_count=4,
+        config=config,
+        grouped_evidence=evidence,
+    )
+    assert result["evidence_model"] == "grouped_robust_composite"
+    assert result["map_hypothesis_id"] == "high_gain"
+
+
+def test_unidentifiable_abduction_returns_exact_joint_prior() -> None:
+    bank, belief, observations, mask, config, evidence = _problem()
+    identifiability = assess_intervention_identifiability(
+        np.asarray([[1.0], [1.0]]),
+        np.asarray([[1.0], [1.0]]),
+    )
+    factual = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=config,
+        grouped_evidence=evidence,
+        identifiability=identifiability,
+        abstain_when_unidentifiable=True,
+    )
+    assert not identifiability.identifiable
+    assert np.array_equal(factual.weights, bank.prior_joint_weights.reshape(-1))
+    assert factual.metadata["abduction_abstained_unidentifiable"] is True

--- a/tests/test_identifiability.py
+++ b/tests/test_identifiability.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+from causal4d.identifiability import (
+    IdentifiabilityConfig,
+    assess_intervention_identifiability,
+    finite_response_sensitivity,
+)
+
+
+def test_camera_only_common_mode_is_unidentifiable() -> None:
+    intervention = np.asarray([[1.0], [1.0]])
+    nuisance = np.asarray([[1.0], [1.0]])
+    result = assess_intervention_identifiability(intervention, nuisance)
+    assert not result.identifiable
+    assert result.effective_rank == 0
+    assert "intervention_response_absorbed_by_nuisance" in result.failure_reasons
+
+
+def test_independent_anchor_restores_identifiability() -> None:
+    intervention = np.asarray([[1.0], [1.0], [1.0]])
+    nuisance = np.asarray([[1.0], [1.0], [0.0]])
+    result = assess_intervention_identifiability(
+        intervention,
+        nuisance,
+        config=IdentifiabilityConfig(
+            minimum_information_eigenvalue=0.1,
+            minimum_residualized_response_fraction=0.1,
+            maximum_subspace_cosine=0.95,
+        ),
+    )
+    assert result.identifiable
+    assert result.effective_rank == 1
+    assert result.residualized_response_fraction > 0.1
+
+
+def test_finite_response_sensitivity_uses_declared_steps() -> None:
+    reference = np.zeros((2, 1))
+    perturbed = np.asarray([[[2.0], [4.0]], [[-3.0], [6.0]]])
+    matrix = finite_response_sensitivity(reference, perturbed, [2.0, 3.0])
+    assert np.array_equal(matrix, np.asarray([[1.0, -1.0], [2.0, 2.0]]))

--- a/tests/test_observation_evidence.py
+++ b/tests/test_observation_evidence.py
@@ -1,0 +1,48 @@
+import numpy as np
+
+from causal4d.grouped_likelihood import posterior_weights_from_grouped_evidence
+from causal4d.observation_evidence import GroupedObservationEvidence, ObservationGroup
+
+
+def _group(group_id: str, contributor: str) -> ObservationGroup:
+    return ObservationGroup(
+        group_id=group_id,
+        values_m=np.asarray([1.0]),
+        frame_indices=np.asarray([1]),
+        node_indices=np.asarray([0]),
+        coordinate_indices=np.asarray([0]),
+        covariance_m2=np.asarray([[0.01]]),
+        contributor_ids=(contributor,),
+        prior_nominal_probability=0.9,
+        outlier_scale_multiplier=100.0,
+        degrees_of_freedom=4.0,
+        source_id="unit",
+    )
+
+
+def test_duplicate_contributor_does_not_sharpen_posterior() -> None:
+    components = np.zeros((2, 3, 1, 1), dtype=float)
+    components[1, 1, 0, 0] = 1.0
+    prior = np.asarray([0.5, 0.5])
+    single = GroupedObservationEvidence(groups=(_group("g1", "same"),))
+    duplicated = GroupedObservationEvidence(
+        groups=(_group("g1", "same"), _group("g2", "same"))
+    )
+    first, _ = posterior_weights_from_grouped_evidence(
+        prior, components, single, prefix_frame_count=2
+    )
+    second, _ = posterior_weights_from_grouped_evidence(
+        prior, components, duplicated, prefix_frame_count=2
+    )
+    assert np.allclose(first, second, atol=1e-12, rtol=1e-12)
+    assert first[1] > first[0]
+
+
+def test_dense_prefix_excludes_future_frames() -> None:
+    observations = np.zeros((5, 2, 3), dtype=float)
+    evidence = GroupedObservationEvidence.from_dense_prefix(
+        observations,
+        prefix_frame_count=3,
+        scale_m=0.01,
+    )
+    assert {int(group.frame_indices[0]) for group in evidence.groups} == {1, 2}


### PR DESCRIPTION
## Summary

This PR implements the first high-value Causal4D improvement slice identified in the repository review:

- adds typed, provenance-complete grouped observation evidence;
- adds a full-covariance robust multivariate Student-t nominal/outlier mixture;
- caps repeated contributors so duplicated correlated evidence cannot sharpen the posterior;
- adds intervention-versus-nuisance identifiability diagnostics based on whitened conditional information;
- integrates grouped evidence into factual intervention abduction;
- adds exact joint-prior abstention when intervention response is not identifiable;
- exposes grouped evidence and source-frozen identifiability inputs through the PhysTwin abduction CLI;
- reconciles the same-object protocol documentation with the amended 12-fit-execution/9-calibration-session folds;
- retains the legacy dense likelihood as the default and does not modify frozen milestone artifacts.

## Scientific behavior

The new diagnostic projects intervention sensitivities onto the orthogonal complement of admitted nuisance sensitivities and reports rank, information eigenvalues, conditioning, residualized response energy, subspace overlap, and explicit rejection reasons.

When guarded abduction is enabled and identifiability fails, the returned `FactualIntervention` preserves the original joint prior over physical particles and intervention hypotheses exactly rather than concentrating on an observationally confounded explanation.

Grouped likelihood scoring keeps prior reliability separate from residual-conditioned posterior responsibility and includes particle-specific discrepancy variance in the selected observation covariance.

## Compatibility

- Existing calls to `abduct_factual_intervention` use the unchanged legacy path.
- Existing factual-artifact metadata is unchanged unless one of the new optional inputs is supplied.
- No target future is read by grouped evidence validation or guarded abduction.
- No frozen protocol, milestone, or result artifact is changed.

## Validation

- `python -m py_compile` passed for all new and modified Python files.
- Seven targeted tests passed: grouped evidence, duplicate-contributor power capping, prefix sealing, camera-only non-identifiability, independent-anchor recovery, grouped intervention recovery, and exact-prior abstention.
- The CLI parser and identifiability-NPZ loader passed an isolated validation harness.
- The branch is mergeable with `main`.
- GitHub currently reports no automated status checks or workflow runs for the PR head, so the complete repository suite has not been executed in this environment.
