### PR TITLE
Add grouped robust abduction and action-conditioned discrepancy

### DIFF
--- a/docs/grouped_robust_abduction_and_action_discrepancy.md
+++ b/docs/grouped_robust_abduction_and_action_discrepancy.md
@@ -1,0 +1,81 @@
+# Grouped Robust Abduction and Action-Conditioned Discrepancy
+
+## Scope
+
+This development path adds two opt-in models without changing frozen Causal4D
+results or the default command behavior:
+
+1. effective grouped observation factors with a nominal/outlier multivariate
+   Student-t mixture and conservative composite weights;
+2. action-conditioned low-rank graph-discrepancy increments around graph
+   persistence.
+
+The legacy factual-abduction likelihood remains the default. Existing milestone
+commands therefore reproduce their recorded results unless
+`--observation-model grouped_robust` is supplied explicitly.
+
+## Grouped robust observation factors
+
+`causal4d.grouped_observations.ObservationGroup` records one effective factor,
+including its frame, node, covariance, source/view provenance, prior nominal
+probability, outlier scale multiplier, and composite weight. A group may also
+represent an explicit frame increment by naming a reference frame.
+
+The likelihood is
+
+\[
+\ell_g = \rho_g t_\nu(r_g;0,\Psi_g)
+       +(1-\rho_g)t_\nu(r_g;0,\lambda_{\rm out}\Psi_g),
+\]
+
+where the supplied covariance is converted to the corresponding Student-t scale
+matrix. Consequently, grouped mode requires `nu > 2`. The dense-prefix adapter
+uses one node/frame vector per group and normalizes composite weights by the
+number of valid coordinates, so increasing graph density does not silently
+increase the total likelihood power. Position increments are disabled by
+default because they reuse position evidence; when enabled, they enter as
+separate, explicitly downweighted factors.
+
+Run the new path with:
+
+```bash
+causal4d-abduct-phystwin-intervention \
+  rollout_bank.npz belief.npz final_data.pkl factual.npz evaluation.json \
+  --observation-model grouped_robust \
+  --robust-nominal-probability 0.95 \
+  --robust-outlier-scale-multiplier 25
+```
+
+The grouped updater accepts either a static discrepancy field with shape
+`(particle, node, coordinate)` or a time-varying field with shape
+`(particle, frame, node, coordinate)`. A static discrepancy and its uncertainty
+cancel exactly in displacement factors; temporal marginal variances are added
+conservatively because cross-time covariance is not yet represented.
+
+## Action-conditioned graph discrepancy
+
+`ActionConditionedGraphDiscrepancyModel` implements
+
+\[
+c_{t+1}=c_t+d+B\psi_t+w_t,
+\]
+
+where `c_t` contains graph-Laplacian coefficients and `psi_t` contains measured
+or abduced causal features. Drift and input maps are coordinate-specific. The
+null model is graph persistence (`d=0`, `B=0`), and forecast covariance grows
+from the fitted innovation covariance plus projection uncertainty.
+
+The implementation deliberately does not inject this field into simulator
+position or velocity. It supplies a source-fitted readout-discrepancy candidate
+that can enter the existing cross-fitted mechanism gate. Appropriate features
+include measured applied translation, signed speed, hold/return phase, registered
+contact-patch coordinates, and slip probability. Features must be frozen before
+confirmatory outcomes are opened.
+
+## Claim boundary
+
+These additions are software and source-development capabilities. They do not
+promote a mechanism, establish calibration, or alter the frozen Causal4D paper
+claim. Promotion still requires the preregistered source-panel shrinkage,
+held-out prediction, plausibility, transfer, and calibration gates, with exact
+fallback to graph persistence on rejection.

--- a/src/causal4d/__init__.py
+++ b/src/causal4d/__init__.py
@@ -1,5 +1,10 @@
 """Controlled counterfactual benchmarks for intervention-ready world models."""
 
+from causal4d.action_conditioned_discrepancy import (
+    ActionConditionedGraphDiscrepancyModel,
+    fit_action_conditioned_graph_discrepancy,
+    forecast_action_conditioned_graph_discrepancy,
+)
 from causal4d.benchmark import CounterfactualBenchmarkConfig, build_protocol
 from causal4d.contact_evaluation import run_latent_contact_benchmark
 from causal4d.contact_inference import LatentContactConfig
@@ -12,6 +17,11 @@ from causal4d.contracts import (
 )
 from causal4d.counterfactual import apply_counterfactual_operator
 from causal4d.evaluation import run_counterfactual_benchmark
+from causal4d.grouped_observations import (
+    ObservationGroup,
+    dense_prefix_observation_groups,
+    update_from_grouped_observations,
+)
 from causal4d.rollout_bank import JointRolloutBank, SparseTrajectoryEvidence
 from causal4d.semantic_freshness import (
     SEMANTIC_TIMING_SCHEMA_VERSION,
@@ -23,11 +33,13 @@ from causal4d.semantic_freshness import (
 )
 
 __all__ = [
+    "ActionConditionedGraphDiscrepancyModel",
     "CounterfactualBenchmarkConfig",
     "CounterfactualQuery",
     "FactualIntervention",
     "LatentContactConfig",
     "JointRolloutBank",
+    "ObservationGroup",
     "PhysicalPosterior",
     "SEMANTIC_TIMING_SCHEMA_VERSION",
     "SEMANTIC_TIMING_SCOPE",
@@ -40,8 +52,12 @@ __all__ = [
     "apply_counterfactual_operator",
     "apply_semantic_freshness_gate",
     "build_protocol",
+    "dense_prefix_observation_groups",
+    "fit_action_conditioned_graph_discrepancy",
+    "forecast_action_conditioned_graph_discrepancy",
     "run_counterfactual_benchmark",
     "run_latent_contact_benchmark",
+    "update_from_grouped_observations",
 ]
 
 __version__ = "0.3.0"

--- a/src/causal4d/action_conditioned_discrepancy.py
+++ b/src/causal4d/action_conditioned_discrepancy.py
@@ -1,0 +1,247 @@
+"""Action-conditioned graph discrepancy dynamics around persistence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+from causal4d.graph_temporal_discrepancy import project_graph_coefficients
+
+
+@dataclass(frozen=True)
+class ActionConditionedGraphDiscrepancyModel:
+    """Low-rank discrepancy increments driven by measured causal features.
+
+    The model retains graph persistence as its null and adds coordinate-specific
+    low-rank increments,
+
+    ``c[t+1] = c[t] + d + B psi[t] + w[t]``.
+    """
+
+    basis: np.ndarray
+    drift: np.ndarray
+    input_matrix: np.ndarray
+    innovation_covariance: np.ndarray
+    projection_variance_m2: np.ndarray
+    feature_mean: np.ndarray
+    feature_scale: np.ndarray
+    feature_names: tuple[str, ...]
+    fit_frame_count: int
+    projection_ridge: float
+    dynamics_ridge: float
+
+    def __post_init__(self) -> None:
+        basis = np.asarray(self.basis, dtype=float)
+        drift = np.asarray(self.drift, dtype=float)
+        input_matrix = np.asarray(self.input_matrix, dtype=float)
+        innovation = np.asarray(self.innovation_covariance, dtype=float)
+        projection = np.asarray(self.projection_variance_m2, dtype=float)
+        feature_mean = np.asarray(self.feature_mean, dtype=float)
+        feature_scale = np.asarray(self.feature_scale, dtype=float)
+        if basis.ndim != 2:
+            raise ValueError("basis must have shape (node, rank)")
+        rank = basis.shape[1]
+        if drift.shape != (rank, 3):
+            raise ValueError("drift must have shape (rank, 3)")
+        if input_matrix.ndim != 3 or input_matrix.shape[:2] != (rank, 3):
+            raise ValueError("input_matrix must have shape (rank, 3, feature)")
+        feature_count = input_matrix.shape[2]
+        if innovation.shape != (3, rank, rank):
+            raise ValueError("innovation_covariance must have shape (3, rank, rank)")
+        if projection.shape != (3,):
+            raise ValueError("projection_variance_m2 must have three coordinates")
+        if feature_mean.shape != (feature_count,) or feature_scale.shape != (
+            feature_count,
+        ):
+            raise ValueError("feature normalization must match input_matrix")
+        if len(self.feature_names) != feature_count:
+            raise ValueError("feature_names must match input_matrix")
+        if np.any(feature_scale <= 0.0):
+            raise ValueError("feature_scale must be positive")
+        if np.any(projection < 0.0):
+            raise ValueError("projection variance must be nonnegative")
+        for coordinate in range(3):
+            if np.min(np.linalg.eigvalsh(innovation[coordinate])) < -1e-10:
+                raise ValueError("innovation covariance must be nonnegative")
+        if not all(
+            np.all(np.isfinite(value))
+            for value in (
+                basis,
+                drift,
+                input_matrix,
+                innovation,
+                projection,
+                feature_mean,
+                feature_scale,
+            )
+        ):
+            raise ValueError("action-conditioned model arrays must be finite")
+        if self.fit_frame_count < 3:
+            raise ValueError("fit_frame_count must be at least three")
+        if self.projection_ridge <= 0.0 or self.dynamics_ridge <= 0.0:
+            raise ValueError("ridge parameters must be positive")
+        object.__setattr__(self, "basis", basis)
+        object.__setattr__(self, "drift", drift)
+        object.__setattr__(self, "input_matrix", input_matrix)
+        object.__setattr__(self, "innovation_covariance", innovation)
+        object.__setattr__(self, "projection_variance_m2", projection)
+        object.__setattr__(self, "feature_mean", feature_mean)
+        object.__setattr__(self, "feature_scale", feature_scale)
+
+
+def fit_action_conditioned_graph_discrepancy(
+    residual_m: np.ndarray,
+    valid: np.ndarray,
+    basis: np.ndarray,
+    action_features: np.ndarray,
+    *,
+    feature_names: Sequence[str] | None = None,
+    projection_ridge: float = 1e-5,
+    dynamics_ridge: float = 1e-4,
+) -> ActionConditionedGraphDiscrepancyModel:
+    """Fit ``c[t+1] = c[t] + d + B psi[t] + w[t]`` on source-only data."""
+
+    residual = np.asarray(residual_m, dtype=float)
+    mask = np.asarray(valid, dtype=bool)
+    modes = np.asarray(basis, dtype=float)
+    features = np.asarray(action_features, dtype=float)
+    if residual.ndim != 3 or residual.shape[2] != 3 or len(residual) < 3:
+        raise ValueError("residual_m must have shape (T>=3, node, 3)")
+    if mask.shape != residual.shape[:2]:
+        raise ValueError("valid must have shape (T, node)")
+    if features.ndim != 2 or features.shape[0] != len(residual) - 1:
+        raise ValueError("action_features must have shape (T-1, feature)")
+    if modes.ndim != 2 or modes.shape[0] < residual.shape[1]:
+        raise ValueError("basis does not cover observed residual nodes")
+    if not np.all(np.isfinite(features)):
+        raise ValueError("action_features must be finite")
+    if projection_ridge <= 0.0 or dynamics_ridge <= 0.0:
+        raise ValueError("ridge parameters must be positive")
+    names = (
+        tuple(f"feature_{index}" for index in range(features.shape[1]))
+        if feature_names is None
+        else tuple(feature_names)
+    )
+    if len(names) != features.shape[1] or len(set(names)) != len(names):
+        raise ValueError("feature_names must be unique and match action_features")
+    coefficients = project_graph_coefficients(
+        residual,
+        mask,
+        modes,
+        ridge=projection_ridge,
+    )
+    feature_mean = np.mean(features, axis=0)
+    feature_scale = np.std(features, axis=0)
+    feature_scale = np.where(feature_scale > 1e-12, feature_scale, 1.0)
+    normalized = (features - feature_mean) / feature_scale
+    design = np.vstack((np.ones((1, len(normalized))), normalized.T))
+    penalty = np.eye(features.shape[1] + 1) * dynamics_ridge
+    penalty[0, 0] = 0.0
+    inverse_precision = np.linalg.inv(design @ design.T + penalty)
+    deltas = np.diff(coefficients, axis=0)
+    drift = np.zeros((modes.shape[1], 3), dtype=float)
+    input_matrix = np.zeros(
+        (modes.shape[1], 3, features.shape[1]),
+        dtype=float,
+    )
+    innovation_covariance = np.zeros((3, modes.shape[1], modes.shape[1]))
+    for coordinate in range(3):
+        target = deltas[:, :, coordinate].T
+        coefficient_map = target @ design.T @ inverse_precision
+        drift[:, coordinate] = coefficient_map[:, 0]
+        input_matrix[:, coordinate] = coefficient_map[:, 1:]
+        innovation = target - coefficient_map @ design
+        covariance = innovation @ innovation.T / innovation.shape[1]
+        innovation_covariance[coordinate] = (
+            0.5 * (covariance + covariance.T)
+            + 1e-12 * np.eye(modes.shape[1])
+        )
+    reconstructed = np.einsum(
+        "nr,trc->tnc",
+        modes[: residual.shape[1]],
+        coefficients,
+    )
+    projection_error = reconstructed - residual
+    projection_variance = np.asarray(
+        [
+            np.mean(np.square(projection_error[:, :, coordinate][mask]))
+            for coordinate in range(3)
+        ]
+    )
+    return ActionConditionedGraphDiscrepancyModel(
+        basis=modes,
+        drift=drift,
+        input_matrix=input_matrix,
+        innovation_covariance=innovation_covariance,
+        projection_variance_m2=projection_variance,
+        feature_mean=feature_mean,
+        feature_scale=feature_scale,
+        feature_names=names,
+        fit_frame_count=len(residual),
+        projection_ridge=projection_ridge,
+        dynamics_ridge=dynamics_ridge,
+    )
+
+
+def forecast_action_conditioned_graph_discrepancy(
+    model: ActionConditionedGraphDiscrepancyModel,
+    prefix_residual_m: np.ndarray,
+    prefix_valid: np.ndarray,
+    action_features: np.ndarray,
+    *,
+    total_frame_count: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Forecast discrepancy with source-fitted action-conditioned increments."""
+
+    prefix = np.asarray(prefix_residual_m, dtype=float)
+    valid = np.asarray(prefix_valid, dtype=bool)
+    features = np.asarray(action_features, dtype=float)
+    if not 2 <= len(prefix) < total_frame_count:
+        raise ValueError("prefix must reveal evidence and leave future frames")
+    if prefix.ndim != 3 or prefix.shape[2] != 3:
+        raise ValueError("prefix_residual_m must have shape (T, node, 3)")
+    if valid.shape != prefix.shape[:2]:
+        raise ValueError("prefix_valid must have shape (T, node)")
+    if features.shape != (total_frame_count - 1, len(model.feature_names)):
+        raise ValueError("action_features must cover every rollout transition")
+    if not np.all(np.isfinite(features)):
+        raise ValueError("action_features must be finite")
+    coefficients = project_graph_coefficients(
+        prefix,
+        valid,
+        model.basis,
+        ridge=model.projection_ridge,
+    )
+    mean = np.zeros((total_frame_count, model.basis.shape[0], 3), dtype=float)
+    variance = np.zeros_like(mean)
+    mean[: len(prefix)] = np.einsum(
+        "nr,trc->tnc",
+        model.basis,
+        coefficients,
+    )
+    variance[: len(prefix)] = model.projection_variance_m2[None, None]
+    current = coefficients[-1].copy()
+    covariance = np.zeros_like(model.innovation_covariance)
+    normalized = (features - model.feature_mean) / model.feature_scale
+    for frame in range(len(prefix), total_frame_count):
+        increment = model.drift + np.einsum(
+            "rcf,f->rc",
+            model.input_matrix,
+            normalized[frame - 1],
+        )
+        current = current + increment
+        covariance = covariance + model.innovation_covariance
+        mean[frame] = model.basis @ current
+        for coordinate in range(3):
+            marginal = np.einsum(
+                "ni,ij,nj->n",
+                model.basis,
+                covariance[coordinate],
+                model.basis,
+            )
+            variance[frame, :, coordinate] = (
+                marginal + model.projection_variance_m2[coordinate]
+            )
+    return mean, variance

--- a/src/causal4d/cli/abduct_phystwin_intervention.py
+++ b/src/causal4d/cli/abduct_phystwin_intervention.py
@@ -37,6 +37,30 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--likelihood-power", type=float, default=12.0)
     parser.add_argument("--dynamic-likelihood-weight", type=float, default=0.25)
     parser.add_argument("--degrees-of-freedom", type=float, default=4.0)
+    parser.add_argument(
+        "--observation-model",
+        choices=("legacy", "grouped_robust"),
+        default="legacy",
+        help=(
+            "legacy preserves frozen results; grouped_robust uses effective "
+            "multivariate Student-t mixture factors"
+        ),
+    )
+    parser.add_argument("--robust-nominal-probability", type=float, default=0.95)
+    parser.add_argument(
+        "--robust-outlier-scale-multiplier",
+        type=float,
+        default=25.0,
+    )
+    parser.add_argument(
+        "--grouped-increment-weight",
+        type=float,
+        default=0.0,
+        help=(
+            "additional composite weight for explicit frame-increment factors; "
+            "zero avoids double counting positions by default"
+        ),
+    )
     return parser
 
 
@@ -63,6 +87,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         likelihood_power=args.likelihood_power,
         dynamic_likelihood_weight=args.dynamic_likelihood_weight,
         degrees_of_freedom=args.degrees_of_freedom,
+        observation_model=args.observation_model,
+        robust_nominal_probability=args.robust_nominal_probability,
+        robust_outlier_scale_multiplier=args.robust_outlier_scale_multiplier,
+        grouped_increment_weight=args.grouped_increment_weight,
     )
     factual = abduct_factual_intervention(
         bank,
@@ -106,6 +134,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 ),
                 "factual_intervention_id": factual.artifact_id,
                 "map_hypothesis_id": evaluation["map_hypothesis_id"],
+                "observation_model": evaluation["observation_model"],
                 "relative_track_error_improvement": evaluation[
                     "relative_track_error_improvement"
                 ],

--- a/src/causal4d/grouped_observations.py
+++ b/src/causal4d/grouped_observations.py
@@ -1,0 +1,424 @@
+"""Grouped robust observation factors for finite physical rollout banks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Sequence
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from causal4d.rollout_bank import JointRolloutBank
+
+
+@dataclass(frozen=True)
+class ObservationGroup:
+    """One effective, possibly correlated observation likelihood factor.
+
+    A group observes one rollout node at one frame. When ``reference_frame_index``
+    is provided, ``values_m`` is interpreted as a displacement from that reference
+    frame. This keeps position and increment evidence explicit instead of silently
+    counting finite differences as independent position measurements.
+    """
+
+    frame_index: int
+    node_index: int
+    values_m: np.ndarray
+    covariance_m2: np.ndarray
+    nominal_probability: float = 0.95
+    outlier_scale_multiplier: float = 25.0
+    composite_weight: float = 1.0
+    reference_frame_index: int | None = None
+    source_id: str = "physical_observation"
+    view_id: str | None = None
+
+    def __post_init__(self) -> None:
+        values = np.asarray(self.values_m, dtype=float)
+        covariance = np.asarray(self.covariance_m2, dtype=float)
+        if values.ndim != 1 or not len(values):
+            raise ValueError("values_m must be a nonempty coordinate vector")
+        if covariance.shape != (len(values), len(values)):
+            raise ValueError("covariance_m2 must match values_m")
+        if not np.all(np.isfinite(covariance)):
+            raise ValueError("covariance_m2 must be finite")
+        covariance = 0.5 * (covariance + covariance.T)
+        if np.min(np.linalg.eigvalsh(covariance)) <= 0.0:
+            raise ValueError("covariance_m2 must be positive definite")
+        if self.frame_index < 0 or self.node_index < 0:
+            raise ValueError("frame and node indices must be nonnegative")
+        if self.reference_frame_index is not None:
+            if self.reference_frame_index < 0:
+                raise ValueError("reference_frame_index must be nonnegative")
+            if self.reference_frame_index == self.frame_index:
+                raise ValueError("reference and observed frames must differ")
+        if not 0.0 <= self.nominal_probability <= 1.0:
+            raise ValueError("nominal_probability must lie in [0, 1]")
+        if self.outlier_scale_multiplier <= 1.0:
+            raise ValueError("outlier_scale_multiplier must exceed one")
+        if self.composite_weight <= 0.0 or not np.isfinite(self.composite_weight):
+            raise ValueError("composite_weight must be finite and positive")
+        if not self.source_id:
+            raise ValueError("source_id must be nonempty")
+        object.__setattr__(self, "values_m", values)
+        object.__setattr__(self, "covariance_m2", covariance)
+
+
+def _normalize_joint_log_weights(log_weights: np.ndarray) -> np.ndarray:
+    values = np.asarray(log_weights, dtype=float)
+    if values.ndim != 2 or not np.any(np.isfinite(values)):
+        raise ValueError("joint log weights must contain finite support")
+    maximum = float(np.max(values[np.isfinite(values)]))
+    weights = np.exp(np.where(np.isfinite(values), values - maximum, -np.inf))
+    total = float(np.sum(weights))
+    if not np.isfinite(total) or total <= 0.0:
+        raise RuntimeError("joint posterior normalization failed")
+    return weights / total
+
+
+def _base_log_weights(
+    bank: "JointRolloutBank", base_weights: np.ndarray | None
+) -> np.ndarray:
+    weights = (
+        bank.prior_joint_weights
+        if base_weights is None
+        else np.asarray(base_weights, dtype=float)
+    )
+    if weights.shape != bank.prior_joint_weights.shape:
+        raise ValueError("base_weights must match the joint rollout support")
+    if np.any(weights < 0.0) or not np.isclose(np.sum(weights), 1.0):
+        raise ValueError("base_weights must be nonnegative and sum to one")
+    return np.log(np.maximum(weights, 1e-300))
+
+
+def _particle_field_at_frame(
+    values: np.ndarray | None,
+    *,
+    particle_count: int,
+    frame_count: int,
+    node_count: int,
+    coordinate_count: int,
+    frame_index: int,
+    name: str,
+) -> np.ndarray | None:
+    if values is None:
+        return None
+    field = np.asarray(values, dtype=float)
+    static_shape = (particle_count, node_count, coordinate_count)
+    temporal_shape = (particle_count, frame_count, node_count, coordinate_count)
+    if field.shape == static_shape:
+        selected = field
+    elif field.shape == temporal_shape:
+        selected = field[:, frame_index]
+    else:
+        raise ValueError(f"{name} must have shape {static_shape} or {temporal_shape}")
+    if not np.all(np.isfinite(selected)):
+        raise ValueError(f"{name} must be finite")
+    return selected
+
+
+def _multivariate_student_t_logpdf(
+    residual: np.ndarray,
+    covariance_m2: np.ndarray,
+    *,
+    degrees_of_freedom: float,
+) -> np.ndarray:
+    """Return normalized multivariate Student-t log densities.
+
+    ``covariance_m2`` is the desired covariance, not the Student-t scale matrix.
+    Therefore ``degrees_of_freedom`` must exceed two.
+    """
+
+    if degrees_of_freedom <= 2.0:
+        raise ValueError("grouped Student-t degrees_of_freedom must exceed two")
+    vectors = np.asarray(residual, dtype=float)
+    covariance = np.asarray(covariance_m2, dtype=float)
+    dimension = vectors.shape[-1]
+    if covariance.shape[-2:] != (dimension, dimension):
+        raise ValueError("covariance does not match residual dimension")
+    scale = covariance * ((degrees_of_freedom - 2.0) / degrees_of_freedom)
+    sign, logdet = np.linalg.slogdet(scale)
+    if np.any(sign <= 0.0):
+        raise ValueError("Student-t scale must be positive definite")
+    solved = np.linalg.solve(scale, vectors[..., None])[..., 0]
+    mahalanobis = np.sum(vectors * solved, axis=-1)
+    from math import lgamma, log, pi
+
+    constant = (
+        lgamma((degrees_of_freedom + dimension) / 2.0)
+        - lgamma(degrees_of_freedom / 2.0)
+        - 0.5 * dimension * log(degrees_of_freedom * pi)
+    )
+    return (
+        constant
+        - 0.5 * logdet
+        - 0.5
+        * (degrees_of_freedom + dimension)
+        * np.log1p(mahalanobis / degrees_of_freedom)
+    )
+
+
+def _mixture_log_score(
+    residual: np.ndarray,
+    covariance_m2: np.ndarray,
+    *,
+    degrees_of_freedom: float,
+    nominal_probability: float,
+    outlier_scale_multiplier: float,
+) -> np.ndarray:
+    nominal = _multivariate_student_t_logpdf(
+        residual,
+        covariance_m2,
+        degrees_of_freedom=degrees_of_freedom,
+    )
+    if nominal_probability == 1.0:
+        return nominal
+    outlier = _multivariate_student_t_logpdf(
+        residual,
+        covariance_m2 * outlier_scale_multiplier,
+        degrees_of_freedom=degrees_of_freedom,
+    )
+    if nominal_probability == 0.0:
+        return outlier
+    return np.logaddexp(
+        np.log(nominal_probability) + nominal,
+        np.log1p(-nominal_probability) + outlier,
+    )
+
+
+def update_from_grouped_observations(
+    bank: "JointRolloutBank",
+    groups: Sequence[ObservationGroup],
+    *,
+    degrees_of_freedom: float = 4.0,
+    base_weights: np.ndarray | None = None,
+    particle_discrepancy_m: np.ndarray | None = None,
+    particle_discrepancy_variance_m2: np.ndarray | None = None,
+) -> np.ndarray:
+    """Update a rollout bank with robust effective observation groups."""
+
+    if degrees_of_freedom <= 2.0:
+        raise ValueError("degrees_of_freedom must exceed two for covariance semantics")
+    factors = tuple(groups)
+    if not factors:
+        raise ValueError("at least one observation group is required")
+    particle_count = len(bank.parameter_weights)
+    log_weights = _base_log_weights(bank, base_weights)
+    for group in factors:
+        if group.frame_index >= bank.frame_count or group.node_index >= bank.node_count:
+            raise ValueError("observation group exceeds rollout support")
+        if len(group.values_m) != bank.coordinate_count:
+            raise ValueError(
+                "observation group coordinate count differs from rollout bank"
+            )
+        predicted = bank.trajectories[
+            :, :, group.frame_index, group.node_index
+        ].astype(float)
+        mean_field = _particle_field_at_frame(
+            particle_discrepancy_m,
+            particle_count=particle_count,
+            frame_count=bank.frame_count,
+            node_count=bank.node_count,
+            coordinate_count=bank.coordinate_count,
+            frame_index=group.frame_index,
+            name="particle_discrepancy_m",
+        )
+        if mean_field is not None:
+            predicted += mean_field[None, :, group.node_index]
+        if group.reference_frame_index is not None:
+            if group.reference_frame_index >= bank.frame_count:
+                raise ValueError("reference frame exceeds rollout support")
+            reference = bank.trajectories[
+                :, :, group.reference_frame_index, group.node_index
+            ].astype(float)
+            reference_field = _particle_field_at_frame(
+                particle_discrepancy_m,
+                particle_count=particle_count,
+                frame_count=bank.frame_count,
+                node_count=bank.node_count,
+                coordinate_count=bank.coordinate_count,
+                frame_index=group.reference_frame_index,
+                name="particle_discrepancy_m",
+            )
+            if reference_field is not None:
+                reference += reference_field[None, :, group.node_index]
+            predicted -= reference
+        valid = np.isfinite(group.values_m)
+        if not np.any(valid):
+            continue
+        residual = predicted[..., valid] - group.values_m[valid]
+        covariance = group.covariance_m2[np.ix_(valid, valid)]
+        static_variance_shape = (
+            particle_count,
+            bank.node_count,
+            bank.coordinate_count,
+        )
+        static_increment_variance_cancels = (
+            group.reference_frame_index is not None
+            and particle_discrepancy_variance_m2 is not None
+            and np.asarray(particle_discrepancy_variance_m2).shape
+            == static_variance_shape
+        )
+        variance_field = (
+            None
+            if static_increment_variance_cancels
+            else _particle_field_at_frame(
+                particle_discrepancy_variance_m2,
+                particle_count=particle_count,
+                frame_count=bank.frame_count,
+                node_count=bank.node_count,
+                coordinate_count=bank.coordinate_count,
+                frame_index=group.frame_index,
+                name="particle_discrepancy_variance_m2",
+            )
+        )
+        if variance_field is None:
+            covariance_by_particle = np.broadcast_to(
+                covariance,
+                (particle_count, *covariance.shape),
+            ).copy()
+        else:
+            selected_variance = variance_field[:, group.node_index][:, valid]
+            if np.any(selected_variance < 0.0):
+                raise ValueError("particle discrepancy variance must be nonnegative")
+            covariance_by_particle = np.broadcast_to(
+                covariance,
+                (particle_count, *covariance.shape),
+            ).copy()
+            diagonal = np.arange(np.sum(valid))
+            covariance_by_particle[:, diagonal, diagonal] += selected_variance
+        if (
+            group.reference_frame_index is not None
+            and not static_increment_variance_cancels
+        ):
+            reference_variance = _particle_field_at_frame(
+                particle_discrepancy_variance_m2,
+                particle_count=particle_count,
+                frame_count=bank.frame_count,
+                node_count=bank.node_count,
+                coordinate_count=bank.coordinate_count,
+                frame_index=group.reference_frame_index,
+                name="particle_discrepancy_variance_m2",
+            )
+            if reference_variance is not None:
+                selected_reference_variance = reference_variance[
+                    :, group.node_index
+                ][:, valid]
+                if np.any(selected_reference_variance < 0.0):
+                    raise ValueError(
+                        "particle discrepancy variance must be nonnegative"
+                    )
+                diagonal = np.arange(np.sum(valid))
+                covariance_by_particle[
+                    :, diagonal, diagonal
+                ] += selected_reference_variance
+        score = _mixture_log_score(
+            residual,
+            covariance_by_particle[None],
+            degrees_of_freedom=degrees_of_freedom,
+            nominal_probability=group.nominal_probability,
+            outlier_scale_multiplier=group.outlier_scale_multiplier,
+        )
+        log_weights += group.composite_weight * score
+    return _normalize_joint_log_weights(log_weights)
+
+
+def dense_prefix_observation_groups(
+    observations_m: np.ndarray,
+    *,
+    prefix_frame_count: int,
+    observation_scale_m: float,
+    likelihood_power: float,
+    mask: np.ndarray | None = None,
+    nominal_probability: float = 0.95,
+    outlier_scale_multiplier: float = 25.0,
+    increment_likelihood_weight: float = 0.0,
+    source_id: str = "dense_prefix",
+    view_id: str | None = None,
+) -> tuple[ObservationGroup, ...]:
+    """Convert a dense causal prefix into conservatively weighted 3-D groups."""
+
+    observations = np.asarray(observations_m, dtype=float)
+    if observations.ndim != 3 or observations.shape[2] not in {2, 3}:
+        raise ValueError("observations_m must have shape (T, N, 2|3)")
+    if not 2 <= prefix_frame_count <= len(observations):
+        raise ValueError(
+            "prefix_frame_count must reveal at least one post-endpoint frame"
+        )
+    if observation_scale_m <= 0.0 or likelihood_power <= 0.0:
+        raise ValueError("observation scale and likelihood power must be positive")
+    if increment_likelihood_weight < 0.0:
+        raise ValueError("increment_likelihood_weight must be nonnegative")
+    valid = np.isfinite(observations)
+    if mask is not None:
+        supplied = np.asarray(mask, dtype=bool)
+        if supplied.shape == observations.shape[:2]:
+            supplied = np.repeat(
+                supplied[:, :, None], observations.shape[2], axis=2
+            )
+        if supplied.shape != observations.shape:
+            raise ValueError("mask must have shape (T, N) or (T, N, C)")
+        valid &= supplied
+    positions = []
+    for frame in range(1, prefix_frame_count):
+        for node in range(observations.shape[1]):
+            if np.any(valid[frame, node]):
+                values = observations[frame, node].copy()
+                values[~valid[frame, node]] = np.nan
+                positions.append((frame, node, values))
+    if not positions:
+        raise ValueError("prefix contains no valid observation groups")
+    position_coordinate_count = sum(
+        np.sum(np.isfinite(values)) for _, _, values in positions
+    )
+    position_weight = likelihood_power / float(position_coordinate_count)
+    covariance = np.eye(observations.shape[2]) * observation_scale_m**2
+    groups = [
+        ObservationGroup(
+            frame_index=frame,
+            node_index=node,
+            values_m=values,
+            covariance_m2=covariance,
+            nominal_probability=nominal_probability,
+            outlier_scale_multiplier=outlier_scale_multiplier,
+            composite_weight=position_weight,
+            source_id=source_id,
+            view_id=view_id,
+        )
+        for frame, node, values in positions
+    ]
+    if increment_likelihood_weight > 0.0 and prefix_frame_count >= 3:
+        increments = []
+        for frame in range(2, prefix_frame_count):
+            for node in range(observations.shape[1]):
+                pair_valid = valid[frame, node] & valid[frame - 1, node]
+                if np.any(pair_valid):
+                    values = observations[frame, node] - observations[frame - 1, node]
+                    values = values.copy()
+                    values[~pair_valid] = np.nan
+                    increments.append((frame, node, values))
+        if increments:
+            increment_coordinate_count = sum(
+                np.sum(np.isfinite(values)) for _, _, values in increments
+            )
+            increment_weight = (
+                likelihood_power
+                * increment_likelihood_weight
+                / float(increment_coordinate_count)
+            )
+            increment_covariance = 2.0 * covariance
+            groups.extend(
+                ObservationGroup(
+                    frame_index=frame,
+                    reference_frame_index=frame - 1,
+                    node_index=node,
+                    values_m=values,
+                    covariance_m2=increment_covariance,
+                    nominal_probability=nominal_probability,
+                    outlier_scale_multiplier=outlier_scale_multiplier,
+                    composite_weight=increment_weight,
+                    source_id=f"{source_id}:increment",
+                    view_id=view_id,
+                )
+                for frame, node, values in increments
+            )
+    return tuple(groups)

--- a/src/causal4d/intervention_abduction.py
+++ b/src/causal4d/intervention_abduction.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 
 from causal4d.contracts import FactualIntervention, TwinBelief, array_sha256
+from causal4d.grouped_observations import (
+    dense_prefix_observation_groups,
+    update_from_grouped_observations,
+)
 from causal4d.rollout_bank import JointRolloutBank
 
 
@@ -19,6 +23,10 @@ class FactualAbductionConfig:
     likelihood_power: float = 12.0
     dynamic_likelihood_weight: float = 0.25
     degrees_of_freedom: float = 4.0
+    observation_model: Literal["legacy", "grouped_robust"] = "legacy"
+    robust_nominal_probability: float = 0.95
+    robust_outlier_scale_multiplier: float = 25.0
+    grouped_increment_weight: float = 0.0
 
     def __post_init__(self) -> None:
         if self.observation_scale_m <= 0.0 or self.likelihood_power <= 0.0:
@@ -27,6 +35,18 @@ class FactualAbductionConfig:
             raise ValueError("dynamic_likelihood_weight must be nonnegative")
         if self.degrees_of_freedom <= 0.0:
             raise ValueError("degrees_of_freedom must be positive")
+        if self.observation_model not in {"legacy", "grouped_robust"}:
+            raise ValueError("observation_model must be legacy or grouped_robust")
+        if not 0.0 <= self.robust_nominal_probability <= 1.0:
+            raise ValueError("robust_nominal_probability must lie in [0, 1]")
+        if self.robust_outlier_scale_multiplier <= 1.0:
+            raise ValueError("robust_outlier_scale_multiplier must exceed one")
+        if self.grouped_increment_weight < 0.0:
+            raise ValueError("grouped_increment_weight must be nonnegative")
+        if self.observation_model == "grouped_robust" and self.degrees_of_freedom <= 2.0:
+            raise ValueError(
+                "grouped_robust degrees_of_freedom must exceed two for covariance semantics"
+            )
 
 
 def _belief_readout(
@@ -64,6 +84,51 @@ def physical_readout_components(
     return bank.trajectories.astype(float) + discrepancy[None, :, None]
 
 
+def _update_joint_weights(
+    bank: JointRolloutBank,
+    belief: TwinBelief,
+    observations_from_endpoint_m: np.ndarray,
+    *,
+    prefix_frame_count: int,
+    observation_mask: np.ndarray | None,
+    settings: FactualAbductionConfig,
+    base_weights: np.ndarray | None = None,
+) -> np.ndarray:
+    discrepancy, discrepancy_variance = _belief_readout(bank, belief)
+    if settings.observation_model == "legacy":
+        return bank.update_from_observations(
+            observations_from_endpoint_m,
+            prefix_frame_count=prefix_frame_count,
+            scale_m=settings.observation_scale_m,
+            likelihood_power=settings.likelihood_power,
+            dynamic_likelihood_weight=settings.dynamic_likelihood_weight,
+            degrees_of_freedom=settings.degrees_of_freedom,
+            mask=observation_mask,
+            base_weights=base_weights,
+            particle_discrepancy_m=discrepancy,
+            particle_discrepancy_variance_m2=discrepancy_variance,
+        )
+    groups = dense_prefix_observation_groups(
+        observations_from_endpoint_m,
+        prefix_frame_count=prefix_frame_count,
+        observation_scale_m=settings.observation_scale_m,
+        likelihood_power=settings.likelihood_power,
+        mask=observation_mask,
+        nominal_probability=settings.robust_nominal_probability,
+        outlier_scale_multiplier=settings.robust_outlier_scale_multiplier,
+        increment_likelihood_weight=settings.grouped_increment_weight,
+        source_id="phystwin_o_plus",
+    )
+    return update_from_grouped_observations(
+        bank,
+        groups,
+        degrees_of_freedom=settings.degrees_of_freedom,
+        base_weights=base_weights,
+        particle_discrepancy_m=discrepancy,
+        particle_discrepancy_variance_m2=discrepancy_variance,
+    )
+
+
 def abduct_factual_intervention(
     bank: JointRolloutBank,
     belief: TwinBelief,
@@ -81,17 +146,13 @@ def abduct_factual_intervention(
     expected_stop = belief.context.o_plus.frame_start + prefix_frame_count - 1
     if expected_stop > belief.context.o_plus.frame_stop:
         raise ValueError("abduction prefix extends beyond O+")
-    discrepancy, discrepancy_variance = _belief_readout(bank, belief)
-    joint_weights = bank.update_from_observations(
+    joint_weights = _update_joint_weights(
+        bank,
+        belief,
         observations_from_endpoint_m,
         prefix_frame_count=prefix_frame_count,
-        scale_m=settings.observation_scale_m,
-        likelihood_power=settings.likelihood_power,
-        dynamic_likelihood_weight=settings.dynamic_likelihood_weight,
-        degrees_of_freedom=settings.degrees_of_freedom,
-        mask=observation_mask,
-        particle_discrepancy_m=discrepancy,
-        particle_discrepancy_variance_m2=discrepancy_variance,
+        observation_mask=observation_mask,
+        settings=settings,
     )
     hand_count = len(bank.hypothesis_metadata[0]["contact"]["attachment_shifts"])
     phi_names = ("gain_multiplier", "delay_steps", "rotation_degrees")
@@ -144,6 +205,8 @@ def abduct_factual_intervention(
             "rollout_bank_trajectories_sha256": array_sha256(bank.trajectories),
             "discrepancy_scored_as_separate_readout": True,
             "discrepancy_injected_into_simulator_state": False,
+            "grouped_observation_factors": settings.observation_model
+            == "grouped_robust",
         },
     )
 
@@ -226,7 +289,6 @@ def evaluate_factual_abduction(
     """Compare BPT+z with a same-evidence BPT posterior fixed to nominal z."""
 
     settings = config or FactualAbductionConfig()
-    discrepancy, discrepancy_variance = _belief_readout(bank, belief)
     z_weights = factual_joint_weights(
         factual,
         hypothesis_count=len(bank.hypothesis_ids),
@@ -237,17 +299,14 @@ def evaluate_factual_abduction(
     action_mass = bank.hypothesis_prior_weights[nominal]
     action_mass = action_mass / np.sum(action_mass)
     nominal_base[nominal] = action_mass[:, None] * bank.parameter_weights[None]
-    nominal_weights = bank.update_from_observations(
+    nominal_weights = _update_joint_weights(
+        bank,
+        belief,
         observations_from_endpoint_m,
         prefix_frame_count=prefix_frame_count,
-        scale_m=settings.observation_scale_m,
-        likelihood_power=settings.likelihood_power,
-        dynamic_likelihood_weight=settings.dynamic_likelihood_weight,
-        degrees_of_freedom=settings.degrees_of_freedom,
-        mask=observation_mask,
+        observation_mask=observation_mask,
+        settings=settings,
         base_weights=nominal_base,
-        particle_discrepancy_m=discrepancy,
-        particle_discrepancy_variance_m2=discrepancy_variance,
     )
     components = physical_readout_components(bank, belief)
     z_prediction = np.einsum("hp,hptnc->tnc", z_weights, components)
@@ -269,6 +328,7 @@ def evaluate_factual_abduction(
     return {
         "abduction_prefix_frame_count_including_endpoint": prefix_frame_count,
         "held_out_rollout_interval": [prefix_frame_count, bank.frame_count],
+        "observation_model": settings.observation_model,
         "bpt_without_z": nominal_metrics,
         "bpt_plus_causal4d_z": z_metrics,
         "relative_track_error_improvement": float(improvement),

--- a/tests/test_causal4d_action_conditioned_discrepancy.py
+++ b/tests/test_causal4d_action_conditioned_discrepancy.py
@@ -1,0 +1,55 @@
+import numpy as np
+
+from causal4d.action_conditioned_discrepancy import (
+    fit_action_conditioned_graph_discrepancy,
+    forecast_action_conditioned_graph_discrepancy,
+)
+
+
+def test_action_conditioned_forecast_beats_persistence_on_driven_modes() -> None:
+    rng = np.random.default_rng(2)
+    node_count = 8
+    rank = 2
+    basis, _ = np.linalg.qr(rng.normal(size=(node_count, rank)))
+    frame_count = 20
+    features = np.zeros((frame_count - 1, 2), dtype=float)
+    features[:, 0] = np.tile([-1.0, 1.0], 10)[: frame_count - 1]
+    features[:, 1] = np.linspace(-1.0, 1.0, frame_count - 1)
+    true_input = np.asarray(
+        [
+            [[0.004, 0.001], [0.0, 0.002], [-0.001, 0.0]],
+            [[-0.002, 0.0], [0.003, -0.001], [0.0, 0.001]],
+        ]
+    )
+    coefficients = np.zeros((frame_count, rank, 3), dtype=float)
+    for frame in range(frame_count - 1):
+        coefficients[frame + 1] = coefficients[frame] + np.einsum(
+            "rcf,f->rc",
+            true_input,
+            features[frame],
+        )
+    residual = np.einsum("nr,trc->tnc", basis, coefficients)
+    valid = np.ones((frame_count, node_count), dtype=bool)
+    model = fit_action_conditioned_graph_discrepancy(
+        residual[:14],
+        valid[:14],
+        basis,
+        features[:13],
+        feature_names=("signed_speed", "hold_phase"),
+        dynamics_ridge=1e-8,
+    )
+    mean, variance = forecast_action_conditioned_graph_discrepancy(
+        model,
+        residual[:5],
+        valid[:5],
+        features,
+        total_frame_count=frame_count,
+    )
+    persistence = np.repeat(residual[4:5], frame_count - 5, axis=0)
+    action_rmse = np.sqrt(np.mean(np.square(mean[5:] - residual[5:])))
+    persistence_rmse = np.sqrt(
+        np.mean(np.square(persistence - residual[5:]))
+    )
+    assert action_rmse < 0.05 * persistence_rmse
+    assert np.all(variance >= 0.0)
+    assert model.feature_names == ("signed_speed", "hold_phase")

--- a/tests/test_causal4d_grouped_observations.py
+++ b/tests/test_causal4d_grouped_observations.py
@@ -1,0 +1,99 @@
+import numpy as np
+import pytest
+
+from causal4d.grouped_observations import (
+    ObservationGroup,
+    dense_prefix_observation_groups,
+    update_from_grouped_observations,
+)
+from causal4d.intervention_abduction import FactualAbductionConfig
+from causal4d.rollout_bank import JointRolloutBank
+
+
+def _bank() -> JointRolloutBank:
+    trajectories = np.zeros((2, 1, 5, 1, 3), dtype=float)
+    trajectories[1, 0, :, 0, 0] = np.arange(5, dtype=float) * 0.01
+    return JointRolloutBank(
+        hypothesis_ids=("static", "moving"),
+        hypothesis_metadata=(
+            {"action": {"proposal_id": "static"}},
+            {"action": {"proposal_id": "moving"}},
+        ),
+        hypothesis_prior_weights=np.asarray([0.5, 0.5]),
+        parameter_particles=np.asarray([[0.0]]),
+        parameter_weights=np.asarray([1.0]),
+        trajectories=trajectories,
+    )
+
+
+def test_grouped_robust_factor_tolerates_one_gross_outlier() -> None:
+    bank = _bank()
+    observations = bank.trajectories[1, 0].copy()
+    observations[2, 0, 0] = 2.0
+    groups = dense_prefix_observation_groups(
+        observations,
+        prefix_frame_count=4,
+        observation_scale_m=0.005,
+        likelihood_power=12.0,
+        nominal_probability=0.90,
+        outlier_scale_multiplier=100.0,
+    )
+    weights = update_from_grouped_observations(bank, groups)
+    assert weights[1, 0] > weights[0, 0]
+
+
+def test_grouped_update_scores_time_varying_discrepancy() -> None:
+    trajectories = np.zeros((1, 2, 4, 1, 3), dtype=float)
+    bank = JointRolloutBank(
+        hypothesis_ids=("nominal",),
+        hypothesis_metadata=({"action": {"proposal_id": "nominal"}},),
+        hypothesis_prior_weights=np.asarray([1.0]),
+        parameter_particles=np.asarray([[0.0], [1.0]]),
+        parameter_weights=np.asarray([0.5, 0.5]),
+        trajectories=trajectories,
+    )
+    observations = np.zeros((4, 1, 3), dtype=float)
+    observations[1:, 0, 0] = [0.01, 0.02, 0.03]
+    groups = dense_prefix_observation_groups(
+        observations,
+        prefix_frame_count=4,
+        observation_scale_m=0.001,
+        likelihood_power=20.0,
+        nominal_probability=1.0,
+    )
+    discrepancy = np.zeros((2, 4, 1, 3), dtype=float)
+    discrepancy[1, :, 0, 0] = [0.0, 0.01, 0.02, 0.03]
+    weights = update_from_grouped_observations(
+        bank,
+        groups,
+        particle_discrepancy_m=discrepancy,
+    )
+    assert weights[0, 1] > 0.99
+
+
+def test_static_discrepancy_uncertainty_cancels_in_increment_factor() -> None:
+    bank = _bank()
+    group = ObservationGroup(
+        frame_index=2,
+        reference_frame_index=1,
+        node_index=0,
+        values_m=np.asarray([0.01, 0.0, 0.0]),
+        covariance_m2=np.eye(3) * 1e-6,
+        nominal_probability=1.0,
+    )
+    without_discrepancy = update_from_grouped_observations(bank, (group,))
+    static_variance = np.full((1, 1, 3), 100.0)
+    with_static_discrepancy = update_from_grouped_observations(
+        bank,
+        (group,),
+        particle_discrepancy_variance_m2=static_variance,
+    )
+    assert np.allclose(with_static_discrepancy, without_discrepancy)
+
+
+def test_grouped_covariance_semantics_require_finite_student_t_variance() -> None:
+    with pytest.raises(ValueError, match="must exceed two"):
+        FactualAbductionConfig(
+            observation_model="grouped_robust",
+            degrees_of_freedom=2.0,
+        )


### PR DESCRIPTION
## What changed

- add typed effective observation groups with full covariance, source/view provenance, composite weights, and nominal/outlier multivariate Student-t mixture factors
- integrate an opt-in `grouped_robust` factual-abduction path while keeping `legacy` as the default for frozen milestone reproducibility
- expose CLI controls for nominal probability, outlier covariance inflation, and separately weighted increment factors
- support static or time-varying discrepancy means and variances in grouped scoring; static discrepancy uncertainty cancels exactly for displacement factors
- add a coordinate-specific action-conditioned graph-discrepancy model around persistence,
  `c[t+1] = c[t] + d + B psi[t] + w[t]`
- export the new public primitives and document their claim/evidence boundary

## Why

The real oracle audit attributes most remaining prediction headroom to model discrepancy rather than intervention proposal support. This PR therefore improves the observation update and adds a conservative action-conditioned readout-discrepancy candidate instead of expanding the intervention grid or reviving the rejected generic state-reset branch.

## Compatibility

- existing factual-abduction behavior remains byte-for-byte on the default `legacy` path
- the grouped path is explicit and opt-in
- the new discrepancy model is a source-development candidate only; it does not inject corrections into simulator state or bypass the existing prospective mechanism gates

## Validation

Focused local validation completed:

- Python compilation of all changed modules and test files
- robust grouped factor retained the matching rollout under a gross 2 m outlier
- time-varying discrepancy scoring selected the correct physical particle with posterior mass > 0.99
- static discrepancy variance canceled exactly in displacement likelihoods
- coordinate-specific action-conditioned synthetic forecast achieved future RMSE ratio `1.97e-5` relative to persistence

A full repository test run was not available in the execution environment because the GitHub CLI and external network checkout were unavailable; the PR is left as draft for CI/full-suite confirmation.