### PR TITLE
Harden baseline numerics and immutable result objects

### DIFF
--- a/src/causal4d/baselines.py
+++ b/src/causal4d/baselines.py
@@ -15,6 +15,18 @@ from causal4d.simulator import (
 )
 
 
+def _readonly_array(
+    values: np.ndarray,
+    *,
+    dtype: np.dtype | type = float,
+) -> np.ndarray:
+    """Return an owned, immutable NumPy array."""
+
+    array = np.asarray(values, dtype=dtype).copy()
+    array.setflags(write=False)
+    return array
+
+
 @dataclass(frozen=True)
 class ParameterPosterior:
     particles: np.ndarray
@@ -22,9 +34,9 @@ class ParameterPosterior:
     log_likelihood: np.ndarray
 
     def __post_init__(self) -> None:
-        particles = np.asarray(self.particles, dtype=float)
-        weights = np.asarray(self.weights, dtype=float)
-        log_likelihood = np.asarray(self.log_likelihood, dtype=float)
+        particles = _readonly_array(self.particles)
+        weights = _readonly_array(self.weights)
+        log_likelihood = _readonly_array(self.log_likelihood)
         if particles.ndim != 2 or particles.shape[1] != 3:
             raise ValueError("particles must have shape (particle, 3)")
         if weights.shape != (particles.shape[0],):
@@ -32,8 +44,19 @@ class ParameterPosterior:
         if log_likelihood.shape != weights.shape:
             raise ValueError("log_likelihood must match particle count")
         if not np.all(np.isfinite(particles)) or not np.all(np.isfinite(weights)):
-            raise ValueError("posterior arrays must be finite")
-        if np.any(weights < 0.0) or not np.isclose(np.sum(weights), 1.0):
+            raise ValueError("posterior particles and weights must be finite")
+        if np.any(np.isnan(log_likelihood)) or np.any(np.isposinf(log_likelihood)):
+            raise ValueError("log_likelihood must not contain NaN or positive infinity")
+        if np.any(np.isneginf(log_likelihood) & (weights > 0.0)):
+            raise ValueError(
+                "negative-infinite likelihood requires zero posterior mass"
+            )
+        if np.any(weights < 0.0) or not np.isclose(
+            np.sum(weights),
+            1.0,
+            atol=1e-10,
+            rtol=1e-10,
+        ):
             raise ValueError("weights must be non-negative and sum to one")
         object.__setattr__(self, "particles", particles)
         object.__setattr__(self, "weights", weights)
@@ -57,8 +80,10 @@ class PredictiveDistribution:
     interval_upper: np.ndarray | None = None
 
     def __post_init__(self) -> None:
-        mean = np.asarray(self.mean, dtype=float)
-        variance = np.asarray(self.variance, dtype=float)
+        if not self.method:
+            raise ValueError("predictive method must be nonempty")
+        mean = _readonly_array(self.mean)
+        variance = _readonly_array(self.variance)
         if mean.ndim != 3 or mean.shape[-1] != 2:
             raise ValueError("predictive mean must have shape (frame, node, 2)")
         if variance.shape != mean.shape:
@@ -70,8 +95,8 @@ class PredictiveDistribution:
         if (self.interval_lower is None) != (self.interval_upper is None):
             raise ValueError("predictive interval bounds must be provided together")
         if self.interval_lower is not None and self.interval_upper is not None:
-            lower = np.asarray(self.interval_lower, dtype=float)
-            upper = np.asarray(self.interval_upper, dtype=float)
+            lower = _readonly_array(self.interval_lower)
+            upper = _readonly_array(self.interval_upper)
             if lower.shape != mean.shape or upper.shape != mean.shape:
                 raise ValueError("predictive interval bounds must match the mean")
             if not np.all(np.isfinite(lower)) or not np.all(np.isfinite(upper)):
@@ -89,18 +114,80 @@ class RidgeTrajectoryModel:
     feature_mean: np.ndarray
     feature_scale: np.ndarray
     coefficients: np.ndarray
-    gram_inverse: np.ndarray
+    gram_inverse: np.ndarray | None
     residual_variance: np.ndarray
     output_shape: tuple[int, int, int]
+    gram_matrix: np.ndarray | None = None
+
+    def __post_init__(self) -> None:
+        feature_mean = _readonly_array(self.feature_mean)
+        feature_scale = _readonly_array(self.feature_scale)
+        coefficients = _readonly_array(self.coefficients)
+        residual_variance = _readonly_array(self.residual_variance)
+        if feature_mean.ndim != 1 or feature_scale.shape != feature_mean.shape:
+            raise ValueError("feature statistics must be aligned vectors")
+        if not np.all(np.isfinite(feature_mean)) or not np.all(
+            np.isfinite(feature_scale)
+        ):
+            raise ValueError("feature statistics must be finite")
+        if np.any(feature_scale <= 0.0):
+            raise ValueError("feature scales must be positive")
+        feature_count = len(feature_mean) + 1
+        output_size = int(np.prod(self.output_shape))
+        if coefficients.shape != (feature_count, output_size):
+            raise ValueError("coefficients do not match features and output shape")
+        if residual_variance.shape != (output_size,):
+            raise ValueError("residual_variance does not match output shape")
+        if not np.all(np.isfinite(coefficients)) or not np.all(
+            np.isfinite(residual_variance)
+        ):
+            raise ValueError("ridge model arrays must be finite")
+        if np.any(residual_variance <= 0.0):
+            raise ValueError("residual variances must be positive")
+        if (self.gram_inverse is None) == (self.gram_matrix is None):
+            raise ValueError("provide exactly one of gram_inverse or gram_matrix")
+        gram_inverse = None
+        gram_matrix = None
+        if self.gram_inverse is not None:
+            gram_inverse = _readonly_array(self.gram_inverse)
+            if gram_inverse.shape != (feature_count, feature_count):
+                raise ValueError("gram_inverse has incompatible shape")
+            if not np.all(np.isfinite(gram_inverse)):
+                raise ValueError("gram_inverse must be finite")
+        if self.gram_matrix is not None:
+            gram_matrix = _readonly_array(self.gram_matrix)
+            if gram_matrix.shape != (feature_count, feature_count):
+                raise ValueError("gram_matrix has incompatible shape")
+            if not np.all(np.isfinite(gram_matrix)):
+                raise ValueError("gram_matrix must be finite")
+            if not np.allclose(gram_matrix, gram_matrix.T, atol=1e-12, rtol=1e-12):
+                raise ValueError("gram_matrix must be symmetric")
+            try:
+                np.linalg.cholesky(gram_matrix)
+            except np.linalg.LinAlgError as error:
+                raise ValueError("gram_matrix must be positive definite") from error
+        object.__setattr__(self, "feature_mean", feature_mean)
+        object.__setattr__(self, "feature_scale", feature_scale)
+        object.__setattr__(self, "coefficients", coefficients)
+        object.__setattr__(self, "gram_inverse", gram_inverse)
+        object.__setattr__(self, "gram_matrix", gram_matrix)
+        object.__setattr__(self, "residual_variance", residual_variance)
 
     def predict(self, descriptor: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         descriptor = np.asarray(descriptor, dtype=float)
         if descriptor.shape != self.feature_mean.shape:
             raise ValueError("descriptor shape does not match fitted features")
+        if not np.all(np.isfinite(descriptor)):
+            raise ValueError("descriptor must be finite")
         standardized = (descriptor - self.feature_mean) / self.feature_scale
         feature = np.concatenate(([1.0], standardized))
         mean = feature @ self.coefficients
-        leverage = max(float(feature @ self.gram_inverse @ feature), 0.0)
+        if self.gram_matrix is not None:
+            leverage_vector = np.linalg.solve(self.gram_matrix, feature)
+            leverage = max(float(feature @ leverage_vector), 0.0)
+        else:
+            assert self.gram_inverse is not None
+            leverage = max(float(feature @ self.gram_inverse @ feature), 0.0)
         variance = self.residual_variance * (1.0 + min(leverage, 25.0))
         return mean.reshape(self.output_shape), variance.reshape(self.output_shape)
 
@@ -244,6 +331,12 @@ def _fit_ridge_trajectory(
         raise ValueError("descriptors and trajectory targets have invalid rank")
     if descriptors.shape[0] != targets.shape[0] or descriptors.shape[0] < 2:
         raise ValueError("at least two aligned training examples are required")
+    if not np.all(np.isfinite(descriptors)) or not np.all(np.isfinite(targets)):
+        raise ValueError("descriptors and trajectory targets must be finite")
+    if not np.isfinite(ridge) or ridge <= 0.0:
+        raise ValueError("ridge must be finite and positive")
+    if not np.isfinite(variance_floor) or variance_floor <= 0.0:
+        raise ValueError("variance_floor must be finite and positive")
 
     feature_mean = np.mean(descriptors, axis=0)
     feature_scale = np.std(descriptors, axis=0)
@@ -254,8 +347,7 @@ def _fit_ridge_trajectory(
     penalty = np.eye(design.shape[1]) * ridge
     penalty[0, 0] = ridge * 1e-3
     gram = design.T @ design + penalty
-    gram_inverse = np.linalg.inv(gram)
-    coefficients = gram_inverse @ design.T @ flat_targets
+    coefficients = np.linalg.solve(gram, design.T @ flat_targets)
 
     # Leave-one-out errors provide a non-degenerate uncertainty estimate even
     # when the feature dimension approaches the number of interactions.
@@ -274,9 +366,10 @@ def _fit_ridge_trajectory(
         feature_mean=feature_mean,
         feature_scale=feature_scale,
         coefficients=coefficients,
-        gram_inverse=gram_inverse,
+        gram_inverse=None,
         residual_variance=residual_variance,
         output_shape=tuple(targets.shape[1:]),
+        gram_matrix=gram,
     )
 
 

--- a/src/causal4d/preacquisition_analysis.py
+++ b/src/causal4d/preacquisition_analysis.py
@@ -164,8 +164,8 @@ def cluster_robust_linear_regression(
     if np.linalg.matrix_rank(design) < parameter_count:
         raise ValueError("regression design is rank deficient")
 
-    gram_inverse = np.linalg.inv(design.T @ design)
-    coefficients = gram_inverse @ design.T @ y
+    gram = design.T @ design
+    coefficients = np.linalg.solve(gram, design.T @ y)
     residual = y - design @ coefficients
     meat = np.zeros((parameter_count, parameter_count), dtype=float)
     for cluster in clusters:
@@ -177,7 +177,9 @@ def cluster_robust_linear_regression(
     correction = (len(clusters) / (len(clusters) - 1.0)) * (
         (n - 1.0) / (n - parameter_count)
     )
-    covariance = correction * gram_inverse @ meat @ gram_inverse
+    left_sandwich = np.linalg.solve(gram, meat)
+    covariance = correction * np.linalg.solve(gram, left_sandwich.T).T
+    covariance = 0.5 * (covariance + covariance.T)
     standard_errors = np.sqrt(np.maximum(np.diag(covariance), 0.0))
     t_statistics = np.divide(
         coefficients,

--- a/tests/test_causal4d_benchmark.py
+++ b/tests/test_causal4d_benchmark.py
@@ -1,6 +1,12 @@
 import numpy as np
+import pytest
 
-from causal4d.baselines import fit_baselines
+from causal4d.baselines import (
+    ParameterPosterior,
+    PredictiveDistribution,
+    _fit_ridge_trajectory,
+    fit_baselines,
+)
 from causal4d.benchmark import (
     CounterfactualBenchmarkConfig,
     build_protocol,
@@ -106,3 +112,104 @@ def test_held_out_world_condition_never_changes_model_inputs() -> None:
     for first, second in zip(matched, shifted, strict=True):
         assert np.array_equal(first.mean, second.mean)
         assert np.array_equal(first.variance, second.variance)
+
+
+def test_baseline_result_arrays_are_owned_and_read_only() -> None:
+    particles = np.asarray([[1.0, 2.0, 3.0]])
+    weights = np.asarray([1.0])
+    log_likelihood = np.asarray([-2.0])
+    posterior = ParameterPosterior(particles, weights, log_likelihood)
+    particles[...] = 9.0
+    weights[...] = 0.0
+    log_likelihood[...] = 7.0
+
+    np.testing.assert_array_equal(posterior.particles, [[1.0, 2.0, 3.0]])
+    np.testing.assert_array_equal(posterior.weights, [1.0])
+    np.testing.assert_array_equal(posterior.log_likelihood, [-2.0])
+    assert not posterior.particles.flags.writeable
+    assert not posterior.weights.flags.writeable
+    assert not posterior.log_likelihood.flags.writeable
+
+    mean = np.zeros((3, 2, 2), dtype=float)
+    variance = np.ones_like(mean)
+    lower = mean - 1.0
+    upper = mean + 1.0
+    prediction = PredictiveDistribution(
+        method="unit",
+        mean=mean,
+        variance=variance,
+        interval_lower=lower,
+        interval_upper=upper,
+    )
+    mean[...] = 5.0
+    variance[...] = 5.0
+    lower[...] = 5.0
+    upper[...] = 5.0
+
+    assert np.all(prediction.mean == 0.0)
+    assert np.all(prediction.variance == 1.0)
+    assert np.all(prediction.interval_lower == -1.0)
+    assert np.all(prediction.interval_upper == 1.0)
+    assert not prediction.mean.flags.writeable
+    assert not prediction.variance.flags.writeable
+    assert not prediction.interval_lower.flags.writeable
+    assert not prediction.interval_upper.flags.writeable
+
+
+def test_parameter_posterior_rejects_invalid_log_likelihood_support() -> None:
+    with pytest.raises(ValueError, match="positive infinity"):
+        ParameterPosterior(
+            particles=np.zeros((1, 3)),
+            weights=np.ones(1),
+            log_likelihood=np.asarray([np.inf]),
+        )
+    with pytest.raises(ValueError, match="zero posterior mass"):
+        ParameterPosterior(
+            particles=np.zeros((1, 3)),
+            weights=np.ones(1),
+            log_likelihood=np.asarray([-np.inf]),
+        )
+    posterior = ParameterPosterior(
+        particles=np.zeros((2, 3)),
+        weights=np.asarray([1.0, 0.0]),
+        log_likelihood=np.asarray([0.0, -np.inf]),
+    )
+    assert np.isneginf(posterior.log_likelihood[1])
+
+
+def test_ridge_fit_uses_linear_solves_and_freezes_model_arrays(monkeypatch) -> None:
+    def forbidden_inverse(*_args, **_kwargs):
+        raise AssertionError("ridge fitting must not form an explicit inverse")
+
+    monkeypatch.setattr(np.linalg, "inv", forbidden_inverse)
+    descriptors = np.asarray(
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [0.0, 1.0],
+            [1.0, 1.0],
+        ]
+    )
+    targets = np.zeros((4, 2, 1, 2), dtype=float)
+    targets[:, :, 0, 0] = descriptors[:, :1]
+    targets[:, :, 0, 1] = descriptors[:, 1:]
+    model = _fit_ridge_trajectory(
+        descriptors,
+        targets,
+        ridge=1e-3,
+        variance_floor=1e-8,
+    )
+    mean, variance = model.predict(np.asarray([0.5, 0.5]))
+
+    assert mean.shape == (2, 1, 2)
+    assert variance.shape == mean.shape
+    assert model.gram_matrix is not None
+    assert model.gram_inverse is None
+    for values in (
+        model.feature_mean,
+        model.feature_scale,
+        model.coefficients,
+        model.gram_matrix,
+        model.residual_variance,
+    ):
+        assert not values.flags.writeable

--- a/tests/test_preacquisition_analysis.py
+++ b/tests/test_preacquisition_analysis.py
@@ -49,6 +49,30 @@ def test_cluster_robust_regression_recovers_linear_coefficients() -> None:
     assert result["parameters"]["speed"]["coefficient"] == pytest.approx(3.0)
 
 
+def test_cluster_robust_regression_uses_linear_solves(monkeypatch) -> None:
+    def forbidden_inverse(*_args, **_kwargs):
+        raise AssertionError("cluster regression must not form an explicit inverse")
+
+    monkeypatch.setattr(np.linalg, "inv", forbidden_inverse)
+    features = np.column_stack(
+        [
+            np.arange(12, dtype=float),
+            np.tile(np.asarray([0.0, 1.0]), 6),
+        ]
+    )
+    response = 1.5 + 0.75 * features[:, 0] - 2.0 * features[:, 1]
+    result = cluster_robust_linear_regression(
+        response,
+        features,
+        [f"session-{index // 2}" for index in range(len(response))],
+        feature_names=["speed", "direction"],
+    )
+
+    assert result["parameters"]["intercept"]["coefficient"] == pytest.approx(1.5)
+    assert result["parameters"]["speed"]["coefficient"] == pytest.approx(0.75)
+    assert result["parameters"]["direction"]["coefficient"] == pytest.approx(-2.0)
+
+
 def test_conformal_rank_exposes_nine_session_minimum_at_90_percent() -> None:
     too_small = conformal_rank_plan(2, coverage=0.90)
     finite = conformal_rank_plan(9, coverage=0.90)


### PR DESCRIPTION
## Summary

- defensively copy and freeze controlled-benchmark posterior, predictive, and ridge-model arrays;
- reject malformed likelihood support, non-finite descriptors, invalid ridge controls, and inconsistent fitted-model shapes;
- replace the ridge fit's explicit Gram-matrix inverse with linear solves while retaining compatibility for callers that supply a precomputed inverse;
- replace the clustered-regression inverse and sandwich product with solve-based equivalents and explicitly symmetrize the resulting covariance;
- add adversarial regressions for caller-side mutation, invalid log-likelihood support, and accidental reintroduction of `np.linalg.inv`.

## Why

The dataclasses were frozen only at the attribute level: caller-owned NumPy buffers remained mutable after construction. The controlled ridge baseline and the pre-acquisition clustered regression also formed explicit matrix inverses even though only linear-system solutions were required.

## Compatibility

The fitted baseline formulas and frozen scientific results are unchanged for finite valid inputs. `RidgeTrajectoryModel` still accepts the historical `gram_inverse` representation; newly fitted models store the regularized Gram matrix and solve for leverage on demand.

## Validation

- focused benchmark and pre-acquisition suite: `12 passed`;
- changed Python sources and tests compile successfully;
- all changed lines satisfy the repository's 88-character limit;
- a broader source-distribution run reaches only expected collection blockers from unavailable private/optional Bayesian-PhysTwin and PyRecEst packages; GitHub Actions is the authoritative provider-enabled full-suite gate.

## Scientific boundary

This is numerical and contract hardening only. It does not change the locked real-experiment method, protocol, target-data access, or claim boundary.