### PR TITLE
Add stable regime-conditioned discrepancy transitions

### DIFF
--- a/docs/regime_conditioned_discrepancy.md
+++ b/docs/regime_conditioned_discrepancy.md
@@ -1,0 +1,85 @@
+# Regime-conditioned graph discrepancy
+
+## Purpose
+
+Graph persistence is the current real-data discrepancy baseline, but the frozen
+state diagnostics show interaction-dependent contraction, rotation, and transfer
+between graph modes. This opt-in module adds a stable mean transition conditioned
+on the declared contact regime and action features. It does not alter the frozen
+`v0.3.0-causal4d-aip` path or promote a new real-data mechanism.
+
+## Stable transition
+
+For contact regime `r` and feature vector `f_t`, the coefficient transition is
+
+```text
+rate_r(f_t) = base_rate_r + (w_r^T f_t)^2
+alpha_r(f_t) = 1 - exp(-rate_r(f_t))
+A_r(f_t) = (1 - alpha_r) I + alpha_r T_r
+```
+
+Each declared target operator `T_r` must have spectral norm at most one. The
+convex combination is therefore non-expansive, while allowing contraction,
+rotation, and mode mixing. Zero base rates and zero feature weights return the
+identity exactly, giving byte-exact coefficient persistence when no innovation
+covariance is supplied.
+
+The forecast propagates
+
+```text
+a_(t+1) = A_r(f_t) a_t
+P_(t+1) = A_r(f_t) P_t A_r(f_t)^T + Q(f_t)
+```
+
+where `Q(f_t)` may be supplied by the existing
+`ActionConditionedDiscrepancyModel`. This reuses its positive-semidefinite,
+action-conditioned covariance growth while extending the discrepancy mean.
+
+## Contact-path interface
+
+`forecast_regime_conditioned_discrepancy` accepts either one shared regime path
+with shape `(H,)` or component-specific paths with shape `(K, H)`. The indices
+follow `causal4d.dynamic_contact.ContactRegime`:
+
+- inactive;
+- sticking;
+- slipping;
+- detached.
+
+The routine also accepts shared or component-specific action features and checks
+component IDs, graph-basis hashes, model rank, feature schemas, regime support,
+and non-expansiveness.
+
+## Example
+
+```python
+from causal4d import (
+    RegimeConditionedDiscrepancyTransitionModel,
+    forecast_regime_conditioned_discrepancy,
+)
+
+transition = RegimeConditionedDiscrepancyTransitionModel(
+    feature_names=features.names,
+    target_matrices=source_frozen_targets,
+    base_activation_rates=source_frozen_rates,
+    feature_weights=source_frozen_weights,
+)
+
+forecast = forecast_regime_conditioned_discrepancy(
+    discrepancy_belief,
+    transition,
+    features,
+    contact_path.regime_paths,
+    graph_basis,
+    innovation_model=action_conditioned_covariance,
+)
+```
+
+## Evidence boundary
+
+Target futures must not select target matrices, activation rates, feature
+weights, basis rank, or innovation parameters. Candidate transitions should be
+fit on source executions, shrunk toward identity, and compared prospectively
+against exact graph persistence in leave-one-action and leave-one-contact folds.
+The registered same-object multi-action protocol remains the required promotion
+gate.

--- a/src/causal4d/__init__.py
+++ b/src/causal4d/__init__.py
@@ -53,6 +53,11 @@ from causal4d.prefix_likelihood import (
     prefix_component_log_likelihood,
     update_joint_weights_from_prefix,
 )
+from causal4d.regime_conditioned_discrepancy import (
+    RegimeConditionedDiscrepancyForecast,
+    RegimeConditionedDiscrepancyTransitionModel,
+    forecast_regime_conditioned_discrepancy,
+)
 from causal4d.rollout_bank import JointRolloutBank, SparseTrajectoryEvidence
 from causal4d.semantic_freshness import (
     SEMANTIC_TIMING_SCHEMA_VERSION,
@@ -82,6 +87,8 @@ __all__ = [
     "ObservationGroup",
     "PhysicalPosterior",
     "PrefixLikelihoodConfig",
+    "RegimeConditionedDiscrepancyForecast",
+    "RegimeConditionedDiscrepancyTransitionModel",
     "SEMANTIC_TIMING_SCHEMA_VERSION",
     "SEMANTIC_TIMING_SCOPE",
     "SemanticFreshnessDecision",
@@ -99,6 +106,7 @@ __all__ = [
     "build_protocol",
     "finite_response_sensitivity",
     "forecast_action_conditioned_persistence",
+    "forecast_regime_conditioned_discrepancy",
     "graph_mode_joint_weights",
     "grouped_component_log_likelihoods",
     "load_graph_discrepancy_belief",

--- a/src/causal4d/regime_conditioned_discrepancy.py
+++ b/src/causal4d/regime_conditioned_discrepancy.py
@@ -1,0 +1,292 @@
+"""Stable contact-regime-conditioned graph-discrepancy mean transitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from causal4d.action_conditioned_discrepancy import (
+    ActionConditionedDiscrepancyFeatures,
+    ActionConditionedDiscrepancyModel,
+)
+from causal4d.contracts import array_sha256
+from causal4d.discrepancy_belief import GraphDiscrepancyBelief
+from causal4d.dynamic_contact import CONTACT_REGIME_NAMES
+
+
+def _readonly(values: np.ndarray, *, dtype: type | None = float) -> np.ndarray:
+    array = np.asarray(values, dtype=dtype).copy()
+    array.setflags(write=False)
+    return array
+
+
+def _positive_semidefinite(matrix: np.ndarray) -> np.ndarray:
+    symmetric = 0.5 * (matrix + matrix.T)
+    eigenvalues, eigenvectors = np.linalg.eigh(symmetric)
+    return (eigenvectors * np.maximum(eigenvalues, 0.0)) @ eigenvectors.T
+
+
+@dataclass(frozen=True)
+class RegimeConditionedDiscrepancyTransitionModel:
+    """Stable feature-activated transition toward one operator per regime.
+
+    The transition is a convex combination of identity and a declared
+    non-expansive target operator. Therefore it cannot increase the Euclidean
+    coefficient norm. Zero base rates and zero feature weights recover identity
+    exactly.
+    """
+
+    feature_names: tuple[str, ...]
+    target_matrices: np.ndarray
+    base_activation_rates: np.ndarray
+    feature_weights: np.ndarray
+    regime_names: tuple[str, ...] = CONTACT_REGIME_NAMES
+    model_id: str = "regime-conditioned-graph-transition-v1"
+
+    def __post_init__(self) -> None:
+        feature_names = tuple(map(str, self.feature_names))
+        regime_names = tuple(map(str, self.regime_names))
+        targets = _readonly(self.target_matrices)
+        base_rates = _readonly(self.base_activation_rates)
+        weights = _readonly(self.feature_weights)
+        if not self.model_id or not feature_names:
+            raise ValueError("model_id and feature_names must be nonempty")
+        if len(set(feature_names)) != len(feature_names):
+            raise ValueError("feature_names must be unique")
+        if not regime_names or len(set(regime_names)) != len(regime_names):
+            raise ValueError("regime_names must be nonempty and unique")
+        if targets.ndim != 3 or targets.shape[0] != len(regime_names):
+            raise ValueError(
+                "target_matrices must have shape (regime_count, rank, rank)"
+            )
+        if targets.shape[1] < 1 or targets.shape[1] != targets.shape[2]:
+            raise ValueError("target_matrices must be square with positive rank")
+        if base_rates.shape != (len(regime_names),):
+            raise ValueError("base_activation_rates must match regime_names")
+        if weights.shape != (len(regime_names), len(feature_names)):
+            raise ValueError("feature_weights must have shape (regime_count, F)")
+        if not all(
+            np.all(np.isfinite(value)) for value in (targets, base_rates, weights)
+        ):
+            raise ValueError("transition arrays must be finite")
+        if np.any(base_rates < 0.0):
+            raise ValueError("base activation rates must be nonnegative")
+        spectral_norms = np.linalg.svd(targets, compute_uv=False)[:, 0]
+        if np.any(spectral_norms > 1.0 + 1e-10):
+            raise ValueError("target transition matrices must be non-expansive")
+        object.__setattr__(self, "feature_names", feature_names)
+        object.__setattr__(self, "regime_names", regime_names)
+        object.__setattr__(self, "target_matrices", targets)
+        object.__setattr__(self, "base_activation_rates", base_rates)
+        object.__setattr__(self, "feature_weights", weights)
+
+    @property
+    def rank(self) -> int:
+        return int(self.target_matrices.shape[1])
+
+    def transition_matrix(
+        self,
+        regime: int,
+        feature_vector: np.ndarray,
+    ) -> np.ndarray:
+        """Return a stable transition, with exact identity at zero activation."""
+
+        regime_index = int(regime)
+        if not 0 <= regime_index < len(self.regime_names):
+            raise ValueError("regime index is outside the declared support")
+        features = np.asarray(feature_vector, dtype=float)
+        if features.shape != (len(self.feature_names),) or not np.all(
+            np.isfinite(features)
+        ):
+            raise ValueError("feature vector does not match the transition model")
+        projected = float(self.feature_weights[regime_index] @ features)
+        rate = self.base_activation_rates[regime_index] + projected * projected
+        if not np.isfinite(rate):
+            raise ValueError("feature activation produced a non-finite rate")
+        identity = np.eye(self.rank)
+        if rate == 0.0:
+            return identity
+        activation = -np.expm1(-rate)
+        return (
+            (1.0 - activation) * identity
+            + activation * self.target_matrices[regime_index]
+        )
+
+
+@dataclass(frozen=True)
+class RegimeConditionedDiscrepancyForecast:
+    """Coefficient and graph-readout moments for a declared contact path."""
+
+    coefficient_mean_m: np.ndarray
+    coefficient_covariance_m2: np.ndarray
+    readout_mean_m: np.ndarray
+    readout_variance_m2: np.ndarray
+    transition_matrices: np.ndarray
+    regime_paths: np.ndarray
+    transition_model_id: str
+    innovation_model_id: str | None
+
+
+def _component_features(
+    features: ActionConditionedDiscrepancyFeatures,
+    component_ids: tuple[str, ...],
+) -> np.ndarray:
+    component_count = len(component_ids)
+    values = np.asarray(features.values, dtype=float)
+    if values.ndim == 2:
+        return np.broadcast_to(
+            values[None],
+            (component_count, *values.shape),
+        )
+    if values.ndim != 3:
+        raise ValueError("feature values must have shape (H, F) or (K, H, F)")
+    if features.component_ids != component_ids:
+        raise ValueError("component-specific feature IDs differ from the belief")
+    return values
+
+
+def _component_regime_paths(
+    regime_paths: np.ndarray,
+    *,
+    component_count: int,
+    horizon: int,
+    regime_count: int,
+) -> np.ndarray:
+    supplied = np.asarray(regime_paths)
+    if supplied.ndim == 1:
+        if supplied.shape != (horizon,):
+            raise ValueError("shared regime path must have shape (H,)")
+        supplied = np.broadcast_to(supplied[None], (component_count, horizon))
+    elif supplied.shape != (component_count, horizon):
+        raise ValueError("regime_paths must have shape (H,) or (K, H)")
+    if not np.issubdtype(supplied.dtype, np.integer):
+        if not np.all(np.equal(supplied, np.floor(supplied))):
+            raise ValueError("regime paths must contain integer indices")
+    paths = np.asarray(supplied, dtype=np.int64)
+    if np.any(paths < 0) or np.any(paths >= regime_count):
+        raise ValueError("regime paths contain an unknown regime")
+    return paths
+
+
+def forecast_regime_conditioned_discrepancy(
+    belief: GraphDiscrepancyBelief,
+    transition_model: RegimeConditionedDiscrepancyTransitionModel,
+    features: ActionConditionedDiscrepancyFeatures,
+    regime_paths: np.ndarray,
+    basis: np.ndarray,
+    *,
+    innovation_model: ActionConditionedDiscrepancyModel | None = None,
+) -> RegimeConditionedDiscrepancyForecast:
+    """Propagate discrepancy moments under stable contact-conditioned dynamics."""
+
+    graph_basis = np.asarray(basis, dtype=float)
+    if graph_basis.ndim != 2 or graph_basis.shape[1] != belief.rank:
+        raise ValueError("basis must have shape (node_count, belief.rank)")
+    if not np.all(np.isfinite(graph_basis)):
+        raise ValueError("basis must be finite")
+    if array_sha256(graph_basis) != belief.basis_sha256:
+        raise ValueError("basis hash differs from the graph-discrepancy belief")
+    if transition_model.rank != belief.rank:
+        raise ValueError("transition rank differs from the discrepancy belief")
+    if transition_model.feature_names != features.names:
+        raise ValueError("transition feature schema differs from supplied features")
+    if innovation_model is not None and (
+        innovation_model.rank != belief.rank
+        or innovation_model.feature_names != features.names
+    ):
+        raise ValueError("innovation model differs from the belief or features")
+
+    component_ids = tuple(belief.component_ids)
+    component_count = len(component_ids)
+    horizon = features.horizon
+    feature_values = _component_features(features, component_ids)
+    paths = _component_regime_paths(
+        regime_paths,
+        component_count=component_count,
+        horizon=horizon,
+        regime_count=len(transition_model.regime_names),
+    )
+
+    mean = np.empty(
+        (component_count, horizon + 1, belief.rank, 3),
+        dtype=float,
+    )
+    covariance = np.empty(
+        (component_count, horizon + 1, 3, belief.rank, belief.rank),
+        dtype=float,
+    )
+    transitions = np.empty(
+        (component_count, horizon, belief.rank, belief.rank),
+        dtype=float,
+    )
+    mean[:, 0] = belief.coefficient_mean_m
+    covariance[:, 0] = belief.coefficient_covariance_m2
+    identity = np.eye(belief.rank)
+    zero_innovation = np.zeros((belief.rank, belief.rank), dtype=float)
+
+    for component in range(component_count):
+        for step in range(horizon):
+            feature = feature_values[component, step]
+            transition = transition_model.transition_matrix(
+                int(paths[component, step]),
+                feature,
+            )
+            transitions[component, step] = transition
+            innovation = (
+                zero_innovation
+                if innovation_model is None
+                else innovation_model.innovation_covariance_m2(feature)
+            )
+            innovation = _positive_semidefinite(innovation)
+            if np.array_equal(transition, identity):
+                mean[component, step + 1] = mean[component, step]
+                if np.array_equal(innovation, zero_innovation):
+                    covariance[component, step + 1] = covariance[component, step]
+                else:
+                    for coordinate in range(3):
+                        covariance[component, step + 1, coordinate] = (
+                            _positive_semidefinite(
+                                covariance[component, step, coordinate] + innovation
+                            )
+                        )
+                continue
+            for coordinate in range(3):
+                mean[component, step + 1, :, coordinate] = (
+                    transition @ mean[component, step, :, coordinate]
+                )
+                covariance[component, step + 1, coordinate] = (
+                    _positive_semidefinite(
+                        transition
+                        @ covariance[component, step, coordinate]
+                        @ transition.T
+                        + innovation
+                    )
+                )
+
+    readout_mean = np.einsum("nr,khrc->khnc", graph_basis, mean)
+    readout_variance = np.empty_like(readout_mean)
+    for component in range(component_count):
+        for step in range(horizon + 1):
+            for coordinate in range(3):
+                readout_variance[component, step, :, coordinate] = (
+                    np.einsum(
+                        "ni,ij,nj->n",
+                        graph_basis,
+                        covariance[component, step, coordinate],
+                        graph_basis,
+                    )
+                    + belief.projection_variance_m2[coordinate]
+                )
+    return RegimeConditionedDiscrepancyForecast(
+        coefficient_mean_m=mean,
+        coefficient_covariance_m2=covariance,
+        readout_mean_m=readout_mean,
+        readout_variance_m2=np.maximum(readout_variance, 0.0),
+        transition_matrices=transitions,
+        regime_paths=paths,
+        transition_model_id=transition_model.model_id,
+        innovation_model_id=(
+            None if innovation_model is None else innovation_model.model_id
+        ),
+    )

--- a/tests/test_causal4d_regime_conditioned_discrepancy.py
+++ b/tests/test_causal4d_regime_conditioned_discrepancy.py
@@ -1,0 +1,183 @@
+import numpy as np
+import pytest
+
+from causal4d.action_conditioned_discrepancy import (
+    ActionConditionedDiscrepancyFeatures,
+    ActionConditionedDiscrepancyModel,
+)
+from causal4d.contracts import array_sha256
+from causal4d.discrepancy_belief import GraphDiscrepancyBelief
+from causal4d.dynamic_contact import ContactRegime
+from causal4d.regime_conditioned_discrepancy import (
+    RegimeConditionedDiscrepancyTransitionModel,
+    forecast_regime_conditioned_discrepancy,
+)
+
+
+def _belief(basis: np.ndarray) -> GraphDiscrepancyBelief:
+    return GraphDiscrepancyBelief(
+        basis_sha256=array_sha256(basis),
+        component_ids=("component-a", "component-b"),
+        coefficient_mean_m=np.asarray(
+            [
+                [[0.01, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                [[0.01, 0.0, 0.0], [0.0, 0.0, 0.0]],
+            ]
+        ),
+        coefficient_covariance_m2=np.broadcast_to(
+            np.asarray([[1e-4, 2e-5], [2e-5, 7e-5]])[None, None],
+            (2, 3, 2, 2),
+        ).copy(),
+        projection_variance_m2=np.asarray([1e-6] * 3),
+        transition_model_id="persistence",
+        innovation_model_id="unit-test",
+    )
+
+
+def _model(
+    *,
+    base_rates: np.ndarray | None = None,
+    feature_weights: np.ndarray | None = None,
+) -> RegimeConditionedDiscrepancyTransitionModel:
+    targets = np.repeat(np.eye(2)[None], 4, axis=0)
+    targets[ContactRegime.STICKING] = np.asarray([[0.0, -0.8], [0.8, 0.0]])
+    return RegimeConditionedDiscrepancyTransitionModel(
+        feature_names=("speed",),
+        target_matrices=targets,
+        base_activation_rates=(
+            np.zeros(4) if base_rates is None else base_rates
+        ),
+        feature_weights=(
+            np.zeros((4, 1)) if feature_weights is None else feature_weights
+        ),
+    )
+
+
+def test_zero_activation_is_exact_persistence() -> None:
+    basis = np.eye(2)
+    belief = _belief(basis)
+    features = ActionConditionedDiscrepancyFeatures(
+        names=("speed",),
+        values=np.asarray([[0.0], [3.0]]),
+    )
+    forecast = forecast_regime_conditioned_discrepancy(
+        belief,
+        _model(),
+        features,
+        np.asarray([ContactRegime.INACTIVE, ContactRegime.STICKING]),
+        basis,
+    )
+    np.testing.assert_array_equal(
+        forecast.coefficient_mean_m,
+        np.broadcast_to(
+            belief.coefficient_mean_m[:, None],
+            forecast.coefficient_mean_m.shape,
+        ),
+    )
+    np.testing.assert_array_equal(
+        forecast.coefficient_covariance_m2,
+        np.broadcast_to(
+            belief.coefficient_covariance_m2[:, None],
+            forecast.coefficient_covariance_m2.shape,
+        ),
+    )
+
+
+def test_sticking_transition_contracts_and_mixes_modes() -> None:
+    basis = np.eye(2)
+    belief = _belief(basis)
+    features = ActionConditionedDiscrepancyFeatures(
+        names=("speed",),
+        values=np.asarray([[1.0]]),
+    )
+    base_rates = np.zeros(4)
+    base_rates[ContactRegime.STICKING] = np.log(2.0)
+    forecast = forecast_regime_conditioned_discrepancy(
+        belief,
+        _model(base_rates=base_rates),
+        features,
+        np.asarray([ContactRegime.STICKING]),
+        basis,
+    )
+    expected_transition = 0.5 * np.eye(2) + 0.5 * np.asarray(
+        [[0.0, -0.8], [0.8, 0.0]]
+    )
+    np.testing.assert_allclose(
+        forecast.transition_matrices[0, 0],
+        expected_transition,
+    )
+    np.testing.assert_allclose(
+        forecast.coefficient_mean_m[0, 1, :, 0],
+        expected_transition @ np.asarray([0.01, 0.0]),
+    )
+    assert np.linalg.norm(forecast.coefficient_mean_m[0, 1, :, 0]) < 0.01
+    assert forecast.coefficient_mean_m[0, 1, 1, 0] > 0.0
+
+
+def test_component_specific_regimes_produce_different_means() -> None:
+    basis = np.eye(2)
+    belief = _belief(basis)
+    features = ActionConditionedDiscrepancyFeatures(
+        names=("speed",),
+        values=np.asarray([[1.0]]),
+    )
+    base_rates = np.zeros(4)
+    base_rates[ContactRegime.STICKING] = 2.0
+    forecast = forecast_regime_conditioned_discrepancy(
+        belief,
+        _model(base_rates=base_rates),
+        features,
+        np.asarray(
+            [[ContactRegime.INACTIVE], [ContactRegime.STICKING]]
+        ),
+        basis,
+    )
+    np.testing.assert_array_equal(
+        forecast.coefficient_mean_m[0, 1],
+        belief.coefficient_mean_m[0],
+    )
+    assert not np.array_equal(
+        forecast.coefficient_mean_m[1, 1],
+        belief.coefficient_mean_m[1],
+    )
+
+
+def test_covariance_uses_transition_and_conditioned_innovation() -> None:
+    basis = np.eye(2)
+    belief = _belief(basis)
+    features = ActionConditionedDiscrepancyFeatures(
+        names=("speed",),
+        values=np.asarray([[2.0]]),
+    )
+    base_rates = np.zeros(4)
+    base_rates[ContactRegime.STICKING] = 1.0
+    innovation_model = ActionConditionedDiscrepancyModel(
+        feature_names=("speed",),
+        base_innovation_covariance_m2=np.eye(2) * 1e-6,
+        feature_directions=np.asarray([[1.0, 0.0]]),
+        feature_weights=np.asarray([[0.01]]),
+    )
+    forecast = forecast_regime_conditioned_discrepancy(
+        belief,
+        _model(base_rates=base_rates),
+        features,
+        np.asarray([ContactRegime.STICKING]),
+        basis,
+        innovation_model=innovation_model,
+    )
+    assert np.all(
+        np.linalg.eigvalsh(forecast.coefficient_covariance_m2) >= -1e-12
+    )
+    assert forecast.innovation_model_id == innovation_model.model_id
+
+
+def test_expansive_target_is_rejected() -> None:
+    targets = np.repeat(np.eye(2)[None], 4, axis=0)
+    targets[0, 0, 0] = 1.01
+    with pytest.raises(ValueError, match="non-expansive"):
+        RegimeConditionedDiscrepancyTransitionModel(
+            feature_names=("speed",),
+            target_matrices=targets,
+            base_activation_rates=np.zeros(4),
+            feature_weights=np.zeros((4, 1)),
+        )


### PR DESCRIPTION
## What changed

- add `RegimeConditionedDiscrepancyTransitionModel`, which activates a stable contact-regime-specific mean operator from action features
- propagate graph-discrepancy means and covariances with `A P A^T + Q`, reusing the existing action-conditioned innovation model
- support shared or component-specific contact paths and action features
- preserve exact coefficient persistence when activation and innovation are zero
- reject expansive target operators and validate graph hashes, ranks, schemas, component IDs, and regime support
- expose the new API from `causal4d`
- document the source-only fitting and prospective promotion boundary

## Why

The frozen diagnostics show interaction-dependent contraction, rotation, and transfer between graph modes, while the current action-conditioned discrepancy path keeps the mean persistent and changes only covariance. This PR adds the smallest auditable extension that can represent those effects without replacing or modifying the frozen `v0.3.0-causal4d-aip` path.

## Validation

- focused unit suite: 5 passed
- Python compilation passed
- line-length audit passed for the new module and tests

The focused tests cover exact persistence fallback, stable contraction and mode mixing, component-specific contact regimes, covariance propagation with the existing action-conditioned innovation model, and rejection of expansive operators.

## Evidence boundary

This is opt-in inference machinery, not promoted real-data evidence. Target futures must not select the transition operators, activation rates, feature weights, rank, or innovation model. Promotion remains contingent on source-frozen leave-one-action/contact evaluation and the registered same-object multi-action protocol.