### PR TITLE
Require strict claim-bearing three-repository admission

### DIFF
--- a/.github/workflows/bayesian-phystwin-provider-compatibility.yml
+++ b/.github/workflows/bayesian-phystwin-provider-compatibility.yml
@@ -8,14 +8,18 @@ on:
       - "ci/three_repository_*.py"
       - "docs/ci.md"
       - "docs/molmo_visual_inputs_v2.md"
+      - "docs/prob4d_provider_attestation.md"
       - "pyproject.toml"
       - "src/causal4d/bpt_belief.py"
+      - "src/causal4d/claim_bearing_observation_lineage.py"
       - "src/causal4d/cli/molmo_phystwin_forecast_v2.py"
       - "src/causal4d/molmo_visual_inputs_v2.py"
       - "src/causal4d/observation_lineage.py"
       - "src/causal4d/phystwin_backend.py"
       - "src/causal4d/phystwin_resumable.py"
       - "src/causal4d/prob4d_observation_contract.py"
+      - "src/causal4d/prob4d_observation_lineage.py"
+      - "src/causal4d/prob4d_provider_attestation.py"
       - "src/causal4d/provider_contract.py"
       - "src/causal4d/replay_provider_contract.py"
       - "src/causal4d/rollout_cache.py"
@@ -25,8 +29,10 @@ on:
       - "tests/test_causal4d_molmo_visual_inputs_v2.py"
       - "tests/test_causal4d_phystwin_backend.py"
       - "tests/test_phystwin_resumable.py"
+      - "tests/test_prob4d_stream_contract_version.py"
       - "tests/test_replay_provider_contract.py"
       - "tests/test_rollout_cache.py"
+      - "tests/test_three_repository_workflow_policy.py"
   push:
     branches: [main]
     paths:
@@ -34,14 +40,18 @@ on:
       - "ci/three_repository_*.py"
       - "docs/ci.md"
       - "docs/molmo_visual_inputs_v2.md"
+      - "docs/prob4d_provider_attestation.md"
       - "pyproject.toml"
       - "src/causal4d/bpt_belief.py"
+      - "src/causal4d/claim_bearing_observation_lineage.py"
       - "src/causal4d/cli/molmo_phystwin_forecast_v2.py"
       - "src/causal4d/molmo_visual_inputs_v2.py"
       - "src/causal4d/observation_lineage.py"
       - "src/causal4d/phystwin_backend.py"
       - "src/causal4d/phystwin_resumable.py"
       - "src/causal4d/prob4d_observation_contract.py"
+      - "src/causal4d/prob4d_observation_lineage.py"
+      - "src/causal4d/prob4d_provider_attestation.py"
       - "src/causal4d/provider_contract.py"
       - "src/causal4d/replay_provider_contract.py"
       - "src/causal4d/rollout_cache.py"
@@ -51,8 +61,10 @@ on:
       - "tests/test_causal4d_molmo_visual_inputs_v2.py"
       - "tests/test_causal4d_phystwin_backend.py"
       - "tests/test_phystwin_resumable.py"
+      - "tests/test_prob4d_stream_contract_version.py"
       - "tests/test_replay_provider_contract.py"
       - "tests/test_rollout_cache.py"
+      - "tests/test_three_repository_workflow_policy.py"
   workflow_dispatch:
     inputs:
       bpt_ref:
@@ -188,6 +200,14 @@ jobs:
           python -m build --wheel --outdir "$wheelhouse" causal4d
           test "$(find "$wheelhouse" -maxdepth 1 -name '*.whl' | wc -l)" -eq 3
 
+      - name: Record wheel SHA-256 identities
+        run: |
+          wheelhouse="$RUNNER_TEMP/three-repository-wheelhouse"
+          (
+            cd "$wheelhouse"
+            sha256sum ./*.whl | sort
+          ) | tee "$RUNNER_TEMP/three-repository-wheel-sha256.txt"
+
       - name: Install wheels in a clean virtual environment
         run: |
           venv="$RUNNER_TEMP/three-repository-venv"
@@ -201,7 +221,7 @@ jobs:
             opencv-python-headless
           "$venv/bin/python" -m pip check
 
-      - name: Run the isolated three-repository golden path
+      - name: Run the isolated three-repository compatibility path
         run: |
           run_dir="$RUNNER_TEMP/three-repository-run"
           mkdir -p "$run_dir"
@@ -221,6 +241,19 @@ jobs:
               --output "$RUNNER_TEMP/three-repository-summary.json" \
             | tee "$RUNNER_TEMP/three-repository-golden-path.log"
 
+      - name: Run strict claim-bearing provider-v2 admission path
+        run: |
+          cd "$RUNNER_TEMP/three-repository-run"
+          env -u PYTHONPATH \
+            "$RUNNER_TEMP/three-repository-venv/bin/python" \
+            three_repository_provider_v2_attestation.py \
+              --prob4d-fixture \
+                "$GITHUB_WORKSPACE/prob4d/tests/fixtures/prob4d_joint_observation_v1.json" \
+              --prob4d-revision "${{ steps.revisions.outputs.prob4d }}" \
+              --output-dir "$RUNNER_TEMP/three-repository-provider-v2-work" \
+              --output "$RUNNER_TEMP/three-repository-provider-v2-summary.json" \
+            | tee "$RUNNER_TEMP/three-repository-provider-v2.log"
+
       - name: Run cross-repository contract tests against installed wheels
         env:
           CAUSAL4D_REQUIRE_BPT_PROVIDER: "1"
@@ -229,11 +262,13 @@ jobs:
           env -u PYTHONPATH \
             "$RUNNER_TEMP/three-repository-venv/bin/python" -m pytest -q \
               --import-mode=importlib \
+              "$GITHUB_WORKSPACE/prob4d/tests/test_claim_bearing_observation.py" \
               "$GITHUB_WORKSPACE/prob4d/tests/test_joint_observation_contract_fixture.py" \
               "$GITHUB_WORKSPACE/bayesian-phystwin/tests/test_causal4d_provider_v1.py" \
               "$GITHUB_WORKSPACE/bayesian-phystwin/tests/test_causal4d_provider_v2.py" \
               "$GITHUB_WORKSPACE/bayesian-phystwin/tests/test_causal4d_artifacts_v2.py" \
               "$GITHUB_WORKSPACE/bayesian-phystwin/tests/test_observation_belief_gauge_adapter.py" \
+              "$GITHUB_WORKSPACE/bayesian-phystwin/tests/test_prob4d_causal_lineage.py" \
               "$GITHUB_WORKSPACE/bayesian-phystwin/tests/test_run_manifest_v2.py" \
               "$GITHUB_WORKSPACE/causal4d/tests/test_bpt_provider_import_boundary.py" \
               "$GITHUB_WORKSPACE/causal4d/tests/test_bpt_provider_integration.py" \
@@ -253,10 +288,28 @@ jobs:
         run: |
           if [[ -f "$RUNNER_TEMP/three-repository-summary.json" ]]; then
             {
-              echo "### Three-repository installed-wheel compatibility"
+              echo "### Compatibility path"
               echo
               echo '```json'
               cat "$RUNNER_TEMP/three-repository-summary.json"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [[ -f "$RUNNER_TEMP/three-repository-provider-v2-summary.json" ]]; then
+            {
+              echo "### Strict claim-bearing provider-v2 path"
+              echo
+              echo '```json'
+              cat "$RUNNER_TEMP/three-repository-provider-v2-summary.json"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [[ -f "$RUNNER_TEMP/three-repository-wheel-sha256.txt" ]]; then
+            {
+              echo "### Wheel SHA-256 identities"
+              echo
+              echo '```text'
+              cat "$RUNNER_TEMP/three-repository-wheel-sha256.txt"
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
           fi
@@ -269,5 +322,8 @@ jobs:
           path: |
             ${{ runner.temp }}/three-repository-summary.json
             ${{ runner.temp }}/three-repository-golden-path.log
+            ${{ runner.temp }}/three-repository-provider-v2-summary.json
+            ${{ runner.temp }}/three-repository-provider-v2.log
+            ${{ runner.temp }}/three-repository-wheel-sha256.txt
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/bayesian-phystwin-provider-compatibility.yml
+++ b/.github/workflows/bayesian-phystwin-provider-compatibility.yml
@@ -223,6 +223,7 @@ jobs:
 
       - name: Run the isolated three-repository compatibility path
         run: |
+          set -o pipefail
           run_dir="$RUNNER_TEMP/three-repository-run"
           mkdir -p "$run_dir"
           cp causal4d/ci/three_repository_*.py "$run_dir/"
@@ -240,9 +241,13 @@ jobs:
               --checkout-root "$GITHUB_WORKSPACE/causal4d" \
               --output "$RUNNER_TEMP/three-repository-summary.json" \
             | tee "$RUNNER_TEMP/three-repository-golden-path.log"
+          test -s "$RUNNER_TEMP/three-repository-summary.json"
+          "$RUNNER_TEMP/three-repository-venv/bin/python" -m json.tool \
+            "$RUNNER_TEMP/three-repository-summary.json" >/dev/null
 
       - name: Run strict claim-bearing provider-v2 admission path
         run: |
+          set -o pipefail
           cd "$RUNNER_TEMP/three-repository-run"
           env -u PYTHONPATH \
             "$RUNNER_TEMP/three-repository-venv/bin/python" \
@@ -253,6 +258,9 @@ jobs:
               --output-dir "$RUNNER_TEMP/three-repository-provider-v2-work" \
               --output "$RUNNER_TEMP/three-repository-provider-v2-summary.json" \
             | tee "$RUNNER_TEMP/three-repository-provider-v2.log"
+          test -s "$RUNNER_TEMP/three-repository-provider-v2-summary.json"
+          "$RUNNER_TEMP/three-repository-venv/bin/python" -m json.tool \
+            "$RUNNER_TEMP/three-repository-provider-v2-summary.json" >/dev/null
 
       - name: Run cross-repository contract tests against installed wheels
         env:

--- a/ci/three_repository_provider_v2_attestation.py
+++ b/ci/three_repository_provider_v2_attestation.py
@@ -363,7 +363,7 @@ def run(
         "Causal4D validated a different provider manifest",
     )
     require(
-        producer["artifact_id"] == bpt["adapter"]["source_observation_belief_id"],
+        producer["artifact_id"] == bpt["adapter"]["observation_artifact_id"],
         "BPT strict adapter lost the claim-bearing observation identity",
     )
     require(

--- a/ci/three_repository_provider_v2_attestation.py
+++ b/ci/three_repository_provider_v2_attestation.py
@@ -174,6 +174,14 @@ def _validate_bpt(path: Path) -> dict[str, object]:
     )
     metadata = adapted.batch.metadata
     require(isinstance(metadata, Mapping), "BPT adapted batch metadata is missing")
+    np.testing.assert_array_equal(
+        adapted.batch.observation_covariance_m2,
+        belief.local_covariance_m2,
+    )
+    require(
+        metadata.get("low_rank_covariance_double_counted") is False,
+        "BPT strict adapter double-counted explicit gauge covariance",
+    )
     require(
         metadata.get("prob4d_claim_bearing_provider_v2_validated") is True,
         "BPT strict adapter did not retain claim-bearing validation",
@@ -191,6 +199,10 @@ def _validate_bpt(path: Path) -> dict[str, object]:
     second = update_gauge_aware_belief(adapted.batch, config=config)
     require(first.accepted, f"BPT claim-bearing update abstained: {first.reason}")
     require(second.accepted, f"repeated BPT update abstained: {second.reason}")
+    require(
+        first.input_lineage.get("observation_artifact_id") == belief.artifact_id,
+        "BPT claim-bearing update lost its observation artifact binding",
+    )
     np.testing.assert_array_equal(first.state_coefficients, second.state_coefficients)
     np.testing.assert_array_equal(
         first.posterior_covariance,
@@ -215,6 +227,7 @@ def _validate_bpt(path: Path) -> dict[str, object]:
             first.robust_weights,
         ),
         "adapter": adapted.summary(),
+        "low_rank_covariance_double_counted": False,
     }
 
 

--- a/ci/three_repository_provider_v2_attestation.py
+++ b/ci/three_repository_provider_v2_attestation.py
@@ -1,17 +1,19 @@
-"""Installed-wheel compatibility for the self-contained Prob4D provider-v2 contract."""
+"""Installed-wheel compatibility for the strict Prob4D provider-v2 boundary."""
 
 from __future__ import annotations
 
 import argparse
 import hashlib
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from copy import deepcopy
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
-from three_repository_common import require
+import numpy as np
+
+from three_repository_common import array_digest, require
 from three_repository_observation import fixture_artifact
 
 
@@ -51,6 +53,43 @@ def _build_attested_fixture(artifact: Any, *, prob4d_revision: str) -> Any:
         "point_artifact_id": _digest("contract-test-point-calibration-v1"),
     }
     metadata = deepcopy(dict(artifact.metadata))
+    posterior = metadata.get("gauge_posterior")
+    require(isinstance(posterior, dict), "fixture gauge posterior is missing")
+    alignments = posterior.get("alignments")
+    require(isinstance(alignments, list), "fixture gauge alignments are missing")
+    alignment_count = len(alignments)
+
+    metadata["prob4d_causal_stream_contract_version"] = 2
+    metadata["prob4d_causal_stream_contract"] = {
+        "version": 2,
+        "causal_frame_stop_convention": "exclusive",
+    }
+    metadata["metric_anchor_covariance_in_joint_factor"] = True
+    anchor = metadata.get("metric_gauge_anchor")
+    require(isinstance(anchor, dict), "fixture metric anchor is missing")
+    anchor.update(
+        {
+            "schema_name": "prob4d.metric-gauge-anchor",
+            "schema_version": 1,
+            "case_id": artifact.case_id,
+            "coordinate_frame": metadata["coordinate_frame"],
+            "world_frame_id": metadata["coordinate_frame"],
+            "metric_units": "m",
+            "calibration_artifact_sha256": _digest(
+                "contract-test-metric-anchor-calibration-v1"
+            ),
+            "covariance_treatment": "propagated_external_prior",
+        }
+    )
+    metadata["covariance_calibration"] = {
+        "status": "calibrated",
+        **calibration_ids,
+        "alignment_count": alignment_count,
+        "gauge_calibrated_alignment_count": alignment_count,
+        "covariance_fallback_counts": {},
+        "uncalibrated_exploratory_covariance_allowed": False,
+        "pointwise_covariance_fallback_allowed": False,
+    }
     metadata["prob4d_provider_attestation"] = build_provider_attestation(
         provider_manifest=prob4d_provider_manifest(
             provider_revision=prob4d_revision,
@@ -68,8 +107,9 @@ def _build_attested_fixture(artifact: Any, *, prob4d_revision: str) -> Any:
         "fixture_only": True,
         "synthetic_calibration_ids": True,
         "purpose": (
-            "installed-wheel schema and independent consumer validation; not "
-            "prospective covariance calibration or physical-prediction evidence"
+            "installed-wheel schema, strict update admission, and independent "
+            "consumer validation; not prospective covariance calibration or "
+            "physical-prediction evidence"
         ),
     }
     return replace(
@@ -79,46 +119,218 @@ def _build_attested_fixture(artifact: Any, *, prob4d_revision: str) -> Any:
     )
 
 
+def _validate_prob4d(path: Path) -> dict[str, object]:
+    from prob4d.provider_v2_loading import load_claim_bearing_observation_belief
+
+    validated = load_claim_bearing_observation_belief(path)
+    return {
+        "artifact_id": validated.artifact_id,
+        "provider_manifest_id": validated.provider_manifest_id,
+        "gauge_calibration_id": validated.gauge_calibration_id,
+        "point_calibration_id": validated.point_calibration_id,
+        "runtime_revision": validated.runtime_revision,
+    }
+
+
+def _state_design(observation_count: int) -> np.ndarray:
+    require(observation_count == 6, "claim-bearing fixture observation count changed")
+    design = np.zeros((observation_count, 3, 1), dtype=np.float64)
+    design[0, 1, 0] = 1.0
+    design[0, 2, 0] = -1.0
+    design[1, 0, 0] = 1.0
+    design[2, 1, 0] = -1.0
+    design[3, 2, 0] = 1.0
+    design[5, 0, 0] = -1.0
+    return design
+
+
 def _validate_bpt(path: Path) -> dict[str, object]:
+    from bayesian_phystwin.claim_bearing_prob4d import (
+        build_claim_bearing_gauge_aware_batch_from_observation_belief,
+    )
+    from bayesian_phystwin.gauge_aware_belief import (
+        GaugeAwareBeliefConfig,
+        update_gauge_aware_belief,
+    )
     from bayesian_phystwin.observation_belief import load_observation_belief
     from bayesian_phystwin.prob4d_causal_lineage import (
         validate_claim_bearing_prob4d_observation_belief,
     )
 
     belief = load_observation_belief(path)
-    result = validate_claim_bearing_prob4d_observation_belief(belief)
-    provider = result.get("provider_attestation")
-    require(isinstance(provider, dict), "BPT lost the provider-attestation summary")
-    require(
-        provider.get("claim_bearing") is True, "BPT did not require calibrated mode"
+    validation = validate_claim_bearing_prob4d_observation_belief(belief)
+    state = _state_design(belief.observation_count)
+    injected_coefficient_m = 0.004
+    prediction = belief.mean_xyz_m - injected_coefficient_m * state[:, :, 0]
+    query = np.zeros((1, 3, 1), dtype=np.float64)
+    query[0, 0, 0] = 1.0
+    adapted = build_claim_bearing_gauge_aware_batch_from_observation_belief(
+        belief,
+        physical_prediction_xyz_m=prediction,
+        state_jacobian=state,
+        query_state_jacobian=query,
+        physical_response_scale_m=0.02,
+        state_prior_covariance_m2=np.asarray([[4e-4]], dtype=np.float64),
     )
+    metadata = adapted.batch.metadata
+    require(isinstance(metadata, Mapping), "BPT adapted batch metadata is missing")
     require(
-        provider.get("runtime_revision_independently_verified") is True,
-        "BPT did not require independently verified runtime provenance",
+        metadata.get("prob4d_claim_bearing_provider_v2_validated") is True,
+        "BPT strict adapter did not retain claim-bearing validation",
     )
-    return result
+    provider = validation.get("provider_attestation")
+    require(isinstance(provider, Mapping), "BPT lost the provider-attestation summary")
+    require(
+        metadata.get("prob4d_claim_bearing_provider_manifest_id")
+        == provider.get("provider_manifest_id"),
+        "BPT strict adapter bound a different provider manifest",
+    )
+
+    config = GaugeAwareBeliefConfig(maximum_iterations=20)
+    first = update_gauge_aware_belief(adapted.batch, config=config)
+    second = update_gauge_aware_belief(adapted.batch, config=config)
+    require(first.accepted, f"BPT claim-bearing update abstained: {first.reason}")
+    require(second.accepted, f"repeated BPT update abstained: {second.reason}")
+    np.testing.assert_array_equal(first.state_coefficients, second.state_coefficients)
+    np.testing.assert_array_equal(
+        first.posterior_covariance,
+        second.posterior_covariance,
+    )
+    coefficient = float(first.state_coefficients[0])
+    require(
+        0.002 <= coefficient <= 0.006,
+        f"BPT claim-bearing update left the deterministic interval: {coefficient}",
+    )
+    return {
+        "claim_bearing_provider_v2_validated": validation[
+            "claim_bearing_provider_v2_validated"
+        ],
+        "provider_manifest_id": provider["provider_manifest_id"],
+        "calibration": validation["claim_bearing_covariance_calibration"],
+        "state_coefficient_m": coefficient,
+        "injected_coefficient_m": injected_coefficient_m,
+        "update_id": array_digest(
+            first.state_coefficients,
+            first.posterior_covariance,
+            first.robust_weights,
+        ),
+        "adapter": adapted.summary(),
+    }
 
 
-def _validate_causal4d(path: Path) -> Any:
+def _validate_causal4d(path: Path) -> dict[str, object]:
     from causal4d.claim_bearing_observation_lineage import (
         load_claim_bearing_prob4d_observation_lineage,
     )
 
     lineage = load_claim_bearing_prob4d_observation_lineage(path)
-    provider = lineage.provider_validation.get("provider_attestation")
+    validation = lineage.provider_validation
+    provider = validation.get("provider_attestation")
+    calibration = validation.get("claim_bearing_covariance_calibration")
     require(
-        isinstance(provider, dict),
+        validation.get("claim_bearing_provider_v2_validated") is True,
+        "Causal4D did not complete claim-bearing provider-v2 validation",
+    )
+    require(
+        isinstance(provider, Mapping),
         "Causal4D lost the provider-attestation summary",
     )
     require(
-        provider.get("claim_bearing") is True,
-        "Causal4D did not require calibrated mode",
+        isinstance(calibration, Mapping),
+        "Causal4D lost the covariance-calibration summary",
     )
-    require(
-        provider.get("runtime_revision_independently_verified") is True,
-        "Causal4D did not require independently verified runtime provenance",
-    )
-    return lineage
+    return {
+        "artifact_id": lineage.artifact_id,
+        "provider_manifest_id": provider["provider_manifest_id"],
+        "calibration": calibration,
+        "stream_contract_version": validation["stream_contract_version"],
+        "stream_contract_version_inferred": validation[
+            "stream_contract_version_inferred"
+        ],
+        "covariance_semantics": validation["covariance_semantics"],
+    }
+
+
+def _write_variant(
+    artifact: Any,
+    target: Path,
+    mutate: Callable[[dict[str, Any]], None],
+) -> None:
+    from prob4d.provider_v2 import save_observation_belief_export
+
+    metadata = deepcopy(dict(artifact.metadata))
+    mutate(metadata)
+    save_observation_belief_export(target, replace(artifact, metadata=metadata))
+
+
+def _consumer_rejections(path: Path, label: str) -> list[dict[str, str]]:
+    return [
+        _expect_failure(
+            f"prob4d:{label}",
+            lambda: _validate_prob4d(path),
+        ),
+        _expect_failure(
+            f"bpt:{label}",
+            lambda: _validate_bpt(path),
+        ),
+        _expect_failure(
+            f"causal4d:{label}",
+            lambda: _validate_causal4d(path),
+        ),
+    ]
+
+
+def _rejection_corpus(artifact: Any, output_dir: Path) -> list[dict[str, str]]:
+    results: list[dict[str, str]] = []
+
+    def provider_manifest_tamper(metadata: dict[str, Any]) -> None:
+        metadata["prob4d_provider_attestation"]["provider_manifest"][
+            "provider_version"
+        ] = "tampered"
+
+    path = output_dir / "rejected-provider-manifest-tamper.npz"
+    _write_variant(artifact, path, provider_manifest_tamper)
+    results.extend(_consumer_rejections(path, "provider-manifest-tamper"))
+
+    def calibration_identity_drift(metadata: dict[str, Any]) -> None:
+        metadata["covariance_calibration"]["gauge_artifact_id"] = "3" * 64
+
+    path = output_dir / "rejected-calibration-identity-drift.npz"
+    _write_variant(artifact, path, calibration_identity_drift)
+    results.extend(_consumer_rejections(path, "calibration-identity-drift"))
+
+    def incomplete_gauge_calibration(metadata: dict[str, Any]) -> None:
+        metadata["covariance_calibration"]["gauge_calibrated_alignment_count"] -= 1
+
+    path = output_dir / "rejected-incomplete-gauge-calibration.npz"
+    _write_variant(artifact, path, incomplete_gauge_calibration)
+    results.extend(_consumer_rejections(path, "incomplete-gauge-calibration"))
+
+    def covariance_fallback(metadata: dict[str, Any]) -> None:
+        metadata["covariance_calibration"]["covariance_fallback_counts"] = {
+            "pointwise": 1
+        }
+
+    path = output_dir / "rejected-covariance-fallback.npz"
+    _write_variant(artifact, path, covariance_fallback)
+    results.extend(_consumer_rejections(path, "covariance-fallback"))
+
+    def fallback_permission(metadata: dict[str, Any]) -> None:
+        metadata["covariance_calibration"][
+            "pointwise_covariance_fallback_allowed"
+        ] = True
+
+    path = output_dir / "rejected-fallback-permission.npz"
+    _write_variant(artifact, path, fallback_permission)
+    results.extend(_consumer_rejections(path, "fallback-permission"))
+
+    def inferred_stream_version(metadata: dict[str, Any]) -> None:
+        metadata.pop("prob4d_causal_stream_contract_version")
+
+    path = output_dir / "rejected-inferred-stream-version.npz"
+    _write_variant(artifact, path, inferred_stream_version)
+    results.extend(_consumer_rejections(path, "inferred-stream-version"))
+    return results
 
 
 def run(
@@ -138,54 +350,39 @@ def run(
     observation_path = output_dir / "provider-v2-observation.npz"
     save_observation_belief_export(observation_path, attested)
 
+    producer = _validate_prob4d(observation_path)
     bpt = _validate_bpt(observation_path)
     causal4d = _validate_causal4d(observation_path)
-    producer = attested.metadata["prob4d_provider_attestation"]
-    producer_manifest_id = producer["provider_manifest_id"]
+    provider_manifest_id = producer["provider_manifest_id"]
     require(
-        bpt["provider_attestation"]["provider_manifest_id"] == producer_manifest_id,
+        bpt["provider_manifest_id"] == provider_manifest_id,
         "BPT validated a different provider manifest",
     )
     require(
-        causal4d.provider_validation["provider_attestation"]["provider_manifest_id"]
-        == producer_manifest_id,
+        causal4d["provider_manifest_id"] == provider_manifest_id,
         "Causal4D validated a different provider manifest",
     )
-
-    tampered_metadata = deepcopy(dict(attested.metadata))
-    tampered_metadata["prob4d_provider_attestation"]["provider_manifest"][
-        "provider_version"
-    ] = "tampered"
-    tampered = replace(attested, metadata=tampered_metadata)
-    tampered_path = output_dir / "rejected-provider-manifest-tamper.npz"
-    save_observation_belief_export(tampered_path, tampered)
-    rejections = [
-        _expect_failure(
-            "bpt:provider-manifest-tamper", lambda: _validate_bpt(tampered_path)
-        ),
-        _expect_failure(
-            "causal4d:provider-manifest-tamper",
-            lambda: _validate_causal4d(tampered_path),
-        ),
-    ]
+    require(
+        producer["artifact_id"] == bpt["adapter"]["source_observation_belief_id"],
+        "BPT strict adapter lost the claim-bearing observation identity",
+    )
+    require(
+        producer["artifact_id"] == causal4d["artifact_id"],
+        "Causal4D validated a different observation artifact",
+    )
 
     return {
-        "schema": producer["schema_name"],
-        "schema_version": producer["schema_version"],
+        "status": "passed",
+        "schema_version": 2,
         "prob4d_revision": prob4d_revision,
         "observation_artifact_id": attested.artifact_id,
-        "provider_manifest_id": producer_manifest_id,
-        "export_mode": producer["export_mode"],
-        "covariance_root_mode": producer["covariance_root_mode"],
-        "composition_jacobian_mode": producer["composition_jacobian_mode"],
-        "runtime_revision": producer["runtime_revision"],
-        "bpt_provider_attestation_validated": bpt["provider_attestation_validated"],
-        "causal4d_provider_attestation_validated": (
-            causal4d.provider_validation["provider_attestation_validated"]
-        ),
+        "provider_manifest_id": provider_manifest_id,
+        "producer": producer,
+        "bpt": bpt,
+        "causal4d": causal4d,
         "fixture_only": True,
         "claim_evidence": False,
-        "rejections": rejections,
+        "rejections": _rejection_corpus(attested, output_dir),
     }
 
 

--- a/ci/three_repository_provider_v2_attestation.py
+++ b/ci/three_repository_provider_v2_attestation.py
@@ -329,9 +329,9 @@ def _rejection_corpus(artifact: Any, output_dir: Path) -> list[dict[str, str]]:
     results.extend(_consumer_rejections(path, "covariance-fallback"))
 
     def fallback_permission(metadata: dict[str, Any]) -> None:
-        metadata["covariance_calibration"][
-            "pointwise_covariance_fallback_allowed"
-        ] = True
+        metadata["covariance_calibration"]["pointwise_covariance_fallback_allowed"] = (
+            True
+        )
 
     path = output_dir / "rejected-fallback-permission.npz"
     _write_variant(artifact, path, fallback_permission)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -42,6 +42,7 @@ does not need to change. Trusted same-repository pull requests, pushes,
 scheduled runs, and manual dispatches now **fail** when the secret is absent.
 The three-repository workflow is not allowed to report success after skipping
 its checkouts, wheel builds, and compatibility tests.
+
 Tag releases also fail in the main CI workflow when the credential is absent,
 so a skipped pinned-provider job cannot authorize release publication.
 
@@ -64,46 +65,85 @@ missing `BPT_READ_TOKEN` is a hard configuration failure and prevents a false
 green result. Only an external-fork pull request can use the explicitly labelled
 unavailable path, because GitHub withholds repository secrets by design.
 
-The installed-wheel job then:
+The installed-wheel job records the exact clean revision of every checkout,
+builds one wheel for each repository, records each wheel's SHA-256 identity, and
+installs only those wheels plus runtime dependencies into a fresh virtual
+environment. The runner modules are copied outside every source checkout,
+`PYTHONPATH` is unset, and editable or checkout-resolved imports are rejected.
 
-1. records the exact clean revision of every checkout;
-2. builds one wheel for each repository and installs only those wheels plus
-   runtime dependencies into a fresh virtual environment;
-3. copies the runner modules outside every source checkout, unsets `PYTHONPATH`,
-   and rejects editable or checkout-resolved imports;
-4. reconstructs the deterministic Prob4D joint-gauge observation fixture and
+The job then executes two deliberately separate paths.
+
+### Compatibility and frozen-reproduction path
+
+The compatibility path:
+
+1. reconstructs the deterministic Prob4D joint-gauge observation fixture and
    checks its fixed content address;
-5. lets Bayesian-PhysTwin independently validate causal lineage, adapt the
+2. lets Bayesian-PhysTwin independently validate causal lineage, adapt the
    observation to a gauge-aware batch, and execute a deterministic update;
-6. asserts that conditional local covariance is passed unchanged while the
+3. asserts that conditional local covariance is passed unchanged while the
    shared low-rank gauge root remains an explicit nuisance, preventing
    covariance double counting;
-7. lets Causal4D independently recompute observation lineage, bind a
+4. lets Causal4D independently recompute observation lineage, bind a
    content-addressed `TwinBelief`, validate separate scientific-provider-v1 and
    replay-provider-v2 manifests, and execute a CPU-only counterfactual rollout
    through a typed fake provider-v2 implementation;
-8. verifies staged BPT truncation, Causal4D support reduction, composed posterior
+5. verifies staged BPT truncation, Causal4D support reduction, composed posterior
    mass, rejection of inconsistent composition, and exclusion of exact-zero
    support cells from replay;
-9. writes and verifies a clean `RunManifestV2` binding all three Git revisions,
+6. writes and verifies a clean `RunManifestV2` binding all three Git revisions,
    installed package versions, the observation input, `TwinBelief`, rollout
    bank, provider manifest, and method/protocol/split/baseline identifiers;
-10. exercises expected rejections for payload-digest tampering, an opened future
-    payload, a source window crossing the causal cutoff, metric-anchor lineage
-    mismatch, insufficient retained gauge covariance, contradictory stream
-    versions, fixed-lag covariance falsely labelled as strict v2, incomplete
-    evidence manifests, and dirty promotable evidence;
-11. validates immutable replay request IDs, frame provenance, position and
-    velocity histories, and complete resumable-cache reconstruction; and
-12. runs the existing producer, provider, lineage, belief, manifest, cache, and
-    backend tests with `--import-mode=importlib` against the installed wheels.
+7. exercises expected rejections for payload-digest tampering, an opened future
+   payload, a source window crossing the causal cutoff, metric-anchor lineage
+   mismatch, insufficient retained gauge covariance, contradictory stream
+   versions, fixed-lag covariance falsely labelled as strict v2, incomplete
+   evidence manifests, and dirty promotable evidence; and
+8. validates immutable replay request IDs, frame provenance, position and
+   velocity histories, and complete resumable-cache reconstruction.
 
-The workflow uploads `three-repository-summary.json` and the complete runner log
-as the `three-repository-installed-wheel-golden-path` artifact. The JSON summary
-records package origins and repository revisions, the observation artifact ID,
-the BPT update digest, the bound `TwinBelief` ID, rollout digest and shape,
-provider compatibility, staged posterior-mass accounting, the evidence
-fingerprint, and every expected rejection.
+### Strict claim-bearing provider-v2 path
+
+The prospective path constructs a fixture-only, calibrated provider-v2 artifact
+and exercises every strict admission boundary before a physical-state update is
+formed:
+
+1. Prob4D's strict loader requires an explicit causal stream contract v2, the
+   sequential joint gauge tree, canonical shared factors, both calibration IDs,
+   and independently verified runtime provenance;
+2. Bayesian-PhysTwin's claim-bearing adapter validates the producer statement,
+   full cross-window covariance, calibration completeness, and fallback policy
+   before constructing the innovation, then executes the deterministic guarded
+   update twice and requires exact parity;
+3. Causal4D independently recomputes the provider manifest and observation
+   content address, requires the explicit stream-v2 contract and joint
+   covariance, binds the same calibration identities, and refuses lineage with
+   incomplete alignment calibration or any covariance fallback; and
+4. all three consumers must reject provider-manifest tampering, calibration-ID
+   drift, incomplete gauge calibration, recorded covariance fallback,
+   permission for pointwise fallback, and a stream version that is merely
+   inferred rather than explicitly declared.
+
+The fixture uses synthetic calibration identities and is permanently labelled
+`claim_evidence=false`. Passing this path establishes installed-wheel contract
+compatibility and fail-closed admission, not empirical observation quality,
+calibration, or physical-prediction benefit.
+
+The workflow also runs the producer, provider, lineage, belief, manifest, cache,
+and backend test files with `--import-mode=importlib` against the installed
+wheels.
+
+The uploaded `three-repository-installed-wheel-golden-path` artifact contains:
+
+- `three-repository-summary.json` and the compatibility-path log;
+- `three-repository-provider-v2-summary.json` and the strict-path log; and
+- `three-repository-wheel-sha256.txt`, binding the three built wheel bytes.
+
+The summaries record package origins and repository revisions, observation and
+provider-manifest identities, the deterministic BPT update digest, the bound
+`TwinBelief` ID, rollout digest and shape, staged posterior-mass accounting, the
+evidence fingerprint, strict covariance-calibration semantics, and every
+expected rejection.
 
 ## Scheduled and optional checks
 
@@ -133,7 +173,8 @@ python -m venv /tmp/three-repo-venv
 ```
 
 Copy all `Causal4D/ci/three_repository_*.py` modules to one directory outside
-all three checkouts before running the main module, unset `PYTHONPATH`, and pass
+all three checkouts before running the main compatibility module and the strict
+`three_repository_provider_v2_attestation.py` module. Unset `PYTHONPATH`, pass
 the Prob4D fixture, all three exact Git revisions, and each checkout root. The
-runner deliberately fails if it or an installed import resolves under any
+runners deliberately fail if they or an installed import resolve under any
 checkout.

--- a/docs/prob4d_provider_attestation.md
+++ b/docs/prob4d_provider_attestation.md
@@ -32,6 +32,10 @@ The independent checks cover:
 - covariance-root and composition-Jacobian modes; and
 - matched, independently verified runtime revision evidence.
 
+An artifact that labels itself claim-bearing is checked against the complete
+strict boundary even when it enters through the compatibility loader. It cannot
+use the looser entry point to bypass calibration or fallback checks.
+
 ## Prospective claim-bearing boundary
 
 New Prob4D-to-Bayesian-PhysTwin-to-Causal4D evidence should use the strict loader:
@@ -56,14 +60,38 @@ from causal4d.claim_bearing_observation_lineage import (
 lineage = require_claim_bearing_prob4d_lineage(lineage)
 ```
 
-The strict boundary rejects:
+The strict boundary requires all of the following:
+
+- an explicitly declared causal stream contract version 2 using the exclusive
+  frame-stop convention; inferred legacy or joint-stream versions are
+  insufficient;
+- the sequential joint spanning-tree covariance model, canonical shared factor
+  names, one shared factor group, and preserved cross-window covariance;
+- metric-anchor uncertainty represented inside the joint factor;
+- calibrated covariance metadata with valid gauge and point calibration IDs
+  identical to the IDs embedded in the provider attestation;
+- `gauge_calibrated_alignment_count == alignment_count`;
+- both uncalibrated covariance and pointwise fallback permissions set to false;
+- an empty covariance-fallback count, proving that no fallback was used; and
+- matched, independently verified runtime revision evidence.
+
+It therefore rejects:
 
 - provider-v1 artifacts without a provider-v2 attestation;
 - exploratory provider-v2 exports;
 - fixed-lag products without the strict causal-stream contract;
 - missing or incompatible covariance calibrations;
+- partially calibrated gauge alignments;
+- calibration-identity drift between metadata and attestation;
+- permission for uncalibrated or pointwise covariance fallback;
+- any recorded covariance fallback use;
 - legacy covariance roots or composition derivatives; and
 - environment-only, mismatched, unavailable, or dirty runtime provenance.
+
+The installed-wheel three-repository workflow exercises the same artifact
+through Prob4D's strict loader, Bayesian-PhysTwin's claim-bearing adapter and
+update, and Causal4D's strict lineage loader. It also requires all three layers
+to reject the same tampered and fallback-bearing variants.
 
 This validation establishes provenance and contract consistency, not empirical
 observation quality, covariance calibration, or downstream physical-prediction

--- a/src/causal4d/claim_bearing_observation_lineage.py
+++ b/src/causal4d/claim_bearing_observation_lineage.py
@@ -33,6 +33,18 @@ def require_claim_bearing_prob4d_lineage(
             "claim-bearing Prob4D observation requires explicit causal stream "
             "contract version 2"
         )
+    stream_contract = validation.get("claim_bearing_stream_contract")
+    if not isinstance(stream_contract, Mapping):
+        raise ValueError(
+            "claim-bearing Prob4D causal stream contract was not validated"
+        )
+    if (
+        stream_contract.get("version")
+        != PROB4D_CAUSAL_STREAM_CONTRACT_VERSION
+        or stream_contract.get("causal_frame_stop_convention") != "exclusive"
+    ):
+        raise ValueError("claim-bearing Prob4D causal stream contract is invalid")
+
     if (
         validation.get("covariance_semantics") != PROB4D_JOINT_GAUGE_MODEL
         or validation.get("cross_window_covariance_preserved") is not True

--- a/src/causal4d/claim_bearing_observation_lineage.py
+++ b/src/causal4d/claim_bearing_observation_lineage.py
@@ -6,29 +6,63 @@ from collections.abc import Mapping
 from pathlib import Path
 
 from .observation_lineage import ObservationLineage, load_observation_lineage
+from .prob4d_observation_lineage import (
+    PROB4D_CAUSAL_STREAM_CONTRACT_VERSION,
+    PROB4D_JOINT_GAUGE_MODEL,
+)
 
 
 def require_claim_bearing_prob4d_lineage(
     lineage: ObservationLineage,
 ) -> ObservationLineage:
-    """Reject provider-v1, exploratory, or approximate Prob4D lineage."""
+    """Reject provider-v1, exploratory, approximate, or fallback-bearing lineage."""
 
     validation = lineage.provider_validation
     if not isinstance(validation, Mapping):
         raise ValueError("a validated Prob4D provider boundary is required")
-    if validation.get("strict_causal_stream_contract") is not True:
+    if validation.get("claim_bearing_provider_v2_validated") is not True:
         raise ValueError(
-            "claim-bearing Prob4D observation requires a strict causal stream contract"
+            "the complete claim-bearing Prob4D provider-v2 boundary was not validated"
         )
+    if (
+        validation.get("stream_contract_version")
+        != PROB4D_CAUSAL_STREAM_CONTRACT_VERSION
+        or validation.get("stream_contract_version_inferred") is not False
+    ):
+        raise ValueError(
+            "claim-bearing Prob4D observation requires explicit causal stream "
+            "contract version 2"
+        )
+    if (
+        validation.get("covariance_semantics") != PROB4D_JOINT_GAUGE_MODEL
+        or validation.get("cross_window_covariance_preserved") is not True
+    ):
+        raise ValueError(
+            "claim-bearing Prob4D observation requires full joint cross-window "
+            "gauge covariance"
+        )
+
     provider = validation.get("provider_attestation")
     if not isinstance(provider, Mapping):
         raise ValueError("a claim-bearing Prob4D provider-v2 attestation is required")
     if provider.get("claim_bearing") is not True:
-        raise ValueError("exploratory Prob4D provider-v2 artifacts are not claim-bearing")
+        raise ValueError(
+            "exploratory Prob4D provider-v2 artifacts are not claim-bearing"
+        )
     if provider.get("calibration_compatibility_validated") is not True:
         raise ValueError("Prob4D calibration compatibility was not validated")
     if provider.get("runtime_revision_independently_verified") is not True:
         raise ValueError("Prob4D runtime revision was not independently verified")
+
+    calibration = validation.get("claim_bearing_covariance_calibration")
+    if not isinstance(calibration, Mapping):
+        raise ValueError(
+            "claim-bearing Prob4D covariance calibration was not validated"
+        )
+    if calibration.get("status") != "calibrated":
+        raise ValueError("claim-bearing Prob4D covariance calibration is incomplete")
+    if calibration.get("covariance_fallback_counts") != {}:
+        raise ValueError("claim-bearing Prob4D covariance fallback use is not allowed")
     return lineage
 
 

--- a/src/causal4d/claim_bearing_observation_lineage.py
+++ b/src/causal4d/claim_bearing_observation_lineage.py
@@ -39,8 +39,7 @@ def require_claim_bearing_prob4d_lineage(
             "claim-bearing Prob4D causal stream contract was not validated"
         )
     if (
-        stream_contract.get("version")
-        != PROB4D_CAUSAL_STREAM_CONTRACT_VERSION
+        stream_contract.get("version") != PROB4D_CAUSAL_STREAM_CONTRACT_VERSION
         or stream_contract.get("causal_frame_stop_convention") != "exclusive"
     ):
         raise ValueError("claim-bearing Prob4D causal stream contract is invalid")

--- a/src/causal4d/prob4d_observation_lineage.py
+++ b/src/causal4d/prob4d_observation_lineage.py
@@ -34,6 +34,27 @@ PROB4D_CAUSAL_STREAM_CONTRACT_VERSION = 2
 PROB4D_LEGACY_COVARIANCE_SEMANTICS = "legacy_per_window_sim3_marginals_v1"
 
 
+def _require_mapping(value: object, *, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    return value
+
+
+def _require_sha256(value: object, *, name: str) -> str:
+    digest = str(value)
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _require_nonnegative_integer(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return value
+
+
 def _resolved_stream_contract(
     metadata: Mapping[str, Any],
     covariance_semantics: object,
@@ -110,6 +131,90 @@ def _provider_attestation_summary(
     }
 
 
+def _claim_bearing_calibration_summary(
+    metadata: Mapping[str, Any],
+    provider: Mapping[str, Any],
+) -> dict[str, object]:
+    calibration = _require_mapping(
+        metadata.get("covariance_calibration"),
+        name="claim-bearing Prob4D covariance calibration metadata",
+    )
+    if calibration.get("status") != "calibrated":
+        raise ValueError(
+            "claim-bearing Prob4D observation requires calibrated covariance metadata"
+        )
+    if calibration.get("uncalibrated_exploratory_covariance_allowed") is not False:
+        raise ValueError(
+            "claim-bearing Prob4D observation cannot allow uncalibrated covariance"
+        )
+    if calibration.get("pointwise_covariance_fallback_allowed") is not False:
+        raise ValueError(
+            "claim-bearing Prob4D observation cannot allow pointwise covariance "
+            "fallback"
+        )
+
+    alignment_count = _require_nonnegative_integer(
+        calibration.get("alignment_count"),
+        name="claim-bearing Prob4D alignment_count",
+    )
+    calibrated_alignment_count = _require_nonnegative_integer(
+        calibration.get("gauge_calibrated_alignment_count"),
+        name="claim-bearing Prob4D gauge_calibrated_alignment_count",
+    )
+    if calibrated_alignment_count != alignment_count:
+        raise ValueError(
+            "claim-bearing Prob4D observation has uncalibrated gauge alignments"
+        )
+    fallback_counts = _require_mapping(
+        calibration.get("covariance_fallback_counts"),
+        name="claim-bearing Prob4D covariance fallback counts",
+    )
+    if fallback_counts:
+        raise ValueError(
+            "claim-bearing Prob4D observation reports covariance fallback use"
+        )
+
+    attested_ids = _require_mapping(
+        provider.get("calibration_artifact_ids"),
+        name="attested Prob4D calibration artifact IDs",
+    )
+    gauge_id = _require_sha256(
+        calibration.get("gauge_artifact_id"),
+        name="Prob4D gauge calibration artifact ID",
+    )
+    point_id = _require_sha256(
+        calibration.get("point_artifact_id"),
+        name="Prob4D point calibration artifact ID",
+    )
+    if gauge_id != _require_sha256(
+        attested_ids.get("gauge_artifact_id"),
+        name="attested Prob4D gauge calibration artifact ID",
+    ):
+        raise ValueError(
+            "Prob4D gauge calibration metadata differs from its provider attestation"
+        )
+    if point_id != _require_sha256(
+        attested_ids.get("point_artifact_id"),
+        name="attested Prob4D point calibration artifact ID",
+    ):
+        raise ValueError(
+            "Prob4D point calibration metadata differs from its provider attestation"
+        )
+
+    return {
+        "status": "calibrated",
+        "calibration_artifact_ids": {
+            "gauge_artifact_id": gauge_id,
+            "point_artifact_id": point_id,
+        },
+        "alignment_count": alignment_count,
+        "gauge_calibrated_alignment_count": calibrated_alignment_count,
+        "covariance_fallback_counts": {},
+        "uncalibrated_exploratory_covariance_allowed": False,
+        "pointwise_covariance_fallback_allowed": False,
+    }
+
+
 def validate_prob4d_causal_observation_metadata(
     descriptor: Mapping[str, Any],
     arrays: Mapping[str, np.ndarray],
@@ -120,7 +225,9 @@ def validate_prob4d_causal_observation_metadata(
 
     Frozen provider-v1 artifacts remain valid when no attestation is present. New
     prospective evidence can set ``require_claim_bearing_provider_v2=True`` to
-    reject provider-v1 and exploratory provider-v2 artifacts.
+    reject provider-v1 and exploratory provider-v2 artifacts. An artifact that
+    labels itself claim-bearing is always checked against the complete calibrated
+    provider-v2 boundary, even when loaded through the compatibility entry point.
     """
 
     result = dict(_validate_prob4d_semantics(descriptor, arrays))
@@ -144,9 +251,28 @@ def validate_prob4d_causal_observation_metadata(
         provider_attestation_validated=provider is not None,
         provider_attestation=provider,
     )
-    if require_claim_bearing_provider_v2 and version is None:
-        raise ValueError(
-            "claim-bearing Prob4D observation requires a strict causal stream contract"
+
+    claim_bearing = provider is not None and provider.get("claim_bearing") is True
+    if require_claim_bearing_provider_v2 and not claim_bearing:
+        raise ValueError("a claim-bearing Prob4D provider-v2 attestation is required")
+    if claim_bearing:
+        if version != PROB4D_CAUSAL_STREAM_CONTRACT_VERSION or inferred:
+            raise ValueError(
+                "claim-bearing Prob4D observation requires explicit causal stream "
+                "contract version 2"
+            )
+        if (
+            result.get("covariance_semantics") != PROB4D_JOINT_GAUGE_MODEL
+            or result.get("cross_window_covariance_preserved") is not True
+        ):
+            raise ValueError(
+                "claim-bearing Prob4D observation requires the full joint cross-window "
+                "gauge covariance"
+            )
+        calibration = _claim_bearing_calibration_summary(metadata, provider)
+        result.update(
+            claim_bearing_provider_v2_validated=True,
+            claim_bearing_covariance_calibration=calibration,
         )
     return result
 
@@ -155,13 +281,16 @@ def validate_claim_bearing_prob4d_observation_metadata(
     descriptor: Mapping[str, Any],
     arrays: Mapping[str, np.ndarray],
 ) -> dict[str, object]:
-    """Require a calibrated provider-v2 artifact and strict causal stream."""
+    """Require calibrated provider-v2 evidence on the explicit strict stream."""
 
-    return validate_prob4d_causal_observation_metadata(
+    result = validate_prob4d_causal_observation_metadata(
         descriptor,
         arrays,
         require_claim_bearing_provider_v2=True,
     )
+    if result.get("claim_bearing_provider_v2_validated") is not True:
+        raise ValueError("claim-bearing Prob4D provider-v2 validation did not complete")
+    return result
 
 
 __all__ = [

--- a/src/causal4d/prob4d_observation_lineage.py
+++ b/src/causal4d/prob4d_observation_lineage.py
@@ -125,9 +125,7 @@ def _provider_attestation_summary(
         "covariance_root_mode": validated["covariance_root_mode"],
         "composition_jacobian_mode": validated["composition_jacobian_mode"],
         "runtime_revision_source": runtime["source"],
-        "runtime_revision_independently_verified": runtime[
-            "independently_verified"
-        ],
+        "runtime_revision_independently_verified": runtime["independently_verified"],
     }
 
 
@@ -139,9 +137,7 @@ def _claim_bearing_stream_contract_summary(
         name="claim-bearing Prob4D causal stream contract",
     )
     if contract.get("version") != PROB4D_CAUSAL_STREAM_CONTRACT_VERSION:
-        raise ValueError(
-            "claim-bearing Prob4D causal stream contract changed version"
-        )
+        raise ValueError("claim-bearing Prob4D causal stream contract changed version")
     if contract.get("causal_frame_stop_convention") != "exclusive":
         raise ValueError(
             "claim-bearing Prob4D causal stream must use an exclusive frame stop"

--- a/src/causal4d/prob4d_observation_lineage.py
+++ b/src/causal4d/prob4d_observation_lineage.py
@@ -131,6 +131,27 @@ def _provider_attestation_summary(
     }
 
 
+def _claim_bearing_stream_contract_summary(
+    metadata: Mapping[str, Any],
+) -> dict[str, object]:
+    contract = _require_mapping(
+        metadata.get("prob4d_causal_stream_contract"),
+        name="claim-bearing Prob4D causal stream contract",
+    )
+    if contract.get("version") != PROB4D_CAUSAL_STREAM_CONTRACT_VERSION:
+        raise ValueError(
+            "claim-bearing Prob4D causal stream contract changed version"
+        )
+    if contract.get("causal_frame_stop_convention") != "exclusive":
+        raise ValueError(
+            "claim-bearing Prob4D causal stream must use an exclusive frame stop"
+        )
+    return {
+        "version": PROB4D_CAUSAL_STREAM_CONTRACT_VERSION,
+        "causal_frame_stop_convention": "exclusive",
+    }
+
+
 def _claim_bearing_calibration_summary(
     metadata: Mapping[str, Any],
     provider: Mapping[str, Any],
@@ -269,9 +290,11 @@ def validate_prob4d_causal_observation_metadata(
                 "claim-bearing Prob4D observation requires the full joint cross-window "
                 "gauge covariance"
             )
+        stream_contract = _claim_bearing_stream_contract_summary(metadata)
         calibration = _claim_bearing_calibration_summary(metadata, provider)
         result.update(
             claim_bearing_provider_v2_validated=True,
+            claim_bearing_stream_contract=stream_contract,
             claim_bearing_covariance_calibration=calibration,
         )
     return result

--- a/tests/test_prob4d_stream_contract_version.py
+++ b/tests/test_prob4d_stream_contract_version.py
@@ -97,6 +97,10 @@ def _provider_attestation() -> dict[str, object]:
 def _claim_bearing_metadata() -> dict[str, object]:
     return {
         "prob4d_causal_stream_contract_version": 2,
+        "prob4d_causal_stream_contract": {
+            "version": 2,
+            "causal_frame_stop_convention": "exclusive",
+        },
         "prob4d_provider_attestation": _provider_attestation(),
         "covariance_calibration": {
             "status": "calibrated",
@@ -181,6 +185,10 @@ def test_claim_bearing_provider_attestation_is_validated_independently(
         "point_artifact_id": "2" * 64,
     }
     assert calibration["covariance_fallback_counts"] == {}
+    assert result["claim_bearing_stream_contract"] == {
+        "version": 2,
+        "causal_frame_stop_convention": "exclusive",
+    }
 
 
 def test_strict_provider_validation_rejects_provider_v1_artifact(monkeypatch) -> None:
@@ -301,6 +309,18 @@ def test_claim_bearing_requires_explicit_stream_v2(monkeypatch) -> None:
         lineage.validate_claim_bearing_prob4d_observation_metadata(descriptor, {})
 
 
+def test_claim_bearing_requires_explicit_stream_contract_metadata(monkeypatch) -> None:
+    monkeypatch.setattr(
+        lineage,
+        "_validate_prob4d_semantics",
+        lambda descriptor, arrays: _semantic_result(lineage.PROB4D_JOINT_GAUGE_MODEL),
+    )
+    descriptor = _claim_bearing_descriptor()
+    descriptor["metadata"].pop("prob4d_causal_stream_contract")
+    with pytest.raises(ValueError, match="causal stream contract"):
+        lineage.validate_claim_bearing_prob4d_observation_metadata(descriptor, {})
+
+
 def test_claim_bearing_lineage_wrapper_requires_validated_summary() -> None:
     provider = {
         "claim_bearing": True,
@@ -319,6 +339,10 @@ def test_claim_bearing_lineage_wrapper_requires_validated_summary() -> None:
             "stream_contract_version_inferred": False,
             "covariance_semantics": lineage.PROB4D_JOINT_GAUGE_MODEL,
             "cross_window_covariance_preserved": True,
+            "claim_bearing_stream_contract": {
+                "version": 2,
+                "causal_frame_stop_convention": "exclusive",
+            },
             "provider_attestation": provider,
             "claim_bearing_covariance_calibration": calibration,
         }

--- a/tests/test_prob4d_stream_contract_version.py
+++ b/tests/test_prob4d_stream_contract_version.py
@@ -20,6 +20,9 @@ def _semantic_result(value: str) -> dict[str, object]:
     return {
         "validated": True,
         "covariance_semantics": value,
+        "cross_window_covariance_preserved": (
+            value == lineage.PROB4D_JOINT_GAUGE_MODEL
+        ),
     }
 
 
@@ -91,6 +94,30 @@ def _provider_attestation() -> dict[str, object]:
     }
 
 
+def _claim_bearing_metadata() -> dict[str, object]:
+    return {
+        "prob4d_causal_stream_contract_version": 2,
+        "prob4d_provider_attestation": _provider_attestation(),
+        "covariance_calibration": {
+            "status": "calibrated",
+            "gauge_artifact_id": "1" * 64,
+            "point_artifact_id": "2" * 64,
+            "alignment_count": 2,
+            "gauge_calibrated_alignment_count": 2,
+            "covariance_fallback_counts": {},
+            "uncalibrated_exploratory_covariance_allowed": False,
+            "pointwise_covariance_fallback_allowed": False,
+        },
+    }
+
+
+def _claim_bearing_descriptor() -> dict[str, object]:
+    return {
+        "source_revision": "a" * 40,
+        "metadata": _claim_bearing_metadata(),
+    }
+
+
 def test_legacy_stream_version_is_inferred(monkeypatch) -> None:
     monkeypatch.setattr(
         lineage,
@@ -137,22 +164,23 @@ def test_claim_bearing_provider_attestation_is_validated_independently(
         lambda descriptor, arrays: _semantic_result(lineage.PROB4D_JOINT_GAUGE_MODEL),
     )
     result = lineage.validate_claim_bearing_prob4d_observation_metadata(
-        {
-            "source_revision": "a" * 40,
-            "metadata": {
-                "prob4d_causal_stream_contract_version": 2,
-                "prob4d_provider_attestation": _provider_attestation(),
-            },
-        },
+        _claim_bearing_descriptor(),
         {},
     )
 
     provider = result["provider_attestation"]
+    calibration = result["claim_bearing_covariance_calibration"]
     assert result["provider_attestation_present"] is True
     assert result["provider_attestation_validated"] is True
+    assert result["claim_bearing_provider_v2_validated"] is True
     assert provider["provider_api_version"] == 2
     assert provider["claim_bearing"] is True
     assert provider["runtime_revision_independently_verified"] is True
+    assert calibration["calibration_artifact_ids"] == {
+        "gauge_artifact_id": "1" * 64,
+        "point_artifact_id": "2" * 64,
+    }
+    assert calibration["covariance_fallback_counts"] == {}
 
 
 def test_strict_provider_validation_rejects_provider_v1_artifact(monkeypatch) -> None:
@@ -216,28 +244,99 @@ def test_rehashed_provider_capability_removal_is_rejected(monkeypatch) -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (
+            lambda metadata: metadata["covariance_calibration"].__setitem__(
+                "gauge_artifact_id", "3" * 64
+            ),
+            "gauge calibration metadata differs",
+        ),
+        (
+            lambda metadata: metadata["covariance_calibration"].__setitem__(
+                "gauge_calibrated_alignment_count", 1
+            ),
+            "uncalibrated gauge alignments",
+        ),
+        (
+            lambda metadata: metadata["covariance_calibration"].__setitem__(
+                "covariance_fallback_counts", {"pointwise": 1}
+            ),
+            "reports covariance fallback use",
+        ),
+        (
+            lambda metadata: metadata["covariance_calibration"].__setitem__(
+                "pointwise_covariance_fallback_allowed", True
+            ),
+            "cannot allow pointwise covariance fallback",
+        ),
+    ],
+)
+def test_claim_bearing_calibration_failures_are_rejected(
+    monkeypatch,
+    mutation,
+    message: str,
+) -> None:
+    monkeypatch.setattr(
+        lineage,
+        "_validate_prob4d_semantics",
+        lambda descriptor, arrays: _semantic_result(lineage.PROB4D_JOINT_GAUGE_MODEL),
+    )
+    descriptor = _claim_bearing_descriptor()
+    mutation(descriptor["metadata"])
+    with pytest.raises(ValueError, match=message):
+        lineage.validate_prob4d_causal_observation_metadata(descriptor, {})
+
+
+def test_claim_bearing_requires_explicit_stream_v2(monkeypatch) -> None:
+    monkeypatch.setattr(
+        lineage,
+        "_validate_prob4d_semantics",
+        lambda descriptor, arrays: _semantic_result(lineage.PROB4D_JOINT_GAUGE_MODEL),
+    )
+    descriptor = _claim_bearing_descriptor()
+    descriptor["metadata"].pop("prob4d_causal_stream_contract_version")
+    with pytest.raises(ValueError, match="requires explicit causal stream contract"):
+        lineage.validate_claim_bearing_prob4d_observation_metadata(descriptor, {})
+
+
 def test_claim_bearing_lineage_wrapper_requires_validated_summary() -> None:
     provider = {
         "claim_bearing": True,
         "calibration_compatibility_validated": True,
         "runtime_revision_independently_verified": True,
     }
+    calibration = {
+        "status": "calibrated",
+        "covariance_fallback_counts": {},
+    }
     candidate = SimpleNamespace(
         provider_validation={
+            "claim_bearing_provider_v2_validated": True,
             "strict_causal_stream_contract": True,
+            "stream_contract_version": 2,
+            "stream_contract_version_inferred": False,
+            "covariance_semantics": lineage.PROB4D_JOINT_GAUGE_MODEL,
+            "cross_window_covariance_preserved": True,
             "provider_attestation": provider,
+            "claim_bearing_covariance_calibration": calibration,
         }
     )
     assert require_claim_bearing_prob4d_lineage(candidate) is candidate
 
-    with pytest.raises(ValueError, match="provider-v2 attestation is required"):
+    incomplete = copy.deepcopy(candidate.provider_validation)
+    incomplete["claim_bearing_provider_v2_validated"] = False
+    with pytest.raises(ValueError, match="complete claim-bearing"):
         require_claim_bearing_prob4d_lineage(
-            SimpleNamespace(
-                provider_validation={
-                    "strict_causal_stream_contract": True,
-                    "provider_attestation": None,
-                }
-            )
+            SimpleNamespace(provider_validation=incomplete)
+        )
+
+    missing_calibration = copy.deepcopy(candidate.provider_validation)
+    missing_calibration.pop("claim_bearing_covariance_calibration")
+    with pytest.raises(ValueError, match="covariance calibration"):
+        require_claim_bearing_prob4d_lineage(
+            SimpleNamespace(provider_validation=missing_calibration)
         )
 
 

--- a/tests/test_three_repository_workflow_policy.py
+++ b/tests/test_three_repository_workflow_policy.py
@@ -41,7 +41,7 @@ def test_strict_claim_bearing_path_is_mandatory_and_fail_closed() -> None:
     assert "bayesian-phystwin/tests/test_prob4d_causal_lineage.py" in text
     assert "causal4d/tests/test_prob4d_stream_contract_version.py" in text
     assert text.count("set -o pipefail") >= 2
-    assert text.count("python\" -m json.tool") >= 2
+    assert text.count('python" -m json.tool') >= 2
     assert text.count('test -s "$RUNNER_TEMP/three-repository-') >= 2
 
 

--- a/tests/test_three_repository_workflow_policy.py
+++ b/tests/test_three_repository_workflow_policy.py
@@ -29,3 +29,23 @@ def test_external_fork_limitation_is_separate_and_explicit() -> None:
     assert "External PR cannot access private providers" in text
     assert "github.event.pull_request.head.repo.full_name != github.repository" in text
     assert "maintainers must run the installed-wheel golden path" in text
+
+
+def test_strict_claim_bearing_path_is_mandatory() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Run strict claim-bearing provider-v2 admission path" in text
+    assert "three_repository_provider_v2_attestation.py" in text
+    assert "three-repository-provider-v2-summary.json" in text
+    assert "prob4d/tests/test_claim_bearing_observation.py" in text
+    assert "bayesian-phystwin/tests/test_prob4d_causal_lineage.py" in text
+    assert "causal4d/tests/test_prob4d_stream_contract_version.py" in text
+
+
+def test_built_wheels_receive_persistent_content_identities() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Record wheel SHA-256 identities" in text
+    assert "sha256sum ./*.whl | sort" in text
+    assert "three-repository-wheel-sha256.txt" in text
+    assert "Wheel SHA-256 identities" in text

--- a/tests/test_three_repository_workflow_policy.py
+++ b/tests/test_three_repository_workflow_policy.py
@@ -31,7 +31,7 @@ def test_external_fork_limitation_is_separate_and_explicit() -> None:
     assert "maintainers must run the installed-wheel golden path" in text
 
 
-def test_strict_claim_bearing_path_is_mandatory() -> None:
+def test_strict_claim_bearing_path_is_mandatory_and_fail_closed() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
 
     assert "Run strict claim-bearing provider-v2 admission path" in text
@@ -40,6 +40,9 @@ def test_strict_claim_bearing_path_is_mandatory() -> None:
     assert "prob4d/tests/test_claim_bearing_observation.py" in text
     assert "bayesian-phystwin/tests/test_prob4d_causal_lineage.py" in text
     assert "causal4d/tests/test_prob4d_stream_contract_version.py" in text
+    assert text.count("set -o pipefail") >= 2
+    assert text.count("python\" -m json.tool") >= 2
+    assert text.count('test -s "$RUNNER_TEMP/three-repository-') >= 2
 
 
 def test_built_wheels_receive_persistent_content_identities() -> None:


### PR DESCRIPTION
## Summary

- make Causal4D independently enforce the complete prospective Prob4D provider-v2 boundary: an explicitly declared causal stream contract v2, full joint cross-window gauge covariance, complete gauge/point calibration, calibration IDs matching the provider attestation, and no covariance fallback permission or recorded fallback use;
- run a strict fixture-only Prob4D → Bayesian-PhysTwin → Causal4D installed-wheel path that validates the producer artifact, forms a Bayesian-PhysTwin innovation only after strict admission, executes the deterministic guarded update twice with exact parity, and independently admits the same lineage in Causal4D;
- require all three installed consumers to reject provider-manifest tampering, calibration-ID drift, incomplete gauge calibration, recorded fallback, fallback permission, and an inferred rather than explicit stream version;
- make both piped runner steps fail closed with `pipefail`, require nonempty parseable JSON summaries, record SHA-256 identities for all three built wheels, and publish separate compatibility and strict summaries;
- expand workflow policy tests and document the exact contract and scientific boundary.

## Coordinated producer fix

The strict installed-wheel runner exposed that Prob4D's own claim-bearing loader did not yet enforce alignment-complete calibration and fallback prohibition. That producer-side gap was fixed and merged independently as FlorianPfaff/Prob4D#44 at `7cf9568651786a214d2073f4402af366d9319eca`.

The first strict runner attempt also exposed a workflow-policy bug: Bash returned `tee`'s success even when the Python runner raised. This PR now uses `set -o pipefail` and verifies that each summary exists, is nonempty, and parses as JSON before the job can pass.

## Validation

All required workflows are green on head `8964f7f5920467229b8500bb51881f714af1266f`:

- `CI and release` run 376: Ruff, incremental formatting, mypy, Python 3.10/3.12/3.14 core suites, pinned Bayesian-PhysTwin integration, wheel/sdist build and installation, every CLI help surface, deterministic result bundles, and frozen-manifest validation;
- `Extended compatibility` run 10: passed;
- `Three-repository installed-wheel compatibility` run 63: clean Prob4D, Bayesian-PhysTwin, and Causal4D wheels built and installed outside their source trees; ordinary and strict golden paths passed; cross-repository installed-wheel tests passed.

The strict summary records:

- Prob4D revision `7cf9568651786a214d2073f4402af366d9319eca`;
- observation artifact `8561023e99dcae13a52e7785757479b47c053b1b615c5c70acbec7fc0a39b170`;
- provider manifest `97d14c9d7e7cf33d244711d890e2c1d194950a95976365353116833d6494c567`;
- deterministic BPT update `fd3e102bf8d3f027ffeb719b5575100deb830928aa3662f31f6a9094700f63f0`;
- complete 2/2 gauge calibration, no fallback permission or use, and no low-rank covariance double counting;
- 18 expected rejections: six adversarial conditions independently rejected by Prob4D, Bayesian-PhysTwin, and Causal4D.

Built-wheel SHA-256 identities:

- Causal4D: `03e1e9452d5e10845816dc9fe8aef5a17fcf4b2638207cfef65a783b7458d032`;
- Prob4D: `a49b93fd27fdf7bae7408ac0773ce6579d54035cf8a6831689c53ca85a90f7ad`;
- Bayesian-PhysTwin: `ffe7b0723776e9f96e16fe9a2f11f0b60b43e1a8edcbc1b9a7953a1bf6ca38e3`.

## Scientific boundary

The provider-v2 fixture uses synthetic calibration identities and is permanently labelled `claim_evidence=false`. Passing this path establishes installed-wheel compatibility, provenance consistency, and fail-closed admission only. It is not evidence of empirical covariance calibration, observation quality, or physical-prediction benefit.