### PR TITLE
Preserve exact rollout support during evidence updates

### DIFF
--- a/src/causal4d/rollout_bank.py
+++ b/src/causal4d/rollout_bank.py
@@ -8,6 +8,8 @@ from typing import Any, Sequence
 
 import numpy as np
 
+from causal4d.weighting import log_weights_from_probabilities
+
 
 def _readonly_array(
     values: np.ndarray,
@@ -302,18 +304,23 @@ class JointRolloutBank:
     def coordinate_count(self) -> int:
         return int(self.trajectories.shape[4])
 
-    def _base_log_weights(self, base_weights: np.ndarray | None) -> np.ndarray:
+    def _base_weights(self, base_weights: np.ndarray | None) -> np.ndarray:
         weights = (
             self.prior_joint_weights
             if base_weights is None
             else np.asarray(base_weights, dtype=float)
         )
-        weights = _validated_joint_weights(
+        return _validated_joint_weights(
             weights,
             expected_shape=self.prior_joint_weights.shape,
             name="base_weights",
         )
-        return np.log(np.maximum(weights, 1e-300))
+
+    def _base_log_weights(self, base_weights: np.ndarray | None) -> np.ndarray:
+        return log_weights_from_probabilities(
+            self._base_weights(base_weights),
+            name="base_weights",
+        )
 
     def update_from_observations(
         self,
@@ -451,6 +458,8 @@ class JointRolloutBank:
     ) -> np.ndarray:
         """Apply robust product-of-experts evidence over physical rollouts."""
 
+        if evidence.likelihood_weight == 0.0:
+            return self._base_weights(base_weights).copy()
         predicted = self._interpolated_nodes(evidence)
         if (
             evidence.compare_displacements

--- a/tests/test_rollout_bank_exact_support.py
+++ b/tests/test_rollout_bank_exact_support.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import numpy as np
+
+from causal4d.rollout_bank import JointRolloutBank, SparseTrajectoryEvidence
+
+
+def _joint_bank() -> JointRolloutBank:
+    trajectories = np.zeros((2, 1, 5, 1, 3), dtype=float)
+    trajectories[1, 0, :, 0, 0] = np.arange(5, dtype=float) * 0.1
+    return JointRolloutBank(
+        hypothesis_ids=("supported", "excluded"),
+        hypothesis_metadata=({}, {}),
+        hypothesis_prior_weights=np.asarray([0.5, 0.5]),
+        parameter_particles=np.asarray([[0.0]]),
+        parameter_weights=np.asarray([1.0]),
+        trajectories=trajectories,
+    )
+
+
+def test_dense_update_does_not_resurrect_zero_base_mass() -> None:
+    bank = _joint_bank()
+    posterior = bank.update_from_observations(
+        bank.trajectories[1, 0].copy(),
+        prefix_frame_count=4,
+        scale_m=1e-4,
+        likelihood_power=100.0,
+        base_weights=np.asarray([[1.0], [0.0]]),
+    )
+    np.testing.assert_array_equal(posterior[:, 0], [1.0, 0.0])
+
+
+def test_sparse_update_does_not_resurrect_zero_base_mass() -> None:
+    bank = _joint_bank()
+    evidence = SparseTrajectoryEvidence(
+        positions_m=bank.trajectories[1, 0, 1:4].copy(),
+        node_indices=np.asarray([0]),
+        rollout_frame_indices=np.asarray([1.0, 2.0, 3.0]),
+        scale_m=1e-4,
+        likelihood_weight=100.0,
+        compare_displacements=False,
+    )
+    posterior = bank.update_from_sparse_evidence(
+        evidence,
+        base_weights=np.asarray([[1.0], [0.0]]),
+    )
+    np.testing.assert_array_equal(posterior[:, 0], [1.0, 0.0])
+
+
+def test_zero_weight_sparse_evidence_is_exact_noop() -> None:
+    bank = _joint_bank()
+    evidence = SparseTrajectoryEvidence(
+        positions_m=np.full((1, 1, 3), np.nan),
+        node_indices=np.asarray([0]),
+        rollout_frame_indices=np.asarray([1.0]),
+        likelihood_weight=0.0,
+        compare_displacements=False,
+        valid=np.zeros((1, 1, 3), dtype=bool),
+    )
+    base = np.asarray([[0.25], [0.75]])
+    posterior = bank.update_from_sparse_evidence(evidence, base_weights=base)
+    np.testing.assert_array_equal(posterior, base)


### PR DESCRIPTION
## Summary

- preserve exact zero probability in the legacy dense and sparse rollout-bank update paths;
- reuse the shared `log_weights_from_probabilities` utility instead of replacing zero mass with `1e-300`;
- make `likelihood_weight=0` sparse evidence an exact, bit-for-bit no-op;
- add adversarial regression tests for dense evidence, sparse evidence, and zero-weight evidence.

## Root cause

`JointRolloutBank._base_log_weights` previously evaluated `log(max(weight, 1e-300))`. This converted excluded components from `0` to finite support. A sufficiently strong likelihood could therefore assign essentially all posterior mass to a component that the supplied prior or previous guard had explicitly excluded.

The sparse-evidence API also allows a zero likelihood weight, but still evaluated the evidence. With no valid coordinates, this raised instead of returning the input belief unchanged.

## Impact

Hard support exclusions now remain hard across the legacy rollout-bank paths, matching the prefix, grouped-evidence, and semantic update contracts. Zero-weight sparse evidence now preserves the validated input weights exactly.

## Validation

Focused adversarial tests were run against both implementations:

- patched implementation: `3 passed`;
- original implementation: all three regression tests fail;
- under the original dense path, the excluded component receives posterior probability approximately `1.0` despite zero base mass;
- under the original sparse path, the same support resurrection occurs;
- zero-weight all-invalid sparse evidence raises under the original implementation and returns the exact base weights after this patch.

GitHub Actions run 309 passed in full:

- Ruff, incremental formatting, and stable-contract type checks;
- core suites on Python 3.10, 3.12, and 3.14;
- pinned Bayesian-PhysTwin provider integration;
- wheel and source-distribution builds and metadata checks;
- isolated installed wheel and sdist CLI smoke checks;
- deterministic result-bundle production and verification;
- frozen milestone manifest validation.