### PR TITLE
Harden real-experiment claim readiness with evidence contract v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,17 @@ causal4d-real-experiment-freeze seal \
   --frozen-by "<operator-or-principal-investigator>"
 ```
 
+Independently validate and attest that exact freeze before collection:
+
+```bash
+causal4d-real-experiment-freeze attest \
+  /data/causal4d-sloth-multi-action-v1/method_freeze.json \
+  configs/causal4d/sloth_multi_action_v1.json \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1/method_freeze_validation.json \
+  --verified-by "<independent-verifier>"
+```
+
 Track acquisition progress without counting templates as evidence:
 
 ```bash
@@ -168,9 +179,12 @@ causal4d-real-protocol status \
   /data/causal4d-sloth-multi-action-v1/evidence-status.json
 ```
 
-Before analysis, add `--verify-file-hashes --require-complete`. The command
-returns exit code 3 until all 36 executions and every registered artifact are
-claim-ready. See
+Before analysis, add
+`--repository-root <frozen-checkout> --verify-file-hashes --require-complete`.
+The version-2 gate remains closed until the approved timebase, schema-3 physical
+contact registration, sealed and independently attested method freeze, all 18
+same-grasp session manifests, all 36 execution manifests, and every registered
+artifact hash validate. See
 [docs/causal4d_real_evidence_status.md](docs/causal4d_real_evidence_status.md)
 for the exact accounting and exit-code contract.
 

--- a/docs/causal4d_real_evidence_status.md
+++ b/docs/causal4d_real_evidence_status.md
@@ -1,14 +1,103 @@
 # Real-Evidence Status and Claim-Readiness Gate
 
-The same-object multi-action protocol contains 36 preregistered executions. A
-scaffolded directory is only an acquisition template; it is not evidence. The
-status command therefore reports templates, completed manifests, validated
-executions, inclusion/exclusion accounting, and verified artifact hashes as
-separate quantities.
+The same-object multi-action protocol contains 18 same-grasp sessions and 36
+preregistered executions. Scaffolded files are acquisition templates, not
+evidence. The version-2 status contract therefore separates acquisition
+progress, evidence completeness, statistical analysability, and claim readiness.
+
+## Required evidence tree
+
+A claim-ready dataset contains the locked protocol and acquisition schedule plus:
+
+- `object_registration.json` and every hashed canonical contact-node set;
+- approved schema-3 `contact_registration.json`, including multiview overlays,
+  rejected attachment candidates, independent reviews, and source checksums that
+  bind the simple registration and each canonical node set;
+- `slip_pilot.json` with the preregistered bounded-slip decision;
+- approved `timebase_calibration.json` for the exact timestamped-stream set and
+  one common `clock_domain_id`;
+- sealed `method_freeze.json`, verified against a clean checkout at the frozen
+  Causal4D commit and its Bayesian-PhysTwin pin;
+- independent `method_freeze_validation.json`, signed by someone other than the
+  freezer and bound to the exact freeze-file SHA-256;
+- one completed `sessions/<session-id>/session.json` for each of the 18 sessions;
+- one completed and hash-verified execution manifest for each of the 36 locked
+  executions.
+
+Create the independent freeze attestation from a second operator account or
+review step after sealing:
+
+```bash
+causal4d-real-experiment-freeze attest \
+  /data/causal4d-sloth-multi-action-v1/method_freeze.json \
+  configs/causal4d/sloth_multi_action_v1.json \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1/method_freeze_validation.json \
+  --verified-by "<independent-verifier>"
+```
+
+The command revalidates the clean checkout, every locked file hash, and the
+Bayesian-PhysTwin pin before writing the attestation. It rejects a verifier ID
+that matches the original freezer.
+
+The physical registration uses `PhysicalContactRegistration` schema 3 as the
+authoritative contact record. Its `source_checksums` mapping must include
+`object_registration.json` and `contact_node_set:<region-id>` entries. The
+simpler registration remains as a compact acquisition index and is checked
+against the authoritative artifact.
+
+## Scaffold
+
+Create the acquisition tree with the CLI so the version-2 prerequisite and
+same-grasp templates are installed as well as the execution templates:
+
+```bash
+causal4d-real-protocol scaffold \
+  configs/causal4d/sloth_multi_action_v1.json \
+  /data/causal4d-sloth-multi-action-v1
+```
+
+`session.template.json`, `timebase_calibration.template.json`,
+`method_freeze_validation.template.json`, and every `manifest.template.json`
+remain explicitly incomplete. Copy a template to its non-template name only
+after recording the required evidence; changing a filename alone never makes it
+valid.
+
+## Execution and session continuity
+
+Every completed execution manifest retains the version-1 fields and adds these
+members under `acquisition`:
+
+```json
+{
+  "ended_at_utc": "2026-07-28T10:31:12Z",
+  "acquisition_execution_index": 0,
+  "grasp_instance_id": "grasp-session-001",
+  "clock_domain_id": "ptp-clock-0"
+}
+```
+
+All timestamps must be UTC. Every present timestamped artifact must use the same
+clock domain. Numeric quality values must be finite and nonnegative, and
+`dropped_rgbd_frames` must be a nonnegative integer; JSON `NaN` and infinities
+are rejected before validation.
+
+Each session manifest binds:
+
+- the exact two execution IDs in locked order;
+- a unique `grasp_instance_id` shared by both executions;
+- the approved timebase and contact-registration SHA-256 values;
+- the exact SHA-256 of both execution manifests;
+- chronological, non-overlapping execution timestamps;
+- successful neutral-state checks before, between, and after the pair;
+- `same_grasp_confirmed: true` and `release_between_executions: false`;
+- an approval timestamp after session completion.
+
+A grasp identifier reused across sessions is rejected.
 
 ## Progress report
 
-After scaffolding the dataset, write a machine-readable progress snapshot:
+Write an observational progress snapshot at any stage:
 
 ```bash
 causal4d-real-protocol status \
@@ -18,51 +107,46 @@ causal4d-real-protocol status \
   /data/causal4d-sloth-multi-action-v1/evidence-status.json
 ```
 
-`manifest.template.json` files are never counted as acquired executions. An
-execution is acquired only when `manifest.json` exists and explicitly declares
-`acquisition_status: complete`. It is validated only when the completed manifest
-passes the frozen protocol, quality-gate, exclusion, artifact-descriptor, and
-information-boundary checks.
+The report includes prerequisite, execution, and session validation details and
+uses separate decisions:
 
-The report includes:
+- `acquisition_complete`: the original protocol, schedule, simple registration,
+  slip pilot, and all 36 executions are present, valid, and accounted for;
+- `evidence_complete`: every version-2 prerequisite and all 18 session records
+  also validate, there are no unexpected directories, and all requested hashes
+  were checked;
+- `analysis_ready`: every registered fold still contains at least one included
+  fit, calibration, and target execution and at least one same-grasp pair remains;
+- `full_registered_power`: no execution was excluded;
+- `claim_ready`: the evidence tree is complete and hash verified.
 
-- prerequisite status for the dataset protocol, locked acquisition schedule,
-  object registration, and slip pilot;
-- specified, manifest-present, acquired, validated, included, and excluded
-  execution counts;
-- ordered missing, incomplete, and invalid execution IDs;
-- the next unresolved execution in the preregistered acquisition order;
-- per-execution validation errors and quality-gate failures;
-- unexpected directories under `executions/`;
-- `complete`, `file_hashes_verified`, and `claim_ready` decisions.
+`claim_ready` does not silently discard a negative or exclusion-limited result.
+It can be true while `analysis_ready` or `full_registered_power` is false, so the
+mandatory report can state the registered limitation explicitly.
 
-## Fail-closed completion gate
+## Fail-closed final gate
 
-Before analysis or release of a multi-action real-data claim, rehash every
-registered artifact and require claim readiness:
+Run the final gate from, or point it at, a clean checkout of the exact frozen
+Causal4D commit:
 
 ```bash
 causal4d-real-protocol status \
   configs/causal4d/sloth_multi_action_v1.json \
   /data/causal4d-sloth-multi-action-v1 \
+  --repository-root /opt/causal4d-frozen \
   --verify-file-hashes \
   --output-json \
   /data/causal4d-sloth-multi-action-v1/evidence-status.json \
   --require-complete
 ```
 
-Exit codes are:
+The command returns:
 
-- `0`: the report was produced and, when `--require-complete` is present, the
-  evidence is claim-ready;
-- `2`: the command or locked protocol could not be interpreted;
-- `3`: `--require-complete` was requested but the evidence is not claim-ready.
+- `0` when the report is produced and, with `--require-complete`, is claim-ready;
+- `2` when an input or locked contract cannot be interpreted;
+- `3` when `--require-complete` is requested but any evidence blocker remains.
 
-`complete=true` means that all prerequisites and all 36 execution manifests are
-present, explicitly complete, valid, and fully accounted for. `claim_ready=true`
-additionally requires `--verify-file-hashes` and successful checksum validation
-of every execution artifact and registered contact-node set.
-
-The status command is observational. It does not create completed manifests,
-repair failed gates, replace excluded executions, or transform scaffolded
-placeholders into evidence.
+`validate-dataset` applies the same version-2 contract. Without
+`--skip-file-hashes`, it fails unless the complete evidence tree is claim-ready.
+The status command never creates evidence, repairs failed gates, replaces an
+excluded execution, or converts a template into a completed record.

--- a/src/causal4d/cli/real_experiment_freeze.py
+++ b/src/causal4d/cli/real_experiment_freeze.py
@@ -1,4 +1,4 @@
-"""Seal or validate the frozen Causal4D confirmatory real-experiment method."""
+"""Seal, attest, or validate the frozen Causal4D real-experiment method."""
 
 from __future__ import annotations
 
@@ -6,6 +6,10 @@ import argparse
 import json
 from collections.abc import Sequence
 
+from causal4d.real_evidence_contract_v2 import (
+    build_method_freeze_validation_attestation,
+    write_method_freeze_validation_attestation,
+)
 from causal4d.real_experiment_freeze import (
     build_method_freeze_manifest,
     load_method_freeze_manifest,
@@ -14,6 +18,7 @@ from causal4d.real_experiment_freeze import (
     validate_repository_checkout,
     write_method_freeze_manifest,
 )
+from causal4d.real_protocol import load_protocol
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -28,6 +33,17 @@ def build_parser() -> argparse.ArgumentParser:
     seal.add_argument("output_json")
     seal.add_argument("--frozen-by", required=True)
     seal.add_argument("--frozen-at-utc")
+
+    attest = subparsers.add_parser(
+        "attest",
+        help="independently verify and bind the exact method-freeze file",
+    )
+    attest.add_argument("manifest_json")
+    attest.add_argument("protocol_json")
+    attest.add_argument("repository_root")
+    attest.add_argument("output_json")
+    attest.add_argument("--verified-by", required=True)
+    attest.add_argument("--verified-at-utc")
 
     validate = subparsers.add_parser(
         "validate",
@@ -60,6 +76,28 @@ def main(argv: Sequence[str] | None = None) -> int:
                     args.repository_root,
                     expected_causal4d_commit_sha=git_state["commit_sha"],
                 ),
+                "output": str(output.resolve()),
+            }
+        elif args.command == "attest":
+            attestation = build_method_freeze_validation_attestation(
+                load_protocol(args.protocol_json),
+                args.manifest_json,
+                args.repository_root,
+                verified_by=args.verified_by,
+                verified_at_utc=args.verified_at_utc,
+            )
+            output = write_method_freeze_validation_attestation(
+                args.output_json,
+                attestation,
+            )
+            result = {
+                "passed": True,
+                "method_freeze_sha256": attestation["method_freeze_sha256"],
+                "causal4d_commit_sha": attestation["causal4d_commit_sha"],
+                "bayesian_phystwin_commit_sha": attestation[
+                    "bayesian_phystwin_commit_sha"
+                ],
+                "verifier_id": attestation["verifier_id"],
                 "output": str(output.resolve()),
             }
         else:

--- a/src/causal4d/cli/real_protocol.py
+++ b/src/causal4d/cli/real_protocol.py
@@ -6,15 +6,16 @@ import argparse
 import json
 from collections.abc import Sequence
 
-from causal4d.real_evidence_status import (
+from causal4d.real_evidence_contract_v2 import (
     build_real_evidence_status,
+    scaffold_real_evidence_v2_templates,
+    validate_real_dataset_v2,
     write_real_evidence_status,
 )
 from causal4d.real_protocol import (
     build_same_object_real_protocol,
     load_protocol,
     scaffold_dataset,
-    validate_dataset,
     validate_protocol,
     write_acquisition_schedule,
     write_protocol,
@@ -45,17 +46,24 @@ def build_parser() -> argparse.ArgumentParser:
 
     scaffold = subparsers.add_parser(
         "scaffold",
-        help="create non-overwriting session and execution templates",
+        help="create non-overwriting session, execution, and evidence templates",
     )
     scaffold.add_argument("protocol_json")
     scaffold.add_argument("output_root")
 
     status = subparsers.add_parser(
         "status",
-        help="report acquired, validated, and claim-ready execution evidence",
+        help="report acquisition, evidence, analysis, and claim readiness",
     )
     status.add_argument("protocol_json")
     status.add_argument("dataset_root")
+    status.add_argument(
+        "--repository-root",
+        help=(
+            "clean checkout at the sealed Causal4D commit; required to verify "
+            "method_freeze.json before claim readiness"
+        ),
+    )
     status.add_argument(
         "--verify-file-hashes",
         action="store_true",
@@ -69,21 +77,25 @@ def build_parser() -> argparse.ArgumentParser:
         "--require-complete",
         action="store_true",
         help=(
-            "return exit code 3 until all 36 executions and artifact hashes "
-            "are claim-ready"
+            "return exit code 3 until the freeze, registration, timebase, "
+            "sessions, executions, and hashes are claim-ready"
         ),
     )
 
     dataset = subparsers.add_parser(
         "validate-dataset",
-        help="validate a completed 36-execution acquisition tree",
+        help="validate a completed version-2 acquisition evidence tree",
     )
     dataset.add_argument("protocol_json")
     dataset.add_argument("dataset_root")
     dataset.add_argument(
+        "--repository-root",
+        help="clean checkout at the method-freeze Causal4D commit",
+    )
+    dataset.add_argument(
         "--skip-file-hashes",
         action="store_true",
-        help="validate descriptors without rehashing recorded files",
+        help="validate structure without declaring the evidence claim-ready",
     )
     return parser
 
@@ -102,13 +114,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         elif args.command == "validate-protocol":
             result = validate_protocol(load_protocol(args.protocol_json))
         elif args.command == "scaffold":
-            result = scaffold_dataset(
-                load_protocol(args.protocol_json), args.output_root
-            )
+            protocol = load_protocol(args.protocol_json)
+            result = scaffold_dataset(protocol, args.output_root)
+            result = {
+                **result,
+                **scaffold_real_evidence_v2_templates(protocol, args.output_root),
+            }
         elif args.command == "status":
             result = build_real_evidence_status(
                 load_protocol(args.protocol_json),
                 args.dataset_root,
+                repository_root=args.repository_root,
                 verify_file_hashes=args.verify_file_hashes,
             )
             if args.output_json:
@@ -117,9 +133,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             if args.require_complete and not result["claim_ready"]:
                 exit_code = INCOMPLETE_EVIDENCE_EXIT_CODE
         else:
-            result = validate_dataset(
+            result = validate_real_dataset_v2(
                 load_protocol(args.protocol_json),
                 args.dataset_root,
+                repository_root=args.repository_root,
                 verify_files=not args.skip_file_hashes,
             )
     except (OSError, KeyError, TypeError, ValueError) as error:

--- a/src/causal4d/real_evidence_common.py
+++ b/src/causal4d/real_evidence_common.py
@@ -1,0 +1,522 @@
+"""Shared validators for the Causal4D real-evidence contract."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import math
+import tempfile
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from causal4d.contact_registration import (
+    CONTACT_REGISTRATION_SCHEMA_VERSION,
+    validate_contact_registration,
+)
+from causal4d.real_protocol import (
+    validate_object_registration,
+    validate_protocol,
+    validate_slip_pilot,
+    write_acquisition_schedule,
+)
+
+EVIDENCE_STATUS_SCHEMA_VERSION = 2
+SESSION_MANIFEST_SCHEMA_VERSION = 1
+TIMEBASE_CALIBRATION_SCHEMA_VERSION = 1
+METHOD_FREEZE_ATTESTATION_SCHEMA_VERSION = 1
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _is_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _sha256_file(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+            size += len(block)
+    return digest.hexdigest(), size
+
+
+def _reject_json_constant(value: str) -> Any:
+    raise ValueError(f"non-finite JSON constant is forbidden: {value}")
+
+
+def _load_json_mapping(path: Path) -> dict[str, Any]:
+    payload = json.loads(
+        path.read_text(encoding="utf-8"),
+        parse_constant=_reject_json_constant,
+    )
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"JSON root must be an object: {path}")
+    return dict(payload)
+
+
+def _error_text(error: BaseException) -> str:
+    message = str(error).strip()
+    return f"{type(error).__name__}: {message}" if message else type(error).__name__
+
+
+def _finite_nonnegative(value: Any, *, name: str) -> float:
+    _require(
+        isinstance(value, (int, float)) and not isinstance(value, bool),
+        f"{name} must be numeric",
+    )
+    result = float(value)
+    _require(math.isfinite(result), f"{name} must be finite")
+    _require(result >= 0.0, f"{name} must be nonnegative")
+    return result
+
+
+def _nonnegative_integer(value: Any, *, name: str) -> int:
+    _require(
+        isinstance(value, int) and not isinstance(value, bool) and value >= 0,
+        f"{name} must be a nonnegative integer",
+    )
+    return int(value)
+
+
+def _parse_utc_timestamp(value: Any, *, name: str) -> datetime:
+    _require(isinstance(value, str) and bool(value), f"{name} is missing")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(f"{name} is not ISO 8601") from error
+    _require(parsed.tzinfo is not None, f"{name} must include a timezone")
+    _require(
+        parsed.utcoffset() == timezone.utc.utcoffset(parsed), f"{name} must be UTC"
+    )
+    return parsed
+
+
+def _safe_relative_path(value: Any, *, name: str) -> Path:
+    _require(isinstance(value, str) and bool(value), f"{name} path is missing")
+    path = Path(value)
+    _require(
+        not path.is_absolute() and ".." not in path.parts, f"{name} path is unsafe"
+    )
+    return path
+
+
+def _validate_file_descriptor(
+    dataset_root: Path,
+    descriptor: Mapping[str, Any],
+    *,
+    name: str,
+    verify_file_hashes: bool,
+) -> None:
+    relative = _safe_relative_path(descriptor.get("path"), name=name)
+    _require(_is_sha256(descriptor.get("sha256")), f"{name} SHA-256 is invalid")
+    expected_bytes = _nonnegative_integer(descriptor.get("bytes"), name=f"{name} bytes")
+    if verify_file_hashes:
+        path = dataset_root / relative
+        _require(path.is_file(), f"{name} file is missing: {path}")
+        digest, byte_count = _sha256_file(path)
+        _require(digest == descriptor["sha256"], f"{name} checksum mismatch")
+        _require(byte_count == expected_bytes, f"{name} byte count mismatch")
+
+
+def _iter_descriptors(
+    value: Any, prefix: str = "artifact"
+) -> list[tuple[str, Mapping[str, Any]]]:
+    descriptors: list[tuple[str, Mapping[str, Any]]] = []
+    if isinstance(value, Mapping):
+        if {"path", "sha256", "bytes"} <= set(value):
+            descriptors.append((prefix, value))
+        else:
+            for key, child in value.items():
+                descriptors.extend(_iter_descriptors(child, f"{prefix}.{key}"))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            descriptors.extend(_iter_descriptors(child, f"{prefix}[{index}]"))
+    return descriptors
+
+
+def _prerequisite_result(path: Path) -> dict[str, Any]:
+    return {
+        "path": str(path),
+        "present": path.is_file(),
+        "valid": False,
+        "error": None,
+    }
+
+
+def _finalize_prerequisite(result: dict[str, Any], path: Path) -> dict[str, Any]:
+    result["valid"] = True
+    result["sha256"], result["bytes"] = _sha256_file(path)
+    return result
+
+
+def _validate_dataset_protocol(
+    protocol: Mapping[str, Any],
+    path: Path,
+) -> dict[str, Any]:
+    result = _prerequisite_result(path)
+    if not result["present"]:
+        result["error"] = "dataset protocol.json is missing"
+        return result
+    try:
+        candidate = _load_json_mapping(path)
+        validate_protocol(candidate)
+        _require(
+            candidate == dict(protocol),
+            "dataset protocol differs from the locked protocol",
+        )
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        result["error"] = _error_text(error)
+        return result
+    return _finalize_prerequisite(result, path)
+
+
+def _expected_schedule_rows(protocol: Mapping[str, Any]) -> list[dict[str, str]]:
+    with tempfile.TemporaryDirectory(prefix="causal4d-status-v2-") as directory:
+        generated = write_acquisition_schedule(
+            Path(directory) / "acquisition_schedule.csv",
+            protocol,
+        )
+        with generated.open(newline="", encoding="utf-8") as handle:
+            return list(csv.DictReader(handle))
+
+
+def _validate_acquisition_schedule(
+    protocol: Mapping[str, Any],
+    path: Path,
+) -> dict[str, Any]:
+    result = _prerequisite_result(path)
+    if not result["present"]:
+        result["error"] = "acquisition_schedule.csv is missing"
+        return result
+    try:
+        with path.open(newline="", encoding="utf-8") as handle:
+            rows = list(csv.DictReader(handle))
+        _require(
+            rows == _expected_schedule_rows(protocol),
+            "acquisition schedule differs from the locked design",
+        )
+    except (OSError, csv.Error, KeyError, TypeError, ValueError) as error:
+        result["error"] = _error_text(error)
+        return result
+    result["row_count"] = len(rows)
+    return _finalize_prerequisite(result, path)
+
+
+def _validate_registration_files(
+    dataset_root: Path,
+    registration: Mapping[str, Any],
+) -> None:
+    for region_id, descriptor in registration["contact_regions"].items():
+        relative = _safe_relative_path(
+            descriptor["canonical_node_set_path"],
+            name=f"contact node set {region_id}",
+        )
+        node_path = dataset_root / relative
+        _require(node_path.is_file(), f"contact node set is missing: {region_id}")
+        digest, _ = _sha256_file(node_path)
+        _require(
+            digest == descriptor["canonical_node_set_sha256"],
+            f"contact node-set checksum mismatch: {region_id}",
+        )
+
+
+def _validate_object_registration_prerequisite(
+    protocol: Mapping[str, Any],
+    dataset_root: Path,
+    path: Path,
+    *,
+    verify_file_hashes: bool,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    result = _prerequisite_result(path)
+    result["file_hashes_verified"] = None if not verify_file_hashes else False
+    if not result["present"]:
+        result["error"] = "object_registration.json is missing"
+        return result, None
+    try:
+        registration = _load_json_mapping(path)
+        validate_object_registration(protocol, registration)
+        if verify_file_hashes:
+            _validate_registration_files(dataset_root, registration)
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        result["error"] = _error_text(error)
+        return result, None
+    result["file_hashes_verified"] = True if verify_file_hashes else None
+    return _finalize_prerequisite(result, path), registration
+
+
+def _validate_slip_pilot_prerequisite(
+    protocol: Mapping[str, Any],
+    path: Path,
+) -> dict[str, Any]:
+    result = _prerequisite_result(path)
+    if not result["present"]:
+        result["error"] = "slip_pilot.json is missing"
+        return result
+    try:
+        validate_slip_pilot(protocol, _load_json_mapping(path))
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        result["error"] = _error_text(error)
+        return result
+    return _finalize_prerequisite(result, path)
+
+
+def timebase_calibration_template(protocol: Mapping[str, Any]) -> dict[str, Any]:
+    """Return an explicitly incomplete shared-clock calibration template."""
+
+    validate_protocol(protocol)
+    return {
+        "schema_version": TIMEBASE_CALIBRATION_SCHEMA_VERSION,
+        "artifact_kind": "TimebaseCalibration",
+        "protocol_id": protocol["protocol_id"],
+        "protocol_design_sha256": protocol["design_sha256"],
+        "status": "template",
+        "clock_domain_id": None,
+        "calibrated_streams": sorted(
+            protocol["recording_contract"]["timestamped_artifacts"]
+        ),
+        "measured_max_sync_error_ms": None,
+        "calibrated_at_utc": None,
+        "locked_before_confirmatory_collection": None,
+        "calibration_artifact": {"path": None, "sha256": None, "bytes": None},
+        "approval": {
+            "approved": False,
+            "approver_id": None,
+            "approved_at_utc": None,
+        },
+    }
+
+
+def validate_timebase_calibration(
+    protocol: Mapping[str, Any],
+    calibration: Mapping[str, Any],
+    *,
+    dataset_root: str | Path | None = None,
+    verify_file_hashes: bool = False,
+) -> dict[str, Any]:
+    """Validate the one clock domain used by every timestamped stream."""
+
+    validate_protocol(protocol)
+    _require(
+        calibration.get("schema_version") == TIMEBASE_CALIBRATION_SCHEMA_VERSION,
+        "unsupported timebase calibration schema",
+    )
+    _require(
+        calibration.get("artifact_kind") == "TimebaseCalibration",
+        "unexpected timebase calibration kind",
+    )
+    _require(
+        calibration.get("status") == "approved", "timebase calibration is not approved"
+    )
+    _require(
+        calibration.get("protocol_id") == protocol["protocol_id"],
+        "timebase protocol mismatch",
+    )
+    _require(
+        calibration.get("protocol_design_sha256") == protocol["design_sha256"],
+        "timebase protocol digest mismatch",
+    )
+    clock_domain_id = calibration.get("clock_domain_id")
+    _require(
+        isinstance(clock_domain_id, str) and bool(clock_domain_id),
+        "clock domain id is missing",
+    )
+    expected_streams = set(protocol["recording_contract"]["timestamped_artifacts"])
+    streams = calibration.get("calibrated_streams")
+    _require(
+        isinstance(streams, list)
+        and set(streams) == expected_streams
+        and len(streams) == len(expected_streams),
+        "timebase calibration does not cover the exact timestamped stream set",
+    )
+    measured = _finite_nonnegative(
+        calibration.get("measured_max_sync_error_ms"),
+        name="measured_max_sync_error_ms",
+    )
+    maximum = float(protocol["quality_gates"]["maximum_rgbd_actuator_sync_error_ms"])
+    _require(
+        measured <= maximum, "timebase synchronization error exceeds the locked gate"
+    )
+    _parse_utc_timestamp(
+        calibration.get("calibrated_at_utc"), name="timebase calibrated_at_utc"
+    )
+    _require(
+        calibration.get("locked_before_confirmatory_collection") is True,
+        "timebase was not locked before confirmatory collection",
+    )
+    approval = calibration.get("approval", {})
+    _require(approval.get("approved") is True, "timebase approval is missing")
+    _require(
+        isinstance(approval.get("approver_id"), str) and bool(approval["approver_id"]),
+        "timebase approver id is missing",
+    )
+    _parse_utc_timestamp(
+        approval.get("approved_at_utc"), name="timebase approved_at_utc"
+    )
+    root = Path(dataset_root) if dataset_root is not None else Path(".")
+    _validate_file_descriptor(
+        root,
+        calibration.get("calibration_artifact", {}),
+        name="timebase calibration artifact",
+        verify_file_hashes=verify_file_hashes,
+    )
+    return {
+        "passed": True,
+        "clock_domain_id": clock_domain_id,
+        "measured_max_sync_error_ms": measured,
+        "file_hashes_verified": verify_file_hashes,
+    }
+
+
+def _validate_timebase_prerequisite(
+    protocol: Mapping[str, Any],
+    dataset_root: Path,
+    path: Path,
+    *,
+    verify_file_hashes: bool,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    result = _prerequisite_result(path)
+    result["file_hashes_verified"] = None if not verify_file_hashes else False
+    if not result["present"]:
+        result["error"] = "timebase_calibration.json is missing"
+        return result, None
+    try:
+        calibration = _load_json_mapping(path)
+        validation = validate_timebase_calibration(
+            protocol,
+            calibration,
+            dataset_root=dataset_root,
+            verify_file_hashes=verify_file_hashes,
+        )
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        result["error"] = _error_text(error)
+        return result, None
+    result.update(validation)
+    result["valid"] = True
+    result["sha256"], result["bytes"] = _sha256_file(path)
+    return result, calibration
+
+
+def _cross_check_contact_registration(
+    physical: Mapping[str, Any],
+    simple: Mapping[str, Any],
+    *,
+    simple_sha256: str,
+) -> None:
+    _require(
+        physical.get("schema_version") == CONTACT_REGISTRATION_SCHEMA_VERSION,
+        "physical contact registration must use schema 3",
+    )
+    object_record = physical["object"]
+    _require(
+        object_record["physical_instance_serial"] == simple["object_instance_serial"],
+        "physical and simple registration object serials differ",
+    )
+    _require(
+        object_record["twin_geometry_sha256"] == simple["phystwin_model_sha256"],
+        "physical and simple registration twin hashes differ",
+    )
+    checksums = physical.get("source_checksums", {})
+    _require(
+        checksums.get("object_registration.json") == simple_sha256,
+        "physical registration does not bind object_registration.json",
+    )
+    for region_id, descriptor in simple["contact_regions"].items():
+        attachment = physical["contact_regions"][region_id]["attachment"]
+        _require(
+            descriptor["node_count"] == len(attachment["node_indices"]),
+            f"physical and simple registration node counts differ: {region_id}",
+        )
+        _require(
+            checksums.get(f"contact_node_set:{region_id}")
+            == descriptor["canonical_node_set_sha256"],
+            f"physical registration does not bind the contact node set: {region_id}",
+        )
+
+
+def _validate_contact_registration_prerequisite(
+    protocol: Mapping[str, Any],
+    dataset_root: Path,
+    path: Path,
+    *,
+    simple_registration: Mapping[str, Any] | None,
+    simple_registration_sha256: str | None,
+    verify_file_hashes: bool,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    result = _prerequisite_result(path)
+    result["file_hashes_verified"] = None if not verify_file_hashes else False
+    if not result["present"]:
+        result["error"] = "contact_registration.json is missing"
+        return result, None
+    try:
+        _require(
+            simple_registration is not None,
+            "object_registration.json must validate first",
+        )
+        _require(
+            _is_sha256(simple_registration_sha256),
+            "object registration digest is unavailable",
+        )
+        physical = _load_json_mapping(path)
+        validation = validate_contact_registration(physical, protocol)
+        _cross_check_contact_registration(
+            physical,
+            simple_registration,
+            simple_sha256=str(simple_registration_sha256),
+        )
+        if verify_file_hashes:
+            for name, descriptor in _iter_descriptors(physical, "contact_registration"):
+                _validate_file_descriptor(
+                    dataset_root,
+                    descriptor,
+                    name=name,
+                    verify_file_hashes=True,
+                )
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        result["error"] = _error_text(error)
+        return result, None
+    result.update(validation)
+    result["file_hashes_verified"] = True if verify_file_hashes else None
+    result["valid"] = True
+    result["sha256"], result["bytes"] = _sha256_file(path)
+    return result, physical
+
+
+__all__ = [
+    "EVIDENCE_STATUS_SCHEMA_VERSION",
+    "METHOD_FREEZE_ATTESTATION_SCHEMA_VERSION",
+    "SESSION_MANIFEST_SCHEMA_VERSION",
+    "TIMEBASE_CALIBRATION_SCHEMA_VERSION",
+    "_cross_check_contact_registration",
+    "_error_text",
+    "_finalize_prerequisite",
+    "_finite_nonnegative",
+    "_is_sha256",
+    "_iter_descriptors",
+    "_load_json_mapping",
+    "_nonnegative_integer",
+    "_parse_utc_timestamp",
+    "_prerequisite_result",
+    "_require",
+    "_sha256_file",
+    "_validate_acquisition_schedule",
+    "_validate_contact_registration_prerequisite",
+    "_validate_dataset_protocol",
+    "_validate_file_descriptor",
+    "_validate_object_registration_prerequisite",
+    "_validate_slip_pilot_prerequisite",
+    "_validate_timebase_prerequisite",
+    "timebase_calibration_template",
+    "validate_timebase_calibration",
+]

--- a/src/causal4d/real_evidence_contract_v2.py
+++ b/src/causal4d/real_evidence_contract_v2.py
@@ -1,0 +1,383 @@
+"""Fail-closed version-2 evidence contract for the Causal4D real experiment."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from causal4d.real_evidence_common import (
+    EVIDENCE_STATUS_SCHEMA_VERSION,
+    METHOD_FREEZE_ATTESTATION_SCHEMA_VERSION,
+    SESSION_MANIFEST_SCHEMA_VERSION,
+    TIMEBASE_CALIBRATION_SCHEMA_VERSION,
+    _load_json_mapping,
+    _require,
+    _validate_acquisition_schedule,
+    _validate_contact_registration_prerequisite,
+    _validate_dataset_protocol,
+    _validate_object_registration_prerequisite,
+    _validate_slip_pilot_prerequisite,
+    _validate_timebase_prerequisite,
+    timebase_calibration_template,
+    validate_timebase_calibration,
+)
+from causal4d.real_freeze_evidence import (
+    _validate_method_freeze_attestation,
+    _validate_method_freeze_prerequisites,
+    build_method_freeze_validation_attestation,
+    method_freeze_validation_attestation_template,
+    write_method_freeze_validation_attestation,
+)
+from causal4d.real_execution_evidence import (
+    _execution_status,
+    _validate_execution_contract_v2,
+    scaffold_real_evidence_v2_templates,
+    session_manifest_template,
+)
+from causal4d.real_protocol import validate_protocol
+from causal4d.real_session_evidence import (
+    _analysis_readiness,
+    _claim_blockers,
+    _unexpected_directories,
+    _validate_session_manifest,
+)
+
+
+def build_real_evidence_status(
+    protocol: Mapping[str, Any],
+    dataset_root: str | Path,
+    *,
+    repository_root: str | Path | None = None,
+    verify_file_hashes: bool = False,
+) -> dict[str, Any]:
+    """Summarize acquisition, evidence, analysis, and claim readiness."""
+
+    validate_protocol(protocol)
+    root = Path(dataset_root)
+
+    dataset_protocol = _validate_dataset_protocol(protocol, root / "protocol.json")
+    acquisition_schedule = _validate_acquisition_schedule(
+        protocol, root / "acquisition_schedule.csv"
+    )
+    object_registration, simple_registration = (
+        _validate_object_registration_prerequisite(
+            protocol,
+            root,
+            root / "object_registration.json",
+            verify_file_hashes=verify_file_hashes,
+        )
+    )
+    slip_pilot = _validate_slip_pilot_prerequisite(protocol, root / "slip_pilot.json")
+    timebase, timebase_payload = _validate_timebase_prerequisite(
+        protocol,
+        root,
+        root / "timebase_calibration.json",
+        verify_file_hashes=verify_file_hashes,
+    )
+    contact_registration, _ = _validate_contact_registration_prerequisite(
+        protocol,
+        root,
+        root / "contact_registration.json",
+        simple_registration=simple_registration,
+        simple_registration_sha256=object_registration.get("sha256"),
+        verify_file_hashes=verify_file_hashes,
+    )
+    method_freeze, method_freeze_attestation, _ = _validate_method_freeze_prerequisites(
+        protocol,
+        root,
+        repository_root=repository_root,
+        verify_file_hashes=verify_file_hashes,
+    )
+    prerequisites = {
+        "dataset_protocol": dataset_protocol,
+        "acquisition_schedule": acquisition_schedule,
+        "object_registration": object_registration,
+        "slip_pilot": slip_pilot,
+        "timebase_calibration": timebase,
+        "contact_registration": contact_registration,
+        "method_freeze": method_freeze,
+        "method_freeze_validation": method_freeze_attestation,
+    }
+
+    executions = sorted(
+        protocol["executions"],
+        key=lambda value: int(value["acquisition_execution_index"]),
+    )
+    clock_domain_id = None
+    if timebase.get("valid") and timebase_payload is not None:
+        clock_domain_id = str(timebase_payload["clock_domain_id"])
+    execution_results = [
+        _execution_status(
+            protocol,
+            root,
+            execution,
+            clock_domain_id=clock_domain_id,
+            verify_file_hashes=verify_file_hashes,
+        )
+        for execution in executions
+    ]
+    execution_by_id = {
+        str(result["execution_id"]): result for result in execution_results
+    }
+
+    sessions = sorted(
+        protocol["sessions"],
+        key=lambda value: int(value["acquisition_session_index"]),
+    )
+    session_results = [
+        _validate_session_manifest(
+            protocol,
+            session,
+            root / "sessions" / str(session["session_id"]) / "session.json",
+            execution_results=execution_by_id,
+            contact_registration_sha256=contact_registration.get("sha256"),
+            timebase_calibration_sha256=timebase.get("sha256"),
+            clock_domain_id=clock_domain_id,
+        )
+        for session in sessions
+    ]
+    grasp_ids = [
+        str(result["grasp_instance_id"])
+        for result in session_results
+        if result.get("validated")
+    ]
+    if len(grasp_ids) != len(set(grasp_ids)):
+        duplicated = {
+            identifier for identifier in grasp_ids if grasp_ids.count(identifier) > 1
+        }
+        for result in session_results:
+            if result.get("grasp_instance_id") in duplicated:
+                result["validated"] = False
+                result["error"] = (
+                    "ValueError: grasp_instance_id is reused across sessions"
+                )
+
+    expected_execution_ids = {
+        str(execution["execution_id"]) for execution in executions
+    }
+    expected_session_ids = {str(session["session_id"]) for session in sessions}
+    unexpected_executions = _unexpected_directories(
+        root / "executions",
+        expected_ids=expected_execution_ids,
+    )
+    unexpected_sessions = _unexpected_directories(
+        root / "sessions",
+        expected_ids=expected_session_ids,
+    )
+
+    specified = len(execution_results)
+    manifest_count = sum(
+        bool(result["manifest_present"]) for result in execution_results
+    )
+    acquired = sum(bool(result["acquired"]) for result in execution_results)
+    validated = sum(bool(result["validated"]) for result in execution_results)
+    included = sum(result["included"] is True for result in execution_results)
+    excluded = sum(result["included"] is False for result in execution_results)
+    sessions_validated = sum(bool(result["validated"]) for result in session_results)
+    accounting_complete = included + excluded == specified
+
+    acquisition_prerequisite_names = {
+        "dataset_protocol",
+        "acquisition_schedule",
+        "object_registration",
+        "slip_pilot",
+    }
+    acquisition_prerequisites_valid = all(
+        prerequisites[name]["valid"] for name in acquisition_prerequisite_names
+    )
+    acquisition_complete = bool(
+        acquisition_prerequisites_valid
+        and manifest_count == specified
+        and acquired == specified
+        and validated == specified
+        and accounting_complete
+        and not unexpected_executions
+    )
+
+    blockers = _claim_blockers(
+        prerequisites,
+        execution_results,
+        session_results,
+        unexpected_execution_directories=unexpected_executions,
+        unexpected_session_directories=unexpected_sessions,
+        verify_file_hashes=verify_file_hashes,
+    )
+    evidence_complete = not blockers
+    analysis = _analysis_readiness(protocol, execution_results)
+    claim_ready = evidence_complete
+    next_pending = next(
+        (
+            {
+                "execution_id": result["execution_id"],
+                "session_id": result["session_id"],
+                "acquisition_execution_index": result["acquisition_execution_index"],
+            }
+            for result in execution_results
+            if not result["validated"]
+        ),
+        None,
+    )
+
+    public_execution_results = []
+    for result in execution_results:
+        public = dict(result)
+        public.pop("manifest", None)
+        public.pop("_started_at", None)
+        public.pop("_ended_at", None)
+        public_execution_results.append(public)
+
+    return {
+        "schema_version": EVIDENCE_STATUS_SCHEMA_VERSION,
+        "protocol_id": str(protocol["protocol_id"]),
+        "protocol_design_sha256": str(protocol["design_sha256"]),
+        "dataset_root": str(root.resolve()),
+        "repository_root": None
+        if repository_root is None
+        else str(Path(repository_root).resolve()),
+        "specified_executions": specified,
+        "manifest_executions": manifest_count,
+        "acquired_executions": acquired,
+        "validated_executions": validated,
+        "included_executions": included,
+        "excluded_executions": excluded,
+        "specified_sessions": len(session_results),
+        "validated_sessions": sessions_validated,
+        "missing_execution_ids": [
+            result["execution_id"]
+            for result in execution_results
+            if not result["manifest_present"]
+        ],
+        "incomplete_execution_ids": [
+            result["execution_id"]
+            for result in execution_results
+            if result["manifest_parsed"] and not result["acquired"]
+        ],
+        "invalid_execution_ids": [
+            result["execution_id"]
+            for result in execution_results
+            if result["manifest_present"]
+            and (
+                not result["manifest_parsed"]
+                or (result["acquired"] and not result["validated"])
+            )
+        ],
+        "missing_session_ids": [
+            result["session_id"]
+            for result in session_results
+            if not result["manifest_present"]
+        ],
+        "invalid_session_ids": [
+            result["session_id"]
+            for result in session_results
+            if result["manifest_present"] and not result["validated"]
+        ],
+        "unexpected_execution_directories": unexpected_executions,
+        "unexpected_session_directories": unexpected_sessions,
+        "next_pending_execution": next_pending,
+        "prerequisites": prerequisites,
+        "executions": public_execution_results,
+        "sessions": session_results,
+        "file_hashes_requested": verify_file_hashes,
+        "file_hashes_verified": bool(verify_file_hashes and evidence_complete),
+        "accounting_complete": accounting_complete,
+        "acquisition_complete": acquisition_complete,
+        "evidence_complete": evidence_complete,
+        "analysis_ready": analysis["analysis_ready"],
+        "full_registered_power": analysis["full_registered_power"],
+        "analysis_readiness": analysis,
+        "complete": evidence_complete,
+        "claim_ready": claim_ready,
+        "passed": claim_ready,
+        "blockers": blockers,
+    }
+
+
+def validate_real_dataset_v2(
+    protocol: Mapping[str, Any],
+    dataset_root: str | Path,
+    *,
+    repository_root: str | Path | None = None,
+    verify_files: bool = True,
+) -> dict[str, Any]:
+    """Validate the complete version-2 evidence tree and return its status."""
+
+    status = build_real_evidence_status(
+        protocol,
+        dataset_root,
+        repository_root=repository_root,
+        verify_file_hashes=verify_files,
+    )
+    if verify_files:
+        _require(
+            status["claim_ready"],
+            "real evidence is not claim-ready: " + ", ".join(status["blockers"]),
+        )
+    return status
+
+
+def write_real_evidence_status(
+    path: str | Path,
+    status: Mapping[str, Any],
+) -> Path:
+    """Atomically write one deterministic, human-readable status snapshot."""
+
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    payload = (
+        json.dumps(
+            dict(status),
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        )
+        + "\n"
+    )
+    descriptor: int | None = None
+    temporary_name: str | None = None
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{output.name}.",
+            suffix=".tmp",
+            dir=output.parent,
+            text=True,
+        )
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            descriptor = None
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, output)
+        temporary_name = None
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        if temporary_name is not None:
+            Path(temporary_name).unlink(missing_ok=True)
+    return output
+
+
+__all__ = [
+    "EVIDENCE_STATUS_SCHEMA_VERSION",
+    "METHOD_FREEZE_ATTESTATION_SCHEMA_VERSION",
+    "SESSION_MANIFEST_SCHEMA_VERSION",
+    "TIMEBASE_CALIBRATION_SCHEMA_VERSION",
+    "_analysis_readiness",
+    "_load_json_mapping",
+    "_validate_execution_contract_v2",
+    "_validate_method_freeze_attestation",
+    "_validate_session_manifest",
+    "build_method_freeze_validation_attestation",
+    "build_real_evidence_status",
+    "method_freeze_validation_attestation_template",
+    "scaffold_real_evidence_v2_templates",
+    "session_manifest_template",
+    "timebase_calibration_template",
+    "validate_real_dataset_v2",
+    "validate_timebase_calibration",
+    "write_method_freeze_validation_attestation",
+    "write_real_evidence_status",
+]

--- a/src/causal4d/real_execution_evidence.py
+++ b/src/causal4d/real_execution_evidence.py
@@ -1,0 +1,289 @@
+"""Execution-level and scaffold validation for real evidence."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from causal4d.real_evidence_common import (
+    EVIDENCE_STATUS_SCHEMA_VERSION,
+    SESSION_MANIFEST_SCHEMA_VERSION,
+    _error_text,
+    _finite_nonnegative,
+    _load_json_mapping,
+    _nonnegative_integer,
+    _parse_utc_timestamp,
+    _require,
+    _sha256_file,
+    timebase_calibration_template,
+)
+from causal4d.real_freeze_evidence import (
+    method_freeze_validation_attestation_template,
+)
+from causal4d.real_protocol import validate_execution_manifest, validate_protocol
+
+
+def session_manifest_template(
+    protocol: Mapping[str, Any],
+    session_id: str,
+) -> dict[str, Any]:
+    """Build an explicitly incomplete same-grasp session manifest template."""
+
+    validate_protocol(protocol)
+    session_by_id = {session["session_id"]: session for session in protocol["sessions"]}
+    if session_id not in session_by_id:
+        raise KeyError(session_id)
+    session = session_by_id[session_id]
+    execution_by_id = {
+        execution["execution_id"]: execution for execution in protocol["executions"]
+    }
+    ordered = sorted(
+        session["execution_ids"],
+        key=lambda identifier: execution_by_id[identifier]["pair_order"],
+    )
+    return {
+        "schema_version": SESSION_MANIFEST_SCHEMA_VERSION,
+        "artifact_kind": "SameGraspSessionManifest",
+        "protocol_id": protocol["protocol_id"],
+        "protocol_design_sha256": protocol["design_sha256"],
+        "session_id": session_id,
+        "acquisition_session_index": session["acquisition_session_index"],
+        "acquisition_status": "template",
+        "grasp_instance_id": None,
+        "clock_domain_id": None,
+        "contact_registration_sha256": None,
+        "timebase_calibration_sha256": None,
+        "operator_id": None,
+        "started_at_utc": None,
+        "ended_at_utc": None,
+        "execution_order": ordered,
+        "same_grasp_confirmed": None,
+        "release_between_executions": None,
+        "neutral_state_checks": {
+            "before_first": None,
+            "between_executions": None,
+            "after_second": None,
+        },
+        "execution_manifest_sha256": {identifier: None for identifier in ordered},
+        "approval": {
+            "approved": False,
+            "approver_id": None,
+            "approved_at_utc": None,
+        },
+    }
+
+
+def scaffold_real_evidence_v2_templates(
+    protocol: Mapping[str, Any],
+    dataset_root: str | Path,
+) -> dict[str, Any]:
+    """Add non-evidence v2 templates to a freshly scaffolded dataset."""
+
+    validate_protocol(protocol)
+    root = Path(dataset_root)
+    _require(root.is_dir(), "dataset root must exist before v2 scaffolding")
+    templates = {
+        root / "timebase_calibration.template.json": timebase_calibration_template(
+            protocol
+        ),
+        root
+        / "method_freeze_validation.template.json": method_freeze_validation_attestation_template(
+            protocol
+        ),
+    }
+    for path, payload in templates.items():
+        _require(not path.exists(), f"refusing to overwrite evidence template: {path}")
+        path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+            encoding="utf-8",
+        )
+    for session in protocol["sessions"]:
+        path = root / "sessions" / session["session_id"] / "session.template.json"
+        _require(
+            path.is_file(), f"base session template is missing: {session['session_id']}"
+        )
+        path.write_text(
+            json.dumps(
+                session_manifest_template(protocol, session["session_id"]),
+                indent=2,
+                sort_keys=True,
+                allow_nan=False,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    return {
+        "schema_version": EVIDENCE_STATUS_SCHEMA_VERSION,
+        "session_templates": len(protocol["sessions"]),
+        "prerequisite_templates": len(templates),
+    }
+
+
+def _validate_execution_contract_v2(
+    protocol: Mapping[str, Any],
+    manifest: Mapping[str, Any],
+    expected: Mapping[str, Any],
+    *,
+    clock_domain_id: str | None,
+) -> dict[str, Any]:
+    acquisition = manifest.get("acquisition", {})
+    _require(
+        acquisition.get("acquisition_execution_index")
+        == expected["acquisition_execution_index"],
+        "acquisition execution index differs from the locked schedule",
+    )
+    grasp_instance_id = acquisition.get("grasp_instance_id")
+    _require(
+        isinstance(grasp_instance_id, str) and bool(grasp_instance_id),
+        "execution grasp_instance_id is missing",
+    )
+    execution_clock_domain_id = acquisition.get("clock_domain_id")
+    _require(
+        isinstance(execution_clock_domain_id, str) and bool(execution_clock_domain_id),
+        "execution clock_domain_id is missing",
+    )
+    if clock_domain_id is not None:
+        _require(
+            execution_clock_domain_id == clock_domain_id,
+            "execution clock domain differs from the approved timebase",
+        )
+    effective_clock_domain_id = (
+        clock_domain_id if clock_domain_id is not None else execution_clock_domain_id
+    )
+    started_at = _parse_utc_timestamp(
+        acquisition.get("started_at_utc"),
+        name="execution started_at_utc",
+    )
+    ended_at = _parse_utc_timestamp(
+        acquisition.get("ended_at_utc"),
+        name="execution ended_at_utc",
+    )
+    _require(ended_at > started_at, "execution end must follow its start")
+
+    timestamped = set(protocol["recording_contract"]["timestamped_artifacts"])
+    for name, descriptor in manifest.get("artifacts", {}).items():
+        if name in timestamped and descriptor.get("path"):
+            _require(
+                descriptor.get("clock_id") == effective_clock_domain_id,
+                f"{name} does not use the execution clock domain",
+            )
+
+    quality = manifest.get("quality", {})
+    for metric in (
+        "rgbd_actuator_sync_error_ms",
+        "initial_state_chamfer_m",
+        "end_effector_reset_error_m",
+        "contact_centroid_error_m",
+    ):
+        _finite_nonnegative(quality.get(metric), name=f"quality.{metric}")
+    _nonnegative_integer(
+        quality.get("dropped_rgbd_frames"),
+        name="quality.dropped_rgbd_frames",
+    )
+    slip = quality.get("slip_displacement_m")
+    if slip is not None:
+        _finite_nonnegative(slip, name="quality.slip_displacement_m")
+
+    drift = manifest.get("drift_indicators", {})
+    _nonnegative_integer(drift.get("wear_cycle_count"), name="drift.wear_cycle_count")
+    _finite_nonnegative(
+        drift.get("minutes_since_first_execution"),
+        name="drift.minutes_since_first_execution",
+    )
+    for metric in ("object_temperature_c", "room_temperature_c"):
+        value = drift.get(metric)
+        if value is not None:
+            _require(
+                isinstance(value, (int, float))
+                and not isinstance(value, bool)
+                and math.isfinite(float(value)),
+                f"drift.{metric} must be finite",
+            )
+    return {
+        "grasp_instance_id": grasp_instance_id,
+        "clock_domain_id": effective_clock_domain_id,
+        "timebase_bound": clock_domain_id is not None,
+        "started_at": started_at,
+        "ended_at": ended_at,
+    }
+
+
+def _execution_status(
+    protocol: Mapping[str, Any],
+    dataset_root: Path,
+    execution: Mapping[str, Any],
+    *,
+    clock_domain_id: str | None,
+    verify_file_hashes: bool,
+) -> dict[str, Any]:
+    execution_id = str(execution["execution_id"])
+    execution_root = dataset_root / "executions" / execution_id
+    manifest_path = execution_root / "manifest.json"
+    template_path = execution_root / "manifest.template.json"
+    result: dict[str, Any] = {
+        "execution_id": execution_id,
+        "session_id": str(execution["session_id"]),
+        "acquisition_execution_index": int(execution["acquisition_execution_index"]),
+        "manifest_path": str(manifest_path),
+        "manifest_present": manifest_path.is_file(),
+        "manifest_parsed": False,
+        "template_present": template_path.is_file(),
+        "acquisition_status": None,
+        "acquired": False,
+        "validated": False,
+        "included": None,
+        "quality_gate_failures": [],
+        "file_hashes_verified": None if not verify_file_hashes else False,
+        "error": None,
+    }
+    if not result["manifest_present"]:
+        result["error"] = "manifest.json is missing"
+        return result
+    try:
+        manifest = _load_json_mapping(manifest_path)
+        result["manifest"] = manifest
+        result["manifest_parsed"] = True
+        result["acquisition_status"] = manifest.get("acquisition_status")
+        result["acquired"] = result["acquisition_status"] == "complete"
+        result["manifest_sha256"], result["manifest_bytes"] = _sha256_file(
+            manifest_path
+        )
+        _require(result["acquired"], "execution manifest is not explicitly complete")
+        validation = validate_execution_manifest(
+            protocol,
+            manifest,
+            execution_root=execution_root,
+            verify_files=verify_file_hashes,
+        )
+        strict = _validate_execution_contract_v2(
+            protocol,
+            manifest,
+            execution,
+            clock_domain_id=clock_domain_id,
+        )
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        result["error"] = _error_text(error)
+        return result
+    result["validated"] = True
+    result["included"] = bool(validation["included"])
+    result["quality_gate_failures"] = list(validation["quality_gate_failures"])
+    result["file_hashes_verified"] = True if verify_file_hashes else None
+    result["grasp_instance_id"] = strict["grasp_instance_id"]
+    result["clock_domain_id"] = strict["clock_domain_id"]
+    result["timebase_bound"] = strict["timebase_bound"]
+    result["started_at_utc"] = manifest["acquisition"]["started_at_utc"]
+    result["ended_at_utc"] = manifest["acquisition"]["ended_at_utc"]
+    result["_started_at"] = strict["started_at"]
+    result["_ended_at"] = strict["ended_at"]
+    return result
+
+
+__all__ = [
+    "_execution_status",
+    "_validate_execution_contract_v2",
+    "scaffold_real_evidence_v2_templates",
+    "session_manifest_template",
+]

--- a/src/causal4d/real_freeze_evidence.py
+++ b/src/causal4d/real_freeze_evidence.py
@@ -1,0 +1,263 @@
+"""Method-freeze evidence and independent attestation."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from causal4d.real_evidence_common import (
+    METHOD_FREEZE_ATTESTATION_SCHEMA_VERSION,
+    _error_text,
+    _finalize_prerequisite,
+    _load_json_mapping,
+    _parse_utc_timestamp,
+    _prerequisite_result,
+    _require,
+    _sha256_file,
+)
+from causal4d.real_experiment_freeze import (
+    validate_method_freeze_manifest,
+    validate_repository_checkout,
+)
+from causal4d.real_protocol import validate_protocol
+
+
+def method_freeze_validation_attestation_template(
+    protocol: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return an explicitly incomplete independent freeze-validation record."""
+
+    validate_protocol(protocol)
+    return {
+        "schema_version": METHOD_FREEZE_ATTESTATION_SCHEMA_VERSION,
+        "artifact_kind": "MethodFreezeValidationAttestation",
+        "protocol_id": protocol["protocol_id"],
+        "protocol_design_sha256": protocol["design_sha256"],
+        "method_freeze_sha256": None,
+        "causal4d_commit_sha": None,
+        "bayesian_phystwin_commit_sha": None,
+        "verifier_id": None,
+        "verified_at_utc": None,
+        "independent_of_freezer": None,
+        "repository_checkout_verified": None,
+        "locked_file_hashes_verified": None,
+        "validation_passed": None,
+    }
+
+
+def build_method_freeze_validation_attestation(
+    protocol: Mapping[str, Any],
+    method_freeze_path: str | Path,
+    repository_root: str | Path,
+    *,
+    verified_by: str,
+    verified_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Independently validate and bind an exact method-freeze file."""
+
+    validate_protocol(protocol)
+    path = Path(method_freeze_path)
+    method_freeze = _load_json_mapping(path)
+    verifier_id = str(verified_by).strip()
+    _require(bool(verifier_id), "verified_by is required")
+    freezer_id = method_freeze.get("frozen_by")
+    _require(
+        not isinstance(freezer_id, str)
+        or verifier_id.casefold() != freezer_id.strip().casefold(),
+        "method freeze must be independently verified",
+    )
+    commit_sha = method_freeze.get("causal4d", {}).get("commit_sha")
+    validation = validate_method_freeze_manifest(
+        method_freeze,
+        repository_root,
+        expected_causal4d_commit_sha=commit_sha,
+        verify_files=True,
+    )
+    checkout = validate_repository_checkout(method_freeze, repository_root)
+    _require(not checkout["dirty_worktree"], "acquisition checkout is dirty")
+    timestamp_text = verified_at_utc or datetime.now(timezone.utc).isoformat()
+    verified_at = _parse_utc_timestamp(
+        timestamp_text,
+        name="freeze verified_at_utc",
+    )
+    frozen_at = _parse_utc_timestamp(
+        method_freeze.get("frozen_at_utc"),
+        name="freeze frozen_at_utc",
+    )
+    _require(verified_at >= frozen_at, "freeze attestation predates the method freeze")
+    freeze_sha256, _ = _sha256_file(path)
+    return {
+        "schema_version": METHOD_FREEZE_ATTESTATION_SCHEMA_VERSION,
+        "artifact_kind": "MethodFreezeValidationAttestation",
+        "protocol_id": protocol["protocol_id"],
+        "protocol_design_sha256": protocol["design_sha256"],
+        "method_freeze_sha256": freeze_sha256,
+        "causal4d_commit_sha": validation["causal4d_commit_sha"],
+        "bayesian_phystwin_commit_sha": validation["bayesian_phystwin_commit_sha"],
+        "verifier_id": verifier_id,
+        "verified_at_utc": timestamp_text,
+        "independent_of_freezer": True,
+        "repository_checkout_verified": True,
+        "locked_file_hashes_verified": bool(validation["file_hashes_verified"]),
+        "validation_passed": bool(validation["passed"]),
+    }
+
+
+def write_method_freeze_validation_attestation(
+    path: str | Path,
+    attestation: Mapping[str, Any],
+) -> Path:
+    """Write a deterministic method-freeze validation attestation."""
+
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(dict(attestation), indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    return output
+
+
+def _validate_method_freeze_attestation(
+    protocol: Mapping[str, Any],
+    attestation: Mapping[str, Any],
+    *,
+    method_freeze: Mapping[str, Any],
+    method_freeze_sha256: str,
+) -> dict[str, Any]:
+    _require(
+        attestation.get("schema_version") == METHOD_FREEZE_ATTESTATION_SCHEMA_VERSION,
+        "unsupported method-freeze attestation schema",
+    )
+    _require(
+        attestation.get("artifact_kind") == "MethodFreezeValidationAttestation",
+        "unexpected method-freeze attestation kind",
+    )
+    _require(
+        attestation.get("protocol_id") == protocol["protocol_id"],
+        "attestation protocol mismatch",
+    )
+    _require(
+        attestation.get("protocol_design_sha256") == protocol["design_sha256"],
+        "attestation protocol digest mismatch",
+    )
+    _require(
+        attestation.get("method_freeze_sha256") == method_freeze_sha256,
+        "attestation binds a different method freeze",
+    )
+    _require(
+        attestation.get("causal4d_commit_sha")
+        == method_freeze.get("causal4d", {}).get("commit_sha"),
+        "attestation binds a different Causal4D commit",
+    )
+    _require(
+        attestation.get("bayesian_phystwin_commit_sha")
+        == method_freeze.get("bayesian_phystwin", {}).get("commit_sha"),
+        "attestation binds a different Bayesian-PhysTwin commit",
+    )
+    verifier_id = attestation.get("verifier_id")
+    _require(
+        isinstance(verifier_id, str) and bool(verifier_id.strip()),
+        "freeze verifier id is missing",
+    )
+    freezer_id = method_freeze.get("frozen_by")
+    _require(
+        not isinstance(freezer_id, str)
+        or verifier_id.strip().casefold() != freezer_id.strip().casefold(),
+        "method freeze must be independently verified",
+    )
+    verified_at = _parse_utc_timestamp(
+        attestation.get("verified_at_utc"), name="freeze verified_at_utc"
+    )
+    frozen_at = _parse_utc_timestamp(
+        method_freeze.get("frozen_at_utc"), name="freeze frozen_at_utc"
+    )
+    _require(verified_at >= frozen_at, "freeze attestation predates the method freeze")
+    for field in (
+        "independent_of_freezer",
+        "repository_checkout_verified",
+        "locked_file_hashes_verified",
+        "validation_passed",
+    ):
+        _require(
+            attestation.get(field) is True, f"freeze attestation gate failed: {field}"
+        )
+    return {"passed": True, "verifier_id": verifier_id.strip()}
+
+
+def _validate_method_freeze_prerequisites(
+    protocol: Mapping[str, Any],
+    dataset_root: Path,
+    *,
+    repository_root: str | Path | None,
+    verify_file_hashes: bool,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any] | None]:
+    freeze_path = dataset_root / "method_freeze.json"
+    attestation_path = dataset_root / "method_freeze_validation.json"
+    freeze_result = _prerequisite_result(freeze_path)
+    attestation_result = _prerequisite_result(attestation_path)
+    freeze_result["repository_checkout_verified"] = False
+    freeze_result["file_hashes_verified"] = None if not verify_file_hashes else False
+    method_freeze: dict[str, Any] | None = None
+
+    if not freeze_result["present"]:
+        freeze_result["error"] = "method_freeze.json is missing"
+    else:
+        try:
+            method_freeze = _load_json_mapping(freeze_path)
+            _require(
+                repository_root is not None,
+                "repository_root is required to verify the method freeze",
+            )
+            validation = validate_method_freeze_manifest(
+                method_freeze,
+                repository_root,
+                expected_causal4d_commit_sha=method_freeze.get("causal4d", {}).get(
+                    "commit_sha"
+                ),
+                verify_files=verify_file_hashes,
+            )
+            checkout = validate_repository_checkout(method_freeze, repository_root)
+            freeze_result.update(validation)
+            freeze_result["repository_checkout_verified"] = not checkout[
+                "dirty_worktree"
+            ]
+            freeze_result["file_hashes_verified"] = True if verify_file_hashes else None
+            freeze_result["valid"] = True
+            freeze_result["sha256"], freeze_result["bytes"] = _sha256_file(freeze_path)
+        except (OSError, KeyError, TypeError, ValueError) as error:
+            freeze_result["error"] = _error_text(error)
+
+    if not attestation_result["present"]:
+        attestation_result["error"] = "method_freeze_validation.json is missing"
+    else:
+        try:
+            _require(
+                method_freeze is not None, "method_freeze.json must be readable first"
+            )
+            freeze_sha256, _ = _sha256_file(freeze_path)
+            attestation = _load_json_mapping(attestation_path)
+            attestation_result.update(
+                _validate_method_freeze_attestation(
+                    protocol,
+                    attestation,
+                    method_freeze=method_freeze,
+                    method_freeze_sha256=freeze_sha256,
+                )
+            )
+            _finalize_prerequisite(attestation_result, attestation_path)
+        except (OSError, KeyError, TypeError, ValueError) as error:
+            attestation_result["error"] = _error_text(error)
+    return freeze_result, attestation_result, method_freeze
+
+
+__all__ = [
+    "_validate_method_freeze_attestation",
+    "_validate_method_freeze_prerequisites",
+    "build_method_freeze_validation_attestation",
+    "method_freeze_validation_attestation_template",
+    "write_method_freeze_validation_attestation",
+]

--- a/src/causal4d/real_session_evidence.py
+++ b/src/causal4d/real_session_evidence.py
@@ -1,0 +1,316 @@
+"""Same-grasp session continuity and analysis-readiness checks."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from causal4d.real_evidence_common import (
+    SESSION_MANIFEST_SCHEMA_VERSION,
+    _error_text,
+    _load_json_mapping,
+    _parse_utc_timestamp,
+    _require,
+    _sha256_file,
+)
+
+
+def _validate_session_manifest(
+    protocol: Mapping[str, Any],
+    session: Mapping[str, Any],
+    path: Path,
+    *,
+    execution_results: Mapping[str, Mapping[str, Any]],
+    contact_registration_sha256: str | None,
+    timebase_calibration_sha256: str | None,
+    clock_domain_id: str | None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "session_id": str(session["session_id"]),
+        "manifest_path": str(path),
+        "manifest_present": path.is_file(),
+        "validated": False,
+        "error": None,
+    }
+    if not path.is_file():
+        result["error"] = "session.json is missing"
+        return result
+    try:
+        payload = _load_json_mapping(path)
+        result["manifest_sha256"], result["manifest_bytes"] = _sha256_file(path)
+        _require(
+            payload.get("schema_version") == SESSION_MANIFEST_SCHEMA_VERSION,
+            "unsupported session manifest schema",
+        )
+        _require(
+            payload.get("artifact_kind") == "SameGraspSessionManifest",
+            "unexpected session manifest kind",
+        )
+        _require(
+            payload.get("protocol_id") == protocol["protocol_id"],
+            "session protocol mismatch",
+        )
+        _require(
+            payload.get("protocol_design_sha256") == protocol["design_sha256"],
+            "session protocol digest mismatch",
+        )
+        _require(
+            payload.get("session_id") == session["session_id"], "session id changed"
+        )
+        _require(
+            payload.get("acquisition_session_index")
+            == session["acquisition_session_index"],
+            "session acquisition index changed",
+        )
+        _require(
+            payload.get("acquisition_status") == "complete", "session is incomplete"
+        )
+        grasp_instance_id = payload.get("grasp_instance_id")
+        _require(
+            isinstance(grasp_instance_id, str) and bool(grasp_instance_id),
+            "session grasp_instance_id is missing",
+        )
+        _require(clock_domain_id is not None, "approved timebase is unavailable")
+        _require(
+            payload.get("clock_domain_id") == clock_domain_id,
+            "session clock domain changed",
+        )
+        _require(
+            payload.get("contact_registration_sha256") == contact_registration_sha256,
+            "session binds a different contact registration",
+        )
+        _require(
+            payload.get("timebase_calibration_sha256") == timebase_calibration_sha256,
+            "session binds a different timebase calibration",
+        )
+        _require(
+            isinstance(payload.get("operator_id"), str)
+            and bool(payload["operator_id"]),
+            "session operator id is missing",
+        )
+        started_at = _parse_utc_timestamp(
+            payload.get("started_at_utc"), name="session started_at_utc"
+        )
+        ended_at = _parse_utc_timestamp(
+            payload.get("ended_at_utc"), name="session ended_at_utc"
+        )
+        _require(ended_at > started_at, "session end must follow its start")
+
+        execution_by_id = {
+            execution["execution_id"]: execution for execution in protocol["executions"]
+        }
+        expected_order = sorted(
+            session["execution_ids"],
+            key=lambda identifier: execution_by_id[identifier]["pair_order"],
+        )
+        _require(
+            payload.get("execution_order") == expected_order,
+            "session execution order changed",
+        )
+        _require(
+            payload.get("same_grasp_confirmed") is True, "same grasp was not confirmed"
+        )
+        _require(
+            payload.get("release_between_executions") is False,
+            "object release occurred between paired executions",
+        )
+        _require(
+            payload.get("neutral_state_checks")
+            == {
+                "before_first": True,
+                "between_executions": True,
+                "after_second": True,
+            },
+            "session neutral-state checks are incomplete",
+        )
+        hashes = payload.get("execution_manifest_sha256")
+        _require(
+            isinstance(hashes, Mapping) and set(hashes) == set(expected_order),
+            "session execution hash inventory changed",
+        )
+        ordered_results = []
+        for identifier in expected_order:
+            execution_result = execution_results[identifier]
+            _require(
+                execution_result["validated"],
+                f"session execution is invalid: {identifier}",
+            )
+            _require(
+                hashes[identifier] == execution_result.get("manifest_sha256"),
+                f"session execution manifest checksum mismatch: {identifier}",
+            )
+            _require(
+                execution_result.get("grasp_instance_id") == grasp_instance_id,
+                f"execution grasp identity differs within session: {identifier}",
+            )
+            _require(
+                execution_result.get("clock_domain_id") == clock_domain_id,
+                f"execution clock domain differs within session: {identifier}",
+            )
+            ordered_results.append(execution_result)
+        first, second = ordered_results
+        _require(
+            started_at
+            <= first["_started_at"]
+            < first["_ended_at"]
+            <= second["_started_at"]
+            < second["_ended_at"]
+            <= ended_at,
+            "paired executions are not chronological and non-overlapping",
+        )
+        approval = payload.get("approval", {})
+        _require(approval.get("approved") is True, "session approval is missing")
+        _require(
+            isinstance(approval.get("approver_id"), str)
+            and bool(approval["approver_id"]),
+            "session approver id is missing",
+        )
+        approved_at = _parse_utc_timestamp(
+            approval.get("approved_at_utc"), name="session approved_at_utc"
+        )
+        _require(
+            approved_at >= ended_at, "session approval predates acquisition completion"
+        )
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        result["error"] = _error_text(error)
+        return result
+    result["validated"] = True
+    result["grasp_instance_id"] = grasp_instance_id
+    result["clock_domain_id"] = clock_domain_id
+    return result
+
+
+def _unexpected_directories(root: Path, *, expected_ids: set[str]) -> list[str]:
+    if not root.is_dir():
+        return []
+    return sorted(
+        path.name
+        for path in root.iterdir()
+        if path.is_dir() and path.name not in expected_ids
+    )
+
+
+def _analysis_readiness(
+    protocol: Mapping[str, Any],
+    execution_results: list[Mapping[str, Any]],
+) -> dict[str, Any]:
+    included_ids = {
+        str(result["execution_id"])
+        for result in execution_results
+        if result.get("included") is True
+    }
+    folds = []
+    for fold in protocol["splits"]["cross_action_contact_calibration_folds"]:
+        fit = set(fold["fit_execution_ids"])
+        calibration = set(fold["calibration_execution_ids"])
+        target = set(fold["target_execution_ids"])
+        row = {
+            "outer_fold_id": fold.get(
+                "outer_fold_id",
+                f"hold-{fold['held_out_contact_region_id']}-{fold['held_out_command_profile_id']}",
+            ),
+            "included_fit": len(fit & included_ids),
+            "registered_fit": len(fit),
+            "included_calibration": len(calibration & included_ids),
+            "registered_calibration": len(calibration),
+            "included_target": len(target & included_ids),
+            "registered_target": len(target),
+        }
+        row["analysable"] = bool(
+            row["included_fit"] >= 1
+            and row["included_calibration"] >= 1
+            and row["included_target"] >= 1
+        )
+        folds.append(row)
+    same_grasp_pairs = protocol["splits"]["same_grasp_intervention_prediction"]
+    included_pairs = sum(
+        pair["source_execution_id"] in included_ids
+        and pair["target_execution_id"] in included_ids
+        for pair in same_grasp_pairs
+    )
+    blockers = [str(row["outer_fold_id"]) for row in folds if not row["analysable"]]
+    if included_pairs == 0:
+        blockers.append("same_grasp_intervention_prediction")
+    return {
+        "analysis_ready": not blockers,
+        "full_registered_power": len(included_ids) == len(execution_results),
+        "included_same_grasp_pairs": included_pairs,
+        "registered_same_grasp_pairs": len(same_grasp_pairs),
+        "folds": folds,
+        "blockers": blockers,
+    }
+
+
+def _claim_blockers(
+    prerequisites: Mapping[str, Mapping[str, Any]],
+    execution_results: list[Mapping[str, Any]],
+    session_results: list[Mapping[str, Any]],
+    *,
+    unexpected_execution_directories: list[str],
+    unexpected_session_directories: list[str],
+    verify_file_hashes: bool,
+) -> list[str]:
+    blockers = [
+        f"prerequisite:{name}"
+        for name, result in prerequisites.items()
+        if not result.get("valid")
+    ]
+    missing = [
+        str(result["execution_id"])
+        for result in execution_results
+        if not result["manifest_present"]
+    ]
+    incomplete = [
+        str(result["execution_id"])
+        for result in execution_results
+        if result["manifest_parsed"] and not result["acquired"]
+    ]
+    invalid = [
+        str(result["execution_id"])
+        for result in execution_results
+        if result["manifest_present"]
+        and (
+            not result["manifest_parsed"]
+            or (result["acquired"] and not result["validated"])
+        )
+    ]
+    missing_sessions = [
+        str(result["session_id"])
+        for result in session_results
+        if not result["manifest_present"]
+    ]
+    invalid_sessions = [
+        str(result["session_id"])
+        for result in session_results
+        if result["manifest_present"] and not result["validated"]
+    ]
+    if missing:
+        blockers.append(f"missing_execution_manifests:{len(missing)}")
+    if incomplete:
+        blockers.append(f"incomplete_execution_manifests:{len(incomplete)}")
+    if invalid:
+        blockers.append(f"invalid_execution_manifests:{len(invalid)}")
+    if missing_sessions:
+        blockers.append(f"missing_session_manifests:{len(missing_sessions)}")
+    if invalid_sessions:
+        blockers.append(f"invalid_session_manifests:{len(invalid_sessions)}")
+    if unexpected_execution_directories:
+        blockers.append(
+            f"unexpected_execution_directories:{len(unexpected_execution_directories)}"
+        )
+    if unexpected_session_directories:
+        blockers.append(
+            f"unexpected_session_directories:{len(unexpected_session_directories)}"
+        )
+    if not verify_file_hashes:
+        blockers.append("file_hashes_not_verified")
+    return blockers
+
+
+__all__ = [
+    "_analysis_readiness",
+    "_claim_blockers",
+    "_unexpected_directories",
+    "_validate_session_manifest",
+]

--- a/tests/test_real_evidence_contract_v2.py
+++ b/tests/test_real_evidence_contract_v2.py
@@ -1,0 +1,400 @@
+import json
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+import causal4d.real_evidence_contract_v2 as evidence
+import causal4d.real_freeze_evidence as freeze_evidence
+from causal4d.real_protocol import (
+    build_same_object_real_protocol,
+    execution_manifest_template,
+    scaffold_dataset,
+)
+
+
+def _approved_timebase(protocol: dict, tmp_path: Path) -> dict:
+    artifact = tmp_path / "timebase.bin"
+    artifact.write_bytes(b"timebase\n")
+    import hashlib
+
+    calibration = evidence.timebase_calibration_template(protocol)
+    calibration.update(
+        {
+            "status": "approved",
+            "clock_domain_id": "ptp-clock-0",
+            "measured_max_sync_error_ms": 1.0,
+            "calibrated_at_utc": "2026-07-27T06:00:00Z",
+            "locked_before_confirmatory_collection": True,
+        }
+    )
+    calibration["calibration_artifact"] = {
+        "path": artifact.name,
+        "sha256": hashlib.sha256(artifact.read_bytes()).hexdigest(),
+        "bytes": artifact.stat().st_size,
+    }
+    calibration["approval"] = {
+        "approved": True,
+        "approver_id": "timebase-reviewer",
+        "approved_at_utc": "2026-07-27T06:05:00Z",
+    }
+    return calibration
+
+
+def _strict_execution_manifest(protocol: dict, execution: dict) -> dict:
+    manifest = execution_manifest_template(protocol, execution["execution_id"])
+    manifest["acquisition"] = {
+        "operator_id": "operator-1",
+        "hardware_run_id": f"run-{execution['execution_id']}",
+        "started_at_utc": "2026-07-27T08:00:00Z",
+        "ended_at_utc": "2026-07-27T08:01:00Z",
+        "acquisition_execution_index": execution["acquisition_execution_index"],
+        "grasp_instance_id": f"grasp-{execution['session_id']}",
+        "clock_domain_id": "ptp-clock-0",
+    }
+    manifest["quality"] = {
+        "reset_passed": True,
+        "rgbd_actuator_sync_error_ms": 1.0,
+        "initial_state_chamfer_m": 0.001,
+        "end_effector_reset_error_m": 0.001,
+        "contact_centroid_error_m": 0.002,
+        "dropped_rgbd_frames": 0,
+        "slip_displacement_m": None,
+        "complete_release_observed": None,
+    }
+    manifest["drift_indicators"] = {
+        "wear_cycle_count": 4,
+        "minutes_since_first_execution": 12.5,
+        "object_temperature_c": 22.4,
+        "room_temperature_c": 21.8,
+        "notes": "none",
+    }
+    return manifest
+
+
+def test_v2_scaffold_replaces_session_specs_with_completion_templates(
+    tmp_path: Path,
+) -> None:
+    protocol = build_same_object_real_protocol()
+    root = tmp_path / "dataset"
+    scaffold_dataset(protocol, root)
+
+    summary = evidence.scaffold_real_evidence_v2_templates(protocol, root)
+
+    assert summary["schema_version"] == 2
+    assert summary["session_templates"] == 18
+    assert (root / "timebase_calibration.template.json").is_file()
+    assert (root / "method_freeze_validation.template.json").is_file()
+    template = json.loads(
+        next(root.glob("sessions/*/session.template.json")).read_text(encoding="utf-8")
+    )
+    assert template["artifact_kind"] == "SameGraspSessionManifest"
+    assert template["acquisition_status"] == "template"
+    assert len(template["execution_order"]) == 2
+
+
+def test_timebase_requires_exact_stream_coverage_and_verified_artifact(
+    tmp_path: Path,
+) -> None:
+    protocol = build_same_object_real_protocol()
+    calibration = _approved_timebase(protocol, tmp_path)
+
+    result = evidence.validate_timebase_calibration(
+        protocol,
+        calibration,
+        dataset_root=tmp_path,
+        verify_file_hashes=True,
+    )
+
+    assert result["passed"]
+    assert result["clock_domain_id"] == "ptp-clock-0"
+    missing_stream = deepcopy(calibration)
+    missing_stream["calibrated_streams"].pop()
+    with pytest.raises(ValueError, match="exact timestamped stream set"):
+        evidence.validate_timebase_calibration(protocol, missing_stream)
+
+
+def test_timebase_rejects_nonfinite_and_negative_sync_error(tmp_path: Path) -> None:
+    protocol = build_same_object_real_protocol()
+    calibration = _approved_timebase(protocol, tmp_path)
+    for value in (float("nan"), float("inf"), -0.1):
+        invalid = deepcopy(calibration)
+        invalid["measured_max_sync_error_ms"] = value
+        with pytest.raises(ValueError):
+            evidence.validate_timebase_calibration(protocol, invalid)
+
+
+def test_execution_v2_requires_one_clock_and_physical_quality_domains() -> None:
+    protocol = build_same_object_real_protocol()
+    execution = min(
+        protocol["executions"],
+        key=lambda value: value["acquisition_execution_index"],
+    )
+    manifest = _strict_execution_manifest(protocol, execution)
+    timestamped = protocol["recording_contract"]["timestamped_artifacts"][0]
+    manifest["artifacts"][timestamped] = {
+        "path": "data.bin",
+        "sha256": "1" * 64,
+        "bytes": 1,
+        "clock_id": "ptp-clock-0",
+    }
+
+    result = evidence._validate_execution_contract_v2(
+        protocol,
+        manifest,
+        execution,
+        clock_domain_id="ptp-clock-0",
+    )
+    assert result["grasp_instance_id"] == f"grasp-{execution['session_id']}"
+
+    mixed_clock = deepcopy(manifest)
+    mixed_clock["artifacts"][timestamped]["clock_id"] = "camera-clock"
+    with pytest.raises(ValueError, match="clock domain"):
+        evidence._validate_execution_contract_v2(
+            protocol,
+            mixed_clock,
+            execution,
+            clock_domain_id="ptp-clock-0",
+        )
+
+    for metric, value in (
+        ("initial_state_chamfer_m", -0.001),
+        ("contact_centroid_error_m", float("nan")),
+        ("rgbd_actuator_sync_error_ms", float("inf")),
+    ):
+        invalid = deepcopy(manifest)
+        invalid["quality"][metric] = value
+        with pytest.raises(ValueError):
+            evidence._validate_execution_contract_v2(
+                protocol,
+                invalid,
+                execution,
+                clock_domain_id="ptp-clock-0",
+            )
+
+    noninteger_drop_count = deepcopy(manifest)
+    noninteger_drop_count["quality"]["dropped_rgbd_frames"] = 0.0
+    with pytest.raises(ValueError, match="nonnegative integer"):
+        evidence._validate_execution_contract_v2(
+            protocol,
+            noninteger_drop_count,
+            execution,
+            clock_domain_id="ptp-clock-0",
+        )
+
+
+def test_strict_json_loader_rejects_nan_and_infinity(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.json"
+    for constant in ("NaN", "Infinity", "-Infinity"):
+        path.write_text(f'{{"metric": {constant}}}', encoding="utf-8")
+        with pytest.raises(ValueError, match="non-finite JSON constant"):
+            evidence._load_json_mapping(path)
+
+
+def test_session_manifest_binds_order_grasp_clock_and_execution_hashes(
+    tmp_path: Path,
+) -> None:
+    protocol = build_same_object_real_protocol()
+    session = min(
+        protocol["sessions"],
+        key=lambda value: value["acquisition_session_index"],
+    )
+    execution_by_id = {
+        execution["execution_id"]: execution for execution in protocol["executions"]
+    }
+    ordered = sorted(
+        session["execution_ids"],
+        key=lambda identifier: execution_by_id[identifier]["pair_order"],
+    )
+    base = datetime(2026, 7, 27, 8, 0, tzinfo=timezone.utc)
+    results = {
+        ordered[0]: {
+            "execution_id": ordered[0],
+            "validated": True,
+            "manifest_sha256": "1" * 64,
+            "grasp_instance_id": "grasp-001",
+            "clock_domain_id": "ptp-clock-0",
+            "_started_at": base + timedelta(seconds=10),
+            "_ended_at": base + timedelta(seconds=20),
+        },
+        ordered[1]: {
+            "execution_id": ordered[1],
+            "validated": True,
+            "manifest_sha256": "2" * 64,
+            "grasp_instance_id": "grasp-001",
+            "clock_domain_id": "ptp-clock-0",
+            "_started_at": base + timedelta(seconds=30),
+            "_ended_at": base + timedelta(seconds=40),
+        },
+    }
+    payload = evidence.session_manifest_template(protocol, session["session_id"])
+    payload.update(
+        {
+            "acquisition_status": "complete",
+            "grasp_instance_id": "grasp-001",
+            "clock_domain_id": "ptp-clock-0",
+            "contact_registration_sha256": "3" * 64,
+            "timebase_calibration_sha256": "4" * 64,
+            "operator_id": "operator-1",
+            "started_at_utc": base.isoformat().replace("+00:00", "Z"),
+            "ended_at_utc": (base + timedelta(seconds=50))
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "same_grasp_confirmed": True,
+            "release_between_executions": False,
+            "neutral_state_checks": {
+                "before_first": True,
+                "between_executions": True,
+                "after_second": True,
+            },
+            "execution_manifest_sha256": {
+                ordered[0]: "1" * 64,
+                ordered[1]: "2" * 64,
+            },
+            "approval": {
+                "approved": True,
+                "approver_id": "reviewer-1",
+                "approved_at_utc": (base + timedelta(seconds=60))
+                .isoformat()
+                .replace("+00:00", "Z"),
+            },
+        }
+    )
+    path = tmp_path / "session.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = evidence._validate_session_manifest(
+        protocol,
+        session,
+        path,
+        execution_results=results,
+        contact_registration_sha256="3" * 64,
+        timebase_calibration_sha256="4" * 64,
+        clock_domain_id="ptp-clock-0",
+    )
+
+    assert result["validated"]
+    released = deepcopy(payload)
+    released["release_between_executions"] = True
+    path.write_text(json.dumps(released), encoding="utf-8")
+    result = evidence._validate_session_manifest(
+        protocol,
+        session,
+        path,
+        execution_results=results,
+        contact_registration_sha256="3" * 64,
+        timebase_calibration_sha256="4" * 64,
+        clock_domain_id="ptp-clock-0",
+    )
+    assert not result["validated"]
+    assert "release occurred" in result["error"]
+
+
+def test_method_freeze_attestation_must_be_independent() -> None:
+    protocol = build_same_object_real_protocol()
+    method_freeze = {
+        "frozen_by": "principal-investigator",
+        "frozen_at_utc": "2026-07-27T06:00:00Z",
+        "causal4d": {"commit_sha": "1" * 40},
+        "bayesian_phystwin": {"commit_sha": "2" * 40},
+    }
+    attestation = evidence.method_freeze_validation_attestation_template(protocol)
+    attestation.update(
+        {
+            "method_freeze_sha256": "3" * 64,
+            "causal4d_commit_sha": "1" * 40,
+            "bayesian_phystwin_commit_sha": "2" * 40,
+            "verifier_id": "independent-reviewer",
+            "verified_at_utc": "2026-07-27T07:00:00Z",
+            "independent_of_freezer": True,
+            "repository_checkout_verified": True,
+            "locked_file_hashes_verified": True,
+            "validation_passed": True,
+        }
+    )
+    assert evidence._validate_method_freeze_attestation(
+        protocol,
+        attestation,
+        method_freeze=method_freeze,
+        method_freeze_sha256="3" * 64,
+    )["passed"]
+    attestation["verifier_id"] = "principal-investigator"
+    with pytest.raises(ValueError, match="independently verified"):
+        evidence._validate_method_freeze_attestation(
+            protocol,
+            attestation,
+            method_freeze=method_freeze,
+            method_freeze_sha256="3" * 64,
+        )
+
+
+def test_analysis_readiness_is_separate_from_evidence_accounting() -> None:
+    protocol = build_same_object_real_protocol()
+    results = [
+        {"execution_id": execution["execution_id"], "included": True}
+        for execution in protocol["executions"]
+    ]
+    complete = evidence._analysis_readiness(protocol, results)
+    assert complete["analysis_ready"]
+    assert complete["full_registered_power"]
+
+    first_fold = protocol["splits"]["cross_action_contact_calibration_folds"][0]
+    omitted_targets = set(first_fold["target_execution_ids"])
+    for result in results:
+        if result["execution_id"] in omitted_targets:
+            result["included"] = False
+    limited = evidence._analysis_readiness(protocol, results)
+    assert not limited["analysis_ready"]
+    assert not limited["full_registered_power"]
+    assert limited["blockers"]
+
+
+def test_method_freeze_attestation_builder_binds_exact_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    protocol = build_same_object_real_protocol()
+    freeze = {
+        "frozen_by": "principal-investigator",
+        "frozen_at_utc": "2026-07-27T06:00:00Z",
+        "causal4d": {"commit_sha": "1" * 40},
+        "bayesian_phystwin": {"commit_sha": "2" * 40},
+    }
+    freeze_path = tmp_path / "method_freeze.json"
+    freeze_path.write_text(json.dumps(freeze), encoding="utf-8")
+    monkeypatch.setattr(
+        freeze_evidence,
+        "validate_method_freeze_manifest",
+        lambda *args, **kwargs: {
+            "causal4d_commit_sha": "1" * 40,
+            "bayesian_phystwin_commit_sha": "2" * 40,
+            "file_hashes_verified": True,
+            "passed": True,
+        },
+    )
+    monkeypatch.setattr(
+        freeze_evidence,
+        "validate_repository_checkout",
+        lambda *args, **kwargs: {
+            "commit_sha": "1" * 40,
+            "dirty_worktree": False,
+        },
+    )
+
+    attestation = evidence.build_method_freeze_validation_attestation(
+        protocol,
+        freeze_path,
+        tmp_path,
+        verified_by="independent-reviewer",
+        verified_at_utc="2026-07-27T07:00:00Z",
+    )
+
+    import hashlib
+
+    assert (
+        attestation["method_freeze_sha256"]
+        == hashlib.sha256(freeze_path.read_bytes()).hexdigest()
+    )
+    assert attestation["repository_checkout_verified"]
+    assert attestation["locked_file_hashes_verified"]


### PR DESCRIPTION
## Summary

- add a fail-closed version-2 real-evidence contract while retaining the legacy status module for compatibility;
- require an approved shared timebase, schema-3 physical contact registration, sealed method freeze, and independent freeze attestation;
- bind each same-grasp session to its two execution-manifest hashes, one unique grasp identity, one clock domain, locked order, chronology, neutral checks, and no release between executions;
- reject non-standard JSON constants, non-finite or negative physical quality metrics, and non-integer dropped-frame counts;
- separate acquisition completeness, evidence completeness, analysis readiness, full registered power, and claim readiness;
- route `causal4d-real-protocol` scaffolding, status, and dataset validation through the v2 contract;
- add `causal4d-real-experiment-freeze attest` for an independent verifier to generate the hash-bound attestation;
- document the final acquisition and claim-readiness workflow.

## Scientific rationale

The original gate could become claim-ready from the four basic prerequisites and execution manifests. It did not machine-check the pre-acquisition method freeze, schema-3 contact registration, a common calibrated clock, or preservation of the same grasp across paired commands. This PR makes those conditions explicit and fail-closed while retaining a separate legacy API for already-generated v1 status reports.

## Rebase and compatibility

The branch was rebuilt from current `main` at grouped-CLI commit `3e9a1b84a972454ceb7fcb94c16808d00002fb65`, so it preserves the landed exact-support fixes and the new grouped `causal4d` command surface. The resulting PR is mergeable and changes only the ten intended evidence-contract, CLI, documentation, and test files.

## Validation

Full GitHub Actions run `30470553333` passed on head `642ab00ac20391d18dec93d2fa28ede055fcf934`:

- Ruff, incremental formatting, and stable-contract type checks;
- core suites on Python 3.10, 3.12, and 3.14;
- pinned Bayesian-PhysTwin provider integration;
- wheel and source-distribution builds and metadata validation;
- isolated installed wheel and sdist checks for every CLI help surface;
- deterministic result-bundle production, verification, archival, and consumption;
- frozen milestone manifest validation;
- the focused version-2 evidence-contract regression suite within each core run.

## Scope intentionally deferred

- repository licensing choice;
- new inference or discrepancy mechanisms;
- physical acquisition and the preregistered actuator/contact/evaluation-channel ablations.