### PR TITLE
Trigger CI reconciliation on current main

### DIFF
--- a/.github/workflows/apply-ci-current-main-rebase.yml
+++ b/.github/workflows/apply-ci-current-main-rebase.yml
@@ -264,4 +264,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -m "Rebase dependency-boundary CI onto provider-enabled main"
-          git push --force-with-lease origin HEAD:agent/ci-dependency-boundaries
+          git push --force origin HEAD:agent/ci-dependency-boundaries-current-main

--- a/.github/workflows/apply-ci-current-main-rebase.yml
+++ b/.github/workflows/apply-ci-current-main-rebase.yml
@@ -256,28 +256,62 @@ jobs:
           python -m compileall -q src tests scripts
           python -m pytest --tb=short
           git diff --check
-      - name: Commit reconciled branch
+      - name: Export reviewed scope
         shell: bash
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "Rebase dependency-boundary CI onto provider-enabled main"
-      - name: Package validated commit
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p build/reconciled-ci
-          git format-patch --stdout origin/main..HEAD \
-            > build/reconciled-ci/reconciled.patch
-          git bundle create build/reconciled-ci/reconciled.bundle origin/main..HEAD
-          git diff --name-status origin/main..HEAD \
-            > build/reconciled-ci/changed-files.txt
-          git rev-parse HEAD > build/reconciled-ci/commit.txt
-      - name: Upload validated commit
+          root=build/reconciled-ci/selected
+          mkdir -p "$root"
+          files=(
+            .github/workflows/ci.yml
+            .github/workflows/optional-integrations.yml
+            docs/ci.md
+            pyproject.toml
+            requirements/ci/bayesian-phystwin-provider-v1.sha
+            scripts/ci/changed_python_files.py
+            scripts/ci/check_console_help.py
+            scripts/ci/read_bpt_pin.py
+            scripts/ci/run_bpt_integration_tests.py
+            scripts/ci/verify_frozen_manifest.py
+            scripts/ci/verify_result_bundle.py
+            src/causal4d/cli/abduct_phystwin_intervention.py
+            src/causal4d/cli/adaptive_molmo_task_posterior.py
+            src/causal4d/cli/audit_parameter_support.py
+            src/causal4d/cli/audit_real_oracle_gap.py
+            src/causal4d/cli/counterfactual_phystwin.py
+            src/causal4d/cli/discrepancy_localization_aggregate.py
+            src/causal4d/cli/evaluate_graph_temporal_discrepancy.py
+            src/causal4d/cli/evaluate_molmo_acceptance.py
+            src/causal4d/cli/evaluate_physical_counterfactual.py
+            src/causal4d/cli/evaluate_phystwin_molmo.py
+            src/causal4d/cli/evaluate_rest_geometry.py
+            src/causal4d/cli/export_bpt_belief.py
+            src/causal4d/cli/fit_semantic_trust.py
+            src/causal4d/cli/molmo_phystwin_forecast.py
+            src/causal4d/cli/molmo_task_posterior.py
+            src/causal4d/cli/phystwin_canonical_graph.py
+            src/causal4d/cli/phystwin_discrepancy_localization.py
+            src/causal4d/cli/phystwin_propagated_state.py
+            src/causal4d/cli/phystwin_propagated_state_aggregate.py
+            src/causal4d/cli/phystwin_rest_geometry_transfer.py
+            src/causal4d/cli/phystwin_rollout_bank.py
+            src/causal4d/cli/real_calibration.py
+            src/causal4d/cli/rest_geometry_protocol.py
+            src/causal4d/cli/rest_geometry_register_graph.py
+            src/causal4d/cli/rest_geometry_source_correction.py
+          )
+          : > build/reconciled-ci/modes.txt
+          for path in "${files[@]}"; do
+            test -f "$path"
+            mkdir -p "$root/$(dirname "$path")"
+            cp "$path" "$root/$path"
+            git ls-files -s -- "$path" | awk '{print $1 " " $4}' \
+              >> build/reconciled-ci/modes.txt
+          done
+          printf '%s\n' "${files[@]}" > build/reconciled-ci/selected-files.txt
+      - name: Upload reviewed scope
         uses: actions/upload-artifact@v7
         with:
-          name: reconciled-ci-current-main
+          name: reconciled-ci-selected-scope
           path: build/reconciled-ci/
           if-no-files-found: error

--- a/.github/workflows/apply-ci-current-main-rebase.yml
+++ b/.github/workflows/apply-ci-current-main-rebase.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   reconcile:
@@ -264,106 +264,20 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -m "Rebase dependency-boundary CI onto provider-enabled main"
-      - name: Publish through Git data API
+      - name: Package validated commit
         shell: bash
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          python - <<'PY'
-          from __future__ import annotations
-
-          import base64
-          import json
-          import os
-          from pathlib import Path
-          import subprocess
-          from urllib.error import HTTPError
-          from urllib.request import Request, urlopen
-
-          repository = os.environ["GITHUB_REPOSITORY"]
-          token = os.environ["GITHUB_TOKEN"]
-          target_branch = "agent/ci-dependency-boundaries-current-main"
-
-
-          def git(*args: str) -> str:
-              return subprocess.check_output(["git", *args], text=True).strip()
-
-
-          def api(method: str, path: str, payload: object | None = None) -> object:
-              data = None if payload is None else json.dumps(payload).encode("utf-8")
-              request = Request(
-                  f"https://api.github.com/repos/{repository}{path}",
-                  data=data,
-                  method=method,
-                  headers={
-                      "Accept": "application/vnd.github+json",
-                      "Authorization": f"Bearer {token}",
-                      "X-GitHub-Api-Version": "2022-11-28",
-                      "User-Agent": "causal4d-ci-reconciler",
-                  },
-              )
-              with urlopen(request) as response:
-                  body = response.read()
-              return {} if not body else json.loads(body)
-
-
-          base_sha = git("rev-parse", "origin/main")
-          base_commit = api("GET", f"/git/commits/{base_sha}")
-          base_tree_sha = base_commit["tree"]["sha"]
-          raw_paths = subprocess.check_output(
-              ["git", "diff", "--name-only", "-z", f"{base_sha}..HEAD"]
-          )
-          paths = [value.decode("utf-8") for value in raw_paths.split(b"\0") if value]
-          entries = []
-          for path_text in paths:
-              path = Path(path_text)
-              if not path.exists():
-                  entries.append(
-                      {"path": path_text, "mode": "100644", "type": "blob", "sha": None}
-                  )
-                  continue
-              index_record = git("ls-files", "-s", "--", path_text)
-              mode = index_record.split()[0]
-              blob = api(
-                  "POST",
-                  "/git/blobs",
-                  {
-                      "content": base64.b64encode(path.read_bytes()).decode("ascii"),
-                      "encoding": "base64",
-                  },
-              )
-              entries.append(
-                  {"path": path_text, "mode": mode, "type": "blob", "sha": blob["sha"]}
-              )
-
-          tree = api(
-              "POST",
-              "/git/trees",
-              {"base_tree": base_tree_sha, "tree": entries},
-          )
-          commit = api(
-              "POST",
-              "/git/commits",
-              {
-                  "message": "Rebase dependency-boundary CI onto provider-enabled main",
-                  "tree": tree["sha"],
-                  "parents": [base_sha],
-              },
-          )
-          try:
-              api(
-                  "POST",
-                  "/git/refs",
-                  {"ref": f"refs/heads/{target_branch}", "sha": commit["sha"]},
-              )
-          except HTTPError as error:
-              if error.code != 422:
-                  raise
-              api(
-                  "PATCH",
-                  f"/git/refs/heads/{target_branch}",
-                  {"sha": commit["sha"], "force": True},
-              )
-          print(json.dumps({"branch": target_branch, "commit": commit["sha"]}))
-          PY
+          mkdir -p build/reconciled-ci
+          git format-patch --stdout origin/main..HEAD \
+            > build/reconciled-ci/reconciled.patch
+          git bundle create build/reconciled-ci/reconciled.bundle origin/main..HEAD
+          git diff --name-status origin/main..HEAD \
+            > build/reconciled-ci/changed-files.txt
+          git rev-parse HEAD > build/reconciled-ci/commit.txt
+      - name: Upload validated commit
+        uses: actions/upload-artifact@v7
+        with:
+          name: reconciled-ci-current-main
+          path: build/reconciled-ci/
+          if-no-files-found: error

--- a/.github/workflows/apply-ci-current-main-rebase.yml
+++ b/.github/workflows/apply-ci-current-main-rebase.yml
@@ -256,7 +256,7 @@ jobs:
           python -m compileall -q src tests scripts
           python -m pytest --tb=short
           git diff --check
-      - name: Commit and publish reconciled branch
+      - name: Commit reconciled branch
         shell: bash
         run: |
           set -euo pipefail
@@ -264,4 +264,106 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -m "Rebase dependency-boundary CI onto provider-enabled main"
-          git push --force origin HEAD:agent/ci-dependency-boundaries-current-main
+      - name: Publish through Git data API
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from __future__ import annotations
+
+          import base64
+          import json
+          import os
+          from pathlib import Path
+          import subprocess
+          from urllib.error import HTTPError
+          from urllib.request import Request, urlopen
+
+          repository = os.environ["GITHUB_REPOSITORY"]
+          token = os.environ["GITHUB_TOKEN"]
+          target_branch = "agent/ci-dependency-boundaries-current-main"
+
+
+          def git(*args: str) -> str:
+              return subprocess.check_output(["git", *args], text=True).strip()
+
+
+          def api(method: str, path: str, payload: object | None = None) -> object:
+              data = None if payload is None else json.dumps(payload).encode("utf-8")
+              request = Request(
+                  f"https://api.github.com/repos/{repository}{path}",
+                  data=data,
+                  method=method,
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {token}",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                      "User-Agent": "causal4d-ci-reconciler",
+                  },
+              )
+              with urlopen(request) as response:
+                  body = response.read()
+              return {} if not body else json.loads(body)
+
+
+          base_sha = git("rev-parse", "origin/main")
+          base_commit = api("GET", f"/git/commits/{base_sha}")
+          base_tree_sha = base_commit["tree"]["sha"]
+          raw_paths = subprocess.check_output(
+              ["git", "diff", "--name-only", "-z", f"{base_sha}..HEAD"]
+          )
+          paths = [value.decode("utf-8") for value in raw_paths.split(b"\0") if value]
+          entries = []
+          for path_text in paths:
+              path = Path(path_text)
+              if not path.exists():
+                  entries.append(
+                      {"path": path_text, "mode": "100644", "type": "blob", "sha": None}
+                  )
+                  continue
+              index_record = git("ls-files", "-s", "--", path_text)
+              mode = index_record.split()[0]
+              blob = api(
+                  "POST",
+                  "/git/blobs",
+                  {
+                      "content": base64.b64encode(path.read_bytes()).decode("ascii"),
+                      "encoding": "base64",
+                  },
+              )
+              entries.append(
+                  {"path": path_text, "mode": mode, "type": "blob", "sha": blob["sha"]}
+              )
+
+          tree = api(
+              "POST",
+              "/git/trees",
+              {"base_tree": base_tree_sha, "tree": entries},
+          )
+          commit = api(
+              "POST",
+              "/git/commits",
+              {
+                  "message": "Rebase dependency-boundary CI onto provider-enabled main",
+                  "tree": tree["sha"],
+                  "parents": [base_sha],
+              },
+          )
+          try:
+              api(
+                  "POST",
+                  "/git/refs",
+                  {"ref": f"refs/heads/{target_branch}", "sha": commit["sha"]},
+              )
+          except HTTPError as error:
+              if error.code != 422:
+                  raise
+              api(
+                  "PATCH",
+                  f"/git/refs/heads/{target_branch}",
+                  {"sha": commit["sha"], "force": True},
+              )
+          print(json.dumps({"branch": target_branch, "commit": commit["sha"]}))
+          PY

--- a/.github/workflows/apply-ci-current-main-rebase.yml
+++ b/.github/workflows/apply-ci-current-main-rebase.yml
@@ -1,0 +1,267 @@
+name: Apply CI reconciliation to current main
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  reconcile:
+    if: github.head_ref == 'agent/trigger-ci-current-main-rebase'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out CI implementation branch
+        uses: actions/checkout@v6
+        with:
+          ref: agent/ci-dependency-boundaries
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Merge current main and resolve known overlaps
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          ci_head=$(git rev-parse HEAD)
+          set +e
+          git merge --no-ff --no-commit origin/main
+          set -e
+
+          git show origin/main:pyproject.toml > pyproject.toml
+          for path in \
+            src/causal4d/cli/abduct_phystwin_intervention.py \
+            src/causal4d/cli/audit_parameter_support.py \
+            src/causal4d/cli/audit_real_oracle_gap.py \
+            src/causal4d/cli/evaluate_graph_temporal_discrepancy.py \
+            src/causal4d/cli/evaluate_physical_counterfactual.py \
+            src/causal4d/cli/fit_semantic_trust.py \
+            src/causal4d/cli/real_calibration.py
+          do
+            git show "${ci_head}:${path}" > "${path}"
+          done
+
+          python - <<'PY'
+          from pathlib import Path
+          from textwrap import dedent
+
+          pyproject = Path("pyproject.toml")
+          text = pyproject.read_text(encoding="utf-8")
+          start = text.index("dev = [")
+          end = text.index("]\nphystwin = [", start) + 2
+          dev = dedent(
+              '''\
+              dev = [
+                "build>=1.2",
+                "mypy>=1.11",
+                "pytest>=8",
+                "ruff>=0.15.22,<0.17",
+                "twine>=5",
+              ]
+              '''
+          )
+          text = text[:start] + dev + text[end:]
+          if "[tool.mypy]" not in text:
+              text = text.rstrip() + dedent(
+                  '''\
+
+
+                  [tool.mypy]
+                  python_version = "3.10"
+                  check_untyped_defs = true
+                  follow_imports = "skip"
+                  ignore_missing_imports = true
+                  no_implicit_optional = true
+                  show_error_codes = true
+                  warn_unused_ignores = true
+                  '''
+              )
+          pyproject.write_text(text.rstrip() + "\n", encoding="utf-8")
+
+          cli_paths = (
+              "src/causal4d/cli/abduct_phystwin_intervention.py",
+              "src/causal4d/cli/audit_parameter_support.py",
+              "src/causal4d/cli/audit_real_oracle_gap.py",
+              "src/causal4d/cli/evaluate_graph_temporal_discrepancy.py",
+              "src/causal4d/cli/evaluate_physical_counterfactual.py",
+              "src/causal4d/cli/fit_semantic_trust.py",
+              "src/causal4d/cli/real_calibration.py",
+          )
+          for value in cli_paths:
+              path = Path(value)
+              source = path.read_text(encoding="utf-8")
+              source = source.replace(
+                  "from bayesian_phystwin.phystwin_residual_dynamics import _target_validity",
+                  "from bayesian_phystwin.causal4d_provider_v1 import target_validity",
+              )
+              source = source.replace("_target_validity", "target_validity")
+              path.write_text(source, encoding="utf-8")
+
+          pin = Path("requirements/ci/bayesian-phystwin-provider-v1.sha")
+          pin.parent.mkdir(parents=True, exist_ok=True)
+          pin.write_text(
+              "b0a47e411a919ae367fc9ca3c1e57ffc47e69695\n",
+              encoding="utf-8",
+          )
+
+          Path("scripts/ci/read_bpt_pin.py").write_text(
+              dedent(
+                  '''\
+                  #!/usr/bin/env python3
+                  """Print the exact Bayesian-PhysTwin revision used by pinned CI."""
+
+                  from __future__ import annotations
+
+                  import argparse
+                  from pathlib import Path
+                  import re
+                  import sys
+
+                  DEFAULT_PIN = Path("requirements/ci/bayesian-phystwin-provider-v1.sha")
+                  _SHA40 = re.compile(r"^[0-9a-f]{40}$")
+
+
+                  def read_bpt_pin(path: Path = DEFAULT_PIN) -> str:
+                      value = path.read_text(encoding="utf-8").strip()
+                      if _SHA40.fullmatch(value) is None:
+                          raise ValueError(
+                              f"{path} must contain one lowercase 40-hex commit"
+                          )
+                      return value
+
+
+                  def main(argv: list[str] | None = None) -> int:
+                      parser = argparse.ArgumentParser(description=__doc__)
+                      parser.add_argument(
+                          "pin_file", nargs="?", type=Path, default=DEFAULT_PIN
+                      )
+                      arguments = parser.parse_args(argv)
+                      print(read_bpt_pin(arguments.pin_file))
+                      return 0
+
+
+                  if __name__ == "__main__":
+                      sys.exit(main())
+                  '''
+              ),
+              encoding="utf-8",
+          )
+
+          for name in ("ci.yml", "optional-integrations.yml"):
+              path = Path(".github/workflows") / name
+              source = path.read_text(encoding="utf-8")
+              source = source.replace("BPT_REPOSITORY_TOKEN", "BPT_READ_TOKEN")
+              path.write_text(source, encoding="utf-8")
+
+          Path("docs/ci.md").write_text(
+              dedent(
+                  '''\
+                  # Continuous integration
+
+                  Causal4D separates its lightweight contracts from private-provider and
+                  hardware integrations. This keeps a base installation testable while
+                  still detecting drift at the Bayesian-PhysTwin boundary.
+
+                  ## Required pull-request checks
+
+                  `CI and release` runs the following independent jobs:
+
+                  - **Core-only** installs `.[dev]` without Bayesian-PhysTwin, OpenCV,
+                    PyTorch, or Warp and executes the default test suite on Python 3.10,
+                    3.12, and 3.14.
+                  - **Pinned Bayesian-PhysTwin integration** checks out the exact
+                    provider-API revision recorded in
+                    `requirements/ci/bayesian-phystwin-provider-v1.sha` and runs the
+                    BPT-facing Causal4D tests. The normal `phystwin` extra remains the
+                    supported `>=0.4,<0.5` development range.
+                  - **Distributions and CLI help** build both wheel and source
+                    distribution, install each into a clean virtual environment, and
+                    require every declared console command to render `--help` without
+                    optional providers.
+                  - **Quality** runs Ruff on the repository, Ruff formatting on changed
+                    Python files, and mypy on stable provider contracts and CI utilities.
+                  - **Result bundles** produce small deterministic benchmark bundles,
+                    verify their embedded checksums, archive them, extract them into a
+                    clean directory, and verify the consumed copies again.
+                  - **Frozen manifest** cross-checks the milestone path and checksum
+                    inventories, validates all recorded Git/SHA-256 identities, and
+                    hashes every frozen artifact stored in the checkout.
+
+                  Formatting is an incremental ratchet: modified Python files must be
+                  Ruff-formatted without forcing unrelated historical files into the
+                  same change.
+
+                  ## Private Bayesian-PhysTwin access
+
+                  Bayesian-PhysTwin is private. Add a least-privilege repository secret
+                  named `BPT_READ_TOKEN` with read access to
+                  `FlorianPfaff/Bayesian-PhysTwin`. Pinned, scheduled-main, BPT-vision,
+                  and Warp jobs report an explicit skipped-coverage warning when the
+                  secret is absent; they do not pretend provider compatibility was
+                  tested.
+
+                  ## Scheduled and optional checks
+
+                  `Bayesian-PhysTwin provider compatibility` is the scheduled and
+                  manually dispatchable cross-repository check against BPT `main`. The
+                  ordinary CI job remains locked to the exact provider-API revision in
+                  the dedicated CI pin.
+
+                  `Optional integrations` keeps large or platform-specific dependencies
+                  out of the core job:
+
+                  - hosted CPU vision/OpenCV tests run weekly;
+                  - BPT OpenCV collection and Warp CPU tests run separately when the
+                    private token is configured;
+                  - the CUDA/Warp job is manual and targets a self-hosted runner carrying
+                    the labels `self-hosted`, `linux`, `x64`, and `gpu`.
+
+                  The manual GPU job additionally requires the same `BPT_READ_TOKEN`
+                  secret.
+                  '''
+              ),
+              encoding="utf-8",
+          )
+          PY
+
+          rm -f .github/workflows/bpt-main-compatibility.yml
+          git add -A
+          unresolved=$(git diff --name-only --diff-filter=U)
+          if [[ -n "$unresolved" ]]; then
+            echo "Unresolved merge conflicts:" >&2
+            echo "$unresolved" >&2
+            exit 1
+          fi
+      - name: Format and validate reconciled branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+          mapfile -t files < <(
+            git diff --name-only origin/main...HEAD -- '*.py'
+            git diff --name-only --cached -- '*.py'
+          )
+          mapfile -t files < <(printf '%s\n' "${files[@]}" | sed '/^$/d' | sort -u)
+          if (( ${#files[@]} )); then
+            python -m ruff format "${files[@]}"
+            git add -- "${files[@]}"
+          fi
+          python -m ruff check .
+          python -m mypy scripts/ci src/causal4d/provider_contract.py
+          python -m compileall -q src tests scripts
+          python -m pytest --tb=short
+          git diff --check
+      - name: Commit and publish reconciled branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Rebase dependency-boundary CI onto provider-enabled main"
+          git push --force-with-lease origin HEAD:agent/ci-dependency-boundaries

--- a/.github/workflows/export-ci-workflows.yml
+++ b/.github/workflows/export-ci-workflows.yml
@@ -1,0 +1,36 @@
+name: Export reconciled CI workflows
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  export:
+    if: github.head_ref == 'agent/trigger-ci-current-main-rebase'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out CI implementation branch
+        uses: actions/checkout@v6
+        with:
+          ref: agent/ci-dependency-boundaries
+      - name: Prepare workflow files
+        shell: bash
+        run: |
+          set -euo pipefail
+          root=build/reconciled-workflows
+          mkdir -p "$root/.github/workflows"
+          for name in ci.yml optional-integrations.yml; do
+            sed 's/BPT_REPOSITORY_TOKEN/BPT_READ_TOKEN/g' \
+              ".github/workflows/$name" \
+              > "$root/.github/workflows/$name"
+          done
+      - name: Upload workflow files
+        uses: actions/upload-artifact@v7
+        with:
+          name: reconciled-ci-workflows
+          path: build/reconciled-workflows/
+          include-hidden-files: true
+          if-no-files-found: error


### PR DESCRIPTION
Temporary trigger only. This PR runs the conflict-resolution workflow that rebases #23 onto the provider-enabled and Prob4D-lineage-enabled `main`, preserves lazy CLI imports and public provider calls, moves the pinned provider revision to a dedicated CI lock, removes duplicate scheduled compatibility CI, and validates the full suite. It will be closed without merge.