### PR TITLE
Bind exact Prob4D observation-factor lineage

### DIFF
--- a/docs/observation_belief_lineage.md
+++ b/docs/observation_belief_lineage.md
@@ -1,11 +1,20 @@
-# Observation-belief lineage
+# Observation lineage
 
-Causal4D can validate the versioned `phys4d.observation_belief` artifact emitted
-by Prob4D and consumed by Bayesian-PhysTwin without importing either provider.
-This preserves the repository boundary: Causal4D consumes a content-addressed
-belief and does not reinterpret the feeder's raw files.
+Causal4D validates portable observation artifacts without importing Prob4D or
+Bayesian-PhysTwin. Two related interfaces are supported:
 
-## Validation
+1. `phys4d.observation_belief` is a marginalized, content-addressed observation
+   belief suitable for grouped likelihoods and simple consumers.
+2. `prob4d.observation-factor-bundle` schema v3 preserves the exact unfused
+   points, conditional covariance, explicit `Sim(3)` gauge variables, separate
+   reliability fields, and the exclusive causal cutoff consumed by the
+   gauge-aware Bayesian-PhysTwin update.
+
+The second interface is the stronger estimator-provenance binding. A compatible
+marginalized belief does not prove that the estimator consumed the exact
+factor-bundle manifest and payload pair.
+
+## Observation-belief validation
 
 ```bash
 causal4d-observation-lineage validate \
@@ -13,7 +22,7 @@ causal4d-observation-lineage validate \
   twin_belief.npz
 ```
 
-Validation fails closed unless all of the following hold:
+Validation fails closed unless:
 
 - the schema name, version, exact array set, and content digest are valid;
 - every observation frame lies within the artifact's declared causal prefix;
@@ -23,15 +32,45 @@ Validation fails closed unless all of the following hold:
 - the observation interval is contained in the `TwinBelief` O-minus interval;
 - an already bound `TwinBelief` names the same observation artifact.
 
-Use `--require-bound` when the downstream command requires proof that the
-`TwinBelief` was produced from the validated observation rather than merely
-being compatible with it.
+Use `--require-bound` when a downstream command requires proof that the
+`TwinBelief` was produced from the artifact rather than merely being compatible
+with it.
+
+## Exact factor-bundle validation
+
+```bash
+causal4d-observation-lineage validate-factor-bundle \
+  observation_factors.json \
+  twin_belief.npz
+```
+
+Causal4D independently checks the schema-v3 manifest and its checksum-bound NPZ
+payload. Validation includes:
+
+- exact manifest and payload SHA-256 values and an artifact ID derived from both;
+- a relative payload path that cannot escape the manifest directory;
+- explicit case, stream, sequence, repository, and producer revision identities;
+- one exclusive `causal_frame_stop` shared by every factor;
+- unique factor and gauge identities and valid gauge references;
+- finite `Sim(3)` means and positive-semidefinite gauge covariance;
+- the exact payload array set, types, dimensions, and per-factor row identities;
+- separate association probability and residual-independent prior reliability;
+- fixed nominal-component probability and composite weight within every
+  correlation group;
+- finite active points, covariance, and optional rays;
+- case equality and containment in the `TwinBelief` O-minus interval.
+
+Schema-v2 factor bundles are deliberately not accepted here. Prob4D must first
+load and rewrite them as schema v3 so that the exclusive cutoff and newly
+separated reliability fields are explicit in the exact artifact being bound.
 
 ## Binding
 
-The estimator that actually consumes an observation artifact should bind its
-content address into the resulting `TwinBelief` metadata. The administrative
-CLI supports this operation only with an explicit acknowledgement:
+The estimator that actually consumes an artifact should bind its content
+address into the resulting `TwinBelief`. Administrative binding requires an
+explicit acknowledgement.
+
+For a marginalized observation belief:
 
 ```bash
 causal4d-observation-lineage bind \
@@ -41,19 +80,48 @@ causal4d-observation-lineage bind \
   --confirm-observation-was-consumed
 ```
 
-Binding creates a new content-addressed `TwinBelief`; it never mutates the
-source artifact. The metadata records the observation belief ID, schema,
-case/stream identity, causal cutoff, feeder repository/revision, and source
-manifest digest.
+For an exact Prob4D factor bundle:
 
-The acknowledgement is not a substitute for estimator integration. It prevents
-accidental binding during inspection, while the intended production path is for
-the Bayesian-PhysTwin estimator to call
-`bind_twin_belief_observation_lineage` immediately after constructing the
-belief from that exact artifact.
+```bash
+causal4d-observation-lineage bind-factor-bundle \
+  observation_factors.json \
+  unbound_twin_belief.npz \
+  bound_twin_belief.npz \
+  --confirm-factor-bundle-was-consumed
+```
+
+Binding creates a new content-addressed `TwinBelief`; it never mutates the
+source artifact. Factor-bundle metadata records:
+
+- the exact combined artifact ID;
+- manifest and payload SHA-256 values;
+- schema and version;
+- case, stream, and producer sequence identity;
+- exclusive causal cutoff;
+- source repository and revision.
+
+When a binding already exists, validation checks every recorded lineage field,
+not only the top-level artifact ID. A partial or internally inconsistent binding
+fails closed.
+
+The acknowledgement is not a substitute for estimator integration. Production
+Bayesian-PhysTwin code should bind the exact artifact immediately after
+constructing the belief from it. Inspection of a merely compatible artifact must
+not create provenance.
 
 ## Cross-repository compatibility
 
-Prob4D, Bayesian-PhysTwin, and Causal4D carry the same golden fixture. Its fixed
-artifact ID detects changes to descriptor canonicalization, array names, dtypes,
-shapes, or hashing rules before incompatible artifacts are exchanged.
+Prob4D owns the unfused observation-factor producer. Bayesian-PhysTwin owns the
+state, gauge, bias, and guarded-update inference. Causal4D independently checks
+the immutable artifact identities before using the resulting physical belief.
+This preserves the dependency direction:
+
+```text
+Prob4D factor bundle
+        -> Bayesian-PhysTwin guarded belief
+        -> Causal4D lineage validation and counterfactual inference
+```
+
+The existing cross-repository golden `ObservationBeliefV1` fixture still
+detects changes to the marginalized contract. The factor-bundle validator adds
+an exact byte-level lineage check for the richer estimator input.

--- a/src/causal4d/__init__.py
+++ b/src/causal4d/__init__.py
@@ -64,6 +64,14 @@ from causal4d.observation_evidence import (
     GroupedObservationEvidence,
     ObservationGroup,
 )
+from causal4d.observation_factor_lineage import (
+    OBSERVATION_FACTOR_SCHEMA,
+    OBSERVATION_FACTOR_SCHEMA_VERSION,
+    ObservationFactorLineage,
+    bind_twin_belief_observation_factor_lineage,
+    load_observation_factor_lineage,
+    validate_twin_belief_observation_factor_lineage,
+)
 from causal4d.partial_identifiability import (
     preserve_prior_within_unidentified_subspace,
 )
@@ -128,8 +136,11 @@ __all__ = [
     "IdentifiabilityConfig",
     "IndependentSensorAbductionConfig",
     "InterventionIdentifiabilityResult",
-    "LatentContactConfig",
     "JointRolloutBank",
+    "LatentContactConfig",
+    "OBSERVATION_FACTOR_SCHEMA",
+    "OBSERVATION_FACTOR_SCHEMA_VERSION",
+    "ObservationFactorLineage",
     "ObservationGroup",
     "PHYSICAL_BELIEF_PROVIDER_SCHEMA_VERSION",
     "PhysicalBeliefProviderManifest",
@@ -140,10 +151,10 @@ __all__ = [
     "SEMANTIC_TIMING_SCOPE",
     "SemanticFreshnessDecision",
     "SemanticFreshnessLimits",
+    "SemanticTimingMetadata",
     "SparseTrajectoryEvidence",
     "StableDiscrepancyTransitionModel",
     "TaskPosterior",
-    "SemanticTimingMetadata",
     "TwinBelief",
     "abduct_factual_intervention_graph_mode",
     "abduct_hierarchical_interventions",
@@ -153,6 +164,7 @@ __all__ = [
     "assess_command_residual_sufficiency",
     "assess_finite_query_ambiguity",
     "assess_intervention_identifiability",
+    "bind_twin_belief_observation_factor_lineage",
     "build_action_conditioned_features",
     "build_protocol",
     "finite_response_sensitivity",
@@ -165,6 +177,7 @@ __all__ = [
     "integrate_contact_wrench",
     "load_graph_discrepancy_belief",
     "load_independent_sensor_evidence",
+    "load_observation_factor_lineage",
     "posterior_weights_from_grouped_evidence",
     "predict_affine_actuator_realizations",
     "prefix_component_log_likelihood",
@@ -176,7 +189,8 @@ __all__ = [
     "save_independent_sensor_evidence",
     "update_joint_weights_from_prefix",
     "validate_provider_compatibility",
+    "validate_twin_belief_observation_factor_lineage",
     "write_graph_discrepancy_belief",
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/src/causal4d/cli/observation_lineage.py
+++ b/src/causal4d/cli/observation_lineage.py
@@ -1,4 +1,4 @@
-"""Validate or explicitly bind ObservationBeliefV1 lineage."""
+"""Validate or explicitly bind portable observation lineage."""
 
 from __future__ import annotations
 
@@ -8,6 +8,11 @@ from pathlib import Path
 from typing import Sequence
 
 from causal4d.contracts import TwinBelief, load_contract, save_contract
+from causal4d.observation_factor_lineage import (
+    bind_twin_belief_observation_factor_lineage,
+    load_observation_factor_lineage,
+    validate_twin_belief_observation_factor_lineage,
+)
 from causal4d.observation_lineage import (
     bind_twin_belief_observation_lineage,
     load_observation_lineage,
@@ -15,18 +20,28 @@ from causal4d.observation_lineage import (
 )
 
 
+def _add_twin_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("twin_belief", type=Path)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    validate = subparsers.add_parser("validate")
+    validate = subparsers.add_parser(
+        "validate",
+        help="validate a marginalized ObservationBeliefV1 artifact",
+    )
     validate.add_argument("observation_belief", type=Path)
-    validate.add_argument("twin_belief", type=Path)
+    _add_twin_argument(validate)
     validate.add_argument("--require-bound", action="store_true")
 
-    bind = subparsers.add_parser("bind")
+    bind = subparsers.add_parser(
+        "bind",
+        help="bind a consumed ObservationBeliefV1 artifact",
+    )
     bind.add_argument("observation_belief", type=Path)
-    bind.add_argument("twin_belief", type=Path)
+    _add_twin_argument(bind)
     bind.add_argument("output_twin_belief", type=Path)
     bind.add_argument(
         "--confirm-observation-was-consumed",
@@ -36,37 +51,96 @@ def build_parser() -> argparse.ArgumentParser:
             "this exact observation artifact"
         ),
     )
+
+    validate_factor = subparsers.add_parser(
+        "validate-factor-bundle",
+        help="validate an exact Prob4D schema-v3 factor bundle",
+    )
+    validate_factor.add_argument("factor_bundle_manifest", type=Path)
+    _add_twin_argument(validate_factor)
+    validate_factor.add_argument("--require-bound", action="store_true")
+
+    bind_factor = subparsers.add_parser(
+        "bind-factor-bundle",
+        help="bind the exact Prob4D factor bundle consumed by the estimator",
+    )
+    bind_factor.add_argument("factor_bundle_manifest", type=Path)
+    _add_twin_argument(bind_factor)
+    bind_factor.add_argument("output_twin_belief", type=Path)
+    bind_factor.add_argument(
+        "--confirm-factor-bundle-was-consumed",
+        action="store_true",
+        help=(
+            "required acknowledgement that the estimator consumed the exact "
+            "manifest and payload pair"
+        ),
+    )
     return parser
+
+
+def _load_twin_belief(path: Path) -> TwinBelief:
+    artifact = load_contract(path)
+    if not isinstance(artifact, TwinBelief):
+        raise ValueError("twin_belief must contain a Causal4D TwinBelief")
+    return artifact
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    lineage = load_observation_lineage(args.observation_belief)
-    artifact = load_contract(args.twin_belief)
-    if not isinstance(artifact, TwinBelief):
-        raise ValueError("twin_belief must contain a Causal4D TwinBelief")
+    artifact = _load_twin_belief(args.twin_belief)
 
-    if args.command == "validate":
-        result = validate_twin_belief_observation_lineage(
-            artifact,
-            lineage,
-            require_bound=args.require_bound,
-        )
-    else:
-        if not args.confirm_observation_was_consumed:
-            raise ValueError(
-                "binding requires --confirm-observation-was-consumed; "
-                "validation alone does not establish estimator provenance"
+    if args.command in {"validate", "bind"}:
+        lineage = load_observation_lineage(args.observation_belief)
+        if args.command == "validate":
+            result = validate_twin_belief_observation_lineage(
+                artifact,
+                lineage,
+                require_bound=args.require_bound,
             )
-        bound = bind_twin_belief_observation_lineage(artifact, lineage)
-        save_contract(args.output_twin_belief, bound)
-        result = validate_twin_belief_observation_lineage(
-            bound,
-            lineage,
-            require_bound=True,
+        else:
+            if not args.confirm_observation_was_consumed:
+                raise ValueError(
+                    "binding requires --confirm-observation-was-consumed; "
+                    "validation alone does not establish estimator provenance"
+                )
+            bound = bind_twin_belief_observation_lineage(artifact, lineage)
+            save_contract(args.output_twin_belief, bound)
+            result = validate_twin_belief_observation_lineage(
+                bound,
+                lineage,
+                require_bound=True,
+            )
+            result["output"] = str(args.output_twin_belief.resolve())
+            result["source_twin_belief_id"] = artifact.artifact_id
+    else:
+        lineage = load_observation_factor_lineage(
+            args.factor_bundle_manifest
         )
-        result["output"] = str(args.output_twin_belief.resolve())
-        result["source_twin_belief_id"] = artifact.artifact_id
+        if args.command == "validate-factor-bundle":
+            result = validate_twin_belief_observation_factor_lineage(
+                artifact,
+                lineage,
+                require_bound=args.require_bound,
+            )
+        else:
+            if not args.confirm_factor_bundle_was_consumed:
+                raise ValueError(
+                    "binding requires "
+                    "--confirm-factor-bundle-was-consumed; validation alone "
+                    "does not establish estimator provenance"
+                )
+            bound = bind_twin_belief_observation_factor_lineage(
+                artifact,
+                lineage,
+            )
+            save_contract(args.output_twin_belief, bound)
+            result = validate_twin_belief_observation_factor_lineage(
+                bound,
+                lineage,
+                require_bound=True,
+            )
+            result["output"] = str(args.output_twin_belief.resolve())
+            result["source_twin_belief_id"] = artifact.artifact_id
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0
 

--- a/src/causal4d/observation_factor_lineage.py
+++ b/src/causal4d/observation_factor_lineage.py
@@ -1,0 +1,569 @@
+"""Validate and bind exact Prob4D observation-factor bundle lineage."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Mapping
+
+import numpy as np
+
+from .contracts import TwinBelief
+
+OBSERVATION_FACTOR_SCHEMA = "prob4d.observation-factor-bundle"
+OBSERVATION_FACTOR_SCHEMA_VERSION = 3
+GAUGE_PARAMETERIZATION = "log-scale-rotvec-translation-v1"
+_REQUIRED_FACTOR_ARRAYS = {
+    "point_ids",
+    "points_local_m",
+    "valid_mask",
+    "local_covariance_m2",
+    "association_probability",
+    "prior_reliability",
+}
+
+
+def file_sha256(path: str | Path) -> str:
+    """Hash one artifact file without loading it fully into memory."""
+
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _validate_sha256(value: str, *, name: str) -> None:
+    if len(value) != 64 or any(
+        character not in "0123456789abcdef" for character in value
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+
+
+def compute_observation_factor_bundle_id(
+    manifest_sha256: str,
+    payload_sha256: str,
+) -> str:
+    """Content-address the exact manifest and payload byte pair."""
+
+    _validate_sha256(manifest_sha256, name="manifest_sha256")
+    _validate_sha256(payload_sha256, name="payload_sha256")
+    digest = hashlib.sha256()
+    digest.update(f"{OBSERVATION_FACTOR_SCHEMA}\0".encode("utf-8"))
+    digest.update(str(OBSERVATION_FACTOR_SCHEMA_VERSION).encode("ascii"))
+    digest.update(b"\0")
+    digest.update(manifest_sha256.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(payload_sha256.encode("ascii"))
+    return digest.hexdigest()
+
+
+def _nonempty_string(value: Any, *, name: str) -> str:
+    result = str(value)
+    if not result:
+        raise ValueError(f"{name} must be nonempty")
+    return result
+
+
+def _bounded_probability(value: Any, *, name: str) -> float:
+    result = float(value)
+    if not np.isfinite(result) or not 0.0 <= result <= 1.0:
+        raise ValueError(f"{name} must lie in [0, 1]")
+    return result
+
+
+def _composite_weight(value: Any) -> float:
+    result = float(value)
+    if not np.isfinite(result) or not 0.0 < result <= 1.0:
+        raise ValueError("factor composite_weight must lie in (0, 1]")
+    return result
+
+
+def _probability_vector(values: np.ndarray, *, name: str) -> np.ndarray:
+    result = np.asarray(values, dtype=np.float64)
+    if not np.all(np.isfinite(result)) or np.any(
+        (result < 0.0) | (result > 1.0)
+    ):
+        raise ValueError(f"{name} must lie in [0, 1]")
+    return result
+
+
+def _require_psd(
+    values: np.ndarray,
+    *,
+    name: str,
+    tolerance: float = 1e-12,
+) -> None:
+    symmetric = 0.5 * (values + np.swapaxes(values, -1, -2))
+    if not np.allclose(values, symmetric, atol=1e-12, rtol=1e-10):
+        raise ValueError(f"{name} must be symmetric")
+    eigenvalues = np.linalg.eigvalsh(symmetric)
+    if np.any(eigenvalues < -tolerance):
+        raise ValueError(f"{name} must be positive semidefinite")
+
+
+def _safe_payload_path(manifest: Path, relative: Any) -> Path:
+    relative_path = Path(str(relative))
+    if relative_path.is_absolute() or ".." in relative_path.parts:
+        raise ValueError("factor-bundle payload path must stay below the manifest")
+    root = manifest.parent.resolve()
+    payload = (root / relative_path).resolve()
+    if payload != root and root not in payload.parents:
+        raise ValueError("factor-bundle payload path escapes the manifest directory")
+    if not payload.is_file():
+        raise ValueError("factor-bundle payload file is missing")
+    return payload
+
+
+@dataclass(frozen=True)
+class ObservationFactorLineage:
+    """Immutable summary of a validated Prob4D schema-v3 factor bundle."""
+
+    artifact_id: str
+    manifest_sha256: str
+    payload_sha256: str
+    case_id: str
+    stream_id: str
+    sequence_id: str
+    causal_frame_stop: int
+    minimum_frame_id: int
+    maximum_frame_id: int
+    factor_count: int
+    observation_count: int
+    active_observation_count: int
+    gauge_count: int
+    correlation_group_count: int
+    source_repository: str
+    source_revision: str
+
+    def __post_init__(self) -> None:
+        _validate_sha256(self.artifact_id, name="artifact_id")
+        _validate_sha256(self.manifest_sha256, name="manifest_sha256")
+        _validate_sha256(self.payload_sha256, name="payload_sha256")
+        for name, value in (
+            ("case_id", self.case_id),
+            ("stream_id", self.stream_id),
+            ("sequence_id", self.sequence_id),
+            ("source_repository", self.source_repository),
+            ("source_revision", self.source_revision),
+        ):
+            if not value:
+                raise ValueError(f"{name} must be nonempty")
+        if self.causal_frame_stop < 1:
+            raise ValueError("factor-bundle causal frame stop must be positive")
+        if not 0 <= self.minimum_frame_id <= self.maximum_frame_id:
+            raise ValueError("factor-bundle frame range is invalid")
+        if self.maximum_frame_id >= self.causal_frame_stop:
+            raise ValueError("factor-bundle lineage crosses its causal stop")
+        if min(
+            self.factor_count,
+            self.observation_count,
+            self.active_observation_count,
+            self.gauge_count,
+            self.correlation_group_count,
+        ) < 1:
+            raise ValueError("factor-bundle lineage counts must be positive")
+        if self.active_observation_count > self.observation_count:
+            raise ValueError("active observation count exceeds total observations")
+
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "source_observation_factor_bundle_id": self.artifact_id,
+            "source_observation_factor_schema": OBSERVATION_FACTOR_SCHEMA,
+            "source_observation_factor_schema_version": (
+                OBSERVATION_FACTOR_SCHEMA_VERSION
+            ),
+            "source_observation_factor_case_id": self.case_id,
+            "source_observation_factor_stream_id": self.stream_id,
+            "source_observation_factor_sequence_id": self.sequence_id,
+            "source_observation_factor_causal_frame_stop": (
+                self.causal_frame_stop
+            ),
+            "source_observation_factor_repository": self.source_repository,
+            "source_observation_factor_revision": self.source_revision,
+            "source_observation_factor_manifest_sha256": (
+                self.manifest_sha256
+            ),
+            "source_observation_factor_payload_sha256": self.payload_sha256,
+        }
+
+
+def load_observation_factor_lineage(
+    manifest_path: str | Path,
+) -> ObservationFactorLineage:
+    """Validate a Prob4D factor bundle without importing its producer."""
+
+    manifest = Path(manifest_path)
+    if not manifest.is_file():
+        raise ValueError("factor-bundle manifest file is missing")
+    manifest_sha = file_sha256(manifest)
+    try:
+        record = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError("factor-bundle manifest is not valid UTF-8 JSON") from error
+    if record.get("schema") != OBSERVATION_FACTOR_SCHEMA:
+        raise ValueError("unsupported observation-factor schema")
+    if int(record.get("schema_version", -1)) != (
+        OBSERVATION_FACTOR_SCHEMA_VERSION
+    ):
+        raise ValueError("unsupported observation-factor schema version")
+    if record.get("gauge_parameterization") != GAUGE_PARAMETERIZATION:
+        raise ValueError("unsupported observation-factor gauge parameterization")
+    if record.get("causal_frame_stop_convention") != "exclusive":
+        raise ValueError("factor-bundle causal frame stop must be exclusive")
+
+    sequence_id = _nonempty_string(
+        record.get("sequence_id", ""),
+        name="sequence_id",
+    )
+    case_id = _nonempty_string(record.get("case_id", ""), name="case_id")
+    stream_id = _nonempty_string(record.get("stream_id", ""), name="stream_id")
+    source_repository = _nonempty_string(
+        record.get("source_repository", ""),
+        name="source_repository",
+    )
+    source_revision = _nonempty_string(
+        record.get("source_revision", ""),
+        name="source_revision",
+    )
+    causal_stop = int(record.get("causal_frame_stop", -1))
+    if causal_stop < 1:
+        raise ValueError("factor-bundle causal frame stop must be positive")
+
+    payload_record = record.get("payload")
+    if not isinstance(payload_record, Mapping):
+        raise ValueError("factor-bundle payload descriptor is missing")
+    if payload_record.get("allow_pickle") is not False:
+        raise ValueError("factor-bundle payload must disable pickle")
+    declared_payload_sha = str(payload_record.get("sha256", ""))
+    _validate_sha256(declared_payload_sha, name="payload sha256")
+    payload = _safe_payload_path(manifest, payload_record.get("path", ""))
+    actual_payload_sha = file_sha256(payload)
+    if actual_payload_sha != declared_payload_sha:
+        raise ValueError("factor-bundle payload checksum mismatch")
+
+    gauge_records = record.get("gauges")
+    factor_records = record.get("factors")
+    if not isinstance(gauge_records, list) or not gauge_records:
+        raise ValueError("factor bundle must contain gauge records")
+    if not isinstance(factor_records, list) or not factor_records:
+        raise ValueError("factor bundle must contain factor records")
+
+    expected_array_names: list[str] = []
+    gauge_ids: set[str] = set()
+    factor_ids: set[str] = set()
+    group_parameters: dict[str, tuple[float, float]] = {}
+    frame_ids: list[int] = []
+    total_observations = 0
+    active_observations = 0
+
+    with np.load(payload, allow_pickle=False) as arrays:
+        for position, gauge_record in enumerate(gauge_records):
+            if not isinstance(gauge_record, Mapping):
+                raise ValueError("factor-bundle gauge record must be a mapping")
+            gauge_id = _nonempty_string(
+                gauge_record.get("gauge_id", ""),
+                name=f"gauge {position} ID",
+            )
+            if gauge_id in gauge_ids:
+                raise ValueError("factor-bundle gauge IDs must be unique")
+            gauge_ids.add(gauge_id)
+            mean_key = _nonempty_string(
+                gauge_record.get("mean_key", ""),
+                name=f"gauge {position} mean key",
+            )
+            covariance_key = _nonempty_string(
+                gauge_record.get("covariance_key", ""),
+                name=f"gauge {position} covariance key",
+            )
+            expected_array_names.extend((mean_key, covariance_key))
+            if mean_key not in arrays or covariance_key not in arrays:
+                raise ValueError("factor-bundle gauge payload arrays are missing")
+            mean = np.asarray(arrays[mean_key], dtype=np.float64)
+            covariance = np.asarray(
+                arrays[covariance_key],
+                dtype=np.float64,
+            )
+            if mean.shape != (7,) or not np.all(np.isfinite(mean)):
+                raise ValueError("factor-bundle gauge mean must have shape (7,)")
+            if covariance.shape != (7, 7) or not np.all(
+                np.isfinite(covariance)
+            ):
+                raise ValueError(
+                    "factor-bundle gauge covariance must have shape (7, 7)"
+                )
+            _require_psd(covariance, name="factor-bundle gauge covariance")
+
+        for position, factor_record in enumerate(factor_records):
+            if not isinstance(factor_record, Mapping):
+                raise ValueError("factor-bundle factor record must be a mapping")
+            identifiers = {
+                name: _nonempty_string(
+                    factor_record.get(name, ""),
+                    name=f"factor {position} {name}",
+                )
+                for name in (
+                    "factor_id",
+                    "view_id",
+                    "window_id",
+                    "gauge_id",
+                    "correlation_group_id",
+                )
+            }
+            factor_id = identifiers["factor_id"]
+            if factor_id in factor_ids:
+                raise ValueError("factor-bundle factor IDs must be unique")
+            factor_ids.add(factor_id)
+            if identifiers["gauge_id"] not in gauge_ids:
+                raise ValueError("factor references an unavailable gauge")
+            frame_index = int(factor_record.get("frame_index", -1))
+            factor_stop = int(factor_record.get("causal_frame_stop", -1))
+            if frame_index < 0 or frame_index >= causal_stop:
+                raise ValueError("factor frame crosses the bundle causal stop")
+            if factor_stop != causal_stop:
+                raise ValueError("factor and bundle causal frame stops differ")
+            frame_ids.append(frame_index)
+
+            nominal_probability = _bounded_probability(
+                factor_record.get("prior_nominal_probability"),
+                name="factor prior_nominal_probability",
+            )
+            composite_weight = _composite_weight(
+                factor_record.get("composite_weight")
+            )
+            group_id = identifiers["correlation_group_id"]
+            parameters = (nominal_probability, composite_weight)
+            previous = group_parameters.setdefault(group_id, parameters)
+            if previous != parameters:
+                raise ValueError(
+                    "one correlation group has inconsistent factor metadata"
+                )
+
+            key_record = factor_record.get("arrays")
+            if not isinstance(key_record, Mapping):
+                raise ValueError("factor payload array mapping is missing")
+            missing_keys = _REQUIRED_FACTOR_ARRAYS - key_record.keys()
+            extra_keys = key_record.keys() - _REQUIRED_FACTOR_ARRAYS
+            if missing_keys or extra_keys:
+                raise ValueError(
+                    "factor payload array contract changed; "
+                    f"missing={sorted(missing_keys)}, "
+                    f"extra={sorted(extra_keys)}"
+                )
+            factor_keys = {
+                name: _nonempty_string(
+                    key_record[name],
+                    name=f"factor {position} {name} key",
+                )
+                for name in _REQUIRED_FACTOR_ARRAYS
+            }
+            expected_array_names.extend(factor_keys.values())
+            ray_key_value = factor_record.get("ray_directions_local_key")
+            ray_key = None
+            if ray_key_value is not None:
+                ray_key = _nonempty_string(
+                    ray_key_value,
+                    name=f"factor {position} ray key",
+                )
+                expected_array_names.append(ray_key)
+            if any(key not in arrays for key in factor_keys.values()):
+                raise ValueError("factor payload arrays are missing")
+            if ray_key is not None and ray_key not in arrays:
+                raise ValueError("factor ray payload array is missing")
+
+            point_ids = np.asarray(arrays[factor_keys["point_ids"]])
+            points = np.asarray(
+                arrays[factor_keys["points_local_m"]],
+                dtype=np.float64,
+            )
+            valid = np.asarray(arrays[factor_keys["valid_mask"]])
+            covariance = np.asarray(
+                arrays[factor_keys["local_covariance_m2"]],
+                dtype=np.float64,
+            )
+            association = _probability_vector(
+                arrays[factor_keys["association_probability"]],
+                name="factor association probability",
+            )
+            reliability = _probability_vector(
+                arrays[factor_keys["prior_reliability"]],
+                name="factor prior reliability",
+            )
+            if point_ids.ndim != 1 or len(point_ids) == 0:
+                raise ValueError("factor point IDs must be a nonempty vector")
+            if not np.issubdtype(point_ids.dtype, np.integer):
+                raise ValueError("factor point IDs must use an integer dtype")
+            point_ids = np.asarray(point_ids, dtype=np.int64)
+            if np.any(point_ids < 0) or len(np.unique(point_ids)) != len(
+                point_ids
+            ):
+                raise ValueError(
+                    "factor point IDs must be nonnegative and unique"
+                )
+            count = len(point_ids)
+            if points.shape != (count, 3):
+                raise ValueError("factor points must have shape (N, 3)")
+            if valid.dtype != np.dtype(bool) or valid.shape != (count,):
+                raise ValueError("factor valid mask must be a Boolean vector")
+            if covariance.shape != (count, 3, 3):
+                raise ValueError(
+                    "factor local covariance must have shape (N, 3, 3)"
+                )
+            if association.shape != (count,) or reliability.shape != (count,):
+                raise ValueError(
+                    "factor probability vectors must identify every point"
+                )
+            active = valid & (association > 0.0) & (reliability > 0.0)
+            if not np.all(np.isfinite(points[active])):
+                raise ValueError("active factor points must be finite")
+            if not np.all(np.isfinite(covariance[active])):
+                raise ValueError("active factor covariance must be finite")
+            if np.any(active):
+                _require_psd(
+                    covariance[active],
+                    name="active factor covariance",
+                )
+            if ray_key is not None:
+                rays = np.asarray(arrays[ray_key], dtype=np.float64)
+                if rays.shape != (count, 3):
+                    raise ValueError("factor rays must have shape (N, 3)")
+                if not np.all(np.isfinite(rays[active])):
+                    raise ValueError("active factor rays must be finite")
+                if np.any(
+                    active
+                    & (
+                        np.linalg.norm(rays, axis=1)
+                        <= np.finfo(np.float64).eps
+                    )
+                ):
+                    raise ValueError("active factor rays must be nonzero")
+            total_observations += count
+            active_observations += int(np.sum(active))
+
+        if len(expected_array_names) != len(set(expected_array_names)):
+            raise ValueError("factor-bundle payload array keys are reused")
+        expected_arrays = set(expected_array_names)
+        actual_arrays = set(arrays.files)
+        missing_arrays = expected_arrays - actual_arrays
+        extra_arrays = actual_arrays - expected_arrays
+        if missing_arrays or extra_arrays:
+            raise ValueError(
+                "factor-bundle payload array set changed; "
+                f"missing={sorted(missing_arrays)}, "
+                f"extra={sorted(extra_arrays)}"
+            )
+
+    if active_observations < 1:
+        raise ValueError("factor bundle has no active observation rows")
+    artifact_id = compute_observation_factor_bundle_id(
+        manifest_sha,
+        actual_payload_sha,
+    )
+    return ObservationFactorLineage(
+        artifact_id=artifact_id,
+        manifest_sha256=manifest_sha,
+        payload_sha256=actual_payload_sha,
+        case_id=case_id,
+        stream_id=stream_id,
+        sequence_id=sequence_id,
+        causal_frame_stop=causal_stop,
+        minimum_frame_id=min(frame_ids),
+        maximum_frame_id=max(frame_ids),
+        factor_count=len(factor_records),
+        observation_count=total_observations,
+        active_observation_count=active_observations,
+        gauge_count=len(gauge_records),
+        correlation_group_count=len(group_parameters),
+        source_repository=source_repository,
+        source_revision=source_revision,
+    )
+
+
+def validate_twin_belief_observation_factor_lineage(
+    twin_belief: TwinBelief,
+    lineage: ObservationFactorLineage,
+    *,
+    require_bound: bool = True,
+) -> dict[str, Any]:
+    """Check case, O-minus containment, and exact factor-bundle binding."""
+
+    if twin_belief.context.case_id != lineage.case_id:
+        raise ValueError("factor bundle and TwinBelief identify different cases")
+    if lineage.minimum_frame_id < twin_belief.context.o_minus.frame_start:
+        raise ValueError("factor bundle begins before the TwinBelief O- boundary")
+    if lineage.causal_frame_stop > twin_belief.context.o_minus.frame_stop:
+        raise ValueError("factor bundle extends beyond the TwinBelief O- boundary")
+
+    expected_metadata = lineage.metadata()
+    metadata = twin_belief.metadata
+    bound_id = metadata.get("source_observation_factor_bundle_id")
+    if bound_id is not None and bound_id != lineage.artifact_id:
+        raise ValueError("TwinBelief is bound to a different factor bundle")
+    if require_bound and bound_id is None:
+        raise ValueError("TwinBelief has no source factor-bundle binding")
+    if bound_id is not None:
+        for key, expected in expected_metadata.items():
+            actual = metadata.get(key)
+            if actual != expected:
+                raise ValueError(
+                    f"TwinBelief factor-bundle metadata mismatch for {key}"
+                )
+    return {
+        "status": "valid",
+        "twin_belief_id": twin_belief.artifact_id,
+        "observation_factor_bundle_id": lineage.artifact_id,
+        "case_id": lineage.case_id,
+        "stream_id": lineage.stream_id,
+        "sequence_id": lineage.sequence_id,
+        "lineage_bound": bound_id == lineage.artifact_id,
+        "observation_frame_range": [
+            lineage.minimum_frame_id,
+            lineage.maximum_frame_id,
+        ],
+        "observation_causal_frame_stop": lineage.causal_frame_stop,
+        "twin_o_minus_frame_range": [
+            twin_belief.context.o_minus.frame_start,
+            twin_belief.context.o_minus.frame_stop,
+        ],
+        "factor_count": lineage.factor_count,
+        "observation_count": lineage.observation_count,
+        "active_observation_count": lineage.active_observation_count,
+        "gauge_count": lineage.gauge_count,
+        "correlation_group_count": lineage.correlation_group_count,
+        "manifest_sha256": lineage.manifest_sha256,
+        "payload_sha256": lineage.payload_sha256,
+    }
+
+
+def bind_twin_belief_observation_factor_lineage(
+    twin_belief: TwinBelief,
+    lineage: ObservationFactorLineage,
+) -> TwinBelief:
+    """Bind the exact factor bundle actually consumed by the estimator."""
+
+    validate_twin_belief_observation_factor_lineage(
+        twin_belief,
+        lineage,
+        require_bound=False,
+    )
+    metadata = dict(twin_belief.metadata)
+    existing = metadata.get("source_observation_factor_bundle_id")
+    if existing is not None and existing != lineage.artifact_id:
+        raise ValueError("TwinBelief already has incompatible factor lineage")
+    metadata.update(lineage.metadata())
+    return replace(twin_belief, metadata=metadata)
+
+
+__all__ = [
+    "GAUGE_PARAMETERIZATION",
+    "OBSERVATION_FACTOR_SCHEMA",
+    "OBSERVATION_FACTOR_SCHEMA_VERSION",
+    "ObservationFactorLineage",
+    "bind_twin_belief_observation_factor_lineage",
+    "compute_observation_factor_bundle_id",
+    "file_sha256",
+    "load_observation_factor_lineage",
+    "validate_twin_belief_observation_factor_lineage",
+]

--- a/tests/test_observation_factor_lineage.py
+++ b/tests/test_observation_factor_lineage.py
@@ -1,0 +1,250 @@
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from causal4d.observation_factor_lineage import (
+    OBSERVATION_FACTOR_SCHEMA,
+    bind_twin_belief_observation_factor_lineage,
+    compute_observation_factor_bundle_id,
+    file_sha256,
+    load_observation_factor_lineage,
+    validate_twin_belief_observation_factor_lineage,
+)
+
+
+@dataclass(frozen=True)
+class _Window:
+    frame_stop: int
+    frame_start: int = 0
+
+
+@dataclass(frozen=True)
+class _Context:
+    case_id: str
+    o_minus: _Window
+
+
+@dataclass(frozen=True)
+class _TwinBelief:
+    context: _Context
+    metadata: dict
+    artifact_id: str = "c" * 64
+
+
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_bundle(
+    root: Path,
+    *,
+    case_id: str = "case-1",
+    frame_index: int = 8,
+    reliability: np.ndarray | None = None,
+    association: np.ndarray | None = None,
+    composite_weight: float = 0.5,
+    extra_array: bool = False,
+) -> Path:
+    payload = root / "factors.npz"
+    arrays = {
+        "gauge_mean": np.zeros(7),
+        "gauge_covariance": np.eye(7) * 1e-4,
+        "point_ids": np.asarray([10, 11], dtype=np.int64),
+        "points_local_m": np.asarray(
+            [[0.0, 0.0, 1.0], [0.1, 0.0, 1.0]],
+            dtype=np.float64,
+        ),
+        "valid_mask": np.asarray([True, True]),
+        "local_covariance_m2": np.tile(np.eye(3) * 1e-4, (2, 1, 1)),
+        "association_probability": (
+            np.asarray([0.9, 0.8])
+            if association is None
+            else np.asarray(association)
+        ),
+        "prior_reliability": (
+            np.asarray([0.7, 0.6])
+            if reliability is None
+            else np.asarray(reliability)
+        ),
+    }
+    if extra_array:
+        arrays["unexpected"] = np.asarray([1])
+    np.savez_compressed(payload, **arrays)
+    record = {
+        "schema": OBSERVATION_FACTOR_SCHEMA,
+        "schema_version": 3,
+        "gauge_parameterization": "log-scale-rotvec-translation-v1",
+        "sequence_id": "sequence-1",
+        "case_id": case_id,
+        "stream_id": "prob4d:camera0",
+        "source_repository": "FlorianPfaff/Prob4D",
+        "source_revision": "a" * 40,
+        "causal_frame_stop": 12,
+        "causal_frame_stop_convention": "exclusive",
+        "metadata": {},
+        "payload": {
+            "path": payload.name,
+            "sha256": _sha(payload),
+            "allow_pickle": False,
+        },
+        "gauges": [
+            {
+                "gauge_id": "window-0",
+                "mean_key": "gauge_mean",
+                "covariance_key": "gauge_covariance",
+            }
+        ],
+        "factors": [
+            {
+                "factor_id": "factor-0",
+                "frame_index": frame_index,
+                "view_id": "camera0",
+                "window_id": "window-0",
+                "gauge_id": "window-0",
+                "correlation_group_id": "shared-frame-8",
+                "causal_frame_stop": 12,
+                "prior_nominal_probability": 0.8,
+                "composite_weight": composite_weight,
+                "arrays": {
+                    "point_ids": "point_ids",
+                    "points_local_m": "points_local_m",
+                    "valid_mask": "valid_mask",
+                    "local_covariance_m2": "local_covariance_m2",
+                    "association_probability": "association_probability",
+                    "prior_reliability": "prior_reliability",
+                },
+                "ray_directions_local_key": None,
+            }
+        ],
+    }
+    manifest = root / "factors.json"
+    manifest.write_text(
+        json.dumps(record, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_loads_exact_factor_bundle_and_computes_pair_identity(
+    tmp_path: Path,
+) -> None:
+    manifest = _write_bundle(tmp_path)
+    lineage = load_observation_factor_lineage(manifest)
+
+    assert lineage.case_id == "case-1"
+    assert lineage.stream_id == "prob4d:camera0"
+    assert lineage.minimum_frame_id == 8
+    assert lineage.maximum_frame_id == 8
+    assert lineage.observation_count == 2
+    assert lineage.active_observation_count == 2
+    assert lineage.artifact_id == compute_observation_factor_bundle_id(
+        file_sha256(manifest),
+        lineage.payload_sha256,
+    )
+
+
+def test_binding_requires_exact_metadata_and_preserves_content_address(
+    tmp_path: Path,
+) -> None:
+    lineage = load_observation_factor_lineage(_write_bundle(tmp_path))
+    twin = _TwinBelief(_Context("case-1", _Window(12)), {})
+
+    with pytest.raises(ValueError, match="no source factor-bundle binding"):
+        validate_twin_belief_observation_factor_lineage(
+            twin,
+            lineage,
+            require_bound=True,
+        )
+    bound = bind_twin_belief_observation_factor_lineage(twin, lineage)
+    result = validate_twin_belief_observation_factor_lineage(
+        bound,
+        lineage,
+        require_bound=True,
+    )
+    assert result["lineage_bound"]
+    assert (
+        bound.metadata["source_observation_factor_bundle_id"]
+        == lineage.artifact_id
+    )
+
+    changed = dict(bound.metadata)
+    changed["source_observation_factor_revision"] = "wrong"
+    with pytest.raises(ValueError, match="metadata mismatch"):
+        validate_twin_belief_observation_factor_lineage(
+            _TwinBelief(bound.context, changed),
+            lineage,
+            require_bound=True,
+        )
+
+
+def test_rejects_payload_tampering(tmp_path: Path) -> None:
+    manifest = _write_bundle(tmp_path)
+    payload = tmp_path / "factors.npz"
+    payload.write_bytes(payload.read_bytes() + b"tampered")
+
+    with pytest.raises(ValueError, match="checksum mismatch"):
+        load_observation_factor_lineage(manifest)
+
+
+def test_rejects_case_and_causal_boundary_mismatch(tmp_path: Path) -> None:
+    lineage = load_observation_factor_lineage(_write_bundle(tmp_path))
+
+    with pytest.raises(ValueError, match="different cases"):
+        validate_twin_belief_observation_factor_lineage(
+            _TwinBelief(_Context("other", _Window(12)), {}),
+            lineage,
+            require_bound=False,
+        )
+    with pytest.raises(ValueError, match="beyond"):
+        validate_twin_belief_observation_factor_lineage(
+            _TwinBelief(_Context("case-1", _Window(10)), {}),
+            lineage,
+            require_bound=False,
+        )
+    with pytest.raises(ValueError, match="before"):
+        validate_twin_belief_observation_factor_lineage(
+            _TwinBelief(_Context("case-1", _Window(12, frame_start=9)), {}),
+            lineage,
+            require_bound=False,
+        )
+
+
+def test_rejects_invalid_reliability_even_when_association_is_valid(
+    tmp_path: Path,
+) -> None:
+    manifest = _write_bundle(
+        tmp_path,
+        reliability=np.asarray([1.2, 0.5]),
+        association=np.asarray([0.9, 0.8]),
+    )
+
+    with pytest.raises(ValueError, match="prior reliability"):
+        load_observation_factor_lineage(manifest)
+
+
+def test_rejects_unexpected_payload_array(tmp_path: Path) -> None:
+    manifest = _write_bundle(tmp_path, extra_array=True)
+
+    with pytest.raises(ValueError, match="payload array set changed"):
+        load_observation_factor_lineage(manifest)
+
+
+def test_rejects_nonexclusive_cutoff(tmp_path: Path) -> None:
+    manifest = _write_bundle(tmp_path)
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+    record["causal_frame_stop_convention"] = "inclusive"
+    manifest.write_text(json.dumps(record), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must be exclusive"):
+        load_observation_factor_lineage(manifest)
+
+
+def test_rejects_invalid_composite_weight(tmp_path: Path) -> None:
+    manifest = _write_bundle(tmp_path, composite_weight=0.0)
+
+    with pytest.raises(ValueError, match="composite_weight"):
+        load_observation_factor_lineage(manifest)

--- a/tests/test_observation_lineage_cli.py
+++ b/tests/test_observation_lineage_cli.py
@@ -1,0 +1,30 @@
+from causal4d.cli.observation_lineage import build_parser
+
+
+def test_factor_bundle_validation_command_parses() -> None:
+    args = build_parser().parse_args(
+        [
+            "validate-factor-bundle",
+            "observation_factors.json",
+            "twin_belief.npz",
+            "--require-bound",
+        ]
+    )
+
+    assert args.command == "validate-factor-bundle"
+    assert args.require_bound
+
+
+def test_factor_bundle_binding_requires_explicit_flag_name() -> None:
+    args = build_parser().parse_args(
+        [
+            "bind-factor-bundle",
+            "observation_factors.json",
+            "twin_belief.npz",
+            "bound_twin_belief.npz",
+            "--confirm-factor-bundle-was-consumed",
+        ]
+    )
+
+    assert args.command == "bind-factor-bundle"
+    assert args.confirm_factor_bundle_was_consumed


### PR DESCRIPTION
## What changed

- add an independent validator for `prob4d.observation-factor-bundle` schema v3 without importing Prob4D
- checksum and content-address the exact JSON manifest plus NPZ payload pair
- reject absolute or escaping payload paths, payload checksum changes, missing or extra arrays, reused keys, malformed gauges, invalid factors, and nonexclusive causal cutoffs
- validate explicit case, stream, sequence, repository, revision, gauge, factor, correlation-group, and frame provenance
- validate association probability and residual-independent prior reliability as separate bounded arrays
- validate fixed nominal-component probability and composite weight within each correlation group
- bind the exact factor-bundle identity, manifest hash, payload hash, and causal metadata into a new content-addressed `TwinBelief`
- require complete metadata consistency when a factor-bundle binding already exists
- extend `causal4d-observation-lineage` with `validate-factor-bundle` and `bind-factor-bundle`
- retain the existing `ObservationBeliefV1` validation and binding commands unchanged
- expose the factor-lineage API publicly and align `causal4d.__version__` with package version 0.4.0

## Root cause

The existing lineage path validates a marginalized `ObservationBeliefV1`. Bayesian-PhysTwin's gauge-aware update can instead consume the richer unfused Prob4D factor bundle with explicit gauge variables and conditional covariance. A compatible marginalized artifact does not prove which exact manifest and payload the estimator used, so Causal4D lacked an end-to-end provenance check for the actual inference input.

## Compatibility and information boundary

- only schema-v3 factor bundles are accepted because they explicitly separate reliability from association and use one exclusive causal frame stop
- schema-v2 bundles must first be migrated and rewritten by Prob4D
- validation checks case identity and containment inside the `TwinBelief` O-minus interval
- inspection alone does not create provenance; binding requires `--confirm-factor-bundle-was-consumed`
- the existing observation-belief binding remains available for simpler or marginalized consumers

## Validation

Focused isolated validation:

```text
10 passed
```

The tests cover exact pair identity, binding completeness, checksum tampering, case and causal-boundary mismatch, invalid reliability with valid association, unexpected arrays, nonexclusive cutoffs, invalid group weights, and both new CLI commands.

GitHub Actions passed on the exact PR head:

- Ruff;
- complete test suite on Python 3.10, 3.12, and 3.14;
- wheel and source-distribution build;
- distribution metadata validation;
- built-wheel smoke import.