### PR TITLE
Migrate PhysTwin replay execution to provider v2

### DIFF
--- a/.github/workflows/bayesian-phystwin-provider-compatibility.yml
+++ b/.github/workflows/bayesian-phystwin-provider-compatibility.yml
@@ -7,24 +7,40 @@ on:
       - ".github/workflows/bayesian-phystwin-provider-compatibility.yml"
       - "ci/three_repository_*.py"
       - "docs/ci.md"
+      - "src/causal4d/bpt_belief.py"
       - "src/causal4d/observation_lineage.py"
       - "src/causal4d/phystwin_backend.py"
+      - "src/causal4d/phystwin_resumable.py"
       - "src/causal4d/prob4d_observation_contract.py"
       - "src/causal4d/provider_contract.py"
+      - "src/causal4d/replay_provider_contract.py"
+      - "src/causal4d/rollout_cache.py"
       - "tests/test_bpt_provider_integration.py"
+      - "tests/test_causal4d_bpt_belief.py"
       - "tests/test_causal4d_phystwin_backend.py"
+      - "tests/test_phystwin_resumable.py"
+      - "tests/test_replay_provider_contract.py"
+      - "tests/test_rollout_cache.py"
   push:
     branches: [main]
     paths:
       - ".github/workflows/bayesian-phystwin-provider-compatibility.yml"
       - "ci/three_repository_*.py"
       - "docs/ci.md"
+      - "src/causal4d/bpt_belief.py"
       - "src/causal4d/observation_lineage.py"
       - "src/causal4d/phystwin_backend.py"
+      - "src/causal4d/phystwin_resumable.py"
       - "src/causal4d/prob4d_observation_contract.py"
       - "src/causal4d/provider_contract.py"
+      - "src/causal4d/replay_provider_contract.py"
+      - "src/causal4d/rollout_cache.py"
       - "tests/test_bpt_provider_integration.py"
+      - "tests/test_causal4d_bpt_belief.py"
       - "tests/test_causal4d_phystwin_backend.py"
+      - "tests/test_phystwin_resumable.py"
+      - "tests/test_replay_provider_contract.py"
+      - "tests/test_rollout_cache.py"
   workflow_dispatch:
     inputs:
       bpt_ref:
@@ -203,6 +219,7 @@ jobs:
               --import-mode=importlib \
               "$GITHUB_WORKSPACE/prob4d/tests/test_joint_observation_contract_fixture.py" \
               "$GITHUB_WORKSPACE/bayesian-phystwin/tests/test_causal4d_provider_v1.py" \
+              "$GITHUB_WORKSPACE/bayesian-phystwin/tests/test_causal4d_provider_v2.py" \
               "$GITHUB_WORKSPACE/bayesian-phystwin/tests/test_observation_belief_gauge_adapter.py" \
               "$GITHUB_WORKSPACE/bayesian-phystwin/tests/test_run_manifest_v2.py" \
               "$GITHUB_WORKSPACE/causal4d/tests/test_bpt_provider_import_boundary.py" \
@@ -210,6 +227,9 @@ jobs:
               "$GITHUB_WORKSPACE/causal4d/tests/test_causal4d_provider_contract.py" \
               "$GITHUB_WORKSPACE/causal4d/tests/test_causal4d_phystwin_backend.py" \
               "$GITHUB_WORKSPACE/causal4d/tests/test_causal4d_bpt_belief.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_phystwin_resumable.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_replay_provider_contract.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_rollout_cache.py" \
               "$GITHUB_WORKSPACE/causal4d/tests/test_observation_lineage.py" \
               "$GITHUB_WORKSPACE/causal4d/tests/test_prob4d_joint_contract_fixture.py" \
               "$GITHUB_WORKSPACE/causal4d/tests/test_prob4d_stream_contract_version.py"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Set up Python
+      - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.10"
           cache: pip
       - name: Install development tools
         run: python -m pip install -e ".[dev]"
@@ -56,7 +56,8 @@ jobs:
         run: |
           python -m mypy \
             scripts/ci \
-            src/causal4d/provider_contract.py
+            src/causal4d/provider_contract.py \
+            src/causal4d/replay_provider_contract.py
 
   core:
     name: Core-only / Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ prospective mechanism gates.
 the uncertain deformable-object twin: state and parameter particles, graph
 geometry, PhysTwin/Warp replay, and perception/discrepancy artifacts. Causal4D
 consumes those artifacts and owns the intervention and counterfactual
-inference. The dependency points from Causal4D to Bayesian-PhysTwin through
-`bayesian_phystwin.causal4d_provider_v1`; execution uses the
-`PhysTwinReplayProvider` protocol rather than BPT internals.
+inference. Production replay uses immutable typed requests from
+`bayesian_phystwin.causal4d_provider_v2`; provider v1 remains only as the
+versioned scientific and frozen-diagnostic compatibility facade. Causal4D
+validates both manifests and never imports BPT implementation modules directly.
 
 Install the `phystwin` extra for these adapters. Core controlled benchmarks do
 not require Warp or the PhysTwin checkout. See

--- a/ci/three_repository_manifest.py
+++ b/ci/three_repository_manifest.py
@@ -99,7 +99,7 @@ def run_evidence_manifest_checks(
             "observation_artifact_id": observation_artifact_id,
             "provider_manifest_id": provider_manifest_id,
             "prob4d_causal_stream_contract_version": 2,
-            "replay_provider": "deterministic-cpu-fake-v1",
+            "replay_provider": "deterministic-cpu-fake-v2",
         },
         inputs=(
             _artifact(
@@ -130,7 +130,7 @@ def run_evidence_manifest_checks(
         method_freeze_id="three-repository-golden-path-v1",
         protocol_id="prob4d-bpt-causal4d-installed-wheel-v1",
         split_id="deterministic-contract-fixture-v1",
-        baseline_id="fake-replay-provider-v1",
+        baseline_id="fake-replay-provider-v2",
         created_utc="2026-07-27T00:00:00+00:00",
         notes="No empirical performance claim; this is an interoperability check.",
     )

--- a/ci/three_repository_rollout.py
+++ b/ci/three_repository_rollout.py
@@ -8,6 +8,13 @@ from typing import Any
 
 import numpy as np
 
+from bayesian_phystwin.causal4d_provider_v2 import (
+    PhysTwinReplayProvider,
+    ReplayRequestV1,
+    ReplayTrajectoryV1,
+    RestartReplayRequestV1,
+)
+
 from three_repository_common import (
     EXPECTED_OBSERVATION_ARTIFACT_ID,
     array_digest,
@@ -16,70 +23,48 @@ from three_repository_common import (
 
 
 class _FakeReplayProvider:
-    device = "cpu"
-
-    def __init__(self) -> None:
-        self.group_log_scales = np.zeros(2, dtype=np.float32)
-        self.controller_points: np.ndarray | None = None
-        self.group_scale_calls: list[np.ndarray] = []
+    def __init__(self, **kwargs: Any) -> None:
+        self.device = str(kwargs["device"])
+        self.frame_dt_s = float(kwargs["dt"]) * int(kwargs["num_substeps"])
+        self.simulator_configuration_id = str(kwargs["simulator_configuration_id"])
+        self.released_initial_state_id = str(kwargs["released_initial_state_id"])
+        self.requests: list[RestartReplayRequestV1] = []
         self.restart_calls = 0
         self.closed = False
 
-    def set_group_log_scales(self, values: np.ndarray) -> None:
-        scales = np.asarray(values, dtype=np.float32).copy()
-        require(
-            scales.shape == (2,),
-            "fake provider received invalid group scales",
-        )
-        self.group_log_scales = scales
-        self.group_scale_calls.append(scales)
-
-    def set_controller_points(self, values: np.ndarray) -> None:
-        controls = np.asarray(values, dtype=np.float32).copy()
-        require(
-            controls.ndim == 3 and controls.shape[2] == 3,
-            "fake provider received invalid controller points",
-        )
-        self.controller_points = controls
-
-    def replay_initial(
-        self,
-        *,
-        frame_count: int,
-    ) -> tuple[np.ndarray, np.ndarray]:
-        require(frame_count > 0, "frame_count must be positive")
-        positions = np.zeros((frame_count, 3, 3), dtype=np.float32)
-        velocities = np.zeros_like(positions)
-        return positions, velocities
-
-    def replay_restart(
-        self,
-        position_m: np.ndarray,
-        velocity_mps: np.ndarray,
-        *,
-        start_frame: int,
-        stop_frame: int,
-    ) -> np.ndarray:
+    def replay(self, request: ReplayRequestV1) -> ReplayTrajectoryV1:
         require(not self.closed, "fake provider is closed")
         require(
-            self.controller_points is not None,
-            "controller points were not set",
+            isinstance(request, RestartReplayRequestV1),
+            "golden rollout did not use a restart replay-v2 request",
         )
-        position = np.asarray(position_m, dtype=np.float32).copy()
-        velocity = np.asarray(velocity_mps, dtype=np.float32)
+        position = np.asarray(request.position_m, dtype=np.float32).copy()
+        velocity = np.asarray(request.velocity_mps, dtype=np.float32).copy()
         require(position.shape == velocity.shape, "restart state shapes differ")
-        frame_count = stop_frame - start_frame
+        frame_count = request.stop_frame - request.start_frame
         require(frame_count > 0, "restart interval is empty")
-        result = np.empty((frame_count, *position.shape), dtype=np.float32)
-        scale = float(np.sum(np.exp(self.group_log_scales)))
+        positions = np.empty((frame_count, *position.shape), dtype=np.float32)
+        velocities = np.empty_like(positions)
+        scale = float(np.sum(np.exp(request.group_log_scales)))
         for offset in range(frame_count):
             position = position + 0.01 * velocity
             position[:, 0] += np.float32(0.0005 * scale)
             position[:, 1] += np.float32(0.0001 * (offset + 1))
-            position[-1] = self.controller_points[start_frame + offset, 0]
-            result[offset] = position
+            position[-1] = request.controller_points_m[request.start_frame + offset, 0]
+            velocity[:, 0] += np.float32(0.00001 * (offset + 1))
+            positions[offset] = position
+            velocities[offset] = velocity
+        self.requests.append(request)
         self.restart_calls += 1
-        return result
+        return ReplayTrajectoryV1(
+            positions_m=positions,
+            velocities_mps=velocities,
+            frame_ids=np.arange(request.start_frame, request.stop_frame),
+            dt_s=self.frame_dt_s,
+            request_id=request.request_id,
+            simulator_configuration_id=request.simulator_configuration_id,
+            initial_state_id=request.initial_state_id,
+        )
 
     def close(self) -> None:
         self.closed = True
@@ -147,6 +132,8 @@ def _minimal_backend(
     particles: Any,
     profile_path: Path,
     provider_manifest: Any,
+    replay_provider_manifest: Any,
+    graph_provider_manifest: Any,
     workdir: Path,
 ) -> tuple[Any, np.ndarray, np.ndarray]:
     from causal4d.phystwin_backend import (
@@ -156,6 +143,8 @@ def _minimal_backend(
 
     backend = object.__new__(OfficialPhysTwinBackend)
     backend.provider_manifest = provider_manifest
+    backend.replay_provider_manifest = replay_provider_manifest
+    backend.graph_provider_manifest = graph_provider_manifest
     backend.official_repo = workdir / "official-phystwin"
     backend.final_data_path = workdir / "final-data.pkl"
     backend.optimal_params_path = workdir / "optimal.pkl"
@@ -185,6 +174,9 @@ def _minimal_backend(
         self_collision=False,
         device="cpu",
     )
+    backend.source_artifacts_sha256 = {}
+    backend.base_simulator_configuration_id = "golden-base-configuration-v1"
+    backend.released_initial_state_id = "golden-released-state-v1"
 
     vertices = np.asarray(
         [
@@ -218,7 +210,6 @@ def run_causal4d_rollout(
     """Validate lineage and execute one deterministic fake-provider query."""
 
     import causal4d.phystwin_backend as backend_module
-    from bayesian_phystwin.causal4d_provider_v1 import PhysTwinReplayProvider
     from causal4d.contracts import TwinBelief, load_contract, save_contract
     from causal4d.observation_lineage import (
         bind_twin_belief_observation_lineage,
@@ -231,9 +222,16 @@ def run_causal4d_rollout(
         load_rollout_bank,
         save_rollout_bank,
     )
+    from causal4d.graph_provider_contract import (
+        require_bayesian_phystwin_graph_provider,
+    )
     from causal4d.provider_contract import (
         require_bayesian_phystwin_provider,
         validate_bayesian_phystwin_provider,
+    )
+    from causal4d.replay_provider_contract import (
+        require_bayesian_phystwin_replay_provider,
+        validate_bayesian_phystwin_replay_provider,
     )
 
     provider_manifest = require_bayesian_phystwin_provider(
@@ -241,6 +239,19 @@ def run_causal4d_rollout(
     )
     compatibility = validate_bayesian_phystwin_provider(provider_manifest)
     require(compatibility.compatible, "installed BPT provider is incompatible")
+    replay_provider_manifest = require_bayesian_phystwin_replay_provider(
+        provider_revision="installed-wheel-golden-path"
+    )
+    replay_compatibility = validate_bayesian_phystwin_replay_provider(
+        replay_provider_manifest
+    )
+    require(
+        replay_compatibility.compatible,
+        "installed BPT replay-v2 provider is incompatible",
+    )
+    graph_provider_manifest = require_bayesian_phystwin_graph_provider(
+        provider_revision="installed-wheel-golden-path"
+    )
 
     lineage = load_observation_lineage(observation_path)
     require(
@@ -256,6 +267,8 @@ def run_causal4d_rollout(
         particles=particles,
         profile_path=profile_path,
         provider_manifest=provider_manifest,
+        replay_provider_manifest=replay_provider_manifest,
+        graph_provider_manifest=graph_provider_manifest,
         workdir=workdir,
     )
 
@@ -323,10 +336,10 @@ def run_causal4d_rollout(
             kwargs.get("device") == "cpu",
             "golden provider was not CPU-only",
         )
-        provider = _FakeReplayProvider()
+        provider = _FakeReplayProvider(**kwargs)
         require(
             isinstance(provider, PhysTwinReplayProvider),
-            "fake provider does not satisfy the public replay protocol",
+            "fake provider does not satisfy the public replay-v2 protocol",
         )
         providers.append(provider)
         return provider
@@ -352,9 +365,21 @@ def run_causal4d_rollout(
     require(len(providers) == 1, "golden rollout created unexpected providers")
     require(providers[0].closed, "fake provider was not closed")
     require(providers[0].restart_calls == 2, "unexpected replay count")
+    require(len(providers[0].requests) == 2, "zero-mass support was replayed")
     require(
-        len(providers[0].group_scale_calls) == 2,
-        "zero-mass support was replayed",
+        all(
+            request.simulator_configuration_id
+            == providers[0].simulator_configuration_id
+            for request in providers[0].requests
+        ),
+        "replay request configuration identity changed",
+    )
+    require(
+        all(
+            request.velocity_mps.shape == request.position_m.shape
+            for request in providers[0].requests
+        ),
+        "restart request lost velocity history",
     )
     require(
         bank.trajectories.shape == (1, 2, 4, 2, 3),
@@ -383,6 +408,8 @@ def run_causal4d_rollout(
     return {
         "provider_manifest_id": provider_manifest.manifest_id,
         "provider_compatibility": compatibility.as_dict(),
+        "replay_provider_manifest_id": replay_provider_manifest.manifest_id,
+        "replay_provider_compatibility": replay_compatibility.as_dict(),
         "observation_lineage": validation,
         "twin_belief_id": restored_twin.artifact_id,
         "twin_belief_path": str(twin_path),
@@ -390,6 +417,11 @@ def run_causal4d_rollout(
         "rollout_digest": array_digest(restored_bank.trajectories),
         "rollout_shape": list(restored_bank.trajectories.shape),
         "restart_calls": providers[0].restart_calls,
+        "replay_request_ids": [request.request_id for request in providers[0].requests],
+        "replay_frame_ids": [
+            list(range(request.start_frame, request.stop_frame))
+            for request in providers[0].requests
+        ],
         "probability_mass_accounting": accounting,
         "invalid_mass_rejection": invalid_mass_rejection,
         "zero_mass_cells_replayed": False,

--- a/docs/bayesian_phystwin_provider.md
+++ b/docs/bayesian_phystwin_provider.md
@@ -3,10 +3,10 @@
 Causal4D consumes Bayesian-PhysTwin only through explicit versioned public
 modules:
 
-- `bayesian_phystwin.causal4d_provider_v1` for the existing belief-artifact,
-  replay, fixed Bayesian-anchor, and diagnostic compatibility path;
-- `bayesian_phystwin.causal4d_provider_v2` for immutable request-complete replay
-  contracts used by newer integrations;
+- `bayesian_phystwin.causal4d_provider_v1` for frozen scientific and diagnostic
+  compatibility names;
+- `bayesian_phystwin.causal4d_provider_v2` for all production initial and restart
+  replay execution through immutable request-complete contracts;
 - `bayesian_phystwin.causal4d_graph_provider_v1` for the NumPy-only spring-graph
   value type, graph construction, and released controller grouping semantics;
 - `bayesian_phystwin.causal4d_artifacts_v1` for hash-locked released pickle
@@ -15,10 +15,9 @@ modules:
   diagnostics that still reuse BPT experiment semantics.
 
 The graph module is explicitly parented to Bayesian-PhysTwin's immutable
-`causal4d_provider_v2` contract. This PR does not silently switch the existing
-Causal4D rollout backend from replay provider v1 to v2; that replay migration is
-a separate compatibility change. Provider v1 remains necessary for frozen and
-current diagnostic paths.
+`causal4d_provider_v2` contract. Causal4D's belief exporter, rollout-bank backend,
+and resumable cache now execute replay exclusively through provider v2. Provider
+v1 remains only for frozen scientific and diagnostic compatibility operations.
 
 Production source and scripts no longer import any unversioned
 Bayesian-PhysTwin implementation module. An AST allowlist makes new direct
@@ -28,14 +27,17 @@ experiment imports a blocking test failure.
 
 Normal development accepts Bayesian-PhysTwin versions in the range
 `>=0.4,<0.5`. Compatibility is not inferred from the package version alone.
-Causal4D validates the current replay provider for:
+Causal4D validates two deliberately separate provider manifests:
 
-- provider API/schema version 1;
-- the capabilities required for artifact checksums, parameter particles,
-  particle-specific endpoint state, replay, residual lifting, target validity,
-  the fixed Bayesian-anchor endpoint, and each migrated diagnostic capability
-  group;
-- `TwinBelief` and `GraphBelief` artifact schema version 1.
+- scientific provider API/schema version 1 for frozen compatibility names,
+  fixed-anchor inference, and migrated diagnostics; and
+- replay provider API/schema version 2 for typed initial/restart requests,
+  immutable position/velocity trajectories, frame provenance, and stateless
+  replay execution.
+
+The scientific manifest requires its existing `TwinBelief` and `GraphBelief`
+artifact schemas. The replay manifest additionally requires `ReplayRequest` and
+`ReplayTrajectory` schema version 1 and every provider-v2 replay capability.
 
 The graph provider is checked separately for:
 
@@ -46,9 +48,11 @@ The graph provider is checked separately for:
 - the exact parent `bayesian_phystwin.causal4d_provider_v2` identity and API
   version 2.
 
-The replay manifest is loaded with
+The scientific manifest is loaded with
 `load_bayesian_phystwin_provider_manifest()` and checked with
-`validate_bayesian_phystwin_provider()`. The graph manifest is loaded with
+`validate_bayesian_phystwin_provider()`. The replay manifest is loaded with
+`load_bayesian_phystwin_replay_provider_manifest()` and checked with
+`validate_bayesian_phystwin_replay_provider()`. The graph manifest is loaded with
 `load_bayesian_phystwin_graph_provider_manifest()` and checked with
 `validate_bayesian_phystwin_graph_provider()`. A version, capability, artifact,
 graph-provider, or parent-provider mismatch fails closed and is reported
@@ -56,43 +60,36 @@ explicitly.
 
 ## Execution API
 
-The current `PhysTwinReplayProvider` v1 protocol remains the execution boundary
-for Causal4D's main BPT belief exporter and rollout-bank backend. They use only
-these operations:
+Production simulation uses `PhysTwinReplayProvider` from the explicitly versioned
+`causal4d_provider_v2` module. Each invocation is one immutable
+`InitialReplayRequestV1` or `RestartReplayRequestV1` containing:
 
-- set grouped spring log-scales;
-- set a controller trajectory;
-- replay from the released initial state;
-- replay from an explicit position/velocity endpoint;
-- release runtime resources.
+- a content-addressed request identifier;
+- the exact simulator-configuration and initial-state identifiers;
+- grouped spring log-scales and the complete controller trajectory;
+- for restarts, the particle-specific endpoint position and velocity; and
+- the complete requested frame interval.
 
-`create_official_replay_provider()` constructs BPT's Warp-backed v1
-implementation. Existing specialized diagnostics use public compatibility
-functions from the same versioned module while they are incrementally moved
-onto higher-level execution protocols.
+Causal4D independently validates every `ReplayTrajectoryV1` response against the
+request ID, configuration ID, state ID, frame IDs, timestep, shapes, and finite
+position/velocity values. The resumable cache stores and hashes positions,
+velocities, frame provenance, timestep, and all three identities. A cache hit can
+therefore reconstruct a complete provider-v2 response without instantiating Warp.
 
-Bayesian-PhysTwin provider v2 already supplies immutable request-complete replay
-DTOs, velocity-bearing replay trajectories, and owned replay/geometry/hash
-modules. The graph child contract reuses v2's canonical package metadata and
-declares v2 as its parent without re-exporting or redefining the replay
-protocol. A later Causal4D replay migration can therefore adopt v2 without
-changing this graph/controller contract.
+Provider v1 is not the production replay boundary. It remains a versioned
+compatibility facade for frozen diagnostics and scientific operations that have no
+request-complete replay role. Graph and controller geometry remain in
+`causal4d_graph_provider_v1`, which is NumPy-only and declares replay provider v2
+as its parent contract.
 
-Graph and controller geometry stay outside the accelerator-facing protocol.
-Causal4D imports `PhysTwinSpringGraph`, `PhysTwinSpringGraphConfig`,
-`build_phystwin_spring_graph()`, `controller_hand_count()`, and
-`infer_controller_groups()` only from `causal4d_graph_provider_v1`. The graph
-surface depends only on NumPy and can therefore be validated in core CI without
-Torch, Warp, OpenCV, or SciPy.
-
-The official rollout manifest records both the current replay-provider manifest
-and the graph-provider manifest. Public-data studies additionally record the
-public-study provider manifest, and new Molmo query preparation requires trusted
-SHA-256 identities for both `final_data.pkl` and `calibrate.pkl`. Frozen evidence
-can thus identify the exact replay implementation, graph/controller contract,
-and legacy visual inputs independently.
-This provenance separation improves upgrade auditability; it is not an
-empirical accuracy, calibration, or causal-prediction claim.
+The official rollout manifest records the scientific provider, replay-provider-v2,
+and graph-provider manifests separately. It also records source-artifact hashes,
+simulator/state identifiers, every request ID, exact frame provenance, and position
+and velocity digests. Public-data studies additionally record the public-study
+provider manifest, and Molmo query preparation requires trusted SHA-256 identities
+for both `final_data.pkl` and `calibrate.pkl`. This provenance separation improves
+upgrade auditability; it is not an empirical accuracy, calibration, or
+causal-prediction claim.
 
 ## Development installation
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -77,9 +77,9 @@ The installed-wheel job then:
    shared low-rank gauge root remains an explicit nuisance, preventing
    covariance double counting;
 7. lets Causal4D independently recompute observation lineage, bind a
-   content-addressed `TwinBelief`, validate the installed BPT provider manifest,
-   and execute a CPU-only counterfactual rollout through a fake implementation
-   of `PhysTwinReplayProvider`;
+   content-addressed `TwinBelief`, validate separate scientific-provider-v1 and
+   replay-provider-v2 manifests, and execute a CPU-only counterfactual rollout
+   through a typed fake provider-v2 implementation;
 8. verifies staged BPT truncation, Causal4D support reduction, composed posterior
    mass, rejection of inconsistent composition, and exclusion of exact-zero
    support cells from replay;
@@ -91,8 +91,10 @@ The installed-wheel job then:
     mismatch, insufficient retained gauge covariance, contradictory stream
     versions, fixed-lag covariance falsely labelled as strict v2, incomplete
     evidence manifests, and dirty promotable evidence;
-11. runs the existing producer, provider, lineage, belief, manifest, and backend
-    tests with `--import-mode=importlib` against the installed wheels.
+11. validates immutable replay request IDs, frame provenance, position and
+    velocity histories, and complete resumable-cache reconstruction; and
+12. runs the existing producer, provider, lineage, belief, manifest, cache, and
+    backend tests with `--import-mode=importlib` against the installed wheels.
 
 The workflow uploads `three-repository-summary.json` and the complete runner log
 as the `three-repository-installed-wheel-golden-path` artifact. The JSON summary

--- a/docs/migration_from_bayesian_phystwin.md
+++ b/docs/migration_from_bayesian_phystwin.md
@@ -55,7 +55,8 @@ The Python packages remain `causal4d` and `causal4d_public`. Existing
 | `bpt-aggregate-phystwin-propagated-state` | `causal4d-aggregate-phystwin-propagated-state` |
 
 Frozen tags continue to reproduce their historical tree. New development uses
-`bayesian_phystwin.causal4d_provider_v1`, the `PhysTwinReplayProvider`
-execution protocol, and the BPT compatibility range `>=0.4,<0.5`. See
+`bayesian_phystwin.causal4d_provider_v2` for immutable replay requests,
+`bayesian_phystwin.causal4d_provider_v1` only for frozen scientific compatibility,
+and the BPT compatibility range `>=0.4,<0.5`. See
 [bayesian_phystwin_provider.md](bayesian_phystwin_provider.md) for the
 development and frozen-install policies.

--- a/scripts/ci/run_bpt_integration_tests.py
+++ b/scripts/ci/run_bpt_integration_tests.py
@@ -10,6 +10,7 @@ import pytest
 
 BPT_INTEGRATION_TESTS = (
     "tests/test_bpt_graph_provider_integration.py",
+    "tests/test_bpt_provider_integration.py",
     "tests/test_causal4d_bpt_belief.py",
     "tests/test_causal4d_molmo_acceptance.py",
     "tests/test_causal4d_molmo_adapter.py",
@@ -22,6 +23,8 @@ BPT_INTEGRATION_TESTS = (
     "tests/test_discrepancy_localization_aggregate.py",
     "tests/test_phystwin_propagated_state.py",
     "tests/test_phystwin_resumable.py",
+    "tests/test_replay_provider_contract.py",
+    "tests/test_rollout_cache.py",
 )
 
 

--- a/src/causal4d/bpt_belief.py
+++ b/src/causal4d/bpt_belief.py
@@ -15,15 +15,20 @@ from bayesian_phystwin.causal4d_provider_v1 import (
     FIXED_PROCESS_STD_M,
 )
 from bayesian_phystwin.causal4d_provider_v1 import robust_random_walk_endpoint
-from bayesian_phystwin.causal4d_provider_v1 import (
+from bayesian_phystwin.causal4d_provider_v1 import released_self_collision_for_case
+from bayesian_phystwin.causal4d_provider_v2 import (
+    InitialReplayRequestV1,
     PhysTwinReplayProvider,
     build_lift_map,
     create_official_replay_provider,
     lift_residual,
-    released_self_collision_for_case,
     target_validity,
 )
-from causal4d.contracts import CausalContext, TwinBelief
+from causal4d.contracts import CausalContext, TwinBelief, array_sha256
+from causal4d.replay_provider_contract import (
+    stable_replay_identifier,
+    validate_replay_trajectory,
+)
 
 if TYPE_CHECKING:
     from causal4d.phystwin_backend import OfficialPhysTwinBackend
@@ -243,6 +248,10 @@ def export_official_phystwin_twin_belief(
         if backend.config.self_collision is None
         else backend.config.self_collision
     )
+    simulator_configuration_id = backend.replay_simulator_configuration_id(
+        backend.graph
+    )
+    released_initial_state_id = backend.replay_released_initial_state_id()
     replay_provider: PhysTwinReplayProvider = create_official_replay_provider(
         backend.official_repo,
         backend.data,
@@ -254,20 +263,56 @@ def export_official_phystwin_twin_belief(
         dt=backend.config.dt,
         num_substeps=backend.config.num_substeps,
         self_collision=bool(self_collision),
+        simulator_configuration_id=simulator_configuration_id,
+        released_initial_state_id=released_initial_state_id,
         deterministic_spring_forces=backend.config.deterministic_spring_forces,
         spring_parameterization="grouped",
         device=backend.config.device,
     )
     replay_positions = []
     replay_velocities = []
+    replay_records: list[dict[str, Any]] = []
     try:
-        for particle in backend.particles.log_scales:
-            replay_provider.set_group_log_scales(particle)
-            positions, velocities = replay_provider.replay_initial(
-                frame_count=backend.train_end_frame
+        for particle_index, particle in enumerate(backend.particles.log_scales):
+            request_id = stable_replay_identifier(
+                "causal4d-initial-replay-request-v1",
+                {
+                    "simulator_configuration_id": simulator_configuration_id,
+                    "initial_state_id": released_initial_state_id,
+                    "particle_index": particle_index,
+                    "group_log_scales_sha256": array_sha256(particle),
+                    "controller_points_sha256": array_sha256(backend.controller_points),
+                    "frame_count": backend.train_end_frame,
+                },
             )
-            replay_positions.append(positions)
-            replay_velocities.append(velocities)
+            request = InitialReplayRequestV1(
+                request_id=request_id,
+                simulator_configuration_id=simulator_configuration_id,
+                initial_state_id=released_initial_state_id,
+                group_log_scales=particle,
+                controller_points_m=backend.controller_points,
+                frame_count=backend.train_end_frame,
+            )
+            replay = replay_provider.replay(request)
+            validate_replay_trajectory(
+                request,
+                replay,
+                expected_dt_s=backend.frame_dt_s,
+            )
+            replay_positions.append(replay.positions_m)
+            replay_velocities.append(replay.velocities_mps)
+            replay_records.append(
+                {
+                    "request_id": request_id,
+                    "simulator_configuration_id": simulator_configuration_id,
+                    "initial_state_id": released_initial_state_id,
+                    "particle_index": particle_index,
+                    "frame_ids": replay.frame_ids.tolist(),
+                    "dt_s": float(replay.dt_s),
+                    "positions_sha256": array_sha256(replay.positions_m),
+                    "velocities_sha256": array_sha256(replay.velocities_mps),
+                }
+            )
     finally:
         replay_provider.close()
 
@@ -295,6 +340,8 @@ def export_official_phystwin_twin_belief(
                 backend.particles.represented_probability_mass
             ),
             "official_backend": backend.default_manifest(),
+            "replay_provider_api_version": 2,
+            "initial_replay_requests": replay_records,
         },
         config=config,
     )

--- a/src/causal4d/phystwin_backend.py
+++ b/src/causal4d/phystwin_backend.py
@@ -7,14 +7,16 @@ import pickle
 from dataclasses import asdict, dataclass
 from itertools import product
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Mapping, Sequence
 
 import numpy as np
 
-from bayesian_phystwin.causal4d_provider_v1 import (
+from bayesian_phystwin.causal4d_provider_v1 import released_self_collision_for_case
+from bayesian_phystwin.causal4d_provider_v2 import (
     PhysTwinReplayProvider,
+    RestartReplayRequestV1,
     create_official_replay_provider,
-    released_self_collision_for_case,
+    sha256_file,
 )
 from bayesian_phystwin.causal4d_graph_provider_v1 import (
     controller_hand_count,
@@ -36,12 +38,32 @@ from causal4d.contracts import (
 from causal4d.graph_provider_contract import require_bayesian_phystwin_graph_provider
 from causal4d.parameter_support import SupportMethod, reduce_parameter_support
 from causal4d.provider_contract import require_bayesian_phystwin_provider
+from causal4d.replay_provider_contract import (
+    require_bayesian_phystwin_replay_provider,
+    stable_replay_identifier,
+    validate_replay_trajectory,
+)
 from causal4d.rollout_bank import JointRolloutBank
 
 
 def _load_pickle(path: str | Path) -> Any:
     with Path(path).open("rb") as handle:
         return pickle.load(handle)
+
+
+def _graph_replay_descriptor(graph: PhysTwinSpringGraph) -> dict[str, Any]:
+    return {
+        "vertices_sha256": array_sha256(np.asarray(graph.vertices)),
+        "springs_sha256": array_sha256(np.asarray(graph.springs)),
+        "rest_lengths_sha256": array_sha256(np.asarray(graph.rest_lengths)),
+        "masses_sha256": array_sha256(np.asarray(graph.masses)),
+        "num_object_springs": int(graph.num_object_springs),
+        "num_object_points": int(graph.num_object_points),
+    }
+
+
+def _source_artifact_digests(paths: Mapping[str, str | Path]) -> dict[str, str]:
+    return {name: sha256_file(path) for name, path in paths.items()}
 
 
 @dataclass(frozen=True)
@@ -827,6 +849,7 @@ class OfficialPhysTwinBackend:
         config: OfficialPhysTwinBackendConfig | None = None,
     ) -> None:
         self.provider_manifest = require_bayesian_phystwin_provider()
+        self.replay_provider_manifest = require_bayesian_phystwin_replay_provider()
         self.graph_provider_manifest = require_bayesian_phystwin_graph_provider()
         self.official_repo = Path(official_repo)
         self.final_data_path = Path(final_data_path)
@@ -835,6 +858,15 @@ class OfficialPhysTwinBackend:
         self.baseline_trajectory_path = Path(baseline_trajectory_path)
         self.profile_path = Path(profile_path)
         self.config = config or OfficialPhysTwinBackendConfig()
+        self.source_artifacts_sha256 = _source_artifact_digests(
+            {
+                "final_data": self.final_data_path,
+                "optimal_params": self.optimal_params_path,
+                "checkpoint": self.checkpoint_path,
+                "baseline_trajectory": self.baseline_trajectory_path,
+                "parameter_profile": self.profile_path,
+            }
+        )
         self.data = _load_pickle(self.final_data_path)
         self.optimal = _load_pickle(self.optimal_params_path)
         self.baseline = np.asarray(
@@ -889,6 +921,71 @@ class OfficialPhysTwinBackend:
             maximum_count=parameter_particle_count,
             support_method=parameter_support_method,
         )
+        self.released_initial_state_id = stable_replay_identifier(
+            "causal4d-released-initial-state-v1",
+            {
+                "case": self.case_name,
+                "baseline_frame_zero_sha256": array_sha256(self.baseline[0]),
+                "controller_frame_zero_sha256": array_sha256(self.controller_points[0]),
+            },
+        )
+        self.base_simulator_configuration_id = stable_replay_identifier(
+            "causal4d-phystwin-simulator-base-v1",
+            {
+                "case": self.case_name,
+                "runtime": asdict(self.config),
+                "source_artifacts_sha256": self.source_artifacts_sha256,
+            },
+        )
+
+    @property
+    def frame_dt_s(self) -> float:
+        """Physical interval represented by one provider trajectory frame."""
+
+        return float(self.config.dt * self.config.num_substeps)
+
+    def replay_simulator_configuration_id(
+        self,
+        graph: PhysTwinSpringGraph,
+    ) -> str:
+        """Bind one immutable provider instance to its exact spring graph."""
+
+        base_id = getattr(
+            self,
+            "base_simulator_configuration_id",
+            stable_replay_identifier(
+                "causal4d-phystwin-simulator-base-v1",
+                {
+                    "case": self.case_name,
+                    "runtime": asdict(self.config),
+                    "source_artifacts_sha256": getattr(
+                        self, "source_artifacts_sha256", {}
+                    ),
+                },
+            ),
+        )
+        return stable_replay_identifier(
+            "causal4d-phystwin-simulator-graph-v1",
+            {
+                "base_simulator_configuration_id": base_id,
+                "spring_graph": _graph_replay_descriptor(graph),
+            },
+        )
+
+    def replay_released_initial_state_id(self) -> str:
+        """Return the released initial-state identity used by initial replays."""
+
+        identifier = getattr(self, "released_initial_state_id", None)
+        if identifier is not None:
+            return str(identifier)
+        return stable_replay_identifier(
+            "causal4d-released-initial-state-v1",
+            {
+                "case": self.case_name,
+                "baseline_frame_zero_sha256": array_sha256(self.baseline[0]),
+                "controller_frame_zero_sha256": array_sha256(self.controller_points[0]),
+            },
+        )
 
     @property
     def observations_from_endpoint(self) -> np.ndarray:
@@ -905,9 +1002,21 @@ class OfficialPhysTwinBackend:
         return {
             "backend": "official_phystwin_warp",
             "provider": self.provider_manifest.as_dict(),
+            "replay_provider": self.replay_provider_manifest.as_dict(),
             "graph_provider": self.graph_provider_manifest.as_dict(),
+            "replay_contract": {
+                "provider_api_version": 2,
+                "frame_dt_s": self.frame_dt_s,
+                "base_simulator_configuration_id": getattr(
+                    self, "base_simulator_configuration_id", None
+                ),
+                "released_initial_state_id": self.replay_released_initial_state_id(),
+            },
             "case": self.case_name,
             "train_end_frame": self.train_end_frame,
+            "source_artifacts_sha256": dict(
+                getattr(self, "source_artifacts_sha256", {})
+            ),
             "source_paths": {
                 "official_repo": str(self.official_repo.resolve()),
                 "final_data": str(self.final_data_path.resolve()),
@@ -1075,6 +1184,7 @@ class OfficialPhysTwinBackend:
             else self.config.self_collision
         )
         shift_diagnostics: dict[str, Any] = {}
+        replay_records: list[dict[str, Any]] = []
         unique_shifts = tuple(
             dict.fromkeys(
                 hypothesis.contact.attachment_shifts for hypothesis in hypotheses
@@ -1092,6 +1202,9 @@ class OfficialPhysTwinBackend:
                 "controller_spring_count": len(variant.graph.springs)
                 - variant.graph.num_object_springs,
             }
+            simulator_configuration_id = self.replay_simulator_configuration_id(
+                variant.graph
+            )
             replay_provider: PhysTwinReplayProvider = create_official_replay_provider(
                 self.official_repo,
                 self.data,
@@ -1103,6 +1216,8 @@ class OfficialPhysTwinBackend:
                 dt=self.config.dt,
                 num_substeps=self.config.num_substeps,
                 self_collision=bool(self_collision),
+                simulator_configuration_id=simulator_configuration_id,
+                released_initial_state_id=self.replay_released_initial_state_id(),
                 deterministic_spring_forces=self.config.deterministic_spring_forces,
                 spring_parameterization="grouped",
                 device=self.config.device,
@@ -1121,7 +1236,6 @@ class OfficialPhysTwinBackend:
                         hypothesis.contact,
                         start_frame=self.train_end_frame,
                     )
-                    replay_provider.set_controller_points(controls)
                     for particle_index, particle in enumerate(
                         self.particles.log_scales
                     ):
@@ -1133,21 +1247,81 @@ class OfficialPhysTwinBackend:
                             ],
                             dtype=np.float32,
                         )
-                        replay_provider.set_group_log_scales(group_scales)
-                        future = replay_provider.replay_restart(
-                            twin_belief.endpoint_position_m[particle_index].copy(),
-                            twin_belief.endpoint_velocity_mps[particle_index].copy(),
+                        endpoint_position = twin_belief.endpoint_position_m[
+                            particle_index
+                        ].copy()
+                        endpoint_velocity = twin_belief.endpoint_velocity_mps[
+                            particle_index
+                        ].copy()
+                        initial_state_id = stable_replay_identifier(
+                            "causal4d-twin-belief-endpoint-v1",
+                            {
+                                "twin_belief_id": twin_belief.artifact_id,
+                                "particle_id": twin_belief.particle_ids[particle_index],
+                                "position_sha256": array_sha256(endpoint_position),
+                                "velocity_sha256": array_sha256(endpoint_velocity),
+                            },
+                        )
+                        request_id = stable_replay_identifier(
+                            "causal4d-restart-replay-request-v1",
+                            {
+                                "simulator_configuration_id": (
+                                    simulator_configuration_id
+                                ),
+                                "initial_state_id": initial_state_id,
+                                "hypothesis_id": hypothesis.hypothesis_id,
+                                "particle_id": twin_belief.particle_ids[particle_index],
+                                "group_log_scales_sha256": array_sha256(group_scales),
+                                "controller_points_sha256": array_sha256(controls),
+                                "start_frame": self.train_end_frame,
+                                "stop_frame": self.frame_count,
+                            },
+                        )
+                        request = RestartReplayRequestV1(
+                            request_id=request_id,
+                            simulator_configuration_id=(simulator_configuration_id),
+                            initial_state_id=initial_state_id,
+                            group_log_scales=group_scales,
+                            controller_points_m=controls,
+                            position_m=endpoint_position,
+                            velocity_mps=endpoint_velocity,
                             start_frame=self.train_end_frame,
                             stop_frame=self.frame_count,
                         )
-                        trajectories[hypothesis_index, particle_index, 0] = (
-                            twin_belief.endpoint_position_m[
-                                particle_index, : self.original_count
-                            ]
+                        replay = replay_provider.replay(request)
+                        validate_replay_trajectory(
+                            request,
+                            replay,
+                            expected_dt_s=self.frame_dt_s,
                         )
-                        trajectories[hypothesis_index, particle_index, 1:] = future[
-                            :, : self.original_count
-                        ]
+                        if replay.positions_m.shape[1] < self.original_count:
+                            raise ValueError(
+                                "replay trajectory has fewer nodes than the "
+                                "observed object"
+                            )
+                        trajectories[hypothesis_index, particle_index, 0] = (
+                            endpoint_position[: self.original_count]
+                        )
+                        trajectories[hypothesis_index, particle_index, 1:] = (
+                            replay.positions_m[:, : self.original_count]
+                        )
+                        replay_records.append(
+                            {
+                                "request_id": request_id,
+                                "simulator_configuration_id": (
+                                    simulator_configuration_id
+                                ),
+                                "initial_state_id": initial_state_id,
+                                "hypothesis_id": hypothesis.hypothesis_id,
+                                "particle_id": twin_belief.particle_ids[particle_index],
+                                "frame_ids": replay.frame_ids.tolist(),
+                                "dt_s": float(replay.dt_s),
+                                "positions_sha256": array_sha256(replay.positions_m),
+                                "velocities_sha256": array_sha256(
+                                    replay.velocities_mps
+                                ),
+                            }
+                        )
             finally:
                 replay_provider.close()
 
@@ -1179,6 +1353,9 @@ class OfficialPhysTwinBackend:
                 "attachment_shift_diagnostics": shift_diagnostics,
                 "rollout_shape": list(trajectories.shape),
                 "rollout_frame_interval": [endpoint_index, self.frame_count],
+                "replay_provider_api_version": 2,
+                "replay_request_count": len(replay_records),
+                "replay_requests": replay_records,
                 "causal_context": self.causal_context(
                     action_proposals,
                     protocol_id=twin_belief.context.protocol_id,

--- a/src/causal4d/phystwin_resumable.py
+++ b/src/causal4d/phystwin_resumable.py
@@ -17,6 +17,13 @@ from typing import Any
 
 import numpy as np
 
+from bayesian_phystwin.causal4d_provider_v2 import (
+    InitialReplayRequestV1,
+    ReplayRequestV1,
+    ReplayTrajectoryV1,
+    RestartReplayRequestV1,
+)
+
 import causal4d.phystwin_backend as phystwin_backend_module
 from causal4d.contracts import TwinBelief, array_sha256
 from causal4d.phystwin_backend import (
@@ -28,8 +35,8 @@ from causal4d.phystwin_backend import (
 )
 from causal4d.rollout_bank import JointRolloutBank
 from causal4d.rollout_cache import (
-    ContentAddressedRolloutCache,
-    RolloutCacheResult,
+    ContentAddressedReplayCache,
+    ReplayCacheResult,
     file_sha256,
     repository_source_identity,
 )
@@ -114,6 +121,9 @@ def _provider_source_identity() -> dict[str, Any]:
 
 
 def _source_artifact_digests(backend: OfficialPhysTwinBackend) -> dict[str, str]:
+    recorded = getattr(backend, "source_artifacts_sha256", None)
+    if recorded is not None:
+        return dict(recorded)
     sources = {
         "final_data": backend.final_data_path,
         "optimal_params": backend.optimal_params_path,
@@ -126,7 +136,7 @@ def _source_artifact_digests(backend: OfficialPhysTwinBackend) -> dict[str, str]
 
 @dataclass
 class _RolloutCacheSession:
-    cache: ContentAddressedRolloutCache
+    cache: ContentAddressedReplayCache
     provider_manifest: dict[str, Any]
     provider_source: dict[str, Any]
     official_source: dict[str, Any]
@@ -147,8 +157,8 @@ class _RolloutCacheSession:
         rollout_cache_dir: str | Path,
     ) -> _RolloutCacheSession:
         return cls(
-            cache=ContentAddressedRolloutCache(rollout_cache_dir),
-            provider_manifest=backend.provider_manifest.as_dict(),
+            cache=ContentAddressedReplayCache(rollout_cache_dir),
+            provider_manifest=backend.replay_provider_manifest.as_dict(),
             provider_source=_provider_source_identity(),
             official_source=repository_source_identity(backend.official_repo),
             numerical_runtime=_numerical_runtime_descriptor(),
@@ -158,13 +168,21 @@ class _RolloutCacheSession:
         )
 
     def wrap_factory(self, factory: Callable[..., Any]) -> Callable[..., Any]:
-        def cached_factory(*args: Any, **kwargs: Any) -> _LazyCachedReplayProvider:
+        def cached_factory(*args: Any, **kwargs: Any) -> _LazyCachedReplayProviderV2:
             self.provider_proxy_count += 1
             graph = _factory_value(args, kwargs, name="graph", position=4)
             original_count = int(_factory_value(args, kwargs, name="original_count"))
             deterministic = bool(
                 _factory_value(args, kwargs, name="deterministic_spring_forces")
             )
+            simulator_configuration_id = str(
+                _factory_value(args, kwargs, name="simulator_configuration_id")
+            )
+            released_initial_state_id = str(
+                _factory_value(args, kwargs, name="released_initial_state_id")
+            )
+            dt = float(_factory_value(args, kwargs, name="dt"))
+            num_substeps = int(_factory_value(args, kwargs, name="num_substeps"))
             self.deterministic_modes.add(deterministic)
             static_descriptor = {
                 "provider": self.provider_manifest,
@@ -179,13 +197,14 @@ class _RolloutCacheSession:
                         _factory_value(args, kwargs, name="num_surface_points")
                     ),
                     "original_count": original_count,
-                    "dt": float(_factory_value(args, kwargs, name="dt")),
-                    "num_substeps": int(
-                        _factory_value(args, kwargs, name="num_substeps")
-                    ),
+                    "dt": dt,
+                    "num_substeps": num_substeps,
+                    "frame_dt_s": dt * num_substeps,
                     "self_collision": bool(
                         _factory_value(args, kwargs, name="self_collision")
                     ),
+                    "simulator_configuration_id": simulator_configuration_id,
+                    "released_initial_state_id": released_initial_state_id,
                     "deterministic_spring_forces": deterministic,
                     "spring_parameterization": str(
                         _factory_value(
@@ -197,7 +216,7 @@ class _RolloutCacheSession:
                     "device": str(_factory_value(args, kwargs, name="device")),
                 },
             }
-            return _LazyCachedReplayProvider(
+            return _LazyCachedReplayProviderV2(
                 session=self,
                 factory=factory,
                 factory_args=args,
@@ -214,31 +233,43 @@ class _RolloutCacheSession:
 
     def record_call(
         self,
-        result: RolloutCacheResult,
+        result: ReplayCacheResult,
         *,
-        controller_points: np.ndarray,
-        group_log_scales: np.ndarray,
-        endpoint_position: np.ndarray,
-        endpoint_velocity: np.ndarray,
-        start_frame: int,
-        stop_frame: int,
+        request: ReplayRequestV1,
     ) -> None:
-        self.records.append(
-            {
-                "ordinal": len(self.records),
-                "cache_key": result.cache_key,
-                "cache_status": result.status,
-                "cache_hit": result.cache_hit,
-                "record_path": result.relative_path,
-                "trajectory_sha256": result.trajectory_sha256,
-                "controller_points_sha256": array_sha256(controller_points),
-                "group_log_scales_sha256": array_sha256(group_log_scales),
-                "group_log_scales": np.asarray(group_log_scales, dtype=float).tolist(),
-                "endpoint_position_sha256": array_sha256(endpoint_position),
-                "endpoint_velocity_sha256": array_sha256(endpoint_velocity),
-                "frame_interval": [int(start_frame), int(stop_frame)],
-            }
-        )
+        record: dict[str, Any] = {
+            "ordinal": len(self.records),
+            "cache_key": result.cache_key,
+            "cache_status": result.status,
+            "cache_hit": result.cache_hit,
+            "record_path": result.relative_path,
+            "request_type": type(request).__name__,
+            "request_id": request.request_id,
+            "simulator_configuration_id": request.simulator_configuration_id,
+            "initial_state_id": request.initial_state_id,
+            "positions_sha256": result.positions_sha256,
+            "velocities_sha256": result.velocities_sha256,
+            "frame_ids": result.replay.frame_ids.tolist(),
+            "dt_s": result.replay.dt_s,
+            "controller_points_sha256": array_sha256(request.controller_points_m),
+            "group_log_scales_sha256": array_sha256(request.group_log_scales),
+            "group_log_scales": np.asarray(
+                request.group_log_scales, dtype=float
+            ).tolist(),
+        }
+        if isinstance(request, RestartReplayRequestV1):
+            record.update(
+                {
+                    "endpoint_position_sha256": array_sha256(request.position_m),
+                    "endpoint_velocity_sha256": array_sha256(request.velocity_mps),
+                    "frame_interval": [request.start_frame, request.stop_frame],
+                }
+            )
+        elif isinstance(request, InitialReplayRequestV1):
+            record["frame_interval"] = [0, request.frame_count]
+        else:  # pragma: no cover - typed providers admit only the two requests
+            raise TypeError("unsupported replay request type")
+        self.records.append(record)
 
     def bind_rollout_components(
         self,
@@ -290,7 +321,7 @@ class _RolloutCacheSession:
         return {
             "enabled": True,
             "schema_name": "causal4d.phystwin-rollout-cache-manifest",
-            "schema_version": 1,
+            "schema_version": 2,
             "root": str(self.cache.root),
             "record_count": len(self.records),
             "validated_record_count": len(self.records),
@@ -301,6 +332,7 @@ class _RolloutCacheSession:
             "provider_proxy_count": self.provider_proxy_count,
             "provider_instance_count": self.provider_instance_count,
             "all_records_validated": True,
+            "cached_payload": "positions_velocities_and_provenance",
             "replay_semantics": (
                 "deterministic"
                 if deterministic
@@ -316,8 +348,8 @@ class _RolloutCacheSession:
         }
 
 
-class _LazyCachedReplayProvider:
-    """Instantiate the real provider only when one requested record is absent."""
+class _LazyCachedReplayProviderV2:
+    """Instantiate the real replay-v2 provider only on a cache miss."""
 
     def __init__(
         self,
@@ -336,9 +368,32 @@ class _LazyCachedReplayProvider:
         self._static_descriptor = static_descriptor
         self._original_count = original_count
         self._provider: Any | None = None
-        self._controller_points: np.ndarray | None = None
-        self._group_log_scales: np.ndarray | None = None
-        self.device = str(factory_kwargs.get("device", "unknown"))
+        self._device = str(factory_kwargs.get("device", "unknown"))
+        self._frame_dt_s = float(factory_kwargs["dt"]) * int(
+            factory_kwargs["num_substeps"]
+        )
+        self._simulator_configuration_id = str(
+            factory_kwargs["simulator_configuration_id"]
+        )
+        self._released_initial_state_id = str(
+            factory_kwargs["released_initial_state_id"]
+        )
+
+    @property
+    def device(self) -> str:
+        return self._device
+
+    @property
+    def frame_dt_s(self) -> float:
+        return self._frame_dt_s
+
+    @property
+    def simulator_configuration_id(self) -> str:
+        return self._simulator_configuration_id
+
+    @property
+    def released_initial_state_id(self) -> str:
+        return self._released_initial_state_id
 
     def _ensure_provider(self) -> Any:
         if self._provider is None:
@@ -347,92 +402,90 @@ class _LazyCachedReplayProvider:
                 **self._factory_kwargs,
             )
             self._session.note_provider_instantiation()
-            if self._controller_points is not None:
-                self._provider.set_controller_points(self._controller_points.copy())
-            if self._group_log_scales is not None:
-                self._provider.set_group_log_scales(self._group_log_scales.copy())
         return self._provider
 
-    def set_controller_points(self, values: np.ndarray) -> None:
-        self._controller_points = np.asarray(values, dtype=np.float32).copy()
-        if self._provider is not None:
-            self._provider.set_controller_points(self._controller_points.copy())
-
-    def set_group_log_scales(self, values: np.ndarray) -> None:
-        self._group_log_scales = np.asarray(values, dtype=np.float32).copy()
-        if self._provider is not None:
-            self._provider.set_group_log_scales(self._group_log_scales.copy())
-
-    def replay_initial(self, *, frame_count: int) -> Any:
-        return self._ensure_provider().replay_initial(frame_count=frame_count)
-
-    def replay_restart(
-        self,
-        position_m: np.ndarray,
-        velocity_mps: np.ndarray,
-        *,
-        start_frame: int,
-        stop_frame: int,
-    ) -> np.ndarray:
-        if self._controller_points is None or self._group_log_scales is None:
-            raise RuntimeError(
-                "controller points and group scales must be set before replay"
-            )
-        position = np.asarray(position_m).copy()
-        velocity = np.asarray(velocity_mps).copy()
-        call_descriptor = {
-            **self._static_descriptor,
-            "controller_points": _array_descriptor(self._controller_points),
+    @staticmethod
+    def _request_descriptor(request: ReplayRequestV1) -> dict[str, Any]:
+        descriptor: dict[str, Any] = {
+            "request_type": type(request).__name__,
+            "request_id": request.request_id,
+            "simulator_configuration_id": request.simulator_configuration_id,
+            "initial_state_id": request.initial_state_id,
+            "controller_points": _array_descriptor(request.controller_points_m),
             "group_log_scales": {
-                **_array_descriptor(self._group_log_scales),
-                "values": np.asarray(self._group_log_scales, dtype=float).tolist(),
-            },
-            "endpoint_position": _array_descriptor(position),
-            "endpoint_velocity": _array_descriptor(velocity),
-            "frame_interval": {
-                "start": int(start_frame),
-                "stop": int(stop_frame),
+                **_array_descriptor(request.group_log_scales),
+                "values": np.asarray(request.group_log_scales, dtype=float).tolist(),
             },
         }
-
-        def compute() -> np.ndarray:
-            provider = self._ensure_provider()
-            return np.asarray(
-                provider.replay_restart(
-                    position.copy(),
-                    velocity.copy(),
-                    start_frame=start_frame,
-                    stop_frame=stop_frame,
-                ),
-                dtype=np.float32,
+        if isinstance(request, InitialReplayRequestV1):
+            descriptor["frame_interval"] = {"start": 0, "stop": request.frame_count}
+        elif isinstance(request, RestartReplayRequestV1):
+            descriptor.update(
+                {
+                    "endpoint_position": _array_descriptor(request.position_m),
+                    "endpoint_velocity": _array_descriptor(request.velocity_mps),
+                    "frame_interval": {
+                        "start": request.start_frame,
+                        "stop": request.stop_frame,
+                    },
+                }
             )
+        else:  # pragma: no cover - typed providers admit only the two requests
+            raise TypeError("unsupported replay request type")
+        return descriptor
+
+    def replay(self, request: ReplayRequestV1) -> ReplayTrajectoryV1:
+        if request.simulator_configuration_id != self._simulator_configuration_id:
+            raise ValueError("request configuration does not match cached provider")
+        if (
+            isinstance(request, InitialReplayRequestV1)
+            and request.initial_state_id != self._released_initial_state_id
+        ):
+            raise ValueError("initial request does not identify the released state")
+        if isinstance(request, InitialReplayRequestV1):
+            expected_frame_ids = np.arange(request.frame_count, dtype=np.int64)
+        elif isinstance(request, RestartReplayRequestV1):
+            expected_frame_ids = np.arange(
+                request.start_frame,
+                request.stop_frame,
+                dtype=np.int64,
+            )
+        else:  # pragma: no cover - typed providers admit only the two requests
+            raise TypeError("unsupported replay request type")
+        call_descriptor = {
+            **self._static_descriptor,
+            "request": self._request_descriptor(request),
+        }
+
+        def compute() -> Any:
+            return self._ensure_provider().replay(request)
 
         result = self._session.cache.get_or_compute(
             call_descriptor,
             compute,
-            expected_frame_count=stop_frame - start_frame,
+            expected_frame_ids=expected_frame_ids,
             minimum_node_count=self._original_count,
+            expected_dt_s=self._frame_dt_s,
+            request_id=request.request_id,
+            simulator_configuration_id=request.simulator_configuration_id,
+            initial_state_id=request.initial_state_id,
         )
-        self._session.record_call(
-            result,
-            controller_points=self._controller_points,
-            group_log_scales=self._group_log_scales,
-            endpoint_position=position,
-            endpoint_velocity=velocity,
-            start_frame=start_frame,
-            stop_frame=stop_frame,
+        self._session.record_call(result, request=request)
+        replay = result.replay
+        return ReplayTrajectoryV1(
+            positions_m=replay.positions_m,
+            velocities_mps=replay.velocities_mps,
+            frame_ids=replay.frame_ids,
+            dt_s=replay.dt_s,
+            request_id=replay.request_id,
+            simulator_configuration_id=replay.simulator_configuration_id,
+            initial_state_id=replay.initial_state_id,
         )
-        return result.trajectory
 
     def close(self) -> None:
         if self._provider is not None:
             self._provider.close()
             self._provider = None
-
-    def __getattr__(self, name: str) -> Any:
-        if name.startswith("_"):
-            raise AttributeError(name)
-        return getattr(self._ensure_provider(), name)
 
 
 def build_resumable_rollout_bank(
@@ -455,7 +508,8 @@ def build_resumable_rollout_bank(
         result_manifest["rollout_cache"] = {
             "enabled": False,
             "schema_name": "causal4d.phystwin-rollout-cache-manifest",
-            "schema_version": 1,
+            "schema_version": 2,
+            "cached_payload": "positions_velocities_and_provenance",
         }
         return bank, result_manifest
 

--- a/src/causal4d/replay_provider_contract.py
+++ b/src/causal4d/replay_provider_contract.py
@@ -1,0 +1,187 @@
+"""Fail-closed contract for Bayesian-PhysTwin replay provider API v2."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from typing import Any, cast
+
+import numpy as np
+
+from causal4d.provider_contract import (
+    BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE,
+    PhysicalBeliefProviderManifest,
+    ProviderCompatibilityResult,
+    validate_provider_compatibility,
+)
+
+BAYESIAN_PHYSTWIN_REPLAY_PROVIDER_SCHEMA_VERSION = 2
+BAYESIAN_PHYSTWIN_REPLAY_PROVIDER_CAPABILITIES = (
+    "artifact_checksums",
+    "immutable_replay_trajectories",
+    "particle_endpoint_position",
+    "particle_endpoint_velocity",
+    "physical_parameter_particles",
+    "phystwin_replay",
+    "residual_lifting",
+    "restart_velocity_history",
+    "stateless_replay_requests",
+    "target_validity",
+    "typed_replay_requests",
+)
+BAYESIAN_PHYSTWIN_REPLAY_ARTIFACT_SCHEMA_VERSIONS = {
+    "GraphBelief": 1,
+    "TwinBelief": 1,
+    "ReplayRequest": 1,
+    "ReplayTrajectory": 1,
+}
+
+
+def stable_replay_identifier(namespace: str, payload: Mapping[str, Any]) -> str:
+    """Return a deterministic nonempty identifier for one replay-owned object."""
+
+    if not isinstance(namespace, str):
+        raise TypeError("replay identifier namespace must be a string")
+    prefix = namespace.strip()
+    if not prefix:
+        raise ValueError("replay identifier namespace must be nonempty")
+    try:
+        encoded = json.dumps(
+            dict(payload),
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as error:
+        raise ValueError(
+            "replay identifier payload must contain finite JSON data"
+        ) from error
+    return f"{prefix}:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _manifest(values: Mapping[str, object]) -> PhysicalBeliefProviderManifest:
+    return PhysicalBeliefProviderManifest(
+        provider_name=str(values["provider_name"]),
+        provider_version=str(values["provider_version"]),
+        provider_revision=str(values["provider_revision"]),
+        schema_version=int(cast(int | str, values["schema_version"])),
+        capabilities=tuple(map(str, cast(Iterable[object], values["capabilities"]))),
+        artifact_schema_versions=dict(
+            cast(Mapping[str, int], values["artifact_schema_versions"])
+        ),
+        metadata=dict(cast(Mapping[str, Any], values.get("metadata", {}))),
+    )
+
+
+def load_bayesian_phystwin_replay_provider_manifest(
+    *,
+    provider_revision: str | None = None,
+) -> PhysicalBeliefProviderManifest:
+    """Load BPT's immutable replay descriptor from the versioned v2 module."""
+
+    from bayesian_phystwin.causal4d_provider_v2 import causal4d_provider_manifest
+
+    return _manifest(causal4d_provider_manifest(provider_revision=provider_revision))
+
+
+def validate_bayesian_phystwin_replay_provider(
+    manifest: PhysicalBeliefProviderManifest | None = None,
+    *,
+    provider_revision: str | None = None,
+) -> ProviderCompatibilityResult:
+    """Validate identity, version, capabilities, and replay artifact schemas."""
+
+    candidate = manifest or load_bayesian_phystwin_replay_provider_manifest(
+        provider_revision=provider_revision
+    )
+    if candidate.provider_name != "bayesian-phystwin":
+        raise ValueError("expected the bayesian-phystwin replay provider")
+    if candidate.metadata.get("provider_api") != (
+        "bayesian_phystwin.causal4d_provider_v2"
+    ):
+        raise ValueError("replay provider must identify causal4d_provider_v2")
+    if candidate.metadata.get("provider_api_version") != 2:
+        raise ValueError("replay provider metadata must identify API version 2")
+    return validate_provider_compatibility(
+        candidate,
+        required_capabilities=BAYESIAN_PHYSTWIN_REPLAY_PROVIDER_CAPABILITIES,
+        supported_schema_versions=(BAYESIAN_PHYSTWIN_REPLAY_PROVIDER_SCHEMA_VERSION,),
+        supported_provider_versions=BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE,
+        required_artifact_versions=(BAYESIAN_PHYSTWIN_REPLAY_ARTIFACT_SCHEMA_VERSIONS),
+    )
+
+
+def require_bayesian_phystwin_replay_provider(
+    *,
+    provider_revision: str | None = None,
+) -> PhysicalBeliefProviderManifest:
+    """Return a compatible replay-v2 manifest or fail before simulation."""
+
+    manifest = load_bayesian_phystwin_replay_provider_manifest(
+        provider_revision=provider_revision
+    )
+    result = validate_bayesian_phystwin_replay_provider(manifest)
+    if not result.compatible:
+        raise RuntimeError(
+            "incompatible Bayesian-PhysTwin replay provider: "
+            + json.dumps(result.as_dict(), sort_keys=True)
+        )
+    return manifest
+
+
+def validate_replay_trajectory(
+    request: Any,
+    trajectory: Any,
+    *,
+    expected_dt_s: float,
+) -> None:
+    """Independently bind one provider response to its immutable request."""
+
+    from bayesian_phystwin.causal4d_provider_v2 import (
+        InitialReplayRequestV1,
+        RestartReplayRequestV1,
+    )
+
+    expected_dt = float(expected_dt_s)
+    if not np.isfinite(expected_dt) or expected_dt <= 0.0:
+        raise ValueError("expected_dt_s must be positive and finite")
+    expected_frames: np.ndarray
+    if isinstance(request, InitialReplayRequestV1):
+        expected_frames = np.arange(request.frame_count, dtype=np.int64)
+    elif isinstance(request, RestartReplayRequestV1):
+        expected_frames = np.arange(
+            request.start_frame,
+            request.stop_frame,
+            dtype=np.int64,
+        )
+    else:
+        raise TypeError("unsupported replay request type")
+
+    if trajectory.request_id != request.request_id:
+        raise ValueError("replay trajectory request_id does not match its request")
+    if trajectory.simulator_configuration_id != request.simulator_configuration_id:
+        raise ValueError(
+            "replay trajectory simulator_configuration_id does not match its request"
+        )
+    if trajectory.initial_state_id != request.initial_state_id:
+        raise ValueError(
+            "replay trajectory initial_state_id does not match its request"
+        )
+    if not np.array_equal(np.asarray(trajectory.frame_ids), expected_frames):
+        raise ValueError(
+            "replay trajectory frame provenance does not match its request"
+        )
+    if not np.isclose(float(trajectory.dt_s), expected_dt, rtol=0.0, atol=1e-15):
+        raise ValueError("replay trajectory timestep does not match the backend")
+
+    positions = np.asarray(trajectory.positions_m)
+    velocities = np.asarray(trajectory.velocities_mps)
+    if positions.shape != velocities.shape:
+        raise ValueError("replay trajectory positions and velocities differ in shape")
+    if positions.shape[0] != len(expected_frames):
+        raise ValueError("replay trajectory frame count does not match its request")
+    if positions.ndim != 3 or positions.shape[1] < 1 or positions.shape[2] != 3:
+        raise ValueError("replay trajectory must have shape (T, N>=1, 3)")
+    if not np.all(np.isfinite(positions)) or not np.all(np.isfinite(velocities)):
+        raise ValueError("replay trajectory must contain only finite values")

--- a/src/causal4d/rollout_cache.py
+++ b/src/causal4d/rollout_cache.py
@@ -464,3 +464,467 @@ class ContentAddressedRolloutCache:
             trajectory_sha256=loaded_sha256,
             status=status,
         )
+
+
+REPLAY_CACHE_SCHEMA_NAME = "causal4d.phystwin-replay-cache"
+REPLAY_CACHE_SCHEMA_VERSION = 1
+
+
+def _nonempty_identifier(value: Any, *, name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string")
+    identifier = value.strip()
+    if not identifier:
+        raise ValueError(f"{name} must be a nonempty identifier")
+    return identifier
+
+
+@dataclass(frozen=True)
+class CachedReplayTrajectory:
+    """Provider-neutral immutable representation of one replay-v2 response."""
+
+    positions_m: np.ndarray
+    velocities_mps: np.ndarray
+    frame_ids: np.ndarray
+    dt_s: float
+    request_id: str
+    simulator_configuration_id: str
+    initial_state_id: str
+
+    def __post_init__(self) -> None:
+        raw_positions = np.asarray(self.positions_m)
+        if raw_positions.ndim != 3:
+            raise ValueError("cached replay positions must have shape (T, N, 3)")
+        positions = _validated_trajectory(
+            raw_positions,
+            expected_frame_count=raw_positions.shape[0],
+            minimum_node_count=1,
+        )
+        velocities = _validated_trajectory(
+            self.velocities_mps,
+            expected_frame_count=len(positions),
+            minimum_node_count=positions.shape[1],
+        )
+        if velocities.shape != positions.shape:
+            raise ValueError("cached replay positions and velocities must match")
+        frame_ids = np.asarray(self.frame_ids, dtype=np.int64).copy()
+        if frame_ids.shape != (len(positions),):
+            raise ValueError("cached replay frame_ids must identify every frame")
+        if np.any(frame_ids < 0) or (
+            len(frame_ids) > 1 and np.any(np.diff(frame_ids) <= 0)
+        ):
+            raise ValueError(
+                "cached replay frame_ids must be increasing and nonnegative"
+            )
+        frame_ids.setflags(write=False)
+        dt_s = float(self.dt_s)
+        if not np.isfinite(dt_s) or dt_s <= 0.0:
+            raise ValueError("cached replay dt_s must be positive and finite")
+        object.__setattr__(self, "positions_m", positions)
+        object.__setattr__(self, "velocities_mps", velocities)
+        object.__setattr__(self, "frame_ids", frame_ids)
+        object.__setattr__(self, "dt_s", dt_s)
+        object.__setattr__(
+            self,
+            "request_id",
+            _nonempty_identifier(self.request_id, name="request_id"),
+        )
+        object.__setattr__(
+            self,
+            "simulator_configuration_id",
+            _nonempty_identifier(
+                self.simulator_configuration_id,
+                name="simulator_configuration_id",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "initial_state_id",
+            _nonempty_identifier(self.initial_state_id, name="initial_state_id"),
+        )
+
+    @classmethod
+    def from_object(cls, values: Any) -> CachedReplayTrajectory:
+        """Copy a BPT ReplayTrajectoryV1 without importing the optional provider."""
+
+        return cls(
+            positions_m=np.asarray(values.positions_m),
+            velocities_mps=np.asarray(values.velocities_mps),
+            frame_ids=np.asarray(values.frame_ids),
+            dt_s=float(values.dt_s),
+            request_id=str(values.request_id),
+            simulator_configuration_id=str(values.simulator_configuration_id),
+            initial_state_id=str(values.initial_state_id),
+        )
+
+
+@dataclass(frozen=True)
+class ReplayCacheResult:
+    """One validated replay-v2 cache lookup or newly published record."""
+
+    replay: CachedReplayTrajectory
+    cache_key: str
+    record_path: Path
+    relative_path: str
+    positions_sha256: str
+    velocities_sha256: str
+    status: CacheStatus
+
+    @property
+    def cache_hit(self) -> bool:
+        return self.status in {"hit", "race_hit"}
+
+
+class ContentAddressedReplayCache:
+    """Atomically cache complete replay-v2 positions, velocities, and provenance."""
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root).resolve()
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def descriptor_json(descriptor: Mapping[str, Any]) -> str:
+        return _canonical_json(
+            {
+                "schema_name": REPLAY_CACHE_SCHEMA_NAME,
+                "schema_version": REPLAY_CACHE_SCHEMA_VERSION,
+                "descriptor": dict(descriptor),
+            }
+        )
+
+    @classmethod
+    def cache_key_for(cls, descriptor: Mapping[str, Any]) -> str:
+        return hashlib.sha256(
+            cls.descriptor_json(descriptor).encode("utf-8")
+        ).hexdigest()
+
+    def _record_path(self, cache_key: str) -> Path:
+        return self.root / cache_key[:2] / f"{cache_key}.npz"
+
+    @staticmethod
+    def _validate_expected(
+        replay: CachedReplayTrajectory,
+        *,
+        expected_frame_ids: np.ndarray,
+        minimum_node_count: int,
+        expected_dt_s: float,
+        request_id: str,
+        simulator_configuration_id: str,
+        initial_state_id: str,
+    ) -> None:
+        frames = np.asarray(expected_frame_ids, dtype=np.int64)
+        if replay.positions_m.shape[1] < minimum_node_count:
+            raise ValueError("cached replay contains fewer nodes than requested")
+        if not np.array_equal(replay.frame_ids, frames):
+            raise ValueError("cached replay frame_ids do not match the request")
+        if not np.isclose(replay.dt_s, expected_dt_s, rtol=0.0, atol=1e-15):
+            raise ValueError("cached replay dt_s does not match the provider")
+        if replay.request_id != request_id:
+            raise ValueError("cached replay request_id does not match the request")
+        if replay.simulator_configuration_id != simulator_configuration_id:
+            raise ValueError("cached replay configuration identity changed")
+        if replay.initial_state_id != initial_state_id:
+            raise ValueError("cached replay initial-state identity changed")
+
+    def _load_record(
+        self,
+        path: Path,
+        *,
+        cache_key: str,
+        descriptor_json: str,
+        expected_frame_ids: np.ndarray,
+        minimum_node_count: int,
+        expected_dt_s: float,
+        request_id: str,
+        simulator_configuration_id: str,
+        initial_state_id: str,
+    ) -> tuple[CachedReplayTrajectory, str, str]:
+        try:
+            with np.load(path, allow_pickle=False) as archive:
+                required = {
+                    "schema_name",
+                    "schema_version",
+                    "cache_key",
+                    "descriptor_json",
+                    "positions_m",
+                    "velocities_mps",
+                    "frame_ids",
+                    "dt_s",
+                    "request_id",
+                    "simulator_configuration_id",
+                    "initial_state_id",
+                    "positions_sha256",
+                    "velocities_sha256",
+                }
+                missing = required - set(archive.files)
+                if missing:
+                    raise RolloutCacheValidationError(
+                        "replay cache record is missing: " + ", ".join(sorted(missing))
+                    )
+                if str(np.asarray(archive["schema_name"]).item()) != (
+                    REPLAY_CACHE_SCHEMA_NAME
+                ):
+                    raise RolloutCacheValidationError(
+                        "replay cache schema name changed"
+                    )
+                if int(np.asarray(archive["schema_version"]).item()) != (
+                    REPLAY_CACHE_SCHEMA_VERSION
+                ):
+                    raise RolloutCacheValidationError(
+                        "replay cache schema version changed"
+                    )
+                if str(np.asarray(archive["cache_key"]).item()) != cache_key:
+                    raise RolloutCacheValidationError(
+                        "replay cache key does not match its path"
+                    )
+                if (
+                    str(np.asarray(archive["descriptor_json"]).item())
+                    != descriptor_json
+                ):
+                    raise RolloutCacheValidationError(
+                        "replay cache descriptor does not match the request"
+                    )
+                replay = CachedReplayTrajectory(
+                    positions_m=archive["positions_m"],
+                    velocities_mps=archive["velocities_mps"],
+                    frame_ids=archive["frame_ids"],
+                    dt_s=float(np.asarray(archive["dt_s"]).item()),
+                    request_id=str(np.asarray(archive["request_id"]).item()),
+                    simulator_configuration_id=str(
+                        np.asarray(archive["simulator_configuration_id"]).item()
+                    ),
+                    initial_state_id=str(
+                        np.asarray(archive["initial_state_id"]).item()
+                    ),
+                )
+                stored_positions_sha256 = str(
+                    np.asarray(archive["positions_sha256"]).item()
+                )
+                stored_velocities_sha256 = str(
+                    np.asarray(archive["velocities_sha256"]).item()
+                )
+        except RolloutCacheValidationError:
+            raise
+        except (EOFError, OSError, ValueError, KeyError, zipfile.BadZipFile) as error:
+            raise RolloutCacheValidationError(
+                f"replay cache record could not be decoded: {path}"
+            ) from error
+
+        try:
+            self._validate_expected(
+                replay,
+                expected_frame_ids=expected_frame_ids,
+                minimum_node_count=minimum_node_count,
+                expected_dt_s=expected_dt_s,
+                request_id=request_id,
+                simulator_configuration_id=simulator_configuration_id,
+                initial_state_id=initial_state_id,
+            )
+        except ValueError as error:
+            raise RolloutCacheValidationError(
+                "cached replay provenance does not match the request"
+            ) from error
+        positions_sha256 = array_sha256(replay.positions_m)
+        velocities_sha256 = array_sha256(replay.velocities_mps)
+        if stored_positions_sha256 != positions_sha256:
+            raise RolloutCacheValidationError(
+                "cached replay position checksum mismatch"
+            )
+        if stored_velocities_sha256 != velocities_sha256:
+            raise RolloutCacheValidationError(
+                "cached replay velocity checksum mismatch"
+            )
+        return replay, positions_sha256, velocities_sha256
+
+    def _publish_record(
+        self,
+        path: Path,
+        *,
+        cache_key: str,
+        descriptor_json: str,
+        replay: CachedReplayTrajectory,
+        positions_sha256: str,
+        velocities_sha256: str,
+        replace_existing: bool,
+    ) -> bool:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w+b",
+                dir=path.parent,
+                prefix=f".{cache_key}.",
+                suffix=".tmp",
+                delete=False,
+            ) as handle:
+                temporary_path = Path(handle.name)
+                np.savez_compressed(
+                    handle,
+                    schema_name=np.asarray(REPLAY_CACHE_SCHEMA_NAME),
+                    schema_version=np.asarray(REPLAY_CACHE_SCHEMA_VERSION),
+                    cache_key=np.asarray(cache_key),
+                    descriptor_json=np.asarray(descriptor_json),
+                    positions_m=replay.positions_m,
+                    velocities_mps=replay.velocities_mps,
+                    frame_ids=replay.frame_ids,
+                    dt_s=np.asarray(replay.dt_s),
+                    request_id=np.asarray(replay.request_id),
+                    simulator_configuration_id=np.asarray(
+                        replay.simulator_configuration_id
+                    ),
+                    initial_state_id=np.asarray(replay.initial_state_id),
+                    positions_sha256=np.asarray(positions_sha256),
+                    velocities_sha256=np.asarray(velocities_sha256),
+                )
+                handle.flush()
+                os.fsync(handle.fileno())
+            if replace_existing:
+                os.replace(temporary_path, path)
+                temporary_path = None
+            else:
+                try:
+                    os.link(temporary_path, path)
+                except FileExistsError:
+                    return False
+            ContentAddressedRolloutCache._fsync_directory(path.parent)
+            return True
+        finally:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
+
+    def get_or_compute(
+        self,
+        descriptor: Mapping[str, Any],
+        compute: Callable[[], Any],
+        *,
+        expected_frame_ids: np.ndarray,
+        minimum_node_count: int,
+        expected_dt_s: float,
+        request_id: str,
+        simulator_configuration_id: str,
+        initial_state_id: str,
+    ) -> ReplayCacheResult:
+        """Return a complete validated replay, computing it only when absent."""
+
+        frames = np.asarray(expected_frame_ids, dtype=np.int64)
+        if frames.ndim != 1 or not len(frames) or minimum_node_count < 1:
+            raise ValueError("replay cache dimensions must be positive")
+        expected_dt = float(expected_dt_s)
+        if not np.isfinite(expected_dt) or expected_dt <= 0.0:
+            raise ValueError("expected replay dt_s must be positive and finite")
+        expected_request_id = _nonempty_identifier(request_id, name="request_id")
+        expected_configuration_id = _nonempty_identifier(
+            simulator_configuration_id,
+            name="simulator_configuration_id",
+        )
+        expected_initial_state_id = _nonempty_identifier(
+            initial_state_id,
+            name="initial_state_id",
+        )
+        descriptor_json = self.descriptor_json(descriptor)
+        cache_key = hashlib.sha256(descriptor_json.encode("utf-8")).hexdigest()
+        path = self._record_path(cache_key)
+        relative_path = path.relative_to(self.root).as_posix()
+        invalidated = False
+
+        if path.exists():
+            try:
+                replay, positions_sha256, velocities_sha256 = self._load_record(
+                    path,
+                    cache_key=cache_key,
+                    descriptor_json=descriptor_json,
+                    expected_frame_ids=frames,
+                    minimum_node_count=minimum_node_count,
+                    expected_dt_s=expected_dt,
+                    request_id=expected_request_id,
+                    simulator_configuration_id=expected_configuration_id,
+                    initial_state_id=expected_initial_state_id,
+                )
+            except RolloutCacheValidationError:
+                invalidated = True
+            else:
+                return ReplayCacheResult(
+                    replay=replay,
+                    cache_key=cache_key,
+                    record_path=path,
+                    relative_path=relative_path,
+                    positions_sha256=positions_sha256,
+                    velocities_sha256=velocities_sha256,
+                    status="hit",
+                )
+
+        replay = CachedReplayTrajectory.from_object(compute())
+        self._validate_expected(
+            replay,
+            expected_frame_ids=frames,
+            minimum_node_count=minimum_node_count,
+            expected_dt_s=expected_dt,
+            request_id=expected_request_id,
+            simulator_configuration_id=expected_configuration_id,
+            initial_state_id=expected_initial_state_id,
+        )
+        positions_sha256 = array_sha256(replay.positions_m)
+        velocities_sha256 = array_sha256(replay.velocities_mps)
+        published = self._publish_record(
+            path,
+            cache_key=cache_key,
+            descriptor_json=descriptor_json,
+            replay=replay,
+            positions_sha256=positions_sha256,
+            velocities_sha256=velocities_sha256,
+            replace_existing=invalidated,
+        )
+        try:
+            loaded, loaded_positions_sha256, loaded_velocities_sha256 = (
+                self._load_record(
+                    path,
+                    cache_key=cache_key,
+                    descriptor_json=descriptor_json,
+                    expected_frame_ids=frames,
+                    minimum_node_count=minimum_node_count,
+                    expected_dt_s=expected_dt,
+                    request_id=expected_request_id,
+                    simulator_configuration_id=expected_configuration_id,
+                    initial_state_id=expected_initial_state_id,
+                )
+            )
+        except RolloutCacheValidationError:
+            if published:
+                raise
+            self._publish_record(
+                path,
+                cache_key=cache_key,
+                descriptor_json=descriptor_json,
+                replay=replay,
+                positions_sha256=positions_sha256,
+                velocities_sha256=velocities_sha256,
+                replace_existing=True,
+            )
+            loaded, loaded_positions_sha256, loaded_velocities_sha256 = (
+                self._load_record(
+                    path,
+                    cache_key=cache_key,
+                    descriptor_json=descriptor_json,
+                    expected_frame_ids=frames,
+                    minimum_node_count=minimum_node_count,
+                    expected_dt_s=expected_dt,
+                    request_id=expected_request_id,
+                    simulator_configuration_id=expected_configuration_id,
+                    initial_state_id=expected_initial_state_id,
+                )
+            )
+            status: CacheStatus = "repaired"
+        else:
+            if published:
+                status = "repaired" if invalidated else "miss"
+            else:
+                status = "race_hit"
+        return ReplayCacheResult(
+            replay=loaded,
+            cache_key=cache_key,
+            record_path=path,
+            relative_path=relative_path,
+            positions_sha256=loaded_positions_sha256,
+            velocities_sha256=loaded_velocities_sha256,
+            status=status,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ _BAYESIAN_PHYSTWIN_TEST_MODULES = frozenset(
         "test_discrepancy_localization_aggregate.py",
         "test_phystwin_propagated_state.py",
         "test_phystwin_resumable.py",
+        "test_replay_provider_contract.py",
     }
 )
 
@@ -39,6 +40,6 @@ def pytest_report_header(config) -> str | None:
     if _BAYESIAN_PHYSTWIN_AVAILABLE:
         return None
     return (
-        "bayesian_phystwin is unavailable; excluding 12 private integration "
+        "bayesian_phystwin is unavailable; excluding 13 private integration "
         "test modules"
     )

--- a/tests/test_bpt_provider_integration.py
+++ b/tests/test_bpt_provider_integration.py
@@ -15,6 +15,11 @@ from causal4d.provider_contract import (
     require_bayesian_phystwin_provider,
     validate_bayesian_phystwin_provider,
 )
+from causal4d.replay_provider_contract import (
+    load_bayesian_phystwin_replay_provider_manifest,
+    require_bayesian_phystwin_replay_provider,
+    validate_bayesian_phystwin_replay_provider,
+)
 
 
 def _provider_api():
@@ -26,7 +31,12 @@ def _provider_api():
         pytest.skip("Bayesian-PhysTwin provider is an optional integration")
 
 
-def _provider_import_names() -> set[str]:
+def _replay_provider_api():
+    _provider_api()
+    return import_module("bayesian_phystwin.causal4d_provider_v2")
+
+
+def _provider_import_names(module_name: str) -> set[str]:
     repository_root = Path(__file__).resolve().parents[1]
     names: set[str] = set()
     for directory in (repository_root / "src", repository_root / "scripts"):
@@ -35,11 +45,7 @@ def _provider_import_names() -> set[str]:
         for path in directory.rglob("*.py"):
             tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
             for node in ast.walk(tree):
-                if (
-                    isinstance(node, ast.ImportFrom)
-                    and node.module
-                    == "bayesian_phystwin.causal4d_provider_v1"
-                ):
+                if isinstance(node, ast.ImportFrom) and node.module == module_name:
                     names.update(alias.name for alias in node.names)
     return names
 
@@ -51,16 +57,21 @@ def test_installed_provider_manifest_matches_supported_range() -> None:
     )
     result = validate_bayesian_phystwin_provider(manifest)
     assert result.compatible, result.as_dict()
-    assert require_bayesian_phystwin_provider(
-        provider_revision="cross-repository-test"
-    ).manifest_id == manifest.manifest_id
+    assert (
+        require_bayesian_phystwin_provider(
+            provider_revision="cross-repository-test"
+        ).manifest_id
+        == manifest.manifest_id
+    )
     assert result.supported_provider_versions == BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE
 
 
 def test_provider_exports_every_name_consumed_by_causal4d() -> None:
     provider_api = _provider_api()
     missing = sorted(
-        name for name in _provider_import_names() if not hasattr(provider_api, name)
+        name
+        for name in _provider_import_names("bayesian_phystwin.causal4d_provider_v1")
+        if not hasattr(provider_api, name)
     )
     assert not missing, f"provider API is missing Causal4D imports: {missing}"
 
@@ -96,3 +107,47 @@ def test_replay_protocol_is_runtime_checkable() -> None:
             return None
 
     assert isinstance(MinimalProvider(), provider_api.PhysTwinReplayProvider)
+
+
+def test_installed_replay_provider_manifest_matches_supported_range() -> None:
+    _replay_provider_api()
+    manifest = load_bayesian_phystwin_replay_provider_manifest(
+        provider_revision="cross-repository-replay-test"
+    )
+    result = validate_bayesian_phystwin_replay_provider(manifest)
+    assert result.compatible, result.as_dict()
+    assert (
+        require_bayesian_phystwin_replay_provider(
+            provider_revision="cross-repository-replay-test"
+        ).manifest_id
+        == manifest.manifest_id
+    )
+    assert result.supported_provider_versions == BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE
+
+
+def test_replay_provider_exports_every_v2_name_consumed_by_causal4d() -> None:
+    provider_api = _replay_provider_api()
+    missing = sorted(
+        name
+        for name in _provider_import_names("bayesian_phystwin.causal4d_provider_v2")
+        if not hasattr(provider_api, name)
+    )
+    assert not missing, f"replay provider API is missing Causal4D imports: {missing}"
+
+
+def test_replay_v2_protocol_is_runtime_checkable() -> None:
+    provider_api = _replay_provider_api()
+
+    class MinimalProviderV2:
+        device = "cpu"
+        frame_dt_s = 0.03
+        simulator_configuration_id = "configuration-v2"
+        released_initial_state_id = "released-state-v1"
+
+        def replay(self, request):
+            return request
+
+        def close(self):
+            return None
+
+    assert isinstance(MinimalProviderV2(), provider_api.PhysTwinReplayProvider)

--- a/tests/test_causal4d_bpt_belief.py
+++ b/tests/test_causal4d_bpt_belief.py
@@ -1,8 +1,20 @@
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
 import numpy as np
+import pytest
+
+import causal4d.bpt_belief as belief_module
+from bayesian_phystwin.causal4d_provider_v2 import (
+    InitialReplayRequestV1,
+    ReplayTrajectoryV1,
+)
 
 from causal4d.bpt_belief import (
     BPTBeliefExportConfig,
     build_twin_belief_from_replays,
+    export_official_phystwin_twin_belief,
     lift_isotropic_discrepancy_variance,
 )
 from causal4d.contracts import build_causal_context
@@ -108,3 +120,121 @@ def test_variance_lift_uses_squared_interpolation_weights() -> None:
     expected_extra = 0.25**2 * 1.0 + 0.75**2 * 4.0
     assert np.allclose(lifted[:2, 0], tracked)
     assert np.allclose(lifted[2], expected_extra)
+
+
+def test_official_export_uses_explicit_initial_replay_requests(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frame_count = 4
+    train_end = 3
+    controls = np.zeros((frame_count, 1, 3), dtype=np.float32)
+    observed = np.zeros((frame_count, 1, 3), dtype=np.float32)
+    context = build_causal_context(
+        protocol_id="initial-replay-v2",
+        case_id="unit",
+        observations=observed,
+        observed_actions=controls,
+        counterfactual_actions=controls,
+        intervention_frame=train_end,
+    )
+    particles = SimpleNamespace(
+        log_scales=np.asarray([[0.0, 0.0], [0.2, -0.1]], dtype=float),
+        grid_indices=np.asarray([[0, 0], [1, 0]], dtype=int),
+        weights=np.asarray([0.6, 0.4], dtype=float),
+        source_weight_key="posterior_weights",
+        selection_method="top_mass",
+        retained_probability_mass=1.0,
+        represented_probability_mass=1.0,
+    )
+    backend = SimpleNamespace(
+        case_name="unit",
+        train_end_frame=train_end,
+        config=SimpleNamespace(
+            self_collision=False,
+            dt=0.01,
+            num_substeps=2,
+            deterministic_spring_forces=True,
+            device="cpu",
+        ),
+        official_repo=tmp_path / "official",
+        data={},
+        optimal={},
+        checkpoint_path=tmp_path / "checkpoint.pt",
+        graph=SimpleNamespace(),
+        original_count=1,
+        surface_points=np.zeros((0, 3), dtype=np.float32),
+        particles=particles,
+        controller_points=controls,
+        visible=np.ones((frame_count, 1), dtype=bool),
+        motion_valid=np.ones((frame_count, 1), dtype=bool),
+        object_points=observed,
+        profile_path=tmp_path / "profile.npz",
+        frame_dt_s=0.02,
+    )
+    backend.replay_simulator_configuration_id = lambda graph: "configuration-v2"
+    backend.replay_released_initial_state_id = lambda: "released-state-v1"
+    backend.default_manifest = lambda: {
+        "replay_provider": {"schema_version": 2},
+        "replay_contract": {"frame_dt_s": 0.02},
+    }
+    requests: list[InitialReplayRequestV1] = []
+    closed = False
+
+    class FakeProvider:
+        device = "cpu"
+        frame_dt_s = 0.02
+        simulator_configuration_id = "configuration-v2"
+        released_initial_state_id = "released-state-v1"
+
+        def replay(self, request: InitialReplayRequestV1) -> ReplayTrajectoryV1:
+            requests.append(request)
+            value = float(np.sum(request.group_log_scales))
+            positions = np.full((request.frame_count, 1, 3), value, dtype=np.float32)
+            velocities = np.full(
+                (request.frame_count, 1, 3),
+                value + 1.0,
+                dtype=np.float32,
+            )
+            return ReplayTrajectoryV1(
+                positions_m=positions,
+                velocities_mps=velocities,
+                frame_ids=np.arange(request.frame_count),
+                dt_s=self.frame_dt_s,
+                request_id=request.request_id,
+                simulator_configuration_id=request.simulator_configuration_id,
+                initial_state_id=request.initial_state_id,
+            )
+
+        def close(self) -> None:
+            nonlocal closed
+            closed = True
+
+    def factory(*args: Any, **kwargs: Any) -> FakeProvider:
+        del args, kwargs
+        return FakeProvider()
+
+    monkeypatch.setattr(belief_module, "create_official_replay_provider", factory)
+    belief = export_official_phystwin_twin_belief(
+        backend,
+        context=context,
+        config=BPTBeliefExportConfig(interpolation_neighbors=1),
+    )
+
+    assert closed
+    assert len(requests) == 2
+    for index, request in enumerate(requests):
+        assert request.frame_count == train_end
+        np.testing.assert_array_equal(request.controller_points_m, controls)
+        np.testing.assert_allclose(
+            request.group_log_scales,
+            particles.log_scales[index],
+        )
+        assert request.simulator_configuration_id == "configuration-v2"
+        assert request.initial_state_id == "released-state-v1"
+    assert belief.metadata["replay_provider_api_version"] == 2
+    assert len(belief.metadata["initial_replay_requests"]) == 2
+    np.testing.assert_allclose(
+        belief.endpoint_velocity_mps[:, 0, 0],
+        [1.0, 1.1],
+    )

--- a/tests/test_causal4d_phystwin_backend.py
+++ b/tests/test_causal4d_phystwin_backend.py
@@ -1,6 +1,14 @@
 from pathlib import Path
+from typing import Any
 
 import numpy as np
+import pytest
+
+import causal4d.phystwin_backend as backend_module
+from bayesian_phystwin.causal4d_provider_v2 import (
+    ReplayTrajectoryV1,
+    RestartReplayRequestV1,
+)
 
 from bayesian_phystwin.causal4d_graph_provider_v1 import PhysTwinSpringGraph
 from causal4d.contracts import TwinBelief, array_sha256
@@ -19,6 +27,9 @@ from causal4d.phystwin_backend import (
     transform_controller_trajectory,
 )
 from causal4d.provider_contract import require_bayesian_phystwin_provider
+from causal4d.replay_provider_contract import (
+    require_bayesian_phystwin_replay_provider,
+)
 
 
 def test_profile_loader_selects_and_renormalizes_high_mass_particles(
@@ -105,6 +116,7 @@ def test_profile_loader_preserves_staged_probability_mass(tmp_path: Path) -> Non
 
     backend = object.__new__(OfficialPhysTwinBackend)
     backend.provider_manifest = require_bayesian_phystwin_provider()
+    backend.replay_provider_manifest = require_bayesian_phystwin_replay_provider()
     backend.graph_provider_manifest = require_bayesian_phystwin_graph_provider()
     backend.case_name = "unit_case"
     backend.train_end_frame = 3
@@ -117,6 +129,11 @@ def test_profile_loader_preserves_staged_probability_mass(tmp_path: Path) -> Non
     backend.particles = reduced
     backend.controller_groups = np.asarray([0])
     backend.config = OfficialPhysTwinBackendConfig()
+    backend.baseline = np.zeros((4, 2, 3), dtype=np.float32)
+    backend.controller_points = np.zeros((4, 1, 3), dtype=np.float32)
+    backend.base_simulator_configuration_id = "base-configuration-v1"
+    backend.released_initial_state_id = "released-state-v1"
+    backend.source_artifacts_sha256 = {}
     manifest = backend.default_manifest()["parameter_particles"]
     assert np.isclose(manifest["retained_probability_mass"], 0.8)
     assert manifest["probability_mass_accounting"] == accounting
@@ -274,3 +291,152 @@ def test_backend_reuses_factual_belief_for_a_new_counterfactual_query() -> None:
         provenance="unit",
     )
     backend._validate_twin_belief(belief, (changed,))
+
+
+def test_rollout_bank_uses_explicit_replay_v2_requests(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vertices = np.asarray(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+        dtype=np.float32,
+    )
+    springs = np.asarray([[0, 1], [2, 1]], dtype=np.int32)
+    graph = PhysTwinSpringGraph(
+        vertices=vertices,
+        springs=springs,
+        rest_lengths=np.linalg.norm(
+            vertices[springs[:, 0]] - vertices[springs[:, 1]], axis=1
+        ).astype(np.float32),
+        masses=np.ones(3, dtype=np.float32),
+        num_object_springs=1,
+        num_object_points=2,
+    )
+    backend = object.__new__(OfficialPhysTwinBackend)
+    backend.provider_manifest = require_bayesian_phystwin_provider()
+    backend.replay_provider_manifest = require_bayesian_phystwin_replay_provider()
+    backend.graph_provider_manifest = require_bayesian_phystwin_graph_provider()
+    backend.case_name = "unit_case"
+    backend.train_end_frame = 2
+    backend.frame_count = 4
+    backend.original_count = 2
+    backend.hand_count = 1
+    backend.object_points = np.zeros((4, 2, 3), dtype=np.float32)
+    backend.visible = np.ones((4, 2), dtype=bool)
+    backend.motion_valid = np.ones((4, 2), dtype=bool)
+    backend.controller_points = np.zeros((4, 1, 3), dtype=np.float32)
+    backend.controller_points[2:, 0, 0] = [0.1, 0.2]
+    backend.baseline = np.zeros((4, 3, 3), dtype=np.float32)
+    backend.surface_points = np.zeros((0, 3), dtype=np.float32)
+    backend.graph = graph
+    backend.controller_groups = np.asarray([0])
+    backend.particles = BayesianPhysTwinParticles(
+        log_scales=np.asarray([[0.1, -0.2]]),
+        weights=np.asarray([1.0]),
+        grid_indices=np.asarray([[0, 0]]),
+        source_weight_key="posterior_weights",
+        retained_probability_mass=1.0,
+    )
+    backend.config = OfficialPhysTwinBackendConfig(
+        dt=0.01,
+        num_substeps=2,
+        self_collision=False,
+        device="cpu",
+    )
+    backend.official_repo = tmp_path / "official"
+    backend.final_data_path = tmp_path / "final.pkl"
+    backend.optimal_params_path = tmp_path / "optimal.pkl"
+    backend.checkpoint_path = tmp_path / "checkpoint.pt"
+    backend.baseline_trajectory_path = tmp_path / "baseline.pkl"
+    backend.profile_path = tmp_path / "profile.npz"
+    backend.data = {}
+    backend.optimal = {}
+    backend.source_artifacts_sha256 = {}
+    backend.base_simulator_configuration_id = "base-configuration-v1"
+    backend.released_initial_state_id = "released-state-v1"
+
+    proposal = PhysTwinActionProposal(
+        proposal_id="future",
+        controller_points_m=backend.controller_points,
+        prior_weight=1.0,
+        future_action_observed=False,
+        provenance="unit",
+    )
+    context = backend.causal_context((proposal,), protocol_id="unit")
+    endpoint = vertices[None].astype(float)
+    belief = TwinBelief(
+        context=context,
+        endpoint_frame=1,
+        particle_ids=("particle-0",),
+        theta_names=("object", "controller"),
+        endpoint_position_m=endpoint,
+        endpoint_velocity_mps=np.ones_like(endpoint) * 0.05,
+        theta=backend.particles.log_scales,
+        discrepancy_mean_m=np.zeros_like(endpoint),
+        discrepancy_variance_m2=np.ones_like(endpoint) * 1e-5,
+        weights=backend.particles.weights,
+    )
+    requests: list[RestartReplayRequestV1] = []
+    closed = False
+
+    class FakeProvider:
+        device = "cpu"
+
+        def __init__(self, **kwargs: Any) -> None:
+            self.frame_dt_s = kwargs["dt"] * kwargs["num_substeps"]
+            self.simulator_configuration_id = kwargs["simulator_configuration_id"]
+            self.released_initial_state_id = kwargs["released_initial_state_id"]
+
+        def replay(self, request: RestartReplayRequestV1) -> ReplayTrajectoryV1:
+            requests.append(request)
+            frames = request.stop_frame - request.start_frame
+            positions = np.repeat(request.position_m[None], frames, axis=0)
+            velocities = np.repeat(request.velocity_mps[None], frames, axis=0)
+            return ReplayTrajectoryV1(
+                positions_m=positions,
+                velocities_mps=velocities,
+                frame_ids=np.arange(request.start_frame, request.stop_frame),
+                dt_s=self.frame_dt_s,
+                request_id=request.request_id,
+                simulator_configuration_id=request.simulator_configuration_id,
+                initial_state_id=request.initial_state_id,
+            )
+
+        def close(self) -> None:
+            nonlocal closed
+            closed = True
+
+    def factory(*args: Any, **kwargs: Any) -> FakeProvider:
+        del args
+        return FakeProvider(**kwargs)
+
+    monkeypatch.setattr(backend_module, "create_official_replay_provider", factory)
+    bank, manifest = backend.build_rollout_bank(
+        (proposal,),
+        twin_belief=belief,
+        hypothesis_config=PhysTwinHypothesisConfig(
+            attachment_shift_values=(0,),
+            gain_values=(1.0,),
+            delay_values=(0,),
+            slip_values=(0.0,),
+            rotation_values_degrees=(0.0,),
+            maximum_contact_states=1,
+        ),
+    )
+
+    assert closed
+    assert len(requests) == 1
+    request = requests[0]
+    assert isinstance(request, RestartReplayRequestV1)
+    np.testing.assert_allclose(request.group_log_scales, [0.1, -0.2])
+    np.testing.assert_array_equal(
+        request.controller_points_m,
+        backend.controller_points,
+    )
+    np.testing.assert_array_equal(request.position_m, belief.endpoint_position_m[0])
+    np.testing.assert_allclose(request.velocity_mps, belief.endpoint_velocity_mps[0])
+    np.testing.assert_array_equal(bank.trajectories[0, 0, 0], vertices[:2])
+    assert manifest["replay_provider_api_version"] == 2
+    assert manifest["replay_request_count"] == 1
+    assert manifest["replay_requests"][0]["request_id"] == request.request_id
+    assert manifest["replay_requests"][0]["velocities_sha256"]

--- a/tests/test_phystwin_resumable.py
+++ b/tests/test_phystwin_resumable.py
@@ -5,44 +5,43 @@ from typing import Any
 
 import numpy as np
 
+from bayesian_phystwin.causal4d_provider_v2 import (
+    PhysTwinReplayProvider,
+    ReplayRequestV1,
+    ReplayTrajectoryV1,
+    RestartReplayRequestV1,
+)
 from causal4d.phystwin_resumable import _RolloutCacheSession
-from causal4d.rollout_cache import ContentAddressedRolloutCache
+from causal4d.rollout_cache import ContentAddressedReplayCache
 
 
 class FakeProvider:
-    def __init__(self, counter: dict[str, int]) -> None:
+    def __init__(self, counter: dict[str, int], **kwargs: Any) -> None:
         counter["providers"] += 1
         self.counter = counter
-        self.controller: np.ndarray | None = None
-        self.scales: np.ndarray | None = None
-        self.device = "cpu"
+        self.device = str(kwargs["device"])
+        self.frame_dt_s = float(kwargs["dt"]) * int(kwargs["num_substeps"])
+        self.simulator_configuration_id = str(kwargs["simulator_configuration_id"])
+        self.released_initial_state_id = str(kwargs["released_initial_state_id"])
 
-    def set_controller_points(self, values: np.ndarray) -> None:
-        self.controller = np.asarray(values).copy()
-
-    def set_group_log_scales(self, values: np.ndarray) -> None:
-        self.scales = np.asarray(values).copy()
-
-    def replay_initial(self, *, frame_count: int) -> tuple[np.ndarray, None]:
-        return np.zeros((frame_count, 1, 3), dtype=np.float32), None
-
-    def replay_restart(
-        self,
-        position_m: np.ndarray,
-        velocity_mps: np.ndarray,
-        *,
-        start_frame: int,
-        stop_frame: int,
-    ) -> np.ndarray:
-        del velocity_mps
+    def replay(self, request: ReplayRequestV1) -> ReplayTrajectoryV1:
+        if not isinstance(request, RestartReplayRequestV1):
+            raise TypeError("unit provider expects a restart request")
         self.counter["replays"] += 1
-        frames = stop_frame - start_frame
-        endpoint = np.asarray(position_m, dtype=np.float32)
-        result = np.repeat(endpoint[None], frames, axis=0)
-        if self.scales is None:
-            raise RuntimeError("scales were not set")
-        result += float(np.sum(self.scales))
-        return result
+        frames = request.stop_frame - request.start_frame
+        positions = np.repeat(request.position_m[None], frames, axis=0)
+        positions += float(np.sum(request.group_log_scales))
+        velocities = np.repeat(request.velocity_mps[None], frames, axis=0)
+        velocities += 0.25
+        return ReplayTrajectoryV1(
+            positions_m=positions,
+            velocities_mps=velocities,
+            frame_ids=np.arange(request.start_frame, request.stop_frame),
+            dt_s=self.frame_dt_s,
+            request_id=request.request_id,
+            simulator_configuration_id=request.simulator_configuration_id,
+            initial_state_id=request.initial_state_id,
+        )
 
     def close(self) -> None:
         self.counter["closes"] += 1
@@ -61,12 +60,12 @@ def _graph() -> SimpleNamespace:
 
 def _session(tmp_path: Path) -> _RolloutCacheSession:
     return _RolloutCacheSession(
-        cache=ContentAddressedRolloutCache(tmp_path / "cache"),
+        cache=ContentAddressedReplayCache(tmp_path / "cache"),
         provider_manifest={
-            "manifest_id": "provider",
+            "manifest_id": "provider-v2",
             "provider_version": "0.4.1",
             "provider_revision": "revision",
-            "schema_version": 1,
+            "schema_version": 2,
         },
         provider_source={"fingerprint": "provider-source"},
         official_source={"fingerprint": "source", "revision": "source-rev"},
@@ -86,6 +85,8 @@ def _factory_arguments() -> tuple[tuple[Any, ...], dict[str, Any]]:
             "dt": 1e-4,
             "num_substeps": 4,
             "self_collision": False,
+            "simulator_configuration_id": "configuration-v2",
+            "released_initial_state_id": "released-state-v1",
             "deterministic_spring_forces": True,
             "spring_parameterization": "grouped",
             "device": "cpu",
@@ -93,12 +94,15 @@ def _factory_arguments() -> tuple[tuple[Any, ...], dict[str, Any]]:
     )
 
 
-def _replay(proxy: Any) -> np.ndarray:
-    proxy.set_controller_points(np.zeros((4, 1, 3), dtype=np.float32))
-    proxy.set_group_log_scales(np.asarray([0.1, -0.2], dtype=np.float32))
-    return proxy.replay_restart(
-        np.zeros((3, 3), dtype=np.float32),
-        np.zeros((3, 3), dtype=np.float32),
+def _request() -> RestartReplayRequestV1:
+    return RestartReplayRequestV1(
+        request_id="request-v2",
+        simulator_configuration_id="configuration-v2",
+        initial_state_id="endpoint-state-v1",
+        group_log_scales=np.asarray([0.1, -0.2], dtype=np.float32),
+        controller_points_m=np.zeros((4, 1, 3), dtype=np.float32),
+        position_m=np.zeros((3, 3), dtype=np.float32),
+        velocity_mps=np.ones((3, 3), dtype=np.float32),
         start_frame=2,
         stop_frame=4,
     )
@@ -108,22 +112,25 @@ def test_all_hit_rerun_skips_real_provider_construction(tmp_path: Path) -> None:
     counter = {"providers": 0, "replays": 0, "closes": 0}
 
     def factory(*args: Any, **kwargs: Any) -> FakeProvider:
-        del args, kwargs
-        return FakeProvider(counter)
+        del args
+        return FakeProvider(counter, **kwargs)
 
     args, kwargs = _factory_arguments()
     first_session = _session(tmp_path)
     first_proxy = first_session.wrap_factory(factory)(*args, **kwargs)
-    first = _replay(first_proxy)
+    assert isinstance(first_proxy, PhysTwinReplayProvider)
+    first = first_proxy.replay(_request())
     first_proxy.close()
 
     second_session = _session(tmp_path)
     second_proxy = second_session.wrap_factory(factory)(*args, **kwargs)
-    second = _replay(second_proxy)
+    second = second_proxy.replay(_request())
     second_proxy.close()
 
     assert counter == {"providers": 1, "replays": 1, "closes": 1}
-    assert np.array_equal(first, second)
+    np.testing.assert_array_equal(first.positions_m, second.positions_m)
+    np.testing.assert_array_equal(first.velocities_mps, second.velocities_mps)
+    np.testing.assert_array_equal(first.frame_ids, [2, 3])
     assert first_session.records[0]["cache_status"] == "miss"
     assert second_session.records[0]["cache_status"] == "hit"
     assert first_session.provider_instance_count == 1
@@ -133,6 +140,9 @@ def test_all_hit_rerun_skips_real_provider_construction(tmp_path: Path) -> None:
     record_path = first_session.cache.root / record["record_path"]
     with np.load(record_path, allow_pickle=False) as archive:
         envelope = json.loads(str(archive["descriptor_json"]))
+        assert "positions_m" in archive.files
+        assert "velocities_mps" in archive.files
+        assert str(archive["request_id"]) == "request-v2"
     descriptor = envelope["descriptor"]
     assert {
         "provider",
@@ -141,9 +151,12 @@ def test_all_hit_rerun_skips_real_provider_construction(tmp_path: Path) -> None:
         "numerical_runtime",
         "source_artifacts_sha256",
         "spring_graph",
-        "controller_points",
-        "group_log_scales",
-        "endpoint_position",
-        "endpoint_velocity",
-        "frame_interval",
+        "provider_factory",
+        "request",
     } <= set(descriptor)
+    assert descriptor["request"]["request_type"] == "RestartReplayRequestV1"
+    assert record["positions_sha256"] != record["velocities_sha256"]
+    assert first_session.manifest()["schema_version"] == 2
+    assert first_session.manifest()["cached_payload"] == (
+        "positions_velocities_and_provenance"
+    )

--- a/tests/test_replay_provider_contract.py
+++ b/tests/test_replay_provider_contract.py
@@ -1,0 +1,154 @@
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from bayesian_phystwin.causal4d_provider_v2 import (
+    InitialReplayRequestV1,
+    ReplayTrajectoryV1,
+    RestartReplayRequestV1,
+)
+from causal4d.provider_contract import PhysicalBeliefProviderManifest
+from causal4d.replay_provider_contract import (
+    BAYESIAN_PHYSTWIN_REPLAY_PROVIDER_CAPABILITIES,
+    load_bayesian_phystwin_replay_provider_manifest,
+    require_bayesian_phystwin_replay_provider,
+    stable_replay_identifier,
+    validate_bayesian_phystwin_replay_provider,
+    validate_replay_trajectory,
+)
+
+
+def _manifest(**overrides) -> PhysicalBeliefProviderManifest:
+    values = {
+        "provider_name": "bayesian-phystwin",
+        "provider_version": "0.4.0",
+        "provider_revision": "a" * 40,
+        "schema_version": 2,
+        "capabilities": BAYESIAN_PHYSTWIN_REPLAY_PROVIDER_CAPABILITIES,
+        "artifact_schema_versions": {
+            "GraphBelief": 1,
+            "TwinBelief": 1,
+            "ReplayRequest": 1,
+            "ReplayTrajectory": 1,
+        },
+        "metadata": {
+            "provider_api": "bayesian_phystwin.causal4d_provider_v2",
+            "provider_api_version": 2,
+            "legacy_provider_api": "bayesian_phystwin.causal4d_provider_v1",
+        },
+    }
+    values.update(overrides)
+    return PhysicalBeliefProviderManifest(**values)
+
+
+def test_installed_replay_provider_v2_is_compatible() -> None:
+    manifest = load_bayesian_phystwin_replay_provider_manifest(
+        provider_revision="replay-contract-test"
+    )
+    result = validate_bayesian_phystwin_replay_provider(manifest)
+
+    assert result.compatible, result.as_dict()
+    assert manifest.schema_version == 2
+    assert (
+        require_bayesian_phystwin_replay_provider(
+            provider_revision="replay-contract-test"
+        ).manifest_id
+        == manifest.manifest_id
+    )
+
+
+def test_replay_provider_fails_closed_on_boundary_drift() -> None:
+    missing = _manifest(
+        capabilities=tuple(
+            value
+            for value in BAYESIAN_PHYSTWIN_REPLAY_PROVIDER_CAPABILITIES
+            if value != "stateless_replay_requests"
+        )
+    )
+    assert not validate_bayesian_phystwin_replay_provider(missing).compatible
+
+    with pytest.raises(ValueError, match="causal4d_provider_v2"):
+        validate_bayesian_phystwin_replay_provider(
+            _manifest(metadata={"provider_api": "wrong", "provider_api_version": 2})
+        )
+
+
+def test_replay_trajectory_is_bound_to_request_and_frame_provenance() -> None:
+    request = InitialReplayRequestV1(
+        request_id="request-v1",
+        simulator_configuration_id="configuration-v1",
+        initial_state_id="released-state-v1",
+        group_log_scales=np.zeros(2),
+        controller_points_m=np.zeros((4, 1, 3)),
+        frame_count=3,
+    )
+    replay = ReplayTrajectoryV1(
+        positions_m=np.zeros((3, 2, 3)),
+        velocities_mps=np.ones((3, 2, 3)),
+        frame_ids=np.arange(3),
+        dt_s=0.03,
+        request_id=request.request_id,
+        simulator_configuration_id=request.simulator_configuration_id,
+        initial_state_id=request.initial_state_id,
+    )
+
+    validate_replay_trajectory(request, replay, expected_dt_s=0.03)
+
+    with pytest.raises(ValueError, match="request_id"):
+        validate_replay_trajectory(
+            request,
+            replace(replay, request_id="other-request"),
+            expected_dt_s=0.03,
+        )
+    with pytest.raises(ValueError, match="frame provenance"):
+        validate_replay_trajectory(
+            request,
+            replace(replay, frame_ids=np.asarray([0, 2, 3])),
+            expected_dt_s=0.03,
+        )
+
+
+def test_replay_identifier_is_stable_and_tamper_sensitive() -> None:
+    first = stable_replay_identifier("request", {"frame": 3, "mode": "restart"})
+    same = stable_replay_identifier("request", {"mode": "restart", "frame": 3})
+    changed = stable_replay_identifier("request", {"frame": 4, "mode": "restart"})
+
+    assert first == same
+    assert first != changed
+    assert first.startswith("request:")
+
+
+def test_restart_replay_trajectory_uses_absolute_frame_provenance() -> None:
+    request = RestartReplayRequestV1(
+        request_id="restart-v1",
+        simulator_configuration_id="configuration-v1",
+        initial_state_id="endpoint-v1",
+        group_log_scales=np.zeros(2),
+        controller_points_m=np.zeros((8, 1, 3)),
+        position_m=np.zeros((2, 3)),
+        velocity_mps=np.ones((2, 3)),
+        start_frame=5,
+        stop_frame=8,
+    )
+    replay = ReplayTrajectoryV1(
+        positions_m=np.zeros((3, 2, 3)),
+        velocities_mps=np.ones((3, 2, 3)),
+        frame_ids=np.asarray([5, 6, 7]),
+        dt_s=0.03,
+        request_id=request.request_id,
+        simulator_configuration_id=request.simulator_configuration_id,
+        initial_state_id=request.initial_state_id,
+    )
+
+    validate_replay_trajectory(request, replay, expected_dt_s=0.03)
+
+    with pytest.raises(ValueError, match="timestep"):
+        validate_replay_trajectory(request, replay, expected_dt_s=0.04)
+
+
+def test_replay_identifier_rejects_invalid_identity_inputs() -> None:
+    with pytest.raises(TypeError, match="namespace"):
+        stable_replay_identifier(None, {"frame": 1})  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="finite JSON"):
+        stable_replay_identifier("request", {"value": np.nan})

--- a/tests/test_rollout_cache.py
+++ b/tests/test_rollout_cache.py
@@ -4,6 +4,8 @@ import numpy as np
 import pytest
 
 from causal4d.rollout_cache import (
+    CachedReplayTrajectory,
+    ContentAddressedReplayCache,
     ContentAddressedRolloutCache,
     repository_source_identity,
 )
@@ -102,3 +104,113 @@ def test_invalid_computed_trajectory_is_not_published(tmp_path: Path) -> None:
             minimum_node_count=1,
         )
     assert not tuple((tmp_path / "cache").rglob("*.npz"))
+
+
+def _cached_replay(value: float = 1.0) -> CachedReplayTrajectory:
+    return CachedReplayTrajectory(
+        positions_m=np.full((2, 3, 3), value, dtype=np.float32),
+        velocities_mps=np.full((2, 3, 3), value + 1.0, dtype=np.float32),
+        frame_ids=np.asarray([4, 5]),
+        dt_s=0.03,
+        request_id="request-v2",
+        simulator_configuration_id="configuration-v2",
+        initial_state_id="endpoint-state-v1",
+    )
+
+
+def test_replay_cache_reuses_positions_velocities_and_provenance(
+    tmp_path: Path,
+) -> None:
+    cache = ContentAddressedReplayCache(tmp_path / "replay-cache")
+    calls = 0
+
+    def compute() -> CachedReplayTrajectory:
+        nonlocal calls
+        calls += 1
+        return _cached_replay()
+
+    kwargs = {
+        "expected_frame_ids": np.asarray([4, 5]),
+        "minimum_node_count": 3,
+        "expected_dt_s": 0.03,
+        "request_id": "request-v2",
+        "simulator_configuration_id": "configuration-v2",
+        "initial_state_id": "endpoint-state-v1",
+    }
+    first = cache.get_or_compute({"case": "unit"}, compute, **kwargs)
+    second = cache.get_or_compute({"case": "unit"}, compute, **kwargs)
+
+    assert calls == 1
+    assert first.status == "miss"
+    assert second.status == "hit"
+    np.testing.assert_array_equal(first.replay.positions_m, second.replay.positions_m)
+    np.testing.assert_array_equal(
+        first.replay.velocities_mps,
+        second.replay.velocities_mps,
+    )
+    assert first.positions_sha256 != first.velocities_sha256
+    assert not second.replay.positions_m.flags.writeable
+    assert not second.replay.velocities_mps.flags.writeable
+
+
+def test_replay_cache_rejects_mismatched_response_without_publishing(
+    tmp_path: Path,
+) -> None:
+    cache = ContentAddressedReplayCache(tmp_path / "replay-cache")
+    with pytest.raises(ValueError, match="request_id"):
+        cache.get_or_compute(
+            {"case": "unit"},
+            lambda: CachedReplayTrajectory(
+                **{
+                    **_cached_replay().__dict__,
+                    "request_id": "wrong-request",
+                }
+            ),
+            expected_frame_ids=np.asarray([4, 5]),
+            minimum_node_count=3,
+            expected_dt_s=0.03,
+            request_id="request-v2",
+            simulator_configuration_id="configuration-v2",
+            initial_state_id="endpoint-state-v1",
+        )
+    assert not tuple((tmp_path / "replay-cache").rglob("*.npz"))
+
+
+def test_replay_cache_repairs_semantically_tampered_record(tmp_path: Path) -> None:
+    cache = ContentAddressedReplayCache(tmp_path / "replay-cache")
+    calls = 0
+
+    def compute() -> CachedReplayTrajectory:
+        nonlocal calls
+        calls += 1
+        return _cached_replay(float(calls))
+
+    kwargs = {
+        "expected_frame_ids": np.asarray([4, 5]),
+        "minimum_node_count": 3,
+        "expected_dt_s": 0.03,
+        "request_id": "request-v2",
+        "simulator_configuration_id": "configuration-v2",
+        "initial_state_id": "endpoint-state-v1",
+    }
+    first = cache.get_or_compute({"case": "unit"}, compute, **kwargs)
+    with np.load(first.record_path, allow_pickle=False) as archive:
+        payload = {name: archive[name] for name in archive.files}
+    payload["frame_ids"] = np.asarray([3, 5])
+    with first.record_path.open("wb") as stream:
+        np.savez_compressed(stream, **payload)
+
+    repaired = cache.get_or_compute({"case": "unit"}, compute, **kwargs)
+
+    assert calls == 2
+    assert repaired.status == "repaired"
+    np.testing.assert_array_equal(repaired.replay.frame_ids, [4, 5])
+    assert np.all(repaired.replay.positions_m == 2.0)
+
+
+def test_cached_replay_rejects_nontrajectory_shapes_and_identifiers() -> None:
+    values = _cached_replay().__dict__
+    with pytest.raises(ValueError, match="positions"):
+        CachedReplayTrajectory(**{**values, "positions_m": np.zeros(3)})
+    with pytest.raises(TypeError, match="request_id"):
+        CachedReplayTrajectory(**{**values, "request_id": None})


### PR DESCRIPTION
## Summary

- migrate factual initial replay and counterfactual restart execution from mutable provider-v1 sequencing to immutable `InitialReplayRequestV1` and `RestartReplayRequestV1` messages owned by `bayesian_phystwin.causal4d_provider_v2`;
- validate provider-v2 identity, capabilities, schema versions, request IDs, simulator configuration IDs, state IDs, exact frame provenance, timestep, positions, and velocity histories before consuming a response;
- record a separate replay-provider-v2 manifest while retaining provider v1 only as the frozen scientific/diagnostic compatibility facade;
- preserve resumable content-addressed execution by caching and independently hashing the complete replay response, including positions, velocities, frame IDs, timestep, and request lineage;
- update the installed-wheel compatibility path, CI inventory, documentation, and private integration tests for the provider-v2 boundary.

## Product scope

This pull request is one product commit directly on `main` (`0e203070`). It changes 21 code, test, documentation, and permanent CI files. All temporary source-export, formatter, diagnostics, and payload workflows are absent from the product diff.

## Validation

Exact product commit `0b418b287b305c3fadba4ed6e6838381bb34e8bd` passed the permanent `CI and release` workflow:

- Ruff linting and incremental formatting;
- mypy for CI utilities and both provider contracts on the lowest supported Python 3.10 environment;
- core-only suites on Python 3.10, 3.12, and 3.14;
- wheel and source-distribution build and metadata checks;
- isolated wheel and source-distribution installation plus every CLI help contract;
- deterministic result-bundle production, archival, restoration, and verification;
- frozen milestone inventory and checksum verification.

Before publication, the exact normalized tree also passed `compileall`, the complete core-only suite, and the coordinated installed-BPT suite. The separate private three-repository workflow fails only at its explicit credential gate because `BPT_READ_TOKEN` is not configured; the private checkout and installed-wheel job are therefore correctly not reported as executed.

## Evidence boundary

This is a software-contract and provenance improvement. It does not create physical confirmatory evidence, change the frozen v0.3.0 milestone, or alter the registered 0/36 real-data acquisition status. The credentialed three-repository check remains fail-closed while the repository secret is absent.
