### PR TITLE
Closed: current-main provider migration trigger

### DIFF
--- a/.github/workflows/agent-apply-provider-current-main.yml
+++ b/.github/workflows/agent-apply-provider-current-main.yml
@@ -3,6 +3,8 @@ name: Apply reviewed provider migration to current main
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 
 permissions:
   contents: write
@@ -10,8 +12,11 @@ permissions:
 jobs:
   apply:
     if: >-
+      (github.event_name == 'pull_request' &&
+      github.head_ref == 'agent/trigger-bpt-provider-bootstrap') ||
+      (github.event_name == 'push' &&
       contains(github.event.head_commit.message,
-      'Bootstrap current-main BPT provider migration')
+      'Bootstrap current-main BPT provider migration'))
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
Trigger-only PR. The generated, current-main provider migration was validated and merged through #32; this branch is not intended for merge.