### PR TITLE
Add grouped command registry and root CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,21 @@ with `requirements/frozen/causal4d-0.3.0.txt`. Visual, Warp-runtime, and
 actuator-calibration dependencies remain separate so the controlled benchmark
 stays lightweight.
 
+## Command-line interface
+
+The package now provides a grouped, lazily imported command surface while
+retaining every historical `causal4d-*` executable for frozen manifests:
+
+```bash
+causal4d --help
+causal4d commands list
+causal4d commands migrate causal4d-real-protocol
+causal4d benchmark counterfactual --output-dir runs/causal4d-counterfactual-v1
+```
+
+See [the command-line interface](docs/command_line.md) for lifecycle and
+compatibility rules.
+
 ## Quick Start
 
 Run the controlled counterfactual benchmark:

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -1,0 +1,51 @@
+# Command-line interface
+
+Causal4D provides one grouped executable while retaining every historical
+`causal4d-*` entry point for frozen manifests and compatibility.
+
+```bash
+causal4d --help
+causal4d --version
+causal4d commands list
+causal4d commands list --json --include-legacy
+```
+
+The grouped routes cover the stable benchmark, protocol, evidence, and
+calibration workflows:
+
+```bash
+causal4d benchmark counterfactual --output-dir runs/counterfactual
+causal4d benchmark latent-contact --output-dir runs/latent-contact
+causal4d protocol real validate-protocol configs/causal4d/sloth_multi_action_v1.json
+causal4d protocol freeze validate method_freeze.json protocol.json checkout/
+causal4d evidence observation-lineage validate observation.npz twin_belief.npz
+```
+
+Command modules are imported only after a route is selected. Therefore root
+help, version reporting, and registry inspection stay independent of optional
+Bayesian-PhysTwin, Warp, vision, and GPU dependencies.
+
+## Registry and migration
+
+The registry records the route, Python target, lifecycle, owner, optional
+extras, and historical executable name. Inspect one entry with:
+
+```bash
+causal4d commands describe protocol/real
+causal4d commands migrate causal4d-real-protocol
+```
+
+`commands migrate` reports the preferred grouped spelling without changing the
+historical executable. To invoke an installed compatibility entry point through
+the root command, use its suffix after `legacy`; all remaining arguments are
+passed through unchanged:
+
+```bash
+causal4d legacy real-protocol --help
+```
+
+Historical executable names remain runnable and continue to be stored verbatim
+in frozen result manifests. New stable command families should add a grouped
+route instead of adding another top-level executable. A legacy script may be
+removed from ordinary installations only in a versioned compatibility change;
+frozen tags and recorded environments must remain reproducible.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ pyrecest = [
 ]
 
 [project.scripts]
+causal4d = "causal4d.cli.root:main"
 causal4d-counterfactual-benchmark = "causal4d.cli.counterfactual_benchmark:main"
 causal4d-latent-contact-benchmark = "causal4d.cli.latent_contact_benchmark:main"
 causal4d-dynamic-contact-benchmark = "causal4d.cli.dynamic_contact_benchmark:main"

--- a/scripts/ci/check_console_help.py
+++ b/scripts/ci/check_console_help.py
@@ -29,7 +29,7 @@ def _installed_scripts(distribution: str) -> dict[str, str]:
         entry_point.name: entry_point.value
         for entry_point in installed.entry_points
         if entry_point.group == "console_scripts"
-        and entry_point.name.startswith("causal4d-")
+        and (entry_point.name == "causal4d" or entry_point.name.startswith("causal4d-"))
     }
 
 

--- a/src/causal4d/cli/command_registry.py
+++ b/src/causal4d/cli/command_registry.py
@@ -1,0 +1,179 @@
+"""Typed command registry for the grouped ``causal4d`` executable."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import importlib.metadata
+from typing import Literal
+
+Lifecycle = Literal["stable", "diagnostic", "experimental", "legacy"]
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    """One lazy command route and its compatibility metadata."""
+
+    route: tuple[str, ...]
+    target: str
+    summary: str
+    lifecycle: Lifecycle
+    legacy_name: str | None = None
+    extras: tuple[str, ...] = ()
+    owner: str = "Causal4D"
+
+    def __post_init__(self) -> None:
+        if not self.route or any(
+            not token or token.startswith("-") for token in self.route
+        ):
+            raise ValueError("command routes must contain non-option tokens")
+        if ":" not in self.target:
+            raise ValueError("command targets must use module:function syntax")
+        if not self.summary or not self.owner:
+            raise ValueError("command summary and owner must be nonempty")
+        if self.legacy_name is not None and not self.legacy_name.startswith(
+            "causal4d-"
+        ):
+            raise ValueError("legacy names must start with causal4d-")
+
+    @property
+    def route_name(self) -> str:
+        return " ".join(self.route)
+
+    def as_dict(self) -> dict[str, object]:
+        values = asdict(self)
+        values["route"] = list(self.route)
+        values["route_name"] = self.route_name
+        values["extras"] = list(self.extras)
+        return values
+
+
+GROUPED_COMMANDS = (
+    CommandSpec(
+        route=("benchmark", "counterfactual"),
+        target="causal4d.cli.counterfactual_benchmark:main",
+        summary="Run the controlled counterfactual benchmark.",
+        lifecycle="stable",
+        legacy_name="causal4d-counterfactual-benchmark",
+    ),
+    CommandSpec(
+        route=("benchmark", "latent-contact"),
+        target="causal4d.cli.latent_contact_benchmark:main",
+        summary="Run the controlled latent-contact benchmark.",
+        lifecycle="stable",
+        legacy_name="causal4d-latent-contact-benchmark",
+    ),
+    CommandSpec(
+        route=("benchmark", "dynamic-contact"),
+        target="causal4d.cli.dynamic_contact_benchmark:main",
+        summary="Run the dynamic contact-path benchmark.",
+        lifecycle="experimental",
+        legacy_name="causal4d-dynamic-contact-benchmark",
+    ),
+    CommandSpec(
+        route=("protocol", "real"),
+        target="causal4d.cli.real_protocol:main",
+        summary="Scaffold, validate, and inspect the locked real protocol.",
+        lifecycle="stable",
+        legacy_name="causal4d-real-protocol",
+    ),
+    CommandSpec(
+        route=("protocol", "freeze"),
+        target="causal4d.cli.real_experiment_freeze:main",
+        summary="Seal or validate a confirmatory method freeze.",
+        lifecycle="stable",
+        legacy_name="causal4d-real-experiment-freeze",
+    ),
+    CommandSpec(
+        route=("protocol", "preacquisition-v4"),
+        target="causal4d.cli.preacquisition_protocol_v4:main",
+        summary="Validate the version-4 pre-acquisition amendment.",
+        lifecycle="stable",
+        legacy_name="causal4d-preacquisition-protocol-v4",
+    ),
+    CommandSpec(
+        route=("evidence", "observation-lineage"),
+        target="causal4d.cli.observation_lineage:main",
+        summary="Validate or bind observation provenance.",
+        lifecycle="stable",
+        legacy_name="causal4d-observation-lineage",
+    ),
+    CommandSpec(
+        route=("calibration", "real"),
+        target="causal4d.cli.real_calibration:main",
+        summary="Fit or evaluate real predictive calibration.",
+        lifecycle="diagnostic",
+        legacy_name="causal4d-real-calibration",
+    ),
+    CommandSpec(
+        route=("calibration", "execution-block"),
+        target="causal4d.cli.execution_block_calibration:main",
+        summary="Fit or evaluate execution-block conformal calibration.",
+        lifecycle="stable",
+        legacy_name="causal4d-execution-block-calibration",
+    ),
+    CommandSpec(
+        route=("diagnostic", "real-oracle-gap"),
+        target="causal4d.cli.audit_real_oracle_gap:main",
+        summary="Audit inference, proposal, and model-discrepancy headroom.",
+        lifecycle="diagnostic",
+        legacy_name="causal4d-audit-real-oracle-gap",
+    ),
+)
+
+
+def grouped_commands() -> tuple[CommandSpec, ...]:
+    """Return the frozen grouped command surface after validating uniqueness."""
+
+    routes = [command.route for command in GROUPED_COMMANDS]
+    legacy_names = [
+        command.legacy_name
+        for command in GROUPED_COMMANDS
+        if command.legacy_name is not None
+    ]
+    if len(routes) != len(set(routes)):
+        raise RuntimeError("grouped command routes are not unique")
+    if len(legacy_names) != len(set(legacy_names)):
+        raise RuntimeError("grouped command legacy names are not unique")
+    return GROUPED_COMMANDS
+
+
+def installed_legacy_commands() -> tuple[CommandSpec, ...]:
+    """Discover legacy scripts without importing their target modules."""
+
+    try:
+        distribution = importlib.metadata.distribution("causal4d")
+    except importlib.metadata.PackageNotFoundError:
+        return ()
+    commands = []
+    for entry_point in distribution.entry_points:
+        if entry_point.group != "console_scripts":
+            continue
+        if not entry_point.name.startswith("causal4d-"):
+            continue
+        commands.append(
+            CommandSpec(
+                route=("legacy", entry_point.name.removeprefix("causal4d-")),
+                target=entry_point.value,
+                summary=f"Compatibility route for {entry_point.name}.",
+                lifecycle="legacy",
+                legacy_name=entry_point.name,
+            )
+        )
+    return tuple(sorted(commands, key=lambda command: command.route))
+
+
+def command_inventory(*, include_legacy: bool = False) -> tuple[CommandSpec, ...]:
+    commands = list(grouped_commands())
+    if include_legacy:
+        commands.extend(installed_legacy_commands())
+    return tuple(commands)
+
+
+def find_command(name: str, *, include_legacy: bool = True) -> CommandSpec:
+    """Resolve a route, slash route, or historical executable name."""
+
+    normalized = " ".join(name.replace("/", " ").split())
+    for command in command_inventory(include_legacy=include_legacy):
+        if normalized == command.route_name or normalized == command.legacy_name:
+            return command
+    raise KeyError(name)

--- a/src/causal4d/cli/root.py
+++ b/src/causal4d/cli/root.py
@@ -1,0 +1,194 @@
+"""Grouped, lazy command-line entry point for Causal4D."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+from importlib import import_module, metadata
+import inspect
+import json
+import sys
+
+from causal4d.cli.command_registry import (
+    CommandSpec,
+    command_inventory,
+    find_command,
+    grouped_commands,
+)
+
+
+def _version() -> str:
+    try:
+        return metadata.version("causal4d")
+    except metadata.PackageNotFoundError:
+        return "unknown"
+
+
+def _root_help() -> str:
+    groups: dict[str, list[CommandSpec]] = {}
+    for command in grouped_commands():
+        groups.setdefault(command.route[0], []).append(command)
+    lines = [
+        "usage: causal4d <group> <command> [arguments]",
+        "       causal4d commands {list,describe,migrate} ...",
+        "       causal4d legacy <historical-suffix> [arguments]",
+        "",
+        "Grouped command surface for Causal4D. Command modules are imported lazily.",
+        "",
+        "groups:",
+    ]
+    for group, commands in groups.items():
+        lines.append(f"  {group}")
+        for command in commands:
+            suffix = " ".join(command.route[1:])
+            lines.append(f"    {suffix:<24} {command.summary}")
+    lines.extend(
+        (
+            "",
+            "introspection:",
+            "  commands list [--json] [--include-legacy]",
+            "  commands describe <route-or-legacy-name> [--json]",
+            "  commands migrate <historical-executable> [--json]",
+            "",
+            "Use 'causal4d <group> <command> --help' for command-specific help.",
+        )
+    )
+    return "\n".join(lines)
+
+
+def _invoke(command: CommandSpec, arguments: Sequence[str]) -> int:
+    module_name, function_name = command.target.split(":", 1)
+    function = getattr(import_module(module_name), function_name)
+    parameters = tuple(inspect.signature(function).parameters.values())
+    accepts_argv = any(
+        parameter.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.VAR_POSITIONAL,
+        )
+        for parameter in parameters
+    )
+    if accepts_argv:
+        result = function(list(arguments))
+    else:
+        original_argv = sys.argv
+        sys.argv = [command.legacy_name or "causal4d", *arguments]
+        try:
+            result = function()
+        finally:
+            sys.argv = original_argv
+    return int(result or 0)
+
+
+def _commands_list(arguments: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(prog="causal4d commands list")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--include-legacy", action="store_true")
+    parsed = parser.parse_args(arguments)
+    inventory = command_inventory(include_legacy=parsed.include_legacy)
+    if parsed.json:
+        print(json.dumps([command.as_dict() for command in inventory], indent=2))
+    else:
+        for command in inventory:
+            legacy = f" [{command.legacy_name}]" if command.legacy_name else ""
+            print(f"{command.route_name:<38} {command.lifecycle:<12}{legacy}")
+    return 0
+
+
+def _commands_describe(arguments: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(prog="causal4d commands describe")
+    parser.add_argument("name", nargs="+")
+    parser.add_argument("--json", action="store_true")
+    parsed = parser.parse_args(arguments)
+    name = " ".join(parsed.name)
+    try:
+        command = find_command(name)
+    except KeyError:
+        parser.error(f"unknown command: {name}")
+    if parsed.json:
+        print(json.dumps(command.as_dict(), indent=2, sort_keys=True))
+    else:
+        print(f"route: {command.route_name}")
+        print(f"target: {command.target}")
+        print(f"lifecycle: {command.lifecycle}")
+        print(f"summary: {command.summary}")
+        if command.legacy_name:
+            print(f"legacy executable: {command.legacy_name}")
+        if command.extras:
+            print(f"optional extras: {', '.join(command.extras)}")
+    return 0
+
+
+def _commands_migrate(arguments: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(prog="causal4d commands migrate")
+    parser.add_argument("legacy_name")
+    parser.add_argument("--json", action="store_true")
+    parsed = parser.parse_args(arguments)
+    requested = parsed.legacy_name
+    if not requested.startswith("causal4d-"):
+        requested = f"causal4d-{requested}"
+    matches = [
+        command for command in grouped_commands() if command.legacy_name == requested
+    ]
+    if not matches:
+        parser.error(f"no grouped route is registered for {requested}")
+    command = matches[0]
+    payload = {"legacy_name": requested, "route": list(command.route)}
+    if parsed.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"{requested} -> causal4d {command.route_name}")
+    return 0
+
+
+def _commands(arguments: Sequence[str]) -> int:
+    if not arguments or arguments[0] in {"-h", "--help"}:
+        print(
+            "usage: causal4d commands {list,describe,migrate} ...\n\n"
+            "Inspect the typed command registry and legacy migrations."
+        )
+        return 0
+    operation, *remaining = arguments
+    if operation == "list":
+        return _commands_list(remaining)
+    if operation == "describe":
+        return _commands_describe(remaining)
+    if operation == "migrate":
+        return _commands_migrate(remaining)
+    raise SystemExit(f"unknown commands operation: {operation}")
+
+
+def _resolve_route(arguments: Sequence[str]) -> tuple[CommandSpec, list[str]]:
+    for command in sorted(
+        command_inventory(include_legacy=True),
+        key=lambda item: len(item.route),
+        reverse=True,
+    ):
+        width = len(command.route)
+        if tuple(arguments[:width]) == command.route:
+            return command, list(arguments[width:])
+    raise KeyError(" ".join(arguments))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    if not arguments or arguments[0] in {"-h", "--help"}:
+        print(_root_help())
+        return 0
+    if arguments[0] == "--version":
+        print(_version())
+        return 0
+    if arguments[0] == "commands":
+        return _commands(arguments[1:])
+    try:
+        command, remaining = _resolve_route(arguments)
+    except KeyError:
+        print(_root_help(), file=sys.stderr)
+        print(f"\nerror: unknown command route: {' '.join(arguments)}", file=sys.stderr)
+        return 2
+    return _invoke(command, remaining)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_causal4d_command_registry.py
+++ b/tests/test_causal4d_command_registry.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from causal4d.cli import root
+from causal4d.cli.command_registry import (
+    CommandSpec,
+    find_command,
+    grouped_commands,
+)
+
+
+def test_grouped_registry_has_unique_routes_and_legacy_names() -> None:
+    commands = grouped_commands()
+    assert len({command.route for command in commands}) == len(commands)
+    legacy = [command.legacy_name for command in commands]
+    assert len(set(legacy)) == len(legacy)
+    assert find_command("benchmark/counterfactual").target.endswith(
+        "counterfactual_benchmark:main"
+    )
+
+
+def test_root_help_and_inventory_do_not_import_command_modules(capsys) -> None:
+    assert root.main(["--help"]) == 0
+    help_output = capsys.readouterr().out
+    assert "usage: causal4d" in help_output
+    assert "benchmark" in help_output
+
+    assert root.main(["commands", "list", "--json"]) == 0
+    inventory = json.loads(capsys.readouterr().out)
+    assert any(item["route"] == ["protocol", "real"] for item in inventory)
+
+
+def test_grouped_route_forwards_remaining_arguments(monkeypatch) -> None:
+    received: list[str] = []
+
+    def command_main(arguments):
+        received.extend(arguments)
+        return 7
+
+    monkeypatch.setattr(
+        root,
+        "import_module",
+        lambda name: SimpleNamespace(main=command_main),
+    )
+    result = root.main(["benchmark", "counterfactual", "--output-dir", "result"])
+    assert result == 7
+    assert received == ["--output-dir", "result"]
+
+
+def test_no_argument_main_receives_passthrough_via_sys_argv(monkeypatch) -> None:
+    received: list[str] = []
+    original_argv = sys.argv
+
+    def command_main():
+        received.extend(sys.argv)
+        return 5
+
+    monkeypatch.setattr(
+        root,
+        "import_module",
+        lambda name: SimpleNamespace(main=command_main),
+    )
+    result = root.main(["benchmark", "dynamic-contact", "--output-dir", "result"])
+    assert result == 5
+    assert received == [
+        "causal4d-dynamic-contact-benchmark",
+        "--output-dir",
+        "result",
+    ]
+    assert sys.argv is original_argv
+
+
+def test_describe_and_migrate_report_compatibility_route(capsys) -> None:
+    assert root.main(["commands", "describe", "protocol/real", "--json"]) == 0
+    description = json.loads(capsys.readouterr().out)
+    assert description["legacy_name"] == "causal4d-real-protocol"
+
+    assert root.main(["commands", "migrate", "causal4d-real-protocol", "--json"]) == 0
+    migration = json.loads(capsys.readouterr().out)
+    assert migration["route"] == ["protocol", "real"]
+
+
+def test_command_spec_rejects_invalid_routes() -> None:
+    with pytest.raises(ValueError, match="non-option"):
+        CommandSpec(
+            route=("--bad",),
+            target="module:main",
+            summary="invalid",
+            lifecycle="stable",
+        )


### PR DESCRIPTION
## Implemented on `main`

The grouped CLI and typed command registry were landed directly on `main` as commit `3e9a1b84a972454ceb7fcb94c16808d00002fb65` after the branch passed the full CI matrix and the three-repository installed-wheel compatibility gate.

This draft is closed as redundant; its final reviewed content is preserved on `main`.

## Landed scope

- a single lazy `causal4d` executable with grouped benchmark, protocol, evidence, calibration, diagnostic, and legacy-passthrough routes;
- a typed command registry with lifecycle, owner, optional-extra, target, and historical executable metadata;
- `commands list`, `commands describe`, and `commands migrate` introspection and migration helpers;
- preservation of every existing `causal4d-*` executable for frozen manifests and compatibility;
- installed-artifact help verification for the new root executable;
- command lifecycle, version, migration, and compatibility documentation.

No existing scientific default, frozen milestone, or recorded command string was changed.