### PR TITLE
Fix staged posterior-mass accounting for BPT profiles

### DIFF
--- a/src/causal4d/cli/phystwin_rollout_bank.py
+++ b/src/causal4d/cli/phystwin_rollout_bank.py
@@ -160,6 +160,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "represented_parameter_mass": (
                     backend.particles.represented_probability_mass
                 ),
+                "parameter_mass_accounting": (
+                    backend.particles.probability_mass_accounting()
+                ),
                 "parameter_support_method": support_method,
                 "twin_belief": str(twin_belief_path.resolve()),
                 "twin_belief_id": twin_belief.artifact_id,

--- a/src/causal4d/cli/phystwin_rollout_bank.py
+++ b/src/causal4d/cli/phystwin_rollout_bank.py
@@ -156,6 +156,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "case": backend.case_name,
                 "action_setting": args.action_setting,
                 "rollout_shape": list(bank.trajectories.shape),
+                "bpt_retained_parameter_mass": (
+                    backend.particles.bpt_retained_probability_mass
+                ),
+                "causal4d_retained_parameter_mass": (
+                    backend.particles.causal4d_retained_probability_mass
+                ),
                 "retained_parameter_mass": backend.particles.retained_probability_mass,
                 "represented_parameter_mass": (
                     backend.particles.represented_probability_mass

--- a/src/causal4d/phystwin_backend.py
+++ b/src/causal4d/phystwin_backend.py
@@ -40,7 +40,11 @@ def _load_pickle(path: str | Path) -> Any:
 
 @dataclass(frozen=True)
 class BayesianPhysTwinParticles:
-    """Selected object/controller spring-scale particles from a saved profile."""
+    """Selected spring-scale particles with staged posterior-mass accounting.
+
+    The legacy retained and represented fields are composed masses relative to
+    the pre-truncation Bayesian-PhysTwin posterior.
+    """
 
     log_scales: np.ndarray
     weights: np.ndarray
@@ -50,6 +54,11 @@ class BayesianPhysTwinParticles:
     selection_method: SupportMethod = "top_mass"
     represented_probability_mass: float | None = None
     source_particle_count: int | None = None
+    bpt_retained_probability_mass: float = 1.0
+    causal4d_retained_probability_mass: float | None = None
+    causal4d_represented_probability_mass: float | None = None
+    profile_grid_cell_count: int | None = None
+    bpt_source_weight_key: str | None = None
 
     def __post_init__(self) -> None:
         particles = np.asarray(self.log_scales, dtype=float)
@@ -63,29 +72,153 @@ class BayesianPhysTwinParticles:
             raise ValueError("particle arrays must be finite")
         if np.any(weights < 0.0) or not np.isclose(np.sum(weights), 1.0):
             raise ValueError("particle weights must be nonnegative and sum to one")
-        if not 0.0 < self.retained_probability_mass <= 1.0 + 1e-12:
-            raise ValueError("retained probability mass must lie in (0, 1]")
         if self.selection_method not in {"top_mass", "weighted_coreset"}:
             raise ValueError("unknown parameter support selection method")
-        represented = (
-            self.retained_probability_mass
+
+        composed_retained = float(self.retained_probability_mass)
+        composed_represented = float(
+            composed_retained
             if self.represented_probability_mass is None
             else self.represented_probability_mass
         )
-        if not 0.0 < represented <= 1.0 + 1e-12:
-            raise ValueError("represented probability mass must lie in (0, 1]")
+        bpt_retained = float(self.bpt_retained_probability_mass)
+        for name, value in (
+            ("retained probability mass", composed_retained),
+            ("represented probability mass", composed_represented),
+            ("BPT retained probability mass", bpt_retained),
+        ):
+            if not np.isfinite(value) or not 0.0 < value <= 1.0 + 1e-12:
+                raise ValueError(f"{name} must lie in (0, 1]")
+
+        causal4d_retained = float(
+            composed_retained / bpt_retained
+            if self.causal4d_retained_probability_mass is None
+            else self.causal4d_retained_probability_mass
+        )
+        causal4d_represented = float(
+            composed_represented / bpt_retained
+            if self.causal4d_represented_probability_mass is None
+            else self.causal4d_represented_probability_mass
+        )
+        for name, value in (
+            ("Causal4D retained probability mass", causal4d_retained),
+            ("Causal4D represented probability mass", causal4d_represented),
+        ):
+            if not np.isfinite(value) or not 0.0 < value <= 1.0 + 1e-12:
+                raise ValueError(f"{name} must lie in (0, 1]")
+        if not np.isclose(
+            composed_retained,
+            bpt_retained * causal4d_retained,
+            rtol=1e-12,
+            atol=1e-15,
+        ):
+            raise ValueError("composed retained mass must equal the two stage masses")
+        if not np.isclose(
+            composed_represented,
+            bpt_retained * causal4d_represented,
+            rtol=1e-12,
+            atol=1e-15,
+        ):
+            raise ValueError("composed represented mass must equal the stage masses")
+
         source_count = (
             len(particles)
             if self.source_particle_count is None
             else int(self.source_particle_count)
         )
+        profile_count = (
+            source_count
+            if self.profile_grid_cell_count is None
+            else int(self.profile_grid_cell_count)
+        )
         if source_count < len(particles):
             raise ValueError("source particle count cannot be below selected count")
+        if profile_count < source_count:
+            raise ValueError("profile grid count cannot be below source particle count")
         object.__setattr__(self, "log_scales", particles)
         object.__setattr__(self, "weights", weights)
         object.__setattr__(self, "grid_indices", indices)
-        object.__setattr__(self, "represented_probability_mass", represented)
+        object.__setattr__(self, "retained_probability_mass", composed_retained)
+        object.__setattr__(
+            self, "represented_probability_mass", composed_represented
+        )
+        object.__setattr__(self, "bpt_retained_probability_mass", bpt_retained)
+        object.__setattr__(
+            self, "causal4d_retained_probability_mass", causal4d_retained
+        )
+        object.__setattr__(
+            self,
+            "causal4d_represented_probability_mass",
+            causal4d_represented,
+        )
         object.__setattr__(self, "source_particle_count", source_count)
+        object.__setattr__(self, "profile_grid_cell_count", profile_count)
+
+    def probability_mass_accounting(self) -> dict[str, Any]:
+        """Return producer, consumer, and composed posterior-mass diagnostics."""
+
+        return {
+            "bpt_truncation": {
+                "source_weight_key": self.bpt_source_weight_key,
+                "retained_probability_mass": self.bpt_retained_probability_mass,
+                "profile_grid_cell_count": self.profile_grid_cell_count,
+                "retained_grid_cell_count": self.source_particle_count,
+            },
+            "causal4d_support_reduction": {
+                "method": self.selection_method,
+                "directly_retained_probability_mass": (
+                    self.causal4d_retained_probability_mass
+                ),
+                "represented_probability_mass": (
+                    self.causal4d_represented_probability_mass
+                ),
+                "source_particle_count": self.source_particle_count,
+                "selected_particle_count": len(self.weights),
+            },
+            "composed_relative_to_original_posterior": {
+                "directly_retained_probability_mass": (
+                    self.retained_probability_mass
+                ),
+                "represented_probability_mass": self.represented_probability_mass,
+            },
+        }
+
+
+def _normalized_profile_weight_grid(
+    values: np.ndarray,
+    *,
+    expected_shape: tuple[int, int],
+    label: str,
+) -> np.ndarray:
+    weights = np.asarray(values, dtype=float)
+    if weights.shape != expected_shape:
+        raise ValueError(f"{label} must have shape {expected_shape}")
+    if np.any(weights < 0.0) or not np.all(np.isfinite(weights)):
+        raise ValueError(f"{label} must be finite and nonnegative")
+    total = float(np.sum(weights))
+    if total <= 0.0:
+        raise ValueError(f"{label} must have positive mass")
+    return weights / total
+
+
+def _bpt_truncation_mass(
+    prediction_weights: np.ndarray,
+    source_weights: np.ndarray,
+    *,
+    source_weight_key: str,
+) -> float:
+    active = prediction_weights > 0.0
+    retained = float(np.sum(source_weights[active]))
+    if retained <= 0.0:
+        raise ValueError(f"{source_weight_key} has no mass on prediction support")
+    expected = np.zeros_like(source_weights)
+    expected[active] = source_weights[active] / retained
+    if not np.allclose(prediction_weights, expected, rtol=1e-8, atol=1e-12):
+        raise ValueError(
+            "prediction_weights are not a truncation and renormalization of "
+            f"{source_weight_key}"
+        )
+    return retained
 
 
 def load_bayesian_phystwin_particles(
@@ -122,15 +255,50 @@ def load_bayesian_phystwin_particles(
             if selected_weight_key not in archive.files:
                 raise ValueError(f"parameter profile has no {selected_weight_key!r}")
         weight_grid = np.asarray(archive[selected_weight_key], dtype=float)
+        source_prediction_grid = (
+            np.asarray(archive["source_prediction_weights"], dtype=float)
+            if "source_prediction_weights" in archive.files
+            else None
+        )
+        posterior_grid = (
+            np.asarray(archive["posterior_weights"], dtype=float)
+            if "posterior_weights" in archive.files
+            else None
+        )
+
     expected = (len(object_grid), len(controller_grid))
-    if weight_grid.shape != expected:
-        raise ValueError(f"profile weight grid must have shape {expected}")
-    if np.any(weight_grid < 0.0) or not np.all(np.isfinite(weight_grid)):
-        raise ValueError("profile weights must be finite and nonnegative")
-    total = float(np.sum(weight_grid))
-    if total <= 0.0:
-        raise ValueError("profile weights must have positive mass")
-    normalized = weight_grid / total
+    normalized = _normalized_profile_weight_grid(
+        weight_grid,
+        expected_shape=expected,
+        label=f"profile {selected_weight_key}",
+    )
+    bpt_retained_mass = 1.0
+    bpt_source_weight_key = selected_weight_key
+    if selected_weight_key == "prediction_weights":
+        source_grid = None
+        if source_prediction_grid is not None:
+            bpt_source_weight_key = "source_prediction_weights"
+            source_grid = source_prediction_grid
+        elif posterior_grid is not None:
+            bpt_source_weight_key = "posterior_weights"
+            source_grid = posterior_grid
+        if source_grid is not None:
+            normalized_source = _normalized_profile_weight_grid(
+                source_grid,
+                expected_shape=expected,
+                label=f"profile {bpt_source_weight_key}",
+            )
+            bpt_retained_mass = _bpt_truncation_mass(
+                normalized,
+                normalized_source,
+                source_weight_key=bpt_source_weight_key,
+            )
+        elif np.any(normalized == 0.0):
+            raise ValueError(
+                "truncated prediction_weights require source_prediction_weights "
+                "to recover their mass relative to the original posterior"
+            )
+
     object_mesh, controller_mesh = np.meshgrid(
         object_grid,
         controller_grid,
@@ -141,22 +309,33 @@ def load_bayesian_phystwin_particles(
         np.unravel_index(np.arange(weight_grid.size), weight_grid.shape)
     )
     flat_weights = normalized.reshape(-1)
+    # Exact zeros are outside BPT's retained support and need no Warp rollout.
+    positive = np.flatnonzero(flat_weights > 0.0)
     reduction = reduce_parameter_support(
-        particles,
-        flat_weights,
+        particles[positive],
+        flat_weights[positive],
         maximum_count=maximum_count,
         method=support_method,
     )
-    selected = reduction.indices
+    selected = positive[reduction.indices]
+    causal4d_retained_mass = reduction.directly_retained_probability_mass
+    causal4d_represented_mass = reduction.represented_probability_mass
     return BayesianPhysTwinParticles(
         log_scales=particles[selected],
         weights=reduction.weights,
         grid_indices=grid_indices[selected],
         source_weight_key=selected_weight_key,
-        retained_probability_mass=reduction.directly_retained_probability_mass,
+        retained_probability_mass=bpt_retained_mass * causal4d_retained_mass,
         selection_method=support_method,
-        represented_probability_mass=reduction.represented_probability_mass,
+        represented_probability_mass=(
+            bpt_retained_mass * causal4d_represented_mass
+        ),
         source_particle_count=reduction.source_particle_count,
+        bpt_retained_probability_mass=bpt_retained_mass,
+        causal4d_retained_probability_mass=causal4d_retained_mass,
+        causal4d_represented_probability_mass=causal4d_represented_mass,
+        profile_grid_cell_count=weight_grid.size,
+        bpt_source_weight_key=bpt_source_weight_key,
     )
 
 
@@ -737,12 +916,17 @@ class OfficialPhysTwinBackend:
                 "count": len(self.particles.weights),
                 "log_scale_names": ["object_springs", "controller_springs"],
                 "source_weight_key": self.particles.source_weight_key,
+                "bpt_source_weight_key": self.particles.bpt_source_weight_key,
                 "selection_method": self.particles.selection_method,
                 "retained_probability_mass": self.particles.retained_probability_mass,
                 "represented_probability_mass": (
                     self.particles.represented_probability_mass
                 ),
+                "probability_mass_accounting": (
+                    self.particles.probability_mass_accounting()
+                ),
                 "source_particle_count": self.particles.source_particle_count,
+                "profile_grid_cell_count": self.particles.profile_grid_cell_count,
                 "grid_indices": self.particles.grid_indices.tolist(),
                 "log_scales": self.particles.log_scales.tolist(),
                 "weights": self.particles.weights.tolist(),

--- a/tests/test_causal4d_phystwin_backend.py
+++ b/tests/test_causal4d_phystwin_backend.py
@@ -6,6 +6,7 @@ from bayesian_phystwin.phystwin_graph import PhysTwinSpringGraph
 from causal4d.phystwin_backend import (
     BayesianPhysTwinParticles,
     OfficialPhysTwinBackend,
+    OfficialPhysTwinBackendConfig,
     PhysTwinActionProposal,
     PhysTwinContactState,
     PhysTwinHypothesisConfig,
@@ -42,6 +43,81 @@ def test_profile_loader_selects_and_renormalizes_high_mass_particles(
     assert coreset.represented_probability_mass == 1.0
     assert coreset.source_particle_count == 4
     assert np.isclose(np.sum(coreset.weights), 1.0)
+
+
+def test_profile_loader_preserves_staged_probability_mass(tmp_path: Path) -> None:
+    profile = tmp_path / "truncated_profile.npz"
+    source_weights = np.asarray([[0.5, 0.3], [0.1, 0.1]])
+    prediction_weights = np.asarray([[5 / 9, 3 / 9], [1 / 9, 0.0]])
+    np.savez(
+        profile,
+        object_log_scales=np.asarray([-0.2, 0.2]),
+        controller_log_scales=np.asarray([-0.1, 0.1]),
+        posterior_weights=np.full((2, 2), 0.25),
+        source_prediction_weights=source_weights,
+        prediction_weights=prediction_weights,
+    )
+
+    full = load_bayesian_phystwin_particles(profile, maximum_count=10)
+    assert len(full.weights) == 3
+    assert [1, 1] not in full.grid_indices.tolist()
+    assert full.profile_grid_cell_count == 4
+    assert full.source_particle_count == 3
+    assert np.isclose(full.bpt_retained_probability_mass, 0.9)
+    assert np.isclose(full.causal4d_retained_probability_mass, 1.0)
+    assert np.isclose(full.retained_probability_mass, 0.9)
+
+    reduced = load_bayesian_phystwin_particles(profile, maximum_count=2)
+    np.testing.assert_array_equal(reduced.grid_indices, [[0, 0], [0, 1]])
+    np.testing.assert_allclose(reduced.weights, [5 / 8, 3 / 8])
+    assert reduced.bpt_source_weight_key == "source_prediction_weights"
+    assert np.isclose(reduced.bpt_retained_probability_mass, 0.9)
+    assert np.isclose(reduced.causal4d_retained_probability_mass, 8 / 9)
+    assert np.isclose(reduced.retained_probability_mass, 0.8)
+
+    coreset = load_bayesian_phystwin_particles(
+        profile,
+        maximum_count=2,
+        support_method="weighted_coreset",
+    )
+    assert np.isclose(coreset.bpt_retained_probability_mass, 0.9)
+    assert np.isclose(coreset.causal4d_represented_probability_mass, 1.0)
+    assert np.isclose(coreset.represented_probability_mass, 0.9)
+    assert [1, 1] not in coreset.grid_indices.tolist()
+
+    accounting = reduced.probability_mass_accounting()
+    assert np.isclose(
+        accounting["bpt_truncation"]["retained_probability_mass"],
+        0.9,
+    )
+    assert np.isclose(
+        accounting["causal4d_support_reduction"][
+            "directly_retained_probability_mass"
+        ],
+        8 / 9,
+    )
+    assert np.isclose(
+        accounting["composed_relative_to_original_posterior"][
+            "directly_retained_probability_mass"
+        ],
+        0.8,
+    )
+
+    backend = object.__new__(OfficialPhysTwinBackend)
+    backend.case_name = "unit_case"
+    backend.train_end_frame = 3
+    backend.official_repo = tmp_path / "official"
+    backend.final_data_path = tmp_path / "final_data.pkl"
+    backend.optimal_params_path = tmp_path / "optimal_params.pkl"
+    backend.checkpoint_path = tmp_path / "checkpoint.pt"
+    backend.baseline_trajectory_path = tmp_path / "baseline.pkl"
+    backend.profile_path = profile
+    backend.particles = reduced
+    backend.controller_groups = np.asarray([0])
+    backend.config = OfficialPhysTwinBackendConfig()
+    manifest = backend.default_manifest()["parameter_particles"]
+    assert np.isclose(manifest["retained_probability_mass"], 0.8)
+    assert manifest["probability_mass_accounting"] == accounting
 
 
 def test_hidden_action_proposals_never_read_withheld_future() -> None:


### PR DESCRIPTION
## Summary

- recover the Bayesian-PhysTwin truncation mass from `source_prediction_weights` instead of treating renormalized `prediction_weights` as the original posterior
- track the BPT truncation factor, the Causal4D support-reduction factor, and their composed mass relative to the original posterior
- exclude exact-zero profile cells before support reduction so they cannot trigger unnecessary Warp rollouts
- expose the staged accounting in rollout manifests and CLI output while keeping the existing retained-mass fields as composed values
- add regression coverage for a profile retaining 90% in BPT and then 8/9 in Causal4D, yielding 80% composed mass

## Validation

- `python -m py_compile src/causal4d/phystwin_backend.py src/causal4d/cli/phystwin_rollout_bank.py tests/test_causal4d_phystwin_backend.py`
- targeted loader regression tests: 2 passed
- verified against the Bayesian-PhysTwin revision pinned by Causal4D (`c7ad36aad7e592ce8a391c9ca2d4db7389dee3ac`), whose profile artifact includes both `source_prediction_weights` and truncated, renormalized `prediction_weights`
- GitHub Actions run 37 passed: Ruff; Python 3.10, 3.12, and 3.14 test suites; distribution build; metadata validation; and wheel smoke test
