### PR TITLE
Fail closed when three-repository compatibility cannot run

### DIFF
--- a/.github/workflows/bayesian-phystwin-provider-compatibility.yml
+++ b/.github/workflows/bayesian-phystwin-provider-compatibility.yml
@@ -46,37 +46,69 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  credential-gate:
+    name: Require private-repository read access
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      PRIVATE_REPOSITORY_READ_TOKEN: ${{ secrets.BPT_READ_TOKEN }}
+    steps:
+      - name: Enforce private-repository credential
+        run: |
+          if [[ -z "${PRIVATE_REPOSITORY_READ_TOKEN}" ]]; then
+            echo "::error::BPT_READ_TOKEN is not configured; the required three-repository golden path cannot run."
+            {
+              echo "### Three-repository installed-wheel compatibility"
+              echo
+              echo "**Failed:** the repository secret \`BPT_READ_TOKEN\` is absent."
+              echo
+              echo "This check is not allowed to pass by skipping its private repositories."
+              echo "Configure a least-privilege token with read access to:"
+              echo
+              echo "- \`FlorianPfaff/Bayesian-PhysTwin\`;"
+              echo "- \`FlorianPfaff/Prob4D\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "Private-repository credential is configured."
+
+  external-pull-request:
+    name: External PR cannot access private providers
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Report unavailable private coverage
+        run: |
+          echo "::warning::Repository secrets are unavailable to pull requests from forks; maintainers must run the installed-wheel golden path on a trusted branch before merge."
+          {
+            echo "### Three-repository installed-wheel compatibility"
+            echo
+            echo "This pull request originates from an external fork, so GitHub does not expose private-repository credentials."
+            echo "The private golden path is intentionally marked unavailable rather than simulated with editable or public substitutes."
+            echo "A maintainer must reproduce the head on a trusted same-repository branch before merging."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   installed-wheel-golden-path:
     name: Prob4D -> BPT -> Causal4D installed wheels
+    needs: credential-gate
+    if: needs.credential-gate.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       PRIVATE_REPOSITORY_READ_TOKEN: ${{ secrets.BPT_READ_TOKEN }}
     steps:
-      - name: Detect private-repository credential
-        id: access
-        run: |
-          if [[ -n "${PRIVATE_REPOSITORY_READ_TOKEN}" ]]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::BPT_READ_TOKEN is not configured; the three-repository golden path was not exercised."
-            {
-              echo "### Three-repository installed-wheel compatibility"
-              echo
-              echo "Skipped because the repository secret \`BPT_READ_TOKEN\` is absent."
-              echo "The token must have read access to FlorianPfaff/Bayesian-PhysTwin and FlorianPfaff/Prob4D."
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
-
       - name: Check out Causal4D
-        if: steps.access.outputs.enabled == 'true'
         uses: actions/checkout@v6
         with:
           path: causal4d
 
       - name: Check out Bayesian-PhysTwin
-        if: steps.access.outputs.enabled == 'true'
         uses: actions/checkout@v6
         with:
           repository: FlorianPfaff/Bayesian-PhysTwin
@@ -85,7 +117,6 @@ jobs:
           path: bayesian-phystwin
 
       - name: Check out Prob4D
-        if: steps.access.outputs.enabled == 'true'
         uses: actions/checkout@v6
         with:
           repository: FlorianPfaff/Prob4D
@@ -94,7 +125,6 @@ jobs:
           path: prob4d
 
       - name: Set up Python
-        if: steps.access.outputs.enabled == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -105,7 +135,6 @@ jobs:
             prob4d/pyproject.toml
 
       - name: Record exact clean repository revisions
-        if: steps.access.outputs.enabled == 'true'
         id: revisions
         run: |
           for repository in prob4d bayesian-phystwin causal4d; do
@@ -116,14 +145,12 @@ jobs:
           echo "causal4d=$(git -C causal4d rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Check golden-path script quality
-        if: steps.access.outputs.enabled == 'true'
         run: |
           python -m pip install "ruff>=0.15.22,<0.17"
           python -m ruff check causal4d/ci/three_repository_*.py
           python -m ruff format --check --diff causal4d/ci/three_repository_*.py
 
       - name: Build all three wheels
-        if: steps.access.outputs.enabled == 'true'
         run: |
           python -m pip install --upgrade build pip
           wheelhouse="$RUNNER_TEMP/three-repository-wheelhouse"
@@ -134,7 +161,6 @@ jobs:
           test "$(find "$wheelhouse" -maxdepth 1 -name '*.whl' | wc -l)" -eq 3
 
       - name: Install wheels in a clean virtual environment
-        if: steps.access.outputs.enabled == 'true'
         run: |
           venv="$RUNNER_TEMP/three-repository-venv"
           wheelhouse="$RUNNER_TEMP/three-repository-wheelhouse"
@@ -148,7 +174,6 @@ jobs:
           "$venv/bin/python" -m pip check
 
       - name: Run the isolated three-repository golden path
-        if: steps.access.outputs.enabled == 'true'
         run: |
           run_dir="$RUNNER_TEMP/three-repository-run"
           mkdir -p "$run_dir"
@@ -169,7 +194,6 @@ jobs:
             | tee "$RUNNER_TEMP/three-repository-golden-path.log"
 
       - name: Run cross-repository contract tests against installed wheels
-        if: steps.access.outputs.enabled == 'true'
         env:
           CAUSAL4D_REQUIRE_BPT_PROVIDER: "1"
         run: |
@@ -191,7 +215,7 @@ jobs:
               "$GITHUB_WORKSPACE/causal4d/tests/test_prob4d_stream_contract_version.py"
 
       - name: Publish compatibility summary
-        if: steps.access.outputs.enabled == 'true' && always()
+        if: always()
         run: |
           if [[ -f "$RUNNER_TEMP/three-repository-summary.json" ]]; then
             {
@@ -204,7 +228,7 @@ jobs:
           fi
 
       - name: Upload golden-path diagnostics
-        if: steps.access.outputs.enabled == 'true' && always()
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: three-repository-installed-wheel-golden-path

--- a/ci/three_repository_provider_v2_attestation.py
+++ b/ci/three_repository_provider_v2_attestation.py
@@ -1,0 +1,218 @@
+"""Installed-wheel compatibility for the self-contained Prob4D provider-v2 contract."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Callable
+from copy import deepcopy
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+from three_repository_common import require
+from three_repository_observation import fixture_artifact
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _expect_failure(label: str, operation: Callable[[], Any]) -> dict[str, str]:
+    try:
+        operation()
+    except (RuntimeError, ValueError) as error:
+        return {
+            "label": label,
+            "error": type(error).__name__,
+            "message": str(error),
+        }
+    raise RuntimeError(f"rejection case {label!r} was incorrectly accepted")
+
+
+def _build_attested_fixture(artifact: Any, *, prob4d_revision: str) -> Any:
+    from prob4d.provider_v2 import (
+        RuntimeRevisionAttestation,
+        build_provider_attestation,
+        prob4d_provider_manifest,
+    )
+
+    runtime = RuntimeRevisionAttestation(
+        expected_revision=prob4d_revision,
+        observed_revision=prob4d_revision,
+        source="source_checkout",
+        clean_checkout=True,
+        matched=True,
+        independently_verified=True,
+    )
+    calibration_ids = {
+        "gauge_artifact_id": _digest("contract-test-gauge-calibration-v1"),
+        "point_artifact_id": _digest("contract-test-point-calibration-v1"),
+    }
+    metadata = deepcopy(dict(artifact.metadata))
+    metadata["prob4d_provider_attestation"] = build_provider_attestation(
+        provider_manifest=prob4d_provider_manifest(
+            provider_revision=prob4d_revision,
+        ),
+        provider_revision=prob4d_revision,
+        export_mode="calibrated",
+        calibration_compatibility_validated=True,
+        calibration_artifact_ids=calibration_ids,
+        covariance_root_mode="canonical_eigenspaces",
+        composition_jacobian_mode="analytic",
+        runtime_revision=runtime.as_metadata(),
+    )
+    metadata["provider_attestation_contract_test"] = {
+        "claim_evidence": False,
+        "fixture_only": True,
+        "synthetic_calibration_ids": True,
+        "purpose": (
+            "installed-wheel schema and independent consumer validation; not "
+            "prospective covariance calibration or physical-prediction evidence"
+        ),
+    }
+    return replace(
+        artifact,
+        source_revision=prob4d_revision,
+        metadata=metadata,
+    )
+
+
+def _validate_bpt(path: Path) -> dict[str, object]:
+    from bayesian_phystwin.observation_belief import load_observation_belief
+    from bayesian_phystwin.prob4d_causal_lineage import (
+        validate_claim_bearing_prob4d_observation_belief,
+    )
+
+    belief = load_observation_belief(path)
+    result = validate_claim_bearing_prob4d_observation_belief(belief)
+    provider = result.get("provider_attestation")
+    require(isinstance(provider, dict), "BPT lost the provider-attestation summary")
+    require(
+        provider.get("claim_bearing") is True, "BPT did not require calibrated mode"
+    )
+    require(
+        provider.get("runtime_revision_independently_verified") is True,
+        "BPT did not require independently verified runtime provenance",
+    )
+    return result
+
+
+def _validate_causal4d(path: Path) -> Any:
+    from causal4d.claim_bearing_observation_lineage import (
+        load_claim_bearing_prob4d_observation_lineage,
+    )
+
+    lineage = load_claim_bearing_prob4d_observation_lineage(path)
+    provider = lineage.provider_validation.get("provider_attestation")
+    require(
+        isinstance(provider, dict),
+        "Causal4D lost the provider-attestation summary",
+    )
+    require(
+        provider.get("claim_bearing") is True,
+        "Causal4D did not require calibrated mode",
+    )
+    require(
+        provider.get("runtime_revision_independently_verified") is True,
+        "Causal4D did not require independently verified runtime provenance",
+    )
+    return lineage
+
+
+def run(
+    *,
+    fixture_path: Path,
+    prob4d_revision: str,
+    output_dir: Path,
+) -> dict[str, object]:
+    from prob4d.provider_v2 import save_observation_belief_export
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    fixture, _ = fixture_artifact(fixture_path)
+    attested = _build_attested_fixture(
+        fixture,
+        prob4d_revision=prob4d_revision,
+    )
+    observation_path = output_dir / "provider-v2-observation.npz"
+    save_observation_belief_export(observation_path, attested)
+
+    bpt = _validate_bpt(observation_path)
+    causal4d = _validate_causal4d(observation_path)
+    producer = attested.metadata["prob4d_provider_attestation"]
+    producer_manifest_id = producer["provider_manifest_id"]
+    require(
+        bpt["provider_attestation"]["provider_manifest_id"] == producer_manifest_id,
+        "BPT validated a different provider manifest",
+    )
+    require(
+        causal4d.provider_validation["provider_attestation"]["provider_manifest_id"]
+        == producer_manifest_id,
+        "Causal4D validated a different provider manifest",
+    )
+
+    tampered_metadata = deepcopy(dict(attested.metadata))
+    tampered_metadata["prob4d_provider_attestation"]["provider_manifest"][
+        "provider_version"
+    ] = "tampered"
+    tampered = replace(attested, metadata=tampered_metadata)
+    tampered_path = output_dir / "rejected-provider-manifest-tamper.npz"
+    save_observation_belief_export(tampered_path, tampered)
+    rejections = [
+        _expect_failure(
+            "bpt:provider-manifest-tamper", lambda: _validate_bpt(tampered_path)
+        ),
+        _expect_failure(
+            "causal4d:provider-manifest-tamper",
+            lambda: _validate_causal4d(tampered_path),
+        ),
+    ]
+
+    return {
+        "schema": producer["schema_name"],
+        "schema_version": producer["schema_version"],
+        "prob4d_revision": prob4d_revision,
+        "observation_artifact_id": attested.artifact_id,
+        "provider_manifest_id": producer_manifest_id,
+        "export_mode": producer["export_mode"],
+        "covariance_root_mode": producer["covariance_root_mode"],
+        "composition_jacobian_mode": producer["composition_jacobian_mode"],
+        "runtime_revision": producer["runtime_revision"],
+        "bpt_provider_attestation_validated": bpt["provider_attestation_validated"],
+        "causal4d_provider_attestation_validated": (
+            causal4d.provider_validation["provider_attestation_validated"]
+        ),
+        "fixture_only": True,
+        "claim_evidence": False,
+        "rejections": rejections,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--prob4d-fixture", type=Path, required=True)
+    parser.add_argument("--prob4d-revision", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    summary = run(
+        fixture_path=args.prob4d_fixture,
+        prob4d_revision=args.prob4d_revision,
+        output_dir=args.output_dir,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -38,10 +38,16 @@ access to both private repositories:
 - `FlorianPfaff/Prob4D`.
 
 The historical secret name is retained so existing repository configuration
-does not need to change. Pinned, scheduled-main, BPT-vision, and Warp jobs report
-an explicit skipped-coverage warning when the secret is absent; they do not
-pretend provider compatibility was tested or silently substitute editable or
-public packages.
+does not need to change. Trusted same-repository pull requests, pushes,
+scheduled runs, and manual dispatches now **fail** when the secret is absent.
+The three-repository workflow is not allowed to report success after skipping
+its checkouts, wheel builds, and compatibility tests.
+
+GitHub does not expose repository secrets to pull requests from external forks.
+Those events receive a dedicated `External PR cannot access private providers`
+result explaining that private coverage is unavailable. A maintainer must
+reproduce the proposed head on a trusted same-repository branch and obtain a
+passing installed-wheel golden path before merge.
 
 ## Three-repository installed-wheel golden path
 
@@ -51,7 +57,12 @@ same-repository pull requests and pushes, can be dispatched with explicit BPT
 and Prob4D revisions, and runs weekly against both private repositories' `main`
 branches.
 
-The workflow:
+The workflow begins with a separate credential gate. For trusted events, a
+missing `BPT_READ_TOKEN` is a hard configuration failure and prevents a false
+green result. Only an external-fork pull request can use the explicitly labelled
+unavailable path, because GitHub withholds repository secrets by design.
+
+The installed-wheel job then:
 
 1. records the exact clean revision of every checkout;
 2. builds one wheel for each repository and installs only those wheels plus

--- a/tests/test_three_repository_workflow_policy.py
+++ b/tests/test_three_repository_workflow_policy.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[1]
+    / ".github"
+    / "workflows"
+    / "bayesian-phystwin-provider-compatibility.yml"
+)
+
+
+def test_trusted_events_cannot_pass_by_skipping_private_repositories() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "credential-gate:" in text
+    assert "Require private-repository read access" in text
+    assert "exit 1" in text
+    assert "needs: credential-gate" in text
+    assert "steps.access.outputs.enabled" not in text
+    assert "the required three-repository golden path cannot run" in text
+
+
+def test_external_fork_limitation_is_separate_and_explicit() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "external-pull-request:" in text
+    assert "External PR cannot access private providers" in text
+    assert "github.event.pull_request.head.repo.full_name != github.repository" in text
+    assert "maintainers must run the installed-wheel golden path" in text


### PR DESCRIPTION
## Summary

- split private-repository access into an explicit credential gate and the installed-wheel golden-path job;
- fail trusted same-repository pull requests, pushes, schedules, and manual dispatches when `BPT_READ_TOKEN` is absent;
- retain a separately labelled unavailable result only for external-fork pull requests, where GitHub deliberately withholds repository secrets;
- remove the per-step `enabled` conditions that previously allowed the workflow to finish green without checking out repositories, building wheels, or running tests;
- add an installed-wheel provider-v2 attestation path that requires Prob4D, Bayesian-PhysTwin, and Causal4D to validate the same embedded provider manifest and numerical/provenance semantics;
- verify both consumers reject a tampered embedded provider-manifest payload;
- document that the new provider-v2 fixture is contract-test-only and cannot be promoted as calibration or physical-prediction evidence;
- add regression coverage preventing restoration of the green-by-skip pattern.

## Why

The previous workflow detected a missing credential, emitted a warning, skipped every substantive step, and still completed successfully. That made a green workflow run compatible with zero private checkouts, zero wheels, and zero cross-repository tests.

A terminal compatibility check must distinguish an actually passing three-repository run from unavailable private coverage. Trusted events now fail as a repository-configuration error when the required least-privilege credential is missing. Fork pull requests remain explicitly unavailable because exposing the private token there would be unsafe.

The frozen provider-v1 fixture remains the wire-contract baseline. A second fixture-only path now exercises the self-contained provider-v2 attestation across installed wheels and proves that the two consumers independently recompute and enforce the producer manifest rather than merely storing its ID.

## Repository configuration required

Set `BPT_READ_TOKEN` to a read-only token that can access:

- `FlorianPfaff/Bayesian-PhysTwin`;
- `FlorianPfaff/Prob4D`.

Until that secret is configured, this pull request is expected to expose the existing configuration defect rather than hide it behind a successful skip.

## Validation

- ordinary Causal4D CI validates workflow policy, script quality, package tests, and documentation;
- the private compatibility workflow either runs completely or fails at the credential gate;
- once configured, it builds and installs all three wheels, runs the frozen golden path, validates the provider-v2 attestation in all three packages, executes the tamper rejection, and publishes both compatibility summaries.
