### PR TITLE
Build the reviewed CI consolidation on current main

### DIFF
--- a/.github/workflows/agent-run-ci-consolidation-current-main.yml
+++ b/.github/workflows/agent-run-ci-consolidation-current-main.yml
@@ -1,0 +1,57 @@
+name: Build current-main CI consolidation
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+
+jobs:
+  consolidate:
+    if: github.head_ref == 'agent/run-ci-consolidation-current-main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Merge the reviewed CI patch onto current main
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email \
+            "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin agent/rebased-ci-dependency-boundaries
+          git switch -C agent/ci-boundaries-current-main main
+          git merge --no-commit --no-ff \
+            origin/agent/rebased-ci-dependency-boundaries
+          if git diff --name-only --diff-filter=U | grep -q .; then
+            echo "Unexpected merge conflicts:" >&2
+            git diff --name-only --diff-filter=U >&2
+            exit 1
+          fi
+          git commit -m "Consolidate dependency-boundary CI on current main"
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Validate consolidated branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]"
+          python -m ruff check .
+          python -m pytest -q
+          python scripts/ci/check_console_help.py --pyproject pyproject.toml
+          python scripts/ci/verify_frozen_manifest.py \
+            milestones/v0.3.0-causal4d-aip
+          test -z "$(git status --porcelain)"
+      - name: Publish clean branch
+        run: |
+          git push --force-with-lease \
+            origin HEAD:agent/ci-boundaries-current-main


### PR DESCRIPTION
Trigger-only pull request. Its workflow checks out current `main`, merges the already reviewed dependency-boundary patch, rejects any conflict, runs Ruff, the complete pytest suite, every installed CLI help smoke test, and frozen-manifest verification, then publishes the clean `agent/ci-boundaries-current-main` branch. This trigger PR will not be merged.