### PR TITLE
Validate self-contained Prob4D provider-v2 attestations

### DIFF
--- a/docs/observation_belief_lineage.md
+++ b/docs/observation_belief_lineage.md
@@ -60,6 +60,29 @@ syntactically valid generic observation artifact cannot acquire a causal Prob4D
 claim merely by using the provider's repository name. The completed validation
 summary is retained when the observation belief is bound to a `TwinBelief`.
 
+## Provider-v2 attestation
+
+Historical provider-v1 observations remain valid for frozen reproduction. If a
+Prob4D observation carries `metadata.prob4d_provider_attestation`, Causal4D
+independently validates the complete embedded provider manifest, exact source
+revision, calibration artifact IDs, numerical modes, and runtime-revision
+evidence without importing Prob4D.
+
+New prospective evidence should use
+`load_claim_bearing_prob4d_observation_lineage`. The strict boundary additionally
+requires:
+
+- calibrated provider-v2 export with compatibility validation;
+- both gauge and point covariance-calibration IDs;
+- canonical repeated-eigenspace covariance roots;
+- analytic sequential `Sim(3)` composition Jacobians;
+- independently matched runtime code; and
+- the strict causal-stream contract rather than fixed-lag reconstruction output.
+
+See [Prob4D provider-v2 attestation validation](prob4d_provider_attestation.md).
+The attestation establishes immutable producer semantics and provenance; it does
+not establish empirical observation quality or downstream benefit.
+
 ## Exact factor-bundle validation
 
 ```bash

--- a/docs/prob4d_provider_attestation.md
+++ b/docs/prob4d_provider_attestation.md
@@ -1,0 +1,70 @@
+# Prob4D provider-v2 attestation validation
+
+Causal4D independently validates portable observation content, causal source
+lineage, and the Prob4D stream contract before binding an observation to a
+`TwinBelief`. New prospective Prob4D evidence can additionally require the
+self-contained calibrated provider-v2 producer contract.
+
+The validator in `causal4d.prob4d_provider_attestation` deliberately does not
+import Prob4D. It recomputes the embedded provider-manifest content address and
+checks the exact neutral JSON semantics covered by the observation artifact ID.
+
+## Compatibility mode
+
+`load_observation_lineage` and
+`validate_prob4d_causal_observation_metadata` remain backward compatible:
+
+- historical provider-v1 observations without an attestation remain valid for
+  frozen reproduction;
+- any provider-v2 attestation that is present is validated and fails closed when
+  malformed; and
+- the resulting `ObservationLineage.provider_validation` contains a compact
+  validated provider summary rather than duplicating the full manifest.
+
+The independent checks cover:
+
+- attestation schema and exact declared fields;
+- provider-manifest SHA-256, identity, exact source revision, API version,
+  repository, import boundary, and observation schema versions;
+- capabilities and limitations required by the current provider-v2 contract;
+- calibrated versus exploratory mode consistency;
+- gauge and point calibration artifact IDs;
+- covariance-root and composition-Jacobian modes; and
+- matched, independently verified runtime revision evidence.
+
+## Prospective claim-bearing boundary
+
+New Prob4D-to-Bayesian-PhysTwin-to-Causal4D evidence should use the strict loader:
+
+```python
+from causal4d.claim_bearing_observation_lineage import (
+    load_claim_bearing_prob4d_observation_lineage,
+)
+
+lineage = load_claim_bearing_prob4d_observation_lineage(
+    "observation_belief.npz"
+)
+```
+
+For an already loaded lineage:
+
+```python
+from causal4d.claim_bearing_observation_lineage import (
+    require_claim_bearing_prob4d_lineage,
+)
+
+lineage = require_claim_bearing_prob4d_lineage(lineage)
+```
+
+The strict boundary rejects:
+
+- provider-v1 artifacts without a provider-v2 attestation;
+- exploratory provider-v2 exports;
+- fixed-lag products without the strict causal-stream contract;
+- missing or incompatible covariance calibrations;
+- legacy covariance roots or composition derivatives; and
+- environment-only, mismatched, unavailable, or dirty runtime provenance.
+
+This validation establishes provenance and contract consistency, not empirical
+observation quality, covariance calibration, or downstream physical-prediction
+benefit. Those remain separate held-out gates.

--- a/src/causal4d/__init__.py
+++ b/src/causal4d/__init__.py
@@ -16,6 +16,10 @@ from causal4d.causal_sufficiency import (
     CausalSufficiencyResult,
     assess_command_residual_sufficiency,
 )
+from causal4d.claim_bearing_observation_lineage import (
+    load_claim_bearing_prob4d_observation_lineage,
+    require_claim_bearing_prob4d_lineage,
+)
 from causal4d.contact_evaluation import run_latent_contact_benchmark
 from causal4d.contact_inference import LatentContactConfig
 from causal4d.contact_traction import graph_traction_field, integrate_contact_wrench
@@ -79,6 +83,10 @@ from causal4d.prefix_likelihood import (
     PrefixLikelihoodConfig,
     prefix_component_log_likelihood,
     update_joint_weights_from_prefix,
+)
+from causal4d.prob4d_observation_lineage import (
+    validate_claim_bearing_prob4d_observation_metadata,
+    validate_prob4d_causal_observation_metadata,
 )
 from causal4d.provider_contract import (
     BASE_CAUSAL4D_PROVIDER_CAPABILITIES,
@@ -185,6 +193,7 @@ __all__ = [
     "grouped_component_log_likelihoods",
     "integrate_contact_wrench",
     "load_bayesian_phystwin_provider_manifest",
+    "load_claim_bearing_prob4d_observation_lineage",
     "load_graph_discrepancy_belief",
     "load_independent_sensor_evidence",
     "load_observation_factor_lineage",
@@ -194,12 +203,15 @@ __all__ = [
     "preserve_prior_within_unidentified_subspace",
     "project_identifiable_intervention_update",
     "require_bayesian_phystwin_provider",
+    "require_claim_bearing_prob4d_lineage",
     "reweight_factual_intervention_with_independent_sensors",
     "run_counterfactual_benchmark",
     "run_latent_contact_benchmark",
     "save_independent_sensor_evidence",
     "update_joint_weights_from_prefix",
     "validate_bayesian_phystwin_provider",
+    "validate_claim_bearing_prob4d_observation_metadata",
+    "validate_prob4d_causal_observation_metadata",
     "validate_provider_compatibility",
     "validate_twin_belief_observation_factor_lineage",
     "write_graph_discrepancy_belief",

--- a/src/causal4d/claim_bearing_observation_lineage.py
+++ b/src/causal4d/claim_bearing_observation_lineage.py
@@ -1,0 +1,46 @@
+"""Strict loading boundary for prospective claim-bearing Prob4D observations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+from .observation_lineage import ObservationLineage, load_observation_lineage
+
+
+def require_claim_bearing_prob4d_lineage(
+    lineage: ObservationLineage,
+) -> ObservationLineage:
+    """Reject provider-v1, exploratory, or approximate Prob4D lineage."""
+
+    validation = lineage.provider_validation
+    if not isinstance(validation, Mapping):
+        raise ValueError("a validated Prob4D provider boundary is required")
+    if validation.get("strict_causal_stream_contract") is not True:
+        raise ValueError(
+            "claim-bearing Prob4D observation requires a strict causal stream contract"
+        )
+    provider = validation.get("provider_attestation")
+    if not isinstance(provider, Mapping):
+        raise ValueError("a claim-bearing Prob4D provider-v2 attestation is required")
+    if provider.get("claim_bearing") is not True:
+        raise ValueError("exploratory Prob4D provider-v2 artifacts are not claim-bearing")
+    if provider.get("calibration_compatibility_validated") is not True:
+        raise ValueError("Prob4D calibration compatibility was not validated")
+    if provider.get("runtime_revision_independently_verified") is not True:
+        raise ValueError("Prob4D runtime revision was not independently verified")
+    return lineage
+
+
+def load_claim_bearing_prob4d_observation_lineage(
+    path: str | Path,
+) -> ObservationLineage:
+    """Load an observation and require the prospective Prob4D provider contract."""
+
+    return require_claim_bearing_prob4d_lineage(load_observation_lineage(path))
+
+
+__all__ = [
+    "load_claim_bearing_prob4d_observation_lineage",
+    "require_claim_bearing_prob4d_lineage",
+]

--- a/src/causal4d/prob4d_observation_lineage.py
+++ b/src/causal4d/prob4d_observation_lineage.py
@@ -2,7 +2,8 @@
 
 The semantic implementation lives in :mod:`prob4d_observation_contract`; this
 module name remains the public lightweight lineage API. It also resolves the
-provider-specific stream-contract version without duplicating semantic checks.
+provider-specific stream-contract version and independently validates any
+self-contained provider-v2 attestation.
 """
 
 from __future__ import annotations
@@ -26,6 +27,7 @@ from .prob4d_observation_contract import (
     is_prob4d_causal_observation_descriptor,
     validate_prob4d_causal_observation_metadata as _validate_prob4d_semantics,
 )
+from .prob4d_provider_attestation import validate_prob4d_provider_attestation
 
 PROB4D_LEGACY_CAUSAL_STREAM_CONTRACT_VERSION = 1
 PROB4D_CAUSAL_STREAM_CONTRACT_VERSION = 2
@@ -64,11 +66,62 @@ def _resolved_stream_contract(
     return expected, False
 
 
+def _provider_attestation_summary(
+    descriptor: Mapping[str, Any],
+    metadata: Mapping[str, Any],
+    *,
+    require_claim_bearing: bool,
+) -> dict[str, object] | None:
+    raw = metadata.get("prob4d_provider_attestation")
+    if raw is None:
+        if require_claim_bearing:
+            raise ValueError(
+                "a claim-bearing Prob4D provider-v2 attestation is required"
+            )
+        return None
+    if not isinstance(raw, Mapping):
+        raise ValueError("Prob4D provider attestation must be a mapping")
+    source_revision = descriptor.get("source_revision")
+    if not isinstance(source_revision, str):
+        raise ValueError("observation source_revision must be a string")
+    validated = validate_prob4d_provider_attestation(
+        raw,
+        source_revision=source_revision,
+        require_claim_bearing=require_claim_bearing,
+    )
+    runtime = validated["runtime_revision"]
+    return {
+        "schema_name": validated["schema_name"],
+        "schema_version": validated["schema_version"],
+        "provider_api_version": validated["provider_api_version"],
+        "provider_manifest_id": validated["provider_manifest_id"],
+        "export_mode": validated["export_mode"],
+        "claim_bearing": validated["claim_bearing"],
+        "calibration_compatibility_validated": validated[
+            "calibration_compatibility_validated"
+        ],
+        "calibration_artifact_ids": validated["calibration_artifact_ids"],
+        "covariance_root_mode": validated["covariance_root_mode"],
+        "composition_jacobian_mode": validated["composition_jacobian_mode"],
+        "runtime_revision_source": runtime["source"],
+        "runtime_revision_independently_verified": runtime[
+            "independently_verified"
+        ],
+    }
+
+
 def validate_prob4d_causal_observation_metadata(
     descriptor: Mapping[str, Any],
     arrays: Mapping[str, np.ndarray],
+    *,
+    require_claim_bearing_provider_v2: bool = False,
 ) -> dict[str, object]:
-    """Validate semantics, then bind the resolved provider stream version."""
+    """Validate semantics, stream version, and provider-v2 provenance.
+
+    Frozen provider-v1 artifacts remain valid when no attestation is present. New
+    prospective evidence can set ``require_claim_bearing_provider_v2=True`` to
+    reject provider-v1 and exploratory provider-v2 artifacts.
+    """
 
     result = dict(_validate_prob4d_semantics(descriptor, arrays))
     metadata = descriptor.get("metadata")
@@ -78,12 +131,37 @@ def validate_prob4d_causal_observation_metadata(
         metadata,
         result.get("covariance_semantics"),
     )
+    provider = _provider_attestation_summary(
+        descriptor,
+        metadata,
+        require_claim_bearing=require_claim_bearing_provider_v2,
+    )
     result.update(
         stream_contract_version=version,
         stream_contract_version_inferred=inferred,
         strict_causal_stream_contract=version is not None,
+        provider_attestation_present=provider is not None,
+        provider_attestation_validated=provider is not None,
+        provider_attestation=provider,
     )
+    if require_claim_bearing_provider_v2 and version is None:
+        raise ValueError(
+            "claim-bearing Prob4D observation requires a strict causal stream contract"
+        )
     return result
+
+
+def validate_claim_bearing_prob4d_observation_metadata(
+    descriptor: Mapping[str, Any],
+    arrays: Mapping[str, np.ndarray],
+) -> dict[str, object]:
+    """Require a calibrated provider-v2 artifact and strict causal stream."""
+
+    return validate_prob4d_causal_observation_metadata(
+        descriptor,
+        arrays,
+        require_claim_bearing_provider_v2=True,
+    )
 
 
 __all__ = [
@@ -101,5 +179,6 @@ __all__ = [
     "PROB4D_SOURCE_REPOSITORY",
     "PROPAGATED_EXTERNAL_PRIOR",
     "is_prob4d_causal_observation_descriptor",
+    "validate_claim_bearing_prob4d_observation_metadata",
     "validate_prob4d_causal_observation_metadata",
 ]

--- a/src/causal4d/prob4d_provider_attestation.py
+++ b/src/causal4d/prob4d_provider_attestation.py
@@ -1,0 +1,472 @@
+"""Independently validate self-contained Prob4D provider-v2 attestations.
+
+This module deliberately does not import Prob4D. It rechecks the neutral JSON/hash
+contract before Causal4D binds an observation to an intervention workflow.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from typing import Any
+
+PROB4D_PROVIDER_ATTESTATION_SCHEMA = "prob4d.provider-attestation"
+PROB4D_PROVIDER_ATTESTATION_VERSION = 1
+PROB4D_PROVIDER_API_VERSION = 2
+PROB4D_PROVIDER_IMPORT_BOUNDARY = "prob4d.provider_v2"
+PROB4D_PROVIDER_SOURCE_REPOSITORY = "FlorianPfaff/Prob4D"
+
+_REQUIRED_CAPABILITIES = frozenset(
+    {
+        "analytic_sim3_composition_jacobians",
+        "canonical_repeated_eigenspace_covariance_root",
+        "explicit_exploratory_and_claim_bearing_exports",
+        "provider_attested_observation_artifacts",
+        "runtime_revision_attestation",
+        "strict_prediction_calibration_compatibility",
+    }
+)
+_ATTESTATION_FIELDS = frozenset(
+    {
+        "schema_name",
+        "schema_version",
+        "provider_api_version",
+        "provider_manifest_id",
+        "provider_manifest",
+        "provider_revision",
+        "python_import_boundary",
+        "export_mode",
+        "claim_bearing",
+        "calibration_compatibility_validated",
+        "calibration_artifact_ids",
+        "covariance_root_mode",
+        "composition_jacobian_mode",
+        "runtime_revision",
+    }
+)
+_RUNTIME_FIELDS = frozenset(
+    {
+        "expected_revision",
+        "observed_revision",
+        "source",
+        "clean_checkout",
+        "matched",
+        "independently_verified",
+    }
+)
+_CALIBRATION_FIELDS = frozenset(
+    {
+        "gauge_artifact_id",
+        "point_artifact_id",
+    }
+)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _finite_json_mapping(value: Any, *, name: str) -> dict[str, Any]:
+    _require(isinstance(value, Mapping), f"{name} must be a mapping")
+    try:
+        normalized = json.loads(
+            json.dumps(
+                dict(value),
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            )
+        )
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{name} must contain finite JSON data") from error
+    _require(isinstance(normalized, dict), f"{name} must be a JSON object")
+    return normalized
+
+
+def _require_exact_fields(
+    value: Mapping[str, Any],
+    expected: frozenset[str],
+    *,
+    name: str,
+) -> None:
+    missing = expected - value.keys()
+    extra = value.keys() - expected
+    _require(
+        not missing and not extra,
+        f"{name} fields changed; missing={sorted(missing)}, extra={sorted(extra)}",
+    )
+
+
+def _require_sha256(value: Any, *, name: str) -> str:
+    result = str(value)
+    _require(
+        len(result) == 64
+        and all(character in "0123456789abcdef" for character in result),
+        f"{name} must be a lowercase SHA-256 digest",
+    )
+    return result
+
+
+def _require_revision(value: Any, *, name: str) -> str:
+    result = str(value)
+    _require(
+        len(result) in {40, 64}
+        and all(character in "0123456789abcdef" for character in result),
+        f"{name} must be an exact lowercase Git commit",
+    )
+    return result
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        dict(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def compute_prob4d_provider_manifest_id(manifest: Mapping[str, Any]) -> str:
+    """Recompute the self-declared provider-manifest content address."""
+
+    normalized = _finite_json_mapping(manifest, name="Prob4D provider manifest")
+    normalized.pop("manifest_id", None)
+    return hashlib.sha256(_canonical_json(normalized)).hexdigest()
+
+
+def _validate_manifest(
+    value: Any,
+    *,
+    expected_revision: str,
+) -> dict[str, Any]:
+    manifest = _finite_json_mapping(value, name="Prob4D provider manifest")
+    manifest_id = _require_sha256(
+        manifest.get("manifest_id", ""),
+        name="Prob4D provider manifest_id",
+    )
+    _require(
+        compute_prob4d_provider_manifest_id(manifest) == manifest_id,
+        "Prob4D provider manifest ID does not match its descriptor",
+    )
+    revision = _require_revision(
+        manifest.get("provider_revision", ""),
+        name="Prob4D provider-manifest revision",
+    )
+    _require(
+        revision == expected_revision,
+        "Prob4D provider-manifest revision differs from observation source revision",
+    )
+    _require(
+        manifest.get("provider_name") == "prob4d",
+        "Prob4D provider manifest changed provider name",
+    )
+    _require(
+        manifest.get("provider_api_version") == PROB4D_PROVIDER_API_VERSION,
+        "Prob4D provider manifest is not API version 2",
+    )
+
+    capabilities = manifest.get("capabilities")
+    _require(
+        isinstance(capabilities, list)
+        and all(isinstance(item, str) and item for item in capabilities)
+        and len(capabilities) == len(set(capabilities)),
+        "Prob4D provider capabilities must be unique nonempty strings",
+    )
+    _require(
+        _REQUIRED_CAPABILITIES.issubset(capabilities),
+        "Prob4D provider manifest lacks required claim-bearing capabilities",
+    )
+
+    schemas = manifest.get("artifact_schema_versions")
+    _require(
+        isinstance(schemas, Mapping),
+        "Prob4D provider artifact schemas must be a mapping",
+    )
+    _require(
+        schemas.get("ObservationBeliefV1") == 1
+        and schemas.get("Prob4DCausalObservationStream") == 2,
+        "Prob4D provider manifest declares unsupported observation schemas",
+    )
+
+    limitations = manifest.get("limitations")
+    _require(
+        isinstance(limitations, Mapping),
+        "Prob4D provider limitations must be a mapping",
+    )
+    _require(
+        limitations.get("uncalibrated_export_is_default") is False,
+        "Prob4D provider-v2 manifest must not default to uncalibrated export",
+    )
+    _require(
+        limitations.get(
+            "deployment_environment_revision_is_independent_vcs_evidence"
+        )
+        is False,
+        "Prob4D provider manifest misstates deployment revision evidence",
+    )
+
+    metadata = manifest.get("metadata")
+    _require(
+        isinstance(metadata, Mapping),
+        "Prob4D provider metadata must be a mapping",
+    )
+    _require(
+        metadata.get("source_repository") == PROB4D_PROVIDER_SOURCE_REPOSITORY,
+        "Prob4D provider manifest source repository changed",
+    )
+    _require(
+        metadata.get("python_import_boundary")
+        == PROB4D_PROVIDER_IMPORT_BOUNDARY,
+        "Prob4D provider manifest import boundary changed",
+    )
+    return manifest
+
+
+def _validate_runtime(
+    value: Any,
+    *,
+    provider_revision: str,
+    claim_bearing: bool,
+) -> dict[str, Any]:
+    runtime = _finite_json_mapping(value, name="Prob4D runtime attestation")
+    _require_exact_fields(
+        runtime,
+        _RUNTIME_FIELDS,
+        name="Prob4D runtime attestation",
+    )
+    expected = _require_revision(
+        runtime.get("expected_revision", ""),
+        name="Prob4D runtime expected revision",
+    )
+    _require(
+        expected == provider_revision,
+        "Prob4D runtime expected revision differs from provider revision",
+    )
+    observed_value = runtime.get("observed_revision")
+    observed = (
+        None
+        if observed_value is None
+        else _require_revision(
+            observed_value,
+            name="Prob4D runtime observed revision",
+        )
+    )
+    source = runtime.get("source")
+    _require(
+        source
+        in {
+            "installed_vcs_metadata",
+            "source_checkout",
+            "deployment_environment",
+            "unavailable",
+        },
+        "Prob4D runtime evidence source is unsupported",
+    )
+    clean = runtime.get("clean_checkout")
+    _require(
+        clean is None or isinstance(clean, bool),
+        "Prob4D runtime clean_checkout must be Boolean or null",
+    )
+    matched = runtime.get("matched")
+    independent = runtime.get("independently_verified")
+    _require(isinstance(matched, bool), "Prob4D runtime matched must be Boolean")
+    _require(
+        isinstance(independent, bool),
+        "Prob4D runtime independently_verified must be Boolean",
+    )
+    _require(
+        matched is (observed == expected),
+        "Prob4D runtime matched flag disagrees with its revisions",
+    )
+    expected_independent = bool(
+        matched
+        and source in {"installed_vcs_metadata", "source_checkout"}
+        and clean is not False
+    )
+    _require(
+        independent is expected_independent,
+        "Prob4D runtime verification flag disagrees with its evidence",
+    )
+    if source == "source_checkout":
+        _require(
+            isinstance(clean, bool),
+            "Prob4D source-checkout evidence must declare cleanliness",
+        )
+    else:
+        _require(
+            clean is None,
+            "non-checkout Prob4D runtime evidence cannot declare cleanliness",
+        )
+    if claim_bearing:
+        _require(
+            matched and independent,
+            "claim-bearing Prob4D attestation requires independently matched code",
+        )
+    return runtime
+
+
+def _validate_calibration_ids(
+    value: Any,
+    *,
+    claim_bearing: bool,
+) -> dict[str, Any]:
+    calibration = _finite_json_mapping(
+        value,
+        name="Prob4D calibration artifact IDs",
+    )
+    _require_exact_fields(
+        calibration,
+        _CALIBRATION_FIELDS,
+        name="Prob4D calibration artifact IDs",
+    )
+    for field in sorted(_CALIBRATION_FIELDS):
+        artifact_id = calibration.get(field)
+        if artifact_id is not None:
+            calibration[field] = _require_sha256(
+                artifact_id,
+                name=f"Prob4D calibration {field}",
+            )
+    if claim_bearing:
+        _require(
+            all(calibration[field] is not None for field in _CALIBRATION_FIELDS),
+            "claim-bearing Prob4D attestation requires both calibration IDs",
+        )
+    return calibration
+
+
+def validate_prob4d_provider_attestation(
+    attestation: Mapping[str, Any],
+    *,
+    source_revision: str,
+    require_claim_bearing: bool = False,
+) -> dict[str, Any]:
+    """Validate and normalize a provider-v2 statement without importing Prob4D."""
+
+    normalized = _finite_json_mapping(
+        attestation,
+        name="Prob4D provider attestation",
+    )
+    _require_exact_fields(
+        normalized,
+        _ATTESTATION_FIELDS,
+        name="Prob4D provider attestation",
+    )
+    _require(
+        normalized.get("schema_name") == PROB4D_PROVIDER_ATTESTATION_SCHEMA,
+        "unsupported Prob4D provider-attestation schema",
+    )
+    _require(
+        normalized.get("schema_version") == PROB4D_PROVIDER_ATTESTATION_VERSION,
+        "unsupported Prob4D provider-attestation version",
+    )
+    _require(
+        normalized.get("provider_api_version") == PROB4D_PROVIDER_API_VERSION,
+        "Prob4D provider attestation is not API version 2",
+    )
+
+    revision = _require_revision(
+        normalized.get("provider_revision", ""),
+        name="Prob4D provider-attestation revision",
+    )
+    observation_revision = _require_revision(
+        source_revision,
+        name="observation source revision",
+    )
+    _require(
+        revision == observation_revision,
+        "Prob4D provider-attestation revision differs from observation source revision",
+    )
+    _require(
+        normalized.get("python_import_boundary")
+        == PROB4D_PROVIDER_IMPORT_BOUNDARY,
+        "Prob4D provider-attestation import boundary changed",
+    )
+
+    manifest = _validate_manifest(
+        normalized.get("provider_manifest"),
+        expected_revision=revision,
+    )
+    declared_manifest_id = _require_sha256(
+        normalized.get("provider_manifest_id", ""),
+        name="Prob4D provider-attestation manifest ID",
+    )
+    _require(
+        declared_manifest_id == manifest["manifest_id"],
+        "Prob4D attestation manifest ID differs from embedded manifest",
+    )
+
+    export_mode = normalized.get("export_mode")
+    _require(
+        export_mode in {"calibrated", "exploratory"},
+        "Prob4D provider export mode is unsupported",
+    )
+    claim_bearing = normalized.get("claim_bearing")
+    _require(
+        isinstance(claim_bearing, bool),
+        "Prob4D claim_bearing must be Boolean",
+    )
+    _require(
+        claim_bearing is (export_mode == "calibrated"),
+        "Prob4D claim-bearing flag disagrees with export mode",
+    )
+    compatibility = normalized.get("calibration_compatibility_validated")
+    _require(
+        isinstance(compatibility, bool),
+        "Prob4D calibration compatibility flag must be Boolean",
+    )
+    _require(
+        compatibility is claim_bearing,
+        "Prob4D calibration compatibility flag disagrees with export mode",
+    )
+    if require_claim_bearing:
+        _require(
+            claim_bearing,
+            "a claim-bearing Prob4D provider-v2 artifact is required",
+        )
+
+    calibration = _validate_calibration_ids(
+        normalized.get("calibration_artifact_ids"),
+        claim_bearing=claim_bearing,
+    )
+    covariance_mode = normalized.get("covariance_root_mode")
+    _require(
+        covariance_mode in {"canonical_eigenspaces", "legacy_eigenvectors"},
+        "Prob4D covariance-root mode is unsupported",
+    )
+    composition_mode = normalized.get("composition_jacobian_mode")
+    _require(
+        composition_mode in {"analytic", "legacy_finite_difference"},
+        "Prob4D composition-Jacobian mode is unsupported",
+    )
+    if claim_bearing:
+        _require(
+            covariance_mode == "canonical_eigenspaces",
+            "claim-bearing Prob4D artifact requires canonical covariance roots",
+        )
+        _require(
+            composition_mode == "analytic",
+            "claim-bearing Prob4D artifact requires analytic composition Jacobians",
+        )
+
+    runtime = _validate_runtime(
+        normalized.get("runtime_revision"),
+        provider_revision=revision,
+        claim_bearing=claim_bearing,
+    )
+    normalized["provider_manifest"] = manifest
+    normalized["calibration_artifact_ids"] = calibration
+    normalized["runtime_revision"] = runtime
+    return normalized
+
+
+__all__ = [
+    "PROB4D_PROVIDER_API_VERSION",
+    "PROB4D_PROVIDER_ATTESTATION_SCHEMA",
+    "PROB4D_PROVIDER_ATTESTATION_VERSION",
+    "PROB4D_PROVIDER_IMPORT_BOUNDARY",
+    "PROB4D_PROVIDER_SOURCE_REPOSITORY",
+    "compute_prob4d_provider_manifest_id",
+    "validate_prob4d_provider_attestation",
+]

--- a/tests/test_prob4d_stream_contract_version.py
+++ b/tests/test_prob4d_stream_contract_version.py
@@ -1,14 +1,93 @@
 from __future__ import annotations
 
+import copy
+import hashlib
+import json
+from types import SimpleNamespace
+
 import pytest
 
 import causal4d.prob4d_observation_lineage as lineage
+from causal4d.claim_bearing_observation_lineage import (
+    require_claim_bearing_prob4d_lineage,
+)
+from causal4d.prob4d_provider_attestation import (
+    compute_prob4d_provider_manifest_id,
+)
 
 
 def _semantic_result(value: str) -> dict[str, object]:
     return {
         "validated": True,
         "covariance_semantics": value,
+    }
+
+
+def _provider_manifest() -> dict[str, object]:
+    descriptor: dict[str, object] = {
+        "provider_name": "prob4d",
+        "provider_version": "0.2.0",
+        "provider_revision": "a" * 40,
+        "provider_api_version": 2,
+        "capabilities": [
+            "analytic_sim3_composition_jacobians",
+            "canonical_repeated_eigenspace_covariance_root",
+            "explicit_exploratory_and_claim_bearing_exports",
+            "provider_attested_observation_artifacts",
+            "runtime_revision_attestation",
+            "strict_prediction_calibration_compatibility",
+        ],
+        "artifact_schema_versions": {
+            "ObservationBeliefV1": 1,
+            "Prob4DCausalObservationStream": 2,
+        },
+        "limitations": {
+            "uncalibrated_export_is_default": False,
+            "deployment_environment_revision_is_independent_vcs_evidence": False,
+        },
+        "metadata": {
+            "source_repository": "FlorianPfaff/Prob4D",
+            "python_import_boundary": "prob4d.provider_v2",
+        },
+    }
+    manifest_id = hashlib.sha256(
+        json.dumps(
+            descriptor,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()
+    return {"manifest_id": manifest_id, **descriptor}
+
+
+def _provider_attestation() -> dict[str, object]:
+    manifest = _provider_manifest()
+    return {
+        "schema_name": "prob4d.provider-attestation",
+        "schema_version": 1,
+        "provider_api_version": 2,
+        "provider_manifest_id": manifest["manifest_id"],
+        "provider_manifest": manifest,
+        "provider_revision": "a" * 40,
+        "python_import_boundary": "prob4d.provider_v2",
+        "export_mode": "calibrated",
+        "claim_bearing": True,
+        "calibration_compatibility_validated": True,
+        "calibration_artifact_ids": {
+            "gauge_artifact_id": "1" * 64,
+            "point_artifact_id": "2" * 64,
+        },
+        "covariance_root_mode": "canonical_eigenspaces",
+        "composition_jacobian_mode": "analytic",
+        "runtime_revision": {
+            "expected_revision": "a" * 40,
+            "observed_revision": "a" * 40,
+            "source": "source_checkout",
+            "clean_checkout": True,
+            "matched": True,
+            "independently_verified": True,
+        },
     }
 
 
@@ -29,6 +108,7 @@ def test_legacy_stream_version_is_inferred(monkeypatch) -> None:
     assert result["stream_contract_version"] == 1
     assert result["stream_contract_version_inferred"] is True
     assert result["strict_causal_stream_contract"] is True
+    assert result["provider_attestation_present"] is False
 
 
 def test_explicit_joint_stream_version_is_bound(monkeypatch) -> None:
@@ -46,6 +126,119 @@ def test_explicit_joint_stream_version_is_bound(monkeypatch) -> None:
     assert result["stream_contract_version"] == 2
     assert result["stream_contract_version_inferred"] is False
     assert result["strict_causal_stream_contract"] is True
+
+
+def test_claim_bearing_provider_attestation_is_validated_independently(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        lineage,
+        "_validate_prob4d_semantics",
+        lambda descriptor, arrays: _semantic_result(lineage.PROB4D_JOINT_GAUGE_MODEL),
+    )
+    result = lineage.validate_claim_bearing_prob4d_observation_metadata(
+        {
+            "source_revision": "a" * 40,
+            "metadata": {
+                "prob4d_causal_stream_contract_version": 2,
+                "prob4d_provider_attestation": _provider_attestation(),
+            },
+        },
+        {},
+    )
+
+    provider = result["provider_attestation"]
+    assert result["provider_attestation_present"] is True
+    assert result["provider_attestation_validated"] is True
+    assert provider["provider_api_version"] == 2
+    assert provider["claim_bearing"] is True
+    assert provider["runtime_revision_independently_verified"] is True
+
+
+def test_strict_provider_validation_rejects_provider_v1_artifact(monkeypatch) -> None:
+    monkeypatch.setattr(
+        lineage,
+        "_validate_prob4d_semantics",
+        lambda descriptor, arrays: _semantic_result(lineage.PROB4D_JOINT_GAUGE_MODEL),
+    )
+    with pytest.raises(ValueError, match="provider-v2 attestation is required"):
+        lineage.validate_claim_bearing_prob4d_observation_metadata(
+            {
+                "source_revision": "a" * 40,
+                "metadata": {"prob4d_causal_stream_contract_version": 2},
+            },
+            {},
+        )
+
+
+def test_provider_manifest_tampering_is_rejected(monkeypatch) -> None:
+    monkeypatch.setattr(
+        lineage,
+        "_validate_prob4d_semantics",
+        lambda descriptor, arrays: _semantic_result(lineage.PROB4D_JOINT_GAUGE_MODEL),
+    )
+    attestation = _provider_attestation()
+    attestation["provider_manifest"]["provider_version"] = "999"
+    with pytest.raises(ValueError, match="manifest ID does not match"):
+        lineage.validate_prob4d_causal_observation_metadata(
+            {
+                "source_revision": "a" * 40,
+                "metadata": {
+                    "prob4d_causal_stream_contract_version": 2,
+                    "prob4d_provider_attestation": attestation,
+                },
+            },
+            {},
+        )
+
+
+def test_rehashed_provider_capability_removal_is_rejected(monkeypatch) -> None:
+    monkeypatch.setattr(
+        lineage,
+        "_validate_prob4d_semantics",
+        lambda descriptor, arrays: _semantic_result(lineage.PROB4D_JOINT_GAUGE_MODEL),
+    )
+    attestation = copy.deepcopy(_provider_attestation())
+    manifest = attestation["provider_manifest"]
+    manifest["capabilities"].remove("runtime_revision_attestation")
+    manifest["manifest_id"] = compute_prob4d_provider_manifest_id(manifest)
+    attestation["provider_manifest_id"] = manifest["manifest_id"]
+    with pytest.raises(ValueError, match="required claim-bearing capabilities"):
+        lineage.validate_prob4d_causal_observation_metadata(
+            {
+                "source_revision": "a" * 40,
+                "metadata": {
+                    "prob4d_causal_stream_contract_version": 2,
+                    "prob4d_provider_attestation": attestation,
+                },
+            },
+            {},
+        )
+
+
+def test_claim_bearing_lineage_wrapper_requires_validated_summary() -> None:
+    provider = {
+        "claim_bearing": True,
+        "calibration_compatibility_validated": True,
+        "runtime_revision_independently_verified": True,
+    }
+    candidate = SimpleNamespace(
+        provider_validation={
+            "strict_causal_stream_contract": True,
+            "provider_attestation": provider,
+        }
+    )
+    assert require_claim_bearing_prob4d_lineage(candidate) is candidate
+
+    with pytest.raises(ValueError, match="provider-v2 attestation is required"):
+        require_claim_bearing_prob4d_lineage(
+            SimpleNamespace(
+                provider_validation={
+                    "strict_causal_stream_contract": True,
+                    "provider_attestation": None,
+                }
+            )
+        )
 
 
 def test_joint_stream_rejects_mismatched_explicit_version(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- add an independent JSON/hash validator for `prob4d.provider-attestation` schema v1 without importing Prob4D;
- validate any provider-v2 attestation present at Causal4D's portable observation-lineage boundary;
- verify the complete embedded provider manifest, exact source revision, required capabilities and limitations, calibration IDs, numerical modes, and runtime-revision evidence;
- preserve historical provider-v1 compatibility when no attestation is present;
- add strict metadata and loaded-lineage boundaries for prospective claim-bearing Prob4D observations;
- expose the strict functions from the package API and document their use;
- add successful strict validation, provider-v1 rejection, manifest tampering, rehashed capability stripping, stream-version, and wrapper tests.

## Why

Causal4D independently validates observation content and causal source lineage and should not need to import the producer package to check the producer's exact claim. The provider-v2 attestation embeds a complete content-addressed capability manifest. Causal4D now recomputes that manifest ID and constrains it to the known claim-bearing semantics before an observation can enter a prospective intervention workflow.

This remains backward compatible. A frozen provider-v1 observation without an attestation is still accepted by the ordinary loader. Any attestation that is present is treated as part of the artifact contract and fails closed when malformed.

## Strict prospective boundary

`load_claim_bearing_prob4d_observation_lineage` additionally requires:

- a calibrated provider-v2 export;
- validated prediction/calibration compatibility;
- both gauge and point covariance-calibration IDs;
- canonical covariance roots and analytic sequential composition Jacobians;
- independently matched VCS runtime evidence; and
- the strict Prob4D causal-stream contract rather than fixed-lag reconstruction output.

## Stack

This consumer PR targets the producer schema in Prob4D PR #33. It is backward compatible and can merge independently, but its strict path becomes usable once that producer schema is released.
