### PR TITLE
Add signed continuous-time dynamics and query gates

### DIFF
--- a/docs/signed_continuous_dynamics_and_query_gates.md
+++ b/docs/signed_continuous_dynamics_and_query_gates.md
@@ -1,0 +1,105 @@
+# Signed Continuous-Time Dynamics and Query Gates
+
+## Scope
+
+This development extension closes three gaps without changing the frozen
+`v0.3.0-causal4d-aip` path:
+
+1. discrepancy-mean dynamics need signed realization and action-phase features;
+2. learned dynamics should not change merely because the camera frame rate
+   changes;
+3. local Jacobian identifiability should be complemented by a global check over
+   the actual finite rollout support.
+
+It also introduces a versioned capability contract for the Bayesian-PhysTwin
+provider. None of these additions constitute new held-out real-data evidence.
+
+## Feature schemas
+
+`build_action_conditioned_features` retains `magnitude_v1` as its default and
+byte-compatible semantic path. It uses magnitudes for gain deviation, delay,
+rotation, slip, and attachment shift and remains appropriate for conservative
+covariance inflation.
+
+The opt-in `signed_v2` schema additionally preserves:
+
+- signed gain deviation;
+- signed rotation through sine and cosine-minus-one coordinates;
+- signed mean attachment shift;
+- radial velocity and distance from the controller anchor;
+- the existing Cartesian direction, speed, acceleration, slip, and contact-policy
+  fields.
+
+The radial fields distinguish outbound, hold, and return behavior without
+requiring post hoc phase labels. Every generated feature artifact records its
+schema and physical step duration.
+
+## Continuous-time parameterization
+
+Both `ActionConditionedDiscrepancyModel` and
+`StableDiscrepancyTransitionModel` accept:
+
+```text
+time_parameterization = per_step | per_second
+```
+
+`per_step` preserves all previous behavior. Under `per_second`, the stable mean
+model is interpreted as
+
+```text
+dc/dt = G(f) c + b(f)
+```
+
+and discretized exactly with a matrix exponential for every declared frame
+interval. The covariance model is interpreted as a covariance rate. When both
+mean and covariance models are continuous-time, process covariance is
+discretized with the Van Loan construction. Constant-feature predictions are
+therefore invariant, up to numerical precision, to subdividing the same physical
+interval into more frames.
+
+The counterfactual readout operator accepts an optional stable transition model.
+Omitting it preserves graph persistence exactly. A supplied transition model is
+recorded in posterior metadata together with the feature schema, frame interval,
+and time parameterizations.
+
+## Finite-support query ambiguity
+
+`assess_finite_query_ambiguity` compares every positive-mass pair in a finite
+rollout support. A pair is ambiguous when its allowed-prefix responses are close
+in whitened RMS Mahalanobis distance but its requested future-query responses are
+far apart after declared query scaling.
+
+The gate reports:
+
+- ambiguous pair probability mass;
+- pair-mass-weighted query divergence;
+- maximum query divergence;
+- the exact support pairs responsible for rejection.
+
+Pair mass is defined as the probability of drawing the two components in either
+order. Consequently, the aggregate is invariant to support permutation and to
+splitting a component into exact clones whose weights sum to the original mass.
+This is a global finite-support complement to local sensitivity-based
+identifiability. Rejection should widen uncertainty or trigger fallback; it does
+not authorize target-future tuning.
+
+## Bayesian-PhysTwin provider contract
+
+`PhysicalBeliefProviderManifest` records provider identity, revision, contract
+schema, artifact-schema versions, and explicit capabilities. The compatibility
+gate fails closed on:
+
+- missing endpoint, parameter, or checksum capabilities;
+- unsupported provider-contract versions;
+- mismatched required artifact versions.
+
+The existing pinned Bayesian-PhysTwin revision remains a reproducible installation
+choice. The manifest supplies a stable semantic boundary so future compatible
+providers do not need to be accepted solely by implementation commit identity.
+
+## Promotion boundary
+
+Signed dynamics, covariance rates, ambiguity thresholds, graph rank, and provider
+requirements must be selected from source data or preregistered. The registered
+same-object multi-action protocol remains the promotion gate for held-out
+accuracy, transfer, and independent-execution calibration.

--- a/src/causal4d/__init__.py
+++ b/src/causal4d/__init__.py
@@ -29,6 +29,11 @@ from causal4d.discrepancy_belief import (
     write_graph_discrepancy_belief,
 )
 from causal4d.evaluation import run_counterfactual_benchmark
+from causal4d.finite_query_ambiguity import (
+    FiniteQueryAmbiguityConfig,
+    FiniteQueryAmbiguityResult,
+    assess_finite_query_ambiguity,
+)
 from causal4d.graph_mode_abduction import (
     GraphModeAbductionConfig,
     abduct_factual_intervention_graph_mode,
@@ -62,6 +67,13 @@ from causal4d.prefix_likelihood import (
     prefix_component_log_likelihood,
     update_joint_weights_from_prefix,
 )
+from causal4d.provider_contract import (
+    BASE_CAUSAL4D_PROVIDER_CAPABILITIES,
+    PHYSICAL_BELIEF_PROVIDER_SCHEMA_VERSION,
+    PhysicalBeliefProviderManifest,
+    ProviderCompatibilityResult,
+    validate_provider_compatibility,
+)
 from causal4d.rollout_bank import JointRolloutBank, SparseTrajectoryEvidence
 from causal4d.semantic_freshness import (
     SEMANTIC_TIMING_SCHEMA_VERSION,
@@ -81,9 +93,12 @@ __all__ = [
     "ActionConditionedDiscrepancyForecast",
     "ActionConditionedDiscrepancyModel",
     "ActionConditionedPhysicalPosterior",
+    "BASE_CAUSAL4D_PROVIDER_CAPABILITIES",
     "CounterfactualBenchmarkConfig",
     "CounterfactualQuery",
     "FactualIntervention",
+    "FiniteQueryAmbiguityConfig",
+    "FiniteQueryAmbiguityResult",
     "GraphDiscrepancyBelief",
     "GraphModeAbductionConfig",
     "GroupLikelihoodDiagnostics",
@@ -94,8 +109,11 @@ __all__ = [
     "LatentContactConfig",
     "JointRolloutBank",
     "ObservationGroup",
+    "PHYSICAL_BELIEF_PROVIDER_SCHEMA_VERSION",
+    "PhysicalBeliefProviderManifest",
     "PhysicalPosterior",
     "PrefixLikelihoodConfig",
+    "ProviderCompatibilityResult",
     "SEMANTIC_TIMING_SCHEMA_VERSION",
     "SEMANTIC_TIMING_SCOPE",
     "SemanticFreshnessDecision",
@@ -110,6 +128,7 @@ __all__ = [
     "apply_action_conditioned_counterfactual_operator",
     "apply_counterfactual_operator",
     "apply_semantic_freshness_gate",
+    "assess_finite_query_ambiguity",
     "assess_intervention_identifiability",
     "build_action_conditioned_features",
     "build_protocol",
@@ -127,6 +146,7 @@ __all__ = [
     "run_counterfactual_benchmark",
     "run_latent_contact_benchmark",
     "update_joint_weights_from_prefix",
+    "validate_provider_compatibility",
     "write_graph_discrepancy_belief",
 ]
 

--- a/src/causal4d/action_conditioned_counterfactual.py
+++ b/src/causal4d/action_conditioned_counterfactual.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import json
-from typing import Any, Mapping
+from typing import Any, Literal, Mapping
 
 import numpy as np
 
@@ -23,6 +23,10 @@ from causal4d.contracts import (
 from causal4d.counterfactual import apply_counterfactual_operator
 from causal4d.discrepancy_belief import GraphDiscrepancyBelief
 from causal4d.rollout_bank import JointRolloutBank
+from causal4d.stable_discrepancy_dynamics import (
+    StableDiscrepancyTransitionModel,
+    forecast_action_conditioned_dynamics,
+)
 
 
 def _readonly(values: np.ndarray, *, dtype: type | None = float) -> np.ndarray:
@@ -44,8 +48,7 @@ class ActionConditionedPhysicalPosterior:
 
     ``physical`` preserves the existing provenance-complete Causal4D contract.
     The replacement readout mean and variance have shape ``(K, T, N, 3)`` and
-    are produced by graph-persistent discrepancy means with action-conditioned
-    positive-semidefinite covariance growth.
+    are produced by a separately transported graph-discrepancy belief.
     """
 
     physical: PhysicalPosterior
@@ -141,6 +144,7 @@ def _component_features(
     control_anchor_m: np.ndarray,
     *,
     frame_dt_s: float,
+    feature_schema: Literal["magnitude_v1", "signed_v2"],
 ) -> ActionConditionedDiscrepancyFeatures:
     built = [
         build_action_conditioned_features(
@@ -152,6 +156,7 @@ def _component_features(
             kappa_names=physical.kappa_names,
             kappa=physical.kappa_cf[index],
             contact_policy=query.contact_policy,
+            feature_schema=feature_schema,
         )
         for index in range(len(physical.weights))
     ]
@@ -162,6 +167,8 @@ def _component_features(
         names=names,
         values=np.stack([value.values for value in built], axis=0),
         component_ids=physical.component_ids,
+        step_duration_s=frame_dt_s,
+        schema_id=feature_schema,
     )
 
 
@@ -177,13 +184,16 @@ def apply_action_conditioned_counterfactual_operator(
     control_anchor_m: np.ndarray,
     *,
     frame_dt_s: float,
+    feature_schema: Literal["magnitude_v1", "signed_v2"] = "magnitude_v1",
+    transition_model: StableDiscrepancyTransitionModel | None = None,
 ) -> ActionConditionedPhysicalPosterior:
     """Apply ``do(u_cf)`` with temporal action-conditioned readout uncertainty.
 
-    The ordinary physical operator remains the source of state trajectories,
-    intervention transport, contact handling, weights, and provenance. This
-    extension replaces only the discrepancy-aware readout moments. It reads no
-    held-out object observation.
+    The ordinary physical operator remains authoritative for state trajectories,
+    intervention transport, contact handling, weights, and provenance. The
+    extension replaces only discrepancy-aware readout moments. Supplying a stable
+    transition model activates signed, physical-time discrepancy-mean transport;
+    omitting it preserves graph persistence exactly.
     """
 
     if not np.isfinite(frame_dt_s) or frame_dt_s <= 0.0:
@@ -208,13 +218,25 @@ def apply_action_conditioned_counterfactual_operator(
         query,
         anchor,
         frame_dt_s=frame_dt_s,
+        feature_schema=feature_schema,
     )
-    forecast = forecast_action_conditioned_persistence(
-        aligned_belief,
-        discrepancy_model,
-        features,
-        basis,
-    )
+    if transition_model is None:
+        forecast = forecast_action_conditioned_persistence(
+            aligned_belief,
+            discrepancy_model,
+            features,
+            basis,
+        )
+        mean_transition = "graph_persistence"
+    else:
+        forecast = forecast_action_conditioned_dynamics(
+            aligned_belief,
+            discrepancy_model,
+            transition_model,
+            features,
+            basis,
+        )
+        mean_transition = transition_model.model_id
     if forecast.readout_mean_m.shape != physical.state_trajectories_m.shape:
         raise ValueError(
             "counterfactual rollout must contain the endpoint plus query horizon"
@@ -232,8 +254,18 @@ def apply_action_conditioned_counterfactual_operator(
         discrepancy_model_id=forecast.model_id,
         metadata={
             "operator": "abduction-action-prediction",
-            "discrepancy_mean_transition": "graph_persistence",
-            "discrepancy_covariance_transition": "action_conditioned_psd_growth",
+            "discrepancy_mean_transition": mean_transition,
+            "discrepancy_covariance_transition": discrepancy_model.model_id,
+            "feature_schema": features.schema_id,
+            "frame_dt_s": float(frame_dt_s),
+            "mean_time_parameterization": (
+                "persistence"
+                if transition_model is None
+                else transition_model.time_parameterization
+            ),
+            "covariance_time_parameterization": (
+                discrepancy_model.time_parameterization
+            ),
             "base_physical_posterior_id": physical.artifact_id,
             "aligned_graph_discrepancy_belief_id": aligned_belief.artifact_id,
             "temporal_readout_uncertainty": True,

--- a/src/causal4d/action_conditioned_discrepancy.py
+++ b/src/causal4d/action_conditioned_discrepancy.py
@@ -1,4 +1,4 @@
-"""Action-conditioned covariance growth for graph-persistent discrepancy."""
+"""Action-conditioned covariance growth for graph discrepancy beliefs."""
 
 from __future__ import annotations
 
@@ -12,6 +12,8 @@ from causal4d.discrepancy_belief import GraphDiscrepancyBelief
 
 
 CONTACT_POLICIES = ("same_grasp", "new_contact")
+FEATURE_SCHEMAS = ("magnitude_v1", "signed_v2")
+TIME_PARAMETERIZATIONS = ("per_step", "per_second")
 
 
 def _readonly(values: np.ndarray) -> np.ndarray:
@@ -56,13 +58,43 @@ def _positive_semidefinite(matrix: np.ndarray) -> np.ndarray:
     return (eigenvectors * np.maximum(eigenvalues, 0.0)) @ eigenvectors.T
 
 
+def _step_duration_array(
+    values: np.ndarray | float,
+    *,
+    component_count: int,
+    horizon: int,
+) -> np.ndarray:
+    durations = np.asarray(values, dtype=float)
+    if durations.ndim == 0:
+        result = np.full((component_count, horizon), float(durations))
+    elif durations.shape == (horizon,):
+        result = np.broadcast_to(durations[None], (component_count, horizon))
+    elif durations.shape == (component_count, horizon):
+        result = durations
+    else:
+        raise ValueError(
+            "step_duration_s must be scalar or have shape (H,) or (K, H)"
+        )
+    if not np.all(np.isfinite(result)) or np.any(result <= 0.0):
+        raise ValueError("step durations must be finite and strictly positive")
+    return np.asarray(result, dtype=float)
+
+
 @dataclass(frozen=True)
 class ActionConditionedDiscrepancyFeatures:
-    """Shared or component-specific features for each forecast transition."""
+    """Shared or component-specific features for each forecast transition.
+
+    ``step_duration_s`` binds every transition to physical time. Existing callers
+    that construct features manually retain the historical unit-step behavior.
+    Features created by :func:`build_action_conditioned_features` carry the real
+    frame duration.
+    """
 
     names: tuple[str, ...]
     values: np.ndarray
     component_ids: tuple[str, ...] | None = None
+    step_duration_s: np.ndarray | float = 1.0
+    schema_id: str = "magnitude_v1"
 
     def __post_init__(self) -> None:
         names = tuple(map(str, self.names))
@@ -82,12 +114,36 @@ class ActionConditionedDiscrepancyFeatures:
                 raise ValueError("feature component_ids must be unique")
         elif self.component_ids is not None:
             raise ValueError("shared features must not declare component_ids")
+        if not self.schema_id:
+            raise ValueError("schema_id must be nonempty")
+        component_count = values.shape[0] if values.ndim == 3 else 1
+        durations = _step_duration_array(
+            self.step_duration_s,
+            component_count=component_count,
+            horizon=values.shape[-2],
+        )
+        if values.ndim == 2 and np.all(durations == durations[0, 0]):
+            stored_duration: np.ndarray | float = float(durations[0, 0])
+        elif values.ndim == 2:
+            stored_duration = _readonly(durations[0])
+        else:
+            stored_duration = _readonly(durations)
         object.__setattr__(self, "names", names)
         object.__setattr__(self, "values", values)
+        object.__setattr__(self, "step_duration_s", stored_duration)
 
     @property
     def horizon(self) -> int:
         return int(self.values.shape[-2])
+
+    def component_step_durations(self, component_count: int) -> np.ndarray:
+        """Return transition durations with shape ``(component, horizon)``."""
+
+        return _step_duration_array(
+            self.step_duration_s,
+            component_count=component_count,
+            horizon=self.horizon,
+        )
 
 
 def build_action_conditioned_features(
@@ -100,8 +156,15 @@ def build_action_conditioned_features(
     kappa_names: Sequence[str] = (),
     kappa: np.ndarray | Sequence[float] = (),
     contact_policy: Literal["same_grasp", "new_contact"] = "same_grasp",
+    feature_schema: Literal["magnitude_v1", "signed_v2"] = "magnitude_v1",
 ) -> ActionConditionedDiscrepancyFeatures:
-    """Build interpretable transition features without reading future outcomes."""
+    """Build interpretable transition features without future object outcomes.
+
+    ``magnitude_v1`` is the frozen compatibility schema used by existing
+    covariance-only models. ``signed_v2`` retains action and realization signs,
+    encodes controller phase continuously through radial velocity and distance,
+    and is intended for discrepancy-mean dynamics.
+    """
 
     controls = np.asarray(controller_points_m, dtype=float)
     anchor = np.asarray(control_anchor_m, dtype=float)
@@ -117,6 +180,8 @@ def build_action_conditioned_features(
         raise ValueError("frame_dt_s must be finite and positive")
     if contact_policy not in CONTACT_POLICIES:
         raise ValueError("contact_policy must be same_grasp or new_contact")
+    if feature_schema not in FEATURE_SCHEMAS:
+        raise ValueError(f"feature_schema must be one of {FEATURE_SCHEMAS}")
 
     persistent_names, persistent_values = _parameter_vector(
         phi_names,
@@ -158,55 +223,112 @@ def build_action_conditioned_features(
         0.0,
     )
     slip = _named_value(event_names, event_values, "slip_fraction", 0.0)
-    shifts = [
-        float(event_values[index])
-        for index, name in enumerate(event_names)
-        if name.startswith("attachment_shift_hand_")
-    ]
+    shifts = np.asarray(
+        [
+            float(event_values[index])
+            for index, name in enumerate(event_names)
+            if name.startswith("attachment_shift_hand_")
+        ],
+        dtype=float,
+    )
+    attachment_shift_mean = float(np.mean(shifts)) if len(shifts) else 0.0
     attachment_shift_rms = (
-        float(np.sqrt(np.mean(np.square(shifts)))) if shifts else 0.0
+        float(np.sqrt(np.mean(np.square(shifts)))) if len(shifts) else 0.0
     )
     horizon = len(controls)
 
     def repeated(value: float) -> np.ndarray:
         return np.full(horizon, float(value), dtype=float)
 
-    values = np.column_stack(
-        (
-            speed,
-            acceleration_norm,
-            direction,
-            repeated(abs(gain - 1.0)),
-            repeated(abs(delay_steps) * frame_dt_s),
-            repeated(abs(np.deg2rad(rotation_degrees))),
-            repeated(max(slip, 0.0)),
-            repeated(attachment_shift_rms),
-            repeated(float(contact_policy == "new_contact")),
+    if feature_schema == "magnitude_v1":
+        values = np.column_stack(
+            (
+                speed,
+                acceleration_norm,
+                direction,
+                repeated(abs(gain - 1.0)),
+                repeated(abs(delay_steps) * frame_dt_s),
+                repeated(abs(np.deg2rad(rotation_degrees))),
+                repeated(max(slip, 0.0)),
+                repeated(attachment_shift_rms),
+                repeated(float(contact_policy == "new_contact")),
+            )
         )
+        names = (
+            "control_speed_mps",
+            "control_acceleration_mps2",
+            "direction_x",
+            "direction_y",
+            "direction_z",
+            "gain_abs_deviation",
+            "delay_s",
+            "rotation_abs_rad",
+            "slip_fraction",
+            "attachment_shift_rms",
+            "new_contact",
+        )
+    else:
+        anchor_center = np.mean(anchor, axis=0)
+        controller_center = np.mean(controls, axis=1)
+        radial = controller_center - anchor_center[None]
+        radial_norm = np.linalg.norm(radial, axis=1, keepdims=True)
+        radial_direction = radial / np.maximum(
+            radial_norm,
+            np.finfo(float).eps,
+        )
+        radial_velocity = np.einsum("tc,tc->t", mean_velocity, radial_direction)
+        radial_velocity = np.where(radial_norm[:, 0] > 0.0, radial_velocity, 0.0)
+        rotation_rad = np.deg2rad(rotation_degrees)
+        values = np.column_stack(
+            (
+                speed,
+                acceleration_norm,
+                direction,
+                radial_velocity,
+                radial_norm[:, 0],
+                repeated(gain - 1.0),
+                repeated(delay_steps * frame_dt_s),
+                repeated(np.sin(rotation_rad)),
+                repeated(np.cos(rotation_rad) - 1.0),
+                repeated(slip),
+                repeated(attachment_shift_mean),
+                repeated(attachment_shift_rms),
+                repeated(float(contact_policy == "new_contact")),
+            )
+        )
+        names = (
+            "control_speed_mps",
+            "control_acceleration_mps2",
+            "direction_x",
+            "direction_y",
+            "direction_z",
+            "radial_velocity_mps",
+            "distance_from_anchor_m",
+            "gain_signed_deviation",
+            "delay_s",
+            "rotation_sin",
+            "rotation_cos_minus_one",
+            "slip_fraction",
+            "attachment_shift_mean",
+            "attachment_shift_rms",
+            "new_contact",
+        )
+    return ActionConditionedDiscrepancyFeatures(
+        names=names,
+        values=values,
+        step_duration_s=frame_dt_s,
+        schema_id=feature_schema,
     )
-    names = (
-        "control_speed_mps",
-        "control_acceleration_mps2",
-        "direction_x",
-        "direction_y",
-        "direction_z",
-        "gain_abs_deviation",
-        "delay_s",
-        "rotation_abs_rad",
-        "slip_fraction",
-        "attachment_shift_rms",
-        "new_contact",
-    )
-    return ActionConditionedDiscrepancyFeatures(names=names, values=values)
 
 
 @dataclass(frozen=True)
 class ActionConditionedDiscrepancyModel:
     """Positive-semidefinite feature-conditioned innovation covariance.
 
-    Each feature direction contributes ``(w_j^T f)^2 v_j v_j^T``. Zero feature
-    weights reproduce the base covariance exactly. ``maximum_increment_trace_m2``
-    caps only the action-dependent addition, never the declared base uncertainty.
+    With ``time_parameterization='per_step'``, the declared covariance is added
+    once per transition, preserving historical behavior. With ``per_second``, it
+    is interpreted as a covariance rate and discretized using the supplied step
+    duration.
     """
 
     feature_names: tuple[str, ...]
@@ -215,6 +337,7 @@ class ActionConditionedDiscrepancyModel:
     feature_weights: np.ndarray
     model_id: str = "action-conditioned-graph-persistence-v1"
     maximum_increment_trace_m2: float | None = None
+    time_parameterization: Literal["per_step", "per_second"] = "per_step"
 
     def __post_init__(self) -> None:
         feature_names = tuple(map(str, self.feature_names))
@@ -225,6 +348,10 @@ class ActionConditionedDiscrepancyModel:
             raise ValueError("model id and feature names must be nonempty")
         if len(set(feature_names)) != len(feature_names):
             raise ValueError("feature names must be unique")
+        if self.time_parameterization not in TIME_PARAMETERIZATIONS:
+            raise ValueError(
+                f"time_parameterization must be one of {TIME_PARAMETERIZATIONS}"
+            )
         if base.ndim != 2 or base.shape[0] != base.shape[1] or base.shape[0] < 1:
             raise ValueError("base covariance must have shape (rank, rank)")
         rank = base.shape[0]
@@ -258,8 +385,8 @@ class ActionConditionedDiscrepancyModel:
     def rank(self) -> int:
         return int(self.base_innovation_covariance_m2.shape[0])
 
-    def innovation_covariance_m2(self, feature_vector: np.ndarray) -> np.ndarray:
-        """Return the base covariance plus a capped PSD action increment."""
+    def innovation_rate_m2(self, feature_vector: np.ndarray) -> np.ndarray:
+        """Return the uncoupled PSD innovation covariance or covariance rate."""
 
         features = np.asarray(feature_vector, dtype=float)
         if features.shape != (len(self.feature_names),) or not np.all(
@@ -284,6 +411,21 @@ class ActionConditionedDiscrepancyModel:
             self.base_innovation_covariance_m2 + increment
         )
 
+    def innovation_covariance_m2(
+        self,
+        feature_vector: np.ndarray,
+        *,
+        step_duration_s: float = 1.0,
+    ) -> np.ndarray:
+        """Return the innovation covariance for one transition."""
+
+        if not np.isfinite(step_duration_s) or step_duration_s <= 0.0:
+            raise ValueError("step_duration_s must be finite and positive")
+        covariance = self.innovation_rate_m2(feature_vector)
+        if self.time_parameterization == "per_second":
+            covariance = covariance * float(step_duration_s)
+        return _positive_semidefinite(covariance)
+
 
 @dataclass(frozen=True)
 class ActionConditionedDiscrepancyForecast:
@@ -302,7 +444,7 @@ def forecast_action_conditioned_persistence(
     features: ActionConditionedDiscrepancyFeatures,
     basis: np.ndarray,
 ) -> ActionConditionedDiscrepancyForecast:
-    """Persist the discrepancy mean while growing covariance by action regime."""
+    """Persist discrepancy mean while growing covariance by action regime."""
 
     graph_basis = np.asarray(basis, dtype=float)
     if graph_basis.ndim != 2 or graph_basis.shape[1] != belief.rank:
@@ -326,6 +468,7 @@ def forecast_action_conditioned_persistence(
         if features.component_ids != belief.component_ids:
             raise ValueError("component-specific features differ from belief support")
         feature_values = features.values
+    durations = features.component_step_durations(component_count)
     horizon = features.horizon
     mean = np.broadcast_to(
         belief.coefficient_mean_m[:, None],
@@ -339,7 +482,8 @@ def forecast_action_conditioned_persistence(
     for step in range(horizon):
         for component in range(component_count):
             increment = model.innovation_covariance_m2(
-                feature_values[component, step]
+                feature_values[component, step],
+                step_duration_s=float(durations[component, step]),
             )
             for coordinate in range(3):
                 covariance[component, step + 1, coordinate] = (

--- a/src/causal4d/finite_query_ambiguity.py
+++ b/src/causal4d/finite_query_ambiguity.py
@@ -1,0 +1,244 @@
+"""Finite-support identifiability diagnostics for a specific future query."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+def _readonly(values: np.ndarray, *, dtype: type = float) -> np.ndarray:
+    result = np.asarray(values, dtype=dtype).copy()
+    result.setflags(write=False)
+    return result
+
+
+def _normalized_weights(values: np.ndarray) -> np.ndarray:
+    weights = np.asarray(values, dtype=float).reshape(-1)
+    if not len(weights) or not np.all(np.isfinite(weights)):
+        raise ValueError("prior_weights must be a finite nonempty vector")
+    if np.any(weights < 0.0) or float(np.sum(weights)) <= 0.0:
+        raise ValueError("prior_weights must be nonnegative with positive mass")
+    return weights / np.sum(weights)
+
+
+def _whitened_components(
+    values: np.ndarray,
+    covariance: np.ndarray | float | None,
+) -> np.ndarray:
+    components = np.asarray(values, dtype=float)
+    if components.ndim < 2 or not np.all(np.isfinite(components)):
+        raise ValueError("responses must have shape (component, ...) and be finite")
+    flattened = components.reshape(len(components), -1)
+    dimension = flattened.shape[1]
+    if dimension == 0:
+        raise ValueError("responses must contain at least one coordinate")
+    if covariance is None:
+        return flattened
+    noise = np.asarray(covariance, dtype=float)
+    if noise.ndim == 0:
+        if not np.isfinite(noise) or float(noise) <= 0.0:
+            raise ValueError("scalar covariance must be finite and positive")
+        return flattened / np.sqrt(float(noise))
+    if noise.shape == (dimension,):
+        if not np.all(np.isfinite(noise)) or np.any(noise <= 0.0):
+            raise ValueError("diagonal covariance must be finite and positive")
+        return flattened / np.sqrt(noise)[None]
+    if noise.shape != (dimension, dimension):
+        raise ValueError("covariance must be scalar, diagonal, or full response size")
+    if not np.all(np.isfinite(noise)) or not np.allclose(
+        noise,
+        noise.T,
+        atol=1e-12,
+        rtol=1e-10,
+    ):
+        raise ValueError("full covariance must be finite and symmetric")
+    try:
+        factor = np.linalg.cholesky(noise)
+    except np.linalg.LinAlgError as error:
+        raise ValueError("full covariance must be positive definite") from error
+    return np.linalg.solve(factor, flattened.T).T
+
+
+def _scaled_query_components(
+    values: np.ndarray,
+    scale: np.ndarray | float | None,
+) -> np.ndarray:
+    components = np.asarray(values, dtype=float)
+    if components.ndim < 2 or not np.all(np.isfinite(components)):
+        raise ValueError(
+            "query responses must have shape (component, ...) and be finite"
+        )
+    flattened = components.reshape(len(components), -1)
+    if scale is None:
+        return flattened
+    supplied = np.asarray(scale, dtype=float)
+    if supplied.ndim == 0:
+        if not np.isfinite(supplied) or float(supplied) <= 0.0:
+            raise ValueError("query_scale must be finite and positive")
+        return flattened / float(supplied)
+    if supplied.shape != (flattened.shape[1],):
+        raise ValueError("query_scale must be scalar or match query coordinates")
+    if not np.all(np.isfinite(supplied)) or np.any(supplied <= 0.0):
+        raise ValueError("query_scale must be finite and positive")
+    return flattened / supplied[None]
+
+
+@dataclass(frozen=True)
+class FiniteQueryAmbiguityConfig:
+    """Thresholds for indistinguishable-prefix, divergent-query support pairs."""
+
+    maximum_prefix_rms_mahalanobis: float = 1.0
+    minimum_query_rms_distance: float = 1.0
+    maximum_ambiguous_pair_mass: float = 0.05
+    maximum_weighted_query_distance: float = 0.05
+
+    def __post_init__(self) -> None:
+        if not np.isfinite(self.maximum_prefix_rms_mahalanobis) or (
+            self.maximum_prefix_rms_mahalanobis < 0.0
+        ):
+            raise ValueError("maximum_prefix_rms_mahalanobis must be nonnegative")
+        if not np.isfinite(self.minimum_query_rms_distance) or (
+            self.minimum_query_rms_distance < 0.0
+        ):
+            raise ValueError("minimum_query_rms_distance must be nonnegative")
+        for name in (
+            "maximum_ambiguous_pair_mass",
+            "maximum_weighted_query_distance",
+        ):
+            value = float(getattr(self, name))
+            if not np.isfinite(value) or value < 0.0:
+                raise ValueError(f"{name} must be finite and nonnegative")
+
+
+@dataclass(frozen=True)
+class FiniteQueryAmbiguityResult:
+    """Global ambiguity of a finite posterior support for one future query."""
+
+    component_count: int
+    pair_indices: np.ndarray
+    prefix_rms_mahalanobis: np.ndarray
+    query_rms_distance: np.ndarray
+    pair_probability_mass: np.ndarray
+    ambiguous_pair_mass: float
+    weighted_query_distance: float
+    maximum_query_distance: float
+    admissible: bool
+    failure_reasons: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        pairs = _readonly(self.pair_indices, dtype=np.int64)
+        prefix = _readonly(self.prefix_rms_mahalanobis)
+        query = _readonly(self.query_rms_distance)
+        mass = _readonly(self.pair_probability_mass)
+        count = len(pairs)
+        if pairs.shape != (count, 2):
+            raise ValueError("pair_indices must have shape (pair, 2)")
+        if (
+            prefix.shape != (count,)
+            or query.shape != (count,)
+            or mass.shape != (count,)
+        ):
+            raise ValueError("pair diagnostics must align")
+        if np.any(pairs < 0) or np.any(pairs >= self.component_count):
+            raise ValueError("pair indices exceed component support")
+        if np.any(prefix < 0.0) or np.any(query < 0.0) or np.any(mass < 0.0):
+            raise ValueError("pair diagnostics must be nonnegative")
+        for value, name in (
+            (self.ambiguous_pair_mass, "ambiguous_pair_mass"),
+            (self.weighted_query_distance, "weighted_query_distance"),
+            (self.maximum_query_distance, "maximum_query_distance"),
+        ):
+            if not np.isfinite(value) or value < 0.0:
+                raise ValueError(f"{name} must be finite and nonnegative")
+        object.__setattr__(self, "pair_indices", pairs)
+        object.__setattr__(self, "prefix_rms_mahalanobis", prefix)
+        object.__setattr__(self, "query_rms_distance", query)
+        object.__setattr__(self, "pair_probability_mass", mass)
+        object.__setattr__(self, "failure_reasons", tuple(self.failure_reasons))
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "component_count": self.component_count,
+            "ambiguous_pair_count": len(self.pair_indices),
+            "ambiguous_pair_mass": self.ambiguous_pair_mass,
+            "weighted_query_distance": self.weighted_query_distance,
+            "maximum_query_distance": self.maximum_query_distance,
+            "admissible": self.admissible,
+            "failure_reasons": list(self.failure_reasons),
+            "pair_indices": self.pair_indices.tolist(),
+            "prefix_rms_mahalanobis": self.prefix_rms_mahalanobis.tolist(),
+            "query_rms_distance": self.query_rms_distance.tolist(),
+            "pair_probability_mass": self.pair_probability_mass.tolist(),
+        }
+
+
+def assess_finite_query_ambiguity(
+    prefix_responses: np.ndarray,
+    query_responses: np.ndarray,
+    prior_weights: np.ndarray,
+    *,
+    prefix_covariance: np.ndarray | float | None = None,
+    query_scale: np.ndarray | float | None = None,
+    config: FiniteQueryAmbiguityConfig | None = None,
+) -> FiniteQueryAmbiguityResult:
+    """Detect support pairs hidden by the prefix but divergent for the query.
+
+    The diagnostic is invariant to support permutation and to splitting one
+    component into exact clones whose weights sum to the original mass. Pair mass
+    is the probability of drawing the two distinct components in either order.
+    """
+
+    settings = config or FiniteQueryAmbiguityConfig()
+    prefix = _whitened_components(prefix_responses, prefix_covariance)
+    query = _scaled_query_components(query_responses, query_scale)
+    weights = _normalized_weights(prior_weights)
+    if len(prefix) != len(query) or len(prefix) != len(weights):
+        raise ValueError("prefix, query, and prior support must align")
+    component_count = len(weights)
+    ambiguous_pairs: list[tuple[int, int]] = []
+    prefix_distances: list[float] = []
+    query_distances: list[float] = []
+    pair_masses: list[float] = []
+    for first in range(component_count):
+        if weights[first] <= 0.0:
+            continue
+        for second in range(first + 1, component_count):
+            if weights[second] <= 0.0:
+                continue
+            prefix_distance = float(
+                np.sqrt(np.mean(np.square(prefix[first] - prefix[second])))
+            )
+            query_distance = float(
+                np.sqrt(np.mean(np.square(query[first] - query[second])))
+            )
+            if (
+                prefix_distance <= settings.maximum_prefix_rms_mahalanobis
+                and query_distance >= settings.minimum_query_rms_distance
+            ):
+                ambiguous_pairs.append((first, second))
+                prefix_distances.append(prefix_distance)
+                query_distances.append(query_distance)
+                pair_masses.append(2.0 * weights[first] * weights[second])
+    masses = np.asarray(pair_masses, dtype=float)
+    distances = np.asarray(query_distances, dtype=float)
+    ambiguous_mass = float(np.sum(masses))
+    weighted_distance = float(np.sum(masses * distances))
+    maximum_distance = float(np.max(distances)) if len(distances) else 0.0
+    reasons = []
+    if ambiguous_mass > settings.maximum_ambiguous_pair_mass:
+        reasons.append("ambiguous_support_mass_exceeds_threshold")
+    if weighted_distance > settings.maximum_weighted_query_distance:
+        reasons.append("weighted_query_divergence_exceeds_threshold")
+    return FiniteQueryAmbiguityResult(
+        component_count=component_count,
+        pair_indices=np.asarray(ambiguous_pairs, dtype=np.int64).reshape(-1, 2),
+        prefix_rms_mahalanobis=np.asarray(prefix_distances, dtype=float),
+        query_rms_distance=distances,
+        pair_probability_mass=masses,
+        ambiguous_pair_mass=ambiguous_mass,
+        weighted_query_distance=weighted_distance,
+        maximum_query_distance=maximum_distance,
+        admissible=not reasons,
+        failure_reasons=tuple(reasons),
+    )

--- a/src/causal4d/provider_contract.py
+++ b/src/causal4d/provider_contract.py
@@ -1,0 +1,154 @@
+"""Versioned capability contract for Bayesian-PhysTwin providers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+
+PHYSICAL_BELIEF_PROVIDER_SCHEMA_VERSION = 1
+BASE_CAUSAL4D_PROVIDER_CAPABILITIES = (
+    "artifact_checksums",
+    "particle_endpoint_position",
+    "particle_endpoint_velocity",
+    "physical_parameter_particles",
+)
+
+
+def _json_metadata(values: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        return json.loads(json.dumps(dict(values), sort_keys=True, allow_nan=False))
+    except (TypeError, ValueError) as error:
+        raise ValueError("metadata must contain finite JSON values") from error
+
+
+@dataclass(frozen=True)
+class PhysicalBeliefProviderManifest:
+    """Provider identity, artifact schemas, and explicit capabilities."""
+
+    provider_name: str
+    provider_version: str
+    provider_revision: str
+    schema_version: int
+    capabilities: tuple[str, ...]
+    artifact_schema_versions: Mapping[str, int]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if (
+            not self.provider_name
+            or not self.provider_version
+            or not self.provider_revision
+        ):
+            raise ValueError("provider identity fields must be nonempty")
+        if self.schema_version < 1:
+            raise ValueError("schema_version must be positive")
+        capabilities = tuple(sorted(map(str, self.capabilities)))
+        if not capabilities or any(not value for value in capabilities):
+            raise ValueError("capabilities must contain nonempty names")
+        if len(set(capabilities)) != len(capabilities):
+            raise ValueError("capabilities must be unique")
+        artifact_versions = {
+            str(name): int(version)
+            for name, version in dict(self.artifact_schema_versions).items()
+        }
+        if not artifact_versions or any(
+            not name or version < 1 for name, version in artifact_versions.items()
+        ):
+            raise ValueError("artifact schema versions must be positive and named")
+        object.__setattr__(self, "capabilities", capabilities)
+        object.__setattr__(self, "artifact_schema_versions", artifact_versions)
+        object.__setattr__(self, "metadata", _json_metadata(self.metadata))
+
+    @property
+    def manifest_id(self) -> str:
+        descriptor = {
+            "provider_name": self.provider_name,
+            "provider_version": self.provider_version,
+            "provider_revision": self.provider_revision,
+            "schema_version": self.schema_version,
+            "capabilities": list(self.capabilities),
+            "artifact_schema_versions": self.artifact_schema_versions,
+            "metadata": self.metadata,
+        }
+        return hashlib.sha256(
+            json.dumps(
+                descriptor,
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            ).encode("utf-8")
+        ).hexdigest()
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "manifest_id": self.manifest_id,
+            "provider_name": self.provider_name,
+            "provider_version": self.provider_version,
+            "provider_revision": self.provider_revision,
+            "schema_version": self.schema_version,
+            "capabilities": list(self.capabilities),
+            "artifact_schema_versions": dict(self.artifact_schema_versions),
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class ProviderCompatibilityResult:
+    """Fail-closed compatibility decision for one provider manifest."""
+
+    compatible: bool
+    missing_capabilities: tuple[str, ...]
+    unsupported_schema_version: int | None
+    artifact_version_mismatches: tuple[str, ...]
+    provider_manifest_id: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "compatible": self.compatible,
+            "missing_capabilities": list(self.missing_capabilities),
+            "unsupported_schema_version": self.unsupported_schema_version,
+            "artifact_version_mismatches": list(
+                self.artifact_version_mismatches
+            ),
+            "provider_manifest_id": self.provider_manifest_id,
+        }
+
+
+def validate_provider_compatibility(
+    manifest: PhysicalBeliefProviderManifest,
+    *,
+    required_capabilities: Sequence[str] = BASE_CAUSAL4D_PROVIDER_CAPABILITIES,
+    supported_schema_versions: Sequence[int] = (
+        PHYSICAL_BELIEF_PROVIDER_SCHEMA_VERSION,
+    ),
+    required_artifact_versions: Mapping[str, int] | None = None,
+) -> ProviderCompatibilityResult:
+    """Validate a provider without relying on a hard-coded implementation pin."""
+
+    required = tuple(sorted(map(str, required_capabilities)))
+    if any(not value for value in required) or len(set(required)) != len(required):
+        raise ValueError("required_capabilities must contain unique names")
+    supported = tuple(int(value) for value in supported_schema_versions)
+    if not supported or any(value < 1 for value in supported):
+        raise ValueError("supported_schema_versions must be positive")
+    missing = tuple(
+        value for value in required if value not in set(manifest.capabilities)
+    )
+    unsupported = (
+        None if manifest.schema_version in supported else manifest.schema_version
+    )
+    mismatches = []
+    for name, expected in dict(required_artifact_versions or {}).items():
+        actual = manifest.artifact_schema_versions.get(str(name))
+        if actual != int(expected):
+            mismatches.append(f"{name}:expected={int(expected)}:actual={actual}")
+    return ProviderCompatibilityResult(
+        compatible=not missing and unsupported is None and not mismatches,
+        missing_capabilities=missing,
+        unsupported_schema_version=unsupported,
+        artifact_version_mismatches=tuple(sorted(mismatches)),
+        provider_manifest_id=manifest.manifest_id,
+    )

--- a/src/causal4d/stable_discrepancy_dynamics.py
+++ b/src/causal4d/stable_discrepancy_dynamics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
 import numpy as np
 from scipy.linalg import expm
@@ -14,6 +15,9 @@ from causal4d.action_conditioned_discrepancy import (
 )
 from causal4d.contracts import array_sha256
 from causal4d.discrepancy_belief import GraphDiscrepancyBelief
+
+
+TIME_PARAMETERIZATIONS = ("per_step", "per_second")
 
 
 def _readonly(values: np.ndarray) -> np.ndarray:
@@ -42,13 +46,36 @@ def _normalized_rows(values: np.ndarray, *, width: int, name: str) -> np.ndarray
     return supplied / norms[:, None]
 
 
+def _continuous_process_covariance(
+    generator: np.ndarray,
+    covariance_rate: np.ndarray,
+    step_duration_s: float,
+) -> np.ndarray:
+    """Discretize a continuous covariance rate using the Van Loan method."""
+
+    rank = generator.shape[0]
+    if not np.any(covariance_rate):
+        return np.zeros_like(covariance_rate)
+    if not np.any(generator):
+        return _positive_semidefinite(covariance_rate * step_duration_s)
+    block = np.zeros((2 * rank, 2 * rank), dtype=float)
+    block[:rank, :rank] = generator
+    block[:rank, rank:] = covariance_rate
+    block[rank:, rank:] = -generator.T
+    exponential = expm(block * step_duration_s)
+    transition = exponential[:rank, :rank]
+    cross = exponential[:rank, rank:]
+    return _positive_semidefinite(cross @ transition.T)
+
+
 @dataclass(frozen=True)
 class StableDiscrepancyTransitionModel:
     """Dissipative graph-mode transport with exact identity fallback.
 
     The generator is ``G(f)=S(f)-C(f)``. ``S`` is skew-symmetric and ``C`` is
-    positive semidefinite, so ``A(f)=expm(G(f))`` is non-expansive while allowing
-    graph-mode rotation. Empty arrays produce ``A=I`` and zero drift exactly.
+    positive semidefinite. Under ``per_second`` parameterization, affine mean
+    dynamics are discretized exactly for every declared step duration. Empty
+    arrays produce exact graph persistence.
     """
 
     feature_names: tuple[str, ...]
@@ -61,6 +88,7 @@ class StableDiscrepancyTransitionModel:
     drift_feature_weights: np.ndarray
     model_id: str = "stable-action-conditioned-discrepancy-v1"
     maximum_drift_norm_m: float | None = None
+    time_parameterization: Literal["per_step", "per_second"] = "per_step"
 
     def __post_init__(self) -> None:
         names = tuple(map(str, self.feature_names))
@@ -68,6 +96,10 @@ class StableDiscrepancyTransitionModel:
             raise ValueError("feature_names must be nonempty and unique")
         if self.rank < 1 or not self.model_id:
             raise ValueError("rank and model_id must be valid")
+        if self.time_parameterization not in TIME_PARAMETERIZATIONS:
+            raise ValueError(
+                f"time_parameterization must be one of {TIME_PARAMETERIZATIONS}"
+            )
         feature_count = len(names)
 
         raw_skew = np.asarray(self.skew_generators, dtype=float)
@@ -173,8 +205,8 @@ class StableDiscrepancyTransitionModel:
             raise ValueError("feature vector does not match transition model")
         return values
 
-    def transition_operator(self, feature_vector: np.ndarray) -> np.ndarray:
-        """Return the non-expansive transition matrix for one forecast step."""
+    def generator_matrix(self, feature_vector: np.ndarray) -> np.ndarray:
+        """Return the dissipative generator before time discretization."""
 
         features = self._features(feature_vector)
         generator = np.zeros((self.rank, self.rank), dtype=float)
@@ -192,29 +224,79 @@ class StableDiscrepancyTransitionModel:
                 self.contraction_directions,
                 self.contraction_directions,
             )
-        if not np.any(generator):
-            return np.eye(self.rank)
-        transition = np.asarray(expm(generator), dtype=float)
-        if not np.all(np.isfinite(transition)):
-            raise RuntimeError("discrepancy transition is non-finite")
-        return transition
+        return generator
 
-    def drift_increment_m(self, feature_vector: np.ndarray) -> np.ndarray:
-        """Return a bounded coefficient-space mean increment."""
+    def drift_rate_mps(self, feature_vector: np.ndarray) -> np.ndarray:
+        """Return the affine drift vector before time discretization."""
 
         features = self._features(feature_vector)
         if not len(self.drift_directions_m):
             return np.zeros((self.rank, 3), dtype=float)
-        drift = np.einsum(
+        return np.einsum(
             "j,jrc->rc",
             self.drift_feature_weights @ features,
             self.drift_directions_m,
         )
+
+    def transition_and_drift(
+        self,
+        feature_vector: np.ndarray,
+        *,
+        step_duration_s: float = 1.0,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Return one affine discrete transition for the declared step."""
+
+        if not np.isfinite(step_duration_s) or step_duration_s <= 0.0:
+            raise ValueError("step_duration_s must be finite and positive")
+        generator = self.generator_matrix(feature_vector)
+        drift = self.drift_rate_mps(feature_vector)
+        if not np.any(generator) and not np.any(drift):
+            return np.eye(self.rank), np.zeros((self.rank, 3), dtype=float)
+        if self.time_parameterization == "per_step":
+            transition = expm(generator) if np.any(generator) else np.eye(self.rank)
+            increment = drift.copy()
+        else:
+            augmented = np.zeros((self.rank + 3, self.rank + 3), dtype=float)
+            augmented[: self.rank, : self.rank] = generator
+            augmented[: self.rank, self.rank :] = drift
+            discrete = expm(augmented * float(step_duration_s))
+            transition = discrete[: self.rank, : self.rank]
+            increment = discrete[: self.rank, self.rank :]
         if self.maximum_drift_norm_m is not None:
-            norm = float(np.linalg.norm(drift))
+            norm = float(np.linalg.norm(increment))
             if norm > self.maximum_drift_norm_m:
-                drift *= self.maximum_drift_norm_m / norm
-        return drift
+                increment *= self.maximum_drift_norm_m / norm
+        if not np.all(np.isfinite(transition)) or not np.all(np.isfinite(increment)):
+            raise RuntimeError("discrepancy transition is non-finite")
+        return np.asarray(transition, dtype=float), np.asarray(increment, dtype=float)
+
+    def transition_operator(
+        self,
+        feature_vector: np.ndarray,
+        *,
+        step_duration_s: float = 1.0,
+    ) -> np.ndarray:
+        """Return the non-expansive transition matrix for one forecast step."""
+
+        transition, _ = self.transition_and_drift(
+            feature_vector,
+            step_duration_s=step_duration_s,
+        )
+        return transition
+
+    def drift_increment_m(
+        self,
+        feature_vector: np.ndarray,
+        *,
+        step_duration_s: float = 1.0,
+    ) -> np.ndarray:
+        """Return a bounded coefficient-space mean increment."""
+
+        _, increment = self.transition_and_drift(
+            feature_vector,
+            step_duration_s=step_duration_s,
+        )
+        return increment
 
 
 def forecast_action_conditioned_dynamics(
@@ -224,7 +306,7 @@ def forecast_action_conditioned_dynamics(
     features: ActionConditionedDiscrepancyFeatures,
     basis: np.ndarray,
 ) -> ActionConditionedDiscrepancyForecast:
-    """Propagate mean and covariance under one shared action feature sequence."""
+    """Propagate stable discrepancy dynamics in declared physical time."""
 
     graph_basis = np.asarray(basis, dtype=float)
     if graph_basis.ndim != 2 or graph_basis.shape[1] != belief.rank:
@@ -252,6 +334,7 @@ def forecast_action_conditioned_dynamics(
         if features.component_ids != belief.component_ids:
             raise ValueError("component-specific features differ from belief support")
         feature_values = features.values
+    durations = features.component_step_durations(component_count)
 
     horizon = features.horizon
     mean = np.empty((component_count, horizon + 1, belief.rank, 3), dtype=float)
@@ -264,12 +347,28 @@ def forecast_action_conditioned_dynamics(
     for component in range(component_count):
         for step in range(horizon):
             feature_vector = feature_values[component, step]
-            transition = transition_model.transition_operator(feature_vector)
-            mean[component, step + 1] = (
-                transition @ mean[component, step]
-                + transition_model.drift_increment_m(feature_vector)
+            duration = float(durations[component, step])
+            transition, drift = transition_model.transition_and_drift(
+                feature_vector,
+                step_duration_s=duration,
             )
-            innovation = innovation_model.innovation_covariance_m2(feature_vector)
+            mean[component, step + 1] = (
+                transition @ mean[component, step] + drift
+            )
+            if (
+                transition_model.time_parameterization == "per_second"
+                and innovation_model.time_parameterization == "per_second"
+            ):
+                innovation = _continuous_process_covariance(
+                    transition_model.generator_matrix(feature_vector),
+                    innovation_model.innovation_rate_m2(feature_vector),
+                    duration,
+                )
+            else:
+                innovation = innovation_model.innovation_covariance_m2(
+                    feature_vector,
+                    step_duration_s=duration,
+                )
             for coordinate in range(3):
                 previous = covariance[component, step, coordinate]
                 covariance[component, step + 1, coordinate] = (

--- a/tests/test_causal4d_action_conditioned_counterfactual.py
+++ b/tests/test_causal4d_action_conditioned_counterfactual.py
@@ -16,6 +16,9 @@ from causal4d.contracts import (
 )
 from causal4d.discrepancy_belief import GraphDiscrepancyBelief
 from causal4d.rollout_bank import JointRolloutBank
+from causal4d.stable_discrepancy_dynamics import (
+    StableDiscrepancyTransitionModel,
+)
 
 
 def _problem():
@@ -182,6 +185,7 @@ def test_zero_innovation_matches_static_readout_moments() -> None:
     np.testing.assert_allclose(posterior.readout_variance_m2, 3e-6)
     assert posterior.component_ids == ("nominal::p0", "shift::p0")
     assert posterior.metadata["future_observations_read"] == 0
+    assert posterior.metadata["discrepancy_mean_transition"] == "graph_persistence"
 
 
 def test_action_conditioned_covariance_grows_over_horizon() -> None:
@@ -225,3 +229,59 @@ def test_action_conditioned_covariance_grows_over_horizon() -> None:
         offset.shape,
     )
     np.testing.assert_allclose(offset, expected_offset)
+
+
+def test_stable_transition_contracts_discrepancy_mean() -> None:
+    (
+        bank,
+        manifest,
+        twin,
+        factual,
+        query,
+        discrepancy,
+        basis,
+        anchor,
+        feature_names,
+    ) = _problem()
+    innovation = ActionConditionedDiscrepancyModel(
+        feature_names=feature_names,
+        base_innovation_covariance_m2=np.zeros((1, 1)),
+        feature_directions=np.zeros((0, 1)),
+        feature_weights=np.zeros((0, len(feature_names))),
+    )
+    contraction_weights = np.zeros((1, len(feature_names)))
+    contraction_weights[0, feature_names.index("control_speed_mps")] = 4.0
+    transition = StableDiscrepancyTransitionModel(
+        feature_names=feature_names,
+        rank=1,
+        skew_generators=np.zeros((0, 1, 1)),
+        skew_feature_weights=np.zeros((0, len(feature_names))),
+        contraction_directions=np.ones((1, 1)),
+        contraction_feature_weights=contraction_weights,
+        drift_directions_m=np.zeros((0, 1, 3)),
+        drift_feature_weights=np.zeros((0, len(feature_names))),
+        model_id="unit-stable-contraction",
+    )
+    posterior = apply_action_conditioned_counterfactual_operator(
+        bank,
+        manifest,
+        twin,
+        factual,
+        query,
+        discrepancy,
+        innovation,
+        basis,
+        anchor,
+        frame_dt_s=0.1,
+        transition_model=transition,
+    )
+    offset = (
+        posterior.readout_trajectories_m
+        - posterior.state_trajectories_m
+    )[:, :, 0, 0]
+    assert np.all(np.diff(offset, axis=1) <= 1e-15)
+    assert np.all(offset[:, -1] < offset[:, 0])
+    assert (
+        posterior.metadata["discrepancy_mean_transition"]
+        == "unit-stable-contraction"
+    )

--- a/tests/test_causal4d_finite_query_ambiguity.py
+++ b/tests/test_causal4d_finite_query_ambiguity.py
@@ -1,0 +1,86 @@
+import numpy as np
+
+from causal4d.finite_query_ambiguity import (
+    FiniteQueryAmbiguityConfig,
+    assess_finite_query_ambiguity,
+)
+
+
+_CONFIG = FiniteQueryAmbiguityConfig(
+    maximum_prefix_rms_mahalanobis=0.25,
+    minimum_query_rms_distance=1.0,
+    maximum_ambiguous_pair_mass=0.20,
+    maximum_weighted_query_distance=0.20,
+)
+
+
+def test_query_ambiguity_rejects_prefix_indistinguishable_futures() -> None:
+    result = assess_finite_query_ambiguity(
+        np.asarray([[0.0, 0.0], [0.05, 0.0]]),
+        np.asarray([[0.0], [2.0]]),
+        np.asarray([0.5, 0.5]),
+        prefix_covariance=1.0,
+        query_scale=1.0,
+        config=_CONFIG,
+    )
+    assert not result.admissible
+    assert result.ambiguous_pair_mass == 0.5
+    assert result.weighted_query_distance == 1.0
+    assert result.pair_indices.tolist() == [[0, 1]]
+
+
+def test_query_ambiguity_is_permutation_invariant() -> None:
+    prefix = np.asarray([[0.0, 0.0], [0.05, 0.0], [3.0, 1.0]])
+    query = np.asarray([[0.0], [2.0], [0.0]])
+    weights = np.asarray([0.3, 0.4, 0.3])
+    reference = assess_finite_query_ambiguity(
+        prefix,
+        query,
+        weights,
+        config=_CONFIG,
+    )
+    permutation = np.asarray([2, 0, 1])
+    changed = assess_finite_query_ambiguity(
+        prefix[permutation],
+        query[permutation],
+        weights[permutation],
+        config=_CONFIG,
+    )
+    assert reference.admissible == changed.admissible
+    assert np.isclose(reference.ambiguous_pair_mass, changed.ambiguous_pair_mass)
+    assert np.isclose(
+        reference.weighted_query_distance,
+        changed.weighted_query_distance,
+    )
+
+
+def test_query_ambiguity_is_invariant_to_exact_support_cloning() -> None:
+    reference = assess_finite_query_ambiguity(
+        np.asarray([[0.0], [0.0]]),
+        np.asarray([[0.0], [2.0]]),
+        np.asarray([0.4, 0.6]),
+        config=_CONFIG,
+    )
+    cloned = assess_finite_query_ambiguity(
+        np.asarray([[0.0], [0.0], [0.0]]),
+        np.asarray([[0.0], [0.0], [2.0]]),
+        np.asarray([0.1, 0.3, 0.6]),
+        config=_CONFIG,
+    )
+    assert np.isclose(reference.ambiguous_pair_mass, cloned.ambiguous_pair_mass)
+    assert np.isclose(
+        reference.weighted_query_distance,
+        cloned.weighted_query_distance,
+    )
+
+
+def test_identical_query_predictions_are_not_ambiguous() -> None:
+    result = assess_finite_query_ambiguity(
+        np.zeros((3, 2)),
+        np.ones((3, 4)),
+        np.asarray([0.2, 0.3, 0.5]),
+        config=_CONFIG,
+    )
+    assert result.admissible
+    assert result.ambiguous_pair_mass == 0.0
+    assert len(result.pair_indices) == 0

--- a/tests/test_causal4d_provider_contract.py
+++ b/tests/test_causal4d_provider_contract.py
@@ -1,0 +1,59 @@
+from causal4d.provider_contract import (
+    BASE_CAUSAL4D_PROVIDER_CAPABILITIES,
+    PHYSICAL_BELIEF_PROVIDER_SCHEMA_VERSION,
+    PhysicalBeliefProviderManifest,
+    validate_provider_compatibility,
+)
+
+
+def _manifest(**overrides):
+    values = {
+        "provider_name": "bayesian-phystwin",
+        "provider_version": "0.4.0",
+        "provider_revision": "c7ad36aad7e592ce8a391c9ca2d4db7389dee3ac",
+        "schema_version": PHYSICAL_BELIEF_PROVIDER_SCHEMA_VERSION,
+        "capabilities": (*BASE_CAUSAL4D_PROVIDER_CAPABILITIES, "graph_covariance"),
+        "artifact_schema_versions": {"TwinBelief": 1, "GraphBelief": 1},
+    }
+    values.update(overrides)
+    return PhysicalBeliefProviderManifest(**values)
+
+
+def test_compatible_provider_passes_explicit_contract() -> None:
+    manifest = _manifest()
+    result = validate_provider_compatibility(
+        manifest,
+        required_artifact_versions={"TwinBelief": 1},
+    )
+    assert result.compatible
+    assert not result.missing_capabilities
+    assert result.provider_manifest_id == manifest.manifest_id
+
+
+def test_missing_capability_fails_closed() -> None:
+    manifest = _manifest(capabilities=("artifact_checksums",))
+    result = validate_provider_compatibility(manifest)
+    assert not result.compatible
+    assert "particle_endpoint_velocity" in result.missing_capabilities
+
+
+def test_schema_and_artifact_mismatch_are_reported() -> None:
+    manifest = _manifest(schema_version=2)
+    result = validate_provider_compatibility(
+        manifest,
+        required_artifact_versions={"TwinBelief": 2},
+    )
+    assert not result.compatible
+    assert result.unsupported_schema_version == 2
+    assert result.artifact_version_mismatches == (
+        "TwinBelief:expected=2:actual=1",
+    )
+
+
+def test_manifest_identifier_is_order_invariant() -> None:
+    first = _manifest(
+        capabilities=("graph_covariance", *BASE_CAUSAL4D_PROVIDER_CAPABILITIES),
+        artifact_schema_versions={"GraphBelief": 1, "TwinBelief": 1},
+    )
+    second = _manifest()
+    assert first.manifest_id == second.manifest_id

--- a/tests/test_causal4d_signed_continuous_dynamics.py
+++ b/tests/test_causal4d_signed_continuous_dynamics.py
@@ -1,0 +1,161 @@
+import numpy as np
+
+from causal4d.action_conditioned_discrepancy import (
+    ActionConditionedDiscrepancyFeatures,
+    ActionConditionedDiscrepancyModel,
+    build_action_conditioned_features,
+    forecast_action_conditioned_persistence,
+)
+from causal4d.contracts import array_sha256
+from causal4d.discrepancy_belief import GraphDiscrepancyBelief
+from causal4d.stable_discrepancy_dynamics import (
+    StableDiscrepancyTransitionModel,
+    forecast_action_conditioned_dynamics,
+)
+
+
+def _features(*, gain: float, rotation_degrees: float, schema: str):
+    controls = np.zeros((3, 1, 3), dtype=float)
+    controls[:, 0, 0] = [0.01, 0.02, 0.01]
+    return build_action_conditioned_features(
+        controls,
+        np.zeros((1, 3)),
+        frame_dt_s=0.1,
+        phi_names=("gain_multiplier", "delay_steps", "rotation_degrees"),
+        phi=np.asarray([gain, 0.0, rotation_degrees]),
+        kappa_names=("attachment_shift_hand_0", "slip_fraction"),
+        kappa=np.asarray([-2.0, 0.1]),
+        feature_schema=schema,
+    )
+
+
+def test_signed_feature_schema_preserves_realization_direction() -> None:
+    magnitude_low = _features(gain=0.85, rotation_degrees=-3.0, schema="magnitude_v1")
+    magnitude_high = _features(gain=1.15, rotation_degrees=3.0, schema="magnitude_v1")
+    np.testing.assert_allclose(magnitude_low.values, magnitude_high.values)
+
+    signed_low = _features(gain=0.85, rotation_degrees=-3.0, schema="signed_v2")
+    signed_high = _features(gain=1.15, rotation_degrees=3.0, schema="signed_v2")
+    gain_index = signed_low.names.index("gain_signed_deviation")
+    rotation_index = signed_low.names.index("rotation_sin")
+    shift_index = signed_low.names.index("attachment_shift_mean")
+    assert np.all(signed_low.values[:, gain_index] < 0.0)
+    assert np.all(signed_high.values[:, gain_index] > 0.0)
+    assert np.all(signed_low.values[:, rotation_index] < 0.0)
+    assert np.all(signed_high.values[:, rotation_index] > 0.0)
+    assert np.all(signed_low.values[:, shift_index] < 0.0)
+    assert signed_low.step_duration_s == 0.1
+
+
+def _belief(basis: np.ndarray) -> GraphDiscrepancyBelief:
+    return GraphDiscrepancyBelief(
+        basis_sha256=array_sha256(basis),
+        component_ids=("component-0",),
+        coefficient_mean_m=np.asarray(
+            [[[0.02, 0.0, 0.0], [0.0, -0.01, 0.0]]]
+        ),
+        coefficient_covariance_m2=np.broadcast_to(
+            np.asarray([[4e-6, 1e-6], [1e-6, 3e-6]])[None, None],
+            (1, 3, 2, 2),
+        ).copy(),
+        projection_variance_m2=np.asarray([1e-6, 1e-6, 1e-6]),
+        transition_model_id="persistence",
+        innovation_model_id="unit",
+    )
+
+
+def _constant_features(
+    horizon: int,
+    duration: float,
+) -> ActionConditionedDiscrepancyFeatures:
+    return ActionConditionedDiscrepancyFeatures(
+        names=("drive",),
+        values=np.ones((horizon, 1), dtype=float),
+        step_duration_s=duration,
+        schema_id="unit",
+    )
+
+
+def test_continuous_persistence_covariance_is_frame_rate_invariant() -> None:
+    basis = np.eye(2)
+    belief = _belief(basis)
+    model = ActionConditionedDiscrepancyModel(
+        feature_names=("drive",),
+        base_innovation_covariance_m2=np.asarray(
+            [[2e-6, 5e-7], [5e-7, 1e-6]]
+        ),
+        feature_directions=np.zeros((0, 2)),
+        feature_weights=np.zeros((0, 1)),
+        time_parameterization="per_second",
+    )
+    coarse = forecast_action_conditioned_persistence(
+        belief,
+        model,
+        _constant_features(2, 0.5),
+        basis,
+    )
+    fine = forecast_action_conditioned_persistence(
+        belief,
+        model,
+        _constant_features(10, 0.1),
+        basis,
+    )
+    np.testing.assert_allclose(
+        coarse.coefficient_covariance_m2[:, -1],
+        fine.coefficient_covariance_m2[:, -1],
+        atol=1e-15,
+        rtol=1e-12,
+    )
+
+
+def test_continuous_affine_dynamics_are_frame_rate_invariant() -> None:
+    basis = np.eye(2)
+    belief = _belief(basis)
+    covariance = ActionConditionedDiscrepancyModel(
+        feature_names=("drive",),
+        base_innovation_covariance_m2=np.asarray(
+            [[2e-6, 4e-7], [4e-7, 1e-6]]
+        ),
+        feature_directions=np.zeros((0, 2)),
+        feature_weights=np.zeros((0, 1)),
+        time_parameterization="per_second",
+    )
+    transition = StableDiscrepancyTransitionModel(
+        feature_names=("drive",),
+        rank=2,
+        skew_generators=np.asarray([[[0.0, -1.0], [1.0, 0.0]]]),
+        skew_feature_weights=np.asarray([[0.3]]),
+        contraction_directions=np.asarray([[1.0, 0.0]]),
+        contraction_feature_weights=np.asarray([[0.4]]),
+        drift_directions_m=np.asarray(
+            [[[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]
+        ),
+        drift_feature_weights=np.asarray([[0.005]]),
+        time_parameterization="per_second",
+    )
+    coarse = forecast_action_conditioned_dynamics(
+        belief,
+        covariance,
+        transition,
+        _constant_features(2, 0.5),
+        basis,
+    )
+    fine = forecast_action_conditioned_dynamics(
+        belief,
+        covariance,
+        transition,
+        _constant_features(10, 0.1),
+        basis,
+    )
+    np.testing.assert_allclose(
+        coarse.coefficient_mean_m[:, -1],
+        fine.coefficient_mean_m[:, -1],
+        atol=1e-13,
+        rtol=1e-11,
+    )
+    np.testing.assert_allclose(
+        coarse.coefficient_covariance_m2[:, -1],
+        fine.coefficient_covariance_m2[:, -1],
+        atol=1e-13,
+        rtol=1e-11,
+    )


### PR DESCRIPTION
## Summary

- retain the frozen `magnitude_v1` action-feature schema and add an opt-in `signed_v2` schema with signed gain, rotation, attachment shift, radial velocity, and anchor-distance features
- bind discrepancy features to physical step durations and add backward-compatible `per_step` / opt-in `per_second` parameterizations
- discretize stable affine discrepancy means exactly and continuous covariance rates with the Van Loan construction, making constant-feature forecasts invariant to frame subdivision
- integrate the stable transition model into the action-conditioned counterfactual readout path while preserving exact graph-persistence fallback
- add a global finite-support query-ambiguity gate that detects prefix-indistinguishable components with divergent requested futures
- add a versioned capability and artifact-schema contract for Bayesian-PhysTwin providers
- export the new APIs and document their claim and promotion boundaries
- retain an end-to-end counterfactual regression proving that an enabled stable transition contracts the discrepancy mean while the default remains persistence

## Motivation

The covariance-only feature schema intentionally discarded realization signs, which is safe for uncertainty inflation but insufficient for directed discrepancy-mean dynamics. The existing stable transition also acted once per frame, so changing the frame rate changed its physical effect. Local sensitivity rank alone can miss finite rollout components that fit the allowed prefix equally well but imply very different held-out predictions. Finally, the Bayesian-PhysTwin boundary was reproducible through one pinned commit but lacked an explicit semantic capability contract.

## Compatibility and safety

- `magnitude_v1`, `per_step`, and graph persistence remain the defaults
- existing manually constructed features retain unit-step behavior
- the counterfactual operator uses stable mean dynamics only when an explicit transition model is supplied
- no future object observation enters feature construction, propagation, or ambiguity assessment
- ambiguity thresholds and continuous-time dynamics remain source-fitted or preregistered development components
- the existing pinned Bayesian-PhysTwin dependency remains valid; the manifest is an additional fail-closed contract

## Validation

The complete repository CI passed on the final head:

- Ruff
- full test suite on Python 3.10
- full test suite on Python 3.12
- full test suite on Python 3.14
- wheel and source-distribution build
- distribution metadata validation
- isolated built-wheel import smoke test

Focused coverage includes signed versus magnitude-only realization features, continuous mean/covariance invariance under frame subdivision, end-to-end stable counterfactual transport, query-ambiguity rejection, support permutation and clone invariance, and provider capability/schema compatibility.