### PR TITLE
Add fail-closed real-evidence claim-readiness status

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,9 @@ prospective mechanism gates.
 the uncertain deformable-object twin: state and parameter particles, graph
 geometry, PhysTwin/Warp replay, and perception/discrepancy artifacts. Causal4D
 consumes those artifacts and owns the intervention and counterfactual
-inference. Production replay uses immutable typed requests from
-`bayesian_phystwin.causal4d_provider_v2`; provider v1 remains only as the
-versioned scientific and frozen-diagnostic compatibility facade. Causal4D
-validates both manifests and never imports BPT implementation modules directly.
+inference. The dependency points from Causal4D to Bayesian-PhysTwin through
+`bayesian_phystwin.causal4d_provider_v1`; execution uses the
+`PhysTwinReplayProvider` protocol rather than BPT internals.
 
 Install the `phystwin` extra for these adapters. Core controlled benchmarks do
 not require Warp or the PhysTwin checkout. See
@@ -141,6 +140,22 @@ causal4d-real-experiment-freeze seal \
   /data/causal4d-sloth-multi-action-v1/method_freeze.json \
   --frozen-by "<operator-or-principal-investigator>"
 ```
+
+Track acquisition progress without counting templates as evidence:
+
+```bash
+causal4d-real-protocol status \
+  configs/causal4d/sloth_multi_action_v1.json \
+  /data/causal4d-sloth-multi-action-v1 \
+  --output-json \
+  /data/causal4d-sloth-multi-action-v1/evidence-status.json
+```
+
+Before analysis, add `--verify-file-hashes --require-complete`. The command
+returns exit code 3 until all 36 executions and every registered artifact are
+claim-ready. See
+[docs/causal4d_real_evidence_status.md](docs/causal4d_real_evidence_status.md)
+for the exact accounting and exit-code contract.
 
 The experiment must report either successful transfer/calibration or a
 well-powered negative result without target-informed method selection. See

--- a/docs/causal4d_real_evidence_status.md
+++ b/docs/causal4d_real_evidence_status.md
@@ -1,0 +1,68 @@
+# Real-Evidence Status and Claim-Readiness Gate
+
+The same-object multi-action protocol contains 36 preregistered executions. A
+scaffolded directory is only an acquisition template; it is not evidence. The
+status command therefore reports templates, completed manifests, validated
+executions, inclusion/exclusion accounting, and verified artifact hashes as
+separate quantities.
+
+## Progress report
+
+After scaffolding the dataset, write a machine-readable progress snapshot:
+
+```bash
+causal4d-real-protocol status \
+  configs/causal4d/sloth_multi_action_v1.json \
+  /data/causal4d-sloth-multi-action-v1 \
+  --output-json \
+  /data/causal4d-sloth-multi-action-v1/evidence-status.json
+```
+
+`manifest.template.json` files are never counted as acquired executions. An
+execution is acquired only when `manifest.json` exists and explicitly declares
+`acquisition_status: complete`. It is validated only when the completed manifest
+passes the frozen protocol, quality-gate, exclusion, artifact-descriptor, and
+information-boundary checks.
+
+The report includes:
+
+- prerequisite status for the dataset protocol, locked acquisition schedule,
+  object registration, and slip pilot;
+- specified, manifest-present, acquired, validated, included, and excluded
+  execution counts;
+- ordered missing, incomplete, and invalid execution IDs;
+- the next unresolved execution in the preregistered acquisition order;
+- per-execution validation errors and quality-gate failures;
+- unexpected directories under `executions/`;
+- `complete`, `file_hashes_verified`, and `claim_ready` decisions.
+
+## Fail-closed completion gate
+
+Before analysis or release of a multi-action real-data claim, rehash every
+registered artifact and require claim readiness:
+
+```bash
+causal4d-real-protocol status \
+  configs/causal4d/sloth_multi_action_v1.json \
+  /data/causal4d-sloth-multi-action-v1 \
+  --verify-file-hashes \
+  --output-json \
+  /data/causal4d-sloth-multi-action-v1/evidence-status.json \
+  --require-complete
+```
+
+Exit codes are:
+
+- `0`: the report was produced and, when `--require-complete` is present, the
+  evidence is claim-ready;
+- `2`: the command or locked protocol could not be interpreted;
+- `3`: `--require-complete` was requested but the evidence is not claim-ready.
+
+`complete=true` means that all prerequisites and all 36 execution manifests are
+present, explicitly complete, valid, and fully accounted for. `claim_ready=true`
+additionally requires `--verify-file-hashes` and successful checksum validation
+of every execution artifact and registered contact-node set.
+
+The status command is observational. It does not create completed manifests,
+repair failed gates, replace excluded executions, or transform scaffolded
+placeholders into evidence.

--- a/src/causal4d/cli/real_protocol.py
+++ b/src/causal4d/cli/real_protocol.py
@@ -1,4 +1,4 @@
-"""Generate and validate the Causal4D multi-action real protocol."""
+"""Generate, inspect, and validate the Causal4D multi-action real protocol."""
 
 from __future__ import annotations
 
@@ -6,6 +6,10 @@ import argparse
 import json
 from collections.abc import Sequence
 
+from causal4d.real_evidence_status import (
+    build_real_evidence_status,
+    write_real_evidence_status,
+)
 from causal4d.real_protocol import (
     build_same_object_real_protocol,
     load_protocol,
@@ -15,6 +19,8 @@ from causal4d.real_protocol import (
     write_acquisition_schedule,
     write_protocol,
 )
+
+INCOMPLETE_EVIDENCE_EXIT_CODE = 3
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -44,6 +50,30 @@ def build_parser() -> argparse.ArgumentParser:
     scaffold.add_argument("protocol_json")
     scaffold.add_argument("output_root")
 
+    status = subparsers.add_parser(
+        "status",
+        help="report acquired, validated, and claim-ready execution evidence",
+    )
+    status.add_argument("protocol_json")
+    status.add_argument("dataset_root")
+    status.add_argument(
+        "--verify-file-hashes",
+        action="store_true",
+        help="rehash every registered artifact before declaring claim readiness",
+    )
+    status.add_argument(
+        "--output-json",
+        help="atomically write the complete machine-readable status report",
+    )
+    status.add_argument(
+        "--require-complete",
+        action="store_true",
+        help=(
+            "return exit code 3 until all 36 executions and artifact hashes "
+            "are claim-ready"
+        ),
+    )
+
     dataset = subparsers.add_parser(
         "validate-dataset",
         help="validate a completed 36-execution acquisition tree",
@@ -60,6 +90,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    exit_code = 0
     try:
         if args.command == "generate":
             protocol = build_same_object_real_protocol()
@@ -74,17 +105,28 @@ def main(argv: Sequence[str] | None = None) -> int:
             result = scaffold_dataset(
                 load_protocol(args.protocol_json), args.output_root
             )
+        elif args.command == "status":
+            result = build_real_evidence_status(
+                load_protocol(args.protocol_json),
+                args.dataset_root,
+                verify_file_hashes=args.verify_file_hashes,
+            )
+            if args.output_json:
+                output = write_real_evidence_status(args.output_json, result)
+                result = {**result, "output": str(output.resolve())}
+            if args.require_complete and not result["claim_ready"]:
+                exit_code = INCOMPLETE_EVIDENCE_EXIT_CODE
         else:
             result = validate_dataset(
                 load_protocol(args.protocol_json),
                 args.dataset_root,
                 verify_files=not args.skip_file_hashes,
             )
-    except (OSError, KeyError, ValueError) as error:
+    except (OSError, KeyError, TypeError, ValueError) as error:
         print(json.dumps({"passed": False, "error": str(error)}, indent=2))
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
-    return 0
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/src/causal4d/real_evidence_status.py
+++ b/src/causal4d/real_evidence_status.py
@@ -1,0 +1,464 @@
+"""Fail-closed progress and claim-readiness reporting for real evidence."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import os
+import tempfile
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+from causal4d.real_protocol import (
+    validate_execution_manifest,
+    validate_object_registration,
+    validate_protocol,
+    validate_slip_pilot,
+    write_acquisition_schedule,
+)
+
+EVIDENCE_STATUS_SCHEMA_VERSION = 1
+
+
+def _sha256_file(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+            size += len(block)
+    return digest.hexdigest(), size
+
+
+def _load_json_mapping(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"JSON root must be an object: {path}")
+    return dict(payload)
+
+
+def _error_text(error: BaseException) -> str:
+    message = str(error).strip()
+    return f"{type(error).__name__}: {message}" if message else type(error).__name__
+
+
+def _prerequisite_result(path: Path) -> dict[str, Any]:
+    return {
+        "path": str(path),
+        "present": path.is_file(),
+        "valid": False,
+        "error": None,
+    }
+
+
+def _validate_dataset_protocol(
+    protocol: Mapping[str, Any],
+    path: Path,
+) -> dict[str, Any]:
+    result = _prerequisite_result(path)
+    if not result["present"]:
+        result["error"] = "dataset protocol.json is missing"
+        return result
+    try:
+        candidate = _load_json_mapping(path)
+        validate_protocol(candidate)
+        if candidate != dict(protocol):
+            raise ValueError("dataset protocol differs from the locked protocol")
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+        result["error"] = _error_text(error)
+        return result
+    result["valid"] = True
+    result["sha256"], result["bytes"] = _sha256_file(path)
+    return result
+
+
+def _expected_schedule_rows(protocol: Mapping[str, Any]) -> list[dict[str, str]]:
+    with tempfile.TemporaryDirectory(prefix="causal4d-status-") as directory:
+        generated = write_acquisition_schedule(
+            Path(directory) / "acquisition_schedule.csv",
+            protocol,
+        )
+        with generated.open(newline="", encoding="utf-8") as handle:
+            return list(csv.DictReader(handle))
+
+
+def _validate_acquisition_schedule(
+    protocol: Mapping[str, Any],
+    path: Path,
+) -> dict[str, Any]:
+    result = _prerequisite_result(path)
+    if not result["present"]:
+        result["error"] = "acquisition_schedule.csv is missing"
+        return result
+    try:
+        with path.open(newline="", encoding="utf-8") as handle:
+            rows = list(csv.DictReader(handle))
+        expected = _expected_schedule_rows(protocol)
+        if rows != expected:
+            raise ValueError("acquisition schedule differs from the locked design")
+    except (OSError, csv.Error, KeyError, TypeError, ValueError) as error:
+        result["error"] = _error_text(error)
+        return result
+    result["valid"] = True
+    result["row_count"] = len(rows)
+    result["sha256"], result["bytes"] = _sha256_file(path)
+    return result
+
+
+def _validate_registration_files(
+    dataset_root: Path,
+    registration: Mapping[str, Any],
+) -> None:
+    for region_id, descriptor in registration["contact_regions"].items():
+        relative = Path(descriptor["canonical_node_set_path"])
+        node_path = dataset_root / relative
+        if not node_path.is_file():
+            raise ValueError(f"contact node set is missing: {region_id}")
+        digest, _ = _sha256_file(node_path)
+        if digest != descriptor["canonical_node_set_sha256"]:
+            raise ValueError(f"contact node-set checksum mismatch: {region_id}")
+
+
+def _validate_object_registration_prerequisite(
+    protocol: Mapping[str, Any],
+    dataset_root: Path,
+    path: Path,
+    *,
+    verify_file_hashes: bool,
+) -> dict[str, Any]:
+    result = _prerequisite_result(path)
+    result["file_hashes_verified"] = None if not verify_file_hashes else False
+    if not result["present"]:
+        result["error"] = "object_registration.json is missing"
+        return result
+    try:
+        registration = _load_json_mapping(path)
+        validate_object_registration(protocol, registration)
+        if verify_file_hashes:
+            _validate_registration_files(dataset_root, registration)
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+        result["error"] = _error_text(error)
+        return result
+    result["valid"] = True
+    result["file_hashes_verified"] = True if verify_file_hashes else None
+    result["sha256"], result["bytes"] = _sha256_file(path)
+    return result
+
+
+def _validate_json_prerequisite(
+    protocol: Mapping[str, Any],
+    path: Path,
+    validator: Callable[[Mapping[str, Any], Mapping[str, Any]], None],
+    *,
+    missing_message: str,
+) -> dict[str, Any]:
+    result = _prerequisite_result(path)
+    if not result["present"]:
+        result["error"] = missing_message
+        return result
+    try:
+        payload = _load_json_mapping(path)
+        validator(protocol, payload)
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+        result["error"] = _error_text(error)
+        return result
+    result["valid"] = True
+    result["sha256"], result["bytes"] = _sha256_file(path)
+    return result
+
+
+def _execution_status(
+    protocol: Mapping[str, Any],
+    dataset_root: Path,
+    execution: Mapping[str, Any],
+    *,
+    verify_file_hashes: bool,
+) -> dict[str, Any]:
+    execution_id = str(execution["execution_id"])
+    execution_root = dataset_root / "executions" / execution_id
+    manifest_path = execution_root / "manifest.json"
+    template_path = execution_root / "manifest.template.json"
+    result: dict[str, Any] = {
+        "execution_id": execution_id,
+        "session_id": str(execution["session_id"]),
+        "acquisition_execution_index": int(execution["acquisition_execution_index"]),
+        "manifest_path": str(manifest_path),
+        "manifest_present": manifest_path.is_file(),
+        "manifest_parsed": False,
+        "template_present": template_path.is_file(),
+        "acquisition_status": None,
+        "acquired": False,
+        "validated": False,
+        "included": None,
+        "quality_gate_failures": [],
+        "file_hashes_verified": None if not verify_file_hashes else False,
+        "error": None,
+    }
+    if not result["manifest_present"]:
+        result["error"] = "manifest.json is missing"
+        return result
+    try:
+        manifest = _load_json_mapping(manifest_path)
+        result["manifest_parsed"] = True
+        result["acquisition_status"] = manifest.get("acquisition_status")
+        result["acquired"] = result["acquisition_status"] == "complete"
+        result["manifest_sha256"], result["manifest_bytes"] = _sha256_file(
+            manifest_path
+        )
+        if not result["acquired"]:
+            raise ValueError("execution manifest is not explicitly complete")
+        validation = validate_execution_manifest(
+            protocol,
+            manifest,
+            execution_root=execution_root,
+            verify_files=verify_file_hashes,
+        )
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+        result["error"] = _error_text(error)
+        return result
+    result["validated"] = True
+    result["included"] = bool(validation["included"])
+    result["quality_gate_failures"] = list(validation["quality_gate_failures"])
+    result["file_hashes_verified"] = True if verify_file_hashes else None
+    return result
+
+
+def _unexpected_execution_directories(
+    dataset_root: Path,
+    expected_ids: set[str],
+) -> list[str]:
+    root = dataset_root / "executions"
+    if not root.is_dir():
+        return []
+    return sorted(
+        path.name
+        for path in root.iterdir()
+        if path.is_dir() and path.name not in expected_ids
+    )
+
+
+def _blockers(
+    *,
+    prerequisites: Mapping[str, Mapping[str, Any]],
+    execution_results: list[Mapping[str, Any]],
+    unexpected_execution_directories: list[str],
+    verify_file_hashes: bool,
+) -> list[str]:
+    blockers = [
+        f"prerequisite:{name}"
+        for name, result in prerequisites.items()
+        if not result["valid"]
+    ]
+    missing = [
+        str(result["execution_id"])
+        for result in execution_results
+        if not result["manifest_present"]
+    ]
+    incomplete = [
+        str(result["execution_id"])
+        for result in execution_results
+        if result["manifest_parsed"] and not result["acquired"]
+    ]
+    invalid = [
+        str(result["execution_id"])
+        for result in execution_results
+        if result["manifest_present"]
+        and (
+            not result["manifest_parsed"]
+            or (result["acquired"] and not result["validated"])
+        )
+    ]
+    if missing:
+        blockers.append(f"missing_execution_manifests:{len(missing)}")
+    if incomplete:
+        blockers.append(f"incomplete_execution_manifests:{len(incomplete)}")
+    if invalid:
+        blockers.append(f"invalid_execution_manifests:{len(invalid)}")
+    if unexpected_execution_directories:
+        blockers.append(
+            f"unexpected_execution_directories:{len(unexpected_execution_directories)}"
+        )
+    if not verify_file_hashes:
+        blockers.append("file_hashes_not_verified")
+    return blockers
+
+
+def build_real_evidence_status(
+    protocol: Mapping[str, Any],
+    dataset_root: str | Path,
+    *,
+    verify_file_hashes: bool = False,
+) -> dict[str, Any]:
+    """Summarize progress without treating scaffolded templates as evidence."""
+
+    validate_protocol(protocol)
+    root = Path(dataset_root)
+    prerequisites = {
+        "dataset_protocol": _validate_dataset_protocol(
+            protocol,
+            root / "protocol.json",
+        ),
+        "acquisition_schedule": _validate_acquisition_schedule(
+            protocol,
+            root / "acquisition_schedule.csv",
+        ),
+        "object_registration": _validate_object_registration_prerequisite(
+            protocol,
+            root,
+            root / "object_registration.json",
+            verify_file_hashes=verify_file_hashes,
+        ),
+        "slip_pilot": _validate_json_prerequisite(
+            protocol,
+            root / "slip_pilot.json",
+            validate_slip_pilot,
+            missing_message="slip_pilot.json is missing",
+        ),
+    }
+    executions = sorted(
+        protocol["executions"],
+        key=lambda value: int(value["acquisition_execution_index"]),
+    )
+    execution_results = [
+        _execution_status(
+            protocol,
+            root,
+            execution,
+            verify_file_hashes=verify_file_hashes,
+        )
+        for execution in executions
+    ]
+    expected_ids = {str(execution["execution_id"]) for execution in executions}
+    unexpected = _unexpected_execution_directories(root, expected_ids)
+    specified = len(execution_results)
+    manifest_count = sum(
+        bool(result["manifest_present"]) for result in execution_results
+    )
+    acquired = sum(bool(result["acquired"]) for result in execution_results)
+    validated = sum(bool(result["validated"]) for result in execution_results)
+    included = sum(result["included"] is True for result in execution_results)
+    excluded = sum(result["included"] is False for result in execution_results)
+    prerequisites_valid = all(result["valid"] for result in prerequisites.values())
+    accounting_complete = included + excluded == specified
+    complete = bool(
+        prerequisites_valid
+        and manifest_count == specified
+        and acquired == specified
+        and validated == specified
+        and accounting_complete
+        and not unexpected
+    )
+    file_hashes_verified = bool(verify_file_hashes and complete)
+    claim_ready = bool(complete and file_hashes_verified)
+    blockers = _blockers(
+        prerequisites=prerequisites,
+        execution_results=execution_results,
+        unexpected_execution_directories=unexpected,
+        verify_file_hashes=verify_file_hashes,
+    )
+    if complete and verify_file_hashes:
+        blockers = []
+    next_pending = next(
+        (
+            {
+                "execution_id": result["execution_id"],
+                "session_id": result["session_id"],
+                "acquisition_execution_index": result["acquisition_execution_index"],
+            }
+            for result in execution_results
+            if not result["validated"]
+        ),
+        None,
+    )
+    return {
+        "schema_version": EVIDENCE_STATUS_SCHEMA_VERSION,
+        "protocol_id": str(protocol["protocol_id"]),
+        "protocol_design_sha256": str(protocol["design_sha256"]),
+        "dataset_root": str(root.resolve()),
+        "specified_executions": specified,
+        "manifest_executions": manifest_count,
+        "acquired_executions": acquired,
+        "validated_executions": validated,
+        "included_executions": included,
+        "excluded_executions": excluded,
+        "missing_execution_ids": [
+            result["execution_id"]
+            for result in execution_results
+            if not result["manifest_present"]
+        ],
+        "incomplete_execution_ids": [
+            result["execution_id"]
+            for result in execution_results
+            if result["manifest_parsed"] and not result["acquired"]
+        ],
+        "invalid_execution_ids": [
+            result["execution_id"]
+            for result in execution_results
+            if result["manifest_present"]
+            and (
+                not result["manifest_parsed"]
+                or (result["acquired"] and not result["validated"])
+            )
+        ],
+        "unexpected_execution_directories": unexpected,
+        "next_pending_execution": next_pending,
+        "prerequisites": prerequisites,
+        "executions": execution_results,
+        "file_hashes_requested": verify_file_hashes,
+        "file_hashes_verified": file_hashes_verified,
+        "accounting_complete": accounting_complete,
+        "complete": complete,
+        "claim_ready": claim_ready,
+        "passed": claim_ready,
+        "blockers": blockers,
+    }
+
+
+def write_real_evidence_status(
+    path: str | Path,
+    status: Mapping[str, Any],
+) -> Path:
+    """Atomically write one deterministic, human-readable status snapshot."""
+
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    payload = (
+        json.dumps(
+            dict(status),
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        )
+        + "\n"
+    )
+    descriptor: int | None = None
+    temporary_name: str | None = None
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{output.name}.",
+            suffix=".tmp",
+            dir=output.parent,
+            text=True,
+        )
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            descriptor = None
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, output)
+        temporary_name = None
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        if temporary_name is not None:
+            Path(temporary_name).unlink(missing_ok=True)
+    return output
+
+
+__all__ = [
+    "EVIDENCE_STATUS_SCHEMA_VERSION",
+    "build_real_evidence_status",
+    "write_real_evidence_status",
+]

--- a/tests/test_real_evidence_status.py
+++ b/tests/test_real_evidence_status.py
@@ -1,0 +1,271 @@
+import hashlib
+import json
+from pathlib import Path
+
+from causal4d.cli.real_protocol import INCOMPLETE_EVIDENCE_EXIT_CODE, main
+from causal4d.real_evidence_status import (
+    build_real_evidence_status,
+    write_real_evidence_status,
+)
+from causal4d.real_protocol import (
+    build_same_object_real_protocol,
+    execution_manifest_template,
+    object_registration_template,
+    scaffold_dataset,
+    slip_pilot_template,
+)
+
+
+def _complete_manifest(protocol: dict, execution_id: str) -> dict:
+    manifest = execution_manifest_template(protocol, execution_id)
+    manifest["acquisition_status"] = "complete"
+    manifest["acquisition"] = {
+        "operator_id": "operator-1",
+        "hardware_run_id": f"run-{execution_id}",
+        "started_at_utc": "2026-07-27T08:00:00Z",
+    }
+    manifest["timing"] = {
+        "frame_count": 120,
+        "intervention_frame": 30,
+        "o_plus_prefix_frames": 6,
+    }
+    for name in protocol["recording_contract"]["required_artifacts"]:
+        descriptor = {
+            "path": f"data/{name}.bin",
+            "sha256": "0" * 64,
+            "bytes": 1,
+        }
+        if name in protocol["recording_contract"]["timestamped_artifacts"]:
+            descriptor["clock_id"] = "ptp-clock-0"
+        manifest["artifacts"][name] = descriptor
+    manifest["quality"] = {
+        "reset_passed": True,
+        "rgbd_actuator_sync_error_ms": 1.0,
+        "initial_state_chamfer_m": 0.001,
+        "end_effector_reset_error_m": 0.001,
+        "contact_centroid_error_m": 0.002,
+        "dropped_rgbd_frames": 0,
+        "slip_displacement_m": None,
+        "complete_release_observed": None,
+    }
+    if manifest["realization_condition_id"] == "slip_low_force":
+        manifest["artifacts"]["gripper_normal_force"] = {
+            "path": "data/gripper_normal_force.bin",
+            "sha256": "1" * 64,
+            "bytes": 1,
+            "clock_id": "ptp-clock-0",
+        }
+        manifest["quality"]["slip_displacement_m"] = 0.01
+        manifest["quality"]["complete_release_observed"] = False
+    manifest["drift_indicators"] = {
+        "wear_cycle_count": 4,
+        "minutes_since_first_execution": 12.5,
+        "object_temperature_c": 22.4,
+        "room_temperature_c": 21.8,
+        "notes": "none",
+    }
+    manifest["exclusion"] = {
+        "status": "included",
+        "reason": None,
+        "decided_before_target_evaluation": True,
+    }
+    return manifest
+
+
+def _complete_registration(protocol: dict, root: Path) -> dict:
+    registration = object_registration_template(protocol)
+    registration["object_instance_serial"] = "sloth-001"
+    registration["phystwin_model_id"] = "sloth-twin-v1"
+    registration["phystwin_model_sha256"] = "2" * 64
+    for index, (region_id, descriptor) in enumerate(
+        registration["contact_regions"].items()
+    ):
+        relative = Path(f"contact_{index}.npz")
+        content = f"canonical-node-set:{region_id}\n".encode()
+        (root / relative).write_bytes(content)
+        descriptor["canonical_node_set_path"] = relative.as_posix()
+        descriptor["canonical_node_set_sha256"] = hashlib.sha256(content).hexdigest()
+        descriptor["node_count"] = 24 + index
+    return registration
+
+
+def _passing_slip_pilot(protocol: dict) -> dict:
+    pilot = slip_pilot_template(protocol)
+    pilot.update(
+        {
+            "pilot_execution_ids": [f"pilot-{index}" for index in range(5)],
+            "contact_region_ids": ["left_forepaw", "right_forepaw"],
+            "bounded_slip_successes": 5,
+            "slip_displacement_mean_m": 0.009,
+            "slip_displacement_coefficient_of_variation": 0.2,
+            "complete_release_count": 0,
+            "passed": True,
+            "decided_before_confirmatory_collection": True,
+        }
+    )
+    return pilot
+
+
+def _materialize_manifest_artifacts(manifest: dict, execution_root: Path) -> None:
+    for name, descriptor in manifest["artifacts"].items():
+        if not descriptor.get("path"):
+            continue
+        artifact_path = execution_root / descriptor["path"]
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        content = f"{manifest['execution_id']}:{name}\n".encode()
+        artifact_path.write_bytes(content)
+        descriptor["bytes"] = len(content)
+        descriptor["sha256"] = hashlib.sha256(content).hexdigest()
+
+
+def _complete_dataset(tmp_path: Path) -> tuple[dict, Path]:
+    protocol = build_same_object_real_protocol()
+    root = tmp_path / "dataset"
+    scaffold_dataset(protocol, root)
+    (root / "object_registration.json").write_text(
+        json.dumps(_complete_registration(protocol, root)),
+        encoding="utf-8",
+    )
+    (root / "slip_pilot.json").write_text(
+        json.dumps(_passing_slip_pilot(protocol)),
+        encoding="utf-8",
+    )
+    for execution in protocol["executions"]:
+        execution_root = root / "executions" / execution["execution_id"]
+        manifest = _complete_manifest(protocol, execution["execution_id"])
+        _materialize_manifest_artifacts(manifest, execution_root)
+        (execution_root / "manifest.json").write_text(
+            json.dumps(manifest),
+            encoding="utf-8",
+        )
+    return protocol, root
+
+
+def test_scaffold_status_does_not_count_templates_as_acquired(tmp_path: Path) -> None:
+    protocol = build_same_object_real_protocol()
+    root = tmp_path / "dataset"
+    scaffold_dataset(protocol, root)
+
+    status = build_real_evidence_status(protocol, root)
+
+    assert status["specified_executions"] == 36
+    assert status["manifest_executions"] == 0
+    assert status["acquired_executions"] == 0
+    assert status["validated_executions"] == 0
+    assert len(status["missing_execution_ids"]) == 36
+    assert status["next_pending_execution"]["acquisition_execution_index"] == 0
+    assert not status["complete"]
+    assert not status["claim_ready"]
+    assert "prerequisite:object_registration" in status["blockers"]
+    assert "prerequisite:slip_pilot" in status["blockers"]
+
+
+def test_complete_dataset_requires_explicit_hash_verification(tmp_path: Path) -> None:
+    protocol, root = _complete_dataset(tmp_path)
+
+    unchecked = build_real_evidence_status(protocol, root)
+    assert unchecked["acquired_executions"] == 36
+    assert unchecked["validated_executions"] == 36
+    assert unchecked["accounting_complete"]
+    assert unchecked["complete"]
+    assert not unchecked["claim_ready"]
+    assert unchecked["blockers"] == ["file_hashes_not_verified"]
+
+    checked = build_real_evidence_status(
+        protocol,
+        root,
+        verify_file_hashes=True,
+    )
+    assert checked["file_hashes_verified"]
+    assert checked["complete"]
+    assert checked["claim_ready"]
+    assert checked["passed"]
+    assert checked["blockers"] == []
+    assert checked["next_pending_execution"] is None
+
+
+def test_tampered_artifact_blocks_claim_readiness(tmp_path: Path) -> None:
+    protocol, root = _complete_dataset(tmp_path)
+    first = min(
+        protocol["executions"],
+        key=lambda value: value["acquisition_execution_index"],
+    )
+    manifest_path = root / "executions" / first["execution_id"] / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    artifact = next(
+        descriptor
+        for descriptor in manifest["artifacts"].values()
+        if descriptor.get("path")
+    )
+    artifact_path = manifest_path.parent / artifact["path"]
+    artifact_path.write_bytes(b"tampered\n")
+
+    status = build_real_evidence_status(
+        protocol,
+        root,
+        verify_file_hashes=True,
+    )
+
+    assert status["acquired_executions"] == 36
+    assert status["validated_executions"] == 35
+    assert status["invalid_execution_ids"] == [first["execution_id"]]
+    assert not status["complete"]
+    assert not status["claim_ready"]
+    assert "invalid_execution_manifests:1" in status["blockers"]
+
+
+def test_cli_status_writes_report_and_fails_closed(tmp_path: Path) -> None:
+    protocol = build_same_object_real_protocol()
+    root = tmp_path / "dataset"
+    scaffold_dataset(protocol, root)
+    output = root / "evidence-status.json"
+
+    code = main(
+        [
+            "status",
+            str(root / "protocol.json"),
+            str(root),
+            "--output-json",
+            str(output),
+            "--require-complete",
+        ]
+    )
+
+    assert code == INCOMPLETE_EVIDENCE_EXIT_CODE
+    status = json.loads(output.read_text(encoding="utf-8"))
+    assert status["specified_executions"] == 36
+    assert status["acquired_executions"] == 0
+    assert not status["claim_ready"]
+
+
+def test_status_report_write_is_atomic_and_round_trips(tmp_path: Path) -> None:
+    output = tmp_path / "status.json"
+    status = {"schema_version": 1, "claim_ready": False, "blockers": ["missing"]}
+
+    written = write_real_evidence_status(output, status)
+
+    assert written == output
+    assert json.loads(output.read_text(encoding="utf-8")) == status
+    assert not list(tmp_path.glob(".status.json.*.tmp"))
+
+
+def test_malformed_manifest_is_invalid_not_incomplete(tmp_path: Path) -> None:
+    protocol = build_same_object_real_protocol()
+    root = tmp_path / "dataset"
+    scaffold_dataset(protocol, root)
+    first = min(
+        protocol["executions"],
+        key=lambda value: value["acquisition_execution_index"],
+    )
+    manifest_path = root / "executions" / first["execution_id"] / "manifest.json"
+    manifest_path.write_text("{not-json\n", encoding="utf-8")
+
+    status = build_real_evidence_status(protocol, root)
+
+    assert status["manifest_executions"] == 1
+    assert status["acquired_executions"] == 0
+    assert status["incomplete_execution_ids"] == []
+    assert status["invalid_execution_ids"] == [first["execution_id"]]
+    assert "invalid_execution_manifests:1" in status["blockers"]
+    assert "incomplete_execution_manifests:1" not in status["blockers"]
+    assert not status["claim_ready"]


### PR DESCRIPTION
## Summary

- add `causal4d-real-protocol status` for the locked 36-execution real protocol;
- keep scaffolded `manifest.template.json` files explicitly outside the acquired-evidence count;
- distinguish manifest presence, parseability, explicit completion, protocol validation, inclusion/exclusion accounting, and artifact-hash verification;
- validate the copied protocol, locked acquisition schedule, object registration, slip pilot, every execution manifest, and registered contact-node-set hashes;
- report ordered missing/incomplete/invalid execution IDs, unexpected execution directories, per-execution errors, and the next unresolved execution;
- classify malformed JSON manifests as invalid evidence rather than incomplete work;
- atomically emit a complete JSON evidence-status snapshot;
- return exit code `3` under `--require-complete` until `claim_ready=true`;
- document the operator workflow and add regression coverage for empty scaffolds, complete-but-unverified evidence, verified completion, tamper rejection, malformed manifests, CLI exit behavior, and atomic report writing.

## Why

Issue #54 defines the physical acquisition as the decisive remaining scientific milestone, but the repository had no implementation for the documented `status` command. A scaffolded directory could be inspected manually, but there was no machine-readable, fail-closed distinction between templates, completed manifests, validated executions, and checksum-verified evidence.

This change provides that missing control-plane gate without creating or modifying evidence.

## Scientific and operational boundary

The status command is observational only. It does not create completed manifests, repair quality-gate failures, replace excluded executions, alter the frozen method, or convert templates into evidence. `complete=true` means all prerequisites and all 36 executions are structurally valid and fully accounted for. `claim_ready=true` additionally requires explicit `--verify-file-hashes` and successful checksum validation.

Supports #54; the issue remains open until the physical 36-execution acquisition is actually complete.

## Validation

Validated by overlaying the branch on the complete source-export snapshot from the immediately preceding green Causal4D CI run:

- focused real-protocol and evidence-status tests: **17 passed**;
- complete core-only suite: **400 passed, 6 skipped**;
- skipped tests are only the declared optional PyRecEst and private Bayesian-PhysTwin integrations;
- complete source compilation passed;
- wheel and source distribution builds passed offline;
- the built wheel imports successfully and all **64** installed console commands render `--help`;
- an installed-wheel scaffold reports **0/36 acquired** and exits `3` under `--require-complete`;
- changed Python files contain no lines beyond the configured 88-character limit.

The hosted PR workflow is queued and will independently run Ruff, incremental formatter checks, Python 3.10/3.12/3.14 core suites, distribution builds, installed CLI help checks, result-bundle checks, pinned-provider integration, and frozen-manifest validation.