### PR TITLE
Draft: snapshot current main for provider rebase

### DIFF
--- a/.github/workflows/agent-current-main-snapshot.yml
+++ b/.github/workflows/agent-current-main-snapshot.yml
@@ -1,0 +1,24 @@
+name: Agent current-main snapshot
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  snapshot:
+    if: github.head_ref == 'agent/c4-provider-current-snapshot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+      - name: Package current main
+        run: tar --exclude=.git -czf /tmp/causal4d-current-main.tgz .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: causal4d-current-main
+          path: /tmp/causal4d-current-main.tgz
+          retention-days: 1


### PR DESCRIPTION
Temporary draft PR used only to package the exact current `main` tree for resolving the provider migration against recent commits. No production change is intended from this PR.