### PR TITLE
Harden Molmo artifact immutability

### DIFF
--- a/src/causal4d/molmo_adapter.py
+++ b/src/causal4d/molmo_adapter.py
@@ -10,6 +10,18 @@ from typing import Any, Mapping
 import numpy as np
 
 
+def _readonly_array(
+    values: np.ndarray,
+    *,
+    dtype: np.dtype | type,
+) -> np.ndarray:
+    """Return an owned, immutable NumPy array."""
+
+    array = np.asarray(values, dtype=dtype).copy()
+    array.setflags(write=False)
+    return array
+
+
 def load_trusted_legacy_phystwin_pickle(*args: Any, **kwargs: Any) -> Any:
     """Load a hash-locked legacy artifact without importing BPT at module import."""
 
@@ -76,13 +88,13 @@ class MolmoPhysTwinQuery:
     calibration_sha256: str | None = None
 
     def __post_init__(self) -> None:
-        history = np.asarray(self.history_frame_indices, dtype=int)
-        nodes = np.asarray(self.node_indices, dtype=int)
-        raw_tracks = np.asarray(self.raw_track_indices, dtype=int)
-        points_2d = np.asarray(self.points_2d_xy, dtype=float)
-        points_3d = np.asarray(self.points_3d_world_history_m, dtype=float)
-        camera_to_world = np.asarray(self.camera_to_world, dtype=float)
-        intrinsics = np.asarray(self.intrinsics, dtype=float)
+        history = _readonly_array(self.history_frame_indices, dtype=int)
+        nodes = _readonly_array(self.node_indices, dtype=int)
+        raw_tracks = _readonly_array(self.raw_track_indices, dtype=int)
+        points_2d = _readonly_array(self.points_2d_xy, dtype=float)
+        points_3d = _readonly_array(self.points_3d_world_history_m, dtype=float)
+        camera_to_world = _readonly_array(self.camera_to_world, dtype=float)
+        intrinsics = _readonly_array(self.intrinsics, dtype=float)
         point_count = len(nodes)
         expected_history = tuple(
             range(
@@ -153,7 +165,9 @@ class MolmoPhysTwinQuery:
             "frame_stride": self.frame_stride,
             "final_data_sha256": self.final_data_sha256,
             "calibration_sha256": self.calibration_sha256,
-            "point_coordinate_contract": "raw row/column tracks converted to x/y pixels",
+            "point_coordinate_contract": (
+                "raw row/column tracks converted to x/y pixels"
+            ),
             "trajectory_coordinate_contract": "metric world coordinates",
             "temporal_contract": "history and future sampled at forecast_fps",
         }
@@ -268,7 +282,8 @@ def prepare_molmo_phystwin_query(
     candidates = candidates_by_camera[camera]
     if len(candidates) < point_count:
         raise ValueError(
-            f"camera {camera} has only {len(candidates)} valid tracks; need {point_count}"
+            f"camera {camera} has only {len(candidates)} valid tracks; "
+            f"need {point_count}"
         )
     selected_local = farthest_point_indices(object_points[t0, candidates], point_count)
     nodes = candidates[selected_local]
@@ -323,8 +338,8 @@ class MolmoForecastBundle:
     checkpoint: str
 
     def __post_init__(self) -> None:
-        camera = np.asarray(self.future_camera_m, dtype=float)
-        world = np.asarray(self.future_world_m, dtype=float)
+        camera = _readonly_array(self.future_camera_m, dtype=float)
+        world = _readonly_array(self.future_world_m, dtype=float)
         expected_prefix = (len(self.forecast_ids), len(self.query.node_indices))
         if (
             camera.ndim != 4

--- a/tests/test_causal4d_molmo_immutability.py
+++ b/tests/test_causal4d_molmo_immutability.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from causal4d.molmo_adapter import MolmoForecastBundle, MolmoPhysTwinQuery
+
+
+def _query(tmp_path: Path) -> tuple[MolmoPhysTwinQuery, dict[str, np.ndarray]]:
+    image_paths = []
+    for frame in (0, 2, 4):
+        image_path = tmp_path / f"{frame}.png"
+        image_path.write_bytes(b"image")
+        image_paths.append(image_path)
+
+    inputs = {
+        "history": np.asarray([0, 2, 4], dtype=int),
+        "nodes": np.asarray([1, 3], dtype=int),
+        "raw_tracks": np.asarray([7, 9], dtype=int),
+        "points_2d": np.asarray([[10.0, 20.0], [30.0, 40.0]]),
+        "points_3d": np.arange(18, dtype=float).reshape(3, 2, 3),
+        "camera_to_world": np.eye(4),
+        "intrinsics": np.eye(3),
+    }
+    query = MolmoPhysTwinQuery(
+        case_name="synthetic",
+        raw_case_dir=tmp_path,
+        camera_index=0,
+        t0_frame=4,
+        history_frame_indices=inputs["history"],
+        image_paths=tuple(image_paths),
+        node_indices=inputs["nodes"],
+        raw_track_indices=inputs["raw_tracks"],
+        points_2d_xy=inputs["points_2d"],
+        points_3d_world_history_m=inputs["points_3d"],
+        camera_to_world=inputs["camera_to_world"],
+        intrinsics=inputs["intrinsics"],
+        source_fps=30.0,
+        forecast_fps=15.0,
+        frame_stride=2,
+    )
+    return query, inputs
+
+
+def test_molmo_query_arrays_are_owned_and_read_only(tmp_path: Path) -> None:
+    query, inputs = _query(tmp_path)
+    expected = {
+        "history": query.history_frame_indices.copy(),
+        "nodes": query.node_indices.copy(),
+        "raw_tracks": query.raw_track_indices.copy(),
+        "points_2d": query.points_2d_xy.copy(),
+        "points_3d": query.points_3d_world_history_m.copy(),
+        "camera_to_world": query.camera_to_world.copy(),
+        "intrinsics": query.intrinsics.copy(),
+    }
+
+    for values in inputs.values():
+        values[...] = -123
+
+    pairs = (
+        (query.history_frame_indices, expected["history"]),
+        (query.node_indices, expected["nodes"]),
+        (query.raw_track_indices, expected["raw_tracks"]),
+        (query.points_2d_xy, expected["points_2d"]),
+        (query.points_3d_world_history_m, expected["points_3d"]),
+        (query.camera_to_world, expected["camera_to_world"]),
+        (query.intrinsics, expected["intrinsics"]),
+    )
+    for actual, frozen in pairs:
+        np.testing.assert_array_equal(actual, frozen)
+        assert not actual.flags.writeable
+        with pytest.raises(ValueError, match="read-only"):
+            actual[...] = 0
+
+
+def test_molmo_forecast_arrays_are_owned_and_read_only(tmp_path: Path) -> None:
+    query, _ = _query(tmp_path)
+    camera = np.arange(36, dtype=float).reshape(2, 2, 3, 3)
+    world = camera + 100.0
+    expected_camera = camera.copy()
+    expected_world = world.copy()
+
+    bundle = MolmoForecastBundle(
+        query=query,
+        forecast_ids=("lift", "lower"),
+        captions=("Lift it.", "Lower it."),
+        future_camera_m=camera,
+        future_world_m=world,
+        raw_text=("<tracks>lift", "<tracks>lower"),
+        checkpoint="synthetic",
+    )
+    camera[...] = -1.0
+    world[...] = -2.0
+
+    np.testing.assert_array_equal(bundle.future_camera_m, expected_camera)
+    np.testing.assert_array_equal(bundle.future_world_m, expected_world)
+    assert not bundle.future_camera_m.flags.writeable
+    assert not bundle.future_world_m.flags.writeable
+    with pytest.raises(ValueError, match="read-only"):
+        bundle.future_camera_m[...] = 0.0
+    with pytest.raises(ValueError, match="read-only"):
+        bundle.future_world_m[...] = 0.0


### PR DESCRIPTION
## Summary

- defensively copy every NumPy array retained by `MolmoPhysTwinQuery` and `MolmoForecastBundle`;
- mark the owned arrays read-only after validation so a frozen artifact cannot be changed through either the caller's original buffer or the artifact itself;
- add adversarial regressions covering all seven query arrays and both forecast arrays.

## Root cause

Both classes are declared with `@dataclass(frozen=True)`, but their constructors used `np.asarray(...)` and retained the resulting buffers directly. When the supplied arrays already had the requested dtype, the artifact aliased caller-owned writable memory. Mutating an input after construction therefore changed validated query geometry, calibration, identities, or forecast trajectories without changing the dataclass fields or provenance metadata.

## Validation

Local focused validation on Python 3.13:

- patched implementation: `2 passed`;
- reconstructed current-`main` implementation: both new regressions fail because constructor inputs remain aliased;
- Python bytecode compilation passed for the changed source and test;
- all changed Python lines are at most 88 characters;
- the reconstructed original file's Git blob SHA exactly matches `217e531e7f2e31558c2ed9a7cf20be4336b7e4d9`, confirming the local before/after comparison used the current repository source.

GitHub Actions remains the authoritative full repository and distribution gate.

## Compatibility

Numerical values, shapes, serialization, metadata, and inference behavior are unchanged for valid inputs. The only behavioral change is that retained query and forecast arrays now have independent storage and reject writes.

## Scientific boundary

This is contract hardening for the optional MolmoMotion branch. It does not alter the frozen primary Causal4D method, real-experiment protocol, calibration design, target-data access, or any existing scientific result.