### PR TITLE
Add stable action-conditioned discrepancy movement

### DIFF
--- a/docs/action_conditioned_discrepancy.md
+++ b/docs/action_conditioned_discrepancy.md
@@ -1,8 +1,9 @@
 # Action-conditioned graph discrepancy
 
 This opt-in module keeps the empirically successful graph-persistent discrepancy
-mean while allowing uncertainty to grow with the commanded and realized
-intervention. It does not alter the frozen `v0.3.0-causal4d-aip` inference path.
+as its exact fallback while allowing both uncertainty and the low-rank readout
+mean to evolve with the commanded and realized intervention. It does not alter
+the frozen `v0.3.0-causal4d-aip` inference path.
 
 ## Typed belief
 
@@ -21,23 +22,78 @@ checksummed non-pickled NPZ payload.
 
 ## Feature-conditioned covariance
 
-For transition feature vector `f`, the model uses
+For transition feature vector `f`, the covariance model uses
 
 ```text
 Q(f) = Q0 + sum_j (w_j^T f)^2 v_j v_j^T.
 ```
 
 This is positive semidefinite by construction. With zero feature weights it is
-exactly the declared base persistence model. The discrepancy mean remains fixed;
-only covariance changes. The provided feature builder uses controller speed,
-acceleration and direction together with gain, delay, frame rotation, slip,
-attachment shift, and the same-grasp/new-contact policy. It consumes no future
-object outcome.
+exactly the declared base persistence model. The provided feature builder uses
+controller speed, acceleration and direction together with gain, delay, frame
+rotation, slip, attachment shift, and the same-grasp/new-contact policy. It
+consumes no future object outcome.
 
-`forecast_action_conditioned_persistence` returns coefficient and graph-readout
-moments for every posterior component. This is intended for source-fitted or
-preregistered covariance models. Target outcomes must not select feature weights,
-directions, variance caps, or feature normalization.
+## Stable discrepancy-mean movement
+
+`ActionConditionedMeanTransitionModel` adds an opt-in transition for the graph
+coefficient mean. It separates mode rotation, contraction, and bounded additive
+movement:
+
+```text
+Omega(f) = sum_j (r_j^T f) G_j,       G_j^T = -G_j
+D(f)     = sum_j (c_j^T f)^2 d_j d_j^T
+b(f)     = B f
+A(f)     = exp(Omega(f)) exp(-D(f))
+c_next   = A(f) c + b(f)
+```
+
+The rotation factor is orthogonal and the contraction factor is non-expansive,
+so the homogeneous transition cannot amplify the coefficient norm. Optional
+Frobenius-norm caps bound both transition generators and additive movement. The
+same transition propagates coefficient covariance as
+
+```text
+P_next = A(f) P A(f)^T + Q(f).
+```
+
+`forecast_action_conditioned_movement` applies this model component by component
+and returns graph-readout mean and variance without injecting a correction into
+simulator position or velocity. A zero-weight
+`ActionConditionedMeanTransitionModel.persistence(...)` delegates directly to
+the existing persistence forecast and returns it unchanged, including its model
+identifier and array values.
+
+This parameterization is intended to test the interaction-dependent contraction,
+rotation, and graph-mode transfer observed in the released discrepancy-location
+diagnostics. It is not evidence that such a transition transfers. All movement
+weights, caps, feature normalization, graph rank, and covariance settings must be
+fitted on source executions or preregistered before confirmatory targets are
+opened. Rejection must retain exact graph persistence.
+
+## Forecast API
+
+```python
+from causal4d import (
+    ActionConditionedMeanTransitionModel,
+    forecast_action_conditioned_movement,
+)
+
+mean_model = ActionConditionedMeanTransitionModel.persistence(
+    features.names,
+    belief.rank,
+)
+forecast = forecast_action_conditioned_movement(
+    belief,
+    mean_model,
+    covariance_model,
+    features,
+    basis,
+)
+```
+
+Replace the persistence model only with a source-fitted and prospectively gated
+model. Zero movement weights remain the fail-closed fallback.
 
 ## Correlation-aware factual abduction
 
@@ -49,5 +105,5 @@ includes the endpoint-to-first-response increment.
 
 The legacy `abduct_factual_intervention` function and its default likelihood are
 unchanged, so frozen artifacts remain reproducible. Promotion of the graph-mode
-likelihood requires source-only temperature/covariance selection and a sealed
+likelihood or discrepancy movement requires source-only selection and a sealed
 held-out comparison.

--- a/src/causal4d/__init__.py
+++ b/src/causal4d/__init__.py
@@ -23,6 +23,10 @@ from causal4d.discrepancy_belief import (
     load_graph_discrepancy_belief,
     write_graph_discrepancy_belief,
 )
+from causal4d.discrepancy_mean_transition import (
+    ActionConditionedMeanTransitionModel,
+    forecast_action_conditioned_movement,
+)
 from causal4d.evaluation import run_counterfactual_benchmark
 from causal4d.graph_mode_abduction import (
     GraphModeAbductionConfig,
@@ -67,6 +71,7 @@ __all__ = [
     "ActionConditionedDiscrepancyFeatures",
     "ActionConditionedDiscrepancyForecast",
     "ActionConditionedDiscrepancyModel",
+    "ActionConditionedMeanTransitionModel",
     "CounterfactualBenchmarkConfig",
     "CounterfactualQuery",
     "FactualIntervention",
@@ -98,6 +103,7 @@ __all__ = [
     "build_action_conditioned_features",
     "build_protocol",
     "finite_response_sensitivity",
+    "forecast_action_conditioned_movement",
     "forecast_action_conditioned_persistence",
     "graph_mode_joint_weights",
     "grouped_component_log_likelihoods",

--- a/src/causal4d/discrepancy_mean_transition.py
+++ b/src/causal4d/discrepancy_mean_transition.py
@@ -1,0 +1,311 @@
+"""Stable action-conditioned propagation of low-rank discrepancy means."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.linalg import expm
+
+from causal4d.action_conditioned_discrepancy import (
+    ActionConditionedDiscrepancyFeatures,
+    ActionConditionedDiscrepancyForecast,
+    ActionConditionedDiscrepancyModel,
+    forecast_action_conditioned_persistence,
+)
+from causal4d.contracts import array_sha256
+from causal4d.discrepancy_belief import GraphDiscrepancyBelief
+
+
+def _readonly(values: np.ndarray) -> np.ndarray:
+    array = np.asarray(values, dtype=float).copy()
+    array.setflags(write=False)
+    return array
+
+
+def _positive_semidefinite(matrix: np.ndarray) -> np.ndarray:
+    symmetric = 0.5 * (matrix + matrix.T)
+    eigenvalues, eigenvectors = np.linalg.eigh(symmetric)
+    return (eigenvectors * np.maximum(eigenvalues, 0.0)) @ eigenvectors.T
+
+
+def _bounded_frobenius(matrix: np.ndarray, maximum: float | None) -> np.ndarray:
+    if maximum is None:
+        return matrix
+    norm = float(np.linalg.norm(matrix))
+    if norm <= maximum or norm == 0.0:
+        return matrix
+    return matrix * (maximum / norm)
+
+
+@dataclass(frozen=True)
+class ActionConditionedMeanTransitionModel:
+    """Stable graph-mode movement for a discrepancy coefficient mean.
+
+    A feature vector produces a rotation generator ``Omega(f)``, a positive
+    semidefinite contraction generator ``D(f)``, and a bounded forcing field
+    ``b(f)``. The transition is
+
+    ``A(f) = exp(Omega(f)) @ exp(-D(f))``.
+
+    The first factor is orthogonal and the second is non-expansive. Zero
+    transition and forcing weights reproduce exact graph persistence.
+    """
+
+    feature_names: tuple[str, ...]
+    contraction_directions: np.ndarray
+    contraction_weights: np.ndarray
+    rotation_generators: np.ndarray
+    rotation_weights: np.ndarray
+    forcing_weights_m: np.ndarray
+    model_id: str = "action-conditioned-discrepancy-mean-v1"
+    maximum_generator_norm: float | None = None
+    maximum_forcing_norm_m: float | None = None
+
+    def __post_init__(self) -> None:
+        names = tuple(map(str, self.feature_names))
+        contraction_directions = _readonly(self.contraction_directions)
+        contraction_weights = _readonly(self.contraction_weights)
+        rotation_generators = _readonly(self.rotation_generators)
+        rotation_weights = _readonly(self.rotation_weights)
+        forcing_weights = _readonly(self.forcing_weights_m)
+        if not self.model_id or not names or len(set(names)) != len(names):
+            raise ValueError("model id and unique feature names must be nonempty")
+        if forcing_weights.ndim != 3 or forcing_weights.shape[1:] != (3, len(names)):
+            raise ValueError(
+                "forcing_weights_m must have shape (rank, 3, feature_count)"
+            )
+        rank = forcing_weights.shape[0]
+        if rank < 1:
+            raise ValueError("transition rank must be positive")
+        if (
+            contraction_directions.ndim != 2
+            or contraction_directions.shape[1] != rank
+        ):
+            raise ValueError("contraction_directions must have shape (Jc, rank)")
+        if contraction_weights.shape != (len(contraction_directions), len(names)):
+            raise ValueError(
+                "contraction_weights must have shape (Jc, feature_count)"
+            )
+        if rotation_generators.shape != (len(rotation_generators), rank, rank):
+            raise ValueError("rotation_generators must have shape (Jr, rank, rank)")
+        if rotation_weights.shape != (len(rotation_generators), len(names)):
+            raise ValueError("rotation_weights must have shape (Jr, feature_count)")
+        arrays = (
+            contraction_directions,
+            contraction_weights,
+            rotation_generators,
+            rotation_weights,
+            forcing_weights,
+        )
+        if not all(np.all(np.isfinite(array)) for array in arrays):
+            raise ValueError("mean-transition arrays must be finite")
+        if len(contraction_directions):
+            norms = np.linalg.norm(contraction_directions, axis=1)
+            if np.any(norms <= 0.0):
+                raise ValueError("contraction directions must be nonzero")
+            contraction_directions = _readonly(
+                contraction_directions / norms[:, None]
+            )
+        if not np.allclose(
+            rotation_generators,
+            -rotation_generators.swapaxes(-1, -2),
+            atol=1e-10,
+            rtol=1e-10,
+        ):
+            raise ValueError("rotation generators must be skew-symmetric")
+        for value, name in (
+            (self.maximum_generator_norm, "maximum_generator_norm"),
+            (self.maximum_forcing_norm_m, "maximum_forcing_norm_m"),
+        ):
+            if value is not None and (not np.isfinite(value) or value <= 0.0):
+                raise ValueError(f"{name} must be finite and positive")
+        object.__setattr__(self, "feature_names", names)
+        object.__setattr__(self, "contraction_directions", contraction_directions)
+        object.__setattr__(self, "contraction_weights", contraction_weights)
+        object.__setattr__(self, "rotation_generators", rotation_generators)
+        object.__setattr__(self, "rotation_weights", rotation_weights)
+        object.__setattr__(self, "forcing_weights_m", forcing_weights)
+
+    @classmethod
+    def persistence(
+        cls,
+        feature_names: tuple[str, ...],
+        rank: int,
+    ) -> "ActionConditionedMeanTransitionModel":
+        """Construct the exact graph-persistence fallback."""
+
+        if rank < 1:
+            raise ValueError("rank must be positive")
+        feature_count = len(feature_names)
+        return cls(
+            feature_names=feature_names,
+            contraction_directions=np.zeros((0, rank)),
+            contraction_weights=np.zeros((0, feature_count)),
+            rotation_generators=np.zeros((0, rank, rank)),
+            rotation_weights=np.zeros((0, feature_count)),
+            forcing_weights_m=np.zeros((rank, 3, feature_count)),
+            model_id="graph-persistence-mean",
+        )
+
+    @property
+    def rank(self) -> int:
+        return int(self.forcing_weights_m.shape[0])
+
+    @property
+    def is_exact_persistence(self) -> bool:
+        return (
+            not np.any(self.contraction_weights)
+            and not np.any(self.rotation_weights)
+            and not np.any(self.forcing_weights_m)
+        )
+
+    def transition_and_forcing(
+        self,
+        feature_vector: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Return a non-expansive mode transition and bounded additive movement."""
+
+        features = np.asarray(feature_vector, dtype=float)
+        if features.shape != (len(self.feature_names),) or not np.all(
+            np.isfinite(features)
+        ):
+            raise ValueError(
+                "feature vector does not match the mean-transition model"
+            )
+
+        contraction = np.zeros((self.rank, self.rank), dtype=float)
+        if len(self.contraction_directions):
+            amplitudes = self.contraction_weights @ features
+            contraction = np.einsum(
+                "j,ji,jk->ik",
+                np.square(amplitudes),
+                self.contraction_directions,
+                self.contraction_directions,
+            )
+        rotation = np.zeros((self.rank, self.rank), dtype=float)
+        if len(self.rotation_generators):
+            rates = self.rotation_weights @ features
+            rotation = np.einsum("j,jik->ik", rates, self.rotation_generators)
+
+        contraction = _bounded_frobenius(
+            contraction,
+            self.maximum_generator_norm,
+        )
+        rotation = _bounded_frobenius(rotation, self.maximum_generator_norm)
+        rotation_transition = expm(rotation) if np.any(rotation) else np.eye(self.rank)
+        contraction_transition = (
+            expm(-contraction) if np.any(contraction) else np.eye(self.rank)
+        )
+        transition = rotation_transition @ contraction_transition
+
+        forcing = np.einsum("rcf,f->rc", self.forcing_weights_m, features)
+        forcing = _bounded_frobenius(forcing, self.maximum_forcing_norm_m)
+        return transition, forcing
+
+
+def _component_features(
+    belief: GraphDiscrepancyBelief,
+    features: ActionConditionedDiscrepancyFeatures,
+) -> np.ndarray:
+    component_count = len(belief.component_ids)
+    if features.values.ndim == 2:
+        return np.broadcast_to(
+            features.values[None],
+            (component_count, *features.values.shape),
+        )
+    if features.component_ids != belief.component_ids:
+        raise ValueError("component-specific features differ from belief support")
+    return features.values
+
+
+def forecast_action_conditioned_movement(
+    belief: GraphDiscrepancyBelief,
+    mean_model: ActionConditionedMeanTransitionModel,
+    covariance_model: ActionConditionedDiscrepancyModel,
+    features: ActionConditionedDiscrepancyFeatures,
+    basis: np.ndarray,
+) -> ActionConditionedDiscrepancyForecast:
+    """Propagate graph-mode movement and covariance without state injection.
+
+    When ``mean_model`` is the persistence fallback, this function delegates to
+    ``forecast_action_conditioned_persistence`` and returns that result unchanged.
+    """
+
+    if mean_model.is_exact_persistence:
+        return forecast_action_conditioned_persistence(
+            belief,
+            covariance_model,
+            features,
+            basis,
+        )
+
+    graph_basis = np.asarray(basis, dtype=float)
+    if graph_basis.ndim != 2 or graph_basis.shape[1] != belief.rank:
+        raise ValueError("basis must have shape (node, belief.rank)")
+    if not np.all(np.isfinite(graph_basis)):
+        raise ValueError("basis must be finite")
+    if array_sha256(graph_basis) != belief.basis_sha256:
+        raise ValueError("basis hash differs from the graph-discrepancy belief")
+    if (
+        mean_model.rank != belief.rank
+        or covariance_model.rank != belief.rank
+        or mean_model.feature_names != features.names
+        or covariance_model.feature_names != features.names
+    ):
+        raise ValueError(
+            "model rank or feature schema differs from belief/features"
+        )
+
+    feature_values = _component_features(belief, features)
+    component_count = len(belief.component_ids)
+    horizon = features.horizon
+    mean = np.empty(
+        (component_count, horizon + 1, belief.rank, 3),
+        dtype=float,
+    )
+    covariance = np.empty(
+        (component_count, horizon + 1, 3, belief.rank, belief.rank),
+        dtype=float,
+    )
+    mean[:, 0] = belief.coefficient_mean_m
+    covariance[:, 0] = belief.coefficient_covariance_m2
+
+    for step in range(horizon):
+        for component in range(component_count):
+            feature_vector = feature_values[component, step]
+            transition, forcing = mean_model.transition_and_forcing(feature_vector)
+            mean[component, step + 1] = (
+                transition @ mean[component, step] + forcing
+            )
+            innovation = covariance_model.innovation_covariance_m2(feature_vector)
+            for coordinate in range(3):
+                previous = covariance[component, step, coordinate]
+                covariance[component, step + 1, coordinate] = (
+                    _positive_semidefinite(
+                        transition @ previous @ transition.T + innovation
+                    )
+                )
+
+    readout_mean = np.einsum("nr,khrc->khnc", graph_basis, mean)
+    readout_variance = np.empty_like(readout_mean)
+    for component in range(component_count):
+        for step in range(horizon + 1):
+            for coordinate in range(3):
+                readout_variance[component, step, :, coordinate] = (
+                    np.einsum(
+                        "ni,ij,nj->n",
+                        graph_basis,
+                        covariance[component, step, coordinate],
+                        graph_basis,
+                    )
+                    + belief.projection_variance_m2[coordinate]
+                )
+
+    return ActionConditionedDiscrepancyForecast(
+        coefficient_mean_m=mean,
+        coefficient_covariance_m2=covariance,
+        readout_mean_m=readout_mean,
+        readout_variance_m2=np.maximum(readout_variance, 0.0),
+        model_id=f"{mean_model.model_id}+{covariance_model.model_id}",
+    )

--- a/tests/test_causal4d_discrepancy_mean_transition.py
+++ b/tests/test_causal4d_discrepancy_mean_transition.py
@@ -1,0 +1,172 @@
+import numpy as np
+import pytest
+
+from causal4d.action_conditioned_discrepancy import (
+    ActionConditionedDiscrepancyFeatures,
+    ActionConditionedDiscrepancyModel,
+    forecast_action_conditioned_persistence,
+)
+from causal4d.contracts import array_sha256
+from causal4d.discrepancy_belief import GraphDiscrepancyBelief
+from causal4d.discrepancy_mean_transition import (
+    ActionConditionedMeanTransitionModel,
+    forecast_action_conditioned_movement,
+)
+
+
+def _belief(basis: np.ndarray, *, zero_mean: bool = False) -> GraphDiscrepancyBelief:
+    mean = np.zeros((1, 2, 3), dtype=float)
+    if not zero_mean:
+        mean[0, 0, 0] = 1.0
+    covariance = np.zeros((1, 3, 2, 2), dtype=float)
+    covariance[0, 0] = np.diag([4e-6, 1e-6])
+    return GraphDiscrepancyBelief(
+        basis_sha256=array_sha256(basis),
+        component_ids=("component-0",),
+        coefficient_mean_m=mean,
+        coefficient_covariance_m2=covariance,
+        projection_variance_m2=np.asarray([1e-6, 2e-6, 3e-6]),
+        transition_model_id="persistence",
+        innovation_model_id="unit-test",
+        metadata={"future_frames_read": 0},
+    )
+
+
+def _covariance_model(
+    feature_names: tuple[str, ...],
+    *,
+    base: np.ndarray | None = None,
+) -> ActionConditionedDiscrepancyModel:
+    return ActionConditionedDiscrepancyModel(
+        feature_names=feature_names,
+        base_innovation_covariance_m2=(
+            np.zeros((2, 2), dtype=float) if base is None else base
+        ),
+        feature_directions=np.zeros((0, 2), dtype=float),
+        feature_weights=np.zeros((0, len(feature_names)), dtype=float),
+    )
+
+
+def test_persistence_model_reproduces_existing_forecast_exactly() -> None:
+    basis = np.asarray([[1.0, 0.0], [0.0, 1.0], [0.5, -0.5]])
+    belief = _belief(basis)
+    features = ActionConditionedDiscrepancyFeatures(
+        names=("speed",),
+        values=np.asarray([[0.0], [3.0], [7.0]]),
+    )
+    covariance_model = _covariance_model(
+        features.names,
+        base=np.asarray([[2e-6, 5e-7], [5e-7, 1e-6]]),
+    )
+    persistence = ActionConditionedMeanTransitionModel.persistence(
+        features.names,
+        belief.rank,
+    )
+
+    expected = forecast_action_conditioned_persistence(
+        belief,
+        covariance_model,
+        features,
+        basis,
+    )
+    actual = forecast_action_conditioned_movement(
+        belief,
+        persistence,
+        covariance_model,
+        features,
+        basis,
+    )
+
+    assert actual.model_id == expected.model_id
+    for field in (
+        "coefficient_mean_m",
+        "coefficient_covariance_m2",
+        "readout_mean_m",
+        "readout_variance_m2",
+    ):
+        np.testing.assert_array_equal(getattr(actual, field), getattr(expected, field))
+
+
+def test_transition_contracts_and_rotates_between_graph_modes() -> None:
+    basis = np.eye(2)
+    belief = _belief(basis)
+    features = ActionConditionedDiscrepancyFeatures(
+        names=("movement",),
+        values=np.ones((1, 1), dtype=float),
+    )
+    model = ActionConditionedMeanTransitionModel(
+        feature_names=features.names,
+        contraction_directions=np.asarray([[1.0, 0.0]]),
+        contraction_weights=np.asarray([[np.sqrt(np.log(2.0))]]),
+        rotation_generators=np.asarray([[[0.0, -1.0], [1.0, 0.0]]]),
+        rotation_weights=np.asarray([[np.pi / 2.0]]),
+        forcing_weights_m=np.zeros((2, 3, 1), dtype=float),
+    )
+
+    transition, forcing = model.transition_and_forcing(np.ones(1))
+    singular_values = np.linalg.svd(transition, compute_uv=False)
+    assert singular_values[0] <= 1.0 + 1e-12
+    np.testing.assert_array_equal(forcing, np.zeros((2, 3)))
+
+    forecast = forecast_action_conditioned_movement(
+        belief,
+        model,
+        _covariance_model(features.names),
+        features,
+        basis,
+    )
+    np.testing.assert_allclose(
+        forecast.coefficient_mean_m[0, 1, :, 0],
+        np.asarray([0.0, 0.5]),
+        atol=1e-12,
+    )
+    assert np.trace(forecast.coefficient_covariance_m2[0, 1, 0]) < np.trace(
+        belief.coefficient_covariance_m2[0, 0]
+    )
+
+
+def test_action_forcing_is_bounded_in_graph_coefficient_space() -> None:
+    basis = np.eye(2)
+    belief = _belief(basis, zero_mean=True)
+    features = ActionConditionedDiscrepancyFeatures(
+        names=("movement",),
+        values=np.ones((1, 1), dtype=float),
+    )
+    forcing_weights = np.zeros((2, 3, 1), dtype=float)
+    forcing_weights[0, 0, 0] = 10.0
+    model = ActionConditionedMeanTransitionModel(
+        feature_names=features.names,
+        contraction_directions=np.zeros((0, 2), dtype=float),
+        contraction_weights=np.zeros((0, 1), dtype=float),
+        rotation_generators=np.zeros((0, 2, 2), dtype=float),
+        rotation_weights=np.zeros((0, 1), dtype=float),
+        forcing_weights_m=forcing_weights,
+        maximum_forcing_norm_m=0.01,
+    )
+
+    _, forcing = model.transition_and_forcing(np.ones(1))
+    np.testing.assert_allclose(np.linalg.norm(forcing), 0.01, atol=1e-15)
+    forecast = forecast_action_conditioned_movement(
+        belief,
+        model,
+        _covariance_model(features.names),
+        features,
+        basis,
+    )
+    np.testing.assert_allclose(
+        np.linalg.norm(forecast.coefficient_mean_m[0, 1]),
+        0.01,
+        atol=1e-15,
+    )
+
+
+def test_rotation_generators_must_be_skew_symmetric() -> None:
+    with pytest.raises(ValueError, match="skew-symmetric"):
+        ActionConditionedMeanTransitionModel(
+            feature_names=("movement",),
+            contraction_directions=np.zeros((0, 2), dtype=float),
+            contraction_weights=np.zeros((0, 1), dtype=float),
+            rotation_generators=np.asarray([[[0.0, 1.0], [0.0, 0.0]]]),
+            rotation_weights=np.ones((1, 1), dtype=float),
+            forcing_weights_m=np.zeros((2, 3, 1), dtype=float),
+        )


### PR DESCRIPTION
## What changed

- add `ActionConditionedMeanTransitionModel` for low-rank graph-discrepancy mean movement
- parameterize movement as an orthogonal mode rotation followed by a non-expansive contraction, plus bounded additive forcing
- propagate covariance consistently as `A P A^T + Q`
- preserve the current graph-persistence implementation exactly through a zero-weight fast fallback
- export the new API and document its source-only fitting and fail-closed promotion boundary
- add focused tests for exact fallback, contraction/rotation and mode transfer, bounded forcing, and skew-generator validation

## Why

The released discrepancy diagnostics indicate interaction-dependent contraction, rotation, and graph-mode transfer, while the existing action-conditioned module changes covariance only and keeps the discrepancy mean fixed. This PR adds the smallest stable movement model that can represent those effects without injecting corrections into simulator state.

## Scientific boundary

This is opt-in inference machinery, not a promoted real-data mechanism. Movement parameters, graph rank, caps, feature normalization, and covariance settings must be selected on source executions or preregistered. Rejection retains byte-identical graph persistence through the existing forecast path.

## Validation

- isolated mathematical/API tests: 3 passed locally
- Python syntax compilation passed locally
- repository-native tests are included for CI

The execution environment could not clone GitHub or run the full repository suite, so full-suite validation is intentionally left to GitHub CI.