### PR TITLE
Preserve exact-zero posterior support

### DIFF
--- a/src/causal4d/grouped_likelihood.py
+++ b/src/causal4d/grouped_likelihood.py
@@ -8,6 +8,8 @@ from typing import Mapping
 
 import numpy as np
 
+from causal4d.weighting import log_weights_from_probabilities
+
 from causal4d.observation_evidence import GroupedObservationEvidence, ObservationGroup
 
 
@@ -44,11 +46,7 @@ def _multivariate_student_t_log_density(
     normalization = (
         lgamma(0.5 * (degrees_of_freedom + dimension))
         - lgamma(0.5 * degrees_of_freedom)
-        - 0.5
-        * (
-            dimension * np.log(degrees_of_freedom * np.pi)
-            + log_determinant
-        )
+        - 0.5 * (dimension * np.log(degrees_of_freedom * np.pi) + log_determinant)
     )
     return normalization - 0.5 * (degrees_of_freedom + dimension) * np.log1p(
         mahalanobis / degrees_of_freedom
@@ -102,7 +100,9 @@ def group_log_likelihood(
 
     predictions = np.asarray(predicted_values_m, dtype=float)
     if predictions.shape[-1] != group.coordinate_count:
-        raise ValueError("predicted group coordinates do not match the observation group")
+        raise ValueError(
+            "predicted group coordinates do not match the observation group"
+        )
     residual = predictions - group.values_m
     covariance = group.covariance_m2
     if additive_variance_m2 is not None:
@@ -111,7 +111,9 @@ def group_log_likelihood(
             raise ValueError("additive_variance_m2 must match predicted group values")
         if np.any(~np.isfinite(additive)) or np.any(additive < 0.0):
             raise ValueError("additive variances must be finite and nonnegative")
-        covariance = covariance + additive[..., :, None] * np.eye(group.coordinate_count)
+        covariance = covariance + additive[..., :, None] * np.eye(
+            group.coordinate_count
+        )
     if additive_covariance_m2 is not None:
         covariance = covariance + _broadcast_additive_covariance(
             additive_covariance_m2,
@@ -173,7 +175,9 @@ def grouped_component_log_likelihoods(
     known_group_ids = {group.group_id for group in evidence.groups}
     unknown = set(covariance_by_group) - known_group_ids
     if unknown:
-        raise ValueError(f"component covariance references unknown groups: {sorted(unknown)}")
+        raise ValueError(
+            f"component covariance references unknown groups: {sorted(unknown)}"
+        )
     total = np.zeros(leading_shape, dtype=float)
     responsibilities = []
     effective_weights = evidence.effective_group_weights
@@ -226,7 +230,7 @@ def posterior_weights_from_grouped_evidence(
         component_variance_m2=component_variance_m2,
         component_group_covariance_m2=component_group_covariance_m2,
     )
-    log_posterior = np.log(np.maximum(prior, 1e-300)) + score
+    log_posterior = log_weights_from_probabilities(prior, name="prior_weights") + score
     maximum = float(np.max(log_posterior))
     posterior = np.exp(log_posterior - maximum)
     posterior /= np.sum(posterior)

--- a/src/causal4d/prefix_likelihood.py
+++ b/src/causal4d/prefix_likelihood.py
@@ -7,6 +7,8 @@ from typing import Sequence
 
 import numpy as np
 
+from causal4d.weighting import log_weights_from_probabilities
+
 from causal4d.rollout_bank import JointRolloutBank
 
 
@@ -85,7 +87,9 @@ def _student_t_mean_log_score(
         standardized = values / scale
         log_scale = np.broadcast_to(np.log(scale), values.shape)
     except ValueError as error:
-        raise ValueError("likelihood scale is not broadcastable to residuals") from error
+        raise ValueError(
+            "likelihood scale is not broadcastable to residuals"
+        ) from error
     terms = -log_scale - 0.5 * (degrees_of_freedom + 1.0) * np.log1p(
         np.square(standardized) / degrees_of_freedom
     )
@@ -95,10 +99,13 @@ def _student_t_mean_log_score(
     count = np.sum(valid_float, axis=reduction_axes)
     if np.any(count <= 0.0):
         raise ValueError("likelihood update has no valid coordinates")
-    return np.sum(
-        np.where(valid_float > 0.0, terms, 0.0),
-        axis=reduction_axes,
-    ) / count
+    return (
+        np.sum(
+            np.where(valid_float > 0.0, terms, 0.0),
+            axis=reduction_axes,
+        )
+        / count
+    )
 
 
 def _normalized_joint_weights(log_weights: np.ndarray) -> np.ndarray:
@@ -141,7 +148,9 @@ def prefix_component_log_likelihood(
     if not 2 <= prefix_frame_count < bank.frame_count:
         raise ValueError("prefix_frame_count must leave at least one future frame")
     nodes = np.asarray(
-        tuple(range(bank.node_count)) if observed_nodes is None else tuple(observed_nodes),
+        tuple(range(bank.node_count))
+        if observed_nodes is None
+        else tuple(observed_nodes),
         dtype=int,
     )
     if (
@@ -151,14 +160,14 @@ def prefix_component_log_likelihood(
         or np.any(nodes >= bank.node_count)
         or len(np.unique(nodes)) != len(nodes)
     ):
-        raise ValueError("observed_nodes must uniquely identify available rollout nodes")
+        raise ValueError(
+            "observed_nodes must uniquely identify available rollout nodes"
+        )
 
     coordinate_valid = _coordinate_mask(observations, mask)
     observed_prefix = observations[:prefix_frame_count, nodes]
     valid_prefix = coordinate_valid[:prefix_frame_count, nodes]
-    predicted_prefix = bank.trajectories[:, :, :prefix_frame_count, nodes].astype(
-        float
-    )
+    predicted_prefix = bank.trajectories[:, :, :prefix_frame_count, nodes].astype(float)
 
     position_scale: np.ndarray | float = settings.observation_scale_m
     if particle_discrepancy_m is not None:
@@ -169,9 +178,7 @@ def prefix_component_log_likelihood(
             bank.coordinate_count,
         )
         if discrepancy.shape != expected_shape:
-            raise ValueError(
-                "particle_discrepancy_m must have shape " f"{expected_shape}"
-            )
+            raise ValueError(f"particle_discrepancy_m must have shape {expected_shape}")
         if not np.all(np.isfinite(discrepancy)):
             raise ValueError("particle discrepancy must be finite")
         predicted_prefix = predicted_prefix + discrepancy[None, :, None, nodes]
@@ -188,16 +195,14 @@ def prefix_component_log_likelihood(
         )
         if discrepancy_variance.shape != expected_shape:
             raise ValueError(
-                "particle_discrepancy_variance_m2 must have shape "
-                f"{expected_shape}"
+                f"particle_discrepancy_variance_m2 must have shape {expected_shape}"
             )
         if not np.all(np.isfinite(discrepancy_variance)) or np.any(
             discrepancy_variance < 0.0
         ):
             raise ValueError("particle discrepancy variance must be nonnegative")
         position_scale = np.sqrt(
-            settings.observation_scale_m**2
-            + discrepancy_variance[None, :, None, nodes]
+            settings.observation_scale_m**2 + discrepancy_variance[None, :, None, nodes]
         )
 
     result = np.zeros(
@@ -271,5 +276,5 @@ def update_joint_weights_from_prefix(
         particle_discrepancy_variance_m2=particle_discrepancy_variance_m2,
     )
     return _normalized_joint_weights(
-        np.log(np.maximum(weights, 1e-300)) + log_likelihood
+        log_weights_from_probabilities(weights, name="base_weights") + log_likelihood
     )

--- a/src/causal4d/semantic_posterior.py
+++ b/src/causal4d/semantic_posterior.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from causal4d.weighting import log_weights_from_probabilities
+
 from causal4d.contracts import PhysicalPosterior, TaskPosterior, array_sha256
 
 if TYPE_CHECKING:
@@ -37,7 +39,9 @@ class SparseSemanticEvidence:
         if nodes.shape != (positions.shape[1],):
             raise ValueError("node_indices must identify every semantic point")
         if frames.shape != (positions.shape[0],):
-            raise ValueError("physical_frame_indices must identify every forecast frame")
+            raise ValueError(
+                "physical_frame_indices must identify every forecast frame"
+            )
         if np.any(nodes < 0) or not np.all(np.isfinite(frames)):
             raise ValueError("semantic node and frame indices must be valid")
         if self.scale_m <= 0.0 or self.degrees_of_freedom <= 0.0:
@@ -50,7 +54,9 @@ class SparseSemanticEvidence:
             if supplied.shape == positions.shape[:2]:
                 supplied = np.repeat(supplied[:, :, None], 3, axis=2)
             if supplied.shape != positions.shape:
-                raise ValueError("semantic valid mask must have shape (F, Q) or (F, Q, 3)")
+                raise ValueError(
+                    "semantic valid mask must have shape (F, Q) or (F, Q, 3)"
+                )
             valid &= supplied
         if not np.any(valid):
             raise ValueError("semantic evidence has no valid coordinates")
@@ -116,13 +122,19 @@ def query_point_readout(
     nodes = np.asarray(node_indices, dtype=np.int64)
     frames = np.asarray(frame_indices, dtype=float)
     trajectory = posterior.readout_trajectories_m
-    if nodes.ndim != 1 or not len(nodes) or np.any(nodes < 0) or np.any(
-        nodes >= trajectory.shape[2]
+    if (
+        nodes.ndim != 1
+        or not len(nodes)
+        or np.any(nodes < 0)
+        or np.any(nodes >= trajectory.shape[2])
     ):
         raise ValueError("node_indices exceed the physical posterior")
-    if frames.ndim != 1 or not len(frames) or np.min(frames) < 0.0 or np.max(
-        frames
-    ) > trajectory.shape[1] - 1:
+    if (
+        frames.ndim != 1
+        or not len(frames)
+        or np.min(frames) < 0.0
+        or np.max(frames) > trajectory.shape[1] - 1
+    ):
         raise ValueError("frame_indices exceed the physical posterior")
     lower = np.floor(frames).astype(int)
     upper = np.ceil(frames).astype(int)
@@ -153,8 +165,10 @@ def semantic_component_log_scores(
     valid = np.asarray(evidence.valid, dtype=bool)
     residual = predicted - target[None]
     standardized = residual / evidence.scale_m
-    terms = -0.5 * (evidence.degrees_of_freedom + 1.0) * np.log1p(
-        np.square(standardized) / evidence.degrees_of_freedom
+    terms = (
+        -0.5
+        * (evidence.degrees_of_freedom + 1.0)
+        * np.log1p(np.square(standardized) / evidence.degrees_of_freedom)
     )
     valid_count = int(np.sum(valid))
     return np.sum(np.where(valid[None], terms, 0.0), axis=(1, 2, 3)) / valid_count
@@ -174,7 +188,13 @@ def build_task_posterior(
     if beta == 0.0:
         task_weights = physical.weights.copy()
     else:
-        log_weights = np.log(np.maximum(physical.weights, 1e-300)) + beta * scores
+        log_weights = (
+            log_weights_from_probabilities(
+                physical.weights,
+                name="physical_weights",
+            )
+            + beta * scores
+        )
         maximum = float(np.max(log_weights))
         task_weights = np.exp(log_weights - maximum)
         task_weights /= np.sum(task_weights)

--- a/src/causal4d/weighting.py
+++ b/src/causal4d/weighting.py
@@ -1,0 +1,30 @@
+"""Finite-support probability-weight utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def log_weights_from_probabilities(
+    values: np.ndarray,
+    *,
+    name: str = "weights",
+) -> np.ndarray:
+    """Convert nonnegative weights to log space without creating support.
+
+    Exact zeros map to negative infinity. Subsequent likelihood, tempering, or
+    semantic factors therefore cannot assign probability to components excluded
+    by the input support.
+    """
+
+    weights = np.asarray(values, dtype=float)
+    if weights.size == 0:
+        raise ValueError(f"{name} must be nonempty")
+    if not np.all(np.isfinite(weights)) or np.any(weights < 0.0):
+        raise ValueError(f"{name} must be finite and nonnegative")
+    positive = weights > 0.0
+    if not np.any(positive):
+        raise ValueError(f"{name} must contain positive mass")
+    result = np.full(weights.shape, -np.inf, dtype=float)
+    result[positive] = np.log(weights[positive])
+    return result

--- a/tests/test_exact_zero_support.py
+++ b/tests/test_exact_zero_support.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from causal4d.contracts import PhysicalPosterior, build_causal_context
+from causal4d.grouped_likelihood import posterior_weights_from_grouped_evidence
+from causal4d.observation_evidence import GroupedObservationEvidence, ObservationGroup
+from causal4d.prefix_likelihood import (
+    PrefixLikelihoodConfig,
+    update_joint_weights_from_prefix,
+)
+from causal4d.rollout_bank import JointRolloutBank
+from causal4d.semantic_posterior import SparseSemanticEvidence, build_task_posterior
+from causal4d.weighting import log_weights_from_probabilities
+
+
+def _context():
+    observations = np.zeros((6, 1, 3), dtype=float)
+    actions = np.zeros((6, 1, 3), dtype=float)
+    return build_causal_context(
+        protocol_id="exact_zero_support",
+        case_id="unit",
+        observations=observations,
+        observed_actions=actions,
+        counterfactual_actions=actions,
+        intervention_frame=2,
+    )
+
+
+def _joint_bank() -> JointRolloutBank:
+    trajectories = np.zeros((2, 1, 5, 1, 3), dtype=float)
+    trajectories[1, 0, :, 0, 0] = np.arange(5, dtype=float) * 0.1
+    return JointRolloutBank(
+        hypothesis_ids=("supported", "excluded"),
+        hypothesis_metadata=({}, {}),
+        hypothesis_prior_weights=np.asarray([0.5, 0.5]),
+        parameter_particles=np.asarray([[0.0]]),
+        parameter_weights=np.asarray([1.0]),
+        trajectories=trajectories,
+    )
+
+
+def _physical() -> PhysicalPosterior:
+    trajectories = np.zeros((2, 5, 1, 3), dtype=float)
+    trajectories[1, :, 0, 0] = np.arange(5, dtype=float) * 0.1
+    return PhysicalPosterior(
+        context=_context(),
+        component_ids=("supported", "excluded"),
+        state_trajectories_m=trajectories,
+        readout_trajectories_m=trajectories,
+        readout_variance_m2=np.full((2, 1, 3), 1e-8),
+        weights=np.asarray([1.0, 0.0]),
+        phi=np.asarray([[1.0], [2.0]]),
+        kappa_cf=np.asarray([[0.0], [1.0]]),
+        hypothesis_indices=np.asarray([0, 1]),
+        twin_particle_indices=np.asarray([0, 0]),
+        phi_names=("gain",),
+        kappa_names=("contact",),
+        source_twin_belief_id="1" * 64,
+        source_factual_intervention_id="2" * 64,
+        source_query_id="3" * 64,
+    )
+
+
+def test_log_weights_preserve_exact_support_and_validate_mass() -> None:
+    result = log_weights_from_probabilities(np.asarray([0.75, 0.0, 0.25]))
+    assert np.isneginf(result[1])
+    np.testing.assert_allclose(np.exp(result[[0, 2]]), [0.75, 0.25])
+    with pytest.raises(ValueError, match="positive mass"):
+        log_weights_from_probabilities(np.zeros(2))
+
+
+def test_prefix_update_does_not_resurrect_zero_base_mass() -> None:
+    bank = _joint_bank()
+    observations = bank.trajectories[1, 0].copy()
+    posterior = update_joint_weights_from_prefix(
+        bank,
+        observations,
+        prefix_frame_count=4,
+        config=PrefixLikelihoodConfig(
+            observation_scale_m=1e-4,
+            likelihood_power=100.0,
+            dynamic_likelihood_weight=0.0,
+        ),
+        base_weights=np.asarray([[1.0], [0.0]]),
+    )
+    np.testing.assert_array_equal(posterior[:, 0], [1.0, 0.0])
+
+
+def test_grouped_update_does_not_resurrect_zero_prior_mass() -> None:
+    bank = _joint_bank()
+    evidence = GroupedObservationEvidence(
+        groups=(
+            ObservationGroup(
+                group_id="frame-1",
+                values_m=np.asarray([0.1]),
+                frame_indices=np.asarray([1]),
+                node_indices=np.asarray([0]),
+                coordinate_indices=np.asarray([0]),
+                covariance_m2=np.asarray([[1e-8]]),
+                contributor_ids=("frame-1",),
+                prior_nominal_probability=0.95,
+                outlier_scale_multiplier=100.0,
+                degrees_of_freedom=4.0,
+                source_id="unit",
+            ),
+        )
+    )
+    posterior, _ = posterior_weights_from_grouped_evidence(
+        np.asarray([1.0, 0.0]),
+        bank.trajectories[:, 0],
+        evidence,
+        prefix_frame_count=4,
+    )
+    np.testing.assert_array_equal(posterior, [1.0, 0.0])
+
+
+def test_semantic_reweighting_cannot_create_physical_support() -> None:
+    physical = _physical()
+    evidence = SparseSemanticEvidence(
+        positions_m=physical.readout_trajectories_m[1, 1:4],
+        node_indices=np.asarray([0]),
+        physical_frame_indices=np.asarray([1.0, 2.0, 3.0]),
+        scale_m=1e-4,
+        compare_displacements=True,
+        anchor_positions_m=np.zeros((1, 3)),
+    )
+    task = build_task_posterior(physical, evidence, beta=100.0)
+    np.testing.assert_array_equal(task.task_weights, [1.0, 0.0])


### PR DESCRIPTION
## Summary

- add one finite-support log-weight utility that maps exact-zero probability to `-inf` rather than an artificial `1e-300` floor;
- apply it to correlation-aware prefix inference, grouped observation evidence, and semantic task-posterior reweighting;
- add adversarial regression tests in which an excluded component fits the new evidence better but must retain exactly zero posterior mass.

## Root cause

Several core probability updates used `np.log(np.maximum(weights, 1e-300))`. That is numerically convenient, but it changes the finite support: a component assigned exact-zero prior probability receives a small positive surrogate mass and can be resurrected by a sufficiently favorable likelihood or semantic score.

This conflicts with Causal4D's explicit support-reduction and exact-fallback semantics. In a finite Bayesian support, zero prior mass must remain zero unless the model explicitly expands the support.

## Implementation

`causal4d.weighting.log_weights_from_probabilities()` validates finite nonnegative input and converts only positive entries to log space; exact zeros become `-inf`. The utility is used by:

- `update_joint_weights_from_prefix()`;
- `posterior_weights_from_grouped_evidence()`;
- `build_task_posterior()`.

Positive-weight behavior is unchanged.

## Validation

Locally exercised against the exact `main` source tree:

- new adversarial exact-zero support tests;
- existing prefix-likelihood tests;
- existing grouped-observation tests;
- existing semantic-posterior tests.

Result: **13 passed**. Source byte-compilation also passed. Standard repository CI is running on the clean one-commit product branch.

Frozen tags and existing artifacts are not modified.