### PR TITLE
Superseded: independently validate Prob4D causal observation lineage

### DIFF
--- a/docs/observation_belief_lineage.md
+++ b/docs/observation_belief_lineage.md
@@ -1,20 +1,11 @@
-# Observation lineage
+# Observation-belief lineage
 
-Causal4D validates portable observation artifacts without importing Prob4D or
-Bayesian-PhysTwin. Two related interfaces are supported:
+Causal4D can validate the versioned `phys4d.observation_belief` artifact emitted
+by Prob4D and consumed by Bayesian-PhysTwin without importing either provider.
+This preserves the repository boundary: Causal4D consumes a content-addressed
+belief and does not reinterpret the feeder's raw files.
 
-1. `phys4d.observation_belief` is a marginalized, content-addressed observation
-   belief suitable for grouped likelihoods and simple consumers.
-2. `prob4d.observation-factor-bundle` schema v3 preserves the exact unfused
-   points, conditional covariance, explicit `Sim(3)` gauge variables, separate
-   reliability fields, and the exclusive causal cutoff consumed by the
-   gauge-aware Bayesian-PhysTwin update.
-
-The second interface is the stronger estimator-provenance binding. A compatible
-marginalized belief does not prove that the estimator consumed the exact
-factor-bundle manifest and payload pair.
-
-## Observation-belief validation
+## Validation
 
 ```bash
 causal4d-observation-lineage validate \
@@ -22,7 +13,7 @@ causal4d-observation-lineage validate \
   twin_belief.npz
 ```
 
-Validation fails closed unless:
+Validation fails closed unless all of the following hold:
 
 - the schema name, version, exact array set, and content digest are valid;
 - every observation frame lies within the artifact's declared causal prefix;
@@ -32,45 +23,38 @@ Validation fails closed unless:
 - the observation interval is contained in the `TwinBelief` O-minus interval;
 - an already bound `TwinBelief` names the same observation artifact.
 
-Use `--require-bound` when a downstream command requires proof that the
-`TwinBelief` was produced from the artifact rather than merely being compatible
-with it.
+Use `--require-bound` when the downstream command requires proof that the
+`TwinBelief` was produced from the validated observation rather than merely
+being compatible with it.
 
-## Exact factor-bundle validation
+## Strict Prob4D causal stream
 
-```bash
-causal4d-observation-lineage validate-factor-bundle \
-  observation_factors.json \
-  twin_belief.npz
-```
+When an artifact declares repository `FlorianPfaff/Prob4D` and stream
+`prob4d:causal-overlap-window-points`, Causal4D performs an additional
+provider-independent validation directly from the descriptor and numeric
+arrays. It requires:
 
-Causal4D independently checks the schema-v3 manifest and its checksum-bound NPZ
-payload. Validation includes:
+- an exact producer revision rather than `unknown`;
+- the frozen seven-dimensional gauge-factor names and factor-group/window
+  mapping;
+- metric units, a nonempty world frame, and a fixed external metric anchor;
+- binding of that anchor to the first selected source payload;
+- the registered MotionCrafter windowing model and independently decoded
+  overlap-window product;
+- equality of descriptor and lineage cutoffs and source digests;
+- zero reported future-payload access;
+- source bounds for every selected window wholly before the cutoff; and
+- containment of every observation row within its declared source window.
 
-- exact manifest and payload SHA-256 values and an artifact ID derived from both;
-- a relative payload path that cannot escape the manifest directory;
-- explicit case, stream, sequence, repository, and producer revision identities;
-- one exclusive `causal_frame_stop` shared by every factor;
-- unique factor and gauge identities and valid gauge references;
-- finite `Sim(3)` means and positive-semidefinite gauge covariance;
-- the exact payload array set, types, dimensions, and per-factor row identities;
-- separate association probability and residual-independent prior reliability;
-- fixed nominal-component probability and composite weight within every
-  correlation group;
-- finite active points, covariance, and optional rays;
-- case equality and containment in the `TwinBelief` O-minus interval.
-
-Schema-v2 factor bundles are deliberately not accepted here. Prob4D must first
-load and rewrite them as schema v3 so that the exclusive cutoff and newly
-separated reliability fields are explicit in the exact artifact being bound.
+This check is implemented independently from Prob4D and Bayesian-PhysTwin. A
+syntactically valid generic observation artifact cannot acquire a causal Prob4D
+claim merely by using the provider's repository name.
 
 ## Binding
 
-The estimator that actually consumes an artifact should bind its content
-address into the resulting `TwinBelief`. Administrative binding requires an
-explicit acknowledgement.
-
-For a marginalized observation belief:
+The estimator that actually consumes an observation artifact should bind its
+content address into the resulting `TwinBelief` metadata. The administrative
+CLI supports this operation only with an explicit acknowledgement:
 
 ```bash
 causal4d-observation-lineage bind \
@@ -80,48 +64,19 @@ causal4d-observation-lineage bind \
   --confirm-observation-was-consumed
 ```
 
-For an exact Prob4D factor bundle:
-
-```bash
-causal4d-observation-lineage bind-factor-bundle \
-  observation_factors.json \
-  unbound_twin_belief.npz \
-  bound_twin_belief.npz \
-  --confirm-factor-bundle-was-consumed
-```
-
 Binding creates a new content-addressed `TwinBelief`; it never mutates the
-source artifact. Factor-bundle metadata records:
+source artifact. The metadata records the observation belief ID, schema,
+case/stream identity, causal cutoff, feeder repository/revision, source digest,
+and any completed provider-specific validation summary.
 
-- the exact combined artifact ID;
-- manifest and payload SHA-256 values;
-- schema and version;
-- case, stream, and producer sequence identity;
-- exclusive causal cutoff;
-- source repository and revision.
-
-When a binding already exists, validation checks every recorded lineage field,
-not only the top-level artifact ID. A partial or internally inconsistent binding
-fails closed.
-
-The acknowledgement is not a substitute for estimator integration. Production
-Bayesian-PhysTwin code should bind the exact artifact immediately after
-constructing the belief from it. Inspection of a merely compatible artifact must
-not create provenance.
+The acknowledgement is not a substitute for estimator integration. It prevents
+accidental binding during inspection, while the intended production path is for
+the Bayesian-PhysTwin estimator to call
+`bind_twin_belief_observation_lineage` immediately after constructing the
+belief from that exact artifact.
 
 ## Cross-repository compatibility
 
-Prob4D owns the unfused observation-factor producer. Bayesian-PhysTwin owns the
-state, gauge, bias, and guarded-update inference. Causal4D independently checks
-the immutable artifact identities before using the resulting physical belief.
-This preserves the dependency direction:
-
-```text
-Prob4D factor bundle
-        -> Bayesian-PhysTwin guarded belief
-        -> Causal4D lineage validation and counterfactual inference
-```
-
-The existing cross-repository golden `ObservationBeliefV1` fixture still
-detects changes to the marginalized contract. The factor-bundle validator adds
-an exact byte-level lineage check for the richer estimator input.
+Prob4D, Bayesian-PhysTwin, and Causal4D carry the same golden fixture. Its fixed
+artifact ID detects changes to descriptor canonicalization, array names, dtypes,
+shapes, or hashing rules before incompatible artifacts are exchanged.

--- a/src/causal4d/observation_lineage.py
+++ b/src/causal4d/observation_lineage.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Mapping
 
 import numpy as np
 
 from .contracts import TwinBelief
+from .prob4d_observation_lineage import (
+    is_prob4d_causal_observation_descriptor,
+    validate_prob4d_causal_observation_metadata,
+)
 
 OBSERVATION_BELIEF_SCHEMA = "phys4d.observation_belief"
 OBSERVATION_BELIEF_VERSION = 1
@@ -37,13 +41,16 @@ def array_sha256(values: np.ndarray) -> str:
     array = np.ascontiguousarray(np.asarray(values))
     digest = hashlib.sha256()
     digest.update(array.dtype.str.encode("ascii"))
-    digest.update(json.dumps(array.shape, separators=(",", ":")).encode("ascii"))
+    digest.update(
+        json.dumps(array.shape, separators=(",", ":")).encode("ascii")
+    )
     digest.update(array.view(np.uint8))
     return digest.hexdigest()
 
 
 def compute_observation_artifact_id(
-    descriptor: Mapping[str, Any], arrays: Mapping[str, np.ndarray]
+    descriptor: Mapping[str, Any],
+    arrays: Mapping[str, np.ndarray],
 ) -> str:
     """Compute the cross-repository observation contract content address."""
 
@@ -71,13 +78,34 @@ def _validate_sha256(value: str, *, name: str) -> None:
         raise ValueError(f"{name} must be a lowercase SHA-256 digest")
 
 
-def _bounded_probability(values: np.ndarray, *, name: str) -> np.ndarray:
+def _bounded_probability(
+    values: np.ndarray,
+    *,
+    name: str,
+) -> np.ndarray:
     result = np.asarray(values, dtype=np.float64)
     if not np.all(np.isfinite(result)) or np.any(
         (result < 0.0) | (result > 1.0)
     ):
         raise ValueError(f"{name} must lie in [0, 1]")
     return result
+
+
+def _validated_json_mapping(
+    values: Mapping[str, Any],
+    *,
+    name: str,
+) -> dict[str, Any]:
+    try:
+        return json.loads(
+            json.dumps(
+                dict(values),
+                sort_keys=True,
+                allow_nan=False,
+            )
+        )
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{name} must be finite JSON data") from error
 
 
 @dataclass(frozen=True)
@@ -96,6 +124,7 @@ class ObservationLineage:
     source_repository: str
     source_revision: str
     source_artifact_sha256: str
+    provider_validation: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         _validate_sha256(self.artifact_id, name="artifact_id")
@@ -108,28 +137,53 @@ class ObservationLineage:
         if not self.source_repository or not self.source_revision:
             raise ValueError("lineage source must be nonempty")
         if self.causal_frame_stop < 1:
-            raise ValueError("lineage causal frame stop must be positive")
+            raise ValueError(
+                "lineage causal frame stop must be positive"
+            )
         if not 0 <= self.minimum_frame_id <= self.maximum_frame_id:
             raise ValueError("lineage frame range is invalid")
         if self.maximum_frame_id >= self.causal_frame_stop:
-            raise ValueError("lineage crosses its causal frame boundary")
+            raise ValueError(
+                "lineage crosses its causal frame boundary"
+            )
         if self.observation_count < 1 or self.group_count < 1:
-            raise ValueError("lineage must describe observations and groups")
+            raise ValueError(
+                "lineage must describe observations and groups"
+            )
         if self.factor_rank < 0:
             raise ValueError("lineage factor rank must be nonnegative")
+        object.__setattr__(
+            self,
+            "provider_validation",
+            _validated_json_mapping(
+                self.provider_validation,
+                name="provider validation",
+            ),
+        )
 
     def metadata(self) -> dict[str, Any]:
-        return {
+        metadata: dict[str, Any] = {
             "source_observation_belief_id": self.artifact_id,
             "source_observation_schema": OBSERVATION_BELIEF_SCHEMA,
-            "source_observation_schema_version": OBSERVATION_BELIEF_VERSION,
+            "source_observation_schema_version": (
+                OBSERVATION_BELIEF_VERSION
+            ),
             "source_observation_case_id": self.case_id,
             "source_observation_stream_id": self.stream_id,
-            "source_observation_causal_frame_stop": self.causal_frame_stop,
+            "source_observation_causal_frame_stop": (
+                self.causal_frame_stop
+            ),
             "source_observation_repository": self.source_repository,
             "source_observation_revision": self.source_revision,
-            "source_observation_artifact_sha256": self.source_artifact_sha256,
+            "source_observation_artifact_sha256": (
+                self.source_artifact_sha256
+            ),
         }
+        if self.provider_validation:
+            metadata["source_observation_provider_validation"] = dict(
+                self.provider_validation
+            )
+        return metadata
 
 
 def load_observation_lineage(path: str | Path) -> ObservationLineage:
@@ -137,7 +191,9 @@ def load_observation_lineage(path: str | Path) -> ObservationLineage:
 
     with np.load(path, allow_pickle=False) as archive:
         if "descriptor_json" not in archive:
-            raise ValueError("observation artifact has no descriptor_json")
+            raise ValueError(
+                "observation artifact has no descriptor_json"
+            )
         descriptor = json.loads(str(archive["descriptor_json"]))
         arrays = {
             name: np.asarray(archive[name])
@@ -146,7 +202,10 @@ def load_observation_lineage(path: str | Path) -> ObservationLineage:
         }
     if descriptor.get("schema_name") != OBSERVATION_BELIEF_SCHEMA:
         raise ValueError("unsupported observation-belief schema")
-    if int(descriptor.get("schema_version", -1)) != OBSERVATION_BELIEF_VERSION:
+    if (
+        int(descriptor.get("schema_version", -1))
+        != OBSERVATION_BELIEF_VERSION
+    ):
         raise ValueError("unsupported observation-belief version")
     missing = _REQUIRED_ARRAYS - arrays.keys()
     extra = arrays.keys() - _REQUIRED_ARRAYS
@@ -159,11 +218,19 @@ def load_observation_lineage(path: str | Path) -> ObservationLineage:
     _validate_sha256(expected, name="artifact_id")
     actual = compute_observation_artifact_id(descriptor, arrays)
     if actual != expected:
-        raise ValueError("observation artifact digest does not match its payload")
+        raise ValueError(
+            "observation artifact digest does not match its payload"
+        )
 
-    view_names = tuple(map(str, descriptor.get("view_names", ())))
-    window_names = tuple(map(str, descriptor.get("window_names", ())))
-    factor_names = tuple(map(str, descriptor.get("factor_names", ())))
+    view_names = tuple(
+        map(str, descriptor.get("view_names", ()))
+    )
+    window_names = tuple(
+        map(str, descriptor.get("window_names", ()))
+    )
+    factor_names = tuple(
+        map(str, descriptor.get("factor_names", ()))
+    )
     if (
         not view_names
         or any(not name for name in view_names)
@@ -171,35 +238,61 @@ def load_observation_lineage(path: str | Path) -> ObservationLineage:
         or any(not name for name in window_names)
         or any(not name for name in factor_names)
     ):
-        raise ValueError("observation view, window, or factor names are invalid")
+        raise ValueError(
+            "observation view, window, or factor names are invalid"
+        )
     _validate_sha256(
         str(descriptor.get("source_artifact_sha256", "")),
         name="source_artifact_sha256",
     )
 
-    declared_frames = np.asarray(arrays["declared_frame_ids"], dtype=np.int64)
+    declared_frames = np.asarray(
+        arrays["declared_frame_ids"],
+        dtype=np.int64,
+    )
     mean = np.asarray(arrays["mean_xyz_m"], dtype=np.float64)
     frame_ids = np.asarray(arrays["frame_ids"], dtype=np.int64)
     entity_ids = np.asarray(arrays["entity_ids"], dtype=np.int64)
-    view_indices = np.asarray(arrays["view_indices"], dtype=np.int64)
-    window_indices = np.asarray(arrays["window_indices"], dtype=np.int64)
-    correlation_groups = np.asarray(
-        arrays["correlation_group_ids"], dtype=np.int64
+    view_indices = np.asarray(
+        arrays["view_indices"],
+        dtype=np.int64,
     )
-    factor_groups = np.asarray(arrays["factor_group_ids"], dtype=np.int64)
-    local_covariance = np.asarray(arrays["local_covariance_m2"], dtype=np.float64)
-    factors = np.asarray(arrays["low_rank_factor_m"], dtype=np.float64)
+    window_indices = np.asarray(
+        arrays["window_indices"],
+        dtype=np.int64,
+    )
+    correlation_groups = np.asarray(
+        arrays["correlation_group_ids"],
+        dtype=np.int64,
+    )
+    factor_groups = np.asarray(
+        arrays["factor_group_ids"],
+        dtype=np.int64,
+    )
+    local_covariance = np.asarray(
+        arrays["local_covariance_m2"],
+        dtype=np.float64,
+    )
+    factors = np.asarray(
+        arrays["low_rank_factor_m"],
+        dtype=np.float64,
+    )
     group_ids = np.asarray(arrays["group_ids"], dtype=np.int64)
     group_prior = _bounded_probability(
         arrays["group_prior_nominal_probability"],
         name="group prior nominal probability",
     )
-    group_weight = np.asarray(arrays["group_composite_weight"], dtype=np.float64)
+    group_weight = np.asarray(
+        arrays["group_composite_weight"],
+        dtype=np.float64,
+    )
     prior_reliability = _bounded_probability(
-        arrays["prior_reliability"], name="prior reliability"
+        arrays["prior_reliability"],
+        name="prior reliability",
     )
     association = _bounded_probability(
-        arrays["association_probability"], name="association probability"
+        arrays["association_probability"],
+        name="association probability",
     )
     causal_stop = int(descriptor["causal_frame_stop"])
     if (
@@ -209,7 +302,9 @@ def load_observation_lineage(path: str | Path) -> ObservationLineage:
         or np.any(declared_frames < 0)
         or np.any(declared_frames >= causal_stop)
     ):
-        raise ValueError("declared observation frames violate the causal boundary")
+        raise ValueError(
+            "declared observation frames violate the causal boundary"
+        )
     if mean.ndim != 2 or mean.shape[1] != 3 or len(mean) == 0:
         raise ValueError("observation means must have shape (N, 3)")
     count = len(mean)
@@ -224,42 +319,89 @@ def load_observation_lineage(path: str | Path) -> ObservationLineage:
         ("association_probability", association),
     ):
         if values.shape != (count,):
-            raise ValueError(f"{name} must identify every observation row")
+            raise ValueError(
+                f"{name} must identify every observation row"
+            )
     if not np.all(np.isin(frame_ids, declared_frames)):
-        raise ValueError("observation frame identities are inconsistent")
+        raise ValueError(
+            "observation frame identities are inconsistent"
+        )
     if np.any(entity_ids < 0):
-        raise ValueError("observation entity identities must be nonnegative")
-    if np.any(view_indices < 0) or np.any(view_indices >= len(view_names)):
+        raise ValueError(
+            "observation entity identities must be nonnegative"
+        )
+    if np.any(view_indices < 0) or np.any(
+        view_indices >= len(view_names)
+    ):
         raise ValueError("observation view indices are invalid")
-    if np.any(window_indices < 0) or np.any(window_indices >= len(window_names)):
+    if np.any(window_indices < 0) or np.any(
+        window_indices >= len(window_names)
+    ):
         raise ValueError("observation window indices are invalid")
     if np.any(correlation_groups < 0) or np.any(factor_groups < 0):
-        raise ValueError("observation group identities must be nonnegative")
+        raise ValueError(
+            "observation group identities must be nonnegative"
+        )
     if local_covariance.shape != (count, 3, 3):
-        raise ValueError("observation local covariance shape changed")
-    symmetric = 0.5 * (local_covariance + np.swapaxes(local_covariance, 1, 2))
+        raise ValueError(
+            "observation local covariance shape changed"
+        )
+    symmetric = 0.5 * (
+        local_covariance
+        + np.swapaxes(local_covariance, 1, 2)
+    )
     if (
         not np.all(np.isfinite(local_covariance))
-        or not np.allclose(local_covariance, symmetric, atol=1e-12, rtol=1e-10)
-        or np.any(np.min(np.linalg.eigvalsh(symmetric), axis=1) <= 0.0)
+        or not np.allclose(
+            local_covariance,
+            symmetric,
+            atol=1e-12,
+            rtol=1e-10,
+        )
+        or np.any(
+            np.min(np.linalg.eigvalsh(symmetric), axis=1) <= 0.0
+        )
     ):
-        raise ValueError("observation local covariance is not positive definite")
+        raise ValueError(
+            "observation local covariance is not positive definite"
+        )
     if factors.shape != (count, 3, len(factor_names)) or not np.all(
         np.isfinite(factors)
     ):
-        raise ValueError("observation low-rank factor shape changed")
-    if not np.array_equal(group_ids, np.unique(correlation_groups)):
-        raise ValueError("observation group IDs do not match row assignments")
-    if group_prior.shape != group_ids.shape or group_weight.shape != group_ids.shape:
-        raise ValueError("observation group metadata shape changed")
+        raise ValueError(
+            "observation low-rank factor shape changed"
+        )
+    if not np.array_equal(
+        group_ids,
+        np.unique(correlation_groups),
+    ):
+        raise ValueError(
+            "observation group IDs do not match row assignments"
+        )
+    if (
+        group_prior.shape != group_ids.shape
+        or group_weight.shape != group_ids.shape
+    ):
+        raise ValueError(
+            "observation group metadata shape changed"
+        )
     if not np.all(np.isfinite(group_weight)) or np.any(
         (group_weight <= 0.0) | (group_weight > 1.0)
     ):
-        raise ValueError("observation group weights must lie in (0, 1]")
+        raise ValueError(
+            "observation group weights must lie in (0, 1]"
+        )
     if not np.all(np.isfinite(mean)):
         raise ValueError("observation means must be finite")
 
-    order = np.lexsort((window_indices, view_indices, entity_ids, frame_ids))
+    order = np.lexsort(
+        (
+            window_indices,
+            view_indices,
+            entity_ids,
+            frame_ids,
+        )
+    )
     keys = np.column_stack(
         (
             frame_ids[order],
@@ -268,8 +410,19 @@ def load_observation_lineage(path: str | Path) -> ObservationLineage:
             window_indices[order],
         )
     )
-    if len(keys) > 1 and np.any(np.all(keys[1:] == keys[:-1], axis=1)):
+    if len(keys) > 1 and np.any(
+        np.all(keys[1:] == keys[:-1], axis=1)
+    ):
         raise ValueError("observation row identity is not unique")
+
+    provider_validation: dict[str, object] = {}
+    if is_prob4d_causal_observation_descriptor(descriptor):
+        provider_validation = (
+            validate_prob4d_causal_observation_metadata(
+                descriptor,
+                arrays,
+            )
+        )
 
     return ObservationLineage(
         artifact_id=actual,
@@ -283,7 +436,10 @@ def load_observation_lineage(path: str | Path) -> ObservationLineage:
         factor_rank=factors.shape[2],
         source_repository=str(descriptor["source_repository"]),
         source_revision=str(descriptor["source_revision"]),
-        source_artifact_sha256=str(descriptor["source_artifact_sha256"]),
+        source_artifact_sha256=str(
+            descriptor["source_artifact_sha256"]
+        ),
+        provider_validation=provider_validation,
     )
 
 
@@ -293,19 +449,37 @@ def validate_twin_belief_observation_lineage(
     *,
     require_bound: bool = True,
 ) -> dict[str, Any]:
-    """Check case, O-minus containment, and content-addressed metadata binding."""
+    """Check case, O-minus containment, and content-addressed binding."""
 
     if twin_belief.context.case_id != lineage.case_id:
-        raise ValueError("observation and twin belief identify different cases")
-    if lineage.minimum_frame_id < twin_belief.context.o_minus.frame_start:
-        raise ValueError("observation begins before the TwinBelief O- boundary")
-    if lineage.causal_frame_stop > twin_belief.context.o_minus.frame_stop:
-        raise ValueError("observation uses frames beyond the TwinBelief O- boundary")
-    bound_id = twin_belief.metadata.get("source_observation_belief_id")
+        raise ValueError(
+            "observation and twin belief identify different cases"
+        )
+    if (
+        lineage.minimum_frame_id
+        < twin_belief.context.o_minus.frame_start
+    ):
+        raise ValueError(
+            "observation begins before the TwinBelief O- boundary"
+        )
+    if (
+        lineage.causal_frame_stop
+        > twin_belief.context.o_minus.frame_stop
+    ):
+        raise ValueError(
+            "observation uses frames beyond the TwinBelief O- boundary"
+        )
+    bound_id = twin_belief.metadata.get(
+        "source_observation_belief_id"
+    )
     if bound_id is not None and bound_id != lineage.artifact_id:
-        raise ValueError("TwinBelief is bound to a different observation artifact")
+        raise ValueError(
+            "TwinBelief is bound to a different observation artifact"
+        )
     if require_bound and bound_id is None:
-        raise ValueError("TwinBelief has no source observation binding")
+        raise ValueError(
+            "TwinBelief has no source observation binding"
+        )
     return {
         "status": "valid",
         "twin_belief_id": twin_belief.artifact_id,
@@ -316,7 +490,9 @@ def validate_twin_belief_observation_lineage(
             lineage.minimum_frame_id,
             lineage.maximum_frame_id,
         ],
-        "observation_causal_frame_stop": lineage.causal_frame_stop,
+        "observation_causal_frame_stop": (
+            lineage.causal_frame_stop
+        ),
         "twin_o_minus_frame_range": [
             twin_belief.context.o_minus.frame_start,
             twin_belief.context.o_minus.frame_stop,
@@ -324,6 +500,7 @@ def validate_twin_belief_observation_lineage(
         "observation_count": lineage.observation_count,
         "group_count": lineage.group_count,
         "factor_rank": lineage.factor_rank,
+        "provider_validation": dict(lineage.provider_validation),
     }
 
 
@@ -346,7 +523,9 @@ def bind_twin_belief_observation_lineage(
     metadata = dict(twin_belief.metadata)
     existing = metadata.get("source_observation_belief_id")
     if existing is not None and existing != lineage.artifact_id:
-        raise ValueError("TwinBelief already has incompatible observation lineage")
+        raise ValueError(
+            "TwinBelief already has incompatible observation lineage"
+        )
     metadata.update(lineage.metadata())
     return replace(twin_belief, metadata=metadata)
 

--- a/src/causal4d/prob4d_observation_lineage.py
+++ b/src/causal4d/prob4d_observation_lineage.py
@@ -1,0 +1,293 @@
+"""Independently validate strict Prob4D causal observation metadata."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import numpy as np
+
+PROB4D_SOURCE_REPOSITORY = "FlorianPfaff/Prob4D"
+PROB4D_CAUSAL_STREAM_ID = "prob4d:causal-overlap-window-points"
+PROB4D_CAUSAL_LINEAGE_VERSION = 1
+PROB4D_GAUGE_FACTOR_NAMES = tuple(
+    f"gauge_latent_{index}" for index in range(7)
+)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _require_sha256(value: Any, *, name: str) -> str:
+    result = str(value)
+    _require(
+        len(result) == 64
+        and all(
+            character in "0123456789abcdef"
+            for character in result
+        ),
+        f"{name} must be a lowercase SHA-256 digest",
+    )
+    return result
+
+
+def _require_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    _require(isinstance(value, Mapping), f"{name} must be a mapping")
+    return value
+
+
+def _require_integer(value: Any, *, name: str) -> int:
+    _require(
+        isinstance(value, (int, np.integer))
+        and not isinstance(value, bool),
+        f"{name} must be an integer",
+    )
+    return int(value)
+
+
+def is_prob4d_causal_observation_descriptor(
+    descriptor: Mapping[str, Any],
+) -> bool:
+    """Return whether the descriptor declares the strict Prob4D stream."""
+
+    return (
+        descriptor.get("source_repository")
+        == PROB4D_SOURCE_REPOSITORY
+        and descriptor.get("stream_id") == PROB4D_CAUSAL_STREAM_ID
+    )
+
+
+def validate_prob4d_causal_observation_metadata(
+    descriptor: Mapping[str, Any],
+    arrays: Mapping[str, np.ndarray],
+) -> dict[str, object]:
+    """Fail closed on inconsistent metric, gauge, or temporal lineage."""
+
+    _require(
+        is_prob4d_causal_observation_descriptor(descriptor),
+        "observation descriptor is not the strict Prob4D causal stream",
+    )
+    source_revision = str(descriptor.get("source_revision", ""))
+    _require(
+        bool(source_revision) and source_revision.lower() != "unknown",
+        "Prob4D causal artifact has no exact source revision",
+    )
+    source_artifact_sha256 = _require_sha256(
+        descriptor.get("source_artifact_sha256", ""),
+        name="source_artifact_sha256",
+    )
+    window_names = tuple(
+        map(str, descriptor.get("window_names", ()))
+    )
+    factor_names = tuple(
+        map(str, descriptor.get("factor_names", ()))
+    )
+    _require(
+        bool(window_names),
+        "Prob4D causal artifact has no source windows",
+    )
+    _require(
+        factor_names == PROB4D_GAUGE_FACTOR_NAMES,
+        "Prob4D causal artifact has changed gauge factor names",
+    )
+    window_indices = np.asarray(
+        arrays["window_indices"],
+        dtype=np.int64,
+    )
+    factor_group_ids = np.asarray(
+        arrays["factor_group_ids"],
+        dtype=np.int64,
+    )
+    _require(
+        np.array_equal(factor_group_ids, window_indices),
+        "Prob4D causal gauge factor groups must equal window indices",
+    )
+
+    metadata = _require_mapping(
+        descriptor.get("metadata"),
+        name="observation metadata",
+    )
+    _require(
+        metadata.get("metric_coordinates") is True,
+        "Prob4D causal artifact must declare metric coordinates",
+    )
+    _require(
+        metadata.get("metric_units") == "m",
+        "Prob4D causal artifact must declare metric units",
+    )
+    coordinate_frame = str(metadata.get("coordinate_frame", ""))
+    _require(
+        bool(coordinate_frame),
+        "Prob4D causal artifact has no coordinate frame",
+    )
+
+    anchor = _require_mapping(
+        metadata.get("metric_gauge_anchor"),
+        name="metric_gauge_anchor",
+    )
+    anchor_id = _require_sha256(
+        anchor.get("artifact_id", ""),
+        name="metric gauge-anchor artifact_id",
+    )
+    anchor_source_sha256 = _require_sha256(
+        anchor.get("source_artifact_sha256", ""),
+        name="metric gauge-anchor source_artifact_sha256",
+    )
+    _require_sha256(
+        anchor.get("calibration_artifact_sha256", ""),
+        name="metric gauge-anchor calibration_artifact_sha256",
+    )
+    _require(
+        anchor.get("window_id") == window_names[0],
+        "metric gauge anchor does not identify the first window",
+    )
+    _require(
+        anchor.get("world_frame_id") == coordinate_frame,
+        "metric gauge-anchor frame differs from observation frame",
+    )
+    _require(
+        anchor.get("covariance_treatment")
+        == "fixed_external_calibration",
+        "portable Prob4D causal artifact requires a fixed metric anchor",
+    )
+
+    causal_stop = _require_integer(
+        descriptor.get("causal_frame_stop"),
+        name="observation causal_frame_stop",
+    )
+    lineage = _require_mapping(
+        metadata.get("causal_source_lineage"),
+        name="causal_source_lineage",
+    )
+    _require(
+        _require_integer(
+            lineage.get("schema_version"),
+            name="causal lineage schema_version",
+        )
+        == PROB4D_CAUSAL_LINEAGE_VERSION,
+        "unsupported Prob4D causal-lineage version",
+    )
+    _require(
+        lineage.get("producer") == "Prob4D",
+        "causal lineage has changed producer",
+    )
+    _require(
+        lineage.get("motioncrafter_lineage_schema_version") == 1,
+        "unsupported MotionCrafter temporal-lineage version",
+    )
+    _require(
+        lineage.get("motioncrafter_windowing_model")
+        == "motioncrafter_sliding_window_v1",
+        "unsupported MotionCrafter windowing model",
+    )
+    _require(
+        lineage.get("source_product")
+        == "independently_decoded_overlap_windows",
+        "Prob4D causal artifact uses an inadmissible source product",
+    )
+    _require(
+        _require_integer(
+            lineage.get("causal_frame_stop_exclusive"),
+            name="causal lineage frame stop",
+        )
+        == causal_stop,
+        "causal lineage cutoff differs from the artifact cutoff",
+    )
+    _require(
+        _require_integer(
+            lineage.get("future_prediction_payloads_opened"),
+            name="future_prediction_payloads_opened",
+        )
+        == 0,
+        "Prob4D causal artifact reports opening future payloads",
+    )
+    _require(
+        lineage.get("admissibility_rule")
+        == "source_frame_max < causal_frame_stop_exclusive",
+        "Prob4D causal artifact has changed its admission rule",
+    )
+    lineage_source_sha256 = _require_sha256(
+        lineage.get("source_artifact_sha256", ""),
+        name="causal lineage source_artifact_sha256",
+    )
+    _require(
+        lineage_source_sha256 == source_artifact_sha256,
+        "causal lineage source digest differs from the descriptor",
+    )
+
+    selected = lineage.get("selected_windows")
+    _require(
+        isinstance(selected, list)
+        and len(selected) == len(window_names),
+        "causal lineage must identify every observation window",
+    )
+    frame_ids = np.asarray(arrays["frame_ids"], dtype=np.int64)
+    for window_index, expected_window_id in enumerate(window_names):
+        record = _require_mapping(
+            selected[window_index],
+            name=f"selected_windows[{window_index}]",
+        )
+        _require(
+            record.get("window_id") == expected_window_id,
+            "causal lineage window order differs from the descriptor",
+        )
+        start = _require_integer(
+            record.get("source_frame_start"),
+            name=f"selected window {expected_window_id} start",
+        )
+        stop = _require_integer(
+            record.get("source_frame_stop_exclusive"),
+            name=f"selected window {expected_window_id} stop",
+        )
+        maximum = _require_integer(
+            record.get("source_frame_max"),
+            name=f"selected window {expected_window_id} maximum",
+        )
+        _require(
+            0 <= start <= maximum < stop <= causal_stop,
+            "selected Prob4D window crosses its causal boundary",
+        )
+        _require_sha256(
+            record.get("frame_indices_sha256", ""),
+            name=f"selected window {expected_window_id} frame digest",
+        )
+        payload_digest = _require_sha256(
+            record.get("payload_sha256", ""),
+            name=f"selected window {expected_window_id} payload digest",
+        )
+        if window_index == 0:
+            _require(
+                payload_digest == anchor_source_sha256,
+                "metric anchor is not bound to the first selected payload",
+            )
+        rows = window_indices == window_index
+        if np.any(rows):
+            row_frames = frame_ids[rows]
+            _require(
+                np.all(
+                    (row_frames >= start)
+                    & (row_frames <= maximum)
+                ),
+                "observation rows exceed their declared source window",
+            )
+
+    return {
+        "validated": True,
+        "schema_version": PROB4D_CAUSAL_LINEAGE_VERSION,
+        "causal_frame_stop": causal_stop,
+        "window_count": len(window_names),
+        "metric_anchor_id": anchor_id,
+        "source_artifact_sha256": source_artifact_sha256,
+    }
+
+
+__all__ = [
+    "PROB4D_CAUSAL_LINEAGE_VERSION",
+    "PROB4D_CAUSAL_STREAM_ID",
+    "PROB4D_GAUGE_FACTOR_NAMES",
+    "PROB4D_SOURCE_REPOSITORY",
+    "is_prob4d_causal_observation_descriptor",
+    "validate_prob4d_causal_observation_metadata",
+]

--- a/tests/test_prob4d_observation_lineage.py
+++ b/tests/test_prob4d_observation_lineage.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from causal4d.observation_lineage import (
+    bind_twin_belief_observation_lineage,
+    compute_observation_artifact_id,
+    load_observation_lineage,
+)
+
+
+@dataclass(frozen=True)
+class _Window:
+    frame_stop: int
+    frame_start: int = 0
+
+
+@dataclass(frozen=True)
+class _Context:
+    case_id: str
+    o_minus: _Window
+
+
+@dataclass(frozen=True)
+class _TwinBelief:
+    context: _Context
+    metadata: dict
+    artifact_id: str = "f" * 64
+
+
+def _artifact_parts() -> tuple[dict, dict[str, np.ndarray]]:
+    arrays = {
+        "declared_frame_ids": np.asarray([1, 2, 3, 4]),
+        "mean_xyz_m": np.asarray(
+            [
+                [0.0, 0.0, 1.0],
+                [0.1, 0.0, 1.0],
+                [0.0, 0.1, 1.0],
+                [0.1, 0.1, 1.0],
+            ]
+        ),
+        "frame_ids": np.asarray([1, 2, 3, 4]),
+        "entity_ids": np.asarray([0, 1, 0, 1]),
+        "view_indices": np.zeros(4, dtype=np.int64),
+        "window_indices": np.asarray([0, 0, 1, 1]),
+        "correlation_group_ids": np.asarray([0, 0, 1, 1]),
+        "factor_group_ids": np.asarray([0, 0, 1, 1]),
+        "prior_reliability": np.asarray([0.9, 0.8, 0.7, 0.6]),
+        "association_probability": np.ones(4),
+        "local_covariance_m2": np.repeat(
+            np.eye(3)[None],
+            4,
+            axis=0,
+        )
+        * 1e-5,
+        "low_rank_factor_m": np.zeros((4, 3, 7)),
+        "group_ids": np.asarray([0, 1]),
+        "group_prior_nominal_probability": np.asarray([0.85, 0.65]),
+        "group_composite_weight": np.asarray([0.5, 0.5]),
+    }
+    descriptor = {
+        "schema_name": "phys4d.observation_belief",
+        "schema_version": 1,
+        "case_id": "case",
+        "stream_id": "prob4d:causal-overlap-window-points",
+        "causal_frame_stop": 6,
+        "view_names": ["camera-0"],
+        "window_names": ["window-0", "window-1"],
+        "factor_names": [
+            f"gauge_latent_{index}" for index in range(7)
+        ],
+        "source_repository": "FlorianPfaff/Prob4D",
+        "source_revision": "d" * 40,
+        "source_artifact_sha256": "c" * 64,
+        "metadata": {
+            "metric_coordinates": True,
+            "metric_units": "m",
+            "coordinate_frame": "phystwin-world",
+            "metric_gauge_anchor": {
+                "artifact_id": "a" * 64,
+                "window_id": "window-0",
+                "world_frame_id": "phystwin-world",
+                "source_artifact_sha256": "1" * 64,
+                "calibration_artifact_sha256": "b" * 64,
+                "covariance_treatment": "fixed_external_calibration",
+            },
+            "causal_source_lineage": {
+                "schema_version": 1,
+                "producer": "Prob4D",
+                "motioncrafter_lineage_schema_version": 1,
+                "motioncrafter_windowing_model": (
+                    "motioncrafter_sliding_window_v1"
+                ),
+                "source_product": (
+                    "independently_decoded_overlap_windows"
+                ),
+                "causal_frame_stop_exclusive": 6,
+                "admissibility_rule": (
+                    "source_frame_max < causal_frame_stop_exclusive"
+                ),
+                "future_prediction_payloads_opened": 0,
+                "source_artifact_sha256": "c" * 64,
+                "selected_windows": [
+                    {
+                        "window_id": "window-0",
+                        "source_frame_start": 0,
+                        "source_frame_stop_exclusive": 3,
+                        "source_frame_max": 2,
+                        "frame_indices_sha256": "2" * 64,
+                        "payload_sha256": "1" * 64,
+                    },
+                    {
+                        "window_id": "window-1",
+                        "source_frame_start": 2,
+                        "source_frame_stop_exclusive": 5,
+                        "source_frame_max": 4,
+                        "frame_indices_sha256": "3" * 64,
+                        "payload_sha256": "4" * 64,
+                    },
+                ],
+            },
+        },
+    }
+    return descriptor, arrays
+
+
+def _write(
+    path: Path,
+    *,
+    mutate=None,
+) -> None:
+    descriptor, arrays = _artifact_parts()
+    descriptor = deepcopy(descriptor)
+    arrays = {name: value.copy() for name, value in arrays.items()}
+    if mutate is not None:
+        mutate(descriptor, arrays)
+    descriptor["artifact_id"] = compute_observation_artifact_id(
+        descriptor,
+        arrays,
+    )
+    np.savez_compressed(
+        path,
+        descriptor_json=np.asarray(
+            json.dumps(
+                descriptor,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        ),
+        **arrays,
+    )
+
+
+def test_prob4d_provider_validation_is_bound_to_twin_belief(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "observation.npz"
+    _write(path)
+    lineage = load_observation_lineage(path)
+    twin = _TwinBelief(_Context("case", _Window(6)), {})
+    bound = bind_twin_belief_observation_lineage(twin, lineage)
+
+    assert lineage.provider_validation["validated"] is True
+    assert lineage.provider_validation["window_count"] == 2
+    assert bound.metadata[
+        "source_observation_provider_validation"
+    ] == lineage.provider_validation
+
+
+def test_prob4d_lineage_rejects_changed_cutoff(tmp_path: Path) -> None:
+    path = tmp_path / "observation.npz"
+
+    def mutate(descriptor, arrays):
+        del arrays
+        descriptor["metadata"]["causal_source_lineage"][
+            "causal_frame_stop_exclusive"
+        ] = 7
+
+    _write(path, mutate=mutate)
+    with pytest.raises(ValueError, match="cutoff differs"):
+        load_observation_lineage(path)
+
+
+def test_prob4d_lineage_rejects_future_payload_access(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "observation.npz"
+
+    def mutate(descriptor, arrays):
+        del arrays
+        descriptor["metadata"]["causal_source_lineage"][
+            "future_prediction_payloads_opened"
+        ] = 1
+
+    _write(path, mutate=mutate)
+    with pytest.raises(ValueError, match="opening future payloads"):
+        load_observation_lineage(path)
+
+
+def test_prob4d_lineage_rejects_window_mismatch(tmp_path: Path) -> None:
+    path = tmp_path / "observation.npz"
+
+    def mutate(descriptor, arrays):
+        del arrays
+        descriptor["metadata"]["causal_source_lineage"][
+            "selected_windows"
+        ][1]["window_id"] = "another-window"
+
+    _write(path, mutate=mutate)
+    with pytest.raises(ValueError, match="window order differs"):
+        load_observation_lineage(path)
+
+
+def test_prob4d_lineage_rejects_source_digest_mismatch(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "observation.npz"
+
+    def mutate(descriptor, arrays):
+        del arrays
+        descriptor["metadata"]["causal_source_lineage"][
+            "source_artifact_sha256"
+        ] = "e" * 64
+
+    _write(path, mutate=mutate)
+    with pytest.raises(ValueError, match="differs from the descriptor"):
+        load_observation_lineage(path)


### PR DESCRIPTION
Closed as redundant: the original implementation was rebased onto the provider-migrated `main`, passed its current matrix, and merged through #30 as `aff060f497fb63df82e06e7e27047c11e98d603e`.