### PR TITLE
Upload focused Ruff diagnostics after CI failures

### DIFF
--- a/.github/workflows/quality-failure-diagnostics.yml
+++ b/.github/workflows/quality-failure-diagnostics.yml
@@ -1,0 +1,56 @@
+name: Quality failure diagnostics
+
+on:
+  workflow_run:
+    workflows: ["CI and release"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: quality-failure-diagnostics-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+jobs:
+  ruff-diagnostics:
+    name: Capture Ruff diagnostics
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out the failed revision
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+          cache: pip
+      - name: Install the repository development tools
+        run: python -m pip install -e ".[dev]"
+      - name: Capture Ruff output without hiding the original CI result
+        shell: bash
+        run: |
+          set +e
+          python -m ruff --version | tee ruff-version.txt
+          python -m ruff check . --output-format=concise \
+            > ruff-output.txt 2>&1
+          status=$?
+          cat ruff-output.txt
+          printf '%s\n' "$status" > ruff-exit-status.txt
+          exit 0
+      - name: Upload focused diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: quality-failure-diagnostics-${{ github.event.workflow_run.id }}
+          path: |
+            ruff-version.txt
+            ruff-output.txt
+            ruff-exit-status.txt
+          if-no-files-found: error
+          retention-days: 14


### PR DESCRIPTION
## Summary

- add a follow-up workflow for failed `CI and release` runs on same-repository revisions;
- reproduce the repository's pinned development-tool installation at the exact failed SHA;
- capture the Ruff version, concise lint output, and exit status in a small retained artifact;
- keep the diagnostic workflow non-authoritative: it never replaces or masks the original CI conclusion.

## Rationale

The main quality job performs a full-history checkout, so a short Ruff diagnostic can be buried behind extensive checkout output in downloaded job logs. The focused artifact makes failures actionable without weakening linting, formatting, typing, tests, or release gates.

## Security boundary

The workflow runs only when the failed revision belongs to this repository. It uses read-only contents permission, receives no private-provider credential, and uploads only Ruff diagnostics.

## Validation

The existing `CI and release` matrix remains authoritative. This PR changes no package, scientific method, protocol, result artifact, or release dependency.