### PR TITLE
Restore standalone release-verification scripts

### DIFF
--- a/scripts/release/capture_file_manifest.py
+++ b/scripts/release/capture_file_manifest.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Capture or verify a deterministic SHA-256 milestone file manifest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+
+def sha256_file(path: str | Path) -> tuple[str, int]:
+    """Hash one regular file and return its digest and byte count."""
+
+    source = Path(path)
+    if not source.is_file():
+        raise FileNotFoundError(source)
+    digest = hashlib.sha256()
+    size = 0
+    with source.open("rb") as handle:
+        for block in iter(lambda: handle.read(8 * 1024 * 1024), b""):
+            digest.update(block)
+            size += len(block)
+    return digest.hexdigest(), size
+
+
+def capture_manifest(specification: dict[str, Any]) -> dict[str, Any]:
+    """Hash every source and verify any declared archive copy."""
+
+    required = {"schema_version", "milestone", "captured_at", "host", "entries"}
+    missing = required - set(specification)
+    if missing:
+        raise ValueError(f"manifest specification is missing: {sorted(missing)}")
+    identifiers: set[str] = set()
+    records = []
+    for entry in specification["entries"]:
+        identifier = str(entry["id"])
+        if identifier in identifiers:
+            raise ValueError(f"duplicate manifest id: {identifier}")
+        identifiers.add(identifier)
+        digest, byte_count = sha256_file(entry["source_path"])
+        record = {
+            "id": identifier,
+            "category": str(entry["category"]),
+            "source_path": str(Path(entry["source_path"])),
+            "bytes": byte_count,
+            "sha256": digest,
+        }
+        archive_path = entry.get("archive_path")
+        if archive_path is not None:
+            archive_digest, archive_bytes = sha256_file(archive_path)
+            if archive_digest != digest or archive_bytes != byte_count:
+                raise ValueError(f"archive copy differs for {identifier}")
+            record["archive_path"] = str(Path(archive_path))
+            record["archive_verified"] = True
+        records.append(record)
+    return {
+        "schema_version": int(specification["schema_version"]),
+        "milestone": str(specification["milestone"]),
+        "captured_at": str(specification["captured_at"]),
+        "host": str(specification["host"]),
+        "entry_count": len(records),
+        "entries": records,
+    }
+
+
+def verify_manifest(
+    manifest: dict[str, Any],
+    *,
+    location: str,
+) -> dict[str, Any]:
+    """Verify source or archive paths against a captured manifest."""
+
+    if location not in {"source", "archive"}:
+        raise ValueError("location must be source or archive")
+    checked = 0
+    skipped = 0
+    failures = []
+    for entry in manifest["entries"]:
+        path_key = "source_path" if location == "source" else "archive_path"
+        if path_key not in entry:
+            skipped += 1
+            continue
+        path = Path(entry[path_key])
+        try:
+            digest, byte_count = sha256_file(path)
+        except FileNotFoundError:
+            failures.append({"id": entry["id"], "reason": "missing", "path": str(path)})
+            continue
+        checked += 1
+        if digest != entry["sha256"] or byte_count != entry["bytes"]:
+            failures.append(
+                {
+                    "id": entry["id"],
+                    "reason": "checksum_mismatch",
+                    "path": str(path),
+                    "expected_sha256": entry["sha256"],
+                    "actual_sha256": digest,
+                    "expected_bytes": entry["bytes"],
+                    "actual_bytes": byte_count,
+                }
+            )
+    return {
+        "milestone": manifest["milestone"],
+        "location": location,
+        "checked": checked,
+        "skipped": skipped,
+        "failures": failures,
+        "passed": not failures,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    capture = subparsers.add_parser("capture")
+    capture.add_argument("specification_json")
+    capture.add_argument("output_json")
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("manifest_json")
+    verify.add_argument("--location", choices=("source", "archive"), required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "capture":
+        specification = json.loads(
+            Path(args.specification_json).read_text(encoding="utf-8")
+        )
+        result = capture_manifest(specification)
+        output = Path(args.output_json)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            json.dumps(result, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        print(json.dumps({"output": str(output.resolve()), **result}, indent=2))
+        return 0
+    manifest = json.loads(Path(args.manifest_json).read_text(encoding="utf-8"))
+    result = verify_manifest(manifest, location=args.location)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/verify_result_bundle.py
+++ b/scripts/release/verify_result_bundle.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Verify a deterministic result directory against its emitted manifest."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _compare_values(
+    expected: Any,
+    actual: Any,
+    *,
+    path: str,
+    numeric_atol: float,
+) -> str | None:
+    if isinstance(expected, bool) or isinstance(actual, bool):
+        return None if expected is actual else f"{path}: {expected!r} != {actual!r}"
+    if isinstance(expected, (int, float)) and isinstance(actual, (int, float)):
+        if math.isclose(float(expected), float(actual), rel_tol=0.0, abs_tol=numeric_atol):
+            return None
+        return f"{path}: {expected!r} != {actual!r}"
+    if type(expected) is not type(actual):
+        return f"{path}: type {type(expected).__name__} != {type(actual).__name__}"
+    if isinstance(expected, dict):
+        if expected.keys() != actual.keys():
+            return f"{path}: object keys differ"
+        for key in expected:
+            difference = _compare_values(
+                expected[key],
+                actual[key],
+                path=f"{path}.{key}",
+                numeric_atol=numeric_atol,
+            )
+            if difference is not None:
+                return difference
+        return None
+    if isinstance(expected, list):
+        if len(expected) != len(actual):
+            return f"{path}: list lengths differ"
+        for index, (expected_item, actual_item) in enumerate(zip(expected, actual)):
+            difference = _compare_values(
+                expected_item,
+                actual_item,
+                path=f"{path}[{index}]",
+                numeric_atol=numeric_atol,
+            )
+            if difference is not None:
+                return difference
+        return None
+    return None if expected == actual else f"{path}: {expected!r} != {actual!r}"
+
+
+def _parse_csv_cell(value: str) -> str | float:
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+def _semantic_difference(
+    expected_path: Path,
+    actual_path: Path,
+    *,
+    numeric_atol: float,
+) -> str | None:
+    if expected_path.suffix == ".json":
+        expected = json.loads(expected_path.read_text(encoding="utf-8"))
+        actual = json.loads(actual_path.read_text(encoding="utf-8"))
+    elif expected_path.suffix == ".csv":
+        with expected_path.open(newline="", encoding="utf-8") as handle:
+            expected = [
+                [_parse_csv_cell(cell) for cell in row] for row in csv.reader(handle)
+            ]
+        with actual_path.open(newline="", encoding="utf-8") as handle:
+            actual = [
+                [_parse_csv_cell(cell) for cell in row] for row in csv.reader(handle)
+            ]
+    else:
+        return "binary checksum differs"
+    return _compare_values(
+        expected,
+        actual,
+        path=expected_path.name,
+        numeric_atol=numeric_atol,
+    )
+
+
+def verify_bundle(
+    expected_manifest: Path,
+    result_dir: Path,
+    *,
+    numeric_atol: float = 0.0,
+) -> dict[str, object]:
+    manifest = json.loads(expected_manifest.read_text(encoding="utf-8"))
+    failures = []
+    tolerance_matches = []
+    for name, expected in manifest["artifacts"].items():
+        path = result_dir / name
+        if not path.is_file():
+            failures.append({"artifact": name, "reason": "missing"})
+            continue
+        actual_size = path.stat().st_size
+        actual_hash = sha256(path)
+        if actual_size != expected["bytes"] or actual_hash != expected["sha256"]:
+            expected_path = expected_manifest.parent / name
+            difference = None
+            if numeric_atol > 0.0 and expected_path.is_file():
+                difference = _semantic_difference(
+                    expected_path,
+                    path,
+                    numeric_atol=numeric_atol,
+                )
+            if difference is None and numeric_atol > 0.0 and expected_path.is_file():
+                tolerance_matches.append(name)
+                continue
+            failures.append(
+                {
+                    "artifact": name,
+                    "reason": "mismatch",
+                    "semantic_difference": difference,
+                    "expected_bytes": expected["bytes"],
+                    "actual_bytes": actual_size,
+                    "expected_sha256": expected["sha256"],
+                    "actual_sha256": actual_hash,
+                }
+            )
+    return {
+        "benchmark": manifest["benchmark"],
+        "checked": len(manifest["artifacts"]),
+        "numeric_atol": numeric_atol,
+        "tolerance_matches": tolerance_matches,
+        "passed": not failures,
+        "failures": failures,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("expected_manifest")
+    parser.add_argument("result_dir")
+    parser.add_argument(
+        "--numeric-atol",
+        type=float,
+        default=0.0,
+        help="accept JSON/CSV numeric drift up to this absolute tolerance",
+    )
+    args = parser.parse_args(argv)
+    if args.numeric_atol < 0.0:
+        parser.error("--numeric-atol must be non-negative")
+    result = verify_bundle(
+        Path(args.expected_manifest),
+        Path(args.result_dir),
+        numeric_atol=args.numeric_atol,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_verification_scripts.py
+++ b/tests/test_release_verification_scripts.py
@@ -1,0 +1,127 @@
+"""Regression tests for standalone milestone verification utilities."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_VERIFY_RESULT_BUNDLE = _REPO_ROOT / "scripts/release/verify_result_bundle.py"
+_CAPTURE_FILE_MANIFEST = _REPO_ROOT / "scripts/release/capture_file_manifest.py"
+
+
+def _run_script(script: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(script), *arguments],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_result_bundle_verifier_accepts_only_bounded_numeric_drift(
+    tmp_path: Path,
+) -> None:
+    expected_dir = tmp_path / "expected"
+    actual_dir = tmp_path / "actual"
+    expected_dir.mkdir()
+    actual_dir.mkdir()
+
+    artifact_name = "summary.json"
+    expected_artifact = expected_dir / artifact_name
+    actual_artifact = actual_dir / artifact_name
+    expected_artifact.write_text(
+        json.dumps({"label": "frozen", "value": 1.0}) + "\n",
+        encoding="utf-8",
+    )
+    actual_artifact.write_text(
+        json.dumps({"label": "frozen", "value": 1.0000000000005}) + "\n",
+        encoding="utf-8",
+    )
+    manifest = {
+        "schema_version": 1,
+        "benchmark": "test-benchmark",
+        "artifacts": {
+            artifact_name: {
+                "bytes": expected_artifact.stat().st_size,
+                "sha256": _sha256(expected_artifact),
+            }
+        },
+    }
+    manifest_path = expected_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    exact = _run_script(
+        _VERIFY_RESULT_BUNDLE,
+        str(manifest_path),
+        str(actual_dir),
+    )
+    assert exact.returncode == 1, exact.stderr
+    assert json.loads(exact.stdout)["passed"] is False
+
+    tolerant = _run_script(
+        _VERIFY_RESULT_BUNDLE,
+        str(manifest_path),
+        str(actual_dir),
+        "--numeric-atol",
+        "1e-12",
+    )
+    assert tolerant.returncode == 0, tolerant.stderr
+    result = json.loads(tolerant.stdout)
+    assert result["passed"] is True
+    assert result["tolerance_matches"] == [artifact_name]
+
+
+def test_file_manifest_capture_and_verification_round_trip(tmp_path: Path) -> None:
+    source = tmp_path / "source.bin"
+    archive = tmp_path / "archive.bin"
+    source.write_bytes(b"frozen milestone payload\n")
+    archive.write_bytes(source.read_bytes())
+
+    specification = {
+        "schema_version": 1,
+        "milestone": "test-milestone",
+        "captured_at": "2026-07-12T00:00:00Z",
+        "host": "test-host",
+        "entries": [
+            {
+                "id": "payload",
+                "category": "test",
+                "source_path": str(source),
+                "archive_path": str(archive),
+            }
+        ],
+    }
+    specification_path = tmp_path / "specification.json"
+    manifest_path = tmp_path / "manifest.json"
+    specification_path.write_text(json.dumps(specification), encoding="utf-8")
+
+    captured = _run_script(
+        _CAPTURE_FILE_MANIFEST,
+        "capture",
+        str(specification_path),
+        str(manifest_path),
+    )
+    assert captured.returncode == 0, captured.stderr
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["entry_count"] == 1
+    assert manifest["entries"][0]["archive_verified"] is True
+
+    for location in ("source", "archive"):
+        verified = _run_script(
+            _CAPTURE_FILE_MANIFEST,
+            "verify",
+            str(manifest_path),
+            "--location",
+            location,
+        )
+        assert verified.returncode == 0, verified.stderr
+        assert json.loads(verified.stdout)["passed"] is True


### PR DESCRIPTION
## What changed

- restore `scripts/release/verify_result_bundle.py`, which `milestones/v0.3.0-causal4d-aip/reproduce_controlled.sh` invokes after regenerating both controlled result bundles
- restore `scripts/release/capture_file_manifest.py`, which the milestone README uses to verify archived source and vault inputs
- add regression tests for exact checksum rejection, the documented `1e-12` JSON/CSV numeric tolerance, and source/archive manifest round-tripping

## Root cause

The standalone repository extraction retained the milestone reproduction wrappers and documentation but omitted the shared `scripts/release/` verification utilities from the source repository. Consequently, controlled reproduction completed its benchmark commands and then failed when Python could not open the missing verifier.

The restored utilities are byte-for-byte identical to the files at the recorded Bayesian-PhysTwin migration source revision `2a0431025e7c7ede02efdc5c9d4492985bae9442`.

## Impact

The controlled milestone wrapper can now execute its final verification phase entirely from the Causal4D checkout, and the README's archived-input verification commands resolve locally as documented.

## Validation

- `python -m py_compile scripts/release/verify_result_bundle.py scripts/release/capture_file_manifest.py`
- focused regression suite: `2 passed`
- verified restored Git blob SHAs against the migration source revision:
  - `verify_result_bundle.py`: `341399a8c175cdd457488939523992840e476561`
  - `capture_file_manifest.py`: `c0740454f60ef4e58e3ea86f07ac5975aa680511`