### PR TITLE
Complete the Bayesian-PhysTwin provider-only import boundary

### DIFF
--- a/docs/bayesian_phystwin_provider.md
+++ b/docs/bayesian_phystwin_provider.md
@@ -1,12 +1,18 @@
 # Bayesian-PhysTwin provider boundary
 
-Causal4D currently consumes Bayesian-PhysTwin through two versioned public
+Causal4D consumes Bayesian-PhysTwin only through explicit versioned public
 modules:
 
 - `bayesian_phystwin.causal4d_provider_v1` for the existing belief-artifact,
-  replay, and diagnostic compatibility path;
+  replay, fixed Bayesian-anchor, and diagnostic compatibility path;
+- `bayesian_phystwin.causal4d_provider_v2` for immutable request-complete replay
+  contracts used by newer integrations;
 - `bayesian_phystwin.causal4d_graph_provider_v1` for the NumPy-only spring-graph
-  value type, graph construction, and released controller grouping semantics.
+  value type, graph construction, and released controller grouping semantics;
+- `bayesian_phystwin.causal4d_artifacts_v1` for hash-locked released pickle
+  inputs and immutable raw-track correspondence;
+- `bayesian_phystwin.causal4d_public_provider_v1` for source-locked public-data
+  diagnostics that still reuse BPT experiment semantics.
 
 The graph module is explicitly parented to Bayesian-PhysTwin's immutable
 `causal4d_provider_v2` contract. This PR does not silently switch the existing
@@ -14,8 +20,9 @@ Causal4D rollout backend from replay provider v1 to v2; that replay migration is
 a separate compatibility change. Provider v1 remains necessary for frozen and
 current diagnostic paths.
 
-Production code no longer imports graph/controller implementations or
-underscore-prefixed Bayesian-PhysTwin functions and modules directly.
+Production source and scripts no longer import any unversioned
+Bayesian-PhysTwin implementation module. An AST allowlist makes new direct
+experiment imports a blocking test failure.
 
 ## Compatibility contract
 
@@ -26,7 +33,8 @@ Causal4D validates the current replay provider for:
 - provider API/schema version 1;
 - the capabilities required for artifact checksums, parameter particles,
   particle-specific endpoint state, replay, residual lifting, target validity,
-  and the migrated diagnostics;
+  the fixed Bayesian-anchor endpoint, and each migrated diagnostic capability
+  group;
 - `TwinBelief` and `GraphBelief` artifact schema version 1.
 
 The graph provider is checked separately for:
@@ -78,8 +86,11 @@ surface depends only on NumPy and can therefore be validated in core CI without
 Torch, Warp, OpenCV, or SciPy.
 
 The official rollout manifest records both the current replay-provider manifest
-and the graph-provider manifest. Frozen evidence can thus identify the exact
-replay implementation and the exact graph/controller contract independently.
+and the graph-provider manifest. Public-data studies additionally record the
+public-study provider manifest, and new Molmo query preparation requires trusted
+SHA-256 identities for both `final_data.pkl` and `calibrate.pkl`. Frozen evidence
+can thus identify the exact replay implementation, graph/controller contract,
+and legacy visual inputs independently.
 This provenance separation improves upgrade auditability; it is not an
 empirical accuracy, calibration, or causal-prediction claim.
 
@@ -98,9 +109,9 @@ CAUSAL4D_REQUIRE_BPT_PROVIDER=1 python -m pytest -q \
 Package-based installations may use `python -m pip install ".[phystwin]"`;
 the extra encodes the supported `>=0.4,<0.5` range rather than one Git commit.
 The cross-repository workflows test the current development branches against
-each other's public contracts. An AST boundary test also rejects future direct
-imports from `phystwin_graph` or `phystwin_controller_sensitivity` in production
-source and scripts.
+each other's public contracts. An AST boundary test rejects every BPT import in
+production source and scripts unless its exact module is present in the
+versioned allowlist above.
 
 ## Frozen experiments
 

--- a/scripts/remote/audit_deform360_dynamic_window_source.py
+++ b/scripts/remote/audit_deform360_dynamic_window_source.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import numpy as np
 
-from bayesian_phystwin.deform360_selective_virtual_sensing_staging import (
+from bayesian_phystwin.causal4d_public_provider_v1 import (
     closure_confidence,
     end_effector_origins,
     select_action_only_window,

--- a/scripts/remote/evaluate_deform360_dynamic_window_source_case.py
+++ b/scripts/remote/evaluate_deform360_dynamic_window_source_case.py
@@ -22,27 +22,27 @@ from bayesian_phystwin.causal4d_provider_v1 import (
     measurement_target_audit,
     sha256_file,
 )
-from bayesian_phystwin.deform360_raw_camera_observation import (
+from bayesian_phystwin.causal4d_public_provider_v1 import (
     MANIFEST_FILENAME,
     MEASUREMENT_FILENAME,
 )
-from bayesian_phystwin.deform360_selective_virtual_sensing_artifacts import (
+from bayesian_phystwin.causal4d_public_provider_v1 import (
     VIRTUAL_SENSING_ARCHIVE_FILENAME,
     VIRTUAL_SENSING_REPORT_FILENAME,
     VIRTUAL_SENSING_SEAL_FILENAME,
     selective_case_records,
     validate_selective_prediction_seal,
 )
-from bayesian_phystwin.deform360_selective_virtual_sensing_evaluation import (
+from bayesian_phystwin.causal4d_public_provider_v1 import (
     ARM_TO_ARCHIVE_KEY,
     SCORED_FRAMES,
     score_selective_virtual_sensing_arrays,
 )
-from bayesian_phystwin.deform360_selective_virtual_sensing_protocol import (
+from bayesian_phystwin.causal4d_public_provider_v1 import (
     PROTOCOL_ID,
     load_selective_virtual_sensing_protocol,
 )
-from bayesian_phystwin.deform360_selective_virtual_sensing_staging import (
+from bayesian_phystwin.causal4d_public_provider_v1 import (
     dynamic_window_source_case,
 )
 from deform360.robot import RobotState, load_robot_state, save_robot_state
@@ -377,7 +377,9 @@ def _stage_source_future(
                 "prediction_archive": sha256_file(prediction_archive),
                 "prediction_prefix_manifest": sha256_file(prefix_manifest_path),
                 "source_preparation_manifest": sha256_file(source_manifest_path),
-                "frame_zero_reconstruction_manifest": sha256_file(frame_zero_manifest_path),
+                "frame_zero_reconstruction_manifest": sha256_file(
+                    frame_zero_manifest_path
+                ),
                 "generic_selector_source": sha256_file(generic_selector_source),
                 "sam2_checkpoint": sha256_file(sam2_checkpoint),
             },
@@ -680,8 +682,12 @@ def main() -> int:
                 "prediction_seal": sha256_file(prediction_seal_path),
                 "prediction_archive": sha256_file(prediction_archive),
                 "prediction_report": sha256_file(prediction_report_path),
-                "measurement_manifest": sha256_file(measurement_dir / MANIFEST_FILENAME),
-                "measurement_archive": sha256_file(measurement_dir / MEASUREMENT_FILENAME),
+                "measurement_manifest": sha256_file(
+                    measurement_dir / MANIFEST_FILENAME
+                ),
+                "measurement_archive": sha256_file(
+                    measurement_dir / MEASUREMENT_FILENAME
+                ),
                 "source_future_manifest": sha256_file(
                     work_case / SOURCE_FUTURE_MANIFEST_FILENAME
                 ),

--- a/scripts/remote/stage_deform360_dynamic_window_source_prefix.py
+++ b/scripts/remote/stage_deform360_dynamic_window_source_prefix.py
@@ -12,7 +12,7 @@ from types import ModuleType
 from typing import Any
 
 from bayesian_phystwin.causal4d_provider_v1 import sha256_file
-from bayesian_phystwin.deform360_selective_virtual_sensing_staging import (
+from bayesian_phystwin.causal4d_public_provider_v1 import (
     dynamic_window_source_case,
 )
 

--- a/src/causal4d/bpt_belief.py
+++ b/src/causal4d/bpt_belief.py
@@ -7,14 +7,14 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from bayesian_phystwin.phystwin_additional_bayesian_confirmation import (
+from bayesian_phystwin.causal4d_provider_v1 import (
     FIXED_INITIAL_STD_M,
     FIXED_INLIER_PRIOR,
     FIXED_OBSERVATION_STD_M,
     FIXED_OUTLIER_VARIANCE_MULTIPLIER,
     FIXED_PROCESS_STD_M,
 )
-from bayesian_phystwin.phystwin_bayesian_anchor import robust_random_walk_endpoint
+from bayesian_phystwin.causal4d_provider_v1 import robust_random_walk_endpoint
 from bayesian_phystwin.causal4d_provider_v1 import (
     PhysTwinReplayProvider,
     build_lift_map,

--- a/src/causal4d/cli/molmo_phystwin_forecast.py
+++ b/src/causal4d/cli/molmo_phystwin_forecast.py
@@ -39,6 +39,16 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("checkpoint")
     parser.add_argument("output_npz")
     parser.add_argument("--train-end-frame", type=int, required=True)
+    parser.add_argument(
+        "--final-data-sha256",
+        required=True,
+        help="trusted digest for the released final_data pickle",
+    )
+    parser.add_argument(
+        "--calibration-sha256",
+        required=True,
+        help="trusted digest for raw_case_dir/calibrate.pkl",
+    )
     parser.add_argument("--history-size", type=int, default=3)
     parser.add_argument("--future-horizon", type=int, default=30)
     parser.add_argument(
@@ -67,6 +77,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     query = prepare_molmo_phystwin_query(
         args.final_data,
         args.raw_case_dir,
+        final_data_sha256=args.final_data_sha256,
+        calibration_sha256=args.calibration_sha256,
         train_end_frame=args.train_end_frame,
         history_size=args.history_size,
         point_count=8,

--- a/src/causal4d/molmo_adapter.py
+++ b/src/causal4d/molmo_adapter.py
@@ -3,14 +3,31 @@
 from __future__ import annotations
 
 import json
-import pickle
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping
 
 import numpy as np
 
-from bayesian_phystwin.phystwin_raw_cues import load_phystwin_raw_track_map
+
+def load_trusted_legacy_phystwin_pickle(*args: Any, **kwargs: Any) -> Any:
+    """Load a hash-locked legacy artifact without importing BPT at module import."""
+
+    from bayesian_phystwin.causal4d_artifacts_v1 import (
+        load_trusted_legacy_phystwin_pickle as provider_loader,
+    )
+
+    return provider_loader(*args, **kwargs)
+
+
+def load_released_phystwin_raw_track_map(*args: Any, **kwargs: Any) -> Any:
+    """Load the immutable raw-track map through the versioned artifact boundary."""
+
+    from bayesian_phystwin.causal4d_artifacts_v1 import (
+        load_released_phystwin_raw_track_map as provider_loader,
+    )
+
+    return provider_loader(*args, **kwargs)
 
 
 def farthest_point_indices(points: np.ndarray, count: int) -> np.ndarray:
@@ -55,6 +72,8 @@ class MolmoPhysTwinQuery:
     source_fps: float
     forecast_fps: float
     frame_stride: int
+    final_data_sha256: str | None = None
+    calibration_sha256: str | None = None
 
     def __post_init__(self) -> None:
         history = np.asarray(self.history_frame_indices, dtype=int)
@@ -94,6 +113,16 @@ class MolmoPhysTwinQuery:
             raise ValueError("frame stride must match source_fps / forecast_fps")
         if np.any(nodes < 0) or np.any(raw_tracks < 0):
             raise ValueError("track indices must be nonnegative")
+        for name, digest in (
+            ("final_data_sha256", self.final_data_sha256),
+            ("calibration_sha256", self.calibration_sha256),
+        ):
+            if digest is None:
+                continue
+            if len(digest) != 64 or any(
+                character not in "0123456789abcdef" for character in digest
+            ):
+                raise ValueError(f"{name} must be a lowercase SHA-256 digest")
         for path in self.image_paths:
             if not Path(path).is_file():
                 raise FileNotFoundError(path)
@@ -122,6 +151,8 @@ class MolmoPhysTwinQuery:
             "source_fps": self.source_fps,
             "forecast_fps": self.forecast_fps,
             "frame_stride": self.frame_stride,
+            "final_data_sha256": self.final_data_sha256,
+            "calibration_sha256": self.calibration_sha256,
             "point_coordinate_contract": "raw row/column tracks converted to x/y pixels",
             "trajectory_coordinate_contract": "metric world coordinates",
             "temporal_contract": "history and future sampled at forecast_fps",
@@ -132,6 +163,8 @@ def prepare_molmo_phystwin_query(
     final_data_path: str | Path,
     raw_case_dir: str | Path,
     *,
+    final_data_sha256: str,
+    calibration_sha256: str,
     train_end_frame: int,
     history_size: int = 3,
     point_count: int = 8,
@@ -142,8 +175,16 @@ def prepare_molmo_phystwin_query(
 
     final_path = Path(final_data_path)
     raw_path = Path(raw_case_dir)
-    with final_path.open("rb") as handle:
-        final_data = pickle.load(handle)
+    final_data = load_trusted_legacy_phystwin_pickle(
+        final_path,
+        expected_sha256=final_data_sha256,
+        artifact_kind="mapping",
+        required_keys=(
+            "object_points",
+            "object_visibilities",
+            "object_motions_valid",
+        ),
+    )
     object_points = np.asarray(final_data["object_points"], dtype=float)
     visible = np.asarray(final_data["object_visibilities"], dtype=bool)
     motion_valid = np.asarray(final_data["object_motions_valid"], dtype=bool)
@@ -171,13 +212,27 @@ def prepare_molmo_phystwin_query(
     )
     if history_frames[0] < 0:
         raise ValueError("train_end_frame cannot provide the requested sampled history")
-    mapping = load_phystwin_raw_track_map(final_path, raw_path)
+    mapping = load_released_phystwin_raw_track_map(
+        final_path,
+        raw_path,
+        final_data_sha256=final_data_sha256,
+    )
     intrinsics = np.asarray(metadata["intrinsics"], dtype=float)
     width, height = map(int, metadata["WH"])
-    with (raw_path / "calibrate.pkl").open("rb") as handle:
-        camera_to_world = np.asarray(pickle.load(handle), dtype=float)
+    camera_to_world = np.asarray(
+        load_trusted_legacy_phystwin_pickle(
+            raw_path / "calibrate.pkl",
+            expected_sha256=calibration_sha256,
+            artifact_kind="ndarray",
+        ),
+        dtype=float,
+    )
     camera_count = len(mapping.track_paths)
-    if intrinsics.shape != (camera_count, 3, 3) or camera_to_world.shape != (camera_count, 4, 4):
+    if intrinsics.shape != (camera_count, 3, 3) or camera_to_world.shape != (
+        camera_count,
+        4,
+        4,
+    ):
         raise ValueError("raw camera calibration does not match the track archives")
 
     candidates_by_camera: list[np.ndarray] = []
@@ -187,16 +242,13 @@ def prepare_molmo_phystwin_query(
         raw_visibility = mapping.visibility_by_camera[camera][
             history_frames[:, None], raw_ids[None]
         ]
-        raw_tracks = mapping.tracks_by_camera[camera][history_frames[:, None], raw_ids[None]]
+        raw_tracks = mapping.tracks_by_camera[camera][
+            history_frames[:, None], raw_ids[None]
+        ]
         # Released archives use row/column coordinates, as required by the pcd lookup.
         row = raw_tracks[..., 0]
         column = raw_tracks[..., 1]
-        in_bounds = (
-            (row >= 0.0)
-            & (row < height)
-            & (column >= 0.0)
-            & (column < width)
-        )
+        in_bounds = (row >= 0.0) & (row < height) & (column >= 0.0) & (column < width)
         processed_valid = np.all(
             visible[history_frames] & motion_valid[history_frames], axis=0
         )
@@ -223,7 +275,9 @@ def prepare_molmo_phystwin_query(
     raw_ids = mapping.source_track[nodes]
     raw_row_column = mapping.tracks_by_camera[camera][t0, raw_ids]
     points_xy = raw_row_column[:, [1, 0]]
-    image_paths = tuple(raw_path / "color" / str(camera) / f"{frame}.png" for frame in history_frames)
+    image_paths = tuple(
+        raw_path / "color" / str(camera) / f"{frame}.png" for frame in history_frames
+    )
     return MolmoPhysTwinQuery(
         case_name=final_path.resolve().parent.name,
         raw_case_dir=raw_path,
@@ -240,10 +294,14 @@ def prepare_molmo_phystwin_query(
         source_fps=source_fps,
         forecast_fps=float(forecast_fps),
         frame_stride=frame_stride,
+        final_data_sha256=final_data_sha256,
+        calibration_sha256=calibration_sha256,
     )
 
 
-def camera_to_world_points(points_camera_m: np.ndarray, camera_to_world: np.ndarray) -> np.ndarray:
+def camera_to_world_points(
+    points_camera_m: np.ndarray, camera_to_world: np.ndarray
+) -> np.ndarray:
     points = np.asarray(points_camera_m, dtype=float)
     transform = np.asarray(camera_to_world, dtype=float)
     if points.ndim < 2 or points.shape[-1] != 3 or transform.shape != (4, 4):
@@ -268,11 +326,17 @@ class MolmoForecastBundle:
         camera = np.asarray(self.future_camera_m, dtype=float)
         world = np.asarray(self.future_world_m, dtype=float)
         expected_prefix = (len(self.forecast_ids), len(self.query.node_indices))
-        if camera.ndim != 4 or camera.shape[:2] != expected_prefix or camera.shape[3] != 3:
+        if (
+            camera.ndim != 4
+            or camera.shape[:2] != expected_prefix
+            or camera.shape[3] != 3
+        ):
             raise ValueError("future_camera_m must have shape (K, P, F, 3)")
         if world.shape != camera.shape:
             raise ValueError("world and camera forecasts must have matching shapes")
-        if len(self.captions) != len(self.forecast_ids) or len(self.raw_text) != len(self.forecast_ids):
+        if len(self.captions) != len(self.forecast_ids) or len(self.raw_text) != len(
+            self.forecast_ids
+        ):
             raise ValueError("forecast metadata must match forecast_ids")
         if len(set(self.forecast_ids)) != len(self.forecast_ids):
             raise ValueError("forecast_ids must be unique")
@@ -310,7 +374,9 @@ def run_molmo_motion_forecasts(
 ) -> MolmoForecastBundle:
     """Load the released checkpoint once and forecast every language control."""
 
-    if not captions or any(not key or not value.strip() for key, value in captions.items()):
+    if not captions or any(
+        not key or not value.strip() for key, value in captions.items()
+    ):
         raise ValueError("captions must map nonempty ids to nonempty text")
     if future_horizon < 1:
         raise ValueError("future_horizon must be positive")
@@ -391,16 +457,22 @@ def save_molmo_forecasts(path: str | Path, bundle: MolmoForecastBundle) -> None:
         node_indices=bundle.query.node_indices,
         raw_track_indices=bundle.query.raw_track_indices,
         points_2d_xy=bundle.query.points_2d_xy.astype(np.float32),
-        points_3d_world_history_m=bundle.query.points_3d_world_history_m.astype(np.float32),
+        points_3d_world_history_m=bundle.query.points_3d_world_history_m.astype(
+            np.float32
+        ),
         camera_to_world=bundle.query.camera_to_world,
         intrinsics=bundle.query.intrinsics,
         source_fps=np.asarray(bundle.query.source_fps),
         forecast_fps=np.asarray(bundle.query.forecast_fps),
         frame_stride=np.asarray(bundle.query.frame_stride),
+        final_data_sha256=np.asarray(bundle.query.final_data_sha256 or ""),
+        calibration_sha256=np.asarray(bundle.query.calibration_sha256 or ""),
         camera_index=np.asarray(bundle.query.camera_index),
         t0_frame=np.asarray(bundle.query.t0_frame),
         history_frame_indices=bundle.query.history_frame_indices,
-        image_paths=np.asarray([str(path.resolve()) for path in bundle.query.image_paths]),
+        image_paths=np.asarray(
+            [str(path.resolve()) for path in bundle.query.image_paths]
+        ),
         raw_case_dir=np.asarray(str(bundle.query.raw_case_dir.resolve())),
         case_name=np.asarray(bundle.query.case_name),
         checkpoint=np.asarray(bundle.checkpoint),
@@ -424,12 +496,26 @@ def load_molmo_forecasts(path: str | Path) -> MolmoForecastBundle:
             )
             forecast_fps = source_fps
             frame_stride = 1
+        final_data_sha256 = (
+            str(archive["final_data_sha256"])
+            if "final_data_sha256" in archive.files
+            and str(archive["final_data_sha256"])
+            else None
+        )
+        calibration_sha256 = (
+            str(archive["calibration_sha256"])
+            if "calibration_sha256" in archive.files
+            and str(archive["calibration_sha256"])
+            else None
+        )
         query = MolmoPhysTwinQuery(
             case_name=str(archive["case_name"]),
             raw_case_dir=raw_case_dir,
             camera_index=int(archive["camera_index"]),
             t0_frame=int(archive["t0_frame"]),
-            history_frame_indices=np.asarray(archive["history_frame_indices"], dtype=int),
+            history_frame_indices=np.asarray(
+                archive["history_frame_indices"], dtype=int
+            ),
             image_paths=tuple(Path(str(value)) for value in archive["image_paths"]),
             node_indices=np.asarray(archive["node_indices"], dtype=int),
             raw_track_indices=np.asarray(archive["raw_track_indices"], dtype=int),
@@ -442,6 +528,8 @@ def load_molmo_forecasts(path: str | Path) -> MolmoForecastBundle:
             source_fps=source_fps,
             forecast_fps=forecast_fps,
             frame_stride=frame_stride,
+            final_data_sha256=final_data_sha256,
+            calibration_sha256=calibration_sha256,
         )
         return MolmoForecastBundle(
             query=query,

--- a/src/causal4d/phystwin_discrepancy_localization.py
+++ b/src/causal4d/phystwin_discrepancy_localization.py
@@ -14,7 +14,7 @@ from causal4d.contracts import TwinBelief, load_contract
 from causal4d.graph_temporal_discrepancy import graph_laplacian_basis
 from causal4d.phystwin_backend import load_bayesian_phystwin_particles
 
-from bayesian_phystwin.dynamic_discrepancy import (
+from bayesian_phystwin.causal4d_provider_v1 import (
     LOCALIZATION_GRAPH_RANK,
     DynamicDiscrepancyCorrection,
     fit_dimensionless_linearized_correction,
@@ -22,12 +22,12 @@ from bayesian_phystwin.dynamic_discrepancy import (
     scale_coefficients_to_field_limit,
     write_dynamic_discrepancy_correction,
 )
-from bayesian_phystwin.observation_model_audit import (
+from bayesian_phystwin.causal4d_provider_v1 import (
     cross_view_residual_audit,
     metric_agreement_audit,
     released_observation_capability_audit,
 )
-from bayesian_phystwin.phystwin_comparison import official_metrics_by_frame
+from bayesian_phystwin.causal4d_provider_v1 import official_metrics_by_frame
 from bayesian_phystwin.causal4d_graph_provider_v1 import (
     PhysTwinSpringGraphConfig,
     build_phystwin_spring_graph,

--- a/src/causal4d/phystwin_propagated_state.py
+++ b/src/causal4d/phystwin_propagated_state.py
@@ -11,11 +11,11 @@ import numpy as np
 from causal4d.contracts import TwinBelief, load_contract
 from causal4d.phystwin_backend import load_bayesian_phystwin_particles
 
-from bayesian_phystwin.dynamic_discrepancy import (
+from bayesian_phystwin.causal4d_provider_v1 import (
     LOCALIZATION_GRAPH_RANK,
     load_dynamic_discrepancy_correction,
 )
-from bayesian_phystwin.phystwin_comparison import official_metrics_by_frame
+from bayesian_phystwin.causal4d_provider_v1 import official_metrics_by_frame
 from .phystwin_discrepancy_localization import (
     BASELINE,
     READOUT,
@@ -41,11 +41,11 @@ from bayesian_phystwin.causal4d_provider_v1 import (
     sha256_file,
     target_validity,
 )
-from bayesian_phystwin.propagated_state_belief import (
+from bayesian_phystwin.causal4d_provider_v1 import (
     PropagatedStateBeliefConfig,
     infer_propagated_state_belief,
 )
-from bayesian_phystwin.propagated_state_correction import (
+from bayesian_phystwin.causal4d_provider_v1 import (
     PropagatedStateCorrection,
     PropagatedStateSelectionConfig,
     decode_limited_state_weights,

--- a/src/causal4d/phystwin_rest_geometry.py
+++ b/src/causal4d/phystwin_rest_geometry.py
@@ -24,29 +24,29 @@ from bayesian_phystwin.causal4d_provider_v1 import (
     simulator_runtime,
     target_validity,
 )
-from bayesian_phystwin.phystwin_additional_bayesian_confirmation import (
+from bayesian_phystwin.causal4d_provider_v1 import (
     FIXED_INITIAL_STD_M,
     FIXED_INLIER_PRIOR,
     FIXED_OBSERVATION_STD_M,
     FIXED_OUTLIER_VARIANCE_MULTIPLIER,
     FIXED_PROCESS_STD_M,
 )
-from bayesian_phystwin.phystwin_bayesian_anchor import robust_random_walk_endpoint
-from bayesian_phystwin.phystwin_comparison import (
+from bayesian_phystwin.causal4d_provider_v1 import robust_random_walk_endpoint
+from bayesian_phystwin.causal4d_provider_v1 import (
     official_metrics_by_frame,
     paired_block_bootstrap,
     phystwin_physical_object_cluster,
 )
-from bayesian_phystwin.phystwin_confirmatory import DEVELOPMENT_CASES
+from bayesian_phystwin.causal4d_provider_v1 import DEVELOPMENT_CASES
 from bayesian_phystwin.causal4d_graph_provider_v1 import (
     PhysTwinSpringGraphConfig,
     build_phystwin_spring_graph,
 )
-from bayesian_phystwin.phystwin_graph_discrepancy import (
+from bayesian_phystwin.causal4d_provider_v1 import (
     graph_discrepancy_diagnostics,
     normalized_spring_laplacian,
 )
-from bayesian_phystwin.phystwin_state_injection import estimate_endpoint_velocity_delta
+from bayesian_phystwin.causal4d_provider_v1 import estimate_endpoint_velocity_delta
 
 from causal4d.rest_geometry import (
     GraphRestGeometryCorrection,

--- a/src/causal4d/phystwin_rest_geometry_transfer.py
+++ b/src/causal4d/phystwin_rest_geometry_transfer.py
@@ -10,7 +10,7 @@ from typing import Any, Mapping
 
 import numpy as np
 
-from bayesian_phystwin.phystwin_comparison import official_metrics_by_frame
+from bayesian_phystwin.causal4d_provider_v1 import official_metrics_by_frame
 from bayesian_phystwin.causal4d_graph_provider_v1 import (
     PhysTwinSpringGraphConfig,
     build_phystwin_spring_graph,
@@ -21,7 +21,7 @@ from bayesian_phystwin.causal4d_provider_v1 import (
     released_self_collision_for_case,
     sha256_file,
 )
-from bayesian_phystwin.phystwin_state_injection import estimate_endpoint_velocity_delta
+from bayesian_phystwin.causal4d_provider_v1 import estimate_endpoint_velocity_delta
 from causal4d.phystwin_rest_geometry import _run_configured_restart
 from causal4d.rest_geometry import (
     apply_frame_correction,

--- a/src/causal4d/provider_contract.py
+++ b/src/causal4d/provider_contract.py
@@ -21,7 +21,13 @@ BASE_CAUSAL4D_PROVIDER_CAPABILITIES = (
 )
 BAYESIAN_PHYSTWIN_PROVIDER_CAPABILITIES = (
     *BASE_CAUSAL4D_PROVIDER_CAPABILITIES,
+    "bayesian_anchor_endpoint",
+    "diagnostic_comparison",
     "diagnostic_compatibility",
+    "diagnostic_discrepancy",
+    "diagnostic_observation_audit",
+    "diagnostic_propagated_state",
+    "diagnostic_rest_geometry",
     "phystwin_replay",
     "residual_lifting",
     "target_validity",
@@ -129,9 +135,7 @@ class ProviderCompatibilityResult:
             "unsupported_schema_version": self.unsupported_schema_version,
             "unsupported_provider_version": self.unsupported_provider_version,
             "supported_provider_versions": self.supported_provider_versions,
-            "artifact_version_mismatches": list(
-                self.artifact_version_mismatches
-            ),
+            "artifact_version_mismatches": list(self.artifact_version_mismatches),
             "provider_manifest_id": self.provider_manifest_id,
         }
 

--- a/src/causal4d/rest_geometry.py
+++ b/src/causal4d/rest_geometry.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from bayesian_phystwin.phystwin_graph_discrepancy import (
+from bayesian_phystwin.causal4d_provider_v1 import (
     graph_smoothed_discrepancy_posterior,
 )
 
@@ -254,14 +254,17 @@ def corrected_spring_rest_lengths(
     corrected_vertices = vertices + correction_scale * field
     object_edges = edges[:num_object_springs]
     geometric = np.linalg.norm(
-        corrected_vertices[object_edges[:, 0]]
-        - corrected_vertices[object_edges[:, 1]],
+        corrected_vertices[object_edges[:, 0]] - corrected_vertices[object_edges[:, 1]],
         axis=1,
     )
     released_object = released[:num_object_springs]
     unclipped_ratio = geometric / released_object
     ratio = np.exp(
-        np.clip(np.log(np.maximum(unclipped_ratio, 1e-12)), -maximum_log_ratio, maximum_log_ratio)
+        np.clip(
+            np.log(np.maximum(unclipped_ratio, 1e-12)),
+            -maximum_log_ratio,
+            maximum_log_ratio,
+        )
     )
     corrected = released.copy()
     corrected[:num_object_springs] = released_object * ratio
@@ -309,7 +312,9 @@ def reattach_controller_rest_lengths(
     released_tail = released[num_object_springs:]
     raw_ratio = geometric / released_tail
     ratio = np.exp(
-        np.clip(np.log(np.maximum(raw_ratio, 1e-12)), -maximum_log_ratio, maximum_log_ratio)
+        np.clip(
+            np.log(np.maximum(raw_ratio, 1e-12)), -maximum_log_ratio, maximum_log_ratio
+        )
     )
     corrected = released.copy()
     corrected[num_object_springs:] = released_tail * ratio

--- a/src/causal4d_public/deform360_phystwin_feasibility.py
+++ b/src/causal4d_public/deform360_phystwin_feasibility.py
@@ -315,7 +315,9 @@ class _OfficialWarpRopeRunner:
             load_official_spring_mass_module,
             make_reliability_simulator_class,
         )
-        from bayesian_phystwin.phystwin_refit import build_phystwin_track_objective
+        from bayesian_phystwin.causal4d_public_provider_v1 import (
+            build_phystwin_track_objective,
+        )
 
         self.torch = torch
         self.wp = wp

--- a/src/causal4d_public/deform360_replication_warp.py
+++ b/src/causal4d_public/deform360_replication_warp.py
@@ -202,12 +202,16 @@ class OfficialWarpSparseGraphRunner:
             import torch
             import warp as wp
         except ImportError as error:  # pragma: no cover - GPU integration
-            raise RuntimeError("official-Warp replication requires torch and warp") from error
+            raise RuntimeError(
+                "official-Warp replication requires torch and warp"
+            ) from error
         from bayesian_phystwin.causal4d_provider_v1 import (
             load_official_spring_mass_module,
             make_reliability_simulator_class,
         )
-        from bayesian_phystwin.phystwin_refit import build_phystwin_track_objective
+        from bayesian_phystwin.causal4d_public_provider_v1 import (
+            build_phystwin_track_objective,
+        )
 
         self.torch = torch
         self.wp = wp
@@ -257,7 +261,10 @@ class OfficialWarpSparseGraphRunner:
         ).astype(np.float32)
         vertices = np.concatenate((self.initial_positions, self.controllers[0]), axis=0)
         masses = np.concatenate(
-            (case.graph.masses.astype(np.float32), np.ones(len(control_edges), np.float32))
+            (
+                case.graph.masses.astype(np.float32),
+                np.ones(len(control_edges), np.float32),
+            )
         )
 
         runtime_config = SimpleNamespace(
@@ -328,9 +335,7 @@ class OfficialWarpSparseGraphRunner:
         )
         wp.synchronize()
 
-    def _spring_log_y(
-        self, candidate: WarpRopeCandidate, active: tuple[bool, ...]
-    ):
+    def _spring_log_y(self, candidate: WarpRopeCandidate, active: tuple[bool, ...]):
         values = np.empty(len(self.springs), dtype=np.float32)
         values[: self.stretch_count] = candidate.stretch_spring_y
         values[self.stretch_count : self.num_object_springs] = candidate.bend_spring_y
@@ -341,9 +346,7 @@ class OfficialWarpSparseGraphRunner:
                 else self.config.inactive_controller_spring_y
             )
         return self.torch.log(
-            self.torch.as_tensor(
-                values, dtype=self.torch.float32, device=self.device
-            )
+            self.torch.as_tensor(values, dtype=self.torch.float32, device=self.device)
         ).contiguous()
 
     def rollout(

--- a/src/causal4d_public/pokeflex_warp_source.py
+++ b/src/causal4d_public/pokeflex_warp_source.py
@@ -365,7 +365,9 @@ def build_pokeflex_warp_case(
     _require(frames == tuple(sorted(robot_by_frame)), "source mesh/robot frames differ")
     _require(len(frames) > cfg.prefix_frame_count, "source take has no forecast future")
 
-    prefix_surfaces = [_obj_vertices(path) for path in mesh_paths[: cfg.prefix_frame_count]]
+    prefix_surfaces = [
+        _obj_vertices(path) for path in mesh_paths[: cfg.prefix_frame_count]
+    ]
     rest_surface = prefix_surfaces[0]
     node_indices = _farthest_point_indices(rest_surface, cfg.graph_node_count)
     rest_positions = rest_surface[node_indices]
@@ -471,7 +473,8 @@ def score_geometry_rollout(
     case: PokeFlexWarpCase, trajectory: np.ndarray
 ) -> dict[str, float]:
     _require(
-        trajectory.shape == (len(case.target_surfaces_m), len(case.initial_positions_m), 3),
+        trajectory.shape
+        == (len(case.target_surfaces_m), len(case.initial_positions_m), 3),
         "trajectory shape does not match the PokeFlex case",
     )
     values = np.asarray(
@@ -502,12 +505,16 @@ class _OfficialWarpSurfaceRunner:
             import torch
             import warp as wp
         except ImportError as error:  # pragma: no cover - GPU integration
-            raise RuntimeError("official PokeFlex-Warp backend requires torch and warp") from error
+            raise RuntimeError(
+                "official PokeFlex-Warp backend requires torch and warp"
+            ) from error
         from bayesian_phystwin.causal4d_provider_v1 import (
             load_official_spring_mass_module,
             make_reliability_simulator_class,
         )
-        from bayesian_phystwin.phystwin_refit import build_phystwin_track_objective
+        from bayesian_phystwin.causal4d_public_provider_v1 import (
+            build_phystwin_track_objective,
+        )
 
         self.torch = torch
         self.wp = wp
@@ -531,7 +538,9 @@ class _OfficialWarpSurfaceRunner:
         node_count = len(case.initial_positions_m)
         visible = np.ones((frame_count, node_count), dtype=bool)
         motion_valid = np.ones((frame_count - 1, node_count), dtype=bool)
-        objective = build_phystwin_track_objective(visible, motion_valid, variant="hard")
+        objective = build_phystwin_track_objective(
+            visible, motion_valid, variant="hard"
+        )
 
         def tensor(values: np.ndarray, dtype):
             return torch.as_tensor(values, dtype=dtype, device=device).contiguous()
@@ -585,9 +594,7 @@ class _OfficialWarpSurfaceRunner:
         )
         wp.synchronize()
 
-    def _spring_log_y(
-        self, candidate: PokeFlexWarpCandidate, active: Sequence[bool]
-    ):
+    def _spring_log_y(self, candidate: PokeFlexWarpCandidate, active: Sequence[bool]):
         values = np.empty(len(self.case.springs), dtype=np.float32)
         values[: self.case.object_spring_count] = candidate.object_spring_y
         for controller, enabled in enumerate(active):
@@ -597,9 +604,7 @@ class _OfficialWarpSurfaceRunner:
                 else self.config.inactive_controller_spring_y
             )
         return self.torch.log(
-            self.torch.as_tensor(
-                values, dtype=self.torch.float32, device=self.device
-            )
+            self.torch.as_tensor(values, dtype=self.torch.float32, device=self.device)
         ).contiguous()
 
     def rollout(self, candidate: PokeFlexWarpCandidate) -> tuple[np.ndarray, float]:
@@ -636,8 +641,7 @@ class _OfficialWarpSurfaceRunner:
                 .detach()
                 .cpu()
                 .numpy()
-                .copy()
-                [: len(self.case.initial_positions_m)]
+                .copy()[: len(self.case.initial_positions_m)]
                 .astype(np.float64)
             )
             trajectory.append(positions)
@@ -683,7 +687,8 @@ def summarize_pooling_controls(
             min(
                 valid_indices,
                 key=lambda index: (
-                    float(np.mean(scores[index, list(columns)])), int(index)
+                    float(np.mean(scores[index, list(columns)])),
+                    int(index),
                 ),
             )
         )
@@ -783,7 +788,10 @@ def run_pokeflex_warp_source_backend(
         _sha256_file(simulator_source) == cfg.official_simulator_sha256,
         "official simulator source changed",
     )
-    cases = [build_pokeflex_warp_case(root / object_id / take_id, cfg) for take_id in take_ids]
+    cases = [
+        build_pokeflex_warp_case(root / object_id / take_id, cfg)
+        for take_id in take_ids
+    ]
     candidates = warp_candidates(cfg)
     scores = np.full((len(candidates), len(cases)), np.inf, dtype=np.float64)
     endpoints = np.full_like(scores, np.inf)
@@ -793,9 +801,9 @@ def run_pokeflex_warp_source_backend(
         persistence = np.repeat(
             case.initial_positions_m[None, :, :], len(case.target_surfaces_m), axis=0
         )
-        persistence_scores[case_index] = score_geometry_rollout(
-            case, persistence
-        )["future_chamfer_m"]
+        persistence_scores[case_index] = score_geometry_rollout(case, persistence)[
+            "future_chamfer_m"
+        ]
         runner = _OfficialWarpSurfaceRunner(official, case, cfg, device=device)
         for candidate_index, candidate in enumerate(candidates):
             trajectory, p99_strain = runner.rollout(candidate)
@@ -804,7 +812,9 @@ def run_pokeflex_warp_source_backend(
                 scores[candidate_index, case_index] = score["future_chamfer_m"]
                 endpoints[candidate_index, case_index] = score["endpoint_chamfer_m"]
                 strains[candidate_index, case_index] = p99_strain
-    pooling = summarize_pooling_controls(candidates, take_ids, scores, persistence_scores)
+    pooling = summarize_pooling_controls(
+        candidates, take_ids, scores, persistence_scores
+    )
     selected_index = int(pooling["pooled_candidate_index"])
     selected = candidates[selected_index]
     repeat_records = []
@@ -824,9 +834,7 @@ def run_pokeflex_warp_source_backend(
             "leave_one_out_persistence_win_fraction"
         ]
         >= cfg.minimum_leave_one_out_persistence_win_fraction,
-        "pooling_beats_single_source": pooling[
-            "pooled_vs_single_source_win_fraction"
-        ]
+        "pooling_beats_single_source": pooling["pooled_vs_single_source_win_fraction"]
         >= cfg.minimum_pooled_vs_single_source_win_fraction,
     }
     result: dict[str, Any] = {

--- a/tests/test_bpt_provider_import_boundary.py
+++ b/tests/test_bpt_provider_import_boundary.py
@@ -1,21 +1,35 @@
-"""Prevent Causal4D from depending on Bayesian-PhysTwin private names again."""
+"""Enforce the complete versioned Bayesian-PhysTwin import boundary."""
 
 from __future__ import annotations
 
 import ast
+import importlib
+import importlib.util
 from pathlib import Path
+
+import pytest
+
+ALLOWED_BAYESIAN_PHYSTWIN_MODULES = frozenset(
+    {
+        "bayesian_phystwin.causal4d_artifacts_v1",
+        "bayesian_phystwin.causal4d_graph_provider_v1",
+        "bayesian_phystwin.causal4d_provider_v1",
+        "bayesian_phystwin.causal4d_provider_v2",
+        "bayesian_phystwin.causal4d_public_provider_v1",
+    }
+)
 
 
 def _python_sources() -> list[Path]:
     repository_root = Path(__file__).resolve().parents[1]
-    sources = []
+    sources: list[Path] = []
     for directory in (repository_root / "src", repository_root / "scripts"):
         if directory.exists():
             sources.extend(directory.rglob("*.py"))
     return sorted(sources)
 
 
-def test_causal4d_imports_only_public_bayesian_phystwin_modules_and_names() -> None:
+def test_causal4d_imports_bpt_only_through_versioned_provider_modules() -> None:
     violations: list[str] = []
     for path in _python_sources():
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
@@ -24,27 +38,41 @@ def test_causal4d_imports_only_public_bayesian_phystwin_modules_and_names() -> N
                 module = node.module or ""
                 if not module.startswith("bayesian_phystwin"):
                     continue
-                private_module = any(
-                    component.startswith("_") for component in module.split(".")
-                )
-                private_names = [
+                private_names = sorted(
                     alias.name for alias in node.names if alias.name.startswith("_")
-                ]
-                if private_module or private_names:
+                )
+                if module not in ALLOWED_BAYESIAN_PHYSTWIN_MODULES or private_names:
                     violations.append(
-                        f"{path}:{node.lineno}: {module}: {private_names}"
+                        f"{path}:{node.lineno}: module={module!r}: "
+                        f"private_names={private_names}"
                     )
             elif isinstance(node, ast.Import):
                 for alias in node.names:
                     if not alias.name.startswith("bayesian_phystwin"):
                         continue
-                    if any(
-                        component.startswith("_")
-                        for component in alias.name.split(".")
-                    ):
+                    if alias.name not in ALLOWED_BAYESIAN_PHYSTWIN_MODULES:
                         violations.append(
-                            f"{path}:{node.lineno}: {alias.name}"
+                            f"{path}:{node.lineno}: module={alias.name!r}"
                         )
-    assert not violations, "private Bayesian-PhysTwin imports:\n" + "\n".join(
+    assert not violations, "unversioned Bayesian-PhysTwin imports:\n" + "\n".join(
         violations
     )
+
+
+def test_every_imported_provider_name_resolves_when_bpt_is_installed() -> None:
+    if importlib.util.find_spec("bayesian_phystwin") is None:
+        pytest.skip("Bayesian-PhysTwin is not installed in the core-only environment")
+    for path in _python_sources():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            module_name = node.module or ""
+            if module_name not in ALLOWED_BAYESIAN_PHYSTWIN_MODULES:
+                continue
+            module = importlib.import_module(module_name)
+            for alias in node.names:
+                assert alias.name != "*"
+                assert hasattr(module, alias.name), (
+                    f"{path}:{node.lineno}: {module_name}.{alias.name}"
+                )

--- a/tests/test_causal4d_molmo_adapter.py
+++ b/tests/test_causal4d_molmo_adapter.py
@@ -1,12 +1,15 @@
 import numpy as np
 
-from causal4d.molmo_adapter import camera_to_world_points, farthest_point_indices
+import causal4d.molmo_adapter as molmo_adapter
+from causal4d.molmo_adapter import (
+    camera_to_world_points,
+    farthest_point_indices,
+    prepare_molmo_phystwin_query,
+)
 
 
 def test_farthest_points_are_deterministic_and_distributed() -> None:
-    points = np.asarray(
-        [[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0], [1.5, 0.0]]
-    )
+    points = np.asarray([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0], [1.5, 0.0]])
     first = farthest_point_indices(points, 3)
     second = farthest_point_indices(points, 3)
     assert np.array_equal(first, second)
@@ -20,3 +23,94 @@ def test_camera_forecast_transforms_to_world_coordinates() -> None:
     world = camera_to_world_points(points, transform)
     assert np.allclose(world, points + np.asarray([0.5, -1.0, 2.0]))
 
+
+def test_prepare_query_hash_locks_legacy_inputs(tmp_path, monkeypatch) -> None:
+    final_path = tmp_path / "processed" / "final_data.pkl"
+    final_path.parent.mkdir()
+    final_path.write_bytes(b"placeholder")
+    raw_path = tmp_path / "raw"
+    (raw_path / "color" / "0").mkdir(parents=True)
+    for frame in (0, 2):
+        (raw_path / "color" / "0" / f"{frame}.png").write_bytes(b"image")
+    (raw_path / "metadata.json").write_text(
+        '{"fps": 2, "intrinsics": [[[1, 0, 0], [0, 1, 0], [0, 0, 1]]], "WH": [10, 10]}',
+        encoding="utf-8",
+    )
+
+    final_digest = "1" * 64
+    calibration_digest = "2" * 64
+    final_data = {
+        "object_points": np.asarray(
+            [
+                [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+                [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+                [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+                [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+            ]
+        ),
+        "object_visibilities": np.ones((4, 2), dtype=bool),
+        "object_motions_valid": np.ones((4, 2), dtype=bool),
+    }
+    calibration = np.eye(4)[None]
+    calls = []
+
+    def load_legacy(path, *, expected_sha256, artifact_kind, required_keys=()):
+        calls.append((str(path), expected_sha256, artifact_kind, tuple(required_keys)))
+        if str(path).endswith("final_data.pkl"):
+            return final_data
+        assert str(path).endswith("calibrate.pkl")
+        return calibration
+
+    class Mapping:
+        track_paths = (raw_path / "cotracker" / "0.npz",)
+        tracks_by_camera = (
+            np.asarray(
+                [
+                    [[1.0, 1.0], [2.0, 2.0]],
+                    [[1.0, 1.0], [2.0, 2.0]],
+                    [[1.0, 1.0], [2.0, 2.0]],
+                    [[1.0, 1.0], [2.0, 2.0]],
+                ]
+            ),
+        )
+        visibility_by_camera = (np.ones((4, 2), dtype=bool),)
+        source_camera = np.asarray((0, 0))
+        source_track = np.asarray((0, 1))
+
+    def load_raw_map(final_data_path, raw_case_dir, *, final_data_sha256):
+        assert final_data_path == final_path
+        assert raw_case_dir == raw_path
+        assert final_data_sha256 == final_digest
+        return Mapping()
+
+    monkeypatch.setattr(
+        molmo_adapter,
+        "load_trusted_legacy_phystwin_pickle",
+        load_legacy,
+    )
+    monkeypatch.setattr(
+        molmo_adapter,
+        "load_released_phystwin_raw_track_map",
+        load_raw_map,
+    )
+
+    query = prepare_molmo_phystwin_query(
+        final_path,
+        raw_path,
+        final_data_sha256=final_digest,
+        calibration_sha256=calibration_digest,
+        train_end_frame=3,
+        history_size=2,
+        point_count=1,
+        camera_index=0,
+        forecast_fps=1.0,
+    )
+
+    assert query.final_data_sha256 == final_digest
+    assert query.calibration_sha256 == calibration_digest
+    assert calls[0][1:] == (
+        final_digest,
+        "mapping",
+        ("object_points", "object_visibilities", "object_motions_valid"),
+    )
+    assert calls[1][1:] == (calibration_digest, "ndarray", ())


### PR DESCRIPTION
## Summary

Closes #44. The coordinated Bayesian-PhysTwin provider boundary was merged in FlorianPfaff/Bayesian-PhysTwin#79 (`072d7d7c520b9c9da3931ee8bc8c07370cccb50c`; validated product head `17e03f47be557bfbf0144ed9ce410688b27153e3`).

- route every Bayesian-PhysTwin dependency under `src/` and `scripts/` through an explicitly versioned provider or artifact module;
- replace the private-name-only AST guard with an exact module allowlist and, when BPT is installed, verify that every imported provider symbol resolves;
- require the newly declared fixed-anchor, diagnostic, public-data, and trusted-artifact capabilities in the provider contract;
- hash-lock both legacy pickle inputs used to prepare MolmoMotion queries before deserialization;
- preserve digest provenance in saved Molmo query artifacts while remaining able to load older archives;
- keep optional Bayesian-PhysTwin imports lazy so the core-only package and CLI help surface remain usable without private integrations;
- document the complete ownership and compatibility boundary.

## Boundary after this change

Normal Causal4D code may import Bayesian-PhysTwin only through:

- `bayesian_phystwin.causal4d_provider_v1`;
- `bayesian_phystwin.causal4d_provider_v2`;
- `bayesian_phystwin.causal4d_graph_provider_v1`;
- `bayesian_phystwin.causal4d_artifacts_v1`;
- `bayesian_phystwin.causal4d_public_provider_v1`.

Any other Bayesian-PhysTwin module import, or any underscore-prefixed imported provider name, fails the repository-wide AST inventory. Provider-v1 historical diagnostic names resolve lazily through BPT #79's versioned scientific facade rather than through direct experiment-module imports.

## Rebase

This branch is one product commit directly on Causal4D `main` after the Prob4D provider-v2 attestation and fail-closed three-repository workflow changes (#57 and #53). None of the 18 product files overlapped those intervening commits, so the reviewed blobs were preserved exactly.

## Validation

The original product tree passed repository-wide Ruff, stable-contract mypy, focused provider-boundary/Molmo/provider-contract tests, the complete core-only suite, and the normal `CI and release` workflow. A coordinated installed-source run against the provider implementation now merged through BPT #79 passed the complete Causal4D suite with **442 passed, 1 skipped**. This rebased exact head will rerun the repository and cross-repository gates before merge.
