### PR TITLE
Document contribution and security boundaries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,131 @@
+# Contributing to Causal4D
+
+Causal4D is both a software project and a scientific evidence pipeline. A change can
+be technically correct while still invalidating a frozen comparison, target-access
+boundary, provider contract, or claim-bearing artifact. Contributions therefore
+need to preserve both software correctness and scientific provenance.
+
+## Before starting
+
+1. Search existing issues and pull requests for overlapping work.
+2. Identify the change as one of:
+   - core causal contracts or inference;
+   - a versioned Bayesian-PhysTwin or Prob4D boundary;
+   - exploratory or diagnostic research code;
+   - claim-bearing acquisition, calibration, or evidence tooling;
+   - documentation, packaging, or infrastructure.
+3. Discuss changes that alter a public contract, registered analysis, frozen method,
+   evidence schema, or target-data boundary before implementing them.
+
+Do not edit files under `milestones/` to update a result in place. Add a new,
+versioned artifact or milestone with an explicit relationship to the historical
+record.
+
+## Development environment
+
+Install the project and development tools with:
+
+```bash
+python -m pip install -e ".[dev]"
+```
+
+Bayesian-PhysTwin integrations require the optional provider environment:
+
+```bash
+python -m pip install -e ".[phystwin]"
+```
+
+Some provider-enabled and three-repository checks require private or separately
+installed dependencies. The GitHub Actions workflows are authoritative for those
+checks; a local success that skipped an unavailable provider is not equivalent to
+an executed integration test.
+
+## Design rules
+
+### Preserve the causal and temporal boundary
+
+Every claim-bearing path must make the allowed observation prefix, factual action,
+realized intervention, counterfactual action, prediction interval, and target-access
+status explicit. Future or target observations must not influence proposal
+construction, calibration, threshold selection, model selection, or fallback
+selection unless the relevant protocol explicitly permits that use.
+
+### Keep artifacts genuinely immutable
+
+`@dataclass(frozen=True)` only prevents attribute reassignment. Any retained NumPy
+array must be defensively copied and marked read-only. Nested JSON-like metadata
+must be recursively immutable or copied on export. Add adversarial tests that mutate
+constructor inputs and attempt mutation through the resulting artifact.
+
+### Use versioned provider boundaries
+
+Production code must consume Bayesian-PhysTwin and Prob4D through their declared,
+versioned provider or artifact facades. Do not import another repository's private
+implementation modules to bypass a contract. A backward-incompatible field,
+semantic, coordinate-frame, timing, covariance, or provenance change requires a
+new contract version and cross-repository tests.
+
+### Fail closed on malformed evidence
+
+Validate shapes, units, finite values, probability support, calibration identities,
+content hashes, chronology, and source/target disjointness before using evidence.
+Exact zero probability is excluded support and must not be resurrected by numerical
+floors. A rejected optional observation or semantic component must preserve the
+registered physical fallback exactly.
+
+### Prefer stable numerical operations
+
+Use linear solves or factorizations rather than explicit matrix inverses. Validate
+conditioning and finite outputs, preserve covariance symmetry where required, and
+add regression tests for degenerate or adversarial inputs. Numerical safeguards must
+not silently change a frozen estimator or comparison.
+
+### Preserve evidence files safely
+
+Claim-bearing output should use canonical serialization, content hashes, atomic
+publication, and fail-closed validation. Do not replace a failed or excluded
+physical execution with an unregistered substitute; retain the original record and
+encode its status explicitly.
+
+## Tests
+
+Run the smallest relevant tests while developing, then the broadest locally
+available suite. At minimum, a pull request should include:
+
+- a regression that fails on the unpatched implementation;
+- positive coverage for valid inputs;
+- negative coverage for malformed, mutable, or provenance-inconsistent inputs;
+- serialization or installed-artifact coverage when a public contract changes;
+- cross-repository compatibility coverage when a provider boundary changes.
+
+Useful local checks include:
+
+```bash
+python -m pytest -q
+python -m compileall -q src tests
+python -m ruff check .
+python -m ruff format --check .
+```
+
+Record skipped optional integrations honestly in the pull-request description.
+
+## Pull requests
+
+Keep each pull request focused enough that its scientific effect is reviewable.
+Describe:
+
+- the root cause or scientific motivation;
+- the exact behavioral and artifact changes;
+- compatibility and migration effects;
+- tests executed, including meaningful skips;
+- whether the change affects a frozen method, target-data access, or a scientific
+  claim.
+
+Do not combine a method change with acquisition, target evaluation, or result
+promotion. When a change is maintenance-only, state that boundary explicitly.
+
+## Licensing
+
+A repository license has not yet been selected. Do not add, replace, or infer a
+license in a technical pull request. Licensing requires an explicit maintainer and,
+where applicable, institutional rights-holder decision.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,84 @@
+# Security Policy
+
+## Supported code
+
+Security fixes are applied to the current default branch and, when practical, the
+most recent release line. Frozen scientific tags and milestone artifacts are not
+rewritten: a security advisory or successor release must identify the affected
+historical revision and the corrected replacement.
+
+## Reporting a vulnerability
+
+Please do not disclose an exploitable vulnerability, secret, private dataset path,
+or unsafe artifact publicly before it has been assessed.
+
+Use GitHub's private vulnerability-reporting facility for this repository when it
+is available. Otherwise, contact the repository owner privately through the
+institutional contact listed on the owner's GitHub profile. Include:
+
+- the affected revision, package version, and execution environment;
+- the smallest reproducible example;
+- the expected and observed behavior;
+- the security impact and required preconditions;
+- whether untrusted files, checkpoints, repositories, or network services are
+  involved;
+- any proposed mitigation, without including unrelated private data.
+
+The maintainers will assess scope, coordinate a fix or advisory, and preserve the
+scientific provenance of any affected release or evidence artifact.
+
+## Important trust boundaries
+
+### Legacy pickle files are trusted-code inputs
+
+Some compatibility paths load legacy Python pickle artifacts through a
+Bayesian-PhysTwin provider boundary. Unpickling can execute code. A SHA-256 check
+proves that the bytes match an expected digest; it does not make arbitrary pickle
+content safe or sandbox its execution.
+
+Only load a legacy pickle when all of the following hold:
+
+1. the expected digest was obtained through a trusted, independently identified
+   manifest or release channel;
+2. the file came from the corresponding trusted producer;
+3. the digest is verified before loading and rechecked where the provider contract
+   requires it;
+4. the process and host are appropriate for trusted research artifacts.
+
+Do not use Causal4D's legacy loaders as a general-purpose pickle inspection tool.
+
+### Digests provide identity, not authenticity by themselves
+
+A digest supplied beside an artifact by the same untrusted source does not establish
+trust. Claim-bearing manifests must bind expected identities, producer revisions,
+provider versions, protocol files, and relevant environment information through a
+trusted chain.
+
+### Optional model code and checkpoints execute with process privileges
+
+MolmoMotion, Warp/PhysTwin, GPU libraries, externally installed providers, and model
+checkpoints may load native code or Python code and can access the permissions of the
+running process. Use pinned sources and isolated environments, and do not expose
+secrets or unrelated private datasets to exploratory model environments.
+
+### NumPy, NPZ, JSON, and image inputs still require validation
+
+Use `allow_pickle=False` for NumPy archives unless a narrowly documented trusted
+legacy boundary requires otherwise. Validate paths, shapes, dtypes, finite values,
+units, coordinate frames, timing, and content inventories before claim-bearing use.
+Reject path traversal and unexpected files rather than guessing intent.
+
+### Evidence and provenance data may be sensitive
+
+Manifests, logs, exception traces, absolute paths, device identifiers, timestamps,
+and raw acquisition metadata can reveal private infrastructure or participant data.
+Do not commit credentials, tokens, private URLs, personal data, or unrestricted raw
+acquisition artifacts. Redact only copies intended for sharing; never silently alter
+the sealed original evidence record.
+
+## Out of scope for public issue reports
+
+General model accuracy, a failed scientific hypothesis, expected floating-point
+variation within a registered tolerance, and missing optional research hardware are
+not security vulnerabilities unless they create a concrete confidentiality,
+integrity, availability, or code-execution risk.


### PR DESCRIPTION
## Summary

- add contribution guidance tailored to a claim-bearing research codebase;
- distinguish core contracts, versioned provider boundaries, exploratory work, and evidence tooling;
- document requirements for causal/temporal isolation, immutable artifacts, numerical safeguards, evidence publication, and regression tests;
- add a security policy covering trusted legacy pickle loading, digest limitations, optional model/provider execution, path and archive validation, and sensitive provenance data;
- explicitly leave the repository license undecided rather than selecting one implicitly in a technical change.

## Why

Causal4D already enforces many of these rules in code and CI, but contributors currently have no top-level explanation of why ordinary software changes can invalidate a frozen comparison, target-access boundary, provider contract, or evidence artifact. The security-sensitive legacy artifact boundary also needs an explicit warning: matching a SHA-256 digest proves byte identity but does not sandbox Python pickle execution or establish authenticity when the digest came from the same untrusted source.

## Validation

This is documentation-only. The branch adds exactly `CONTRIBUTING.md` and `SECURITY.md`; it does not change package code, dependencies, protocol files, milestones, generated evidence, or CI configuration.

## Scientific boundary

No estimator, acquisition plan, calibration rule, target-data boundary, provider schema, scientific result, or frozen artifact is changed.