### PR TITLE
Add dynamic contact-path inference

### DIFF
--- a/docs/causal4d_dynamic_contact_paths.md
+++ b/docs/causal4d_dynamic_contact_paths.md
@@ -1,0 +1,125 @@
+# Dynamic Contact-Path Inference
+
+## Status and scope
+
+This is a development extension of Causal4D. It does not modify the frozen
+`v0.3.0-causal4d-aip` milestone and is not promoted as real-data evidence. Its
+purpose is to close one explicit model gap: the mathematical formulation treats
+contact as a path-valued variable `kappa_t`, whereas the first PhysTwin rollout
+bank associates one static contact summary with each complete rollout.
+
+The extension is motivated by the Deform360 `001-rope` target, where a gripper
+is inactive at the final prefix frame but activates at the first held-out frame.
+A static prefix-conditioned contact state necessarily misses that onset. The
+new code evaluates whether an action-conditioned distribution over future
+contact paths can represent such cases without consuming future observations.
+
+## Contact regimes
+
+Each frame has one discrete regime:
+
+- `inactive`: no realized force transmission;
+- `sticking`: active contact with no modeled sliding;
+- `slipping`: active contact with reduced or redistributed transmission;
+- `detached`: a previously active contact has separated.
+
+The transition matrix is conditioned on a normalized command-activation signal
+and its frame-to-frame change. The default model permits activation,
+stick-to-slip transitions, release, recovery, and reattachment. The transition
+configuration is explicit and serializable.
+
+`enumerate_contact_paths` uses deterministic beam pruning. It returns the
+retained prior mass in addition to normalized retained weights, so aggressive
+pruning cannot be silently interpreted as complete support.
+
+## Backend boundary
+
+`DynamicContactPathBank` is simulator-neutral. A backend supplies:
+
+- one complete regime path per component;
+- one physical/readout trajectory per path;
+- a prior weight;
+- scalar, node-wise, component-wise, or time-varying conditional variance.
+
+The module does not splice static trajectories at a regime switch. Such
+splicing would generally violate simulator state continuity. PhysTwin/Warp or
+another simulator must generate the path-conditioned trajectory, including
+correct restart state and contact mechanics.
+
+## Prefix-only inference
+
+For a bank of trajectories `X^(k)` and observations through frame `tau`, the
+posterior is
+
+```text
+w_k^+ proportional to w_k^- L(O_0:tau | X_0:tau^(k)).
+```
+
+The likelihood is a robust Student-t score over position and, optionally,
+frame differences. It consumes only frames before `prefix_frame_count`.
+Changing any held-out observation leaves posterior weights and predictive
+moments unchanged; this is covered by a byte-exact unit test.
+
+The known future command is allowed because it is part of the intervention
+query. Future object observations are not allowed.
+
+## Intervention-conditioned uncertainty
+
+The per-component conditional variance evolves as
+
+```text
+V_k(t) = V_k(0)
+       + q_switch * cumulative_switches_k(t)
+       + q_command * cumulative_squared_command_changes(t)
+       + q_ood * cumulative_squared_action_ood(t).
+```
+
+The predictive variance then includes both path-mixture dispersion and the
+weighted conditional variance. This preserves the successful persistent mean
+while allowing uncertainty to widen after predicted contact changes, abrupt
+commands, or action extrapolation.
+
+Setting all three inflation coefficients to zero recovers the supplied static
+conditional variance exactly. Setting all transition hazards to zero produces
+one constant-regime path with unit weight.
+
+## Controlled delayed-onset benchmark
+
+Run:
+
+```bash
+causal4d-dynamic-contact-benchmark \
+  --require-gates \
+  --output-json runs/dynamic-contact-delayed-onset-v1.json
+```
+
+The benchmark fixes an inactive observed prefix and a known command activation
+at the first held-out frame. It compares static prefix persistence with the
+dynamic path mixture and checks:
+
+1. at least 50% RMSE improvement over static prefix persistence;
+2. posterior expected onset within one frame of the controlled onset;
+3. zero future observations consumed by inference.
+
+This is a software and controlled-model test. It is not evidence that the
+transition probabilities are calibrated for Deform360 or real PhysTwin data.
+Those probabilities must be frozen on source interactions and evaluated under
+the locked same-object multi-action protocol.
+
+## PhysTwin integration path
+
+A real integration should:
+
+1. generate a source-frozen contact path beam from command, registration, and
+   optional tactile/contact evidence;
+2. run official Warp continuously for each retained path and Bayesian-PhysTwin
+   particle;
+3. build `DynamicContactPathBank` from those trajectories;
+4. reweight with the permitted response prefix;
+5. report contact-onset, regime, trajectory, and calibration metrics by horizon
+   and graph region;
+6. retain the static Causal4D operator as the exact zero-hazard control.
+
+The extension should not delay the registered 36-execution acquisition. It is a
+specific candidate for the already observed contact-onset failure, not a reason
+to reopen unrestricted architecture search on exhausted cases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ pyrecest = [
 [project.scripts]
 causal4d-counterfactual-benchmark = "causal4d.cli.counterfactual_benchmark:main"
 causal4d-latent-contact-benchmark = "causal4d.cli.latent_contact_benchmark:main"
+causal4d-dynamic-contact-benchmark = "causal4d.cli.dynamic_contact_benchmark:main"
 causal4d-phystwin-rollout-bank = "causal4d.cli.phystwin_rollout_bank:main"
 causal4d-export-bpt-belief = "causal4d.cli.export_bpt_belief:main"
 causal4d-abduct-phystwin-intervention = "causal4d.cli.abduct_phystwin_intervention:main"

--- a/src/causal4d/cli/dynamic_contact_benchmark.py
+++ b/src/causal4d/cli/dynamic_contact_benchmark.py
@@ -1,0 +1,190 @@
+"""Controlled delayed-contact benchmark for dynamic Causal4D interventions."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from causal4d.dynamic_contact import (
+    ContactRegime,
+    ContactTransitionConfig,
+    DynamicContactInferenceConfig,
+    DynamicContactPathBank,
+    enumerate_contact_paths,
+    first_activation_frame,
+    infer_dynamic_contact_posterior,
+)
+
+
+def _simulate_path(
+    regime_path: np.ndarray,
+    command_activation: np.ndarray,
+    *,
+    sticking_step_m: float = 0.006,
+    slipping_step_m: float = 0.003,
+) -> np.ndarray:
+    frame_count = len(regime_path)
+    trajectory = np.zeros((frame_count, 1, 3), dtype=float)
+    for frame in range(1, frame_count):
+        regime = int(regime_path[frame])
+        if regime == ContactRegime.STICKING:
+            step = sticking_step_m * command_activation[frame]
+        elif regime == ContactRegime.SLIPPING:
+            step = slipping_step_m * command_activation[frame]
+        else:
+            step = 0.0
+        trajectory[frame] = trajectory[frame - 1]
+        trajectory[frame, 0, 0] += step
+    return trajectory
+
+
+def delayed_contact_case(
+    *,
+    seed: int = 0,
+    frame_count: int = 24,
+    prefix_frame_count: int = 6,
+) -> dict[str, Any]:
+    """Run one action-known contact-onset case without reading future observations."""
+
+    if not 2 <= prefix_frame_count < frame_count - 2:
+        raise ValueError("prefix_frame_count must leave a meaningful future")
+    rng = np.random.default_rng(seed)
+    activation = np.zeros(frame_count, dtype=float)
+    activation[prefix_frame_count:] = 1.0
+    transition = ContactTransitionConfig(
+        activation_floor=0.0,
+        activation_gain=0.96,
+        slip_floor=0.0,
+        slip_change_gain=0.0,
+        release_floor=0.0,
+        release_gain=0.0,
+        slip_recovery_probability=0.0,
+        reattachment_gain=0.0,
+        maximum_paths=32,
+    )
+    prior = enumerate_contact_paths(activation, config=transition)
+    trajectories = np.stack(
+        [_simulate_path(path, activation) for path in prior.regime_paths],
+        axis=0,
+    )
+    bank = DynamicContactPathBank(
+        path_ids=prior.path_ids,
+        regime_paths=prior.regime_paths,
+        trajectories_m=trajectories,
+        prior_weights=prior.weights,
+        base_variance_m2=(0.0005**2),
+    )
+
+    truth_path = np.full(frame_count, ContactRegime.INACTIVE, dtype=np.int8)
+    truth_path[prefix_frame_count:] = ContactRegime.STICKING
+    truth = _simulate_path(truth_path, activation)
+    observations = truth + rng.normal(scale=0.0005, size=truth.shape)
+    inference = DynamicContactInferenceConfig(
+        observation_scale_m=0.001,
+        degrees_of_freedom=4.0,
+        likelihood_power=1.0,
+        dynamic_likelihood_weight=0.25,
+        switch_variance_m2=0.00075**2,
+        command_change_variance_m2=0.00025**2,
+        ood_variance_m2=0.0,
+        confidence_level=0.90,
+    )
+    posterior = infer_dynamic_contact_posterior(
+        bank,
+        observations,
+        prefix_frame_count=prefix_frame_count,
+        command_activation=activation,
+        config=inference,
+    )
+
+    static_inactive = _simulate_path(
+        np.full(frame_count, ContactRegime.INACTIVE, dtype=np.int8),
+        activation,
+    )
+    future = slice(prefix_frame_count, frame_count)
+
+    def rmse(prediction: np.ndarray) -> float:
+        return float(np.sqrt(np.mean(np.square(prediction[future] - truth[future]))))
+
+    static_rmse = rmse(static_inactive)
+    dynamic_rmse = rmse(posterior.mean_m)
+    oracle_rmse = rmse(truth)
+    active_frames = [first_activation_frame(path) for path in prior.regime_paths]
+    onset_values = np.asarray(
+        [frame_count if value is None else value for value in active_frames],
+        dtype=float,
+    )
+    expected_onset = float(np.dot(posterior.weights, onset_values))
+    truth_covered = (truth >= posterior.interval_lower_m) & (
+        truth <= posterior.interval_upper_m
+    )
+    future_coverage = float(np.mean(truth_covered[future]))
+    improvement = 1.0 - dynamic_rmse / static_rmse
+    return {
+        "protocol": "delayed_contact_onset_v1",
+        "seed": seed,
+        "frame_count": frame_count,
+        "prefix_frame_count": prefix_frame_count,
+        "future_observations_read": posterior.metadata["future_observations_read"],
+        "path_count": len(prior.weights),
+        "retained_prior_mass": prior.retained_prior_mass,
+        "transition_config": asdict(transition),
+        "inference_config": asdict(inference),
+        "static_prefix_persistence_rmse_m": static_rmse,
+        "dynamic_contact_rmse_m": dynamic_rmse,
+        "oracle_rmse_m": oracle_rmse,
+        "relative_rmse_improvement": improvement,
+        "true_contact_onset_frame": prefix_frame_count,
+        "posterior_expected_contact_onset_frame": expected_onset,
+        "contact_onset_absolute_error_frames": abs(
+            expected_onset - prefix_frame_count
+        ),
+        "future_coverage": future_coverage,
+        "map_path_id": posterior.map_path_id,
+        "maximum_switch_probability": float(np.max(posterior.switch_probability)),
+        "gates": {
+            "dynamic_beats_static_by_50_percent": improvement >= 0.50,
+            "onset_error_at_most_one_frame": (
+                abs(expected_onset - prefix_frame_count) <= 1.0
+            ),
+            "prefix_only_inference": (
+                posterior.metadata["future_observations_read"] == 0
+            ),
+        },
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--frame-count", type=int, default=24)
+    parser.add_argument("--prefix-frame-count", type=int, default=6)
+    parser.add_argument("--output-json", type=Path)
+    parser.add_argument("--require-gates", action="store_true")
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    result = delayed_contact_case(
+        seed=args.seed,
+        frame_count=args.frame_count,
+        prefix_frame_count=args.prefix_frame_count,
+    )
+    payload = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output_json is None:
+        print(payload, end="")
+    else:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(payload, encoding="utf-8")
+    if args.require_gates and not all(result["gates"].values()):
+        raise SystemExit("dynamic-contact benchmark failed one or more gates")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/causal4d/dynamic_contact.py
+++ b/src/causal4d/dynamic_contact.py
@@ -1,0 +1,650 @@
+"""Dynamic contact-path inference for deformable-object interventions.
+
+The existing Causal4D PhysTwin path represents one contact realization per
+rollout. This module adds a backend-neutral finite-support approximation to a
+path-valued contact posterior. Simulator backends remain responsible for
+producing one trajectory for each candidate contact path; inference and
+uncertainty propagation are handled here without reading held-out observations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import IntEnum
+from statistics import NormalDist
+from typing import Any
+
+import numpy as np
+
+
+class ContactRegime(IntEnum):
+    """Discrete contact regime used by the dynamic intervention model."""
+
+    INACTIVE = 0
+    STICKING = 1
+    SLIPPING = 2
+    DETACHED = 3
+
+
+CONTACT_REGIME_NAMES = tuple(regime.name.lower() for regime in ContactRegime)
+
+
+def _readonly(values: np.ndarray, *, dtype: Any = None) -> np.ndarray:
+    array = np.asarray(values, dtype=dtype).copy()
+    array.setflags(write=False)
+    return array
+
+
+def _normalized_weights(values: np.ndarray, *, name: str) -> np.ndarray:
+    weights = np.asarray(values, dtype=float)
+    if weights.ndim != 1 or len(weights) == 0:
+        raise ValueError(f"{name} must be a nonempty vector")
+    if not np.all(np.isfinite(weights)) or np.any(weights < 0.0):
+        raise ValueError(f"{name} must be finite and nonnegative")
+    total = float(np.sum(weights))
+    if total <= 0.0:
+        raise ValueError(f"{name} must have positive mass")
+    return _readonly(weights / total)
+
+
+def _probability(value: float, *, name: str) -> float:
+    result = float(value)
+    if not np.isfinite(result) or not 0.0 <= result <= 1.0:
+        raise ValueError(f"{name} must lie in [0, 1]")
+    return result
+
+
+@dataclass(frozen=True)
+class ContactTransitionConfig:
+    """Action-conditioned transition probabilities for contact regimes."""
+
+    activation_floor: float = 0.01
+    activation_gain: float = 0.90
+    slip_floor: float = 0.005
+    slip_change_gain: float = 0.20
+    release_floor: float = 0.005
+    release_gain: float = 0.80
+    slip_recovery_probability: float = 0.15
+    reattachment_gain: float = 0.35
+    maximum_paths: int = 64
+    minimum_transition_probability: float = 1e-12
+
+    def __post_init__(self) -> None:
+        for name in (
+            "activation_floor",
+            "activation_gain",
+            "slip_floor",
+            "slip_change_gain",
+            "release_floor",
+            "release_gain",
+            "slip_recovery_probability",
+            "reattachment_gain",
+        ):
+            _probability(getattr(self, name), name=name)
+        if self.maximum_paths < 1:
+            raise ValueError("maximum_paths must be positive")
+        if not 0.0 <= self.minimum_transition_probability < 1.0:
+            raise ValueError("minimum_transition_probability must lie in [0, 1)")
+
+
+@dataclass(frozen=True)
+class ContactPathPrior:
+    """Finite beam approximation to an action-conditioned contact-path prior."""
+
+    path_ids: tuple[str, ...]
+    regime_paths: np.ndarray
+    weights: np.ndarray
+    retained_prior_mass: float
+
+    def __post_init__(self) -> None:
+        paths = _readonly(self.regime_paths, dtype=np.int8)
+        weights = _normalized_weights(self.weights, name="contact-path weights")
+        if paths.ndim != 2 or paths.shape[0] != len(weights):
+            raise ValueError("regime_paths must have shape (K, T)")
+        if paths.shape[1] < 1:
+            raise ValueError("contact paths must contain at least one frame")
+        if np.any(paths < 0) or np.any(paths >= len(CONTACT_REGIME_NAMES)):
+            raise ValueError("contact paths contain an unknown regime")
+        if (
+            len(self.path_ids) != len(weights)
+            or len(set(self.path_ids)) != len(weights)
+        ):
+            raise ValueError("path_ids must uniquely identify every contact path")
+        if not np.isfinite(self.retained_prior_mass) or not (
+            0.0 < self.retained_prior_mass <= 1.0 + 1e-12
+        ):
+            raise ValueError("retained_prior_mass must lie in (0, 1]")
+        object.__setattr__(self, "regime_paths", paths)
+        object.__setattr__(self, "weights", weights)
+
+
+def contact_transition_matrix(
+    activation: float,
+    previous_activation: float,
+    config: ContactTransitionConfig | None = None,
+) -> np.ndarray:
+    """Return one row-stochastic action-conditioned regime transition matrix."""
+
+    settings = config or ContactTransitionConfig()
+    current = _probability(activation, name="activation")
+    previous = _probability(previous_activation, name="previous_activation")
+    change = abs(current - previous)
+    release_drive = max(1.0 - current, previous - current)
+
+    matrix = np.zeros((len(ContactRegime), len(ContactRegime)), dtype=float)
+
+    p_activate = np.clip(
+        settings.activation_floor + settings.activation_gain * current,
+        0.0,
+        1.0,
+    )
+    matrix[ContactRegime.INACTIVE, ContactRegime.STICKING] = p_activate
+    matrix[ContactRegime.INACTIVE, ContactRegime.INACTIVE] = 1.0 - p_activate
+
+    p_detach = np.clip(
+        settings.release_floor + settings.release_gain * release_drive,
+        0.0,
+        1.0,
+    )
+    p_slip = np.clip(
+        settings.slip_floor + settings.slip_change_gain * change,
+        0.0,
+        1.0 - p_detach,
+    )
+    matrix[ContactRegime.STICKING, ContactRegime.DETACHED] = p_detach
+    matrix[ContactRegime.STICKING, ContactRegime.SLIPPING] = p_slip
+    matrix[ContactRegime.STICKING, ContactRegime.STICKING] = (
+        1.0 - p_detach - p_slip
+    )
+
+    p_recover = np.clip(
+        settings.slip_recovery_probability * current,
+        0.0,
+        1.0 - p_detach,
+    )
+    matrix[ContactRegime.SLIPPING, ContactRegime.DETACHED] = p_detach
+    matrix[ContactRegime.SLIPPING, ContactRegime.STICKING] = p_recover
+    matrix[ContactRegime.SLIPPING, ContactRegime.SLIPPING] = (
+        1.0 - p_detach - p_recover
+    )
+
+    p_reattach = np.clip(settings.reattachment_gain * current, 0.0, 1.0)
+    matrix[ContactRegime.DETACHED, ContactRegime.STICKING] = p_reattach
+    matrix[ContactRegime.DETACHED, ContactRegime.DETACHED] = 1.0 - p_reattach
+
+    if not np.allclose(np.sum(matrix, axis=1), 1.0, atol=1e-12, rtol=0.0):
+        raise RuntimeError("contact transition matrix is not row stochastic")
+    return matrix
+
+
+def _path_id(path: tuple[int, ...]) -> str:
+    runs: list[str] = []
+    start = 0
+    for stop in range(1, len(path) + 1):
+        if stop == len(path) or path[stop] != path[start]:
+            name = CONTACT_REGIME_NAMES[path[start]]
+            runs.append(f"{name}:{start}-{stop - 1}")
+            start = stop
+    return "|".join(runs)
+
+
+def enumerate_contact_paths(
+    command_activation: np.ndarray,
+    *,
+    config: ContactTransitionConfig | None = None,
+    initial_probabilities: np.ndarray | None = None,
+) -> ContactPathPrior:
+    """Enumerate the highest-probability contact paths with deterministic pruning."""
+
+    settings = config or ContactTransitionConfig()
+    activation = np.asarray(command_activation, dtype=float)
+    if activation.ndim != 1 or len(activation) < 1:
+        raise ValueError("command_activation must be a nonempty vector")
+    if not np.all(np.isfinite(activation)) or np.any(
+        (activation < 0.0) | (activation > 1.0)
+    ):
+        raise ValueError("command_activation must lie in [0, 1]")
+    if initial_probabilities is None:
+        initial = np.zeros(len(ContactRegime), dtype=float)
+        initial[ContactRegime.INACTIVE] = 1.0
+    else:
+        initial = _normalized_weights(
+            initial_probabilities,
+            name="initial regime probabilities",
+        )
+        if initial.shape != (len(ContactRegime),):
+            raise ValueError("initial regime probabilities must identify four regimes")
+
+    beam: list[tuple[tuple[int, ...], float]] = [
+        ((int(regime),), float(np.log(probability)))
+        for regime, probability in enumerate(initial)
+        if probability > settings.minimum_transition_probability
+    ]
+    retained_mass = 1.0
+    for frame in range(1, len(activation)):
+        transition = contact_transition_matrix(
+            activation[frame],
+            activation[frame - 1],
+            settings,
+        )
+        expanded: list[tuple[tuple[int, ...], float]] = []
+        for path, log_probability in beam:
+            for next_regime, probability in enumerate(transition[path[-1]]):
+                if probability <= settings.minimum_transition_probability:
+                    continue
+                expanded.append(
+                    (
+                        (*path, next_regime),
+                        log_probability + float(np.log(probability)),
+                    )
+                )
+        if not expanded:
+            raise RuntimeError("contact-path beam lost all probability mass")
+        expanded.sort(key=lambda item: (-item[1], item[0]))
+        beam = expanded[: settings.maximum_paths]
+        maximum = max(log_probability for _, log_probability in beam)
+        retained_mass = float(
+            np.exp(maximum)
+            * np.sum(
+                [np.exp(log_probability - maximum) for _, log_probability in beam]
+            )
+        )
+
+    log_weights = np.asarray([value for _, value in beam], dtype=float)
+    maximum = float(np.max(log_weights))
+    weights = np.exp(log_weights - maximum)
+    weights /= np.sum(weights)
+    paths = np.asarray([path for path, _ in beam], dtype=np.int8)
+    return ContactPathPrior(
+        path_ids=tuple(_path_id(path) for path, _ in beam),
+        regime_paths=paths,
+        weights=weights,
+        retained_prior_mass=min(retained_mass, 1.0),
+    )
+
+
+@dataclass(frozen=True)
+class DynamicContactPathBank:
+    """Precomputed simulator trajectories indexed by complete contact paths."""
+
+    path_ids: tuple[str, ...]
+    regime_paths: np.ndarray
+    trajectories_m: np.ndarray
+    prior_weights: np.ndarray
+    base_variance_m2: np.ndarray | float
+
+    def __post_init__(self) -> None:
+        trajectories = _readonly(self.trajectories_m, dtype=float)
+        paths = _readonly(self.regime_paths, dtype=np.int8)
+        weights = _normalized_weights(self.prior_weights, name="path-bank weights")
+        if trajectories.ndim != 4 or trajectories.shape[-1] not in {2, 3}:
+            raise ValueError("trajectories_m must have shape (K, T, N, 2|3)")
+        path_count, frame_count, node_count, coordinate_count = trajectories.shape
+        if paths.shape != (path_count, frame_count):
+            raise ValueError("regime_paths must match path and frame counts")
+        if len(weights) != path_count:
+            raise ValueError("prior_weights must identify every path")
+        if len(self.path_ids) != path_count or len(set(self.path_ids)) != path_count:
+            raise ValueError("path_ids must uniquely identify every path")
+        if np.any(paths < 0) or np.any(paths >= len(CONTACT_REGIME_NAMES)):
+            raise ValueError("regime_paths contain an unknown regime")
+        if not np.all(np.isfinite(trajectories)):
+            raise ValueError("path trajectories must be finite")
+
+        variance = np.asarray(self.base_variance_m2, dtype=float)
+        allowed_shapes = {
+            (),
+            (node_count, coordinate_count),
+            (path_count, node_count, coordinate_count),
+            (path_count, frame_count, node_count, coordinate_count),
+        }
+        if variance.shape not in allowed_shapes:
+            raise ValueError(
+                "base_variance_m2 must be scalar or have shape (N, C), "
+                "(K, N, C), or (K, T, N, C)"
+            )
+        if not np.all(np.isfinite(variance)) or np.any(variance < 0.0):
+            raise ValueError("base_variance_m2 must be finite and nonnegative")
+        variance = _readonly(variance, dtype=float)
+
+        object.__setattr__(self, "trajectories_m", trajectories)
+        object.__setattr__(self, "regime_paths", paths)
+        object.__setattr__(self, "prior_weights", weights)
+        object.__setattr__(self, "base_variance_m2", variance)
+
+
+@dataclass(frozen=True)
+class DynamicContactInferenceConfig:
+    """Robust prefix likelihood and intervention-conditioned variance settings."""
+
+    observation_scale_m: float = 0.01
+    degrees_of_freedom: float = 4.0
+    likelihood_power: float = 1.0
+    dynamic_likelihood_weight: float = 0.25
+    switch_variance_m2: float = 4e-6
+    command_change_variance_m2: float = 1e-6
+    ood_variance_m2: float = 4e-6
+    confidence_level: float = 0.90
+
+    def __post_init__(self) -> None:
+        positive = (
+            self.observation_scale_m,
+            self.degrees_of_freedom,
+            self.likelihood_power,
+        )
+        if any(not np.isfinite(value) or value <= 0.0 for value in positive):
+            raise ValueError(
+                "likelihood scale, degrees of freedom, and power must be positive"
+            )
+        nonnegative = (
+            self.dynamic_likelihood_weight,
+            self.switch_variance_m2,
+            self.command_change_variance_m2,
+            self.ood_variance_m2,
+        )
+        if any(not np.isfinite(value) or value < 0.0 for value in nonnegative):
+            raise ValueError("likelihood and variance weights must be nonnegative")
+        if not 0.0 < self.confidence_level < 1.0:
+            raise ValueError("confidence_level must lie in (0, 1)")
+
+
+@dataclass(frozen=True)
+class DynamicContactPosterior:
+    """Posterior moments and contact-regime probabilities over a path bank."""
+
+    path_ids: tuple[str, ...]
+    weights: np.ndarray
+    mean_m: np.ndarray
+    variance_m2: np.ndarray
+    interval_lower_m: np.ndarray
+    interval_upper_m: np.ndarray
+    conditional_variance_m2: np.ndarray
+    regime_probabilities: np.ndarray
+    switch_probability: np.ndarray
+    evidence_frame_stop: int
+    metadata: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        weights = _normalized_weights(self.weights, name="dynamic posterior weights")
+        mean = _readonly(self.mean_m, dtype=float)
+        variance = _readonly(self.variance_m2, dtype=float)
+        lower = _readonly(self.interval_lower_m, dtype=float)
+        upper = _readonly(self.interval_upper_m, dtype=float)
+        conditional = _readonly(self.conditional_variance_m2, dtype=float)
+        regime = _readonly(self.regime_probabilities, dtype=float)
+        switch = _readonly(self.switch_probability, dtype=float)
+        if len(self.path_ids) != len(weights):
+            raise ValueError("path_ids must match posterior weights")
+        if mean.ndim != 3 or mean.shape[-1] not in {2, 3}:
+            raise ValueError("posterior mean must have shape (T, N, 2|3)")
+        if (
+            variance.shape != mean.shape
+            or lower.shape != mean.shape
+            or upper.shape != mean.shape
+        ):
+            raise ValueError("posterior variance and intervals must match the mean")
+        if conditional.shape != (len(weights), *mean.shape):
+            raise ValueError("conditional variance must have shape (K, T, N, C)")
+        if regime.shape != (mean.shape[0], len(ContactRegime)):
+            raise ValueError("regime probabilities must have shape (T, 4)")
+        if switch.shape != (mean.shape[0],):
+            raise ValueError("switch_probability must have shape (T,)")
+        if not 1 <= self.evidence_frame_stop < mean.shape[0]:
+            raise ValueError("evidence_frame_stop must leave held-out frames")
+        if np.any(variance <= 0.0) or np.any(conditional < 0.0):
+            raise ValueError("posterior variances must be positive")
+        if np.any(lower > upper):
+            raise ValueError("posterior interval lower bound exceeds upper bound")
+        if not np.allclose(np.sum(regime, axis=1), 1.0, atol=1e-10, rtol=0.0):
+            raise ValueError("regime probabilities must sum to one per frame")
+        if np.any((switch < 0.0) | (switch > 1.0)):
+            raise ValueError("switch probabilities must lie in [0, 1]")
+        object.__setattr__(self, "weights", weights)
+        object.__setattr__(self, "mean_m", mean)
+        object.__setattr__(self, "variance_m2", variance)
+        object.__setattr__(self, "interval_lower_m", lower)
+        object.__setattr__(self, "interval_upper_m", upper)
+        object.__setattr__(self, "conditional_variance_m2", conditional)
+        object.__setattr__(self, "regime_probabilities", regime)
+        object.__setattr__(self, "switch_probability", switch)
+
+    @property
+    def map_path_id(self) -> str:
+        """Identifier of the maximum-posterior contact path."""
+
+        return self.path_ids[int(np.argmax(self.weights))]
+
+
+def _base_variance_schedule(bank: DynamicContactPathBank) -> np.ndarray:
+    path_count, frame_count, node_count, coordinate_count = (
+        bank.trajectories_m.shape
+    )
+    variance = np.asarray(bank.base_variance_m2, dtype=float)
+    if variance.ndim == 0:
+        return np.full(bank.trajectories_m.shape, float(variance), dtype=float)
+    if variance.shape == (node_count, coordinate_count):
+        return np.broadcast_to(
+            variance[None, None],
+            bank.trajectories_m.shape,
+        ).copy()
+    if variance.shape == (path_count, node_count, coordinate_count):
+        return np.broadcast_to(
+            variance[:, None],
+            bank.trajectories_m.shape,
+        ).copy()
+    if variance.shape == (
+        path_count,
+        frame_count,
+        node_count,
+        coordinate_count,
+    ):
+        return variance.copy()
+    raise RuntimeError("validated variance shape became unsupported")
+
+
+def contact_conditioned_variance(
+    bank: DynamicContactPathBank,
+    command_activation: np.ndarray,
+    *,
+    ood_distance: np.ndarray | None = None,
+    config: DynamicContactInferenceConfig | None = None,
+) -> np.ndarray:
+    """Forecast conditional variance with switch, command, and OOD increments."""
+
+    settings = config or DynamicContactInferenceConfig()
+    activation = np.asarray(command_activation, dtype=float)
+    frame_count = bank.trajectories_m.shape[1]
+    if activation.shape != (frame_count,):
+        raise ValueError("command_activation must match the rollout frame count")
+    if not np.all(np.isfinite(activation)) or np.any(
+        (activation < 0.0) | (activation > 1.0)
+    ):
+        raise ValueError("command_activation must lie in [0, 1]")
+    if ood_distance is None:
+        ood = np.zeros(frame_count, dtype=float)
+    else:
+        ood = np.asarray(ood_distance, dtype=float)
+        if (
+            ood.shape != (frame_count,)
+            or not np.all(np.isfinite(ood))
+            or np.any(ood < 0.0)
+        ):
+            raise ValueError("ood_distance must be a nonnegative frame vector")
+
+    switches = np.zeros_like(bank.regime_paths, dtype=float)
+    switches[:, 1:] = bank.regime_paths[:, 1:] != bank.regime_paths[:, :-1]
+    cumulative_switches = np.cumsum(switches, axis=1)
+    command_change = np.zeros(frame_count, dtype=float)
+    command_change[1:] = np.diff(activation)
+    cumulative_command_energy = np.cumsum(np.square(command_change))
+    cumulative_ood_energy = np.cumsum(np.square(ood))
+    increment = (
+        settings.switch_variance_m2 * cumulative_switches
+        + settings.command_change_variance_m2 * cumulative_command_energy[None]
+        + settings.ood_variance_m2 * cumulative_ood_energy[None]
+    )
+    return _base_variance_schedule(bank) + increment[:, :, None, None]
+
+
+def _coordinate_mask(observations: np.ndarray, mask: np.ndarray | None) -> np.ndarray:
+    finite = np.isfinite(observations)
+    if mask is None:
+        return finite
+    supplied = np.asarray(mask, dtype=bool)
+    if supplied.shape == observations.shape[:2]:
+        supplied = np.repeat(supplied[:, :, None], observations.shape[2], axis=2)
+    if supplied.shape != observations.shape:
+        raise ValueError("mask must have shape (T, N) or (T, N, C)")
+    return finite & supplied
+
+
+def _student_t_mean_log_score(
+    residual: np.ndarray,
+    valid: np.ndarray,
+    scale_m: np.ndarray,
+    degrees_of_freedom: float,
+) -> np.ndarray:
+    standardized = residual / scale_m
+    terms = -0.5 * (degrees_of_freedom + 1.0) * np.log1p(
+        np.square(standardized) / degrees_of_freedom
+    )
+    valid_float = np.asarray(valid, dtype=float)[None]
+    count = np.sum(valid_float, axis=(1, 2, 3))
+    if np.any(count <= 0.0):
+        raise ValueError("dynamic contact update has no valid coordinates")
+    return np.sum(
+        np.where(valid_float > 0.0, terms, 0.0),
+        axis=(1, 2, 3),
+    ) / count
+
+
+def _normalized_log_weights(log_weights: np.ndarray) -> np.ndarray:
+    values = np.asarray(log_weights, dtype=float)
+    maximum = float(np.max(values))
+    weights = np.exp(values - maximum)
+    total = float(np.sum(weights))
+    if not np.isfinite(total) or total <= 0.0:
+        raise RuntimeError("dynamic contact posterior normalization failed")
+    return weights / total
+
+
+def infer_dynamic_contact_posterior(
+    bank: DynamicContactPathBank,
+    observations_m: np.ndarray,
+    *,
+    prefix_frame_count: int,
+    command_activation: np.ndarray,
+    mask: np.ndarray | None = None,
+    ood_distance: np.ndarray | None = None,
+    config: DynamicContactInferenceConfig | None = None,
+) -> DynamicContactPosterior:
+    """Infer a contact-path posterior from a prefix and predict the held-out suffix."""
+
+    settings = config or DynamicContactInferenceConfig()
+    observations = np.asarray(observations_m, dtype=float)
+    expected_shape = bank.trajectories_m.shape[1:]
+    if observations.shape != expected_shape:
+        raise ValueError(f"observations_m must have shape {expected_shape}")
+    if not 1 <= prefix_frame_count < expected_shape[0]:
+        raise ValueError("prefix_frame_count must be nonempty and leave a future")
+    valid = _coordinate_mask(observations, mask)
+    prefix_valid = valid[:prefix_frame_count]
+    if not np.any(prefix_valid):
+        raise ValueError("contact update prefix contains no valid observations")
+
+    conditional_variance = contact_conditioned_variance(
+        bank,
+        command_activation,
+        ood_distance=ood_distance,
+        config=settings,
+    )
+    position_scale = np.sqrt(
+        settings.observation_scale_m**2
+        + conditional_variance[:, :prefix_frame_count]
+    )
+    position_score = _student_t_mean_log_score(
+        bank.trajectories_m[:, :prefix_frame_count]
+        - observations[None, :prefix_frame_count],
+        prefix_valid,
+        position_scale,
+        settings.degrees_of_freedom,
+    )
+    score = position_score
+    if settings.dynamic_likelihood_weight > 0.0 and prefix_frame_count >= 2:
+        predicted_delta = np.diff(
+            bank.trajectories_m[:, :prefix_frame_count],
+            axis=1,
+        )
+        observed_delta = np.diff(observations[:prefix_frame_count], axis=0)
+        delta_valid = prefix_valid[1:] & prefix_valid[:-1]
+        delta_variance = (
+            2.0 * settings.observation_scale_m**2
+            + conditional_variance[:, 1:prefix_frame_count]
+            + conditional_variance[:, : prefix_frame_count - 1]
+        )
+        if np.any(delta_valid):
+            dynamic_score = _student_t_mean_log_score(
+                predicted_delta - observed_delta[None],
+                delta_valid,
+                np.sqrt(delta_variance),
+                settings.degrees_of_freedom,
+            )
+            score = score + settings.dynamic_likelihood_weight * dynamic_score
+
+    log_prior = np.log(np.maximum(bank.prior_weights, np.finfo(float).tiny))
+    weights = _normalized_log_weights(log_prior + settings.likelihood_power * score)
+    components = bank.trajectories_m
+    mean = np.einsum("k,ktnc->tnc", weights, components)
+    centered = components - mean[None]
+    epistemic = np.einsum("k,ktnc->tnc", weights, np.square(centered))
+    conditional = np.einsum("k,ktnc->tnc", weights, conditional_variance)
+    variance = np.maximum(epistemic + conditional, np.finfo(float).tiny)
+    z_score = NormalDist().inv_cdf(0.5 * (1.0 + settings.confidence_level))
+    margin = z_score * np.sqrt(variance)
+
+    regime_probabilities = np.zeros(
+        (expected_shape[0], len(ContactRegime)),
+        dtype=float,
+    )
+    for regime in ContactRegime:
+        regime_probabilities[:, regime] = np.einsum(
+            "k,kt->t",
+            weights,
+            bank.regime_paths == regime,
+        )
+    switch_probability = np.zeros(expected_shape[0], dtype=float)
+    switch_probability[1:] = np.einsum(
+        "k,kt->t",
+        weights,
+        bank.regime_paths[:, 1:] != bank.regime_paths[:, :-1],
+    )
+
+    return DynamicContactPosterior(
+        path_ids=bank.path_ids,
+        weights=weights,
+        mean_m=mean,
+        variance_m2=variance,
+        interval_lower_m=mean - margin,
+        interval_upper_m=mean + margin,
+        conditional_variance_m2=conditional_variance,
+        regime_probabilities=regime_probabilities,
+        switch_probability=switch_probability,
+        evidence_frame_stop=prefix_frame_count,
+        metadata={
+            "model": "dynamic_contact_path_bank",
+            "contact_regimes": list(CONTACT_REGIME_NAMES),
+            "prefix_frame_count": prefix_frame_count,
+            "future_observations_read": 0,
+            "config": asdict(settings),
+        },
+    )
+
+
+def first_activation_frame(regime_path: np.ndarray) -> int | None:
+    """Return the first sticking/slipping frame of one contact path."""
+
+    path = np.asarray(regime_path, dtype=int)
+    active = np.flatnonzero(
+        (path == ContactRegime.STICKING) | (path == ContactRegime.SLIPPING)
+    )
+    return int(active[0]) if len(active) else None

--- a/tests/test_dynamic_contact.py
+++ b/tests/test_dynamic_contact.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import numpy as np
+
+from causal4d.cli.dynamic_contact_benchmark import delayed_contact_case
+from causal4d.dynamic_contact import (
+    ContactRegime,
+    ContactTransitionConfig,
+    DynamicContactInferenceConfig,
+    DynamicContactPathBank,
+    contact_conditioned_variance,
+    contact_transition_matrix,
+    enumerate_contact_paths,
+    infer_dynamic_contact_posterior,
+)
+
+
+def _simple_bank() -> tuple[DynamicContactPathBank, np.ndarray]:
+    activation = np.asarray([0.0, 0.0, 1.0, 1.0, 1.0])
+    paths = np.asarray(
+        [
+            [0, 0, 0, 0, 0],
+            [0, 0, 1, 1, 1],
+        ],
+        dtype=np.int8,
+    )
+    trajectories = np.zeros((2, 5, 1, 3), dtype=float)
+    trajectories[1, 2:, 0, 0] = [0.01, 0.02, 0.03]
+    return (
+        DynamicContactPathBank(
+            path_ids=("inactive", "onset-2"),
+            regime_paths=paths,
+            trajectories_m=trajectories,
+            prior_weights=np.asarray([0.25, 0.75]),
+            base_variance_m2=1e-6,
+        ),
+        activation,
+    )
+
+
+def test_transition_matrix_is_row_stochastic() -> None:
+    matrix = contact_transition_matrix(0.8, 0.2)
+    assert np.all(matrix >= 0.0)
+    assert np.allclose(np.sum(matrix, axis=1), 1.0)
+    assert matrix[ContactRegime.INACTIVE, ContactRegime.STICKING] > 0.5
+    assert matrix[ContactRegime.STICKING, ContactRegime.SLIPPING] > 0.0
+
+
+def test_zero_hazard_path_is_exactly_static() -> None:
+    zero = ContactTransitionConfig(
+        activation_floor=0.0,
+        activation_gain=0.0,
+        slip_floor=0.0,
+        slip_change_gain=0.0,
+        release_floor=0.0,
+        release_gain=0.0,
+        slip_recovery_probability=0.0,
+        reattachment_gain=0.0,
+    )
+    prior = enumerate_contact_paths(np.ones(6), config=zero)
+    assert prior.path_ids == ("inactive:0-5",)
+    assert np.array_equal(prior.regime_paths, np.zeros((1, 6), dtype=np.int8))
+    assert np.array_equal(prior.weights, np.ones(1))
+    assert prior.retained_prior_mass == 1.0
+
+
+def test_prefix_inference_does_not_read_future_observations() -> None:
+    bank, activation = _simple_bank()
+    observations = np.zeros((5, 1, 3), dtype=float)
+    first = infer_dynamic_contact_posterior(
+        bank,
+        observations,
+        prefix_frame_count=2,
+        command_activation=activation,
+    )
+    perturbed = observations.copy()
+    perturbed[2:] = 1e6
+    second = infer_dynamic_contact_posterior(
+        bank,
+        perturbed,
+        prefix_frame_count=2,
+        command_activation=activation,
+    )
+    assert np.array_equal(first.weights, second.weights)
+    assert np.array_equal(first.mean_m, second.mean_m)
+    assert first.metadata["future_observations_read"] == 0
+
+
+def test_zero_inflation_preserves_static_conditional_variance() -> None:
+    bank, activation = _simple_bank()
+    config = DynamicContactInferenceConfig(
+        switch_variance_m2=0.0,
+        command_change_variance_m2=0.0,
+        ood_variance_m2=0.0,
+    )
+    variance = contact_conditioned_variance(bank, activation, config=config)
+    assert np.array_equal(variance, np.full(bank.trajectories_m.shape, 1e-6))
+
+
+def test_switch_variance_grows_after_contact_onset() -> None:
+    bank, activation = _simple_bank()
+    config = DynamicContactInferenceConfig(
+        switch_variance_m2=4e-6,
+        command_change_variance_m2=0.0,
+        ood_variance_m2=0.0,
+    )
+    variance = contact_conditioned_variance(bank, activation, config=config)
+    assert np.array_equal(variance[0], np.full((5, 1, 3), 1e-6))
+    assert np.all(variance[1, :2] == 1e-6)
+    assert np.allclose(variance[1, 2:], 5e-6)
+
+
+def test_delayed_contact_benchmark_closes_static_failure() -> None:
+    result = delayed_contact_case(seed=3)
+    assert result["gates"]["dynamic_beats_static_by_50_percent"]
+    assert result["gates"]["onset_error_at_most_one_frame"]
+    assert result["gates"]["prefix_only_inference"]
+    assert result["dynamic_contact_rmse_m"] < result[
+        "static_prefix_persistence_rmse_m"
+    ]


### PR DESCRIPTION
## Summary

Adds a development-only dynamic contact extension for path-valued realized interventions.

- enumerates action-conditioned contact paths over inactive, sticking, slipping, and detached regimes with deterministic beam pruning;
- reports retained prior mass so truncated path support is explicit;
- robustly reweights complete path-conditioned trajectories using only the permitted observation prefix;
- propagates time-varying conditional uncertainty from contact switches, command changes, and action OOD distance;
- preserves exact static controls when transition hazards and variance inflations are zero;
- adds a controlled delayed-contact-onset benchmark and a documented PhysTwin/Warp integration boundary.

## Motivation

The mathematical model already treats `kappa_t` as time varying, but the first PhysTwin implementation associates one static contact summary with each complete rollout. The Deform360 `001-rope` pilot exposed the resulting failure mode: a gripper was inactive at the final prefix frame and activated at the first held-out frame, so static contact persistence missed the onset.

The real oracle audit also showed that expanding a static intervention grid is not the main priority. This change therefore combines a dynamic contact path with uncertainty growth rather than adding more static hypotheses.

## Validation

Isolated checks run against the added modules:

- `python -m compileall`: passed;
- `pytest tests/test_dynamic_contact.py`: 6 passed;
- `causal4d-dynamic-contact-benchmark --require-gates`: passed all gates.

Default controlled result:

- static prefix-persistence RMSE: `37.497 mm`;
- dynamic contact RMSE: `0.144 mm`;
- relative improvement: `99.62%`;
- posterior onset error: `0.042` frames;
- future observations read: `0`.

The test suite verifies row-stochastic transitions, exact zero-hazard static behavior, suffix leakage resistance, exact zero-inflation variance compatibility, switch-aware variance growth, and delayed-onset improvement.

## Scope boundary

This does not alter `milestones/v0.3.0-causal4d-aip`, does not promote a new real-data claim, and does not splice static rollouts across switches. A PhysTwin/Warp backend must generate continuous path-conditioned trajectories before real evaluation. The registered 36-execution acquisition remains the decisive evidence package.