### PR TITLE
Preserve discrepancy covariance and add query-aware identifiability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,195 @@
+name: CI and release
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Ruff
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package and development tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ".[dev]"
+
+      - name: Run Ruff
+        run: python -m ruff check .
+
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.12"
+          - "3.14"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ".[dev]"
+
+      - name: Run test suite
+        run: >-
+          python -m pytest
+          --tb=short
+          --junitxml=pytest-results-${{ matrix.python-version }}.xml
+
+      - name: Upload pytest report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pytest-results-${{ matrix.python-version }}
+          path: pytest-results-${{ matrix.python-version }}.xml
+          if-no-files-found: warn
+          retention-days: 14
+
+  build:
+    name: Build distribution
+    needs:
+      - lint
+      - test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build wheel and source distribution
+        run: python -m build
+
+      - name: Validate distribution metadata
+        run: python -m twine check dist/*
+
+      - name: Smoke-test built wheel
+        shell: bash
+        run: |
+          python -m venv "$RUNNER_TEMP/causal4d-wheel-smoke"
+          "$RUNNER_TEMP/causal4d-wheel-smoke/bin/python" -m pip install --upgrade pip
+          "$RUNNER_TEMP/causal4d-wheel-smoke/bin/python" -m pip install dist/*.whl
+          cd "$RUNNER_TEMP"
+          "$RUNNER_TEMP/causal4d-wheel-smoke/bin/python" - <<'PY'
+          import causal4d
+
+          print(f"Imported causal4d {causal4d.__version__} from the built wheel")
+          PY
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-distributions
+          path: dist/
+          if-no-files-found: error
+          retention-days: 14
+
+  release:
+    name: Publish GitHub release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Download distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: python-distributions
+          path: dist
+
+      - name: Verify tag matches package version
+        shell: bash
+        run: |
+          package_version="$(python - <<'PY'
+          import pathlib
+          import tomllib
+
+          with pathlib.Path("pyproject.toml").open("rb") as stream:
+              print(tomllib.load(stream)["project"]["version"])
+          PY
+          )"
+          expected_tag="v${package_version}"
+          if [[ "$GITHUB_REF_NAME" != "$expected_tag" ]]; then
+            echo "Tag $GITHUB_REF_NAME does not match package version $package_version."
+            echo "Expected tag: $expected_tag"
+            exit 1
+          fi
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" dist/* --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" dist/* \
+              --generate-notes \
+              --title "$GITHUB_REF_NAME" \
+              --verify-tag
+          fi

--- a/docs/covariance_and_query_identifiability.md
+++ b/docs/covariance_and_query_identifiability.md
@@ -1,0 +1,106 @@
+# Correlation-Preserving Abduction and Query-Aware Identifiability
+
+## Scope
+
+This development path is opt-in and does not modify the frozen
+`v0.3.0-causal4d-aip` milestone. It addresses two limitations of the current
+finite-bank inference:
+
+1. low-rank discrepancy, shared camera bias, and gauge uncertainty can be
+   correlated across nodes, coordinates, and frames, whereas a diagonal variance
+   loses that dependence;
+2. complete recovery of every intervention parameter is stronger than the actual
+   goal of identifying a particular held-out interventional prediction.
+
+The legacy diagonal grouped likelihood and binary identifiability decision remain
+unchanged when the new arguments are omitted.
+
+## Full grouped component covariance
+
+`posterior_weights_from_grouped_evidence` and
+`grouped_component_log_likelihoods` accept
+`component_group_covariance_m2`, a mapping from observation-group ID to a
+component-specific covariance. Each value must be broadcastable to
+
+```text
+component_shape + (group_coordinate_count, group_coordinate_count).
+```
+
+The covariance is added to the observation covariance and to any legacy
+component-wise diagonal variance before the robust Student-t mixture is scored.
+Every supplied matrix must be finite, symmetric, and positive semidefinite.
+Unknown group IDs fail closed.
+
+`graph_discrepancy_group_covariances` maps a `GraphDiscrepancyBelief` and its
+hash-locked graph basis into those grouped covariance matrices. The graph
+coefficient state is treated as persistent over the scored prefix, so the same
+mode observed at different frames remains correlated. The current belief stores
+separate coefficient covariance per Cartesian coordinate; cross-coordinate
+terms are therefore zero, while the declared projection variance remains a
+coordinate-wise diagonal remainder.
+
+Example:
+
+```python
+covariance_by_group = graph_discrepancy_group_covariances(
+    discrepancy_belief,
+    graph_basis,
+    grouped_evidence,
+    component_ids=particle_ids,
+)
+posterior, diagnostics = posterior_weights_from_grouped_evidence(
+    prior_weights,
+    predicted_components,
+    grouped_evidence,
+    prefix_frame_count=prefix_frame_count,
+    component_group_covariance_m2=covariance_by_group,
+)
+```
+
+A covariance with leading shape `(particle, d, d)` broadcasts over a rollout
+bank with leading shape `(hypothesis, particle)`. This lets one discrepancy
+belief per physical particle be shared across its intervention hypotheses.
+
+## Standardized partial identifiability
+
+`assess_intervention_identifiability` now accepts positive
+`parameter_scales`. For physical intervention coordinates `z` and standardized
+coordinates `eta`, use
+
+```text
+z - z0 = diag(parameter_scales) eta.
+```
+
+The conditional information matrix and its identified/null bases are computed in
+`eta` coordinates. Equivalent unit changes therefore give the same diagnostic
+when the sensitivity columns and scales are transformed consistently.
+
+The returned `identified_basis` and `null_basis` provide an explicit orthogonal
+decomposition. `project_identifiable_intervention_update` converts a proposed
+physical-unit update to standardized coordinates, removes its unresolved
+component, and converts it back.
+
+## Query-aware gate
+
+An optional `query_sensitivity` describes the local response of the requested
+future prediction to the intervention variables. The diagnostic reports
+
+```text
+query_null_response_fraction
+```
+
+as the fraction of squared query sensitivity lying in the unresolved
+intervention subspace. `query_identifiable` passes when that fraction does not
+exceed the preregistered
+`maximum_query_null_response_fraction`.
+
+This deliberately separates two statements:
+
+- `identifiable`: every declared intervention coordinate is locally identified;
+- `query_identifiable`: the requested prediction is insensitive enough to the
+  unidentified combinations.
+
+Thus a held-out prediction may remain admissible even when gain, delay, contact,
+or frame-bias components cannot all be individually recovered. Conversely, a
+query that amplifies an unresolved direction must widen uncertainty or abstain.
+Neither local result establishes global recovery or held-out calibration.

--- a/src/causal4d/__init__.py
+++ b/src/causal4d/__init__.py
@@ -20,6 +20,7 @@ from causal4d.contracts import (
 from causal4d.counterfactual import apply_counterfactual_operator
 from causal4d.discrepancy_belief import (
     GraphDiscrepancyBelief,
+    graph_discrepancy_group_covariances,
     load_graph_discrepancy_belief,
     write_graph_discrepancy_belief,
 )
@@ -43,6 +44,7 @@ from causal4d.identifiability import (
     InterventionIdentifiabilityResult,
     assess_intervention_identifiability,
     finite_response_sensitivity,
+    project_identifiable_intervention_update,
 )
 from causal4d.observation_evidence import (
     GroupedObservationEvidence,
@@ -99,11 +101,13 @@ __all__ = [
     "build_protocol",
     "finite_response_sensitivity",
     "forecast_action_conditioned_persistence",
+    "graph_discrepancy_group_covariances",
     "graph_mode_joint_weights",
     "grouped_component_log_likelihoods",
     "load_graph_discrepancy_belief",
     "posterior_weights_from_grouped_evidence",
     "prefix_component_log_likelihood",
+    "project_identifiable_intervention_update",
     "run_counterfactual_benchmark",
     "run_latent_contact_benchmark",
     "update_joint_weights_from_prefix",

--- a/src/causal4d/discrepancy_belief.py
+++ b/src/causal4d/discrepancy_belief.py
@@ -6,11 +6,12 @@ import hashlib
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 import numpy as np
 
 from causal4d.contracts import array_sha256
+from causal4d.observation_evidence import GroupedObservationEvidence
 
 
 GRAPH_DISCREPANCY_BELIEF_VERSION = 1
@@ -147,6 +148,85 @@ class GraphDiscrepancyBelief:
             digest.update(name.encode("utf-8"))
             digest.update(array_sha256(values).encode("ascii"))
         return digest.hexdigest()
+
+
+def graph_discrepancy_group_covariances(
+    belief: GraphDiscrepancyBelief,
+    graph_basis: np.ndarray,
+    evidence: GroupedObservationEvidence,
+    *,
+    component_ids: Sequence[str] | None = None,
+) -> dict[str, np.ndarray]:
+    """Map coefficient covariance to complete grouped observation covariance.
+
+    The coefficient state is persistent over the scored prefix. Consequently,
+    observations of the same graph mode at different frames remain correlated.
+    Cross-coordinate covariance is zero because the current belief stores one
+    coefficient covariance per Cartesian coordinate. ``projection_variance_m2``
+    is retained as an independent coordinate-wise diagonal remainder.
+
+    When ``component_ids`` are supplied, output covariances are selected and
+    reordered to match that component order. A particle-level covariance with
+    shape ``(P, d, d)`` can then broadcast over rollout components with leading
+    shape ``(H, P)`` in the grouped likelihood.
+    """
+
+    basis = np.asarray(graph_basis, dtype=float)
+    if basis.ndim != 2 or basis.shape[1] != belief.rank:
+        raise ValueError("graph_basis must have shape (node_count, belief.rank)")
+    if not np.all(np.isfinite(basis)):
+        raise ValueError("graph_basis must be finite")
+    if array_sha256(basis) != belief.basis_sha256:
+        raise ValueError("graph basis hash differs from the discrepancy belief")
+
+    if component_ids is None:
+        selected_indices = np.arange(len(belief.component_ids), dtype=np.int64)
+    else:
+        requested = tuple(component_ids)
+        if not requested or len(set(requested)) != len(requested):
+            raise ValueError("component_ids must be nonempty and unique")
+        lookup = {
+            identifier: index for index, identifier in enumerate(belief.component_ids)
+        }
+        missing = [identifier for identifier in requested if identifier not in lookup]
+        if missing:
+            raise ValueError(f"unknown discrepancy components: {missing}")
+        selected_indices = np.asarray(
+            [lookup[identifier] for identifier in requested],
+            dtype=np.int64,
+        )
+
+    coefficient_covariance = belief.coefficient_covariance_m2[selected_indices]
+    result: dict[str, np.ndarray] = {}
+    for group in evidence.groups:
+        if np.any(group.node_indices >= basis.shape[0]):
+            raise ValueError(
+                f"group {group.group_id!r} references unavailable graph nodes"
+            )
+        if np.any(group.coordinate_indices >= 3):
+            raise ValueError(
+                f"group {group.group_id!r} references unavailable coordinates"
+            )
+        count = group.coordinate_count
+        covariance = np.zeros((len(selected_indices), count, count), dtype=float)
+        for coordinate in range(3):
+            selected = np.flatnonzero(group.coordinate_indices == coordinate)
+            if not len(selected):
+                continue
+            design = basis[group.node_indices[selected]]
+            block = np.einsum(
+                "ir,krs,js->kij",
+                design,
+                coefficient_covariance[:, coordinate],
+                design,
+            )
+            covariance[:, selected[:, None], selected[None, :]] = block
+        diagonal = np.arange(count)
+        covariance[:, diagonal, diagonal] += belief.projection_variance_m2[
+            group.coordinate_indices
+        ]
+        result[group.group_id] = covariance
+    return result
 
 
 def write_graph_discrepancy_belief(

--- a/src/causal4d/grouped_likelihood.py
+++ b/src/causal4d/grouped_likelihood.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from math import lgamma
+from typing import Mapping
 
 import numpy as np
 
@@ -17,6 +18,7 @@ class GroupLikelihoodDiagnostics:
     group_ids: tuple[str, ...]
     effective_group_weights: tuple[float, ...]
     nominal_responsibilities: np.ndarray
+    full_covariance_group_ids: tuple[str, ...] = ()
 
 
 def _multivariate_student_t_log_density(
@@ -53,13 +55,50 @@ def _multivariate_student_t_log_density(
     )
 
 
+def _broadcast_additive_covariance(
+    values: np.ndarray,
+    *,
+    leading_shape: tuple[int, ...],
+    dimension: int,
+) -> np.ndarray:
+    covariance = np.asarray(values, dtype=float)
+    try:
+        covariance = np.broadcast_to(
+            covariance,
+            (*leading_shape, dimension, dimension),
+        )
+    except ValueError as error:
+        raise ValueError(
+            "additive_covariance_m2 must broadcast to component leading dimensions "
+            "and end in (coordinate, coordinate)"
+        ) from error
+    if not np.all(np.isfinite(covariance)):
+        raise ValueError("additive covariance must be finite")
+    if not np.allclose(
+        covariance,
+        covariance.swapaxes(-1, -2),
+        atol=1e-12,
+        rtol=1e-10,
+    ):
+        raise ValueError("additive covariance must be symmetric")
+    if float(np.min(np.linalg.eigvalsh(covariance), initial=0.0)) < -1e-10:
+        raise ValueError("additive covariance must be positive semidefinite")
+    return covariance
+
+
 def group_log_likelihood(
     predicted_values_m: np.ndarray,
     group: ObservationGroup,
     *,
     additive_variance_m2: np.ndarray | None = None,
+    additive_covariance_m2: np.ndarray | None = None,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Return robust mixture log likelihood and posterior nominal responsibility."""
+    """Return robust mixture log likelihood and posterior nominal responsibility.
+
+    ``additive_covariance_m2`` preserves component-specific correlation. The
+    legacy ``additive_variance_m2`` argument remains a diagonal convenience and
+    can be combined with the full covariance term.
+    """
 
     predictions = np.asarray(predicted_values_m, dtype=float)
     if predictions.shape[-1] != group.coordinate_count:
@@ -73,6 +112,12 @@ def group_log_likelihood(
         if np.any(~np.isfinite(additive)) or np.any(additive < 0.0):
             raise ValueError("additive variances must be finite and nonnegative")
         covariance = covariance + additive[..., :, None] * np.eye(group.coordinate_count)
+    if additive_covariance_m2 is not None:
+        covariance = covariance + _broadcast_additive_covariance(
+            additive_covariance_m2,
+            leading_shape=predictions.shape[:-1],
+            dimension=group.coordinate_count,
+        )
     nominal = _multivariate_student_t_log_density(
         residual,
         covariance,
@@ -97,8 +142,15 @@ def grouped_component_log_likelihoods(
     *,
     prefix_frame_count: int,
     component_variance_m2: np.ndarray | None = None,
+    component_group_covariance_m2: Mapping[str, np.ndarray] | None = None,
 ) -> tuple[np.ndarray, GroupLikelihoodDiagnostics]:
-    """Score arbitrary leading component dimensions against grouped O-plus evidence."""
+    """Score arbitrary leading component dimensions against grouped O-plus evidence.
+
+    ``component_group_covariance_m2`` maps a group ID to a covariance that is
+    broadcastable to ``component_shape + (group_coordinate, group_coordinate)``.
+    It is intended for low-rank graph discrepancy, shared camera bias, gauge, or
+    other correlated component uncertainty that would be lost by diagonalization.
+    """
 
     components = np.asarray(predicted_components_m, dtype=float)
     if components.ndim < 4:
@@ -117,16 +169,28 @@ def grouped_component_log_likelihoods(
         )
         if np.any(~np.isfinite(variance)) or np.any(variance < 0.0):
             raise ValueError("component variances must be finite and nonnegative")
+    covariance_by_group = dict(component_group_covariance_m2 or {})
+    known_group_ids = {group.group_id for group in evidence.groups}
+    unknown = set(covariance_by_group) - known_group_ids
+    if unknown:
+        raise ValueError(f"component covariance references unknown groups: {sorted(unknown)}")
     total = np.zeros(leading_shape, dtype=float)
     responsibilities = []
     effective_weights = evidence.effective_group_weights
+    full_covariance_groups = []
     for group, weight in zip(evidence.groups, effective_weights, strict=True):
         selected = group.selected_predictions(components)
         selected_variance = (
             None if variance is None else group.selected_predictions(variance)
         )
+        selected_covariance = covariance_by_group.get(group.group_id)
+        if selected_covariance is not None:
+            full_covariance_groups.append(group.group_id)
         log_likelihood, responsibility = group_log_likelihood(
-            selected, group, additive_variance_m2=selected_variance
+            selected,
+            group,
+            additive_variance_m2=selected_variance,
+            additive_covariance_m2=selected_covariance,
         )
         total += weight * log_likelihood
         responsibilities.append(responsibility)
@@ -134,6 +198,7 @@ def grouped_component_log_likelihoods(
         group_ids=tuple(group.group_id for group in evidence.groups),
         effective_group_weights=effective_weights,
         nominal_responsibilities=np.stack(responsibilities, axis=-1),
+        full_covariance_group_ids=tuple(full_covariance_groups),
     )
     return total, diagnostics
 
@@ -145,6 +210,7 @@ def posterior_weights_from_grouped_evidence(
     *,
     prefix_frame_count: int,
     component_variance_m2: np.ndarray | None = None,
+    component_group_covariance_m2: Mapping[str, np.ndarray] | None = None,
 ) -> tuple[np.ndarray, GroupLikelihoodDiagnostics]:
     """Apply grouped evidence to finite component support in log space."""
 
@@ -158,6 +224,7 @@ def posterior_weights_from_grouped_evidence(
         evidence,
         prefix_frame_count=prefix_frame_count,
         component_variance_m2=component_variance_m2,
+        component_group_covariance_m2=component_group_covariance_m2,
     )
     log_posterior = np.log(np.maximum(prior, 1e-300)) + score
     maximum = float(np.max(log_posterior))

--- a/src/causal4d/identifiability.py
+++ b/src/causal4d/identifiability.py
@@ -59,6 +59,7 @@ class InterventionIdentifiabilityResult:
     identifiable: bool
     failure_reasons: tuple[str, ...]
     query_failure_reasons: tuple[str, ...] = ()
+    extended_diagnostics: bool = False
 
     def __post_init__(self) -> None:
         information = np.asarray(self.conditional_information, dtype=float).copy()
@@ -130,7 +131,7 @@ class InterventionIdentifiabilityResult:
         return self.identified_basis @ self.identified_basis.T
 
     def as_dict(self) -> dict[str, object]:
-        return {
+        result: dict[str, object] = {
             "effective_rank": self.effective_rank,
             "parameter_count": self.parameter_count,
             "minimum_eigenvalue": self.minimum_eigenvalue,
@@ -139,16 +140,22 @@ class InterventionIdentifiabilityResult:
             ),
             "residualized_response_fraction": self.residualized_response_fraction,
             "maximum_subspace_cosine": self.maximum_subspace_cosine,
-            "parameter_scales": self.parameter_scales.tolist(),
-            "identified_basis": self.identified_basis.tolist(),
-            "null_basis": self.null_basis.tolist(),
-            "query_null_response_fraction": self.query_null_response_fraction,
-            "query_identifiable": self.query_identifiable,
             "identifiable": self.identifiable,
             "failure_reasons": list(self.failure_reasons),
-            "query_failure_reasons": list(self.query_failure_reasons),
             "eigenvalues": self.eigenvalues.tolist(),
         }
+        if self.extended_diagnostics:
+            result.update(
+                {
+                    "parameter_scales": self.parameter_scales.tolist(),
+                    "identified_basis": self.identified_basis.tolist(),
+                    "null_basis": self.null_basis.tolist(),
+                    "query_null_response_fraction": self.query_null_response_fraction,
+                    "query_identifiable": self.query_identifiable,
+                    "query_failure_reasons": list(self.query_failure_reasons),
+                }
+            )
+        return result
 
 
 def finite_response_sensitivity(
@@ -363,4 +370,7 @@ def assess_intervention_identifiability(
         identifiable=not reasons,
         failure_reasons=tuple(reasons),
         query_failure_reasons=tuple(query_reasons),
+        extended_diagnostics=(
+            parameter_scales is not None or query_sensitivity is not None
+        ),
     )

--- a/src/causal4d/identifiability.py
+++ b/src/causal4d/identifiability.py
@@ -17,6 +17,7 @@ class IdentifiabilityConfig:
     maximum_condition_number: float = 1e8
     minimum_residualized_response_fraction: float = 0.10
     maximum_subspace_cosine: float = 0.995
+    maximum_query_null_response_fraction: float = 0.10
 
     def __post_init__(self) -> None:
         if not 0.0 < self.relative_rank_tolerance < 1.0:
@@ -29,11 +30,18 @@ class IdentifiabilityConfig:
             raise ValueError("minimum_residualized_response_fraction must lie in [0, 1]")
         if not 0.0 <= self.maximum_subspace_cosine <= 1.0:
             raise ValueError("maximum_subspace_cosine must lie in [0, 1]")
+        if not 0.0 <= self.maximum_query_null_response_fraction <= 1.0:
+            raise ValueError("maximum_query_null_response_fraction must lie in [0, 1]")
 
 
 @dataclass(frozen=True)
 class InterventionIdentifiabilityResult:
-    """Conditional information remaining after projecting out nuisance response."""
+    """Conditional information remaining after projecting out nuisance response.
+
+    ``identified_basis`` and ``null_basis`` are expressed in standardized
+    intervention coordinates. ``parameter_scales`` maps those coordinates back
+    to the physical parameter units supplied to the sensitivity calculation.
+    """
 
     conditional_information: np.ndarray
     eigenvalues: np.ndarray
@@ -43,23 +51,83 @@ class InterventionIdentifiabilityResult:
     condition_number: float
     residualized_response_fraction: float
     maximum_subspace_cosine: float
+    parameter_scales: np.ndarray
+    identified_basis: np.ndarray
+    null_basis: np.ndarray
+    query_null_response_fraction: float | None
+    query_identifiable: bool | None
     identifiable: bool
     failure_reasons: tuple[str, ...]
+    query_failure_reasons: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         information = np.asarray(self.conditional_information, dtype=float).copy()
         eigenvalues = np.asarray(self.eigenvalues, dtype=float).copy()
+        scales = np.asarray(self.parameter_scales, dtype=float).copy()
+        identified = np.asarray(self.identified_basis, dtype=float).copy()
+        null = np.asarray(self.null_basis, dtype=float).copy()
         if information.shape != (self.parameter_count, self.parameter_count):
             raise ValueError("conditional_information must match parameter_count")
         if eigenvalues.shape != (self.parameter_count,):
             raise ValueError("eigenvalues must match parameter_count")
-        if not np.all(np.isfinite(information)) or not np.all(np.isfinite(eigenvalues)):
+        if scales.shape != (self.parameter_count,):
+            raise ValueError("parameter_scales must match parameter_count")
+        if identified.shape != (self.parameter_count, self.effective_rank):
+            raise ValueError("identified_basis must match effective_rank")
+        if null.shape != (
+            self.parameter_count,
+            self.parameter_count - self.effective_rank,
+        ):
+            raise ValueError("null_basis must span the unresolved complement")
+        if not all(
+            np.all(np.isfinite(value))
+            for value in (information, eigenvalues, scales, identified, null)
+        ):
             raise ValueError("identifiability arrays must be finite")
+        if np.any(scales <= 0.0):
+            raise ValueError("parameter_scales must be positive")
+        for basis, name in ((identified, "identified_basis"), (null, "null_basis")):
+            if basis.shape[1] and not np.allclose(
+                basis.T @ basis,
+                np.eye(basis.shape[1]),
+                atol=1e-10,
+                rtol=1e-10,
+            ):
+                raise ValueError(f"{name} must have orthonormal columns")
+        if identified.shape[1] and null.shape[1] and not np.allclose(
+            identified.T @ null,
+            0.0,
+            atol=1e-10,
+            rtol=1e-10,
+        ):
+            raise ValueError("identified and null bases must be orthogonal")
+        if self.query_null_response_fraction is not None and not (
+            np.isfinite(self.query_null_response_fraction)
+            and 0.0 <= self.query_null_response_fraction <= 1.0 + 1e-12
+        ):
+            raise ValueError("query_null_response_fraction must lie in [0, 1]")
         information.setflags(write=False)
         eigenvalues.setflags(write=False)
+        scales.setflags(write=False)
+        identified.setflags(write=False)
+        null.setflags(write=False)
         object.__setattr__(self, "conditional_information", information)
         object.__setattr__(self, "eigenvalues", eigenvalues)
+        object.__setattr__(self, "parameter_scales", scales)
+        object.__setattr__(self, "identified_basis", identified)
+        object.__setattr__(self, "null_basis", null)
         object.__setattr__(self, "failure_reasons", tuple(self.failure_reasons))
+        object.__setattr__(
+            self,
+            "query_failure_reasons",
+            tuple(self.query_failure_reasons),
+        )
+
+    @property
+    def identified_projection(self) -> np.ndarray:
+        """Projection onto identified standardized intervention directions."""
+
+        return self.identified_basis @ self.identified_basis.T
 
     def as_dict(self) -> dict[str, object]:
         return {
@@ -71,8 +139,14 @@ class InterventionIdentifiabilityResult:
             ),
             "residualized_response_fraction": self.residualized_response_fraction,
             "maximum_subspace_cosine": self.maximum_subspace_cosine,
+            "parameter_scales": self.parameter_scales.tolist(),
+            "identified_basis": self.identified_basis.tolist(),
+            "null_basis": self.null_basis.tolist(),
+            "query_null_response_fraction": self.query_null_response_fraction,
+            "query_identifiable": self.query_identifiable,
             "identifiable": self.identifiable,
             "failure_reasons": list(self.failure_reasons),
+            "query_failure_reasons": list(self.query_failure_reasons),
             "eigenvalues": self.eigenvalues.tolist(),
         }
 
@@ -143,22 +217,61 @@ def _orthonormal_basis(matrix: np.ndarray, tolerance: float) -> np.ndarray:
     return left[:, :rank]
 
 
+def _parameter_scales(values: np.ndarray | None, parameter_count: int) -> np.ndarray:
+    if values is None:
+        return np.ones(parameter_count, dtype=float)
+    scales = np.asarray(values, dtype=float)
+    if scales.shape != (parameter_count,):
+        raise ValueError("parameter_scales must match the intervention parameter count")
+    if np.any(~np.isfinite(scales)) or np.any(scales <= 0.0):
+        raise ValueError("parameter_scales must be finite and positive")
+    return scales
+
+
+def project_identifiable_intervention_update(
+    update: np.ndarray,
+    result: InterventionIdentifiabilityResult,
+) -> np.ndarray:
+    """Project a physical-unit update onto locally identified directions.
+
+    Scaling occurs before projection, so the result is invariant to equivalent
+    unit changes when ``parameter_scales`` are transformed consistently.
+    """
+
+    values = np.asarray(update, dtype=float)
+    if values.shape[-1] != result.parameter_count or not np.all(np.isfinite(values)):
+        raise ValueError("update must be finite and end in parameter_count")
+    standardized = values / result.parameter_scales
+    projected = standardized @ result.identified_projection
+    return projected * result.parameter_scales
+
+
 def assess_intervention_identifiability(
     intervention_sensitivity: np.ndarray,
     nuisance_sensitivity: np.ndarray | None = None,
     *,
     covariance: np.ndarray | None = None,
+    parameter_scales: np.ndarray | None = None,
+    query_sensitivity: np.ndarray | None = None,
     config: IdentifiabilityConfig | None = None,
 ) -> InterventionIdentifiabilityResult:
     """Assess intervention information conditional on nuisance response.
 
-    The supplied sensitivities are whitened by ``covariance``. Intervention
-    columns are then projected onto the orthogonal complement of the nuisance
-    response. The resulting Gram matrix is the local conditional information.
+    Intervention columns are first converted to standardized parameter
+    coordinates using ``parameter_scales`` and whitened by ``covariance``. They
+    are then projected onto the orthogonal complement of nuisance response. If a
+    future ``query_sensitivity`` is supplied, the result also reports how much of
+    that query response lies in the unresolved intervention subspace. Thus a
+    parameter vector can be only partially identified while a particular future
+    prediction remains locally identifiable.
     """
 
     settings = config or IdentifiabilityConfig()
-    intervention = _whiten(intervention_sensitivity, covariance)
+    raw_intervention = np.asarray(intervention_sensitivity, dtype=float)
+    if raw_intervention.ndim != 2 or raw_intervention.shape[1] == 0:
+        raise ValueError("intervention_sensitivity must be a nonempty matrix")
+    scales = _parameter_scales(parameter_scales, raw_intervention.shape[1])
+    intervention = _whiten(raw_intervention * scales[None], covariance)
     response_count, parameter_count = intervention.shape
     if nuisance_sensitivity is None:
         nuisance = np.zeros((response_count, 0), dtype=float)
@@ -175,12 +288,16 @@ def assess_intervention_identifiability(
     residualized = intervention - nuisance_basis @ (nuisance_basis.T @ intervention)
     information = residualized.T @ residualized
     information = 0.5 * (information + information.T)
-    eigenvalues = np.maximum(np.linalg.eigvalsh(information), 0.0)
+    eigenvalues, eigenvectors = np.linalg.eigh(information)
+    eigenvalues = np.maximum(eigenvalues, 0.0)
     largest = float(eigenvalues[-1])
     tolerance = settings.relative_rank_tolerance * max(largest, 1.0)
-    effective_rank = int(np.sum(eigenvalues > tolerance))
+    identified_mask = eigenvalues > tolerance
+    effective_rank = int(np.sum(identified_mask))
+    identified_basis = eigenvectors[:, identified_mask]
+    null_basis = eigenvectors[:, ~identified_mask]
     minimum = float(eigenvalues[0])
-    positive = eigenvalues[eigenvalues > tolerance]
+    positive = eigenvalues[identified_mask]
     condition_number = (
         float(np.max(positive) / np.min(positive)) if len(positive) else float("inf")
     )
@@ -205,6 +322,30 @@ def assess_intervention_identifiability(
         reasons.append("intervention_response_absorbed_by_nuisance")
     if maximum_cosine > settings.maximum_subspace_cosine:
         reasons.append("intervention_and_nuisance_subspaces_nearly_collinear")
+
+    query_fraction: float | None = None
+    query_identifiable: bool | None = None
+    query_reasons: list[str] = []
+    if query_sensitivity is not None:
+        query = np.asarray(query_sensitivity, dtype=float)
+        if query.ndim != 2 or query.shape[1] != parameter_count:
+            raise ValueError("query_sensitivity must have shape (query, parameter)")
+        if not np.all(np.isfinite(query)):
+            raise ValueError("query_sensitivity must be finite")
+        standardized_query = query * scales[None]
+        total_query_energy = float(np.sum(np.square(standardized_query)))
+        null_query = standardized_query @ null_basis
+        null_query_energy = float(np.sum(np.square(null_query)))
+        query_fraction = (
+            null_query_energy / total_query_energy if total_query_energy > 0.0 else 0.0
+        )
+        query_fraction = min(max(query_fraction, 0.0), 1.0)
+        query_identifiable = (
+            query_fraction <= settings.maximum_query_null_response_fraction
+        )
+        if not query_identifiable:
+            query_reasons.append("query_depends_on_unidentified_intervention_directions")
+
     return InterventionIdentifiabilityResult(
         conditional_information=information,
         eigenvalues=eigenvalues,
@@ -214,6 +355,12 @@ def assess_intervention_identifiability(
         condition_number=condition_number,
         residualized_response_fraction=float(residual_fraction),
         maximum_subspace_cosine=maximum_cosine,
+        parameter_scales=scales,
+        identified_basis=identified_basis,
+        null_basis=null_basis,
+        query_null_response_fraction=query_fraction,
+        query_identifiable=query_identifiable,
         identifiable=not reasons,
         failure_reasons=tuple(reasons),
+        query_failure_reasons=tuple(query_reasons),
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+"""Pytest configuration for optional private integrations."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+_BAYESIAN_PHYSTWIN_AVAILABLE = (
+    importlib.util.find_spec("bayesian_phystwin") is not None
+)
+_BAYESIAN_PHYSTWIN_TEST_MODULES = frozenset(
+    {
+        "test_causal4d_bpt_belief.py",
+        "test_causal4d_molmo_acceptance.py",
+        "test_causal4d_molmo_adapter.py",
+        "test_causal4d_phystwin_backend.py",
+        "test_causal4d_real_calibration.py",
+        "test_causal4d_real_oracle_audit.py",
+        "test_causal4d_rest_geometry.py",
+        "test_causal4d_rest_geometry_protocol.py",
+        "test_causal4d_rest_geometry_transfer.py",
+        "test_discrepancy_localization_aggregate.py",
+        "test_phystwin_propagated_state.py",
+    }
+)
+
+
+def pytest_ignore_collect(collection_path: Path, config) -> bool | None:
+    """Exclude private integration modules only when their package is unavailable."""
+
+    if _BAYESIAN_PHYSTWIN_AVAILABLE:
+        return None
+    return collection_path.name in _BAYESIAN_PHYSTWIN_TEST_MODULES
+
+
+def pytest_report_header(config) -> str | None:
+    """Make the reduced public-CI scope visible in every pytest report."""
+
+    if _BAYESIAN_PHYSTWIN_AVAILABLE:
+        return None
+    return (
+        "bayesian_phystwin is unavailable; excluding 11 private integration "
+        "test modules"
+    )

--- a/tests/test_causal4d_covariance_query_identifiability.py
+++ b/tests/test_causal4d_covariance_query_identifiability.py
@@ -1,0 +1,173 @@
+import numpy as np
+import pytest
+
+from causal4d.contracts import array_sha256
+from causal4d.discrepancy_belief import (
+    GraphDiscrepancyBelief,
+    graph_discrepancy_group_covariances,
+)
+from causal4d.grouped_likelihood import (
+    group_log_likelihood,
+    grouped_component_log_likelihoods,
+)
+from causal4d.identifiability import (
+    IdentifiabilityConfig,
+    assess_intervention_identifiability,
+    project_identifiable_intervention_update,
+)
+from causal4d.observation_evidence import (
+    GroupedObservationEvidence,
+    ObservationGroup,
+)
+
+
+def _correlated_group() -> ObservationGroup:
+    return ObservationGroup(
+        group_id="correlated",
+        values_m=np.zeros(2),
+        frame_indices=np.asarray([1, 1]),
+        node_indices=np.asarray([0, 0]),
+        coordinate_indices=np.asarray([0, 1]),
+        covariance_m2=np.eye(2) * 0.01,
+        contributor_ids=("unit:frame:1",),
+        prior_nominal_probability=0.99,
+        outlier_scale_multiplier=100.0,
+        degrees_of_freedom=4.0,
+        source_id="unit",
+    )
+
+
+def test_full_covariance_distinguishes_common_and_difference_modes() -> None:
+    predictions = np.asarray([[1.0, 1.0], [1.0, -1.0]])
+    covariance = np.asarray([[1.0, 0.99], [0.99, 1.0]])
+    score, _ = group_log_likelihood(
+        predictions,
+        _correlated_group(),
+        additive_covariance_m2=covariance,
+    )
+    assert score[0] > score[1]
+
+
+def test_group_covariance_broadcasts_over_component_axes() -> None:
+    components = np.zeros((2, 3, 3, 1, 2))
+    components[0, :, 1, 0] = [1.0, 1.0]
+    components[1, :, 1, 0] = [1.0, -1.0]
+    evidence = GroupedObservationEvidence(groups=(_correlated_group(),))
+    covariance = np.broadcast_to(
+        np.asarray([[1.0, 0.99], [0.99, 1.0]]),
+        (3, 2, 2),
+    )
+    score, diagnostics = grouped_component_log_likelihoods(
+        components,
+        evidence,
+        prefix_frame_count=2,
+        component_group_covariance_m2={"correlated": covariance},
+    )
+    assert score.shape == (2, 3)
+    assert np.all(score[0] > score[1])
+    assert diagnostics.full_covariance_group_ids == ("correlated",)
+
+
+def test_non_psd_component_covariance_is_rejected() -> None:
+    with pytest.raises(ValueError, match="positive semidefinite"):
+        group_log_likelihood(
+            np.asarray([[0.0, 0.0]]),
+            _correlated_group(),
+            additive_covariance_m2=np.asarray([[1.0, 2.0], [2.0, 1.0]]),
+        )
+
+
+def test_graph_covariance_preserves_time_correlation_and_component_order() -> None:
+    basis = np.asarray([[1.0], [2.0]])
+    belief = GraphDiscrepancyBelief(
+        basis_sha256=array_sha256(basis),
+        component_ids=("a", "b"),
+        coefficient_mean_m=np.zeros((2, 1, 3)),
+        coefficient_covariance_m2=np.asarray(
+            [
+                [[[4.0]], [[9.0]], [[16.0]]],
+                [[[1.0]], [[1.0]], [[1.0]]],
+            ]
+        ),
+        projection_variance_m2=np.asarray([0.5, 0.25, 0.1]),
+        transition_model_id="persistence",
+        innovation_model_id="unit",
+    )
+    group = ObservationGroup(
+        group_id="graph",
+        values_m=np.zeros(3),
+        frame_indices=np.asarray([1, 2, 2]),
+        node_indices=np.asarray([0, 0, 1]),
+        coordinate_indices=np.asarray([0, 0, 1]),
+        covariance_m2=np.eye(3),
+        contributor_ids=("unit:graph",),
+        source_id="unit",
+    )
+    covariance = graph_discrepancy_group_covariances(
+        belief,
+        basis,
+        GroupedObservationEvidence(groups=(group,)),
+        component_ids=("b", "a"),
+    )["graph"]
+    assert covariance.shape == (2, 3, 3)
+    assert np.isclose(covariance[0, 0, 1], 1.0)
+    assert np.isclose(covariance[1, 0, 1], 4.0)
+    assert covariance[0, 0, 2] == 0.0
+    assert np.isclose(covariance[1, 2, 2], 4.0 * 9.0 + 0.25)
+
+
+def test_query_can_be_identifiable_under_partial_parameter_identification() -> None:
+    intervention = np.asarray([[1.0, 1.0], [0.0, 1.0]])
+    nuisance = np.asarray([[0.0], [1.0]])
+    result = assess_intervention_identifiability(
+        intervention,
+        nuisance,
+        query_sensitivity=np.asarray([[1.0, 1.0]]),
+        config=IdentifiabilityConfig(
+            minimum_information_eigenvalue=1e-8,
+            minimum_residualized_response_fraction=0.01,
+            maximum_subspace_cosine=1.0,
+            maximum_query_null_response_fraction=1e-8,
+        ),
+    )
+    assert not result.identifiable
+    assert result.effective_rank == 1
+    assert result.query_identifiable
+    assert result.query_null_response_fraction < 1e-12
+    assert np.allclose(
+        project_identifiable_intervention_update([1.0, -1.0], result),
+        0.0,
+    )
+    assert np.allclose(
+        project_identifiable_intervention_update([1.0, 1.0], result),
+        [1.0, 1.0],
+    )
+
+
+def test_query_gate_rejects_unresolved_direction() -> None:
+    intervention = np.asarray([[1.0, 1.0], [0.0, 1.0]])
+    nuisance = np.asarray([[0.0], [1.0]])
+    result = assess_intervention_identifiability(
+        intervention,
+        nuisance,
+        query_sensitivity=np.asarray([[1.0, -1.0]]),
+        config=IdentifiabilityConfig(maximum_subspace_cosine=1.0),
+    )
+    assert result.query_identifiable is False
+    assert result.query_null_response_fraction > 0.99
+
+
+def test_parameter_standardization_is_unit_invariant() -> None:
+    base = assess_intervention_identifiability(
+        np.asarray([[1.0, 0.0], [0.0, 1.0]]),
+        parameter_scales=np.asarray([2.0, 3.0]),
+    )
+    changed_units = assess_intervention_identifiability(
+        np.asarray([[1.0, 0.0], [0.0, 0.001]]),
+        parameter_scales=np.asarray([2.0, 3000.0]),
+    )
+    assert np.allclose(
+        base.conditional_information,
+        changed_units.conditional_information,
+    )
+    assert np.allclose(base.eigenvalues, changed_units.eigenvalues)

--- a/tests/test_identifiability_serialization_compat.py
+++ b/tests/test_identifiability_serialization_compat.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from causal4d.identifiability import assess_intervention_identifiability
+
+
+def test_legacy_identifiability_serialization_is_unchanged() -> None:
+    result = assess_intervention_identifiability(np.asarray([[1.0], [0.0]]))
+    assert tuple(result.as_dict()) == (
+        "effective_rank",
+        "parameter_count",
+        "minimum_eigenvalue",
+        "condition_number",
+        "residualized_response_fraction",
+        "maximum_subspace_cosine",
+        "identifiable",
+        "failure_reasons",
+        "eigenvalues",
+    )
+    assert "identified_basis" not in result.as_dict()


### PR DESCRIPTION
## What changed

- adds component-specific full covariance to grouped robust likelihoods while preserving the existing diagonal variance API
- maps `GraphDiscrepancyBelief` coefficient covariance into observation-group covariance, including persistent cross-frame correlation and basis-hash validation
- standardizes intervention sensitivities with declared physical parameter scales
- exposes identified and unresolved intervention subspaces
- adds a query-specific identifiability gate based on the fraction of future-query sensitivity in unresolved directions
- adds a helper that removes unresolved components from proposed intervention updates
- preserves the legacy `InterventionIdentifiabilityResult.as_dict()` schema unless the new diagnostics are explicitly requested
- documents the opt-in boundary and adds focused numerical tests

## Why

The current real-data audit shows severe undercoverage and discrepancy-dominated error. Collapsing graph discrepancy to independent per-coordinate variances can discard shared uncertainty, while requiring full recovery of every intervention coordinate can be unnecessarily strict for a specific held-out prediction.

This patch preserves correlation where it is represented and distinguishes full parameter identification from identification of the requested interventional prediction. Existing behavior remains unchanged when the new arguments are omitted.

## Compatibility and claim boundary

- the frozen `v0.3.0-causal4d-aip` path is unchanged
- diagonal grouped likelihood calls remain valid
- legacy identifiability metadata remains byte-contract compatible for non-opt-in calls
- the existing binary `identifiable` result remains available
- query-aware admission is opt-in and does not establish held-out calibration
- graph discrepancy remains a readout belief and is not injected into simulator state

## Validation

A focused isolated test harness exercised the exact new numerical paths:

- correlated common-mode versus difference-mode likelihoods
- batched covariance broadcasting
- non-PSD rejection
- graph covariance across frames and reordered components
- partial identification with an identifiable query
- rejection of queries that depend on unresolved directions
- unit-invariant standardized information
- unchanged legacy identifiability serialization

Result: `8 passed`.

A full repository checkout/test run was not available in this environment because outbound GitHub access and `gh` are unavailable; the connected GitHub app was used for repository writes.