### PR TITLE
Add action-conditioned discrepancy inference

### DIFF
--- a/docs/action_conditioned_discrepancy.md
+++ b/docs/action_conditioned_discrepancy.md
@@ -1,0 +1,53 @@
+# Action-conditioned graph discrepancy
+
+This opt-in module keeps the empirically successful graph-persistent discrepancy
+mean while allowing uncertainty to grow with the commanded and realized
+intervention. It does not alter the frozen `v0.3.0-causal4d-aip` inference path.
+
+## Typed belief
+
+`GraphDiscrepancyBelief` stores component-wise graph coefficients and their full
+low-rank covariance:
+
+```text
+coefficient_mean_m        (K, rank, 3)
+coefficient_covariance_m2 (K, 3, rank, rank)
+projection_variance_m2    (3,)
+```
+
+The artifact binds the basis by SHA-256, names the transition and innovation
+models, optionally identifies its source physical posterior, and uses a
+checksummed non-pickled NPZ payload.
+
+## Feature-conditioned covariance
+
+For transition feature vector `f`, the model uses
+
+```text
+Q(f) = Q0 + sum_j (w_j^T f)^2 v_j v_j^T.
+```
+
+This is positive semidefinite by construction. With zero feature weights it is
+exactly the declared base persistence model. The discrepancy mean remains fixed;
+only covariance changes. The provided feature builder uses controller speed,
+acceleration and direction together with gain, delay, frame rotation, slip,
+attachment shift, and the same-grasp/new-contact policy. It consumes no future
+object outcome.
+
+`forecast_action_conditioned_persistence` returns coefficient and graph-readout
+moments for every posterior component. This is intended for source-fitted or
+preregistered covariance models. Target outcomes must not select feature weights,
+directions, variance caps, or feature normalization.
+
+## Correlation-aware factual abduction
+
+`abduct_factual_intervention_graph_mode` is a separate opt-in replacement for the
+coordinatewise pseudo-likelihood. It projects the allowed response prefix onto a
+fixed graph basis and scores multivariate Student-t innovations. A supplied
+source covariance can represent correlated graph modes. The dynamic score
+includes the endpoint-to-first-response increment.
+
+The legacy `abduct_factual_intervention` function and its default likelihood are
+unchanged, so frozen artifacts remain reproducible. Promotion of the graph-mode
+likelihood requires source-only temperature/covariance selection and a sealed
+held-out comparison.

--- a/src/causal4d/__init__.py
+++ b/src/causal4d/__init__.py
@@ -1,5 +1,12 @@
 """Controlled counterfactual benchmarks for intervention-ready world models."""
 
+from causal4d.action_conditioned_discrepancy import (
+    ActionConditionedDiscrepancyFeatures,
+    ActionConditionedDiscrepancyForecast,
+    ActionConditionedDiscrepancyModel,
+    build_action_conditioned_features,
+    forecast_action_conditioned_persistence,
+)
 from causal4d.benchmark import CounterfactualBenchmarkConfig, build_protocol
 from causal4d.contact_evaluation import run_latent_contact_benchmark
 from causal4d.contact_inference import LatentContactConfig
@@ -11,7 +18,17 @@ from causal4d.contracts import (
     TwinBelief,
 )
 from causal4d.counterfactual import apply_counterfactual_operator
+from causal4d.discrepancy_belief import (
+    GraphDiscrepancyBelief,
+    load_graph_discrepancy_belief,
+    write_graph_discrepancy_belief,
+)
 from causal4d.evaluation import run_counterfactual_benchmark
+from causal4d.graph_mode_abduction import (
+    GraphModeAbductionConfig,
+    abduct_factual_intervention_graph_mode,
+    graph_mode_joint_weights,
+)
 from causal4d.rollout_bank import JointRolloutBank, SparseTrajectoryEvidence
 from causal4d.semantic_freshness import (
     SEMANTIC_TIMING_SCHEMA_VERSION,
@@ -23,9 +40,14 @@ from causal4d.semantic_freshness import (
 )
 
 __all__ = [
+    "ActionConditionedDiscrepancyFeatures",
+    "ActionConditionedDiscrepancyForecast",
+    "ActionConditionedDiscrepancyModel",
     "CounterfactualBenchmarkConfig",
     "CounterfactualQuery",
     "FactualIntervention",
+    "GraphDiscrepancyBelief",
+    "GraphModeAbductionConfig",
     "LatentContactConfig",
     "JointRolloutBank",
     "PhysicalPosterior",
@@ -37,11 +59,17 @@ __all__ = [
     "TaskPosterior",
     "SemanticTimingMetadata",
     "TwinBelief",
+    "abduct_factual_intervention_graph_mode",
     "apply_counterfactual_operator",
     "apply_semantic_freshness_gate",
+    "build_action_conditioned_features",
     "build_protocol",
+    "forecast_action_conditioned_persistence",
+    "graph_mode_joint_weights",
+    "load_graph_discrepancy_belief",
     "run_counterfactual_benchmark",
     "run_latent_contact_benchmark",
+    "write_graph_discrepancy_belief",
 ]
 
 __version__ = "0.3.0"

--- a/src/causal4d/__init__.py
+++ b/src/causal4d/__init__.py
@@ -29,6 +29,21 @@ from causal4d.graph_mode_abduction import (
     abduct_factual_intervention_graph_mode,
     graph_mode_joint_weights,
 )
+from causal4d.grouped_likelihood import (
+    GroupLikelihoodDiagnostics,
+    grouped_component_log_likelihoods,
+    posterior_weights_from_grouped_evidence,
+)
+from causal4d.identifiability import (
+    IdentifiabilityConfig,
+    InterventionIdentifiabilityResult,
+    assess_intervention_identifiability,
+    finite_response_sensitivity,
+)
+from causal4d.observation_evidence import (
+    GroupedObservationEvidence,
+    ObservationGroup,
+)
 from causal4d.rollout_bank import JointRolloutBank, SparseTrajectoryEvidence
 from causal4d.semantic_freshness import (
     SEMANTIC_TIMING_SCHEMA_VERSION,
@@ -48,8 +63,13 @@ __all__ = [
     "FactualIntervention",
     "GraphDiscrepancyBelief",
     "GraphModeAbductionConfig",
+    "GroupLikelihoodDiagnostics",
+    "GroupedObservationEvidence",
+    "IdentifiabilityConfig",
+    "InterventionIdentifiabilityResult",
     "LatentContactConfig",
     "JointRolloutBank",
+    "ObservationGroup",
     "PhysicalPosterior",
     "SEMANTIC_TIMING_SCHEMA_VERSION",
     "SEMANTIC_TIMING_SCOPE",
@@ -62,11 +82,15 @@ __all__ = [
     "abduct_factual_intervention_graph_mode",
     "apply_counterfactual_operator",
     "apply_semantic_freshness_gate",
+    "assess_intervention_identifiability",
     "build_action_conditioned_features",
     "build_protocol",
+    "finite_response_sensitivity",
     "forecast_action_conditioned_persistence",
     "graph_mode_joint_weights",
+    "grouped_component_log_likelihoods",
     "load_graph_discrepancy_belief",
+    "posterior_weights_from_grouped_evidence",
     "run_counterfactual_benchmark",
     "run_latent_contact_benchmark",
     "write_graph_discrepancy_belief",

--- a/src/causal4d/action_conditioned_discrepancy.py
+++ b/src/causal4d/action_conditioned_discrepancy.py
@@ -1,0 +1,316 @@
+"""Action-conditioned covariance growth for graph-persistent discrepancy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Sequence
+
+import numpy as np
+
+from causal4d.contracts import array_sha256
+from causal4d.discrepancy_belief import GraphDiscrepancyBelief
+
+
+CONTACT_POLICIES = ("same_grasp", "new_contact")
+
+
+def _readonly(values: np.ndarray) -> np.ndarray:
+    array = np.asarray(values, dtype=float).copy()
+    array.setflags(write=False)
+    return array
+
+
+def _named_value(
+    names: Sequence[str],
+    values: np.ndarray | Sequence[float],
+    name: str,
+    default: float,
+) -> float:
+    try:
+        index = tuple(names).index(name)
+    except ValueError:
+        return float(default)
+    return float(np.asarray(values, dtype=float)[index])
+
+
+def _positive_semidefinite(matrix: np.ndarray) -> np.ndarray:
+    symmetric = 0.5 * (matrix + matrix.T)
+    eigenvalues, eigenvectors = np.linalg.eigh(symmetric)
+    return (eigenvectors * np.maximum(eigenvalues, 0.0)) @ eigenvectors.T
+
+
+@dataclass(frozen=True)
+class ActionConditionedDiscrepancyFeatures:
+    """Shared or component-specific features for each forecast transition."""
+
+    names: tuple[str, ...]
+    values: np.ndarray
+    component_ids: tuple[str, ...] | None = None
+
+    def __post_init__(self) -> None:
+        values = _readonly(self.values)
+        if not self.names or len(set(self.names)) != len(self.names):
+            raise ValueError("feature names must be nonempty and unique")
+        if values.ndim not in {2, 3} or values.shape[-1] != len(self.names):
+            raise ValueError("feature values must have shape (H, F) or (K, H, F)")
+        if values.shape[-2] < 1 or not np.all(np.isfinite(values)):
+            raise ValueError("feature values must contain a finite forecast horizon")
+        if values.ndim == 3:
+            if self.component_ids is None or len(self.component_ids) != values.shape[0]:
+                raise ValueError(
+                    "component-specific features require matching component_ids"
+                )
+            if len(set(self.component_ids)) != len(self.component_ids):
+                raise ValueError("feature component_ids must be unique")
+        elif self.component_ids is not None:
+            raise ValueError("shared features must not declare component_ids")
+        object.__setattr__(self, "values", values)
+
+    @property
+    def horizon(self) -> int:
+        return int(self.values.shape[-2])
+
+
+def build_action_conditioned_features(
+    controller_points_m: np.ndarray,
+    control_anchor_m: np.ndarray,
+    *,
+    frame_dt_s: float,
+    phi_names: Sequence[str] = (),
+    phi: np.ndarray | Sequence[float] = (),
+    kappa_names: Sequence[str] = (),
+    kappa: np.ndarray | Sequence[float] = (),
+    contact_policy: Literal["same_grasp", "new_contact"] = "same_grasp",
+) -> ActionConditionedDiscrepancyFeatures:
+    """Build interpretable transition features without reading future outcomes."""
+
+    controls = np.asarray(controller_points_m, dtype=float)
+    anchor = np.asarray(control_anchor_m, dtype=float)
+    if controls.ndim != 3 or controls.shape[2] != 3:
+        raise ValueError("controller_points_m must have shape (H, C, 3)")
+    if anchor.shape != controls.shape[1:]:
+        raise ValueError("control_anchor_m must have shape (C, 3)")
+    if not np.all(np.isfinite(controls)) or not np.all(np.isfinite(anchor)):
+        raise ValueError("controller trajectories must be finite")
+    if not np.isfinite(frame_dt_s) or frame_dt_s <= 0.0:
+        raise ValueError("frame_dt_s must be finite and positive")
+    if contact_policy not in CONTACT_POLICIES:
+        raise ValueError("contact_policy must be same_grasp or new_contact")
+
+    full = np.concatenate((anchor[None], controls), axis=0)
+    displacement = np.diff(full, axis=0)
+    velocity = displacement / frame_dt_s
+    mean_velocity = np.mean(velocity, axis=1)
+    speed = np.mean(np.linalg.norm(velocity, axis=2), axis=1)
+    acceleration = np.diff(velocity, axis=0, prepend=velocity[:1]) / frame_dt_s
+    acceleration_norm = np.mean(np.linalg.norm(acceleration, axis=2), axis=1)
+    direction_norm = np.linalg.norm(mean_velocity, axis=1, keepdims=True)
+    direction = mean_velocity / np.maximum(direction_norm, np.finfo(float).eps)
+
+    gain = _named_value(phi_names, phi, "gain_multiplier", 1.0)
+    delay_steps = _named_value(phi_names, phi, "delay_steps", 0.0)
+    rotation_degrees = _named_value(phi_names, phi, "rotation_degrees", 0.0)
+    slip = _named_value(kappa_names, kappa, "slip_fraction", 0.0)
+    shifts = [
+        float(np.asarray(kappa, dtype=float)[index])
+        for index, name in enumerate(kappa_names)
+        if str(name).startswith("attachment_shift_hand_")
+    ]
+    attachment_shift_rms = float(np.sqrt(np.mean(np.square(shifts)))) if shifts else 0.0
+    horizon = len(controls)
+
+    def repeated(value: float) -> np.ndarray:
+        return np.full(horizon, float(value), dtype=float)
+
+    values = np.column_stack(
+        (
+            speed,
+            acceleration_norm,
+            direction,
+            repeated(abs(gain - 1.0)),
+            repeated(abs(delay_steps) * frame_dt_s),
+            repeated(abs(np.deg2rad(rotation_degrees))),
+            repeated(max(slip, 0.0)),
+            repeated(attachment_shift_rms),
+            repeated(float(contact_policy == "new_contact")),
+        )
+    )
+    names = (
+        "control_speed_mps",
+        "control_acceleration_mps2",
+        "direction_x",
+        "direction_y",
+        "direction_z",
+        "gain_abs_deviation",
+        "delay_s",
+        "rotation_abs_rad",
+        "slip_fraction",
+        "attachment_shift_rms",
+        "new_contact",
+    )
+    return ActionConditionedDiscrepancyFeatures(names=names, values=values)
+
+
+@dataclass(frozen=True)
+class ActionConditionedDiscrepancyModel:
+    """Positive-semidefinite feature-conditioned innovation covariance.
+
+    Each feature direction contributes ``(w_j^T f)^2 v_j v_j^T``. Zero feature
+    weights therefore reproduce the base covariance exactly, which provides a
+    strict compatibility mode for frozen graph persistence.
+    """
+
+    feature_names: tuple[str, ...]
+    base_innovation_covariance_m2: np.ndarray
+    feature_directions: np.ndarray
+    feature_weights: np.ndarray
+    model_id: str = "action-conditioned-graph-persistence-v1"
+    maximum_increment_trace_m2: float | None = None
+
+    def __post_init__(self) -> None:
+        base = _readonly(self.base_innovation_covariance_m2)
+        directions = _readonly(self.feature_directions)
+        weights = _readonly(self.feature_weights)
+        if not self.model_id or not self.feature_names:
+            raise ValueError("model id and feature names must be nonempty")
+        if len(set(self.feature_names)) != len(self.feature_names):
+            raise ValueError("feature names must be unique")
+        if base.ndim != 2 or base.shape[0] != base.shape[1] or base.shape[0] < 1:
+            raise ValueError("base covariance must have shape (rank, rank)")
+        rank = base.shape[0]
+        if directions.ndim != 2 or directions.shape[1] != rank:
+            raise ValueError("feature directions must have shape (J, rank)")
+        if weights.shape != (directions.shape[0], len(self.feature_names)):
+            raise ValueError("feature weights must have shape (J, feature_count)")
+        if not all(np.all(np.isfinite(value)) for value in (base, directions, weights)):
+            raise ValueError("action-conditioned model arrays must be finite")
+        if not np.allclose(base, base.T, atol=1e-10, rtol=1e-10):
+            raise ValueError("base covariance must be symmetric")
+        if float(np.min(np.linalg.eigvalsh(base), initial=0.0)) < -1e-10:
+            raise ValueError("base covariance must be positive semidefinite")
+        if len(directions):
+            norms = np.linalg.norm(directions, axis=1)
+            if np.any(norms <= 0.0):
+                raise ValueError("feature directions must be nonzero")
+            directions = directions / norms[:, None]
+            directions.setflags(write=False)
+        if self.maximum_increment_trace_m2 is not None and (
+            not np.isfinite(self.maximum_increment_trace_m2)
+            or self.maximum_increment_trace_m2 <= 0.0
+        ):
+            raise ValueError("maximum_increment_trace_m2 must be positive")
+        object.__setattr__(self, "base_innovation_covariance_m2", base)
+        object.__setattr__(self, "feature_directions", directions)
+        object.__setattr__(self, "feature_weights", weights)
+
+    @property
+    def rank(self) -> int:
+        return int(self.base_innovation_covariance_m2.shape[0])
+
+    def innovation_covariance_m2(self, feature_vector: np.ndarray) -> np.ndarray:
+        """Return a finite positive-semidefinite covariance increment."""
+
+        features = np.asarray(feature_vector, dtype=float)
+        if features.shape != (len(self.feature_names),) or not np.all(
+            np.isfinite(features)
+        ):
+            raise ValueError("feature vector does not match the model")
+        covariance = self.base_innovation_covariance_m2.astype(float).copy()
+        if len(self.feature_directions):
+            rates = np.square(self.feature_weights @ features)
+            covariance += np.einsum(
+                "j,ji,jk->ik",
+                rates,
+                self.feature_directions,
+                self.feature_directions,
+            )
+        covariance = _positive_semidefinite(covariance)
+        if self.maximum_increment_trace_m2 is not None:
+            trace = float(np.trace(covariance))
+            if trace > self.maximum_increment_trace_m2:
+                covariance *= self.maximum_increment_trace_m2 / trace
+        return covariance
+
+
+@dataclass(frozen=True)
+class ActionConditionedDiscrepancyForecast:
+    """Coefficient and graph-readout moments including the prefix endpoint."""
+
+    coefficient_mean_m: np.ndarray
+    coefficient_covariance_m2: np.ndarray
+    readout_mean_m: np.ndarray
+    readout_variance_m2: np.ndarray
+    model_id: str
+
+
+def forecast_action_conditioned_persistence(
+    belief: GraphDiscrepancyBelief,
+    model: ActionConditionedDiscrepancyModel,
+    features: ActionConditionedDiscrepancyFeatures,
+    basis: np.ndarray,
+) -> ActionConditionedDiscrepancyForecast:
+    """Persist the discrepancy mean while growing covariance by action regime."""
+
+    graph_basis = np.asarray(basis, dtype=float)
+    if graph_basis.ndim != 2 or graph_basis.shape[1] != belief.rank:
+        raise ValueError("basis must have shape (node, belief.rank)")
+    if array_sha256(graph_basis) != belief.basis_sha256:
+        raise ValueError("basis hash differs from the graph-discrepancy belief")
+    if model.rank != belief.rank or model.feature_names != features.names:
+        raise ValueError(
+            "model rank or feature schema differs from the belief/features"
+        )
+
+    component_count = len(belief.component_ids)
+    if features.values.ndim == 2:
+        feature_values = np.broadcast_to(
+            features.values[None],
+            (component_count, *features.values.shape),
+        )
+    else:
+        if features.component_ids != belief.component_ids:
+            raise ValueError("component-specific features differ from belief support")
+        feature_values = features.values
+    horizon = features.horizon
+    mean = np.broadcast_to(
+        belief.coefficient_mean_m[:, None],
+        (component_count, horizon + 1, belief.rank, 3),
+    ).copy()
+    covariance = np.empty(
+        (component_count, horizon + 1, 3, belief.rank, belief.rank),
+        dtype=float,
+    )
+    covariance[:, 0] = belief.coefficient_covariance_m2
+    for step in range(horizon):
+        for component in range(component_count):
+            increment = model.innovation_covariance_m2(
+                feature_values[component, step]
+            )
+            for coordinate in range(3):
+                covariance[component, step + 1, coordinate] = (
+                    _positive_semidefinite(
+                        covariance[component, step, coordinate] + increment
+                    )
+                )
+
+    readout_mean = np.einsum("nr,khrc->khnc", graph_basis, mean)
+    readout_variance = np.empty_like(readout_mean)
+    for component in range(component_count):
+        for step in range(horizon + 1):
+            for coordinate in range(3):
+                readout_variance[component, step, :, coordinate] = (
+                    np.einsum(
+                        "ni,ij,nj->n",
+                        graph_basis,
+                        covariance[component, step, coordinate],
+                        graph_basis,
+                    )
+                    + belief.projection_variance_m2[coordinate]
+                )
+    return ActionConditionedDiscrepancyForecast(
+        coefficient_mean_m=mean,
+        coefficient_covariance_m2=covariance,
+        readout_mean_m=readout_mean,
+        readout_variance_m2=np.maximum(readout_variance, 0.0),
+        model_id=model.model_id,
+    )

--- a/src/causal4d/action_conditioned_discrepancy.py
+++ b/src/causal4d/action_conditioned_discrepancy.py
@@ -20,17 +20,34 @@ def _readonly(values: np.ndarray) -> np.ndarray:
     return array
 
 
-def _named_value(
+def _parameter_vector(
     names: Sequence[str],
     values: np.ndarray | Sequence[float],
+    *,
+    label: str,
+) -> tuple[tuple[str, ...], np.ndarray]:
+    declared_names = tuple(map(str, names))
+    supplied_values = np.asarray(values, dtype=float)
+    if supplied_values.shape != (len(declared_names),):
+        raise ValueError(f"{label} values must match {label}_names")
+    if not np.all(np.isfinite(supplied_values)):
+        raise ValueError(f"{label} values must be finite")
+    if len(set(declared_names)) != len(declared_names):
+        raise ValueError(f"{label}_names must be unique")
+    return declared_names, supplied_values
+
+
+def _named_value(
+    names: tuple[str, ...],
+    values: np.ndarray,
     name: str,
     default: float,
 ) -> float:
     try:
-        index = tuple(names).index(name)
+        index = names.index(name)
     except ValueError:
         return float(default)
-    return float(np.asarray(values, dtype=float)[index])
+    return float(values[index])
 
 
 def _positive_semidefinite(matrix: np.ndarray) -> np.ndarray:
@@ -48,10 +65,11 @@ class ActionConditionedDiscrepancyFeatures:
     component_ids: tuple[str, ...] | None = None
 
     def __post_init__(self) -> None:
+        names = tuple(map(str, self.names))
         values = _readonly(self.values)
-        if not self.names or len(set(self.names)) != len(self.names):
+        if not names or len(set(names)) != len(names):
             raise ValueError("feature names must be nonempty and unique")
-        if values.ndim not in {2, 3} or values.shape[-1] != len(self.names):
+        if values.ndim not in {2, 3} or values.shape[-1] != len(names):
             raise ValueError("feature values must have shape (H, F) or (K, H, F)")
         if values.shape[-2] < 1 or not np.all(np.isfinite(values)):
             raise ValueError("feature values must contain a finite forecast horizon")
@@ -64,6 +82,7 @@ class ActionConditionedDiscrepancyFeatures:
                 raise ValueError("feature component_ids must be unique")
         elif self.component_ids is not None:
             raise ValueError("shared features must not declare component_ids")
+        object.__setattr__(self, "names", names)
         object.__setattr__(self, "values", values)
 
     @property
@@ -88,6 +107,8 @@ def build_action_conditioned_features(
     anchor = np.asarray(control_anchor_m, dtype=float)
     if controls.ndim != 3 or controls.shape[2] != 3:
         raise ValueError("controller_points_m must have shape (H, C, 3)")
+    if controls.shape[0] < 1:
+        raise ValueError("controller_points_m must contain a forecast horizon")
     if anchor.shape != controls.shape[1:]:
         raise ValueError("control_anchor_m must have shape (C, 3)")
     if not np.all(np.isfinite(controls)) or not np.all(np.isfinite(anchor)):
@@ -96,6 +117,17 @@ def build_action_conditioned_features(
         raise ValueError("frame_dt_s must be finite and positive")
     if contact_policy not in CONTACT_POLICIES:
         raise ValueError("contact_policy must be same_grasp or new_contact")
+
+    persistent_names, persistent_values = _parameter_vector(
+        phi_names,
+        phi,
+        label="phi",
+    )
+    event_names, event_values = _parameter_vector(
+        kappa_names,
+        kappa,
+        label="kappa",
+    )
 
     full = np.concatenate((anchor[None], controls), axis=0)
     displacement = np.diff(full, axis=0)
@@ -107,16 +139,33 @@ def build_action_conditioned_features(
     direction_norm = np.linalg.norm(mean_velocity, axis=1, keepdims=True)
     direction = mean_velocity / np.maximum(direction_norm, np.finfo(float).eps)
 
-    gain = _named_value(phi_names, phi, "gain_multiplier", 1.0)
-    delay_steps = _named_value(phi_names, phi, "delay_steps", 0.0)
-    rotation_degrees = _named_value(phi_names, phi, "rotation_degrees", 0.0)
-    slip = _named_value(kappa_names, kappa, "slip_fraction", 0.0)
+    gain = _named_value(
+        persistent_names,
+        persistent_values,
+        "gain_multiplier",
+        1.0,
+    )
+    delay_steps = _named_value(
+        persistent_names,
+        persistent_values,
+        "delay_steps",
+        0.0,
+    )
+    rotation_degrees = _named_value(
+        persistent_names,
+        persistent_values,
+        "rotation_degrees",
+        0.0,
+    )
+    slip = _named_value(event_names, event_values, "slip_fraction", 0.0)
     shifts = [
-        float(np.asarray(kappa, dtype=float)[index])
-        for index, name in enumerate(kappa_names)
-        if str(name).startswith("attachment_shift_hand_")
+        float(event_values[index])
+        for index, name in enumerate(event_names)
+        if name.startswith("attachment_shift_hand_")
     ]
-    attachment_shift_rms = float(np.sqrt(np.mean(np.square(shifts)))) if shifts else 0.0
+    attachment_shift_rms = (
+        float(np.sqrt(np.mean(np.square(shifts)))) if shifts else 0.0
+    )
     horizon = len(controls)
 
     def repeated(value: float) -> np.ndarray:
@@ -156,8 +205,8 @@ class ActionConditionedDiscrepancyModel:
     """Positive-semidefinite feature-conditioned innovation covariance.
 
     Each feature direction contributes ``(w_j^T f)^2 v_j v_j^T``. Zero feature
-    weights therefore reproduce the base covariance exactly, which provides a
-    strict compatibility mode for frozen graph persistence.
+    weights reproduce the base covariance exactly. ``maximum_increment_trace_m2``
+    caps only the action-dependent addition, never the declared base uncertainty.
     """
 
     feature_names: tuple[str, ...]
@@ -168,19 +217,20 @@ class ActionConditionedDiscrepancyModel:
     maximum_increment_trace_m2: float | None = None
 
     def __post_init__(self) -> None:
+        feature_names = tuple(map(str, self.feature_names))
         base = _readonly(self.base_innovation_covariance_m2)
         directions = _readonly(self.feature_directions)
         weights = _readonly(self.feature_weights)
-        if not self.model_id or not self.feature_names:
+        if not self.model_id or not feature_names:
             raise ValueError("model id and feature names must be nonempty")
-        if len(set(self.feature_names)) != len(self.feature_names):
+        if len(set(feature_names)) != len(feature_names):
             raise ValueError("feature names must be unique")
         if base.ndim != 2 or base.shape[0] != base.shape[1] or base.shape[0] < 1:
             raise ValueError("base covariance must have shape (rank, rank)")
         rank = base.shape[0]
         if directions.ndim != 2 or directions.shape[1] != rank:
             raise ValueError("feature directions must have shape (J, rank)")
-        if weights.shape != (directions.shape[0], len(self.feature_names)):
+        if weights.shape != (directions.shape[0], len(feature_names)):
             raise ValueError("feature weights must have shape (J, feature_count)")
         if not all(np.all(np.isfinite(value)) for value in (base, directions, weights)):
             raise ValueError("action-conditioned model arrays must be finite")
@@ -188,17 +238,18 @@ class ActionConditionedDiscrepancyModel:
             raise ValueError("base covariance must be symmetric")
         if float(np.min(np.linalg.eigvalsh(base), initial=0.0)) < -1e-10:
             raise ValueError("base covariance must be positive semidefinite")
+        base = _readonly(_positive_semidefinite(base))
         if len(directions):
             norms = np.linalg.norm(directions, axis=1)
             if np.any(norms <= 0.0):
                 raise ValueError("feature directions must be nonzero")
-            directions = directions / norms[:, None]
-            directions.setflags(write=False)
+            directions = _readonly(directions / norms[:, None])
         if self.maximum_increment_trace_m2 is not None and (
             not np.isfinite(self.maximum_increment_trace_m2)
             or self.maximum_increment_trace_m2 <= 0.0
         ):
             raise ValueError("maximum_increment_trace_m2 must be positive")
+        object.__setattr__(self, "feature_names", feature_names)
         object.__setattr__(self, "base_innovation_covariance_m2", base)
         object.__setattr__(self, "feature_directions", directions)
         object.__setattr__(self, "feature_weights", weights)
@@ -208,28 +259,30 @@ class ActionConditionedDiscrepancyModel:
         return int(self.base_innovation_covariance_m2.shape[0])
 
     def innovation_covariance_m2(self, feature_vector: np.ndarray) -> np.ndarray:
-        """Return a finite positive-semidefinite covariance increment."""
+        """Return the base covariance plus a capped PSD action increment."""
 
         features = np.asarray(feature_vector, dtype=float)
         if features.shape != (len(self.feature_names),) or not np.all(
             np.isfinite(features)
         ):
             raise ValueError("feature vector does not match the model")
-        covariance = self.base_innovation_covariance_m2.astype(float).copy()
+        increment = np.zeros_like(self.base_innovation_covariance_m2)
         if len(self.feature_directions):
             rates = np.square(self.feature_weights @ features)
-            covariance += np.einsum(
+            increment = np.einsum(
                 "j,ji,jk->ik",
                 rates,
                 self.feature_directions,
                 self.feature_directions,
             )
-        covariance = _positive_semidefinite(covariance)
+            increment = _positive_semidefinite(increment)
         if self.maximum_increment_trace_m2 is not None:
-            trace = float(np.trace(covariance))
+            trace = float(np.trace(increment))
             if trace > self.maximum_increment_trace_m2:
-                covariance *= self.maximum_increment_trace_m2 / trace
-        return covariance
+                increment *= self.maximum_increment_trace_m2 / trace
+        return _positive_semidefinite(
+            self.base_innovation_covariance_m2 + increment
+        )
 
 
 @dataclass(frozen=True)
@@ -254,6 +307,8 @@ def forecast_action_conditioned_persistence(
     graph_basis = np.asarray(basis, dtype=float)
     if graph_basis.ndim != 2 or graph_basis.shape[1] != belief.rank:
         raise ValueError("basis must have shape (node, belief.rank)")
+    if not np.all(np.isfinite(graph_basis)):
+        raise ValueError("basis must be finite")
     if array_sha256(graph_basis) != belief.basis_sha256:
         raise ValueError("basis hash differs from the graph-discrepancy belief")
     if model.rank != belief.rank or model.feature_names != features.names:

--- a/src/causal4d/discrepancy_belief.py
+++ b/src/causal4d/discrepancy_belief.py
@@ -1,0 +1,217 @@
+"""Typed low-rank graph-discrepancy beliefs with provenance-complete storage."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+import numpy as np
+
+from causal4d.contracts import array_sha256
+
+
+GRAPH_DISCREPANCY_BELIEF_VERSION = 1
+
+
+def _readonly(values: np.ndarray, *, dtype: type | None = float) -> np.ndarray:
+    array = np.asarray(values, dtype=dtype).copy()
+    array.setflags(write=False)
+    return array
+
+
+def _validate_sha256(value: str, *, name: str) -> None:
+    if len(value) != 64 or any(char not in "0123456789abcdef" for char in value):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+
+
+def _json_metadata(values: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        return json.loads(json.dumps(dict(values), sort_keys=True, allow_nan=False))
+    except (TypeError, ValueError) as error:
+        raise ValueError("metadata must contain finite JSON values") from error
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _positive_semidefinite(covariance: np.ndarray, *, name: str) -> None:
+    if not np.allclose(
+        covariance,
+        covariance.swapaxes(-1, -2),
+        atol=1e-10,
+        rtol=1e-10,
+    ):
+        raise ValueError(f"{name} must be symmetric")
+    minimum = float(np.min(np.linalg.eigvalsh(covariance), initial=0.0))
+    if minimum < -1e-10:
+        raise ValueError(f"{name} must be positive semidefinite")
+
+
+@dataclass(frozen=True)
+class GraphDiscrepancyBelief:
+    """Component-wise Gaussian belief over graph discrepancy coefficients.
+
+    The coefficient state remains separate from simulator state. The graph basis
+    is identified by hash so a belief cannot silently move between topologies or
+    basis conventions.
+    """
+
+    basis_sha256: str
+    component_ids: tuple[str, ...]
+    coefficient_mean_m: np.ndarray
+    coefficient_covariance_m2: np.ndarray
+    projection_variance_m2: np.ndarray
+    transition_model_id: str
+    innovation_model_id: str
+    source_physical_posterior_id: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _validate_sha256(self.basis_sha256, name="basis_sha256")
+        if self.source_physical_posterior_id is not None:
+            _validate_sha256(
+                self.source_physical_posterior_id,
+                name="source_physical_posterior_id",
+            )
+        if not self.transition_model_id or not self.innovation_model_id:
+            raise ValueError("discrepancy model identifiers must be nonempty")
+        if not self.component_ids or len(set(self.component_ids)) != len(
+            self.component_ids
+        ):
+            raise ValueError("component_ids must be nonempty and unique")
+
+        mean = _readonly(self.coefficient_mean_m)
+        covariance = _readonly(self.coefficient_covariance_m2)
+        projection = _readonly(self.projection_variance_m2)
+        component_count = len(self.component_ids)
+        if mean.ndim != 3 or mean.shape[0] != component_count or mean.shape[2] != 3:
+            raise ValueError("coefficient_mean_m must have shape (K, rank, 3)")
+        rank = mean.shape[1]
+        if rank < 1 or covariance.shape != (component_count, 3, rank, rank):
+            raise ValueError(
+                "coefficient_covariance_m2 must have shape (K, 3, rank, rank)"
+            )
+        if projection.shape != (3,):
+            raise ValueError("projection_variance_m2 must have shape (3,)")
+        if not all(
+            np.all(np.isfinite(value))
+            for value in (mean, covariance, projection)
+        ):
+            raise ValueError("discrepancy belief arrays must be finite")
+        if np.any(projection < 0.0):
+            raise ValueError("projection variance must be nonnegative")
+        _positive_semidefinite(covariance, name="coefficient covariance")
+
+        object.__setattr__(self, "coefficient_mean_m", mean)
+        object.__setattr__(self, "coefficient_covariance_m2", covariance)
+        object.__setattr__(self, "projection_variance_m2", projection)
+        object.__setattr__(self, "metadata", _json_metadata(self.metadata))
+
+    @property
+    def rank(self) -> int:
+        return int(self.coefficient_mean_m.shape[1])
+
+    @property
+    def artifact_id(self) -> str:
+        descriptor = {
+            "artifact_kind": "GraphDiscrepancyBelief",
+            "version": GRAPH_DISCREPANCY_BELIEF_VERSION,
+            "basis_sha256": self.basis_sha256,
+            "component_ids": list(self.component_ids),
+            "transition_model_id": self.transition_model_id,
+            "innovation_model_id": self.innovation_model_id,
+            "source_physical_posterior_id": self.source_physical_posterior_id,
+            "metadata": self.metadata,
+        }
+        digest = hashlib.sha256(
+            json.dumps(
+                descriptor,
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            ).encode("utf-8")
+        )
+        for name, values in (
+            ("coefficient_mean_m", self.coefficient_mean_m),
+            ("coefficient_covariance_m2", self.coefficient_covariance_m2),
+            ("projection_variance_m2", self.projection_variance_m2),
+        ):
+            digest.update(name.encode("utf-8"))
+            digest.update(array_sha256(values).encode("ascii"))
+        return digest.hexdigest()
+
+
+def write_graph_discrepancy_belief(
+    manifest_path: str | Path,
+    belief: GraphDiscrepancyBelief,
+) -> dict[str, Any]:
+    """Write a JSON manifest and non-pickled NPZ payload."""
+
+    manifest = Path(manifest_path)
+    payload = manifest.with_suffix(".npz")
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(
+        payload,
+        coefficient_mean_m=belief.coefficient_mean_m,
+        coefficient_covariance_m2=belief.coefficient_covariance_m2,
+        projection_variance_m2=belief.projection_variance_m2,
+    )
+    record = {
+        "artifact_kind": "GraphDiscrepancyBelief",
+        "version": GRAPH_DISCREPANCY_BELIEF_VERSION,
+        "artifact_id": belief.artifact_id,
+        "basis_sha256": belief.basis_sha256,
+        "component_ids": list(belief.component_ids),
+        "transition_model_id": belief.transition_model_id,
+        "innovation_model_id": belief.innovation_model_id,
+        "source_physical_posterior_id": belief.source_physical_posterior_id,
+        "metadata": belief.metadata,
+        "payload": {
+            "path": payload.name,
+            "sha256": _file_sha256(payload),
+        },
+    }
+    manifest.write_text(
+        json.dumps(record, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    return record
+
+
+def load_graph_discrepancy_belief(
+    manifest_path: str | Path,
+) -> GraphDiscrepancyBelief:
+    """Load and verify a graph-discrepancy belief artifact."""
+
+    manifest = Path(manifest_path)
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+    if record.get("artifact_kind") != "GraphDiscrepancyBelief":
+        raise ValueError("manifest is not a graph-discrepancy belief")
+    if int(record.get("version", -1)) != GRAPH_DISCREPANCY_BELIEF_VERSION:
+        raise ValueError("unsupported graph-discrepancy belief version")
+    payload = manifest.parent / str(record["payload"]["path"])
+    if _file_sha256(payload) != record["payload"]["sha256"]:
+        raise ValueError("graph-discrepancy payload checksum changed")
+    with np.load(payload, allow_pickle=False) as arrays:
+        belief = GraphDiscrepancyBelief(
+            basis_sha256=str(record["basis_sha256"]),
+            component_ids=tuple(map(str, record["component_ids"])),
+            coefficient_mean_m=arrays["coefficient_mean_m"],
+            coefficient_covariance_m2=arrays["coefficient_covariance_m2"],
+            projection_variance_m2=arrays["projection_variance_m2"],
+            transition_model_id=str(record["transition_model_id"]),
+            innovation_model_id=str(record["innovation_model_id"]),
+            source_physical_posterior_id=record.get("source_physical_posterior_id"),
+            metadata=record.get("metadata", {}),
+        )
+    if belief.artifact_id != record["artifact_id"]:
+        raise ValueError("graph-discrepancy artifact identifier changed")
+    return belief

--- a/src/causal4d/graph_mode_abduction.py
+++ b/src/causal4d/graph_mode_abduction.py
@@ -1,0 +1,338 @@
+"""Correlation-aware graph-mode likelihood for factual intervention abduction."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from causal4d.contracts import FactualIntervention, TwinBelief, array_sha256
+from causal4d.intervention_abduction import physical_readout_components
+from causal4d.rollout_bank import JointRolloutBank
+
+
+def _readonly(values: np.ndarray) -> np.ndarray:
+    array = np.asarray(values, dtype=float).copy()
+    array.setflags(write=False)
+    return array
+
+
+def _coordinate_mask(observations: np.ndarray, mask: np.ndarray | None) -> np.ndarray:
+    valid = np.isfinite(observations)
+    if mask is None:
+        return valid
+    supplied = np.asarray(mask, dtype=bool)
+    if supplied.shape == observations.shape[:2]:
+        supplied = np.repeat(supplied[:, :, None], observations.shape[2], axis=2)
+    if supplied.shape != observations.shape:
+        raise ValueError("observation mask must have shape (T, N) or (T, N, 3)")
+    return valid & supplied
+
+
+def _normalize_log_weights(log_weights: np.ndarray) -> np.ndarray:
+    values = np.asarray(log_weights, dtype=float)
+    if values.ndim != 2 or not np.any(np.isfinite(values)):
+        raise ValueError("joint log weights must contain finite support")
+    maximum = float(np.max(values[np.isfinite(values)]))
+    weights = np.exp(np.where(np.isfinite(values), values - maximum, -np.inf))
+    total = float(np.sum(weights))
+    if not np.isfinite(total) or total <= 0.0:
+        raise RuntimeError("graph-mode posterior normalization failed")
+    return weights / total
+
+
+def _inverse_square_root(covariance: np.ndarray) -> np.ndarray:
+    symmetric = 0.5 * (covariance + covariance.T)
+    eigenvalues, eigenvectors = np.linalg.eigh(symmetric)
+    if float(np.min(eigenvalues)) <= 0.0:
+        raise ValueError("graph-mode covariance must be positive definite")
+    return (eigenvectors / np.sqrt(eigenvalues)) @ eigenvectors.T
+
+
+@dataclass(frozen=True)
+class GraphModeAbductionConfig:
+    """Settings for a low-dimensional correlation-aware robust likelihood."""
+
+    position_scale_m: float = 0.01
+    dynamic_scale_m: float = 0.01
+    dynamic_likelihood_weight: float = 0.25
+    likelihood_temperature: float = 1.0
+    degrees_of_freedom: float = 4.0
+    projection_ridge: float = 1e-5
+    mode_covariance_m2: np.ndarray | None = None
+
+    def __post_init__(self) -> None:
+        scalars = (
+            self.position_scale_m,
+            self.dynamic_scale_m,
+            self.likelihood_temperature,
+            self.degrees_of_freedom,
+            self.projection_ridge,
+        )
+        if any(not np.isfinite(value) or value <= 0.0 for value in scalars):
+            raise ValueError(
+                "graph-mode scales, temperature, dof, and ridge must be positive"
+            )
+        if self.dynamic_likelihood_weight < 0.0:
+            raise ValueError("dynamic_likelihood_weight must be nonnegative")
+        if self.mode_covariance_m2 is not None:
+            covariance = _readonly(self.mode_covariance_m2)
+            if covariance.ndim != 2 or covariance.shape[0] != covariance.shape[1]:
+                raise ValueError("mode_covariance_m2 must have shape (rank, rank)")
+            if not np.allclose(covariance, covariance.T, atol=1e-10, rtol=1e-10):
+                raise ValueError("mode covariance must be symmetric")
+            if float(np.min(np.linalg.eigvalsh(covariance), initial=0.0)) < -1e-10:
+                raise ValueError("mode covariance must be positive semidefinite")
+            object.__setattr__(self, "mode_covariance_m2", covariance)
+
+    def metadata(self, rank: int) -> dict[str, Any]:
+        covariance = self.mode_covariance_m2
+        if covariance is not None and covariance.shape != (rank, rank):
+            raise ValueError("mode covariance rank differs from graph basis")
+        return {
+            "position_scale_m": self.position_scale_m,
+            "dynamic_scale_m": self.dynamic_scale_m,
+            "dynamic_likelihood_weight": self.dynamic_likelihood_weight,
+            "likelihood_temperature": self.likelihood_temperature,
+            "degrees_of_freedom": self.degrees_of_freedom,
+            "projection_ridge": self.projection_ridge,
+            "mode_covariance_m2_sha256": (
+                array_sha256(covariance) if covariance is not None else None
+            ),
+        }
+
+
+def _project_component_residuals(
+    residual: np.ndarray,
+    valid: np.ndarray,
+    basis: np.ndarray,
+    *,
+    ridge: float,
+) -> np.ndarray:
+    """Project (H, P, T, N, 3) residuals onto graph modes."""
+
+    values = np.asarray(residual, dtype=float)
+    mask = np.asarray(valid, dtype=bool)
+    modes = np.asarray(basis, dtype=float)
+    if values.ndim != 5 or values.shape[-1] != 3:
+        raise ValueError("component residuals must have shape (H, P, T, N, 3)")
+    if mask.shape != values.shape[2:]:
+        raise ValueError("validity mask must match residual frames, nodes, coordinates")
+    if modes.ndim != 2 or modes.shape[0] != values.shape[3]:
+        raise ValueError("graph basis must cover every rollout node")
+    rank = modes.shape[1]
+    identity = np.eye(rank)
+    coefficients = np.zeros((*values.shape[:3], rank, 3), dtype=float)
+    for frame in range(values.shape[2]):
+        for coordinate in range(3):
+            selected = mask[frame, :, coordinate]
+            if not np.any(selected):
+                raise ValueError("graph-mode likelihood has an empty frame/coordinate")
+            design = modes[selected]
+            precision = design.T @ design + ridge * identity
+            right = np.einsum(
+                "nr,hpn->hpr",
+                design,
+                values[:, :, frame, selected, coordinate],
+            )
+            solved = np.linalg.solve(
+                precision,
+                right.reshape(-1, rank).T,
+            ).T.reshape(*right.shape)
+            coefficients[:, :, frame, :, coordinate] = solved
+    return coefficients
+
+
+def _multivariate_student_t_score(
+    coefficients: np.ndarray,
+    covariance_m2: np.ndarray,
+    *,
+    degrees_of_freedom: float,
+) -> np.ndarray:
+    """Return mean robust score over frames and coordinates for every H/P pair."""
+
+    inverse_root = _inverse_square_root(covariance_m2)
+    whitened = np.einsum("ij,hptjc->hptic", inverse_root, coefficients)
+    squared = np.sum(np.square(whitened), axis=3)
+    dimension = covariance_m2.shape[0]
+    terms = -0.5 * (degrees_of_freedom + dimension) * np.log1p(
+        squared / degrees_of_freedom
+    )
+    return np.mean(terms, axis=(2, 3))
+
+
+def graph_mode_joint_weights(
+    bank: JointRolloutBank,
+    belief: TwinBelief,
+    observations_from_endpoint_m: np.ndarray,
+    graph_basis: np.ndarray,
+    *,
+    prefix_frame_count: int,
+    observation_mask: np.ndarray | None = None,
+    config: GraphModeAbductionConfig | None = None,
+    base_weights: np.ndarray | None = None,
+) -> np.ndarray:
+    """Update a rollout bank from graph modes without changing legacy inference."""
+
+    settings = config or GraphModeAbductionConfig()
+    observations = np.asarray(observations_from_endpoint_m, dtype=float)
+    basis = np.asarray(graph_basis, dtype=float)
+    if observations.shape != bank.trajectories.shape[2:]:
+        raise ValueError("observations must match rollout-bank frames and nodes")
+    if basis.ndim != 2 or basis.shape[0] != bank.node_count or basis.shape[1] < 1:
+        raise ValueError("graph_basis must have shape (node_count, rank>=1)")
+    if not 2 <= prefix_frame_count < bank.frame_count:
+        raise ValueError(
+            "prefix_frame_count must reveal evidence and leave future frames"
+        )
+    if (
+        settings.mode_covariance_m2 is not None
+        and settings.mode_covariance_m2.shape
+        != (basis.shape[1], basis.shape[1])
+    ):
+        raise ValueError("mode covariance rank differs from graph basis")
+
+    components = physical_readout_components(bank, belief)
+    selected_observations = observations[:prefix_frame_count]
+    selected_mask = (
+        None
+        if observation_mask is None
+        else np.asarray(observation_mask)[:prefix_frame_count]
+    )
+    valid = _coordinate_mask(selected_observations, selected_mask)
+    residual = components[:, :, :prefix_frame_count] - selected_observations[None, None]
+    coefficients = _project_component_residuals(
+        residual,
+        valid,
+        basis,
+        ridge=settings.projection_ridge,
+    )
+    rank = basis.shape[1]
+    correlated = (
+        np.zeros((rank, rank), dtype=float)
+        if settings.mode_covariance_m2 is None
+        else settings.mode_covariance_m2
+    )
+    position_covariance = correlated + settings.position_scale_m**2 * np.eye(rank)
+    position_score = _multivariate_student_t_score(
+        coefficients[:, :, 1:],
+        position_covariance,
+        degrees_of_freedom=settings.degrees_of_freedom,
+    )
+    score = position_score
+    if settings.dynamic_likelihood_weight > 0.0:
+        # Includes the endpoint-to-first-O+ increment, which the legacy positional
+        # slice cannot express on its own.
+        increments = np.diff(coefficients, axis=2)
+        dynamic_covariance = 2.0 * correlated + settings.dynamic_scale_m**2 * np.eye(
+            rank
+        )
+        dynamic_score = _multivariate_student_t_score(
+            increments,
+            dynamic_covariance,
+            degrees_of_freedom=settings.degrees_of_freedom,
+        )
+        score = score + settings.dynamic_likelihood_weight * dynamic_score
+
+    prior = bank.prior_joint_weights if base_weights is None else np.asarray(
+        base_weights,
+        dtype=float,
+    )
+    if prior.shape != bank.prior_joint_weights.shape:
+        raise ValueError("base_weights must match the rollout bank")
+    if np.any(prior < 0.0) or not np.isclose(np.sum(prior), 1.0):
+        raise ValueError("base_weights must be nonnegative and sum to one")
+    return _normalize_log_weights(
+        np.log(np.maximum(prior, 1e-300)) + settings.likelihood_temperature * score
+    )
+
+
+def abduct_factual_intervention_graph_mode(
+    bank: JointRolloutBank,
+    belief: TwinBelief,
+    observations_from_endpoint_m: np.ndarray,
+    graph_basis: np.ndarray,
+    *,
+    prefix_frame_count: int,
+    observation_mask: np.ndarray | None = None,
+    config: GraphModeAbductionConfig | None = None,
+) -> FactualIntervention:
+    """Infer factual ``(phi, kappa_obs)`` using the opt-in graph-mode likelihood."""
+
+    settings = config or GraphModeAbductionConfig()
+    expected_stop = belief.context.o_plus.frame_start + prefix_frame_count - 1
+    if expected_stop > belief.context.o_plus.frame_stop:
+        raise ValueError("abduction prefix extends beyond O+")
+    weights = graph_mode_joint_weights(
+        bank,
+        belief,
+        observations_from_endpoint_m,
+        graph_basis,
+        prefix_frame_count=prefix_frame_count,
+        observation_mask=observation_mask,
+        config=settings,
+    )
+    hand_count = len(bank.hypothesis_metadata[0]["contact"]["attachment_shifts"])
+    phi_names = ("gain_multiplier", "delay_steps", "rotation_degrees")
+    kappa_names = tuple(
+        f"attachment_shift_hand_{index}" for index in range(hand_count)
+    ) + ("slip_fraction",)
+    component_ids: list[str] = []
+    phi: list[tuple[float, ...]] = []
+    kappa: list[tuple[float, ...]] = []
+    hypothesis_indices: list[int] = []
+    particle_indices: list[int] = []
+    for hypothesis_index, (hypothesis_id, metadata) in enumerate(
+        zip(bank.hypothesis_ids, bank.hypothesis_metadata, strict=True)
+    ):
+        action = metadata["action"]
+        if not bool(action["future_action_observed"]):
+            raise ValueError("factual abduction requires the observed u_obs action")
+        contact = metadata["contact"]
+        persistent = (
+            float(contact["gain_multiplier"]),
+            float(contact["delay_steps"]),
+            float(contact["rotation_degrees"]),
+        )
+        event = tuple(map(float, contact["attachment_shifts"])) + (
+            float(contact["slip_fraction"]),
+        )
+        for particle_index, particle_id in enumerate(belief.particle_ids):
+            component_ids.append(f"{hypothesis_id}::{particle_id}")
+            phi.append(persistent)
+            kappa.append(event)
+            hypothesis_indices.append(hypothesis_index)
+            particle_indices.append(particle_index)
+    metadata = {
+        "abduction_likelihood": {
+            "family": "multivariate_student_t_graph_modes",
+            **settings.metadata(np.asarray(graph_basis).shape[1]),
+        },
+        "graph_basis_sha256": array_sha256(np.asarray(graph_basis, dtype=float)),
+        "graph_mode_count": int(np.asarray(graph_basis).shape[1]),
+        "observation_prefix_frame_count_including_endpoint": prefix_frame_count,
+        "o_plus_frames_used": prefix_frame_count - 1,
+        "dynamic_increments_used": prefix_frame_count - 1,
+        "endpoint_to_first_o_plus_increment_included": True,
+        "future_frames_read_by_abduction": 0,
+        "legacy_factual_abduction_unchanged": True,
+        "discrepancy_scored_as_separate_readout": True,
+        "discrepancy_injected_into_simulator_state": False,
+    }
+    json.dumps(metadata, allow_nan=False)
+    return FactualIntervention(
+        context=belief.context,
+        component_ids=tuple(component_ids),
+        phi_names=phi_names,
+        kappa_names=kappa_names,
+        phi=np.asarray(phi, dtype=float),
+        kappa_obs=np.asarray(kappa, dtype=float),
+        hypothesis_indices=np.asarray(hypothesis_indices, dtype=np.int64),
+        twin_particle_indices=np.asarray(particle_indices, dtype=np.int64),
+        weights=weights.reshape(-1),
+        evidence_frame_stop=expected_stop,
+        source_twin_belief_id=belief.artifact_id,
+        metadata=metadata,
+    )

--- a/tests/test_causal4d_action_conditioned_discrepancy.py
+++ b/tests/test_causal4d_action_conditioned_discrepancy.py
@@ -1,0 +1,138 @@
+import numpy as np
+
+from causal4d.action_conditioned_discrepancy import (
+    ActionConditionedDiscrepancyFeatures,
+    ActionConditionedDiscrepancyModel,
+    build_action_conditioned_features,
+    forecast_action_conditioned_persistence,
+)
+from causal4d.contracts import array_sha256
+from causal4d.discrepancy_belief import (
+    GraphDiscrepancyBelief,
+    load_graph_discrepancy_belief,
+    write_graph_discrepancy_belief,
+)
+
+
+def _belief(basis: np.ndarray) -> GraphDiscrepancyBelief:
+    return GraphDiscrepancyBelief(
+        basis_sha256=array_sha256(basis),
+        component_ids=("component-0",),
+        coefficient_mean_m=np.asarray([[[0.01, 0.0, 0.0], [0.0, -0.02, 0.0]]]),
+        coefficient_covariance_m2=np.zeros((1, 3, 2, 2)),
+        projection_variance_m2=np.asarray([1e-6, 2e-6, 3e-6]),
+        transition_model_id="persistence",
+        innovation_model_id="unit-test",
+        metadata={"future_frames_read": 0},
+    )
+
+
+def test_graph_discrepancy_belief_round_trip(tmp_path) -> None:
+    basis = np.asarray([[1.0, 0.0], [0.0, 1.0], [0.5, -0.5]])
+    belief = _belief(basis)
+    manifest = tmp_path / "belief.json"
+    record = write_graph_discrepancy_belief(manifest, belief)
+    loaded = load_graph_discrepancy_belief(manifest)
+    assert record["artifact_id"] == belief.artifact_id == loaded.artifact_id
+    np.testing.assert_array_equal(loaded.coefficient_mean_m, belief.coefficient_mean_m)
+    np.testing.assert_array_equal(
+        loaded.coefficient_covariance_m2,
+        belief.coefficient_covariance_m2,
+    )
+
+
+def test_zero_feature_weights_reproduce_base_persistence_exactly() -> None:
+    basis = np.asarray([[1.0, 0.0], [0.0, 1.0], [0.5, -0.5]])
+    belief = _belief(basis)
+    features = ActionConditionedDiscrepancyFeatures(
+        names=("speed",),
+        values=np.asarray([[0.0], [3.0], [7.0]]),
+    )
+    base = np.asarray([[2e-6, 5e-7], [5e-7, 1e-6]])
+    model = ActionConditionedDiscrepancyModel(
+        feature_names=features.names,
+        base_innovation_covariance_m2=base,
+        feature_directions=np.asarray([[1.0, 0.0]]),
+        feature_weights=np.zeros((1, 1)),
+    )
+    forecast = forecast_action_conditioned_persistence(belief, model, features, basis)
+    for step in range(features.horizon + 1):
+        for coordinate in range(3):
+            np.testing.assert_allclose(
+                forecast.coefficient_covariance_m2[0, step, coordinate],
+                step * base,
+                atol=1e-15,
+            )
+    np.testing.assert_allclose(
+        forecast.coefficient_mean_m,
+        np.broadcast_to(
+            belief.coefficient_mean_m[:, None],
+            forecast.coefficient_mean_m.shape,
+        ),
+    )
+
+
+def test_action_and_realized_intervention_increase_uncertainty_only() -> None:
+    basis = np.asarray([[1.0, 0.0], [0.0, 1.0], [0.5, -0.5]])
+    belief = _belief(basis)
+    controls = np.zeros((3, 1, 3), dtype=float)
+    quiet = build_action_conditioned_features(
+        controls,
+        np.zeros((1, 3)),
+        frame_dt_s=0.1,
+        phi_names=("gain_multiplier", "delay_steps", "rotation_degrees"),
+        phi=np.asarray([1.0, 0.0, 0.0]),
+        kappa_names=("attachment_shift_hand_0", "slip_fraction"),
+        kappa=np.asarray([0.0, 0.0]),
+    )
+    moving = controls.copy()
+    moving[:, 0, 0] = np.asarray([0.01, 0.03, 0.06])
+    aggressive = build_action_conditioned_features(
+        moving,
+        np.zeros((1, 3)),
+        frame_dt_s=0.1,
+        phi_names=("gain_multiplier", "delay_steps", "rotation_degrees"),
+        phi=np.asarray([1.15, 2.0, 3.0]),
+        kappa_names=("attachment_shift_hand_0", "slip_fraction"),
+        kappa=np.asarray([2.0, 0.2]),
+        contact_policy="new_contact",
+    )
+    weights = np.zeros((2, len(quiet.names)))
+    weights[0, quiet.names.index("control_speed_mps")] = 0.01
+    weights[0, quiet.names.index("gain_abs_deviation")] = 0.2
+    weights[1, quiet.names.index("slip_fraction")] = 0.2
+    weights[1, quiet.names.index("new_contact")] = 0.2
+    model = ActionConditionedDiscrepancyModel(
+        feature_names=quiet.names,
+        base_innovation_covariance_m2=np.zeros((2, 2)),
+        feature_directions=np.eye(2),
+        feature_weights=weights,
+    )
+    quiet_forecast = forecast_action_conditioned_persistence(
+        belief,
+        model,
+        quiet,
+        basis,
+    )
+    aggressive_forecast = forecast_action_conditioned_persistence(
+        belief,
+        model,
+        aggressive,
+        basis,
+    )
+    np.testing.assert_array_equal(
+        quiet_forecast.coefficient_mean_m,
+        aggressive_forecast.coefficient_mean_m,
+    )
+    quiet_trace = np.trace(
+        quiet_forecast.coefficient_covariance_m2[0, -1],
+        axis1=1,
+        axis2=2,
+    ).sum()
+    aggressive_trace = np.trace(
+        aggressive_forecast.coefficient_covariance_m2[0, -1],
+        axis1=1,
+        axis2=2,
+    ).sum()
+    assert aggressive_trace > quiet_trace
+    assert np.all(np.diff(aggressive_forecast.readout_variance_m2[0], axis=0) >= -1e-15)

--- a/tests/test_causal4d_action_conditioned_discrepancy_cap.py
+++ b/tests/test_causal4d_action_conditioned_discrepancy_cap.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+from causal4d.action_conditioned_discrepancy import (
+    ActionConditionedDiscrepancyModel,
+)
+
+
+def test_increment_cap_never_shrinks_base_covariance() -> None:
+    base = np.diag([4.0, 2.0])
+    model = ActionConditionedDiscrepancyModel(
+        feature_names=("action",),
+        base_innovation_covariance_m2=base,
+        feature_directions=np.asarray([[1.0, 0.0], [0.0, 1.0]]),
+        feature_weights=np.asarray([[10.0], [10.0]]),
+        maximum_increment_trace_m2=1.0,
+    )
+
+    covariance = model.innovation_covariance_m2(np.asarray([1.0]))
+    increment = covariance - base
+
+    assert np.trace(increment) <= 1.0 + 1e-12
+    assert np.min(np.linalg.eigvalsh(increment)) >= -1e-12
+    assert np.min(np.linalg.eigvalsh(covariance - base)) >= -1e-12
+
+
+def test_zero_action_increment_preserves_base_exactly_with_cap() -> None:
+    base = np.asarray([[2.0, 0.25], [0.25, 1.0]])
+    model = ActionConditionedDiscrepancyModel(
+        feature_names=("action",),
+        base_innovation_covariance_m2=base,
+        feature_directions=np.asarray([[1.0, 0.0]]),
+        feature_weights=np.asarray([[5.0]]),
+        maximum_increment_trace_m2=0.1,
+    )
+
+    np.testing.assert_allclose(
+        model.innovation_covariance_m2(np.asarray([0.0])),
+        base,
+        atol=1e-14,
+        rtol=1e-14,
+    )

--- a/tests/test_causal4d_graph_mode_abduction.py
+++ b/tests/test_causal4d_graph_mode_abduction.py
@@ -1,0 +1,156 @@
+import numpy as np
+
+from causal4d.contracts import TwinBelief, build_causal_context
+from causal4d.graph_mode_abduction import (
+    GraphModeAbductionConfig,
+    abduct_factual_intervention_graph_mode,
+    graph_mode_joint_weights,
+)
+from causal4d.intervention_abduction import factual_joint_weights
+from causal4d.rollout_bank import JointRolloutBank
+
+
+def _problem(node_count: int = 3):
+    bank_frames = 8
+    trajectories = np.zeros((3, 1, bank_frames, node_count, 3), dtype=float)
+    time = np.arange(bank_frames, dtype=float)
+    spatial = np.linspace(0.8, 1.2, node_count)
+    trajectories[1, 0, :, :, 0] = 0.01 * time[:, None] * spatial[None]
+    trajectories[2, 0, :, :, 0] = -0.01 * time[:, None] * spatial[None]
+
+    def metadata(identifier, gain, shift):
+        return {
+            "hypothesis_id": identifier,
+            "action": {
+                "proposal_id": "known",
+                "future_action_observed": True,
+                "provenance": "unit factual action",
+            },
+            "contact": {
+                "attachment_shifts": [shift],
+                "gain_multiplier": gain,
+                "delay_steps": 0,
+                "slip_fraction": 0.0,
+                "rotation_degrees": 0.0,
+            },
+        }
+
+    bank = JointRolloutBank(
+        hypothesis_ids=("nominal", "high_gain", "shifted"),
+        hypothesis_metadata=(
+            metadata("nominal", 1.0, 0),
+            metadata("high_gain", 1.15, 0),
+            metadata("shifted", 1.0, 1),
+        ),
+        hypothesis_prior_weights=np.asarray([0.6, 0.2, 0.2]),
+        parameter_particles=np.asarray([[0.0]]),
+        parameter_weights=np.asarray([1.0]),
+        trajectories=trajectories,
+        variance_floor_m2=1e-8,
+    )
+    full_frames = 11
+    intervention_frame = 4
+    full_observations = np.zeros((full_frames, node_count, 3), dtype=float)
+    full_observations[intervention_frame - 1 :] = trajectories[1, 0]
+    actions = np.zeros((full_frames, 1, 3), dtype=float)
+    context = build_causal_context(
+        protocol_id="graph_mode_abduction_unit",
+        case_id="synthetic",
+        observations=full_observations,
+        observed_actions=actions,
+        counterfactual_actions=actions,
+        intervention_frame=intervention_frame,
+    )
+    belief = TwinBelief(
+        context=context,
+        endpoint_frame=intervention_frame - 1,
+        particle_ids=("p0",),
+        theta_names=("spring",),
+        endpoint_position_m=np.zeros((1, node_count, 3)),
+        endpoint_velocity_mps=np.zeros((1, node_count, 3)),
+        theta=np.asarray([[0.0]]),
+        discrepancy_mean_m=np.zeros((1, node_count, 3)),
+        discrepancy_variance_m2=np.zeros((1, node_count, 3)),
+        weights=np.asarray([1.0]),
+    )
+    observations = trajectories[1, 0].copy()
+    mask = np.ones((bank_frames, node_count), dtype=bool)
+    basis = np.column_stack(
+        (
+            np.ones(node_count) / np.sqrt(node_count),
+            np.linspace(-1.0, 1.0, node_count),
+        )
+    )
+    basis[:, 1] /= np.linalg.norm(basis[:, 1])
+    config = GraphModeAbductionConfig(
+        position_scale_m=0.001,
+        dynamic_scale_m=0.001,
+        dynamic_likelihood_weight=0.5,
+        likelihood_temperature=20.0,
+        projection_ridge=1e-10,
+    )
+    return bank, belief, observations, mask, basis, config
+
+
+def test_graph_mode_abduction_recovers_realized_intervention() -> None:
+    bank, belief, observations, mask, basis, config = _problem()
+    factual = abduct_factual_intervention_graph_mode(
+        bank,
+        belief,
+        observations,
+        basis,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=config,
+    )
+    joint = factual_joint_weights(
+        factual,
+        hypothesis_count=3,
+        particle_count=1,
+    )
+    assert np.argmax(joint[:, 0]) == 1
+    assert factual.metadata["endpoint_to_first_o_plus_increment_included"]
+    assert factual.metadata["future_frames_read_by_abduction"] == 0
+    assert factual.metadata["legacy_factual_abduction_unchanged"]
+
+
+def test_graph_mode_abduction_is_prefix_only() -> None:
+    bank, belief, observations, mask, basis, config = _problem()
+    first = graph_mode_joint_weights(
+        bank,
+        belief,
+        observations,
+        basis,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=config,
+    )
+    changed = observations.copy()
+    changed[4:] += 1000.0
+    changed_mask = mask.copy()
+    changed_mask[4:] = False
+    second = graph_mode_joint_weights(
+        bank,
+        belief,
+        changed,
+        basis,
+        prefix_frame_count=4,
+        observation_mask=changed_mask,
+        config=config,
+    )
+    np.testing.assert_array_equal(first, second)
+
+
+def test_graph_mode_covariance_must_match_basis_rank() -> None:
+    bank, belief, observations, mask, basis, _ = _problem()
+    config = GraphModeAbductionConfig(mode_covariance_m2=np.eye(3))
+    with np.testing.assert_raises_regex(ValueError, "rank differs"):
+        graph_mode_joint_weights(
+            bank,
+            belief,
+            observations,
+            basis,
+            prefix_frame_count=4,
+            observation_mask=mask,
+            config=config,
+        )


### PR DESCRIPTION
## What changed

- add a typed, checksummed `GraphDiscrepancyBelief` artifact with full low-rank coefficient covariance and explicit basis/model provenance
- add positive-semidefinite action-conditioned covariance growth while preserving the graph-persistent discrepancy mean
- derive forecast features from controller motion and realized intervention variables (`phi`, `kappa`, and contact policy)
- add an opt-in multivariate Student-t graph-mode likelihood for factual intervention abduction, including the endpoint-to-first-response increment
- expose the new belief, forecasting, and abduction APIs through `causal4d`
- keep the legacy abduction path unchanged for frozen-artifact compatibility
- add focused unit tests and protocol-boundary documentation

## Why

The existing audits localize most remaining headroom to model/discrepancy uncertainty rather than intervention proposal support. This change therefore preserves the empirically strong persistence mean while making uncertainty action- and intervention-dependent, and provides a correlation-aware alternative to the coordinatewise pseudo-likelihood.

## Validation

- Python compilation passed for all added modules and tests
- 6 focused tests passed in a local isolated harness covering artifact round trips, exact zero-feature fallback, PSD/monotone covariance growth, intervention recovery, prefix-only inference, and covariance-rank validation
- all new Python lines satisfy the repository's 88-character limit
- the repository currently reports no GitHub Actions workflow or commit status for this branch, so the full repository suite has not run remotely

## Boundaries

This is opt-in development code. It does not modify `abduct_factual_intervention`, frozen milestones, registered protocols, or exact-fallback behavior. Feature weights, covariance, temperature, and variance caps still require source-only or preregistered selection before confirmatory use.