### PR TITLE
Integrate stable discrepancy transport into counterfactual prediction

### DIFF
--- a/docs/action_conditioned_counterfactual.md
+++ b/docs/action_conditioned_counterfactual.md
@@ -12,7 +12,8 @@ keeps the standard operator authoritative for state trajectories, intervention
 transport, contact handling, component weights, and provenance, but replaces the
 readout moments with:
 
-- a graph-persistent discrepancy mean;
+- a graph-persistent discrepancy mean by default;
+- optional stable action-conditioned discrepancy-mean transport;
 - component-specific, action-conditioned positive-semidefinite covariance growth;
 - a full temporal marginal variance with shape `(component, frame, node, 3)`.
 
@@ -33,12 +34,25 @@ physical particle to share its endpoint discrepancy belief.
 ## Readout moments
 
 For graph basis `U`, discrepancy coefficient mean `c`, and component-specific
-action features `f_t`, the mean remains persistent while covariance evolves as
+action features `f_t`, the default remains graph persistence:
 
 ```text
 E[c_t] = E[c_0]
 P_{t+1} = P_t + Q(f_t).
 ```
+
+Supplying a `StableDiscrepancyTransitionModel` activates the source-fitted stable
+transport introduced by the discrepancy-dynamics module:
+
+```text
+E[c_{t+1}] = A(f_t) E[c_t] + b(f_t)
+P_{t+1} = A(f_t) P_t A(f_t)^T + Q(f_t).
+```
+
+The transition is parameterized as `A(f)=expm(S(f)-C(f))`, where `S` is
+skew-symmetric and `C` is positive semidefinite. It can therefore rotate and
+contract graph modes without introducing expansive dynamics. Its identity model
+reproduces graph persistence exactly.
 
 `Q(f_t)` is supplied by `ActionConditionedDiscrepancyModel` and is positive
 semidefinite by construction. The returned readout is
@@ -48,13 +62,17 @@ Y_t = X_t + U E[c_t]
 Var[Y_t] = diag(U P_t U^T) + projection_variance + rollout_variance_floor.
 ```
 
-Zero innovation covariance and zero feature weights preserve the endpoint
-readout mean and variance exactly across the horizon.
+Omitting the transition model preserves the previous API and behavior. Zero
+innovation covariance together with the identity transition preserves the
+endpoint readout mean and variance exactly across the horizon.
 
 ## API
 
 ```python
-from causal4d import apply_action_conditioned_counterfactual_operator
+from causal4d import (
+    StableDiscrepancyTransitionModel,
+    apply_action_conditioned_counterfactual_operator,
+)
 
 posterior = apply_action_conditioned_counterfactual_operator(
     bank,
@@ -67,18 +85,22 @@ posterior = apply_action_conditioned_counterfactual_operator(
     graph_basis,
     control_anchor_m,
     frame_dt_s=1.0 / 30.0,
+    transition_model=stable_transition,
 )
 ```
 
 The result wraps the original `PhysicalPosterior` and exposes temporal
 `readout_trajectories_m`, `readout_variance_m2`, and discrepancy coefficient
-covariances. The frozen standard operator and milestone artifacts are unchanged.
+covariances. Its metadata records whether stable movement was enabled and the
+exact mean and covariance transition identifiers. The frozen standard operator
+and milestone artifacts are unchanged.
 
 ## Claim boundary
 
 This is integration machinery, not a promoted discrepancy model. Feature
-weights, base innovation covariance, graph rank, and variance caps must be
-selected from source-only or preregistered data. Confirmatory use still requires
-held-out action/contact evaluation and execution-level calibration. Outside the
-validated action neighborhood, the caller must widen uncertainty further or
-abstain rather than interpreting covariance growth as calibrated transfer.
+weights, stable-transition parameters, base innovation covariance, graph rank,
+and variance or drift caps must be selected from source-only or preregistered
+data. Confirmatory use still requires held-out action/contact evaluation and
+execution-level calibration. Outside the validated action neighborhood, the
+caller must widen uncertainty further or abstain rather than interpreting
+transport or covariance growth as calibrated transfer.

--- a/src/causal4d/action_conditioned_counterfactual.py
+++ b/src/causal4d/action_conditioned_counterfactual.py
@@ -23,6 +23,10 @@ from causal4d.contracts import (
 from causal4d.counterfactual import apply_counterfactual_operator
 from causal4d.discrepancy_belief import GraphDiscrepancyBelief
 from causal4d.rollout_bank import JointRolloutBank
+from causal4d.stable_discrepancy_dynamics import (
+    StableDiscrepancyTransitionModel,
+    forecast_action_conditioned_dynamics,
+)
 
 
 def _readonly(values: np.ndarray, *, dtype: type | None = float) -> np.ndarray:
@@ -44,8 +48,9 @@ class ActionConditionedPhysicalPosterior:
 
     ``physical`` preserves the existing provenance-complete Causal4D contract.
     The replacement readout mean and variance have shape ``(K, T, N, 3)`` and
-    are produced by graph-persistent discrepancy means with action-conditioned
-    positive-semidefinite covariance growth.
+    are produced either by graph persistence or by a stable action-conditioned
+    discrepancy transition, together with positive-semidefinite covariance
+    propagation.
     """
 
     physical: PhysicalPosterior
@@ -177,12 +182,16 @@ def apply_action_conditioned_counterfactual_operator(
     control_anchor_m: np.ndarray,
     *,
     frame_dt_s: float,
+    transition_model: StableDiscrepancyTransitionModel | None = None,
 ) -> ActionConditionedPhysicalPosterior:
     """Apply ``do(u_cf)`` with temporal action-conditioned readout uncertainty.
 
     The ordinary physical operator remains the source of state trajectories,
     intervention transport, contact handling, weights, and provenance. This
-    extension replaces only the discrepancy-aware readout moments. It reads no
+    extension replaces only the discrepancy-aware readout moments. By default,
+    the discrepancy mean remains graph-persistent. Supplying ``transition_model``
+    enables stable action-conditioned mean transport while retaining the same
+    covariance innovation model and exact persistence fallback. It reads no
     held-out object observation.
     """
 
@@ -209,12 +218,27 @@ def apply_action_conditioned_counterfactual_operator(
         anchor,
         frame_dt_s=frame_dt_s,
     )
-    forecast = forecast_action_conditioned_persistence(
-        aligned_belief,
-        discrepancy_model,
-        features,
-        basis,
-    )
+    if transition_model is None:
+        forecast = forecast_action_conditioned_persistence(
+            aligned_belief,
+            discrepancy_model,
+            features,
+            basis,
+        )
+        mean_transition = "graph_persistence"
+        covariance_transition = "action_conditioned_psd_growth"
+    else:
+        forecast = forecast_action_conditioned_dynamics(
+            aligned_belief,
+            discrepancy_model,
+            transition_model,
+            features,
+            basis,
+        )
+        mean_transition = transition_model.model_id
+        covariance_transition = (
+            "stable_linear_plus_action_conditioned_psd_growth"
+        )
     if forecast.readout_mean_m.shape != physical.state_trajectories_m.shape:
         raise ValueError(
             "counterfactual rollout must contain the endpoint plus query horizon"
@@ -232,8 +256,9 @@ def apply_action_conditioned_counterfactual_operator(
         discrepancy_model_id=forecast.model_id,
         metadata={
             "operator": "abduction-action-prediction",
-            "discrepancy_mean_transition": "graph_persistence",
-            "discrepancy_covariance_transition": "action_conditioned_psd_growth",
+            "discrepancy_mean_transition": mean_transition,
+            "discrepancy_covariance_transition": covariance_transition,
+            "stable_discrepancy_transition_enabled": transition_model is not None,
             "base_physical_posterior_id": physical.artifact_id,
             "aligned_graph_discrepancy_belief_id": aligned_belief.artifact_id,
             "temporal_readout_uncertainty": True,

--- a/tests/test_causal4d_action_conditioned_counterfactual.py
+++ b/tests/test_causal4d_action_conditioned_counterfactual.py
@@ -16,6 +16,9 @@ from causal4d.contracts import (
 )
 from causal4d.discrepancy_belief import GraphDiscrepancyBelief
 from causal4d.rollout_bank import JointRolloutBank
+from causal4d.stable_discrepancy_dynamics import (
+    StableDiscrepancyTransitionModel,
+)
 
 
 def _problem():
@@ -182,6 +185,7 @@ def test_zero_innovation_matches_static_readout_moments() -> None:
     np.testing.assert_allclose(posterior.readout_variance_m2, 3e-6)
     assert posterior.component_ids == ("nominal::p0", "shift::p0")
     assert posterior.metadata["future_observations_read"] == 0
+    assert not posterior.metadata["stable_discrepancy_transition_enabled"]
 
 
 def test_action_conditioned_covariance_grows_over_horizon() -> None:
@@ -225,3 +229,65 @@ def test_action_conditioned_covariance_grows_over_horizon() -> None:
         offset.shape,
     )
     np.testing.assert_allclose(offset, expected_offset)
+
+
+def test_stable_transition_moves_discrepancy_mean_end_to_end() -> None:
+    (
+        bank,
+        manifest,
+        twin,
+        factual,
+        query,
+        discrepancy,
+        basis,
+        anchor,
+        feature_names,
+    ) = _problem()
+    innovation = ActionConditionedDiscrepancyModel(
+        feature_names=feature_names,
+        base_innovation_covariance_m2=np.zeros((1, 1)),
+        feature_directions=np.ones((1, 1)),
+        feature_weights=np.zeros((1, len(feature_names))),
+    )
+    contraction_weights = np.zeros((1, len(feature_names)))
+    contraction_weights[0, feature_names.index("control_speed_mps")] = 10.0
+    transition = StableDiscrepancyTransitionModel(
+        feature_names=feature_names,
+        rank=1,
+        skew_generators=np.zeros((0, 1, 1)),
+        skew_feature_weights=np.zeros((0, len(feature_names))),
+        contraction_directions=np.ones((1, 1)),
+        contraction_feature_weights=contraction_weights,
+        drift_directions_m=np.zeros((0, 1, 3)),
+        drift_feature_weights=np.zeros((0, len(feature_names))),
+        model_id="unit-stable-transition",
+    )
+    posterior = apply_action_conditioned_counterfactual_operator(
+        bank,
+        manifest,
+        twin,
+        factual,
+        query,
+        discrepancy,
+        innovation,
+        basis,
+        anchor,
+        frame_dt_s=0.1,
+        transition_model=transition,
+    )
+    offset = (
+        posterior.readout_trajectories_m
+        - posterior.state_trajectories_m
+    )[:, :, 0, 0]
+    expected = 0.002 * np.exp(-np.arange(query.horizon_frames + 1))
+    np.testing.assert_allclose(
+        offset,
+        np.broadcast_to(expected, offset.shape),
+        rtol=1e-12,
+        atol=1e-15,
+    )
+    assert posterior.metadata["stable_discrepancy_transition_enabled"]
+    assert posterior.metadata["discrepancy_mean_transition"] == (
+        "unit-stable-transition"
+    )
+    assert posterior.discrepancy_model_id.startswith("unit-stable-transition+")


### PR DESCRIPTION
## Summary

- extend `apply_action_conditioned_counterfactual_operator` with an optional `StableDiscrepancyTransitionModel`
- preserve graph-persistent discrepancy means exactly when the new argument is omitted
- propagate stable action-conditioned discrepancy means and covariances through the existing counterfactual operator when enabled
- record the selected mean/covariance transition and whether stable movement was active in posterior metadata
- document the opt-in API and source-only promotion boundary

## Why

The stable discrepancy dynamics and action-conditioned counterfactual operator were previously implemented as separate pieces. The counterfactual path still called the persistence-only forecast, so the non-expansive rotation/contraction/drift model could not affect end-to-end interventional predictions. This PR closes that integration gap while leaving the frozen default unchanged.

## Compatibility and safety

- existing calls are unchanged because `transition_model=None` is the default
- omission of the transition model retains the previous graph-persistence mean and action-conditioned PSD covariance growth
- `StableDiscrepancyTransitionModel.identity(...)` remains an exact persistence fallback
- the standard physical counterfactual operator remains authoritative for state trajectories, intervention transport, contact semantics, weights, and provenance
- no held-out object observation enters the new path

## Validation

- focused counterfactual integration tests: `3 passed`
- new regression verifies the previous persistence behavior and metadata remain unchanged
- new end-to-end regression verifies stable contraction of the discrepancy mean with the expected analytic trajectory
- extracted public release suite: `263 passed`, `1 skipped`; the remaining collection/failures require the private `bayesian_phystwin` dependency or repository-only configuration/result artifacts absent from the release archive
- Python compilation and 88-character line-length audit passed for changed Python files
