### PR TITLE
Superseded: consume Bayesian-PhysTwin provider API v1

### DIFF
--- a/.github/provider-migration-trigger
+++ b/.github/provider-migration-trigger
@@ -1,0 +1,1 @@
+Trigger the provider-boundary migration after pull-request creation.

--- a/.github/workflows/agent-migrate-bpt-provider.yml
+++ b/.github/workflows/agent-migrate-bpt-provider.yml
@@ -1,0 +1,386 @@
+name: Migrate to BPT provider API v1
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  migrate:
+    if: >-
+      github.head_ref == 'agent/consume-bpt-provider-api-v1' &&
+      github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Rewrite provider imports and add compatibility boundary
+        shell: bash
+        run: |
+          python - <<'PY'
+          from __future__ import annotations
+
+          import ast
+          from pathlib import Path
+
+          private_names = {
+              "_attachment_support_nodes": "attachment_support_nodes",
+              "_chamfer_by_frame": "chamfer_by_frame",
+              "_far_graph_observation_error": "far_graph_observation_error",
+              "_git_commit": "git_commit",
+              "_graph_distance": "graph_distance",
+              "_horizon_summary": "horizon_summary",
+              "_initialize_simulator": "initialize_simulator",
+              "_lift_map": "build_lift_map",
+              "_lift_residual": "lift_residual",
+              "_load_pickle": "load_pickle",
+              "_lock_protocol": "lock_protocol",
+              "_metric_summary": "metric_summary",
+              "_object_rest_lengths": "object_rest_lengths",
+              "_released_self_collision_for_case": "released_self_collision_for_case",
+              "_rollout_initial": "rollout_initial",
+              "_rollout_restart": "rollout_restart",
+              "_set_simulator_arrays": "set_simulator_arrays",
+              "_sha256": "sha256_file",
+              "_simulator_runtime": "simulator_runtime",
+              "_state_numpy": "state_numpy",
+              "_target_validity": "target_validity",
+          }
+          provider_public = {
+              "estimate_endpoint_velocity_delta",
+              "load_official_spring_mass_module",
+              "make_reliability_simulator_class",
+          }
+
+          roots = (Path("src/causal4d"), Path("src/causal4d_public"))
+          changed = []
+          for root in roots:
+              for path in sorted(root.rglob("*.py")):
+                  source = path.read_text(encoding="utf-8")
+                  tree = ast.parse(source, filename=str(path))
+                  lines = source.splitlines(keepends=True)
+                  replacements = []
+                  for node in ast.walk(tree):
+                      if not isinstance(node, ast.ImportFrom):
+                          continue
+                      module = node.module or ""
+                      if not module.startswith("bayesian_phystwin."):
+                          continue
+                      private_module = any(
+                          part.startswith("_") for part in module.split(".")[1:]
+                      )
+                      private_import = any(
+                          alias.name.startswith("_") for alias in node.names
+                      )
+                      if not private_module and not private_import:
+                          continue
+                      rendered = []
+                      for alias in node.names:
+                          if alias.name.startswith("_"):
+                              if alias.name not in private_names:
+                                  raise RuntimeError(
+                                      f"unmapped private BPT import {module}:{alias.name} "
+                                      f"in {path}:{node.lineno}"
+                                  )
+                              public_name = private_names[alias.name]
+                          else:
+                              if alias.name not in provider_public:
+                                  raise RuntimeError(
+                                      f"unmapped public sibling {module}:{alias.name} "
+                                      f"in private import block {path}:{node.lineno}"
+                                  )
+                              public_name = alias.name
+                          local_name = alias.asname or alias.name
+                          rendered.append(
+                              public_name
+                              if public_name == local_name
+                              else f"{public_name} as {local_name}"
+                          )
+                      indent = " " * node.col_offset
+                      replacement = (
+                          indent
+                          + "from bayesian_phystwin.causal4d_provider_v1 import (\n"
+                          + "".join(
+                              f"{indent}    {name},\n" for name in rendered
+                          )
+                          + indent
+                          + ")\n"
+                      )
+                      replacements.append((node.lineno - 1, node.end_lineno, replacement))
+                  if not replacements:
+                      continue
+                  for start, stop, replacement in sorted(replacements, reverse=True):
+                      lines[start:stop] = [replacement]
+                  path.write_text("".join(lines), encoding="utf-8")
+                  ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+                  changed.append(str(path))
+
+          remaining = []
+          for root in roots:
+              for path in sorted(root.rglob("*.py")):
+                  tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+                  for node in ast.walk(tree):
+                      if not isinstance(node, ast.ImportFrom):
+                          continue
+                      module = node.module or ""
+                      if not module.startswith("bayesian_phystwin."):
+                          continue
+                      private_module = any(
+                          part.startswith("_") for part in module.split(".")[1:]
+                      )
+                      private_imports = [
+                          alias.name for alias in node.names if alias.name.startswith("_")
+                      ]
+                      if private_module or private_imports:
+                          remaining.append(
+                              f"{path}:{node.lineno}:{module}:{private_imports}"
+                          )
+          if remaining:
+              raise RuntimeError(
+                  "private Bayesian-PhysTwin imports remain:\n" + "\n".join(remaining)
+              )
+          print(f"rewrote {len(changed)} production files")
+          PY
+
+          cat > src/causal4d/bpt_provider.py <<'PY'
+          """Semantic compatibility gate for the installed Bayesian-PhysTwin provider."""
+
+          from __future__ import annotations
+
+          from collections.abc import Mapping, Sequence
+          from typing import Any
+
+          from .provider_contract import (
+              BASE_CAUSAL4D_PROVIDER_CAPABILITIES,
+              PhysicalBeliefProviderManifest,
+              ProviderCompatibilityResult,
+              validate_provider_compatibility,
+          )
+
+          BPT_PROVIDER_API_MODULE = "bayesian_phystwin.causal4d_provider_v1"
+          REQUIRED_BPT_ARTIFACT_VERSIONS = {
+              "observation_belief": 1,
+              "dynamic_discrepancy_correction": 1,
+          }
+
+
+          def _external_provider_manifest(provider_revision: str | None):
+              from bayesian_phystwin.causal4d_provider_v1 import provider_manifest
+
+              return provider_manifest(provider_revision)
+
+
+          def installed_bpt_provider_manifest(
+              provider_revision: str | None = None,
+          ) -> PhysicalBeliefProviderManifest:
+              """Load and normalize the installed BPT provider manifest."""
+
+              external = _external_provider_manifest(provider_revision)
+              return PhysicalBeliefProviderManifest(
+                  provider_name=str(external.provider_name),
+                  provider_version=str(external.provider_version),
+                  provider_revision=str(external.provider_revision),
+                  schema_version=int(external.schema_version),
+                  capabilities=tuple(map(str, external.capabilities)),
+                  artifact_schema_versions={
+                      str(name): int(version)
+                      for name, version in dict(
+                          external.artifact_schema_versions
+                      ).items()
+                  },
+                  metadata={
+                      **dict(getattr(external, "metadata", {})),
+                      "external_provider_manifest_id": str(external.manifest_id),
+                      "external_provider_module": BPT_PROVIDER_API_MODULE,
+                  },
+              )
+
+
+          def validate_installed_bpt_provider(
+              *,
+              provider_revision: str | None = None,
+              required_capabilities: Sequence[str] = (
+                  BASE_CAUSAL4D_PROVIDER_CAPABILITIES
+              ),
+              required_artifact_versions: Mapping[str, int] = (
+                  REQUIRED_BPT_ARTIFACT_VERSIONS
+              ),
+          ) -> ProviderCompatibilityResult:
+              """Fail closed when the installed BPT provider is semantically incompatible."""
+
+              manifest = installed_bpt_provider_manifest(provider_revision)
+              return validate_provider_compatibility(
+                  manifest,
+                  required_capabilities=required_capabilities,
+                  required_artifact_versions=required_artifact_versions,
+              )
+
+
+          def require_installed_bpt_provider(
+              **kwargs: Any,
+          ) -> PhysicalBeliefProviderManifest:
+              """Return the manifest or raise with exact incompatibility diagnostics."""
+
+              manifest = installed_bpt_provider_manifest(
+                  kwargs.pop("provider_revision", None)
+              )
+              result = validate_provider_compatibility(manifest, **kwargs)
+              if not result.compatible:
+                  raise RuntimeError(
+                      "incompatible Bayesian-PhysTwin provider: "
+                      f"missing={result.missing_capabilities}, "
+                      f"schema={result.unsupported_schema_version}, "
+                      f"artifacts={result.artifact_version_mismatches}"
+                  )
+              return manifest
+
+
+          __all__ = [
+              "BPT_PROVIDER_API_MODULE",
+              "REQUIRED_BPT_ARTIFACT_VERSIONS",
+              "installed_bpt_provider_manifest",
+              "require_installed_bpt_provider",
+              "validate_installed_bpt_provider",
+          ]
+          PY
+
+          cat > tests/test_bpt_provider_boundary.py <<'PY'
+          from __future__ import annotations
+
+          import ast
+          from pathlib import Path
+          from types import SimpleNamespace
+
+          import causal4d.bpt_provider as boundary
+
+
+          def test_production_code_has_no_private_bpt_imports() -> None:
+              violations = []
+              for root_name in ("src/causal4d", "src/causal4d_public"):
+                  for path in sorted(Path(root_name).rglob("*.py")):
+                      tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+                      for node in ast.walk(tree):
+                          if not isinstance(node, ast.ImportFrom):
+                              continue
+                          module = node.module or ""
+                          if not module.startswith("bayesian_phystwin."):
+                              continue
+                          private_module = any(
+                              part.startswith("_") for part in module.split(".")[1:]
+                          )
+                          private_names = [
+                              alias.name
+                              for alias in node.names
+                              if alias.name.startswith("_")
+                          ]
+                          if private_module or private_names:
+                              violations.append(
+                                  (str(path), node.lineno, module, private_names)
+                              )
+              assert violations == []
+
+
+          def test_installed_manifest_is_normalized_and_validated(monkeypatch) -> None:
+              external = SimpleNamespace(
+                  provider_name="bayesian-phystwin",
+                  provider_version="0.4.0",
+                  provider_revision="test-revision",
+                  schema_version=1,
+                  capabilities=(
+                      "artifact_checksums",
+                      "particle_endpoint_position",
+                      "particle_endpoint_velocity",
+                      "physical_parameter_particles",
+                  ),
+                  artifact_schema_versions={
+                      "observation_belief": 1,
+                      "dynamic_discrepancy_correction": 1,
+                  },
+                  metadata={"provider_api_version": "1.0.0"},
+                  manifest_id="a" * 64,
+              )
+              monkeypatch.setattr(
+                  boundary,
+                  "_external_provider_manifest",
+                  lambda provider_revision: external,
+              )
+              manifest = boundary.installed_bpt_provider_manifest()
+              assert manifest.provider_revision == "test-revision"
+              assert manifest.metadata["external_provider_manifest_id"] == "a" * 64
+              result = boundary.validate_installed_bpt_provider()
+              assert result.compatible
+          PY
+
+          cat > docs/bayesian_phystwin_provider_boundary.md <<'MD'
+          # Bayesian-PhysTwin provider boundary
+
+          Causal4D consumes Bayesian-PhysTwin through
+          `bayesian_phystwin.causal4d_provider_v1`. Production code must not import
+          underscore-prefixed Bayesian-PhysTwin helpers or modules.
+
+          `causal4d.bpt_provider` converts the external provider manifest into the
+          Causal4D-native `PhysicalBeliefProviderManifest` and validates the required
+          capabilities and artifact versions. Exact Git pins remain appropriate for
+          frozen experiments; the semantic manifest is the normal-development
+          compatibility gate.
+
+          The `phystwin` extra pins the currently validated provider revision. A local
+          compatible provider may be installed separately and checked with
+          `validate_installed_bpt_provider()` before an adapter is used.
+          MD
+
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path("pyproject.toml")
+          text = path.read_text(encoding="utf-8")
+          text = text.replace('version = "0.4.0"', 'version = "0.4.1"', 1)
+          old = (
+              'bayesian-phystwin @ git+https://github.com/FlorianPfaff/'
+              'Bayesian-PhysTwin.git@c7ad36aad7e592ce8a391c9ca2d4db7389dee3ac'
+          )
+          new = (
+              'bayesian-phystwin @ git+https://github.com/FlorianPfaff/'
+              'Bayesian-PhysTwin.git@9f58f4608cfcb0ec215d370395b46d519effb676'
+          )
+          if old not in text:
+              raise RuntimeError("expected Bayesian-PhysTwin pin was not found")
+          path.write_text(text.replace(old, new), encoding="utf-8")
+
+          readme = Path("README.md")
+          text = readme.read_text(encoding="utf-8")
+          old = (
+              "The `phystwin` extra pins the compatible Bayesian-PhysTwin provider revision.\n"
+              "Visual, Warp-runtime, and actuator-calibration dependencies remain separate so\n"
+              "the controlled benchmark stays lightweight."
+          )
+          new = (
+              "The `phystwin` extra pins the reproducible Bayesian-PhysTwin provider revision.\n"
+              "At runtime, adapters additionally validate the versioned semantic provider\n"
+              "manifest and required artifact schemas. Visual, Warp-runtime, and\n"
+              "actuator-calibration dependencies remain separate so the controlled benchmark\n"
+              "stays lightweight."
+          )
+          if old not in text:
+              raise RuntimeError("expected README provider paragraph was not found")
+          readme.write_text(text.replace(old, new), encoding="utf-8")
+          PY
+
+          rm .github/workflows/agent-migrate-bpt-provider.yml
+          python -m compileall -q src tests
+          python -m pip install -e ".[dev]"
+          python -m pytest -q tests/test_bpt_provider_boundary.py tests/test_causal4d_provider_contract.py
+          git diff --check
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Consume Bayesian-PhysTwin provider API v1"
+          git push origin "HEAD:${{ github.head_ref }}"


### PR DESCRIPTION
Superseded by merged PR #32. The final migration was applied to current `main`, retained all subsequent Causal4D work, used the completed Bayesian-PhysTwin provider API, and passed the native test/build matrix.