### PR TITLE
Bind execution-block source and target provenance

### DIFF
--- a/docs/execution_block_conformal_calibration.md
+++ b/docs/execution_block_conformal_calibration.md
@@ -41,6 +41,7 @@ inputs accepted by `causal4d-real-calibration`.
   "protocol_design_sha256": "...",
   "preacquisition_plan_id": "causal4d-sloth-preacquisition-v4",
   "preacquisition_amendment_sha256": "...",
+  "method_freeze_sha256": "...",
   "fit": [
     {
       "execution_id": "source-fit-001",
@@ -62,6 +63,13 @@ inputs accepted by `causal4d-real-calibration`.
 }
 ```
 
+`protocol_id`, `protocol_design_sha256`, `preacquisition_plan_id`, and
+`preacquisition_amendment_sha256` are mandatory. Digests must be lowercase
+SHA-256 values. `method_freeze_sha256` is optional before the final method seal,
+but once supplied it becomes part of the immutable source calibration identity.
+The exact source-manifest digest is also embedded in the checksummed calibration
+artifact.
+
 Fit and seal the calibration artifact with:
 
 ```bash
@@ -74,13 +82,18 @@ causal4d-execution-block-calibration fit \
 
 `--expected-fit-units` may additionally lock the fit count. The command rejects
 repeated session IDs, execution overlap, session overlap between fit and
-calibration, mixed outer folds, incomplete frozen counts, and unattainable
-finite conformal ranks.
+calibration, mixed outer folds, incomplete frozen counts, unattainable finite
+conformal ranks, and incomplete or malformed protocol provenance.
 
 ## Target evaluation
 
 The target manifest uses the same schema and outer-fold ID with a `target` list.
-No target execution or session may occur in the fit or calibration source.
+No target execution or session may occur in the fit or calibration source. It
+must repeat the exact source `protocol_id`, protocol-design digest,
+preacquisition plan ID, and amendment digest. If either source or target names a
+`method_freeze_sha256`, both must name the same digest. A same-named fold from a
+different protocol, amendment, or method freeze is rejected before any target
+case is scored.
 
 ```bash
 causal4d-execution-block-calibration evaluate \
@@ -88,6 +101,12 @@ causal4d-execution-block-calibration evaluate \
   target-fold.json \
   target-evaluation.json
 ```
+
+The output contains a canonical `frozen_source_target_binding` record with the
+source and target manifest digests and the verified protocol identities. This
+record is written alongside the execution-block coverage result so paper-facing
+evidence cannot silently combine calibration and target artifacts from different
+registered designs.
 
 The output reports execution-block coverage as the primary quantity. Pointwise
 coordinate coverage, RMSE, track error, and interval width are diagnostics only.

--- a/src/causal4d/cli/execution_block_calibration.py
+++ b/src/causal4d/cli/execution_block_calibration.py
@@ -16,6 +16,10 @@ from causal4d.execution_block_calibration import (
     load_execution_block_conformal_calibration,
     save_execution_block_conformal_calibration,
 )
+from causal4d.execution_block_provenance import (
+    bind_execution_block_source_manifest,
+    validate_execution_block_target_manifest,
+)
 
 
 def _sha256(path: str | Path) -> str:
@@ -28,6 +32,8 @@ def _sha256(path: str | Path) -> str:
 
 def _load_manifest(path: str | Path) -> dict[str, Any]:
     payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError("execution-block manifest root must be a JSON object")
     if payload.get("schema_version") != 1:
         raise ValueError("unsupported execution-block manifest schema")
     if (
@@ -35,7 +41,7 @@ def _load_manifest(path: str | Path) -> dict[str, Any]:
         or not payload["outer_fold_id"]
     ):
         raise ValueError("execution-block manifest has no outer_fold_id")
-    return payload
+    return dict(payload)
 
 
 def _load_prediction_case(specification: Mapping[str, Any]) -> Any:
@@ -73,20 +79,11 @@ def _artifact_metadata(
     manifest: Mapping[str, Any],
     *,
     manifest_sha256: str,
-) -> dict[str, Any]:
-    retained = {
-        key: manifest[key]
-        for key in (
-            "protocol_id",
-            "protocol_design_sha256",
-            "preacquisition_plan_id",
-            "preacquisition_amendment_sha256",
-            "method_freeze_sha256",
-        )
-        if key in manifest
-    }
-    retained["source_manifest_sha256"] = manifest_sha256
-    return retained
+) -> dict[str, str]:
+    return bind_execution_block_source_manifest(
+        manifest,
+        manifest_sha256=manifest_sha256,
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -172,6 +169,13 @@ def main(argv: Sequence[str] | None = None) -> int:
                 args.calibration_json
             )
             manifest = _load_manifest(args.target_manifest_json)
+            target_manifest_sha256 = _sha256(args.target_manifest_json)
+            frozen_binding = validate_execution_block_target_manifest(
+                calibration.metadata,
+                manifest,
+                expected_outer_fold_id=calibration.outer_fold_id,
+                target_manifest_sha256=target_manifest_sha256,
+            )
             outer_fold_id = str(manifest["outer_fold_id"])
             target_specs = manifest.get("target", manifest.get("cases", []))
             target_cases = tuple(
@@ -186,8 +190,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                 target_cases,
                 calibration,
             )
+            evaluation["frozen_source_target_binding"] = frozen_binding
             evaluation["target_manifest"] = {
-                "sha256": _sha256(args.target_manifest_json),
+                "sha256": target_manifest_sha256,
             }
             output = Path(args.output_evaluation_json)
             output.parent.mkdir(parents=True, exist_ok=True)
@@ -205,6 +210,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "passed": True,
                 "calibration_id": calibration.calibration_id,
                 "outer_fold_id": calibration.outer_fold_id,
+                "frozen_binding_verified": frozen_binding["verified"],
                 "target_execution_count": evaluation["target_execution_count"],
                 "execution_block_coverage": evaluation["execution_block_coverage"],
                 "output": str(output.resolve()),

--- a/src/causal4d/execution_block_provenance.py
+++ b/src/causal4d/execution_block_provenance.py
@@ -1,0 +1,139 @@
+"""Fail-closed provenance binding for execution-block calibration folds."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+EXECUTION_BLOCK_PROVENANCE_SCHEMA_VERSION = 1
+REQUIRED_EXECUTION_BLOCK_BINDING_FIELDS = (
+    "protocol_id",
+    "protocol_design_sha256",
+    "preacquisition_plan_id",
+    "preacquisition_amendment_sha256",
+)
+OPTIONAL_EXECUTION_BLOCK_BINDING_FIELDS = ("method_freeze_sha256",)
+_SHA256_FIELDS = {
+    "protocol_design_sha256",
+    "preacquisition_amendment_sha256",
+    "method_freeze_sha256",
+    "source_manifest_sha256",
+    "target_manifest_sha256",
+}
+
+
+def _require_nonempty_text(value: Any, *, name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _require_sha256(value: Any, *, name: str) -> str:
+    digest = _require_nonempty_text(value, name=name)
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _validated_field(value: Any, *, name: str) -> str:
+    if name in _SHA256_FIELDS:
+        return _require_sha256(value, name=name)
+    return _require_nonempty_text(value, name=name)
+
+
+def extract_execution_block_manifest_binding(
+    manifest: Mapping[str, Any],
+) -> dict[str, str]:
+    """Extract the frozen protocol identity required by a calibration manifest."""
+
+    if not isinstance(manifest, Mapping):
+        raise ValueError("execution-block manifest root must be a JSON object")
+    binding = {
+        name: _validated_field(manifest.get(name), name=name)
+        for name in REQUIRED_EXECUTION_BLOCK_BINDING_FIELDS
+    }
+    for name in OPTIONAL_EXECUTION_BLOCK_BINDING_FIELDS:
+        if name in manifest:
+            binding[name] = _validated_field(manifest[name], name=name)
+    return binding
+
+
+def bind_execution_block_source_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    manifest_sha256: str,
+) -> dict[str, str]:
+    """Bind a source manifest and its bytes to a calibration artifact."""
+
+    return {
+        **extract_execution_block_manifest_binding(manifest),
+        "source_manifest_sha256": _require_sha256(
+            manifest_sha256,
+            name="source_manifest_sha256",
+        ),
+    }
+
+
+def validate_execution_block_target_manifest(
+    calibration_metadata: Mapping[str, Any],
+    target_manifest: Mapping[str, Any],
+    *,
+    expected_outer_fold_id: str,
+    target_manifest_sha256: str,
+) -> dict[str, Any]:
+    """Require source and target to share one frozen protocol/amendment identity."""
+
+    expected_fold = _require_nonempty_text(
+        expected_outer_fold_id,
+        name="expected_outer_fold_id",
+    )
+    source = extract_execution_block_manifest_binding(calibration_metadata)
+    source_manifest_sha256 = _require_sha256(
+        calibration_metadata.get("source_manifest_sha256"),
+        name="source_manifest_sha256",
+    )
+    target = extract_execution_block_manifest_binding(target_manifest)
+    target_fold = _require_nonempty_text(
+        target_manifest.get("outer_fold_id"),
+        name="outer_fold_id",
+    )
+    if target_fold != expected_fold:
+        raise ValueError(
+            "target outer_fold_id differs from the calibration artifact: "
+            f"{target_fold!r} != {expected_fold!r}"
+        )
+
+    for name in REQUIRED_EXECUTION_BLOCK_BINDING_FIELDS:
+        if target[name] != source[name]:
+            raise ValueError(
+                f"target {name} differs from the frozen source calibration"
+            )
+
+    source_freeze = source.get("method_freeze_sha256")
+    target_freeze = target.get("method_freeze_sha256")
+    if (source_freeze is None) != (target_freeze is None):
+        raise ValueError(
+            "method_freeze_sha256 must be present in both source and target "
+            "manifests or in neither"
+        )
+    if source_freeze is not None and target_freeze != source_freeze:
+        raise ValueError(
+            "target method_freeze_sha256 differs from the frozen source calibration"
+        )
+
+    binding: dict[str, Any] = {
+        "schema_version": EXECUTION_BLOCK_PROVENANCE_SCHEMA_VERSION,
+        "artifact_kind": "ExecutionBlockSourceTargetBinding",
+        "verified": True,
+        "outer_fold_id": expected_fold,
+        **source,
+        "source_manifest_sha256": source_manifest_sha256,
+        "target_manifest_sha256": _require_sha256(
+            target_manifest_sha256,
+            name="target_manifest_sha256",
+        ),
+    }
+    return binding

--- a/tests/test_causal4d_execution_block_calibration_cli_provenance.py
+++ b/tests/test_causal4d_execution_block_calibration_cli_provenance.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from causal4d.cli.execution_block_calibration import _artifact_metadata, _load_manifest
+
+
+def _manifest() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "outer_fold_id": "outer-fold-1",
+        "protocol_id": "causal4d-sloth-multi-action-v1",
+        "protocol_design_sha256": "1" * 64,
+        "preacquisition_plan_id": "causal4d-sloth-preacquisition-v4",
+        "preacquisition_amendment_sha256": "2" * 64,
+    }
+
+
+def test_manifest_loader_rejects_non_object_json(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(["not", "an", "object"]), encoding="utf-8")
+    with pytest.raises(ValueError, match="root must be a JSON object"):
+        _load_manifest(path)
+
+
+def test_source_metadata_requires_frozen_protocol_binding() -> None:
+    manifest = _manifest()
+    del manifest["preacquisition_plan_id"]
+    with pytest.raises(ValueError, match="preacquisition_plan_id"):
+        _artifact_metadata(manifest, manifest_sha256="3" * 64)
+
+
+def test_source_metadata_binds_exact_manifest_bytes() -> None:
+    metadata = _artifact_metadata(_manifest(), manifest_sha256="3" * 64)
+    assert metadata["source_manifest_sha256"] == "3" * 64
+    assert metadata["protocol_design_sha256"] == "1" * 64

--- a/tests/test_causal4d_execution_block_provenance.py
+++ b/tests/test_causal4d_execution_block_provenance.py
@@ -1,0 +1,117 @@
+import pytest
+
+from causal4d.execution_block_provenance import (
+    bind_execution_block_source_manifest,
+    extract_execution_block_manifest_binding,
+    validate_execution_block_target_manifest,
+)
+
+
+def _manifest(*, freeze: bool = True) -> dict[str, object]:
+    result: dict[str, object] = {
+        "schema_version": 1,
+        "outer_fold_id": "hold-left_forepaw-lift_high",
+        "protocol_id": "causal4d-sloth-multi-action-v1",
+        "protocol_design_sha256": "1" * 64,
+        "preacquisition_plan_id": "causal4d-sloth-preacquisition-v4",
+        "preacquisition_amendment_sha256": "2" * 64,
+    }
+    if freeze:
+        result["method_freeze_sha256"] = "3" * 64
+    return result
+
+
+def _source_metadata(*, freeze: bool = True) -> dict[str, object]:
+    return bind_execution_block_source_manifest(
+        _manifest(freeze=freeze),
+        manifest_sha256="4" * 64,
+    )
+
+
+def test_source_binding_requires_complete_registered_identity() -> None:
+    manifest = _manifest()
+    del manifest["protocol_design_sha256"]
+    with pytest.raises(ValueError, match="protocol_design_sha256"):
+        extract_execution_block_manifest_binding(manifest)
+
+
+def test_source_binding_rejects_noncanonical_digest() -> None:
+    manifest = _manifest()
+    manifest["preacquisition_amendment_sha256"] = "A" * 64
+    with pytest.raises(ValueError, match="lowercase SHA-256"):
+        bind_execution_block_source_manifest(
+            manifest,
+            manifest_sha256="4" * 64,
+        )
+
+
+def test_matching_source_and_target_binding_is_canonical() -> None:
+    binding = validate_execution_block_target_manifest(
+        _source_metadata(),
+        _manifest(),
+        expected_outer_fold_id="hold-left_forepaw-lift_high",
+        target_manifest_sha256="5" * 64,
+    )
+    assert binding["verified"]
+    assert binding["protocol_design_sha256"] == "1" * 64
+    assert binding["method_freeze_sha256"] == "3" * 64
+    assert binding["source_manifest_sha256"] == "4" * 64
+    assert binding["target_manifest_sha256"] == "5" * 64
+
+
+def test_target_protocol_digest_mismatch_is_rejected() -> None:
+    target = _manifest()
+    target["protocol_design_sha256"] = "6" * 64
+    with pytest.raises(ValueError, match="protocol_design_sha256"):
+        validate_execution_block_target_manifest(
+            _source_metadata(),
+            target,
+            expected_outer_fold_id="hold-left_forepaw-lift_high",
+            target_manifest_sha256="5" * 64,
+        )
+
+
+def test_target_amendment_mismatch_is_rejected() -> None:
+    target = _manifest()
+    target["preacquisition_amendment_sha256"] = "7" * 64
+    with pytest.raises(ValueError, match="preacquisition_amendment_sha256"):
+        validate_execution_block_target_manifest(
+            _source_metadata(),
+            target,
+            expected_outer_fold_id="hold-left_forepaw-lift_high",
+            target_manifest_sha256="5" * 64,
+        )
+
+
+def test_method_freeze_must_be_bound_symmetrically() -> None:
+    with pytest.raises(ValueError, match="present in both"):
+        validate_execution_block_target_manifest(
+            _source_metadata(freeze=False),
+            _manifest(freeze=True),
+            expected_outer_fold_id="hold-left_forepaw-lift_high",
+            target_manifest_sha256="5" * 64,
+        )
+
+
+def test_target_fold_mismatch_is_rejected() -> None:
+    target = _manifest()
+    target["outer_fold_id"] = "another-fold"
+    with pytest.raises(ValueError, match="outer_fold_id"):
+        validate_execution_block_target_manifest(
+            _source_metadata(),
+            target,
+            expected_outer_fold_id="hold-left_forepaw-lift_high",
+            target_manifest_sha256="5" * 64,
+        )
+
+
+def test_source_manifest_digest_is_required_for_target_evaluation() -> None:
+    metadata = _source_metadata()
+    del metadata["source_manifest_sha256"]
+    with pytest.raises(ValueError, match="source_manifest_sha256"):
+        validate_execution_block_target_manifest(
+            metadata,
+            _manifest(),
+            expected_outer_fold_id="hold-left_forepaw-lift_high",
+            target_manifest_sha256="5" * 64,
+        )


### PR DESCRIPTION
## Summary

- require execution-block source manifests to bind the exact protocol ID, protocol-design digest, pre-acquisition plan ID, and amendment digest;
- bind the source-manifest bytes into the checksummed conformal calibration artifact;
- reject target evaluation before loading target cases when the fold, protocol, amendment, or optional method-freeze digest differs;
- record a canonical `frozen_source_target_binding` containing both manifest digests in the evaluation output;
- reject non-object JSON manifests and malformed/noncanonical SHA-256 values;
- document the source/target provenance contract and add focused regression tests.

## Root cause

PR #61 correctly bound source protocol metadata into the calibration artifact, but target evaluation only enforced the outer-fold and execution/session boundaries. A target manifest from a different protocol design or pre-acquisition amendment could therefore be evaluated against a same-named calibrated fold. The result would retain the target manifest digest but would not prove that source calibration and target evaluation shared the same frozen design.

## Impact

Registered target evaluation now fails closed on provenance drift before reading target prediction cases. Existing library-level conformal calculations are unchanged; the stricter behavior applies to the registered CLI artifact path.

## Validation

- focused provenance suite: 11 passed;
- Python compilation: passed for the new provenance module and updated CLI;
- GitHub Actions: Ruff, formatting, types, source distribution and wheel builds, Python 3.10/3.12/3.14 core suites, result-bundle checks, frozen-manifest validation, and installed-wheel CLI smoke tests are green;
- five files changed, including two focused test modules, with no change to the numerical conformal method.

The pinned private Bayesian-PhysTwin steps remain skipped because `BPT_READ_TOKEN` is not configured; repository issue #52 tracks that external credential requirement.