### PR TITLE
Integrate stable discrepancy dynamics into counterfactual prediction

### DIFF
--- a/docs/causal4d_inference_improvements.md
+++ b/docs/causal4d_inference_improvements.md
@@ -1,7 +1,8 @@
 # Session-Aware Abduction and Stable Discrepancy Dynamics
 
-This development extension addresses three limitations without changing the
-frozen `v0.3.0-causal4d-aip` path.
+This development extension addresses correlated execution evidence, partial
+intervention identifiability, and action-dependent readout discrepancy without
+changing the frozen `v0.3.0-causal4d-aip` path.
 
 ## Session-aware hierarchical abduction
 
@@ -15,18 +16,25 @@ recovering its `kappa_e` posterior. Omitting `session_ids` reproduces the origin
 independent-execution product exactly. Explicit `execution_evidence_powers` can
 be supplied for a source-frozen alternative composite likelihood.
 
-The result metadata records the session IDs, evidence powers, session count, and
-evidence mode.
+The result metadata records session IDs, evidence powers, session count, and the
+evidence mode. Equal-session weighting is intentionally described as a
+composite likelihood rather than an exact random-effects posterior. A future
+hierarchical session-nuisance model may replace it after source-only validation.
 
 ## Scale-invariant and partial identifiability
 
 `assess_intervention_identifiability` accepts characteristic
-`parameter_scale`. Intervention sensitivity columns are multiplied by that
-scale before nuisance projection and information analysis. This makes the
-result invariant to unit conversions such as degrees versus radians or frames
-versus seconds, provided the corresponding scale is converted consistently.
+`parameter_scales`. Intervention sensitivity columns are multiplied by those
+scales before nuisance projection and information analysis. The diagnostic is
+therefore invariant to equivalent unit conversions, such as degrees versus
+radians or frames versus seconds, when scales are converted consistently.
 
-The result now retains identifiable and nullspace bases. The helper
+The result retains identifiable and nullspace bases. It can additionally score
+a held-out query sensitivity and report the fraction of query response lying in
+unresolved intervention directions. Full parameter recovery is therefore not
+required when the requested prediction is insensitive to the unresolved
+subspace.
+
 `preserve_prior_within_unidentified_subspace` removes unsupported posterior
 distinctions while retaining evidence between distinguishable projection
 groups:
@@ -36,13 +44,25 @@ groups:
 - partial rank preserves prior-relative weights within each indistinguishable
   group.
 
-The frozen guarded-abduction behavior remains conservative: this helper is
-opt-in and does not silently replace exact-prior abstention.
+The frozen guarded-abduction behavior remains conservative: partial updates are
+opt-in and do not silently replace exact-prior abstention.
+
+## Correlation-aware graph evidence
+
+`GraphDiscrepancyBelief` retains full low-rank coefficient covariance.
+`graph_discrepancy_group_covariances` maps it into grouped observation
+covariances while preserving persistent cross-frame correlation. The grouped
+Student-t likelihood accepts these full component-specific covariances instead
+of forcing graph uncertainty into independent coordinate variances.
+
+The graph basis is hash-bound to both the belief and grouped covariance mapping.
+Target futures must not select covariance rank, temperature, feature scales, or
+group construction.
 
 ## Stable discrepancy mean dynamics
 
-`StableDiscrepancyTransitionModel` augments the existing action-conditioned
-innovation covariance with a mean transition
+`StableDiscrepancyTransitionModel` augments action-conditioned innovation
+covariance with a mean transition
 
 ```text
 d_(t+1) = A(f_t) d_t + b(f_t) + epsilon_t.
@@ -67,13 +87,40 @@ m_(t+1) = A m_t + b
 P_(t+1) = A P_t A^T + Q(f_t),
 ```
 
-using the existing `ActionConditionedDiscrepancyModel` as the innovation model.
-Transition generators, feature weights, and drift caps must be selected on
-source executions or preregistered before confirmatory evaluation.
+using `ActionConditionedDiscrepancyModel` as the innovation model.
+
+## Integrated counterfactual operator
+
+`apply_action_conditioned_counterfactual_operator` first calls the ordinary
+counterfactual operator. That operator remains authoritative for simulator state
+trajectories, posterior weights, `phi` transport, contact handling, and artifact
+provenance. The extension replaces only discrepancy-aware readout moments.
+
+Omitting `transition_model` preserves graph-persistent discrepancy means with
+action-conditioned positive-semidefinite covariance growth. Supplying a stable
+transition propagates both mean and covariance. Neither path injects discrepancy
+into simulator position or velocity, and neither reads held-out object outcomes.
+
+## Same-patch counterfactual semantics
+
+The default `same_grasp` behavior remains `fixed_kappa`: the complete factual
+contact and slip variable is reused. A query may explicitly set
+
+```text
+same_grasp_semantics = evolve_slip
+```
+
+in its metadata. This preserves the factual posterior over `(theta, phi,
+contact patch)` while resampling counterfactual slip from the query-bank prior
+conditional on `(phi, patch)`. `new_contact` continues to sample a fresh complete
+contact event. Posterior metadata records whether the patch, slip, or complete
+`kappa` was reused.
 
 ## Claim boundary
 
 These additions are inference machinery, not new real-data evidence. Promotion
 still requires the locked multi-action protocol, independent-session
 calibration, source-only mechanism selection, and exact persistence/prior
-fallback controls.
+fallback controls. Transition generators, graph rank, feature normalization,
+drift caps, innovation covariance, slip priors, and admission thresholds must be
+source-frozen or preregistered before confirmatory evaluation.

--- a/src/causal4d/action_conditioned_counterfactual.py
+++ b/src/causal4d/action_conditioned_counterfactual.py
@@ -23,6 +23,10 @@ from causal4d.contracts import (
 from causal4d.counterfactual import apply_counterfactual_operator
 from causal4d.discrepancy_belief import GraphDiscrepancyBelief
 from causal4d.rollout_bank import JointRolloutBank
+from causal4d.stable_discrepancy_dynamics import (
+    StableDiscrepancyTransitionModel,
+    forecast_action_conditioned_dynamics,
+)
 
 
 def _readonly(values: np.ndarray, *, dtype: type | None = float) -> np.ndarray:
@@ -42,10 +46,10 @@ def _validated_metadata(values: Mapping[str, Any]) -> dict[str, Any]:
 class ActionConditionedPhysicalPosterior:
     """Physical posterior with component-wise temporal readout uncertainty.
 
-    ``physical`` preserves the existing provenance-complete Causal4D contract.
-    The replacement readout mean and variance have shape ``(K, T, N, 3)`` and
-    are produced by graph-persistent discrepancy means with action-conditioned
-    positive-semidefinite covariance growth.
+    ``physical`` preserves the provenance-complete Causal4D contract. The
+    replacement readout mean and variance have shape ``(K, T, N, 3)`` and are
+    produced by either exact graph persistence or a stable action-conditioned
+    graph-discrepancy transition with positive-semidefinite innovation growth.
     """
 
     physical: PhysicalPosterior
@@ -177,13 +181,15 @@ def apply_action_conditioned_counterfactual_operator(
     control_anchor_m: np.ndarray,
     *,
     frame_dt_s: float,
+    transition_model: StableDiscrepancyTransitionModel | None = None,
 ) -> ActionConditionedPhysicalPosterior:
     """Apply ``do(u_cf)`` with temporal action-conditioned readout uncertainty.
 
-    The ordinary physical operator remains the source of state trajectories,
+    The ordinary physical operator remains authoritative for state trajectories,
     intervention transport, contact handling, weights, and provenance. This
-    extension replaces only the discrepancy-aware readout moments. It reads no
-    held-out object observation.
+    extension replaces only discrepancy-aware readout moments and reads no
+    held-out object observation. Omitting ``transition_model`` preserves the
+    covariance-only graph-persistence behavior exactly.
     """
 
     if not np.isfinite(frame_dt_s) or frame_dt_s <= 0.0:
@@ -209,12 +215,23 @@ def apply_action_conditioned_counterfactual_operator(
         anchor,
         frame_dt_s=frame_dt_s,
     )
-    forecast = forecast_action_conditioned_persistence(
-        aligned_belief,
-        discrepancy_model,
-        features,
-        basis,
-    )
+    if transition_model is None:
+        forecast = forecast_action_conditioned_persistence(
+            aligned_belief,
+            discrepancy_model,
+            features,
+            basis,
+        )
+        mean_transition = "graph_persistence"
+    else:
+        forecast = forecast_action_conditioned_dynamics(
+            aligned_belief,
+            discrepancy_model,
+            transition_model,
+            features,
+            basis,
+        )
+        mean_transition = transition_model.model_id
     if forecast.readout_mean_m.shape != physical.state_trajectories_m.shape:
         raise ValueError(
             "counterfactual rollout must contain the endpoint plus query horizon"
@@ -232,7 +249,7 @@ def apply_action_conditioned_counterfactual_operator(
         discrepancy_model_id=forecast.model_id,
         metadata={
             "operator": "abduction-action-prediction",
-            "discrepancy_mean_transition": "graph_persistence",
+            "discrepancy_mean_transition": mean_transition,
             "discrepancy_covariance_transition": "action_conditioned_psd_growth",
             "base_physical_posterior_id": physical.artifact_id,
             "aligned_graph_discrepancy_belief_id": aligned_belief.artifact_id,

--- a/tests/test_causal4d_action_conditioned_counterfactual.py
+++ b/tests/test_causal4d_action_conditioned_counterfactual.py
@@ -16,6 +16,9 @@ from causal4d.contracts import (
 )
 from causal4d.discrepancy_belief import GraphDiscrepancyBelief
 from causal4d.rollout_bank import JointRolloutBank
+from causal4d.stable_discrepancy_dynamics import (
+    StableDiscrepancyTransitionModel,
+)
 
 
 def _problem():
@@ -182,6 +185,7 @@ def test_zero_innovation_matches_static_readout_moments() -> None:
     np.testing.assert_allclose(posterior.readout_variance_m2, 3e-6)
     assert posterior.component_ids == ("nominal::p0", "shift::p0")
     assert posterior.metadata["future_observations_read"] == 0
+    assert posterior.metadata["discrepancy_mean_transition"] == "graph_persistence"
 
 
 def test_action_conditioned_covariance_grows_over_horizon() -> None:
@@ -225,3 +229,59 @@ def test_action_conditioned_covariance_grows_over_horizon() -> None:
         offset.shape,
     )
     np.testing.assert_allclose(offset, expected_offset)
+
+
+def test_stable_transition_contracts_discrepancy_mean() -> None:
+    (
+        bank,
+        manifest,
+        twin,
+        factual,
+        query,
+        discrepancy,
+        basis,
+        anchor,
+        feature_names,
+    ) = _problem()
+    innovation = ActionConditionedDiscrepancyModel(
+        feature_names=feature_names,
+        base_innovation_covariance_m2=np.zeros((1, 1)),
+        feature_directions=np.zeros((0, 1)),
+        feature_weights=np.zeros((0, len(feature_names))),
+    )
+    contraction_weights = np.zeros((1, len(feature_names)))
+    contraction_weights[0, feature_names.index("control_speed_mps")] = 4.0
+    transition = StableDiscrepancyTransitionModel(
+        feature_names=feature_names,
+        rank=1,
+        skew_generators=np.zeros((0, 1, 1)),
+        skew_feature_weights=np.zeros((0, len(feature_names))),
+        contraction_directions=np.ones((1, 1)),
+        contraction_feature_weights=contraction_weights,
+        drift_directions_m=np.zeros((0, 1, 3)),
+        drift_feature_weights=np.zeros((0, len(feature_names))),
+        model_id="unit-stable-contraction",
+    )
+    posterior = apply_action_conditioned_counterfactual_operator(
+        bank,
+        manifest,
+        twin,
+        factual,
+        query,
+        discrepancy,
+        innovation,
+        basis,
+        anchor,
+        frame_dt_s=0.1,
+        transition_model=transition,
+    )
+    offset = (
+        posterior.readout_trajectories_m
+        - posterior.state_trajectories_m
+    )[:, :, 0, 0]
+    assert np.all(np.diff(offset, axis=1) <= 1e-15)
+    assert np.all(offset[:, -1] < offset[:, 0])
+    assert (
+        posterior.metadata["discrepancy_mean_transition"]
+        == "unit-stable-contraction"
+    )


### PR DESCRIPTION
## Summary

- allow `apply_action_conditioned_counterfactual_operator` to propagate discrepancy means and covariances with the stable transition model introduced in #11
- preserve the existing graph-persistence path exactly when `transition_model` is omitted
- keep the ordinary counterfactual operator authoritative for state trajectories, posterior weights, `phi` transport, contact semantics, and provenance
- add a focused regression test for action-conditioned contraction of the discrepancy mean
- consolidate the session, identifiability, covariance, stable-dynamics, and same-patch claim boundaries in one document

## Why

PR #9 integrated action-conditioned covariance growth into counterfactual prediction, while PR #11 added a stable non-expansive discrepancy mean transition. The two paths were not connected: counterfactual prediction could still only persist the discrepancy mean.

This PR closes that integration gap without changing default behavior or injecting discrepancy into simulator state.

## Compatibility and evidence boundary

- no `transition_model`: byte-compatible graph-persistence behavior and action-conditioned PSD covariance growth
- stable transition supplied: propagate `m_(t+1)=A(f_t)m_t+b(f_t)` and `P_(t+1)=A(f_t)P_tA(f_t)^T+Q(f_t)`
- no held-out object outcomes are read
- transition parameters, graph rank, feature normalization, drift caps, and covariance settings must remain source-frozen or preregistered
- the frozen `v0.3.0-causal4d-aip` path remains unchanged

## Validation

- Ruff passed
- the complete test suite passed on Python 3.10, 3.12, and 3.14
- the added regression test verifies action-conditioned contraction of the discrepancy mean while the pre-existing exact-persistence and covariance-growth tests remain green
- distribution build and isolated wheel-import validation are still queued in GitHub Actions