### PR TITLE
Add sensor-factorized realized-intervention abduction

### DIFF
--- a/docs/sensor_factorized_abduction.md
+++ b/docs/sensor_factorized_abduction.md
@@ -36,10 +36,15 @@ causal frame. `ContactWrenchEvidence` provides the analogous contract for force
 or wrench quantities with explicit column names. Both artifacts:
 
 - are immutable after construction;
+- bind the protocol, case, and observed-action identities;
 - have deterministic SHA-256 artifact identities;
 - serialize to non-pickled NPZ files;
 - reject evidence extending beyond the factual-abduction prefix;
 - require provenance explaining the independently measured sensor stream.
+
+When actuator and wrench evidence are combined, they must name the same trusted
+clock. Evidence from another protocol, case, or observed action is rejected
+before any likelihood is evaluated.
 
 Use `save_independent_sensor_evidence` and
 `load_independent_sensor_evidence` for checksummed round trips.
@@ -70,6 +75,9 @@ from causal4d import (
 )
 
 actuator = ActuatorEvidence(
+    protocol_id=factual.context.protocol_id,
+    case_id=factual.context.case_id,
+    observed_action_id=factual.context.u_obs.action_id,
     stream_id="measured_end_effector",
     clock_id="robot_monotonic",
     provenance="robot encoder independent of RGB-D reconstruction",

--- a/docs/sensor_factorized_abduction.md
+++ b/docs/sensor_factorized_abduction.md
@@ -1,0 +1,144 @@
+# Sensor-Factorized Realized-Intervention Abduction
+
+## Status
+
+This is an opt-in development extension. It does not modify the frozen
+`v0.3.0-causal4d-aip` path or promote a new real-data result.
+
+## Motivation
+
+The ordinary factual-abduction path scores the permitted object-response prefix
+and returns a posterior over physical particles and realized-intervention
+hypotheses. Measured robot motion and force should not be folded into that same
+object likelihood or reconstructed from the object response. They are separate
+sensor factors:
+
+```text
+u_cmd -> measured actuator realization -> contact transmission -> object response
+```
+
+For component `k`, the update is
+
+```text
+p_k^+ proportional to p_k(object prefix)
+                       L_actuator(measured end effector | component k)
+                       L_wrench(measured force/wrench | component k).
+```
+
+No object observation is accepted by the factorized update API. This prevents a
+second use of the object-response prefix after ordinary Causal4D abduction.
+
+## Typed evidence
+
+`ActuatorEvidence` stores synchronized measured end-effector positions, metric
+variance, a validity mask, clock identity, provenance, and the last admissible
+causal frame. `ContactWrenchEvidence` provides the analogous contract for force
+or wrench quantities with explicit column names. Both artifacts:
+
+- are immutable after construction;
+- have deterministic SHA-256 artifact identities;
+- serialize to non-pickled NPZ files;
+- reject evidence extending beyond the factual-abduction prefix;
+- require provenance explaining the independently measured sensor stream.
+
+Use `save_independent_sensor_evidence` and
+`load_independent_sensor_evidence` for checksummed round trips.
+
+## Robust independent-sensor factors
+
+`reweight_factual_intervention_with_independent_sensors` starts from an existing
+`FactualIntervention`. Component predictions must be supplied on the evidence
+sample grid. The update uses diagonal Student-t factors with:
+
+- observation and optional component-prediction variance;
+- separate actuator and wrench likelihood powers;
+- capped effective scalar sample counts;
+- the variance-normalization term, so broad predictions are not rewarded;
+- explicit metadata that the object likelihood was not reused.
+
+Absent evidence, all-invalid evidence, zero-powered evidence, or a
+component-invariant likelihood returns the original `FactualIntervention`
+object exactly. This preserves its artifact identity and weights bit-for-bit.
+
+A minimal actuator update is:
+
+```python
+from causal4d import (
+    ActuatorEvidence,
+    predict_affine_actuator_realizations,
+    reweight_factual_intervention_with_independent_sensors,
+)
+
+actuator = ActuatorEvidence(
+    stream_id="measured_end_effector",
+    clock_id="robot_monotonic",
+    provenance="robot encoder independent of RGB-D reconstruction",
+    sample_times_s=times,
+    positions_m=measured_positions,
+    variance_m2=encoder_variance,
+    evidence_frame_stop=factual.evidence_frame_stop,
+)
+
+predicted = predict_affine_actuator_realizations(
+    commanded_positions,
+    factual.phi_names,
+    factual.phi,
+    rotation_axis=(0.0, 1.0, 0.0),
+)
+
+updated = reweight_factual_intervention_with_independent_sensors(
+    factual,
+    actuator_evidence=actuator,
+    predicted_actuator_positions_m=predicted,
+)
+```
+
+`predict_affine_actuator_realizations` implements the currently typed gain,
+integer delay, and controller-frame rotation variables. Gain and rotation act on
+displacement from the first command pose. Nominal gain, zero delay, and zero
+rotation reproduce the commanded trajectory exactly.
+
+## Distributed contact traction and wrench
+
+`graph_traction_field` lifts low-rank coefficient forces through a graph basis.
+`integrate_contact_wrench` then computes resultant force and torque about a
+specified origin. These utilities support a sparse distributed traction field
+without requiring the inference API to assume one fixed contact node. A
+single-node basis remains an exact special case.
+
+The PhysTwin adapter remains responsible for generating component-wise actuator
+and wrench predictions without target-future object observations. The
+factorized module does not splice trajectories or inject corrections into the
+simulator state.
+
+## Causal-sufficiency falsification
+
+`assess_command_residual_sufficiency` asks whether commanded-action identity
+still predicts held-out residuals after conditioning on the supplied realized-
+intervention features. It compares cross-fitted ridge predictors:
+
+```text
+residual ~ realized-intervention features
+residual ~ realized-intervention features + command identity
+```
+
+The comparison is grouped by independent execution or session and uses a
+permutation diagnostic. A significant command-identity gain indicates that the
+chosen realization variables are incomplete. Failure to detect a gain is not a
+proof of conditional independence.
+
+## Integration boundary
+
+A real Bayesian-PhysTwin integration should:
+
+1. retain measured actuator and force streams on a trusted common clock;
+2. generate component predictions from command, physical particle, contact path,
+   and traction hypotheses without reading future object outcomes;
+3. perform ordinary object-prefix abduction once;
+4. apply the independent sensor factors;
+5. carry the updated joint posterior into the existing counterfactual operator;
+6. evaluate the command-residual sufficiency test on untouched executions.
+
+The locked 36-execution protocol and frozen milestones remain unchanged. Any
+promotion requires source-only factor settings, independent-session evaluation,
+held-out action/contact prediction, and the existing calibration gates.

--- a/src/causal4d/__init__.py
+++ b/src/causal4d/__init__.py
@@ -12,8 +12,13 @@ from causal4d.action_conditioned_discrepancy import (
     forecast_action_conditioned_persistence,
 )
 from causal4d.benchmark import CounterfactualBenchmarkConfig, build_protocol
+from causal4d.causal_sufficiency import (
+    CausalSufficiencyResult,
+    assess_command_residual_sufficiency,
+)
 from causal4d.contact_evaluation import run_latent_contact_benchmark
 from causal4d.contact_inference import LatentContactConfig
+from causal4d.contact_traction import graph_traction_field, integrate_contact_wrench
 from causal4d.contracts import (
     CounterfactualQuery,
     FactualIntervention,
@@ -83,6 +88,18 @@ from causal4d.semantic_freshness import (
     SemanticTimingMetadata,
     apply_semantic_freshness_gate,
 )
+from causal4d.sensor_evidence import (
+    INDEPENDENT_SENSOR_SCHEMA_VERSION,
+    ActuatorEvidence,
+    ContactWrenchEvidence,
+    load_independent_sensor_evidence,
+    save_independent_sensor_evidence,
+)
+from causal4d.sensor_factorized_abduction import (
+    IndependentSensorAbductionConfig,
+    predict_affine_actuator_realizations,
+    reweight_factual_intervention_with_independent_sensors,
+)
 from causal4d.stable_discrepancy_dynamics import (
     StableDiscrepancyTransitionModel,
     forecast_action_conditioned_dynamics,
@@ -93,7 +110,10 @@ __all__ = [
     "ActionConditionedDiscrepancyForecast",
     "ActionConditionedDiscrepancyModel",
     "ActionConditionedPhysicalPosterior",
+    "ActuatorEvidence",
     "BASE_CAUSAL4D_PROVIDER_CAPABILITIES",
+    "CausalSufficiencyResult",
+    "ContactWrenchEvidence",
     "CounterfactualBenchmarkConfig",
     "CounterfactualQuery",
     "FactualIntervention",
@@ -104,7 +124,9 @@ __all__ = [
     "GroupLikelihoodDiagnostics",
     "GroupedObservationEvidence",
     "HierarchicalAbductionResult",
+    "INDEPENDENT_SENSOR_SCHEMA_VERSION",
     "IdentifiabilityConfig",
+    "IndependentSensorAbductionConfig",
     "InterventionIdentifiabilityResult",
     "LatentContactConfig",
     "JointRolloutBank",
@@ -128,6 +150,7 @@ __all__ = [
     "apply_action_conditioned_counterfactual_operator",
     "apply_counterfactual_operator",
     "apply_semantic_freshness_gate",
+    "assess_command_residual_sufficiency",
     "assess_finite_query_ambiguity",
     "assess_intervention_identifiability",
     "build_action_conditioned_features",
@@ -137,14 +160,20 @@ __all__ = [
     "forecast_action_conditioned_persistence",
     "graph_discrepancy_group_covariances",
     "graph_mode_joint_weights",
+    "graph_traction_field",
     "grouped_component_log_likelihoods",
+    "integrate_contact_wrench",
     "load_graph_discrepancy_belief",
+    "load_independent_sensor_evidence",
     "posterior_weights_from_grouped_evidence",
+    "predict_affine_actuator_realizations",
     "prefix_component_log_likelihood",
     "preserve_prior_within_unidentified_subspace",
     "project_identifiable_intervention_update",
+    "reweight_factual_intervention_with_independent_sensors",
     "run_counterfactual_benchmark",
     "run_latent_contact_benchmark",
+    "save_independent_sensor_evidence",
     "update_joint_weights_from_prefix",
     "validate_provider_compatibility",
     "write_graph_discrepancy_belief",

--- a/src/causal4d/causal_sufficiency.py
+++ b/src/causal4d/causal_sufficiency.py
@@ -1,0 +1,272 @@
+"""Cross-fitted falsification test for realized-intervention sufficiency."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+
+def _validated_metadata(values: Mapping[str, Any]) -> dict[str, Any]:
+    import json
+
+    try:
+        return json.loads(json.dumps(dict(values), sort_keys=True, allow_nan=False))
+    except (TypeError, ValueError) as error:
+        raise ValueError("metadata must contain finite JSON values") from error
+
+
+@dataclass(frozen=True)
+class CausalSufficiencyResult:
+    """Cross-fitted incremental predictive value of commanded-action identity."""
+
+    baseline_rmse: float
+    command_augmented_rmse: float
+    relative_rmse_reduction: float
+    permutation_p_value: float
+    command_effect_detected: bool
+    execution_count: int
+    group_count: int
+    command_count: int
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        numeric = (
+            self.baseline_rmse,
+            self.command_augmented_rmse,
+            self.relative_rmse_reduction,
+            self.permutation_p_value,
+        )
+        if not all(np.isfinite(value) for value in numeric):
+            raise ValueError("sufficiency statistics must be finite")
+        if self.baseline_rmse < 0.0 or self.command_augmented_rmse < 0.0:
+            raise ValueError("RMSE values must be nonnegative")
+        if not 0.0 <= self.permutation_p_value <= 1.0:
+            raise ValueError("permutation_p_value must lie in [0, 1]")
+        if min(self.execution_count, self.group_count, self.command_count) < 1:
+            raise ValueError("counts must be positive")
+        object.__setattr__(self, "metadata", _validated_metadata(self.metadata))
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "baseline_rmse": self.baseline_rmse,
+            "command_augmented_rmse": self.command_augmented_rmse,
+            "relative_rmse_reduction": self.relative_rmse_reduction,
+            "permutation_p_value": self.permutation_p_value,
+            "command_effect_detected": self.command_effect_detected,
+            "execution_count": self.execution_count,
+            "group_count": self.group_count,
+            "command_count": self.command_count,
+            "metadata": dict(self.metadata),
+        }
+
+
+def _matrix(values: np.ndarray, name: str) -> np.ndarray:
+    array = np.asarray(values, dtype=float)
+    if array.ndim == 1:
+        array = array[:, None]
+    elif array.ndim > 2:
+        array = array.reshape(array.shape[0], -1)
+    if array.ndim != 2 or array.shape[0] < 4 or not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must be a finite execution-by-feature matrix")
+    return array
+
+
+def _identifiers(values: Sequence[str], count: int, name: str) -> tuple[str, ...]:
+    identifiers = tuple(map(str, values))
+    if len(identifiers) != count or any(not value for value in identifiers):
+        raise ValueError(f"{name} must contain one nonempty value per execution")
+    return identifiers
+
+
+def _command_features(
+    command_ids: tuple[str, ...],
+    categories: tuple[str, ...],
+) -> np.ndarray:
+    if len(categories) <= 1:
+        return np.empty((len(command_ids), 0), dtype=float)
+    return np.asarray(
+        [
+            [float(value == category) for category in categories[1:]]
+            for value in command_ids
+        ],
+        dtype=float,
+    )
+
+
+def _ridge_predict(
+    train_features: np.ndarray,
+    train_targets: np.ndarray,
+    test_features: np.ndarray,
+    *,
+    ridge: float,
+) -> np.ndarray:
+    mean = np.mean(train_features, axis=0)
+    scale = np.std(train_features, axis=0)
+    scale = np.where(scale > 1.0e-12, scale, 1.0)
+    train = (train_features - mean) / scale
+    test = (test_features - mean) / scale
+    train_design = np.column_stack((np.ones(len(train)), train))
+    test_design = np.column_stack((np.ones(len(test)), test))
+    penalty = np.eye(train_design.shape[1], dtype=float) * float(ridge)
+    penalty[0, 0] = 0.0
+    normal = train_design.T @ train_design + penalty
+    right = train_design.T @ train_targets
+    coefficients = np.linalg.lstsq(normal, right, rcond=None)[0]
+    return test_design @ coefficients
+
+
+def _cross_fitted_predictions(
+    features: np.ndarray,
+    targets: np.ndarray,
+    group_ids: tuple[str, ...],
+    *,
+    ridge: float,
+) -> np.ndarray:
+    predictions = np.empty_like(targets)
+    groups = tuple(dict.fromkeys(group_ids))
+    for group in groups:
+        test = np.asarray([value == group for value in group_ids], dtype=bool)
+        train = ~test
+        if int(np.sum(train)) < 2 or int(np.sum(test)) < 1:
+            raise ValueError("every cross-fit fold needs training and test executions")
+        predictions[test] = _ridge_predict(
+            features[train],
+            targets[train],
+            features[test],
+            ridge=ridge,
+        )
+    return predictions
+
+
+def _relative_improvement(
+    targets: np.ndarray,
+    baseline_prediction: np.ndarray,
+    augmented_prediction: np.ndarray,
+) -> tuple[float, float, float]:
+    baseline_rmse = float(np.sqrt(np.mean(np.square(targets - baseline_prediction))))
+    augmented_rmse = float(np.sqrt(np.mean(np.square(targets - augmented_prediction))))
+    if baseline_rmse <= np.finfo(float).eps:
+        return baseline_rmse, augmented_rmse, 0.0
+    return (
+        baseline_rmse,
+        augmented_rmse,
+        float(1.0 - augmented_rmse / baseline_rmse),
+    )
+
+
+def assess_command_residual_sufficiency(
+    future_residual_targets: np.ndarray,
+    realization_features: np.ndarray,
+    command_ids: Sequence[str],
+    *,
+    group_ids: Sequence[str] | None = None,
+    ridge: float = 1.0e-6,
+    permutation_count: int = 199,
+    random_seed: int = 0,
+    significance_level: float = 0.05,
+    minimum_relative_improvement: float = 0.01,
+) -> CausalSufficiencyResult:
+    """Test whether command identity predicts residuals after conditioning on ``z``.
+
+    A significant held-out gain from command identity is evidence that the
+    supplied realization features are causally incomplete. Cross-fitting is by
+    independent group, normally execution session. The permutation test is a
+    finite-sample diagnostic, not a proof of conditional independence.
+    """
+
+    targets = _matrix(future_residual_targets, "future_residual_targets")
+    features = _matrix(realization_features, "realization_features")
+    if len(features) != len(targets):
+        raise ValueError("targets and realization features must align")
+    commands = _identifiers(command_ids, len(targets), "command_ids")
+    groups = (
+        tuple(f"execution-{index}" for index in range(len(targets)))
+        if group_ids is None
+        else _identifiers(group_ids, len(targets), "group_ids")
+    )
+    categories = tuple(sorted(set(commands)))
+    unique_groups = tuple(dict.fromkeys(groups))
+    if len(categories) < 2:
+        raise ValueError("at least two commanded actions are required")
+    if len(unique_groups) < 3:
+        raise ValueError("at least three independent cross-fit groups are required")
+    if not np.isfinite(ridge) or ridge < 0.0:
+        raise ValueError("ridge must be finite and nonnegative")
+    if permutation_count < 1:
+        raise ValueError("permutation_count must be positive")
+    if not 0.0 < significance_level < 1.0:
+        raise ValueError("significance_level must lie in (0, 1)")
+    if not np.isfinite(minimum_relative_improvement):
+        raise ValueError("minimum_relative_improvement must be finite")
+
+    command_features = _command_features(commands, categories)
+    augmented_features = np.column_stack((features, command_features))
+    baseline_prediction = _cross_fitted_predictions(
+        features,
+        targets,
+        groups,
+        ridge=ridge,
+    )
+    augmented_prediction = _cross_fitted_predictions(
+        augmented_features,
+        targets,
+        groups,
+        ridge=ridge,
+    )
+    baseline_rmse, augmented_rmse, observed_improvement = _relative_improvement(
+        targets,
+        baseline_prediction,
+        augmented_prediction,
+    )
+
+    rng = np.random.default_rng(random_seed)
+    command_array = np.asarray(commands, dtype=object)
+    null_improvements = np.empty(permutation_count, dtype=float)
+    for index in range(permutation_count):
+        permuted = tuple(map(str, rng.permutation(command_array)))
+        permuted_features = np.column_stack(
+            (features, _command_features(permuted, categories))
+        )
+        permuted_prediction = _cross_fitted_predictions(
+            permuted_features,
+            targets,
+            groups,
+            ridge=ridge,
+        )
+        _, _, null_improvements[index] = _relative_improvement(
+            targets,
+            baseline_prediction,
+            permuted_prediction,
+        )
+    p_value = float(
+        (1 + np.sum(null_improvements >= observed_improvement))
+        / (permutation_count + 1)
+    )
+    detected = bool(
+        observed_improvement >= minimum_relative_improvement
+        and p_value <= significance_level
+    )
+    return CausalSufficiencyResult(
+        baseline_rmse=baseline_rmse,
+        command_augmented_rmse=augmented_rmse,
+        relative_rmse_reduction=observed_improvement,
+        permutation_p_value=p_value,
+        command_effect_detected=detected,
+        execution_count=len(targets),
+        group_count=len(unique_groups),
+        command_count=len(categories),
+        metadata={
+            "cross_fit_unit": "group",
+            "ridge": float(ridge),
+            "permutation_count": int(permutation_count),
+            "random_seed": int(random_seed),
+            "significance_level": float(significance_level),
+            "minimum_relative_improvement": float(minimum_relative_improvement),
+            "interpretation": (
+                "detected command value indicates incomplete realized-intervention "
+                "features; non-detection is not proof of sufficiency"
+            ),
+        },
+    )

--- a/src/causal4d/contact_traction.py
+++ b/src/causal4d/contact_traction.py
@@ -1,0 +1,59 @@
+"""Low-rank graph traction and resultant-wrench utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def graph_traction_field(
+    graph_basis: np.ndarray,
+    coefficient_forces_n: np.ndarray,
+) -> np.ndarray:
+    """Lift low-rank graph traction coefficients to per-node forces."""
+
+    basis = np.asarray(graph_basis, dtype=float)
+    coefficients = np.asarray(coefficient_forces_n, dtype=float)
+    if basis.ndim != 2 or not np.all(np.isfinite(basis)):
+        raise ValueError("graph_basis must be a finite matrix")
+    if coefficients.ndim < 2 or coefficients.shape[-2:] != (basis.shape[1], 3):
+        raise ValueError(
+            "coefficient_forces_n must have trailing shape (graph_rank, 3)"
+        )
+    if not np.all(np.isfinite(coefficients)):
+        raise ValueError("coefficient_forces_n must be finite")
+    return np.einsum("nr,...rc->...nc", basis, coefficients)
+
+
+def integrate_contact_wrench(
+    node_positions_m: np.ndarray,
+    node_forces_n: np.ndarray,
+    contact_origin_m: np.ndarray,
+) -> np.ndarray:
+    """Integrate graph-node forces into ``[Fx,Fy,Fz,Tx,Ty,Tz]``."""
+
+    positions = np.asarray(node_positions_m, dtype=float)
+    forces = np.asarray(node_forces_n, dtype=float)
+    if positions.ndim < 2 or positions.shape[-1] != 3:
+        raise ValueError("node_positions_m must have trailing shape (node, 3)")
+    try:
+        positions, forces = np.broadcast_arrays(positions, forces)
+    except ValueError as error:
+        raise ValueError(
+            "node positions and forces must be broadcast-compatible"
+        ) from error
+    if not np.all(np.isfinite(positions)) or not np.all(np.isfinite(forces)):
+        raise ValueError("node positions and forces must be finite")
+    origin = np.asarray(contact_origin_m, dtype=float)
+    expected_origin_shape = positions.shape[:-2] + (3,)
+    try:
+        origin = np.broadcast_to(origin, expected_origin_shape)
+    except ValueError as error:
+        raise ValueError(
+            f"contact_origin_m must broadcast to {expected_origin_shape}"
+        ) from error
+    if not np.all(np.isfinite(origin)):
+        raise ValueError("contact_origin_m must be finite")
+    resultant_force = np.sum(forces, axis=-2)
+    lever_arms = positions - origin[..., None, :]
+    resultant_torque = np.sum(np.cross(lever_arms, forces), axis=-2)
+    return np.concatenate((resultant_force, resultant_torque), axis=-1)

--- a/src/causal4d/sensor_evidence.py
+++ b/src/causal4d/sensor_evidence.py
@@ -1,0 +1,340 @@
+"""Typed independent actuator and contact-wrench evidence artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+import numpy as np
+
+from causal4d.contracts import array_sha256
+
+
+INDEPENDENT_SENSOR_SCHEMA_VERSION = 1
+
+
+def _readonly(values: np.ndarray, *, dtype: type | None = float) -> np.ndarray:
+    array = np.asarray(values, dtype=dtype).copy()
+    array.setflags(write=False)
+    return array
+
+
+def _validated_metadata(values: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        return json.loads(json.dumps(dict(values), sort_keys=True, allow_nan=False))
+    except (TypeError, ValueError) as error:
+        raise ValueError("metadata must contain finite JSON values") from error
+
+
+def _broadcast_variance(
+    values: np.ndarray,
+    shape: tuple[int, ...],
+    name: str,
+) -> np.ndarray:
+    supplied = np.asarray(values, dtype=float)
+    try:
+        result = np.broadcast_to(supplied, shape).copy()
+    except ValueError as error:
+        raise ValueError(f"{name} must broadcast to {shape}") from error
+    if not np.all(np.isfinite(result)) or np.any(result <= 0.0):
+        raise ValueError(f"{name} must be finite and strictly positive")
+    result.setflags(write=False)
+    return result
+
+
+def _broadcast_mask(
+    values: np.ndarray | None,
+    shape: tuple[int, ...],
+    name: str,
+) -> np.ndarray:
+    if values is None:
+        result = np.ones(shape, dtype=bool)
+    else:
+        supplied = np.asarray(values, dtype=bool)
+        try:
+            result = np.broadcast_to(supplied, shape).copy()
+        except ValueError as error:
+            raise ValueError(f"{name} must broadcast to {shape}") from error
+    result.setflags(write=False)
+    return result
+
+
+def _validate_times(values: np.ndarray, sample_count: int) -> np.ndarray:
+    times = _readonly(values)
+    if times.shape != (sample_count,) or not np.all(np.isfinite(times)):
+        raise ValueError("sample_times_s must contain one finite value per sample")
+    if sample_count > 1 and np.any(np.diff(times) <= 0.0):
+        raise ValueError("sample_times_s must be strictly increasing")
+    return times
+
+
+def _artifact_id(
+    *,
+    artifact_kind: str,
+    scalar_payload: Mapping[str, Any],
+    arrays: Mapping[str, np.ndarray],
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(artifact_kind.encode("utf-8"))
+    digest.update(
+        json.dumps(
+            dict(scalar_payload),
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    )
+    for name, values in sorted(arrays.items()):
+        digest.update(name.encode("utf-8"))
+        digest.update(array_sha256(values).encode("ascii"))
+    return digest.hexdigest()
+
+
+@dataclass(frozen=True)
+class ActuatorEvidence:
+    """Measured end-effector positions independent of object observations."""
+
+    stream_id: str
+    clock_id: str
+    provenance: str
+    sample_times_s: np.ndarray
+    positions_m: np.ndarray
+    variance_m2: np.ndarray
+    evidence_frame_stop: int
+    valid_mask: np.ndarray | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        positions = _readonly(self.positions_m)
+        if positions.ndim != 3 or positions.shape[2] != 3:
+            raise ValueError("positions_m must have shape (sample, controller, 3)")
+        times = _validate_times(self.sample_times_s, positions.shape[0])
+        variance = _broadcast_variance(
+            self.variance_m2,
+            positions.shape,
+            "variance_m2",
+        )
+        mask = _broadcast_mask(self.valid_mask, positions.shape, "valid_mask")
+        if not self.stream_id or not self.clock_id or not self.provenance:
+            raise ValueError(
+                "stream_id, clock_id, and provenance must be nonempty"
+            )
+        if self.evidence_frame_stop < 1:
+            raise ValueError("evidence_frame_stop must be positive")
+        if not np.all(np.isfinite(positions[mask])):
+            raise ValueError("valid actuator positions must be finite")
+        object.__setattr__(self, "sample_times_s", times)
+        object.__setattr__(self, "positions_m", positions)
+        object.__setattr__(self, "variance_m2", variance)
+        object.__setattr__(self, "valid_mask", mask)
+        object.__setattr__(self, "metadata", _validated_metadata(self.metadata))
+
+    @property
+    def artifact_id(self) -> str:
+        return _artifact_id(
+            artifact_kind="ActuatorEvidence",
+            scalar_payload={
+                "stream_id": self.stream_id,
+                "clock_id": self.clock_id,
+                "provenance": self.provenance,
+                "evidence_frame_stop": self.evidence_frame_stop,
+                "metadata": self.metadata,
+                "independent_of_object_observations": True,
+            },
+            arrays={
+                "sample_times_s": self.sample_times_s,
+                "positions_m": self.positions_m,
+                "variance_m2": self.variance_m2,
+                "valid_mask": self.valid_mask,
+            },
+        )
+
+
+@dataclass(frozen=True)
+class ContactWrenchEvidence:
+    """Measured contact force or wrench evidence on a trusted clock."""
+
+    stream_id: str
+    clock_id: str
+    provenance: str
+    sample_times_s: np.ndarray
+    wrench: np.ndarray
+    variance: np.ndarray
+    quantity_names: tuple[str, ...]
+    evidence_frame_stop: int
+    valid_mask: np.ndarray | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        wrench = _readonly(self.wrench)
+        if wrench.ndim != 2 or wrench.shape[1] == 0:
+            raise ValueError("wrench must have shape (sample, quantity)")
+        if len(self.quantity_names) != wrench.shape[1] or len(
+            set(self.quantity_names)
+        ) != len(self.quantity_names):
+            raise ValueError("quantity_names must uniquely identify every column")
+        if any(not name for name in self.quantity_names):
+            raise ValueError("quantity_names must be nonempty")
+        times = _validate_times(self.sample_times_s, wrench.shape[0])
+        variance = _broadcast_variance(self.variance, wrench.shape, "variance")
+        mask = _broadcast_mask(self.valid_mask, wrench.shape, "valid_mask")
+        if not self.stream_id or not self.clock_id or not self.provenance:
+            raise ValueError(
+                "stream_id, clock_id, and provenance must be nonempty"
+            )
+        if self.evidence_frame_stop < 1:
+            raise ValueError("evidence_frame_stop must be positive")
+        if not np.all(np.isfinite(wrench[mask])):
+            raise ValueError("valid wrench values must be finite")
+        object.__setattr__(self, "sample_times_s", times)
+        object.__setattr__(self, "wrench", wrench)
+        object.__setattr__(self, "variance", variance)
+        object.__setattr__(self, "valid_mask", mask)
+        object.__setattr__(self, "metadata", _validated_metadata(self.metadata))
+
+    @property
+    def artifact_id(self) -> str:
+        return _artifact_id(
+            artifact_kind="ContactWrenchEvidence",
+            scalar_payload={
+                "stream_id": self.stream_id,
+                "clock_id": self.clock_id,
+                "provenance": self.provenance,
+                "quantity_names": list(self.quantity_names),
+                "evidence_frame_stop": self.evidence_frame_stop,
+                "metadata": self.metadata,
+                "independent_of_object_observations": True,
+            },
+            arrays={
+                "sample_times_s": self.sample_times_s,
+                "wrench": self.wrench,
+                "variance": self.variance,
+                "valid_mask": self.valid_mask,
+            },
+        )
+
+
+def save_independent_sensor_evidence(
+    path: str | Path,
+    evidence: ActuatorEvidence | ContactWrenchEvidence,
+) -> None:
+    """Serialize one evidence artifact as a non-pickled checksummed NPZ."""
+
+    if isinstance(evidence, ActuatorEvidence):
+        descriptor = {
+            "schema_version": INDEPENDENT_SENSOR_SCHEMA_VERSION,
+            "artifact_kind": "ActuatorEvidence",
+            "stream_id": evidence.stream_id,
+            "clock_id": evidence.clock_id,
+            "provenance": evidence.provenance,
+            "evidence_frame_stop": evidence.evidence_frame_stop,
+            "metadata": evidence.metadata,
+            "artifact_id": evidence.artifact_id,
+        }
+        arrays = {
+            "sample_times_s": evidence.sample_times_s,
+            "positions_m": evidence.positions_m,
+            "variance_m2": evidence.variance_m2,
+            "valid_mask": evidence.valid_mask,
+        }
+    elif isinstance(evidence, ContactWrenchEvidence):
+        descriptor = {
+            "schema_version": INDEPENDENT_SENSOR_SCHEMA_VERSION,
+            "artifact_kind": "ContactWrenchEvidence",
+            "stream_id": evidence.stream_id,
+            "clock_id": evidence.clock_id,
+            "provenance": evidence.provenance,
+            "quantity_names": list(evidence.quantity_names),
+            "evidence_frame_stop": evidence.evidence_frame_stop,
+            "metadata": evidence.metadata,
+            "artifact_id": evidence.artifact_id,
+        }
+        arrays = {
+            "sample_times_s": evidence.sample_times_s,
+            "wrench": evidence.wrench,
+            "variance": evidence.variance,
+            "valid_mask": evidence.valid_mask,
+        }
+    else:
+        raise TypeError("unsupported independent-sensor evidence type")
+    encoded = json.dumps(
+        descriptor,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("wb") as handle:
+        np.savez_compressed(
+            handle,
+            descriptor_json=np.frombuffer(encoded, dtype=np.uint8),
+            **arrays,
+        )
+
+
+def load_independent_sensor_evidence(
+    path: str | Path,
+) -> ActuatorEvidence | ContactWrenchEvidence:
+    """Load and verify a serialized independent-sensor evidence artifact."""
+
+    with np.load(Path(path), allow_pickle=False) as archive:
+        if "descriptor_json" not in archive.files:
+            raise ValueError("sensor evidence archive is missing descriptor_json")
+        descriptor = json.loads(
+            np.asarray(archive["descriptor_json"], dtype=np.uint8)
+            .tobytes()
+            .decode("utf-8")
+        )
+        if descriptor.get("schema_version") != INDEPENDENT_SENSOR_SCHEMA_VERSION:
+            raise ValueError("unsupported independent-sensor schema version")
+        kind = descriptor.get("artifact_kind")
+        if kind == "ActuatorEvidence":
+            required = {
+                "sample_times_s",
+                "positions_m",
+                "variance_m2",
+                "valid_mask",
+            }
+            if not required.issubset(archive.files):
+                raise ValueError("actuator evidence archive is incomplete")
+            evidence: ActuatorEvidence | ContactWrenchEvidence = ActuatorEvidence(
+                stream_id=str(descriptor["stream_id"]),
+                clock_id=str(descriptor["clock_id"]),
+                provenance=str(descriptor["provenance"]),
+                sample_times_s=archive["sample_times_s"],
+                positions_m=archive["positions_m"],
+                variance_m2=archive["variance_m2"],
+                evidence_frame_stop=int(descriptor["evidence_frame_stop"]),
+                valid_mask=archive["valid_mask"],
+                metadata=descriptor.get("metadata", {}),
+            )
+        elif kind == "ContactWrenchEvidence":
+            required = {
+                "sample_times_s",
+                "wrench",
+                "variance",
+                "valid_mask",
+            }
+            if not required.issubset(archive.files):
+                raise ValueError("contact-wrench evidence archive is incomplete")
+            evidence = ContactWrenchEvidence(
+                stream_id=str(descriptor["stream_id"]),
+                clock_id=str(descriptor["clock_id"]),
+                provenance=str(descriptor["provenance"]),
+                sample_times_s=archive["sample_times_s"],
+                wrench=archive["wrench"],
+                variance=archive["variance"],
+                quantity_names=tuple(map(str, descriptor["quantity_names"])),
+                evidence_frame_stop=int(descriptor["evidence_frame_stop"]),
+                valid_mask=archive["valid_mask"],
+                metadata=descriptor.get("metadata", {}),
+            )
+        else:
+            raise ValueError(f"unsupported sensor evidence kind: {kind!r}")
+    if evidence.artifact_id != descriptor.get("artifact_id"):
+        raise ValueError("independent-sensor evidence checksum mismatch")
+    return evidence

--- a/src/causal4d/sensor_evidence.py
+++ b/src/causal4d/sensor_evidence.py
@@ -29,6 +29,41 @@ def _validated_metadata(values: Mapping[str, Any]) -> dict[str, Any]:
         raise ValueError("metadata must contain finite JSON values") from error
 
 
+def _validate_identity(
+    *,
+    protocol_id: str,
+    case_id: str,
+    observed_action_id: str,
+    stream_id: str,
+    clock_id: str,
+    provenance: str,
+) -> None:
+    identities = {
+        "protocol_id": protocol_id,
+        "case_id": case_id,
+        "observed_action_id": observed_action_id,
+        "stream_id": stream_id,
+        "clock_id": clock_id,
+        "provenance": provenance,
+    }
+    missing = [name for name, value in identities.items() if not value]
+    if missing:
+        raise ValueError(f"sensor evidence identities must be nonempty: {missing}")
+
+
+def _identity_payload(
+    evidence: ActuatorEvidence | ContactWrenchEvidence,
+) -> dict[str, str]:
+    return {
+        "protocol_id": evidence.protocol_id,
+        "case_id": evidence.case_id,
+        "observed_action_id": evidence.observed_action_id,
+        "stream_id": evidence.stream_id,
+        "clock_id": evidence.clock_id,
+        "provenance": evidence.provenance,
+    }
+
+
 def _broadcast_variance(
     values: np.ndarray,
     shape: tuple[int, ...],
@@ -97,6 +132,9 @@ def _artifact_id(
 class ActuatorEvidence:
     """Measured end-effector positions independent of object observations."""
 
+    protocol_id: str
+    case_id: str
+    observed_action_id: str
     stream_id: str
     clock_id: str
     provenance: str
@@ -118,10 +156,14 @@ class ActuatorEvidence:
             "variance_m2",
         )
         mask = _broadcast_mask(self.valid_mask, positions.shape, "valid_mask")
-        if not self.stream_id or not self.clock_id or not self.provenance:
-            raise ValueError(
-                "stream_id, clock_id, and provenance must be nonempty"
-            )
+        _validate_identity(
+            protocol_id=self.protocol_id,
+            case_id=self.case_id,
+            observed_action_id=self.observed_action_id,
+            stream_id=self.stream_id,
+            clock_id=self.clock_id,
+            provenance=self.provenance,
+        )
         if self.evidence_frame_stop < 1:
             raise ValueError("evidence_frame_stop must be positive")
         if not np.all(np.isfinite(positions[mask])):
@@ -137,9 +179,7 @@ class ActuatorEvidence:
         return _artifact_id(
             artifact_kind="ActuatorEvidence",
             scalar_payload={
-                "stream_id": self.stream_id,
-                "clock_id": self.clock_id,
-                "provenance": self.provenance,
+                **_identity_payload(self),
                 "evidence_frame_stop": self.evidence_frame_stop,
                 "metadata": self.metadata,
                 "independent_of_object_observations": True,
@@ -157,6 +197,9 @@ class ActuatorEvidence:
 class ContactWrenchEvidence:
     """Measured contact force or wrench evidence on a trusted clock."""
 
+    protocol_id: str
+    case_id: str
+    observed_action_id: str
     stream_id: str
     clock_id: str
     provenance: str
@@ -181,10 +224,14 @@ class ContactWrenchEvidence:
         times = _validate_times(self.sample_times_s, wrench.shape[0])
         variance = _broadcast_variance(self.variance, wrench.shape, "variance")
         mask = _broadcast_mask(self.valid_mask, wrench.shape, "valid_mask")
-        if not self.stream_id or not self.clock_id or not self.provenance:
-            raise ValueError(
-                "stream_id, clock_id, and provenance must be nonempty"
-            )
+        _validate_identity(
+            protocol_id=self.protocol_id,
+            case_id=self.case_id,
+            observed_action_id=self.observed_action_id,
+            stream_id=self.stream_id,
+            clock_id=self.clock_id,
+            provenance=self.provenance,
+        )
         if self.evidence_frame_stop < 1:
             raise ValueError("evidence_frame_stop must be positive")
         if not np.all(np.isfinite(wrench[mask])):
@@ -200,9 +247,7 @@ class ContactWrenchEvidence:
         return _artifact_id(
             artifact_kind="ContactWrenchEvidence",
             scalar_payload={
-                "stream_id": self.stream_id,
-                "clock_id": self.clock_id,
-                "provenance": self.provenance,
+                **_identity_payload(self),
                 "quantity_names": list(self.quantity_names),
                 "evidence_frame_stop": self.evidence_frame_stop,
                 "metadata": self.metadata,
@@ -227,9 +272,7 @@ def save_independent_sensor_evidence(
         descriptor = {
             "schema_version": INDEPENDENT_SENSOR_SCHEMA_VERSION,
             "artifact_kind": "ActuatorEvidence",
-            "stream_id": evidence.stream_id,
-            "clock_id": evidence.clock_id,
-            "provenance": evidence.provenance,
+            **_identity_payload(evidence),
             "evidence_frame_stop": evidence.evidence_frame_stop,
             "metadata": evidence.metadata,
             "artifact_id": evidence.artifact_id,
@@ -244,9 +287,7 @@ def save_independent_sensor_evidence(
         descriptor = {
             "schema_version": INDEPENDENT_SENSOR_SCHEMA_VERSION,
             "artifact_kind": "ContactWrenchEvidence",
-            "stream_id": evidence.stream_id,
-            "clock_id": evidence.clock_id,
-            "provenance": evidence.provenance,
+            **_identity_payload(evidence),
             "quantity_names": list(evidence.quantity_names),
             "evidence_frame_stop": evidence.evidence_frame_stop,
             "metadata": evidence.metadata,
@@ -276,6 +317,17 @@ def save_independent_sensor_evidence(
         )
 
 
+def _descriptor_identity(descriptor: Mapping[str, Any]) -> dict[str, str]:
+    return {
+        "protocol_id": str(descriptor["protocol_id"]),
+        "case_id": str(descriptor["case_id"]),
+        "observed_action_id": str(descriptor["observed_action_id"]),
+        "stream_id": str(descriptor["stream_id"]),
+        "clock_id": str(descriptor["clock_id"]),
+        "provenance": str(descriptor["provenance"]),
+    }
+
+
 def load_independent_sensor_evidence(
     path: str | Path,
 ) -> ActuatorEvidence | ContactWrenchEvidence:
@@ -292,6 +344,7 @@ def load_independent_sensor_evidence(
         if descriptor.get("schema_version") != INDEPENDENT_SENSOR_SCHEMA_VERSION:
             raise ValueError("unsupported independent-sensor schema version")
         kind = descriptor.get("artifact_kind")
+        identity = _descriptor_identity(descriptor)
         if kind == "ActuatorEvidence":
             required = {
                 "sample_times_s",
@@ -302,9 +355,7 @@ def load_independent_sensor_evidence(
             if not required.issubset(archive.files):
                 raise ValueError("actuator evidence archive is incomplete")
             evidence: ActuatorEvidence | ContactWrenchEvidence = ActuatorEvidence(
-                stream_id=str(descriptor["stream_id"]),
-                clock_id=str(descriptor["clock_id"]),
-                provenance=str(descriptor["provenance"]),
+                **identity,
                 sample_times_s=archive["sample_times_s"],
                 positions_m=archive["positions_m"],
                 variance_m2=archive["variance_m2"],
@@ -322,9 +373,7 @@ def load_independent_sensor_evidence(
             if not required.issubset(archive.files):
                 raise ValueError("contact-wrench evidence archive is incomplete")
             evidence = ContactWrenchEvidence(
-                stream_id=str(descriptor["stream_id"]),
-                clock_id=str(descriptor["clock_id"]),
-                provenance=str(descriptor["provenance"]),
+                **identity,
                 sample_times_s=archive["sample_times_s"],
                 wrench=archive["wrench"],
                 variance=archive["variance"],

--- a/src/causal4d/sensor_factorized_abduction.py
+++ b/src/causal4d/sensor_factorized_abduction.py
@@ -129,6 +129,30 @@ def _normalize_log_weights(log_weights: np.ndarray) -> np.ndarray:
     return weights / total
 
 
+def _validate_evidence_binding(
+    factual: FactualIntervention,
+    evidence: ActuatorEvidence | ContactWrenchEvidence,
+    *,
+    name: str,
+) -> None:
+    expected = (
+        factual.context.protocol_id,
+        factual.context.case_id,
+        factual.context.u_obs.action_id,
+    )
+    supplied = (
+        evidence.protocol_id,
+        evidence.case_id,
+        evidence.observed_action_id,
+    )
+    if supplied != expected:
+        raise ValueError(
+            f"{name} evidence identifies a different protocol, case, or observed action"
+        )
+    if evidence.evidence_frame_stop > factual.evidence_frame_stop:
+        raise ValueError(f"{name} evidence extends beyond the factual prefix")
+
+
 def reweight_factual_intervention_with_independent_sensors(
     factual: FactualIntervention,
     *,
@@ -160,13 +184,18 @@ def reweight_factual_intervention_with_independent_sensors(
         raise ValueError("wrench_evidence requires wrench predictions")
     if actuator_evidence is None and wrench_evidence is None:
         return factual
+    if (
+        actuator_evidence is not None
+        and wrench_evidence is not None
+        and actuator_evidence.clock_id != wrench_evidence.clock_id
+    ):
+        raise ValueError("actuator and wrench evidence must use the same clock")
 
     total_log_factor = np.zeros(component_count, dtype=float)
     factor_summaries: list[dict[str, Any]] = []
 
     if actuator_evidence is not None:
-        if actuator_evidence.evidence_frame_stop > factual.evidence_frame_stop:
-            raise ValueError("actuator evidence extends beyond the factual prefix")
+        _validate_evidence_binding(factual, actuator_evidence, name="actuator")
         predicted = _validate_prediction_shape(
             predicted_actuator_positions_m,
             component_count,
@@ -204,8 +233,7 @@ def reweight_factual_intervention_with_independent_sensors(
         )
 
     if wrench_evidence is not None:
-        if wrench_evidence.evidence_frame_stop > factual.evidence_frame_stop:
-            raise ValueError("wrench evidence extends beyond the factual prefix")
+        _validate_evidence_binding(factual, wrench_evidence, name="wrench")
         predicted = _validate_prediction_shape(
             predicted_contact_wrench,
             component_count,

--- a/src/causal4d/sensor_factorized_abduction.py
+++ b/src/causal4d/sensor_factorized_abduction.py
@@ -1,0 +1,335 @@
+"""Independent-sensor factors for realized-intervention abduction."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import numpy as np
+
+from causal4d.contracts import FactualIntervention
+from causal4d.sensor_evidence import ActuatorEvidence, ContactWrenchEvidence
+
+
+@dataclass(frozen=True)
+class IndependentSensorAbductionConfig:
+    """Robust factor settings with capped effective sample counts."""
+
+    degrees_of_freedom: float = 4.0
+    actuator_likelihood_power: float = 1.0
+    wrench_likelihood_power: float = 1.0
+    actuator_effective_sample_cap: float = 32.0
+    wrench_effective_sample_cap: float = 16.0
+    minimum_variance: float = 1.0e-12
+    uninformative_tolerance: float = 1.0e-12
+
+    def __post_init__(self) -> None:
+        if not np.isfinite(self.degrees_of_freedom) or self.degrees_of_freedom <= 0:
+            raise ValueError("degrees_of_freedom must be finite and positive")
+        for name, value in (
+            ("actuator_likelihood_power", self.actuator_likelihood_power),
+            ("wrench_likelihood_power", self.wrench_likelihood_power),
+        ):
+            if not np.isfinite(value) or value < 0.0:
+                raise ValueError(f"{name} must be finite and nonnegative")
+        for name, value in (
+            ("actuator_effective_sample_cap", self.actuator_effective_sample_cap),
+            ("wrench_effective_sample_cap", self.wrench_effective_sample_cap),
+        ):
+            if not np.isfinite(value) or value <= 0.0:
+                raise ValueError(f"{name} must be finite and positive")
+        if not np.isfinite(self.minimum_variance) or self.minimum_variance <= 0.0:
+            raise ValueError("minimum_variance must be finite and positive")
+        if (
+            not np.isfinite(self.uninformative_tolerance)
+            or self.uninformative_tolerance < 0.0
+        ):
+            raise ValueError("uninformative_tolerance must be finite and nonnegative")
+
+
+def _predicted_variance(
+    values: np.ndarray | None,
+    expected_shape: tuple[int, ...],
+    name: str,
+) -> np.ndarray:
+    if values is None:
+        return np.zeros(expected_shape, dtype=float)
+    supplied = np.asarray(values, dtype=float)
+    try:
+        result = np.broadcast_to(supplied, expected_shape).copy()
+    except ValueError as error:
+        raise ValueError(f"{name} must broadcast to {expected_shape}") from error
+    if not np.all(np.isfinite(result)) or np.any(result < 0.0):
+        raise ValueError(f"{name} must be finite and nonnegative")
+    return result
+
+
+def _student_t_component_log_likelihood(
+    observed: np.ndarray,
+    observation_variance: np.ndarray,
+    valid_mask: np.ndarray,
+    predicted: np.ndarray,
+    predicted_variance: np.ndarray | None,
+    *,
+    degrees_of_freedom: float,
+    effective_sample_cap: float,
+    minimum_variance: float,
+    name: str,
+) -> tuple[np.ndarray, int]:
+    if not np.all(np.isfinite(predicted)):
+        raise ValueError(f"{name} predictions must be finite")
+    component_variance = _predicted_variance(
+        predicted_variance,
+        predicted.shape,
+        f"{name}_predicted_variance",
+    )
+    valid_count = int(np.sum(valid_mask))
+    if valid_count == 0:
+        return np.zeros(predicted.shape[0], dtype=float), 0
+    total_variance = observation_variance[None] + component_variance
+    total_variance = total_variance + float(minimum_variance)
+    residual = predicted - observed[None]
+    nu = float(degrees_of_freedom)
+    score = -0.5 * np.log(total_variance) - 0.5 * (nu + 1.0) * np.log1p(
+        np.square(residual) / (nu * total_variance)
+    )
+    score = np.where(valid_mask[None], score, 0.0)
+    axes = tuple(range(1, score.ndim))
+    log_likelihood = np.sum(score, axis=axes)
+    effective_count = min(float(valid_count), float(effective_sample_cap))
+    log_likelihood *= effective_count / float(valid_count)
+    return log_likelihood, valid_count
+
+
+def _validate_prediction_shape(
+    values: np.ndarray,
+    component_count: int,
+    observation_shape: tuple[int, ...],
+    name: str,
+) -> np.ndarray:
+    predicted = np.asarray(values, dtype=float)
+    expected = (component_count,) + observation_shape
+    if predicted.shape != expected:
+        raise ValueError(f"{name} must have shape {expected}")
+    return predicted
+
+
+def _effective_sample_size(weights: np.ndarray) -> float:
+    return float(1.0 / np.sum(np.square(np.asarray(weights, dtype=float))))
+
+
+def _normalize_log_weights(log_weights: np.ndarray) -> np.ndarray:
+    maximum = float(np.max(log_weights))
+    if not np.isfinite(maximum):
+        raise RuntimeError("independent-sensor posterior normalization failed")
+    weights = np.exp(log_weights - maximum)
+    total = float(np.sum(weights))
+    if not np.isfinite(total) or total <= 0.0:
+        raise RuntimeError("independent-sensor posterior normalization failed")
+    return weights / total
+
+
+def reweight_factual_intervention_with_independent_sensors(
+    factual: FactualIntervention,
+    *,
+    actuator_evidence: ActuatorEvidence | None = None,
+    predicted_actuator_positions_m: np.ndarray | None = None,
+    predicted_actuator_variance_m2: np.ndarray | None = None,
+    wrench_evidence: ContactWrenchEvidence | None = None,
+    predicted_contact_wrench: np.ndarray | None = None,
+    predicted_wrench_variance: np.ndarray | None = None,
+    config: IndependentSensorAbductionConfig | None = None,
+) -> FactualIntervention:
+    """Multiply an existing factual posterior by independent sensor factors.
+
+    The input posterior is assumed to have consumed the permitted object prefix.
+    This API deliberately has no object-observation argument. With absent,
+    invalid, zero-powered, or component-invariant factors it returns ``factual``
+    exactly.
+    """
+
+    settings = config or IndependentSensorAbductionConfig()
+    component_count = len(factual.weights)
+    if actuator_evidence is None and predicted_actuator_positions_m is not None:
+        raise ValueError("actuator predictions require actuator_evidence")
+    if actuator_evidence is not None and predicted_actuator_positions_m is None:
+        raise ValueError("actuator_evidence requires actuator predictions")
+    if wrench_evidence is None and predicted_contact_wrench is not None:
+        raise ValueError("wrench predictions require wrench_evidence")
+    if wrench_evidence is not None and predicted_contact_wrench is None:
+        raise ValueError("wrench_evidence requires wrench predictions")
+    if actuator_evidence is None and wrench_evidence is None:
+        return factual
+
+    total_log_factor = np.zeros(component_count, dtype=float)
+    factor_summaries: list[dict[str, Any]] = []
+
+    if actuator_evidence is not None:
+        if actuator_evidence.evidence_frame_stop > factual.evidence_frame_stop:
+            raise ValueError("actuator evidence extends beyond the factual prefix")
+        predicted = _validate_prediction_shape(
+            predicted_actuator_positions_m,
+            component_count,
+            actuator_evidence.positions_m.shape,
+            "predicted_actuator_positions_m",
+        )
+        log_likelihood, valid_count = _student_t_component_log_likelihood(
+            actuator_evidence.positions_m,
+            actuator_evidence.variance_m2,
+            actuator_evidence.valid_mask,
+            predicted,
+            predicted_actuator_variance_m2,
+            degrees_of_freedom=settings.degrees_of_freedom,
+            effective_sample_cap=settings.actuator_effective_sample_cap,
+            minimum_variance=settings.minimum_variance,
+            name="actuator",
+        )
+        informative = bool(
+            valid_count > 0
+            and settings.actuator_likelihood_power > 0.0
+            and np.ptp(log_likelihood) > settings.uninformative_tolerance
+        )
+        if informative:
+            total_log_factor += settings.actuator_likelihood_power * log_likelihood
+        factor_summaries.append(
+            {
+                "kind": "actuator",
+                "evidence_id": actuator_evidence.artifact_id,
+                "clock_id": actuator_evidence.clock_id,
+                "valid_scalar_count": valid_count,
+                "likelihood_power": settings.actuator_likelihood_power,
+                "informative": informative,
+                "log_likelihood_range": float(np.ptp(log_likelihood)),
+            }
+        )
+
+    if wrench_evidence is not None:
+        if wrench_evidence.evidence_frame_stop > factual.evidence_frame_stop:
+            raise ValueError("wrench evidence extends beyond the factual prefix")
+        predicted = _validate_prediction_shape(
+            predicted_contact_wrench,
+            component_count,
+            wrench_evidence.wrench.shape,
+            "predicted_contact_wrench",
+        )
+        log_likelihood, valid_count = _student_t_component_log_likelihood(
+            wrench_evidence.wrench,
+            wrench_evidence.variance,
+            wrench_evidence.valid_mask,
+            predicted,
+            predicted_wrench_variance,
+            degrees_of_freedom=settings.degrees_of_freedom,
+            effective_sample_cap=settings.wrench_effective_sample_cap,
+            minimum_variance=settings.minimum_variance,
+            name="wrench",
+        )
+        informative = bool(
+            valid_count > 0
+            and settings.wrench_likelihood_power > 0.0
+            and np.ptp(log_likelihood) > settings.uninformative_tolerance
+        )
+        if informative:
+            total_log_factor += settings.wrench_likelihood_power * log_likelihood
+        factor_summaries.append(
+            {
+                "kind": "contact_wrench",
+                "evidence_id": wrench_evidence.artifact_id,
+                "clock_id": wrench_evidence.clock_id,
+                "quantity_names": list(wrench_evidence.quantity_names),
+                "valid_scalar_count": valid_count,
+                "likelihood_power": settings.wrench_likelihood_power,
+                "informative": informative,
+                "log_likelihood_range": float(np.ptp(log_likelihood)),
+            }
+        )
+
+    if not any(summary["informative"] for summary in factor_summaries):
+        return factual
+
+    prior = np.asarray(factual.weights, dtype=float)
+    posterior = _normalize_log_weights(
+        np.log(np.maximum(prior, np.finfo(float).tiny)) + total_log_factor
+    )
+    metadata = dict(factual.metadata)
+    metadata["independent_sensor_abduction"] = {
+        "source_factual_intervention_id": factual.artifact_id,
+        "factors": factor_summaries,
+        "config": asdict(settings),
+        "object_observation_likelihood_reused": False,
+        "future_object_frames_read": 0,
+        "effective_sample_size_before": _effective_sample_size(prior),
+        "effective_sample_size_after": _effective_sample_size(posterior),
+    }
+    return FactualIntervention(
+        context=factual.context,
+        component_ids=factual.component_ids,
+        phi_names=factual.phi_names,
+        kappa_names=factual.kappa_names,
+        phi=factual.phi,
+        kappa_obs=factual.kappa_obs,
+        hypothesis_indices=factual.hypothesis_indices,
+        twin_particle_indices=factual.twin_particle_indices,
+        weights=posterior,
+        evidence_frame_stop=factual.evidence_frame_stop,
+        source_twin_belief_id=factual.source_twin_belief_id,
+        metadata=metadata,
+    )
+
+
+def predict_affine_actuator_realizations(
+    commanded_positions_m: np.ndarray,
+    phi_names: tuple[str, ...],
+    phi: np.ndarray,
+    *,
+    rotation_axis: np.ndarray | tuple[float, float, float] = (0.0, 1.0, 0.0),
+) -> np.ndarray:
+    """Map command trajectories to component-wise actuator realizations."""
+
+    commands = np.asarray(commanded_positions_m, dtype=float)
+    values = np.asarray(phi, dtype=float)
+    if commands.ndim != 3 or commands.shape[2] != 3:
+        raise ValueError(
+            "commanded_positions_m must have shape (frame, controller, 3)"
+        )
+    if not np.all(np.isfinite(commands)):
+        raise ValueError("commanded_positions_m must be finite")
+    if values.ndim != 2 or values.shape[1] != len(phi_names):
+        raise ValueError("phi must have shape (component, len(phi_names))")
+    if not np.all(np.isfinite(values)):
+        raise ValueError("phi must be finite")
+    required = {"gain_multiplier", "delay_steps", "rotation_degrees"}
+    if not required.issubset(phi_names):
+        raise ValueError(
+            "phi_names must include gain_multiplier, delay_steps, and "
+            "rotation_degrees"
+        )
+    axis = np.asarray(rotation_axis, dtype=float).reshape(-1)
+    if axis.shape != (3,) or not np.all(np.isfinite(axis)):
+        raise ValueError("rotation_axis must be a finite three-vector")
+    norm = float(np.linalg.norm(axis))
+    if norm <= np.finfo(float).eps:
+        raise ValueError("rotation_axis must be nonzero")
+    axis = axis / norm
+    gain_index = phi_names.index("gain_multiplier")
+    delay_index = phi_names.index("delay_steps")
+    rotation_index = phi_names.index("rotation_degrees")
+    result = np.empty((len(values),) + commands.shape, dtype=float)
+    anchor = commands[0]
+    frame_indices = np.arange(len(commands))
+    for component, row in enumerate(values):
+        delay_value = float(row[delay_index])
+        delay = int(np.rint(delay_value))
+        if delay < 0 or not np.isclose(delay_value, delay, atol=1.0e-8):
+            raise ValueError("delay_steps must contain nonnegative integers")
+        source = np.maximum(frame_indices - delay, 0)
+        displacement = commands[source] - anchor
+        angle = np.deg2rad(float(row[rotation_index]))
+        cross = np.cross(axis, displacement)
+        projection = np.sum(displacement * axis, axis=-1, keepdims=True) * axis
+        rotated = (
+            displacement * np.cos(angle)
+            + cross * np.sin(angle)
+            + projection * (1.0 - np.cos(angle))
+        )
+        result[component] = anchor + float(row[gain_index]) * rotated
+    return result

--- a/tests/test_causal4d_sensor_factorized_abduction.py
+++ b/tests/test_causal4d_sensor_factorized_abduction.py
@@ -1,0 +1,221 @@
+import numpy as np
+import pytest
+
+from causal4d.causal_sufficiency import assess_command_residual_sufficiency
+from causal4d.contracts import FactualIntervention, array_sha256, build_causal_context
+from causal4d.contact_traction import graph_traction_field, integrate_contact_wrench
+from causal4d.sensor_evidence import (
+    ActuatorEvidence,
+    ContactWrenchEvidence,
+    load_independent_sensor_evidence,
+    save_independent_sensor_evidence,
+)
+from causal4d.sensor_factorized_abduction import (
+    predict_affine_actuator_realizations,
+    reweight_factual_intervention_with_independent_sensors,
+)
+
+
+def _factual() -> FactualIntervention:
+    observations = np.zeros((8, 2, 3), dtype=float)
+    actions = np.zeros((8, 1, 3), dtype=float)
+    context = build_causal_context(
+        protocol_id="sensor_factorized_unit",
+        case_id="unit_case",
+        observations=observations,
+        observed_actions=actions,
+        counterfactual_actions=actions,
+        intervention_frame=4,
+    )
+    return FactualIntervention(
+        context=context,
+        component_ids=("z0", "z1"),
+        phi_names=("gain_multiplier", "delay_steps", "rotation_degrees"),
+        kappa_names=("contact_node", "slip_fraction"),
+        phi=np.asarray([[1.0, 0.0, 0.0], [0.8, 1.0, 0.0]]),
+        kappa_obs=np.asarray([[0.0, 0.0], [1.0, 0.2]]),
+        hypothesis_indices=np.asarray([0, 1]),
+        twin_particle_indices=np.asarray([0, 0]),
+        weights=np.asarray([0.5, 0.5]),
+        evidence_frame_stop=6,
+        source_twin_belief_id=array_sha256(np.zeros(1)),
+    )
+
+
+def _actuator_evidence(*, frame_stop: int = 6) -> ActuatorEvidence:
+    positions = np.zeros((2, 1, 3), dtype=float)
+    return ActuatorEvidence(
+        stream_id="measured_end_effector",
+        clock_id="robot_monotonic",
+        provenance="robot encoder independent of RGB-D object reconstruction",
+        sample_times_s=np.asarray([0.0, 1.0 / 30.0]),
+        positions_m=positions,
+        variance_m2=np.full_like(positions, 1.0e-4),
+        evidence_frame_stop=frame_stop,
+    )
+
+
+def test_absent_sensor_evidence_returns_same_artifact_exactly() -> None:
+    factual = _factual()
+    updated = reweight_factual_intervention_with_independent_sensors(factual)
+    assert updated is factual
+
+
+def test_actuator_factor_prefers_matching_realization() -> None:
+    factual = _factual()
+    evidence = _actuator_evidence()
+    matching = evidence.positions_m
+    predictions = np.stack((matching, matching + 0.2), axis=0)
+    updated = reweight_factual_intervention_with_independent_sensors(
+        factual,
+        actuator_evidence=evidence,
+        predicted_actuator_positions_m=predictions,
+    )
+    assert updated.weights[0] > 0.999
+    diagnostics = updated.metadata["independent_sensor_abduction"]
+    assert diagnostics["object_observation_likelihood_reused"] is False
+    assert diagnostics["future_object_frames_read"] == 0
+
+
+def test_component_invariant_sensor_factor_returns_input_exactly() -> None:
+    factual = _factual()
+    evidence = _actuator_evidence()
+    predictions = np.stack((evidence.positions_m, evidence.positions_m), axis=0)
+    updated = reweight_factual_intervention_with_independent_sensors(
+        factual,
+        actuator_evidence=evidence,
+        predicted_actuator_positions_m=predictions,
+    )
+    assert updated is factual
+
+
+def test_all_invalid_sensor_samples_return_input_exactly() -> None:
+    factual = _factual()
+    base = _actuator_evidence()
+    evidence = ActuatorEvidence(
+        stream_id=base.stream_id,
+        clock_id=base.clock_id,
+        provenance=base.provenance,
+        sample_times_s=base.sample_times_s,
+        positions_m=base.positions_m,
+        variance_m2=base.variance_m2,
+        evidence_frame_stop=base.evidence_frame_stop,
+        valid_mask=np.zeros_like(base.positions_m, dtype=bool),
+    )
+    predictions = np.zeros((2,) + evidence.positions_m.shape)
+    updated = reweight_factual_intervention_with_independent_sensors(
+        factual,
+        actuator_evidence=evidence,
+        predicted_actuator_positions_m=predictions,
+    )
+    assert updated is factual
+
+
+def test_wrench_factor_prefers_matching_contact() -> None:
+    factual = _factual()
+    observed = np.asarray([[1.0, 0.0, 0.0]])
+    evidence = ContactWrenchEvidence(
+        stream_id="wrist_force",
+        clock_id="robot_monotonic",
+        provenance="wrist force sensor independent of RGB-D reconstruction",
+        sample_times_s=np.asarray([0.0]),
+        wrench=observed,
+        variance=np.full_like(observed, 1.0e-3),
+        quantity_names=("force_x_n", "force_y_n", "force_z_n"),
+        evidence_frame_stop=6,
+    )
+    predictions = np.stack((observed, np.zeros_like(observed)), axis=0)
+    updated = reweight_factual_intervention_with_independent_sensors(
+        factual,
+        wrench_evidence=evidence,
+        predicted_contact_wrench=predictions,
+    )
+    assert updated.weights[0] > 0.99
+
+
+def test_sensor_factor_rejects_evidence_beyond_factual_prefix() -> None:
+    factual = _factual()
+    evidence = _actuator_evidence(frame_stop=7)
+    predictions = np.zeros((2,) + evidence.positions_m.shape)
+    with pytest.raises(ValueError, match="beyond the factual prefix"):
+        reweight_factual_intervention_with_independent_sensors(
+            factual,
+            actuator_evidence=evidence,
+            predicted_actuator_positions_m=predictions,
+        )
+
+
+def test_sensor_evidence_round_trip_is_checksummed(tmp_path) -> None:
+    evidence = _actuator_evidence()
+    path = tmp_path / "actuator_evidence.npz"
+    save_independent_sensor_evidence(path, evidence)
+    restored = load_independent_sensor_evidence(path)
+    assert type(restored) is ActuatorEvidence
+    assert restored.artifact_id == evidence.artifact_id
+
+
+def test_affine_actuator_model_has_exact_nominal_path_and_delay() -> None:
+    commands = np.zeros((3, 1, 3), dtype=float)
+    commands[:, 0, 0] = [0.0, 1.0, 2.0]
+    phi = np.asarray([[1.0, 0.0, 0.0], [0.5, 1.0, 0.0]])
+    predicted = predict_affine_actuator_realizations(
+        commands,
+        ("gain_multiplier", "delay_steps", "rotation_degrees"),
+        phi,
+    )
+    np.testing.assert_allclose(predicted[0], commands)
+    np.testing.assert_allclose(predicted[1, :, 0, 0], [0.0, 0.0, 0.5])
+
+
+def test_graph_traction_integrates_to_expected_wrench() -> None:
+    basis = np.eye(2)
+    coefficients = np.asarray([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+    forces = graph_traction_field(basis, coefficients)
+    positions = np.asarray([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    wrench = integrate_contact_wrench(positions, forces, np.zeros(3))
+    np.testing.assert_allclose(wrench[:3], [1.0, 1.0, 0.0])
+    np.testing.assert_allclose(wrench[3:], [0.0, 0.0, 1.0])
+
+
+def test_sufficiency_test_detects_omitted_command_effect() -> None:
+    rng = np.random.default_rng(3)
+    count = 60
+    realization = rng.normal(size=(count, 2))
+    commands = np.asarray(["a", "b"] * (count // 2))
+    target = (
+        0.2 * realization[:, [0]]
+        + 2.0 * (commands == "b")[:, None]
+        + rng.normal(scale=0.05, size=(count, 1))
+    )
+    result = assess_command_residual_sufficiency(
+        target,
+        realization,
+        commands,
+        group_ids=[f"execution-{index}" for index in range(count)],
+        permutation_count=99,
+        random_seed=4,
+    )
+    assert result.command_effect_detected
+    assert result.relative_rmse_reduction > 0.8
+
+
+def test_sufficiency_test_accepts_command_already_explained_by_realization() -> None:
+    rng = np.random.default_rng(5)
+    count = 60
+    commands = np.asarray(["a", "b"] * (count // 2))
+    encoded_command = (commands == "b").astype(float)
+    realization = np.column_stack((rng.normal(size=count), encoded_command))
+    target = (
+        realization[:, [0]]
+        + 2.0 * realization[:, [1]]
+        + rng.normal(scale=0.05, size=(count, 1))
+    )
+    result = assess_command_residual_sufficiency(
+        target,
+        realization,
+        commands,
+        group_ids=[f"execution-{index}" for index in range(count)],
+        permutation_count=49,
+        random_seed=6,
+    )
+    assert not result.command_effect_detected

--- a/tests/test_causal4d_sensor_factorized_abduction.py
+++ b/tests/test_causal4d_sensor_factorized_abduction.py
@@ -42,16 +42,50 @@ def _factual() -> FactualIntervention:
     )
 
 
-def _actuator_evidence(*, frame_stop: int = 6) -> ActuatorEvidence:
+def _sensor_identity() -> dict[str, str]:
+    return {
+        "protocol_id": "sensor_factorized_unit",
+        "case_id": "unit_case",
+        "observed_action_id": "u_obs",
+    }
+
+
+def _actuator_evidence(
+    *,
+    frame_stop: int = 6,
+    case_id: str = "unit_case",
+    clock_id: str = "robot_monotonic",
+) -> ActuatorEvidence:
     positions = np.zeros((2, 1, 3), dtype=float)
+    identity = _sensor_identity()
+    identity["case_id"] = case_id
     return ActuatorEvidence(
+        **identity,
         stream_id="measured_end_effector",
-        clock_id="robot_monotonic",
+        clock_id=clock_id,
         provenance="robot encoder independent of RGB-D object reconstruction",
         sample_times_s=np.asarray([0.0, 1.0 / 30.0]),
         positions_m=positions,
         variance_m2=np.full_like(positions, 1.0e-4),
         evidence_frame_stop=frame_stop,
+    )
+
+
+def _wrench_evidence(
+    *,
+    clock_id: str = "robot_monotonic",
+) -> ContactWrenchEvidence:
+    observed = np.asarray([[1.0, 0.0, 0.0]])
+    return ContactWrenchEvidence(
+        **_sensor_identity(),
+        stream_id="wrist_force",
+        clock_id=clock_id,
+        provenance="wrist force sensor independent of RGB-D reconstruction",
+        sample_times_s=np.asarray([0.0]),
+        wrench=observed,
+        variance=np.full_like(observed, 1.0e-3),
+        quantity_names=("force_x_n", "force_y_n", "force_z_n"),
+        evidence_frame_stop=6,
     )
 
 
@@ -93,6 +127,9 @@ def test_all_invalid_sensor_samples_return_input_exactly() -> None:
     factual = _factual()
     base = _actuator_evidence()
     evidence = ActuatorEvidence(
+        protocol_id=base.protocol_id,
+        case_id=base.case_id,
+        observed_action_id=base.observed_action_id,
         stream_id=base.stream_id,
         clock_id=base.clock_id,
         provenance=base.provenance,
@@ -113,18 +150,8 @@ def test_all_invalid_sensor_samples_return_input_exactly() -> None:
 
 def test_wrench_factor_prefers_matching_contact() -> None:
     factual = _factual()
-    observed = np.asarray([[1.0, 0.0, 0.0]])
-    evidence = ContactWrenchEvidence(
-        stream_id="wrist_force",
-        clock_id="robot_monotonic",
-        provenance="wrist force sensor independent of RGB-D reconstruction",
-        sample_times_s=np.asarray([0.0]),
-        wrench=observed,
-        variance=np.full_like(observed, 1.0e-3),
-        quantity_names=("force_x_n", "force_y_n", "force_z_n"),
-        evidence_frame_stop=6,
-    )
-    predictions = np.stack((observed, np.zeros_like(observed)), axis=0)
+    evidence = _wrench_evidence()
+    predictions = np.stack((evidence.wrench, np.zeros_like(evidence.wrench)), axis=0)
     updated = reweight_factual_intervention_with_independent_sensors(
         factual,
         wrench_evidence=evidence,
@@ -145,6 +172,34 @@ def test_sensor_factor_rejects_evidence_beyond_factual_prefix() -> None:
         )
 
 
+def test_sensor_factor_rejects_evidence_from_another_case() -> None:
+    factual = _factual()
+    evidence = _actuator_evidence(case_id="other_case")
+    predictions = np.zeros((2,) + evidence.positions_m.shape)
+    with pytest.raises(ValueError, match="different protocol, case, or observed action"):
+        reweight_factual_intervention_with_independent_sensors(
+            factual,
+            actuator_evidence=evidence,
+            predicted_actuator_positions_m=predictions,
+        )
+
+
+def test_sensor_factor_rejects_mismatched_clocks() -> None:
+    factual = _factual()
+    actuator = _actuator_evidence(clock_id="robot_monotonic")
+    wrench = _wrench_evidence(clock_id="force_sensor_clock")
+    actuator_predictions = np.zeros((2,) + actuator.positions_m.shape)
+    wrench_predictions = np.zeros((2,) + wrench.wrench.shape)
+    with pytest.raises(ValueError, match="must use the same clock"):
+        reweight_factual_intervention_with_independent_sensors(
+            factual,
+            actuator_evidence=actuator,
+            predicted_actuator_positions_m=actuator_predictions,
+            wrench_evidence=wrench,
+            predicted_contact_wrench=wrench_predictions,
+        )
+
+
 def test_sensor_evidence_round_trip_is_checksummed(tmp_path) -> None:
     evidence = _actuator_evidence()
     path = tmp_path / "actuator_evidence.npz"
@@ -152,6 +207,8 @@ def test_sensor_evidence_round_trip_is_checksummed(tmp_path) -> None:
     restored = load_independent_sensor_evidence(path)
     assert type(restored) is ActuatorEvidence
     assert restored.artifact_id == evidence.artifact_id
+    assert restored.case_id == evidence.case_id
+    assert restored.observed_action_id == evidence.observed_action_id
 
 
 def test_affine_actuator_model_has_exact_nominal_path_and_delay() -> None:


### PR DESCRIPTION
## What changed

- add immutable, checksummed `ActuatorEvidence` and `ContactWrenchEvidence` artifacts with protocol/case/action binding, clock identity, provenance, variances, masks, and causal-prefix bounds
- add robust independent actuator and wrench likelihood factors over an existing `FactualIntervention`
- add exact fallback for absent, invalid, zero-powered, or component-invariant sensor evidence
- add an affine actuator realization model for gain, integer delay, and controller-frame rotation
- add low-rank graph traction lifting and resultant force/torque integration
- add a grouped, cross-fitted command-residual sufficiency diagnostic to detect omitted realized-intervention structure
- add focused tests, public API exports, and method documentation

## Why

The object-response likelihood should be consumed exactly once. Measured robot motion and force/torque streams are independent evidence about command realization and contact transmission; treating them as separate factors reduces confounding between actuator realization, contact, and simulator/readout discrepancy.

## Compatibility and information boundary

- the implementation is opt-in and does not modify the frozen `v0.3.0-causal4d-aip` path
- the factorized update has no object-observation argument and records that the object likelihood was not reused
- evidence is rejected when its protocol, case, observed action, clock, or prefix boundary is incompatible
- no future object frame is read
- uninformative factors return the original `FactualIntervention` object exactly, preserving weights and artifact identity
- the existing single-node contact representation remains a special case of the graph-traction utilities

## Validation

GitHub Actions run `30206630994` passed:

- Ruff
- full pytest suite on Python 3.10
- full pytest suite on Python 3.12
- full pytest suite on Python 3.14
- wheel and source-distribution build
- distribution metadata validation
- built-wheel smoke import
