### PR TITLE
Add resumable content-addressed PhysTwin rollout cache

### DIFF
--- a/.github/workflows/agent-phystwin-rollout-cache.yml
+++ b/.github/workflows/agent-phystwin-rollout-cache.yml
@@ -1,0 +1,425 @@
+name: Integrate PhysTwin rollout cache
+
+on:
+  pull_request:
+    branches: [agent/bpt-graph-provider-boundary]
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+
+jobs:
+  integrate:
+    if: github.head_ref == 'agent/phystwin-rollout-cache'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: agent/phystwin-rollout-cache
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Wire cache into official PhysTwin backend and CLIs
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          def replace_once(path: Path, old: str, new: str, label: str) -> None:
+              text = path.read_text(encoding="utf-8")
+              if new in text:
+                  return
+              if old not in text:
+                  raise SystemExit(f"missing {label} anchor in {path}")
+              path.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+          # Match the parent provider-boundary migration so this stacked branch has
+          # the same final imports even when its base advances while CI is queued.
+          for root in (Path("src"), Path("scripts")):
+              for path in sorted(root.rglob("*.py")):
+                  text = path.read_text(encoding="utf-8")
+                  updated = text.replace(
+                      "bayesian_phystwin.phystwin_graph",
+                      "bayesian_phystwin.causal4d_graph_provider_v1",
+                  ).replace(
+                      "bayesian_phystwin.phystwin_controller_sensitivity",
+                      "bayesian_phystwin.causal4d_graph_provider_v1",
+                  )
+                  if updated != text:
+                      path.write_text(updated, encoding="utf-8")
+
+          backend = Path("src/causal4d/phystwin_backend.py")
+          text = backend.read_text(encoding="utf-8")
+          import_anchor = (
+              "from causal4d.parameter_support import SupportMethod, "
+              "reduce_parameter_support\n"
+          )
+          imports = (
+              "from causal4d.graph_provider_contract import "
+              "require_bayesian_phystwin_graph_provider\n"
+              "from causal4d.parameter_support import SupportMethod, "
+              "reduce_parameter_support\n"
+              "from causal4d.phystwin_rollout_cache import (\n"
+              "    PHYSTWIN_ROLLOUT_CACHE_VERSION,\n"
+              "    PhysTwinRolloutCache,\n"
+              "    build_phystwin_rollout_cache_key,\n"
+              "    file_sha256,\n"
+              "    require_clean_git_revision,\n"
+              ")\n"
+          )
+          if "from causal4d.phystwin_rollout_cache import (" not in text:
+              if import_anchor not in text:
+                  raise SystemExit("missing backend import anchor")
+              text = text.replace(import_anchor, imports, 1)
+
+          field_anchor = "    confidence_level: float = 0.90\n"
+          field_replacement = (
+              field_anchor + "    rollout_cache_dir: str | None = None\n"
+          )
+          if "rollout_cache_dir: str | None" not in text:
+              if field_anchor not in text:
+                  raise SystemExit("missing backend config field anchor")
+              text = text.replace(field_anchor, field_replacement, 1)
+
+          validation_anchor = (
+              "        if not 0.0 < self.confidence_level < 1.0:\n"
+              "            raise ValueError(\"confidence_level must lie in (0, 1)\")\n"
+          )
+          validation_replacement = validation_anchor + (
+              "        if self.rollout_cache_dir is not None and not str(\n"
+              "            self.rollout_cache_dir\n"
+              "        ).strip():\n"
+              "            raise ValueError(\"rollout_cache_dir must be nonempty\")\n"
+              "        if (\n"
+              "            self.rollout_cache_dir is not None\n"
+              "            and not self.deterministic_spring_forces\n"
+              "        ):\n"
+              "            raise ValueError(\n"
+              "                \"rollout caching requires deterministic spring forces\"\n"
+              "            )\n"
+          )
+          if "rollout caching requires deterministic spring forces" not in text:
+              if validation_anchor not in text:
+                  raise SystemExit("missing backend config validation anchor")
+              text = text.replace(validation_anchor, validation_replacement, 1)
+
+          provider_anchor = (
+              "        self.provider_manifest = "
+              "require_bayesian_phystwin_provider()\n"
+          )
+          provider_replacement = provider_anchor + (
+              "        self.graph_provider_manifest = "
+              "require_bayesian_phystwin_graph_provider()\n"
+          )
+          if "self.graph_provider_manifest =" not in text:
+              if provider_anchor not in text:
+                  raise SystemExit("missing backend provider anchor")
+              text = text.replace(provider_anchor, provider_replacement, 1)
+
+          config_anchor = "        self.config = config or OfficialPhysTwinBackendConfig()\n"
+          config_replacement = config_anchor + (
+              "        self.rollout_cache = None\n"
+              "        self.official_phystwin_revision = None\n"
+              "        self.rollout_source_artifact_sha256: dict[str, str] = {}\n"
+              "        if self.config.rollout_cache_dir is not None:\n"
+              "            self.rollout_cache = PhysTwinRolloutCache(\n"
+              "                Path(self.config.rollout_cache_dir)\n"
+              "            )\n"
+              "            self.official_phystwin_revision = require_clean_git_revision(\n"
+              "                self.official_repo\n"
+              "            )\n"
+              "            self.rollout_source_artifact_sha256 = {\n"
+              "                \"baseline_trajectory\": file_sha256(\n"
+              "                    self.baseline_trajectory_path\n"
+              "                ),\n"
+              "                \"checkpoint\": file_sha256(self.checkpoint_path),\n"
+              "                \"final_data\": file_sha256(self.final_data_path),\n"
+              "                \"optimal_params\": file_sha256(\n"
+              "                    self.optimal_params_path\n"
+              "                ),\n"
+              "                \"parameter_profile\": file_sha256(self.profile_path),\n"
+              "            }\n"
+          )
+          if "self.rollout_source_artifact_sha256" not in text:
+              if config_anchor not in text:
+                  raise SystemExit("missing backend config initialization anchor")
+              text = text.replace(config_anchor, config_replacement, 1)
+
+          manifest_method_anchor = (
+              "    def default_manifest(self) -> dict[str, Any]:\n"
+              "        return {\n"
+          )
+          manifest_method_replacement = (
+              "    def default_manifest(self) -> dict[str, Any]:\n"
+              "        graph_provider_manifest = getattr(\n"
+              "            self,\n"
+              "            \"graph_provider_manifest\",\n"
+              "            require_bayesian_phystwin_graph_provider(),\n"
+              "        )\n"
+              "        rollout_cache = getattr(self, \"rollout_cache\", None)\n"
+              "        official_revision = getattr(\n"
+              "            self, \"official_phystwin_revision\", None\n"
+              "        )\n"
+              "        source_digests = dict(\n"
+              "            getattr(self, \"rollout_source_artifact_sha256\", {})\n"
+              "        )\n"
+              "        return {\n"
+          )
+          if "graph_provider_manifest = getattr(" not in text:
+              if manifest_method_anchor not in text:
+                  raise SystemExit("missing default manifest method anchor")
+              text = text.replace(
+                  manifest_method_anchor,
+                  manifest_method_replacement,
+                  1,
+              )
+
+          provider_manifest_anchor = (
+              '            "provider": self.provider_manifest.as_dict(),\n'
+          )
+          provider_manifest_replacement = provider_manifest_anchor + (
+              '            "graph_provider": graph_provider_manifest.as_dict(),\n'
+          )
+          if '"graph_provider": graph_provider_manifest.as_dict()' not in text:
+              if provider_manifest_anchor not in text:
+                  raise SystemExit("missing default manifest provider anchor")
+              text = text.replace(
+                  provider_manifest_anchor,
+                  provider_manifest_replacement,
+                  1,
+              )
+
+          runtime_anchor = '            "runtime": asdict(self.config),\n'
+          runtime_replacement = (
+              '            "rollout_cache": {\n'
+              '                "enabled": rollout_cache is not None,\n'
+              '                "schema_version": (\n'
+              '                    PHYSTWIN_ROLLOUT_CACHE_VERSION\n'
+              '                    if rollout_cache is not None\n'
+              '                    else None\n'
+              '                ),\n'
+              '                "official_phystwin_revision": official_revision,\n'
+              '                "source_artifact_sha256": source_digests,\n'
+              '            },\n'
+              + runtime_anchor
+          )
+          if '"source_artifact_sha256": source_digests' not in text:
+              if runtime_anchor not in text:
+                  raise SystemExit("missing default manifest runtime anchor")
+              text = text.replace(runtime_anchor, runtime_replacement, 1)
+
+          counter_anchor = "        shift_diagnostics: dict[str, Any] = {}\n"
+          counter_replacement = counter_anchor + (
+              "        rollout_cache_hits = 0\n"
+              "        rollout_cache_misses = 0\n"
+              "        rollout_cache_writes = 0\n"
+              "        rollout_cache_ids: list[str] = []\n"
+          )
+          if "rollout_cache_hits = 0" not in text:
+              if counter_anchor not in text:
+                  raise SystemExit("missing rollout counter anchor")
+              text = text.replace(counter_anchor, counter_replacement, 1)
+
+          replay_anchor = (
+              "                        replay_provider.set_group_log_scales(group_scales)\n"
+              "                        future = replay_provider.replay_restart(\n"
+              "                            twin_belief.endpoint_position_m[particle_index].copy(),\n"
+              "                            twin_belief.endpoint_velocity_mps[particle_index].copy(),\n"
+              "                            start_frame=self.train_end_frame,\n"
+              "                            stop_frame=self.frame_count,\n"
+              "                        )\n"
+          )
+          replay_replacement = (
+              "                        replay_provider.set_group_log_scales(group_scales)\n"
+              "                        endpoint_position = twin_belief.endpoint_position_m[\n"
+              "                            particle_index\n"
+              "                        ].copy()\n"
+              "                        endpoint_velocity = twin_belief.endpoint_velocity_mps[\n"
+              "                            particle_index\n"
+              "                        ].copy()\n"
+              "                        expected_future_shape = (\n"
+              "                            self.frame_count - self.train_end_frame,\n"
+              "                            self.baseline.shape[1],\n"
+              "                            3,\n"
+              "                        )\n"
+              "                        future = None\n"
+              "                        cache_key = None\n"
+              "                        if self.rollout_cache is not None:\n"
+              "                            if self.official_phystwin_revision is None:\n"
+              "                                raise RuntimeError(\n"
+              "                                    \"cache-enabled backend has no PhysTwin revision\"\n"
+              "                                )\n"
+              "                            cache_key = build_phystwin_rollout_cache_key(\n"
+              "                                replay_provider_manifest_id=(\n"
+              "                                    self.provider_manifest.manifest_id\n"
+              "                                ),\n"
+              "                                graph_provider_manifest_id=(\n"
+              "                                    self.graph_provider_manifest.manifest_id\n"
+              "                                ),\n"
+              "                                official_phystwin_revision=(\n"
+              "                                    self.official_phystwin_revision\n"
+              "                                ),\n"
+              "                                source_artifact_sha256=(\n"
+              "                                    self.rollout_source_artifact_sha256\n"
+              "                                ),\n"
+              "                                graph_vertices=variant.graph.vertices,\n"
+              "                                graph_springs=variant.graph.springs,\n"
+              "                                graph_rest_lengths=variant.graph.rest_lengths,\n"
+              "                                graph_masses=variant.graph.masses,\n"
+              "                                graph_num_object_springs=(\n"
+              "                                    variant.graph.num_object_springs\n"
+              "                                ),\n"
+              "                                graph_num_object_points=(\n"
+              "                                    variant.graph.num_object_points\n"
+              "                                ),\n"
+              "                                controller_points=controls,\n"
+              "                                endpoint_position=endpoint_position,\n"
+              "                                endpoint_velocity=endpoint_velocity,\n"
+              "                                group_log_scales=group_scales,\n"
+              "                                start_frame=self.train_end_frame,\n"
+              "                                stop_frame=self.frame_count,\n"
+              "                                runtime={\n"
+              "                                    \"deterministic_spring_forces\": (\n"
+              "                                        self.config.deterministic_spring_forces\n"
+              "                                    ),\n"
+              "                                    \"device\": self.config.device,\n"
+              "                                    \"dt\": self.config.dt,\n"
+              "                                    \"num_substeps\": self.config.num_substeps,\n"
+              "                                    \"self_collision\": bool(self_collision),\n"
+              "                                    \"spring_parameterization\": \"grouped\",\n"
+              "                                },\n"
+              "                            )\n"
+              "                            rollout_cache_ids.append(cache_key.cache_id)\n"
+              "                            future = self.rollout_cache.load(\n"
+              "                                cache_key,\n"
+              "                                expected_shape=expected_future_shape,\n"
+              "                            )\n"
+              "                            if future is None:\n"
+              "                                rollout_cache_misses += 1\n"
+              "                            else:\n"
+              "                                rollout_cache_hits += 1\n"
+              "                        if future is None:\n"
+              "                            future = replay_provider.replay_restart(\n"
+              "                                endpoint_position,\n"
+              "                                endpoint_velocity,\n"
+              "                                start_frame=self.train_end_frame,\n"
+              "                                stop_frame=self.frame_count,\n"
+              "                            )\n"
+              "                            if self.rollout_cache is not None:\n"
+              "                                if cache_key is None:\n"
+              "                                    raise RuntimeError(\n"
+              "                                        \"cache key was not built for a cache miss\"\n"
+              "                                    )\n"
+              "                                self.rollout_cache.store(\n"
+              "                                    cache_key,\n"
+              "                                    future,\n"
+              "                                    expected_shape=expected_future_shape,\n"
+              "                                )\n"
+              "                                rollout_cache_writes += 1\n"
+          )
+          if "build_phystwin_rollout_cache_key(" not in text:
+              if replay_anchor not in text:
+                  raise SystemExit("missing replay restart anchor")
+              text = text.replace(replay_anchor, replay_replacement, 1)
+
+          return_anchor = "        return bank, manifest\n"
+          return_replacement = (
+              "        manifest[\"rollout_cache\"] = {\n"
+              "            \"enabled\": self.rollout_cache is not None,\n"
+              "            \"schema_version\": (\n"
+              "                PHYSTWIN_ROLLOUT_CACHE_VERSION\n"
+              "                if self.rollout_cache is not None\n"
+              "                else None\n"
+              "            ),\n"
+              "            \"hits\": rollout_cache_hits,\n"
+              "            \"misses\": rollout_cache_misses,\n"
+              "            \"writes\": rollout_cache_writes,\n"
+              "            \"cache_ids\": sorted(set(rollout_cache_ids)),\n"
+              "            \"official_phystwin_revision\": (\n"
+              "                self.official_phystwin_revision\n"
+              "            ),\n"
+              "            \"source_artifact_sha256\": dict(\n"
+              "                self.rollout_source_artifact_sha256\n"
+              "            ),\n"
+              "        }\n"
+              + return_anchor
+          )
+          if '"cache_ids": sorted(set(rollout_cache_ids))' not in text:
+              if return_anchor not in text:
+                  raise SystemExit("missing rollout manifest return anchor")
+              text = text.replace(return_anchor, return_replacement, 1)
+
+          backend.write_text(text, encoding="utf-8")
+
+          for relative in (
+              "src/causal4d/cli/phystwin_rollout_bank.py",
+              "src/causal4d/cli/counterfactual_phystwin.py",
+          ):
+              path = Path(relative)
+              text = path.read_text(encoding="utf-8")
+              device_anchor = '    parser.add_argument("--device", default="cuda:0")\n'
+              cache_argument = (
+                  device_anchor
+                  + '    parser.add_argument("--rollout-cache-dir")\n'
+              )
+              if 'parser.add_argument("--rollout-cache-dir")' not in text:
+                  if device_anchor not in text:
+                      raise SystemExit(f"missing cache CLI argument anchor in {path}")
+                  text = text.replace(device_anchor, cache_argument, 1)
+              config_device_anchor = "            device=args.device,\n"
+              config_cache = config_device_anchor + (
+                  "            rollout_cache_dir=args.rollout_cache_dir,\n"
+              )
+              if "rollout_cache_dir=args.rollout_cache_dir" not in text:
+                  if config_device_anchor not in text:
+                      raise SystemExit(f"missing cache config anchor in {path}")
+                  text = text.replace(config_device_anchor, config_cache, 1)
+              path.write_text(text, encoding="utf-8")
+
+          integration_runner = Path("scripts/ci/run_bpt_integration_tests.py")
+          runner_text = integration_runner.read_text(encoding="utf-8")
+          runner_anchor = '    "tests/test_causal4d_phystwin_backend.py",\n'
+          runner_replacement = runner_anchor + (
+              '    "tests/test_bpt_graph_provider_integration.py",\n'
+          )
+          if "tests/test_bpt_graph_provider_integration.py" not in runner_text:
+              if runner_anchor not in runner_text:
+                  raise SystemExit("missing BPT integration test-list anchor")
+              integration_runner.write_text(
+                  runner_text.replace(runner_anchor, runner_replacement, 1),
+                  encoding="utf-8",
+              )
+
+          for transient in (
+              Path(".github/workflows/agent-bpt-graph-provider-migration.yml"),
+              Path(".github/workflows/agent-phystwin-rollout-cache.yml"),
+          ):
+              transient.unlink(missing_ok=True)
+          PY
+      - name: Validate cache and lightweight boundaries
+        run: |
+          python -m pip install -e ".[dev]"
+          python -m ruff check \
+            src/causal4d/graph_provider_contract.py \
+            src/causal4d/phystwin_rollout_cache.py \
+            src/causal4d/cli/phystwin_rollout_bank.py \
+            src/causal4d/cli/counterfactual_phystwin.py \
+            tests/test_graph_provider_contract.py \
+            tests/test_bpt_graph_provider_import_boundary.py \
+            tests/test_phystwin_rollout_cache.py \
+            tests/test_phystwin_rollout_cache_cli.py
+          python -m pytest -q \
+            tests/test_graph_provider_contract.py \
+            tests/test_bpt_graph_provider_import_boundary.py \
+            tests/test_phystwin_rollout_cache.py \
+            tests/test_phystwin_rollout_cache_cli.py
+          python -m compileall -q src scripts
+      - name: Commit integrated cache
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Cache official PhysTwin restart rollouts"
+          git push origin HEAD:agent/phystwin-rollout-cache

--- a/docs/phystwin_rollout_cache.md
+++ b/docs/phystwin_rollout_cache.md
@@ -1,0 +1,71 @@
+# Content-addressed PhysTwin rollout cache
+
+Causal4D can optionally cache each expensive official-PhysTwin restart rollout
+before assembling a `JointRolloutBank`. The cache is disabled by default and
+does not alter frozen commands or numerical semantics.
+
+## Enabling the cache
+
+The rollout-bank and counterfactual PhysTwin commands accept an explicit cache
+directory:
+
+```bash
+causal4d-phystwin-rollout-bank \
+  /path/to/PhysTwin /path/to/case profile.npz checkpoint.pt bank.npz \
+  --rollout-cache-dir /scratch/causal4d-phystwin-cache
+
+causal4d-counterfactual-phystwin \
+  /path/to/PhysTwin /path/to/case profile.npz checkpoint.pt \
+  twin_belief.npz factual_intervention.npz physical_posterior.npz \
+  --rollout-cache-dir /scratch/causal4d-phystwin-cache
+```
+
+A cache hit skips one `replay_restart()` call. A cache miss runs the provider,
+atomically writes the complete trajectory, reloads it, and verifies the stored
+content before the rollout bank consumes it.
+
+## Cache identity
+
+One version-1 cache key covers:
+
+- the replay-provider and graph-provider manifest IDs;
+- the exact clean official PhysTwin Git revision;
+- SHA-256 digests of `final_data.pkl`, `optimal_params.pkl`, the checkpoint,
+  released baseline trajectory, and Bayesian-PhysTwin parameter profile;
+- every spring-graph array and object-boundary count;
+- the transformed controller trajectory;
+- particle-specific endpoint position and velocity;
+- grouped spring log-scales;
+- the restart frame interval; and
+- timestep, substeps, collision, force determinism, parameterization, and device.
+
+Array digests bind dtype and shape as well as bytes. Cache records contain their
+canonical descriptor, content address, trajectory dtype/shape, and trajectory
+digest. Loading fails closed on missing fields, descriptor drift, digest drift,
+shape drift, or nonfinite values.
+
+## Reproducibility restrictions
+
+Caching requires:
+
+- deterministic spring forces;
+- a clean official PhysTwin Git checkout with an exact 40-character revision;
+- finite, validated rollout inputs; and
+- the same provider manifests and runtime configuration.
+
+A dirty or non-Git PhysTwin checkout is rejected rather than assigned an
+ambiguous cache identity. Cache paths are execution infrastructure and are not
+part of the scientific result identity; the rollout manifest records whether
+the cache was enabled plus hit/miss/write counts and the content IDs used.
+
+## Concurrency and recovery
+
+Entries are written through a temporary file in the target shard and published
+atomically only after the NPZ payload is complete. Existing entries are verified
+before reuse, so interrupted jobs leave no partially readable target. Re-running
+a failed bank assembly reuses all completed per-rollout records and computes
+only the missing hypotheses and parameter particles.
+
+The cache stores provider outputs, not posterior decisions. Reweighting,
+intervention abduction, discrepancy handling, and final bank assembly remain
+outside the cache and continue to bind their own artifacts and manifests.

--- a/src/causal4d/phystwin_rollout_cache.py
+++ b/src/causal4d/phystwin_rollout_cache.py
@@ -1,0 +1,340 @@
+"""Content-addressed, fail-closed cache for expensive PhysTwin restart rollouts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+from causal4d.contracts import array_sha256
+
+PHYSTWIN_ROLLOUT_CACHE_SCHEMA = "causal4d.phystwin_rollout_cache"
+PHYSTWIN_ROLLOUT_CACHE_VERSION = 1
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    try:
+        return json.dumps(
+            dict(value),
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as error:
+        raise ValueError("cache metadata must contain finite JSON values") from error
+
+
+def _is_digest(value: object, *, length: int) -> bool:
+    return isinstance(value, str) and len(value) == length and all(
+        character in "0123456789abcdef" for character in value
+    )
+
+
+def _require_digest(value: object, *, name: str, length: int = 64) -> str:
+    if not _is_digest(value, length=length):
+        raise ValueError(f"{name} must be a lowercase {length}-hex digest")
+    return str(value)
+
+
+def file_sha256(path: str | Path) -> str:
+    """Hash a source artifact without loading it fully into memory."""
+
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def require_clean_git_revision(repository: str | Path) -> str:
+    """Return an exact revision and reject dirty or non-Git upstream checkouts."""
+
+    root = Path(repository).resolve()
+    try:
+        revision = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        status = subprocess.run(
+            ["git", "-C", str(root), "status", "--porcelain=v1", "--untracked-files=all"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise ValueError(
+            "rollout caching requires a readable official PhysTwin Git checkout"
+        ) from error
+    _require_digest(revision, name="official PhysTwin revision", length=40)
+    if status.strip():
+        raise ValueError(
+            "rollout caching requires a clean official PhysTwin checkout"
+        )
+    return revision
+
+
+@dataclass(frozen=True)
+class PhysTwinRolloutCacheKeyV1:
+    """Complete deterministic identity of one provider restart rollout."""
+
+    replay_provider_manifest_id: str
+    graph_provider_manifest_id: str
+    official_phystwin_revision: str
+    source_artifact_sha256: Mapping[str, str]
+    graph_vertices_sha256: str
+    graph_springs_sha256: str
+    graph_rest_lengths_sha256: str
+    graph_masses_sha256: str
+    graph_num_object_springs: int
+    graph_num_object_points: int
+    controller_points_sha256: str
+    endpoint_position_sha256: str
+    endpoint_velocity_sha256: str
+    group_log_scales_sha256: str
+    start_frame: int
+    stop_frame: int
+    runtime: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        _require_digest(
+            self.replay_provider_manifest_id,
+            name="replay provider manifest id",
+        )
+        _require_digest(
+            self.graph_provider_manifest_id,
+            name="graph provider manifest id",
+        )
+        _require_digest(
+            self.official_phystwin_revision,
+            name="official PhysTwin revision",
+            length=40,
+        )
+        sources = {str(name): str(value) for name, value in self.source_artifact_sha256.items()}
+        if not sources or any(not name for name in sources):
+            raise ValueError("source artifact digests must be named and nonempty")
+        for name, value in sources.items():
+            _require_digest(value, name=f"source artifact {name}")
+        for name, value in (
+            ("graph vertices", self.graph_vertices_sha256),
+            ("graph springs", self.graph_springs_sha256),
+            ("graph rest lengths", self.graph_rest_lengths_sha256),
+            ("graph masses", self.graph_masses_sha256),
+            ("controller points", self.controller_points_sha256),
+            ("endpoint position", self.endpoint_position_sha256),
+            ("endpoint velocity", self.endpoint_velocity_sha256),
+            ("group log scales", self.group_log_scales_sha256),
+        ):
+            _require_digest(value, name=name)
+        if self.graph_num_object_springs < 0 or self.graph_num_object_points < 1:
+            raise ValueError("graph counts are invalid")
+        if not 0 <= self.start_frame < self.stop_frame:
+            raise ValueError("rollout frame interval must be nonempty")
+        runtime = json.loads(_canonical_json(self.runtime))
+        object.__setattr__(self, "source_artifact_sha256", dict(sorted(sources.items())))
+        object.__setattr__(self, "runtime", runtime)
+
+    def descriptor(self) -> dict[str, Any]:
+        return {
+            "schema_name": PHYSTWIN_ROLLOUT_CACHE_SCHEMA,
+            "schema_version": PHYSTWIN_ROLLOUT_CACHE_VERSION,
+            "replay_provider_manifest_id": self.replay_provider_manifest_id,
+            "graph_provider_manifest_id": self.graph_provider_manifest_id,
+            "official_phystwin_revision": self.official_phystwin_revision,
+            "source_artifact_sha256": dict(self.source_artifact_sha256),
+            "graph": {
+                "vertices_sha256": self.graph_vertices_sha256,
+                "springs_sha256": self.graph_springs_sha256,
+                "rest_lengths_sha256": self.graph_rest_lengths_sha256,
+                "masses_sha256": self.graph_masses_sha256,
+                "num_object_springs": self.graph_num_object_springs,
+                "num_object_points": self.graph_num_object_points,
+            },
+            "controller_points_sha256": self.controller_points_sha256,
+            "endpoint_position_sha256": self.endpoint_position_sha256,
+            "endpoint_velocity_sha256": self.endpoint_velocity_sha256,
+            "group_log_scales_sha256": self.group_log_scales_sha256,
+            "start_frame": self.start_frame,
+            "stop_frame": self.stop_frame,
+            "runtime": dict(self.runtime),
+        }
+
+    @property
+    def cache_id(self) -> str:
+        return hashlib.sha256(_canonical_json(self.descriptor())).hexdigest()
+
+
+def build_phystwin_rollout_cache_key(
+    *,
+    replay_provider_manifest_id: str,
+    graph_provider_manifest_id: str,
+    official_phystwin_revision: str,
+    source_artifact_sha256: Mapping[str, str],
+    graph_vertices: np.ndarray,
+    graph_springs: np.ndarray,
+    graph_rest_lengths: np.ndarray,
+    graph_masses: np.ndarray,
+    graph_num_object_springs: int,
+    graph_num_object_points: int,
+    controller_points: np.ndarray,
+    endpoint_position: np.ndarray,
+    endpoint_velocity: np.ndarray,
+    group_log_scales: np.ndarray,
+    start_frame: int,
+    stop_frame: int,
+    runtime: Mapping[str, Any],
+) -> PhysTwinRolloutCacheKeyV1:
+    """Build a cache key from every input that can alter a restart rollout."""
+
+    return PhysTwinRolloutCacheKeyV1(
+        replay_provider_manifest_id=replay_provider_manifest_id,
+        graph_provider_manifest_id=graph_provider_manifest_id,
+        official_phystwin_revision=official_phystwin_revision,
+        source_artifact_sha256=source_artifact_sha256,
+        graph_vertices_sha256=array_sha256(graph_vertices),
+        graph_springs_sha256=array_sha256(graph_springs),
+        graph_rest_lengths_sha256=array_sha256(graph_rest_lengths),
+        graph_masses_sha256=array_sha256(graph_masses),
+        graph_num_object_springs=int(graph_num_object_springs),
+        graph_num_object_points=int(graph_num_object_points),
+        controller_points_sha256=array_sha256(controller_points),
+        endpoint_position_sha256=array_sha256(endpoint_position),
+        endpoint_velocity_sha256=array_sha256(endpoint_velocity),
+        group_log_scales_sha256=array_sha256(group_log_scales),
+        start_frame=int(start_frame),
+        stop_frame=int(stop_frame),
+        runtime=runtime,
+    )
+
+
+@dataclass(frozen=True)
+class PhysTwinRolloutCache:
+    """Atomic directory-backed store for validated restart trajectories."""
+
+    root: Path
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "root", Path(self.root).expanduser().resolve())
+
+    def path_for(self, key: PhysTwinRolloutCacheKeyV1) -> Path:
+        return self.root / key.cache_id[:2] / f"{key.cache_id}.npz"
+
+    def load(
+        self,
+        key: PhysTwinRolloutCacheKeyV1,
+        *,
+        expected_shape: Sequence[int] | None = None,
+    ) -> np.ndarray | None:
+        """Load and verify one cache entry, returning ``None`` only when absent."""
+
+        path = self.path_for(key)
+        if not path.is_file():
+            return None
+        try:
+            with np.load(path, allow_pickle=False) as archive:
+                required = {
+                    "cache_id",
+                    "descriptor_json",
+                    "trajectory",
+                    "trajectory_sha256",
+                }
+                missing = required - set(archive.files)
+                if missing:
+                    raise ValueError(f"rollout cache entry is missing {sorted(missing)}")
+                cache_id = str(archive["cache_id"].item())
+                descriptor = json.loads(str(archive["descriptor_json"].item()))
+                trajectory = np.asarray(archive["trajectory"]).copy()
+                stored_sha256 = str(archive["trajectory_sha256"].item())
+        except (OSError, ValueError, json.JSONDecodeError) as error:
+            raise ValueError(f"invalid rollout cache entry: {path}") from error
+        if cache_id != key.cache_id or descriptor != key.descriptor():
+            raise ValueError("rollout cache descriptor does not match its lookup key")
+        _require_digest(stored_sha256, name="cached trajectory")
+        if array_sha256(trajectory) != stored_sha256:
+            raise ValueError("cached trajectory digest does not match its payload")
+        if expected_shape is not None and trajectory.shape != tuple(expected_shape):
+            raise ValueError(
+                "cached trajectory shape differs from the requested rollout shape"
+            )
+        if not np.all(np.isfinite(trajectory)):
+            raise ValueError("cached trajectory contains nonfinite values")
+        trajectory.setflags(write=False)
+        return trajectory
+
+    def store(
+        self,
+        key: PhysTwinRolloutCacheKeyV1,
+        trajectory: np.ndarray,
+        *,
+        expected_shape: Sequence[int] | None = None,
+    ) -> Path:
+        """Atomically persist one verified trajectory without overwriting conflicts."""
+
+        values = np.asarray(trajectory)
+        if expected_shape is not None and values.shape != tuple(expected_shape):
+            raise ValueError("rollout trajectory has an unexpected shape")
+        if values.ndim != 3 or values.shape[-1] != 3 or not np.all(np.isfinite(values)):
+            raise ValueError("rollout trajectory must have finite shape (T, N, 3)")
+        existing = self.load(key, expected_shape=expected_shape)
+        if existing is not None:
+            if existing.dtype != values.dtype or not np.array_equal(existing, values):
+                raise ValueError("content-addressed rollout cache collision")
+            return self.path_for(key)
+
+        target = self.path_for(key)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        descriptor_json = json.dumps(
+            key.descriptor(),
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+        trajectory_sha256 = array_sha256(values)
+        temporary: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                prefix=f".{key.cache_id}.",
+                suffix=".npz",
+                dir=target.parent,
+                delete=False,
+            ) as handle:
+                temporary = Path(handle.name)
+            np.savez_compressed(
+                temporary,
+                cache_id=np.asarray(key.cache_id),
+                descriptor_json=np.asarray(descriptor_json),
+                trajectory=values,
+                trajectory_sha256=np.asarray(trajectory_sha256),
+            )
+            with temporary.open("rb") as handle:
+                os.fsync(handle.fileno())
+            os.replace(temporary, target)
+            temporary = None
+        finally:
+            if temporary is not None:
+                temporary.unlink(missing_ok=True)
+        verified = self.load(key, expected_shape=expected_shape)
+        if verified is None or verified.dtype != values.dtype or not np.array_equal(
+            verified, values
+        ):
+            raise ValueError("new rollout cache entry did not verify after writing")
+        return target
+
+
+__all__ = [
+    "PHYSTWIN_ROLLOUT_CACHE_SCHEMA",
+    "PHYSTWIN_ROLLOUT_CACHE_VERSION",
+    "PhysTwinRolloutCache",
+    "PhysTwinRolloutCacheKeyV1",
+    "build_phystwin_rollout_cache_key",
+    "file_sha256",
+    "require_clean_git_revision",
+]

--- a/tests/test_phystwin_rollout_cache.py
+++ b/tests/test_phystwin_rollout_cache.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from causal4d.phystwin_rollout_cache import (
+    PhysTwinRolloutCache,
+    build_phystwin_rollout_cache_key,
+    file_sha256,
+    require_clean_git_revision,
+)
+
+
+def _key(*, controller_offset: float = 0.0, substeps: int = 8):
+    return build_phystwin_rollout_cache_key(
+        replay_provider_manifest_id="1" * 64,
+        graph_provider_manifest_id="2" * 64,
+        official_phystwin_revision="3" * 40,
+        source_artifact_sha256={
+            "checkpoint": "4" * 64,
+            "final_data": "5" * 64,
+            "optimal_params": "6" * 64,
+            "parameter_profile": "7" * 64,
+        },
+        graph_vertices=np.asarray(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float32
+        ),
+        graph_springs=np.asarray([[0, 1]], dtype=np.int32),
+        graph_rest_lengths=np.asarray([1.0], dtype=np.float32),
+        graph_masses=np.asarray([1.0, 1.0], dtype=np.float32),
+        graph_num_object_springs=1,
+        graph_num_object_points=2,
+        controller_points=np.asarray(
+            [[[controller_offset, 0.0, 0.0]]], dtype=np.float32
+        ),
+        endpoint_position=np.zeros((2, 3), dtype=np.float32),
+        endpoint_velocity=np.zeros((2, 3), dtype=np.float32),
+        group_log_scales=np.asarray([0.1, -0.2], dtype=np.float32),
+        start_frame=4,
+        stop_frame=7,
+        runtime={
+            "deterministic_spring_forces": True,
+            "device": "cuda:0",
+            "dt": 5e-5,
+            "num_substeps": substeps,
+            "self_collision": False,
+            "spring_parameterization": "grouped",
+        },
+    )
+
+
+def test_cache_key_is_stable_and_covers_rollout_inputs() -> None:
+    first = _key()
+    second = _key()
+    assert first.cache_id == second.cache_id
+    assert first.descriptor() == second.descriptor()
+    assert _key(controller_offset=0.1).cache_id != first.cache_id
+    assert _key(substeps=9).cache_id != first.cache_id
+
+
+def test_cache_round_trip_is_atomic_validated_and_read_only(tmp_path: Path) -> None:
+    cache = PhysTwinRolloutCache(tmp_path / "cache")
+    key = _key()
+    values = np.arange(18, dtype=np.float32).reshape(3, 2, 3)
+    assert cache.load(key, expected_shape=values.shape) is None
+
+    path = cache.store(key, values, expected_shape=values.shape)
+    assert path == cache.path_for(key)
+    assert path.is_file()
+    loaded = cache.load(key, expected_shape=values.shape)
+    assert loaded is not None
+    np.testing.assert_array_equal(loaded, values)
+    assert loaded.dtype == values.dtype
+    assert not loaded.flags.writeable
+
+    assert cache.store(key, values.copy(), expected_shape=values.shape) == path
+    with pytest.raises(ValueError, match="collision"):
+        cache.store(key, values + 1.0, expected_shape=values.shape)
+
+
+def test_cache_rejects_tampering_and_shape_drift(tmp_path: Path) -> None:
+    cache = PhysTwinRolloutCache(tmp_path)
+    key = _key()
+    values = np.zeros((3, 2, 3), dtype=np.float32)
+    path = cache.store(key, values, expected_shape=values.shape)
+
+    with pytest.raises(ValueError, match="shape"):
+        cache.load(key, expected_shape=(4, 2, 3))
+
+    np.savez_compressed(
+        path,
+        cache_id=np.asarray(key.cache_id),
+        descriptor_json=np.asarray(
+            json.dumps(key.descriptor(), sort_keys=True, separators=(",", ":"))
+        ),
+        trajectory=np.ones_like(values),
+        trajectory_sha256=np.asarray("0" * 64),
+    )
+    with pytest.raises(ValueError, match="digest"):
+        cache.load(key, expected_shape=values.shape)
+
+
+def test_cache_validates_source_files_and_upstream_git_state(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"causal4d")
+    assert file_sha256(source) == hashlib.sha256(b"causal4d").hexdigest()
+
+    revision = "a" * 40
+
+    def clean_run(command, **kwargs):
+        del kwargs
+        if command[-2:] == ["rev-parse", "HEAD"]:
+            return SimpleNamespace(stdout=revision + "\n")
+        if command[-3:] == ["--porcelain=v1", "--untracked-files=all"]:
+            return SimpleNamespace(stdout="")
+        raise AssertionError(command)
+
+    monkeypatch.setattr("causal4d.phystwin_rollout_cache.subprocess.run", clean_run)
+    assert require_clean_git_revision(tmp_path) == revision
+
+    def dirty_run(command, **kwargs):
+        del kwargs
+        if command[-2:] == ["rev-parse", "HEAD"]:
+            return SimpleNamespace(stdout=revision + "\n")
+        return SimpleNamespace(stdout=" M simulator.py\n")
+
+    monkeypatch.setattr("causal4d.phystwin_rollout_cache.subprocess.run", dirty_run)
+    with pytest.raises(ValueError, match="clean"):
+        require_clean_git_revision(tmp_path)

--- a/tests/test_phystwin_rollout_cache.py
+++ b/tests/test_phystwin_rollout_cache.py
@@ -119,7 +119,7 @@ def test_cache_validates_source_files_and_upstream_git_state(
         del kwargs
         if command[-2:] == ["rev-parse", "HEAD"]:
             return SimpleNamespace(stdout=revision + "\n")
-        if command[-3:] == ["--porcelain=v1", "--untracked-files=all"]:
+        if command[-2:] == ["--porcelain=v1", "--untracked-files=all"]:
             return SimpleNamespace(stdout="")
         raise AssertionError(command)
 

--- a/tests/test_phystwin_rollout_cache_cli.py
+++ b/tests/test_phystwin_rollout_cache_cli.py
@@ -1,0 +1,34 @@
+from causal4d.cli.counterfactual_phystwin import build_parser as counterfactual_parser
+from causal4d.cli.phystwin_rollout_bank import build_parser as rollout_bank_parser
+
+
+def test_rollout_bank_accepts_explicit_cache_directory() -> None:
+    args = rollout_bank_parser().parse_args(
+        [
+            "official",
+            "case",
+            "profile.npz",
+            "checkpoint.pt",
+            "bank.npz",
+            "--rollout-cache-dir",
+            "cache",
+        ]
+    )
+    assert args.rollout_cache_dir == "cache"
+
+
+def test_counterfactual_accepts_explicit_cache_directory() -> None:
+    args = counterfactual_parser().parse_args(
+        [
+            "official",
+            "case",
+            "profile.npz",
+            "checkpoint.pt",
+            "belief.npz",
+            "factual.npz",
+            "posterior.npz",
+            "--rollout-cache-dir",
+            "cache",
+        ]
+    )
+    assert args.rollout_cache_dir == "cache"


### PR DESCRIPTION
## Summary

Add an opt-in, content-addressed cache for the expensive official-PhysTwin `replay_restart()` calls used to assemble Causal4D rollout banks.

- hash every input that can alter a rollout: replay/graph provider manifests, clean upstream PhysTwin revision, source artifacts, graph arrays, controller trajectory, particle endpoint state, spring scales, frame interval, and runtime;
- store complete restart trajectories as validated NPZ records under a sharded cache ID;
- fail closed on descriptor, digest, dtype/shape, finite-value, or upstream-cleanliness drift;
- write entries atomically and verify them after publication;
- expose `--rollout-cache-dir` on the rollout-bank and counterfactual PhysTwin commands;
- record cache schema, hits, misses, writes, cache IDs, upstream revision, and source digests in the rollout manifest;
- preserve exact uncached behavior by default.

## Reproducibility boundary

Caching is accepted only with deterministic spring forces and a clean, exact official PhysTwin Git revision. Dirty or non-Git upstream checkouts are rejected instead of receiving an ambiguous cache identity. The cache stores provider trajectories only; posterior weighting, abduction, interventions, discrepancy, and final bank assembly remain outside it.

## Validation

Unit tests cover key stability and sensitivity, source/upstream validation, atomic round trips, immutable loads, collision rejection, tamper detection, shape drift, and CLI parsing. The branch workflow wires the cache into the official backend, performs the graph-provider migration from the parent PR, runs focused Ruff/pytest/compile checks, and removes itself before committing.

## Stack

This PR is based on `agent/bpt-graph-provider-boundary` / Causal4D PR #48. After #48 merges, this PR should be retargeted to `main`; its scientific behavior remains independent and cache-disabled by default.