### PR TITLE
Consume the versioned Bayesian-PhysTwin belief provider

### DIFF
--- a/docs/bayesian_phystwin_provider.md
+++ b/docs/bayesian_phystwin_provider.md
@@ -7,6 +7,8 @@ modules:
   compatibility names;
 - `bayesian_phystwin.causal4d_provider_v2` for all production initial and restart
   replay execution through immutable request-complete contracts;
+- `bayesian_phystwin.causal4d_belief_provider_v1` for NumPy-only fixed-anchor
+  endpoint inference and immutable endpoint posteriors;
 - `bayesian_phystwin.causal4d_graph_provider_v1` for the NumPy-only spring-graph
   value type, graph construction, and released controller grouping semantics;
 - `bayesian_phystwin.causal4d_artifacts_v1` for hash-locked released pickle
@@ -15,9 +17,11 @@ modules:
   diagnostics that still reuse BPT experiment semantics.
 
 The graph module is explicitly parented to Bayesian-PhysTwin's immutable
-`causal4d_provider_v2` contract. Causal4D's belief exporter, rollout-bank backend,
-and resumable cache now execute replay exclusively through provider v2. Provider
-v1 remains only for frozen scientific and diagnostic compatibility operations.
+`causal4d_provider_v2` contract. Causal4D's belief exporter validates the
+separate belief-provider manifest and invokes only its fixed-anchor operation.
+The rollout-bank backend and resumable cache execute replay exclusively through
+provider v2. Provider v1 remains only for frozen scientific and diagnostic
+compatibility operations.
 
 Production source and scripts no longer import any unversioned
 Bayesian-PhysTwin implementation module. An AST allowlist makes new direct
@@ -27,17 +31,29 @@ experiment imports a blocking test failure.
 
 Normal development accepts Bayesian-PhysTwin versions in the range
 `>=0.4,<0.5`. Compatibility is not inferred from the package version alone.
-Causal4D validates two deliberately separate provider manifests:
+Causal4D validates four deliberately separate provider manifests:
 
-- scientific provider API/schema version 1 for frozen compatibility names,
-  fixed-anchor inference, and migrated diagnostics; and
+- scientific provider API/schema version 1 for frozen compatibility names and
+  migrated diagnostics;
 - replay provider API/schema version 2 for typed initial/restart requests,
   immutable position/velocity trajectories, frame provenance, and stateless
-  replay execution.
+  replay execution;
+- belief provider API/schema version 1 for the fixed robust discrepancy endpoint,
+  immutable configuration, causal-prefix validation, and immutable posterior;
+- graph provider API/schema version 1 for graph and controller grouping values.
 
 The scientific manifest requires its existing `TwinBelief` and `GraphBelief`
 artifact schemas. The replay manifest additionally requires `ReplayRequest` and
 `ReplayTrajectory` schema version 1 and every provider-v2 replay capability.
+
+The belief provider is checked separately for:
+
+- the exact `bayesian_phystwin.causal4d_belief_provider_v1` API identity;
+- causal-prefix endpoint inference and finite-residual preflight;
+- immutable fixed-anchor configuration and endpoint posterior capabilities;
+- `FixedBayesianAnchorConfig` and `RobustEndpointPosterior` schema version 1;
+- the fixed readout/model-discrepancy inference role; and
+- the supported Bayesian-PhysTwin package range.
 
 The graph provider is checked separately for:
 
@@ -52,11 +68,13 @@ The scientific manifest is loaded with
 `load_bayesian_phystwin_provider_manifest()` and checked with
 `validate_bayesian_phystwin_provider()`. The replay manifest is loaded with
 `load_bayesian_phystwin_replay_provider_manifest()` and checked with
-`validate_bayesian_phystwin_replay_provider()`. The graph manifest is loaded with
-`load_bayesian_phystwin_graph_provider_manifest()` and checked with
+`validate_bayesian_phystwin_replay_provider()`. The belief manifest is loaded
+with `load_bayesian_phystwin_belief_provider_manifest()` and checked with
+`validate_bayesian_phystwin_belief_provider()`. The graph manifest is loaded
+with `load_bayesian_phystwin_graph_provider_manifest()` and checked with
 `validate_bayesian_phystwin_graph_provider()`. A version, capability, artifact,
-graph-provider, or parent-provider mismatch fails closed and is reported
-explicitly.
+provider-identity, inference-role, graph-provider, or parent-provider mismatch
+fails closed and is reported explicitly.
 
 ## Execution API
 
@@ -76,11 +94,18 @@ position/velocity values. The resumable cache stores and hashes positions,
 velocities, frame provenance, timestep, and all three identities. A cache hit can
 therefore reconstruct a complete provider-v2 response without instantiating Warp.
 
-Provider v1 is not the production replay boundary. It remains a versioned
-compatibility facade for frozen diagnostics and scientific operations that have no
-request-complete replay role. Graph and controller geometry remain in
-`causal4d_graph_provider_v1`, which is NumPy-only and declares replay provider v2
-as its parent contract.
+Fixed robust endpoint inference uses
+`infer_fixed_bayesian_anchor_endpoint()` from the belief provider. Causal4D
+validates the installed belief manifest before reading residuals, passes the
+exclusive causal cutoff explicitly, and consumes the immutable
+`RobustEndpointPosteriorV1` fields. The historical broad provider is no longer the
+belief exporter's endpoint-inference dependency.
+
+Provider v1 is not the production replay or endpoint-inference boundary. It
+remains a versioned compatibility facade for frozen diagnostics and scientific
+operations that have no request-complete replay role. Graph and controller
+geometry remain in `causal4d_graph_provider_v1`, which is NumPy-only and declares
+replay provider v2 as its parent contract.
 
 The official rollout manifest records the scientific provider, replay-provider-v2,
 and graph-provider manifests separately. It also records source-artifact hashes,
@@ -100,7 +125,9 @@ python -m pip install -e "../Bayesian-PhysTwin[graph]"
 python -m pip install -e ".[dev]"
 CAUSAL4D_REQUIRE_BPT_PROVIDER=1 python -m pytest -q \
   tests/test_bpt_provider_integration.py \
-  tests/test_bpt_graph_provider_integration.py
+  tests/test_bpt_graph_provider_integration.py \
+  tests/test_belief_provider_contract.py \
+  tests/test_bpt_belief_provider_usage.py
 ```
 
 Package-based installations may use `python -m pip install ".[phystwin]"`;
@@ -122,5 +149,5 @@ python -m pip install -r requirements/frozen/causal4d-0.3.0.txt
 
 That file locks Causal4D and Bayesian-PhysTwin to exact Git commits. Existing
 milestone tags and recorded environments remain unchanged. New experiments
-should record the exact BPT revision in both provider manifests in addition to
+should record the exact BPT revision in every provider manifest in addition to
 using the normal compatibility range during development.

--- a/src/causal4d/belief_provider_contract.py
+++ b/src/causal4d/belief_provider_contract.py
@@ -1,0 +1,128 @@
+"""Versioned compatibility contract for Bayesian-PhysTwin belief providers."""
+
+from __future__ import annotations
+
+import json
+
+from causal4d.provider_contract import (
+    BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE,
+    PhysicalBeliefProviderManifest,
+    ProviderCompatibilityResult,
+    validate_provider_compatibility,
+)
+
+BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_API = (
+    "bayesian_phystwin.causal4d_belief_provider_v1"
+)
+BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_API_VERSION = 1
+BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_CAPABILITIES = (
+    "causal_prefix_endpoint_inference",
+    "fixed_bayesian_anchor_endpoint",
+    "immutable_endpoint_posterior",
+    "numpy_only_endpoint_inference",
+    "residual_finite_preflight",
+)
+BAYESIAN_PHYSTWIN_BELIEF_ARTIFACT_SCHEMA_VERSIONS = {
+    "FixedBayesianAnchorConfig": 1,
+    "RobustEndpointPosterior": 1,
+}
+BAYESIAN_PHYSTWIN_BELIEF_INFERENCE_ROLE = (
+    "fixed robust readout-discrepancy endpoint"
+)
+
+
+def load_bayesian_phystwin_belief_provider_manifest(
+    *,
+    provider_revision: str | None = None,
+) -> PhysicalBeliefProviderManifest:
+    """Load BPT's NumPy-only fixed-anchor provider descriptor."""
+
+    from bayesian_phystwin.causal4d_belief_provider_v1 import (
+        causal4d_belief_provider_manifest,
+    )
+
+    values = causal4d_belief_provider_manifest(
+        provider_revision=provider_revision
+    )
+    return PhysicalBeliefProviderManifest(
+        provider_name=str(values["provider_name"]),
+        provider_version=str(values["provider_version"]),
+        provider_revision=str(values["provider_revision"]),
+        schema_version=int(values["schema_version"]),
+        capabilities=tuple(map(str, values["capabilities"])),
+        artifact_schema_versions=dict(values["artifact_schema_versions"]),
+        metadata=dict(values.get("metadata", {})),
+    )
+
+
+def _validate_belief_provider_metadata(
+    manifest: PhysicalBeliefProviderManifest,
+) -> None:
+    expected = {
+        "provider_api": BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_API,
+        "provider_api_version": BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_API_VERSION,
+        "inference_role": BAYESIAN_PHYSTWIN_BELIEF_INFERENCE_ROLE,
+    }
+    mismatches = {
+        name: (value, manifest.metadata.get(name))
+        for name, value in expected.items()
+        if manifest.metadata.get(name) != value
+    }
+    if mismatches:
+        raise ValueError(
+            "unexpected Bayesian-PhysTwin belief provider metadata: "
+            + json.dumps(mismatches, sort_keys=True)
+        )
+
+
+def validate_bayesian_phystwin_belief_provider(
+    manifest: PhysicalBeliefProviderManifest | None = None,
+    *,
+    provider_revision: str | None = None,
+) -> ProviderCompatibilityResult:
+    """Validate the fixed-anchor child contract before endpoint inference."""
+
+    candidate = manifest or load_bayesian_phystwin_belief_provider_manifest(
+        provider_revision=provider_revision
+    )
+    if candidate.provider_name != "bayesian-phystwin":
+        raise ValueError("expected the bayesian-phystwin belief provider")
+    _validate_belief_provider_metadata(candidate)
+    return validate_provider_compatibility(
+        candidate,
+        required_capabilities=BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_CAPABILITIES,
+        supported_provider_versions=BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE,
+        required_artifact_versions=(
+            BAYESIAN_PHYSTWIN_BELIEF_ARTIFACT_SCHEMA_VERSIONS
+        ),
+    )
+
+
+def require_bayesian_phystwin_belief_provider(
+    *,
+    provider_revision: str | None = None,
+) -> PhysicalBeliefProviderManifest:
+    """Return the installed belief manifest or fail before reading residuals."""
+
+    manifest = load_bayesian_phystwin_belief_provider_manifest(
+        provider_revision=provider_revision
+    )
+    result = validate_bayesian_phystwin_belief_provider(manifest)
+    if not result.compatible:
+        raise RuntimeError(
+            "incompatible Bayesian-PhysTwin belief provider: "
+            + json.dumps(result.as_dict(), sort_keys=True)
+        )
+    return manifest
+
+
+__all__ = [
+    "BAYESIAN_PHYSTWIN_BELIEF_ARTIFACT_SCHEMA_VERSIONS",
+    "BAYESIAN_PHYSTWIN_BELIEF_INFERENCE_ROLE",
+    "BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_API",
+    "BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_API_VERSION",
+    "BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_CAPABILITIES",
+    "load_bayesian_phystwin_belief_provider_manifest",
+    "require_bayesian_phystwin_belief_provider",
+    "validate_bayesian_phystwin_belief_provider",
+]

--- a/src/causal4d/belief_provider_contract.py
+++ b/src/causal4d/belief_provider_contract.py
@@ -11,9 +11,7 @@ from causal4d.provider_contract import (
     validate_provider_compatibility,
 )
 
-BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_API = (
-    "bayesian_phystwin.causal4d_belief_provider_v1"
-)
+BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_API = "bayesian_phystwin.causal4d_belief_provider_v1"
 BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_API_VERSION = 1
 BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_CAPABILITIES = (
     "causal_prefix_endpoint_inference",
@@ -26,9 +24,7 @@ BAYESIAN_PHYSTWIN_BELIEF_ARTIFACT_SCHEMA_VERSIONS = {
     "FixedBayesianAnchorConfig": 1,
     "RobustEndpointPosterior": 1,
 }
-BAYESIAN_PHYSTWIN_BELIEF_INFERENCE_ROLE = (
-    "fixed robust readout-discrepancy endpoint"
-)
+BAYESIAN_PHYSTWIN_BELIEF_INFERENCE_ROLE = "fixed robust readout-discrepancy endpoint"
 
 
 def load_bayesian_phystwin_belief_provider_manifest(
@@ -41,9 +37,7 @@ def load_bayesian_phystwin_belief_provider_manifest(
         causal4d_belief_provider_manifest,
     )
 
-    values = causal4d_belief_provider_manifest(
-        provider_revision=provider_revision
-    )
+    values = causal4d_belief_provider_manifest(provider_revision=provider_revision)
     return PhysicalBeliefProviderManifest(
         provider_name=str(values["provider_name"]),
         provider_version=str(values["provider_version"]),
@@ -92,9 +86,7 @@ def validate_bayesian_phystwin_belief_provider(
         candidate,
         required_capabilities=BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_CAPABILITIES,
         supported_provider_versions=BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE,
-        required_artifact_versions=(
-            BAYESIAN_PHYSTWIN_BELIEF_ARTIFACT_SCHEMA_VERSIONS
-        ),
+        required_artifact_versions=BAYESIAN_PHYSTWIN_BELIEF_ARTIFACT_SCHEMA_VERSIONS,
     )
 
 

--- a/src/causal4d/bpt_belief.py
+++ b/src/causal4d/bpt_belief.py
@@ -51,7 +51,7 @@ class BPTBeliefExportConfig:
     maximum_discrepancy_m: float = 0.01
 
     def __post_init__(self) -> None:
-        FixedBayesianAnchorConfigV1(
+        anchor = FixedBayesianAnchorConfigV1(
             process_std_m=self.process_std_m,
             observation_std_m=self.observation_std_m,
             initial_std_m=self.initial_std_m,
@@ -64,11 +64,20 @@ class BPTBeliefExportConfig:
             or self.interpolation_neighbors < 1
         ):
             raise ValueError("interpolation_neighbors must be a positive integer")
-        if (
-            not np.isfinite(self.maximum_discrepancy_m)
-            or self.maximum_discrepancy_m <= 0.0
-        ):
+        maximum_discrepancy = float(self.maximum_discrepancy_m)
+        if not np.isfinite(maximum_discrepancy) or maximum_discrepancy <= 0.0:
             raise ValueError("maximum_discrepancy_m must be finite and positive")
+        object.__setattr__(self, "process_std_m", anchor.process_std_m)
+        object.__setattr__(self, "observation_std_m", anchor.observation_std_m)
+        object.__setattr__(self, "initial_std_m", anchor.initial_std_m)
+        object.__setattr__(self, "inlier_prior", anchor.inlier_prior)
+        object.__setattr__(
+            self,
+            "outlier_variance_multiplier",
+            anchor.outlier_variance_multiplier,
+        )
+        object.__setattr__(self, "interpolation_neighbors", int(self.interpolation_neighbors))
+        object.__setattr__(self, "maximum_discrepancy_m", maximum_discrepancy)
 
     def fixed_anchor_config(self) -> FixedBayesianAnchorConfigV1:
         """Return the immutable configuration owned by Bayesian-PhysTwin."""
@@ -133,7 +142,7 @@ def build_twin_belief_from_replays(
 ) -> TwinBelief:
     """Build a belief using only the declared pre-intervention prefix."""
 
-    require_bayesian_phystwin_belief_provider()
+    belief_provider_manifest = require_bayesian_phystwin_belief_provider()
     settings = config or BPTBeliefExportConfig()
     anchor_config = settings.fixed_anchor_config()
     positions = np.asarray(replay_positions_m, dtype=float)
@@ -231,6 +240,7 @@ def build_twin_belief_from_replays(
         "maximum_pairwise_endpoint_rmse_m": max(pairwise_rmse, default=0.0),
     }
     diagnostics.update(metadata or {})
+    diagnostics["belief_provider"] = belief_provider_manifest.as_dict()
     identifiers = particle_ids or tuple(
         f"theta_{index:04d}" for index in range(particle_count)
     )

--- a/src/causal4d/bpt_belief.py
+++ b/src/causal4d/bpt_belief.py
@@ -7,14 +7,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from bayesian_phystwin.causal4d_provider_v1 import (
-    FIXED_INITIAL_STD_M,
-    FIXED_INLIER_PRIOR,
-    FIXED_OBSERVATION_STD_M,
-    FIXED_OUTLIER_VARIANCE_MULTIPLIER,
-    FIXED_PROCESS_STD_M,
+from bayesian_phystwin.causal4d_belief_provider_v1 import (
+    DEFAULT_FIXED_BAYESIAN_ANCHOR_CONFIG_V1,
+    FixedBayesianAnchorConfigV1,
+    infer_fixed_bayesian_anchor_endpoint,
 )
-from bayesian_phystwin.causal4d_provider_v1 import robust_random_walk_endpoint
 from bayesian_phystwin.causal4d_provider_v1 import released_self_collision_for_case
 from bayesian_phystwin.causal4d_provider_v2 import (
     InitialReplayRequestV1,
@@ -23,6 +20,9 @@ from bayesian_phystwin.causal4d_provider_v2 import (
     create_official_replay_provider,
     lift_residual,
     target_validity,
+)
+from causal4d.belief_provider_contract import (
+    require_bayesian_phystwin_belief_provider,
 )
 from causal4d.contracts import CausalContext, TwinBelief, array_sha256
 from causal4d.replay_provider_contract import (
@@ -38,25 +38,48 @@ if TYPE_CHECKING:
 class BPTBeliefExportConfig:
     """Fixed, label-free settings for a full endpoint belief export."""
 
-    process_std_m: float = FIXED_PROCESS_STD_M
-    observation_std_m: float = FIXED_OBSERVATION_STD_M
-    initial_std_m: float = FIXED_INITIAL_STD_M
-    inlier_prior: float = FIXED_INLIER_PRIOR
-    outlier_variance_multiplier: float = FIXED_OUTLIER_VARIANCE_MULTIPLIER
+    process_std_m: float = DEFAULT_FIXED_BAYESIAN_ANCHOR_CONFIG_V1.process_std_m
+    observation_std_m: float = (
+        DEFAULT_FIXED_BAYESIAN_ANCHOR_CONFIG_V1.observation_std_m
+    )
+    initial_std_m: float = DEFAULT_FIXED_BAYESIAN_ANCHOR_CONFIG_V1.initial_std_m
+    inlier_prior: float = DEFAULT_FIXED_BAYESIAN_ANCHOR_CONFIG_V1.inlier_prior
+    outlier_variance_multiplier: float = (
+        DEFAULT_FIXED_BAYESIAN_ANCHOR_CONFIG_V1.outlier_variance_multiplier
+    )
     interpolation_neighbors: int = 4
     maximum_discrepancy_m: float = 0.01
 
     def __post_init__(self) -> None:
-        if self.process_std_m < 0.0:
-            raise ValueError("process_std_m must be nonnegative")
-        if self.observation_std_m <= 0.0 or self.initial_std_m <= 0.0:
-            raise ValueError("observation and initial scales must be positive")
-        if not 0.0 < self.inlier_prior < 1.0:
-            raise ValueError("inlier_prior must lie in (0, 1)")
-        if self.outlier_variance_multiplier <= 1.0:
-            raise ValueError("outlier_variance_multiplier must exceed one")
-        if self.interpolation_neighbors < 1 or self.maximum_discrepancy_m <= 0.0:
-            raise ValueError("lifting settings must be positive")
+        FixedBayesianAnchorConfigV1(
+            process_std_m=self.process_std_m,
+            observation_std_m=self.observation_std_m,
+            initial_std_m=self.initial_std_m,
+            inlier_prior=self.inlier_prior,
+            outlier_variance_multiplier=self.outlier_variance_multiplier,
+        )
+        if (
+            isinstance(self.interpolation_neighbors, bool)
+            or not isinstance(self.interpolation_neighbors, (int, np.integer))
+            or self.interpolation_neighbors < 1
+        ):
+            raise ValueError("interpolation_neighbors must be a positive integer")
+        if (
+            not np.isfinite(self.maximum_discrepancy_m)
+            or self.maximum_discrepancy_m <= 0.0
+        ):
+            raise ValueError("maximum_discrepancy_m must be finite and positive")
+
+    def fixed_anchor_config(self) -> FixedBayesianAnchorConfigV1:
+        """Return the immutable configuration owned by Bayesian-PhysTwin."""
+
+        return FixedBayesianAnchorConfigV1(
+            process_std_m=self.process_std_m,
+            observation_std_m=self.observation_std_m,
+            initial_std_m=self.initial_std_m,
+            inlier_prior=self.inlier_prior,
+            outlier_variance_multiplier=self.outlier_variance_multiplier,
+        )
 
 
 def lift_isotropic_discrepancy_variance(
@@ -110,7 +133,9 @@ def build_twin_belief_from_replays(
 ) -> TwinBelief:
     """Build a belief using only the declared pre-intervention prefix."""
 
+    require_bayesian_phystwin_belief_provider()
     settings = config or BPTBeliefExportConfig()
+    anchor_config = settings.fixed_anchor_config()
     positions = np.asarray(replay_positions_m, dtype=float)
     velocities = np.asarray(replay_velocities_mps, dtype=float)
     observed = np.asarray(observed_positions_m, dtype=float)
@@ -151,33 +176,29 @@ def build_twin_belief_from_replays(
         residual = (
             observed[:train_end] - positions[particle_index, :train_end, :tracked_count]
         )
-        posterior = robust_random_walk_endpoint(
+        posterior = infer_fixed_bayesian_anchor_endpoint(
             residual,
             valid[:train_end],
             end_frame=train_end,
-            process_variance=settings.process_std_m**2,
-            observation_variance=settings.observation_std_m**2,
-            initial_variance=settings.initial_std_m**2,
-            inlier_prior=settings.inlier_prior,
-            outlier_variance_multiplier=settings.outlier_variance_multiplier,
+            config=anchor_config,
         )
         discrepancy_means[particle_index] = lift_residual(
-            posterior.mean[None],
+            posterior.mean_m[None],
             state_count,
             lift_indices,
             lift_weights,
             maximum_norm=settings.maximum_discrepancy_m,
         )[0]
         discrepancy_variances[particle_index] = lift_isotropic_discrepancy_variance(
-            posterior.variance,
+            posterior.variance_m2,
             state_count,
             lift_indices,
             lift_weights,
         )
         update_counts.append(int(np.sum(posterior.update_count)))
-        supported = posterior.update_count > 0
+        supported = posterior.updated_mask
         final_inlier_probabilities.append(
-            float(np.mean(posterior.final_inlier_probability[supported]))
+            float(np.mean(posterior.final_nominal_probability[supported]))
             if np.any(supported)
             else 0.0
         )

--- a/src/causal4d/bpt_belief.py
+++ b/src/causal4d/bpt_belief.py
@@ -39,9 +39,7 @@ class BPTBeliefExportConfig:
     """Fixed, label-free settings for a full endpoint belief export."""
 
     process_std_m: float = DEFAULT_FIXED_BAYESIAN_ANCHOR_CONFIG_V1.process_std_m
-    observation_std_m: float = (
-        DEFAULT_FIXED_BAYESIAN_ANCHOR_CONFIG_V1.observation_std_m
-    )
+    observation_std_m: float = DEFAULT_FIXED_BAYESIAN_ANCHOR_CONFIG_V1.observation_std_m
     initial_std_m: float = DEFAULT_FIXED_BAYESIAN_ANCHOR_CONFIG_V1.initial_std_m
     inlier_prior: float = DEFAULT_FIXED_BAYESIAN_ANCHOR_CONFIG_V1.inlier_prior
     outlier_variance_multiplier: float = (
@@ -76,7 +74,9 @@ class BPTBeliefExportConfig:
             "outlier_variance_multiplier",
             anchor.outlier_variance_multiplier,
         )
-        object.__setattr__(self, "interpolation_neighbors", int(self.interpolation_neighbors))
+        object.__setattr__(
+            self, "interpolation_neighbors", int(self.interpolation_neighbors)
+        )
         object.__setattr__(self, "maximum_discrepancy_m", maximum_discrepancy)
 
     def fixed_anchor_config(self) -> FixedBayesianAnchorConfigV1:
@@ -205,7 +205,7 @@ def build_twin_belief_from_replays(
             lift_weights,
         )
         update_counts.append(int(np.sum(posterior.update_count)))
-        supported = posterior.updated_mask
+        supported = posterior.update_count > 0
         final_inlier_probabilities.append(
             float(np.mean(posterior.final_nominal_probability[supported]))
             if np.any(supported)

--- a/tests/test_belief_provider_contract.py
+++ b/tests/test_belief_provider_contract.py
@@ -39,9 +39,7 @@ def _manifest(
             if metadata is not None
             else {
                 "provider_api": BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_API,
-                "provider_api_version": (
-                    BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_API_VERSION
-                ),
+                "provider_api_version": BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_API_VERSION,
                 "inference_role": BAYESIAN_PHYSTWIN_BELIEF_INFERENCE_ROLE,
             }
         ),
@@ -105,9 +103,7 @@ def test_belief_provider_contract_rejects_metadata_drift(
     metadata = dict(_manifest().metadata)
     metadata[name] = value
     with pytest.raises(ValueError, match="unexpected"):
-        validate_bayesian_phystwin_belief_provider(
-            _manifest(metadata=metadata)
-        )
+        validate_bayesian_phystwin_belief_provider(_manifest(metadata=metadata))
 
 
 def test_belief_provider_contract_rejects_wrong_provider_name() -> None:

--- a/tests/test_belief_provider_contract.py
+++ b/tests/test_belief_provider_contract.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import pytest
+
+from causal4d.belief_provider_contract import (
+    BAYESIAN_PHYSTWIN_BELIEF_INFERENCE_ROLE,
+    BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_API,
+    BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_API_VERSION,
+    validate_bayesian_phystwin_belief_provider,
+)
+from causal4d.provider_contract import PhysicalBeliefProviderManifest
+
+
+def _manifest(
+    *,
+    capabilities: tuple[str, ...] = (
+        "causal_prefix_endpoint_inference",
+        "fixed_bayesian_anchor_endpoint",
+        "immutable_endpoint_posterior",
+        "numpy_only_endpoint_inference",
+        "residual_finite_preflight",
+    ),
+    config_schema: int = 1,
+    posterior_schema: int = 1,
+    metadata: dict[str, object] | None = None,
+) -> PhysicalBeliefProviderManifest:
+    return PhysicalBeliefProviderManifest(
+        provider_name="bayesian-phystwin",
+        provider_version="0.4.0",
+        provider_revision="a" * 40,
+        schema_version=1,
+        capabilities=capabilities,
+        artifact_schema_versions={
+            "FixedBayesianAnchorConfig": config_schema,
+            "RobustEndpointPosterior": posterior_schema,
+        },
+        metadata=(
+            metadata
+            if metadata is not None
+            else {
+                "provider_api": BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_API,
+                "provider_api_version": (
+                    BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_API_VERSION
+                ),
+                "inference_role": BAYESIAN_PHYSTWIN_BELIEF_INFERENCE_ROLE,
+            }
+        ),
+    )
+
+
+def test_belief_provider_contract_accepts_complete_v1_manifest() -> None:
+    result = validate_bayesian_phystwin_belief_provider(_manifest())
+    assert result.compatible
+    assert result.missing_capabilities == ()
+    assert result.artifact_version_mismatches == ()
+
+
+def test_belief_provider_contract_rejects_missing_capability() -> None:
+    capabilities = tuple(
+        value
+        for value in _manifest().capabilities
+        if value != "residual_finite_preflight"
+    )
+    result = validate_bayesian_phystwin_belief_provider(
+        _manifest(capabilities=capabilities)
+    )
+    assert not result.compatible
+    assert result.missing_capabilities == ("residual_finite_preflight",)
+
+
+@pytest.mark.parametrize(
+    ("config_schema", "posterior_schema", "expected"),
+    [
+        (2, 1, "FixedBayesianAnchorConfig:expected=1:actual=2"),
+        (1, 2, "RobustEndpointPosterior:expected=1:actual=2"),
+    ],
+)
+def test_belief_provider_contract_rejects_schema_drift(
+    config_schema: int,
+    posterior_schema: int,
+    expected: str,
+) -> None:
+    result = validate_bayesian_phystwin_belief_provider(
+        _manifest(
+            config_schema=config_schema,
+            posterior_schema=posterior_schema,
+        )
+    )
+    assert not result.compatible
+    assert result.artifact_version_mismatches == (expected,)
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("provider_api", "bayesian_phystwin.fixed_anchor"),
+        ("provider_api_version", 2),
+        ("inference_role", "physical state correction"),
+    ],
+)
+def test_belief_provider_contract_rejects_metadata_drift(
+    name: str,
+    value: object,
+) -> None:
+    metadata = dict(_manifest().metadata)
+    metadata[name] = value
+    with pytest.raises(ValueError, match="unexpected"):
+        validate_bayesian_phystwin_belief_provider(
+            _manifest(metadata=metadata)
+        )
+
+
+def test_belief_provider_contract_rejects_wrong_provider_name() -> None:
+    manifest = _manifest()
+    wrong = PhysicalBeliefProviderManifest(
+        provider_name="other-provider",
+        provider_version=manifest.provider_version,
+        provider_revision=manifest.provider_revision,
+        schema_version=manifest.schema_version,
+        capabilities=manifest.capabilities,
+        artifact_schema_versions=manifest.artifact_schema_versions,
+        metadata=manifest.metadata,
+    )
+    with pytest.raises(ValueError, match="bayesian-phystwin"):
+        validate_bayesian_phystwin_belief_provider(wrong)

--- a/tests/test_bpt_belief_provider_usage.py
+++ b/tests/test_bpt_belief_provider_usage.py
@@ -25,9 +25,16 @@ def test_belief_export_validates_and_uses_fixed_anchor_provider(
     events: list[str] = []
     received: dict[str, Any] = {}
 
-    def require_provider():
+    class ProviderManifest:
+        def as_dict(self) -> dict[str, object]:
+            return {
+                "manifest_id": "belief-provider-v1",
+                "provider_revision": "a" * 40,
+            }
+
+    def require_provider() -> ProviderManifest:
         events.append("validate-provider")
-        return object()
+        return ProviderManifest()
 
     def infer_endpoint(
         residual_m: np.ndarray,
@@ -104,6 +111,10 @@ def test_belief_export_validates_and_uses_fixed_anchor_provider(
     assert received["config"] == settings.fixed_anchor_config()
     assert belief.metadata["particle_update_counts"] == [2]
     assert belief.metadata["particle_mean_final_inlier_probability"] == [0.8]
+    assert belief.metadata["belief_provider"] == {
+        "manifest_id": "belief-provider-v1",
+        "provider_revision": "a" * 40,
+    }
 
 
 @pytest.mark.parametrize(
@@ -120,3 +131,14 @@ def test_belief_export_config_rejects_nonfinite_or_boolean_settings(
 ) -> None:
     with pytest.raises(ValueError):
         BPTBeliefExportConfig(**kwargs)
+
+
+def test_belief_export_config_normalizes_numpy_scalars() -> None:
+    settings = BPTBeliefExportConfig(
+        process_std_m=np.float32(0.005),
+        interpolation_neighbors=np.int64(2),
+        maximum_discrepancy_m=np.float32(0.01),
+    )
+    assert type(settings.process_std_m) is float
+    assert type(settings.interpolation_neighbors) is int
+    assert type(settings.maximum_discrepancy_m) is float

--- a/tests/test_bpt_belief_provider_usage.py
+++ b/tests/test_bpt_belief_provider_usage.py
@@ -5,12 +5,17 @@ from typing import Any
 import numpy as np
 import pytest
 
+pytest.importorskip("bayesian_phystwin")
+
 import causal4d.bpt_belief as belief_module
 from bayesian_phystwin.causal4d_belief_provider_v1 import (
     FixedBayesianAnchorConfigV1,
     RobustEndpointPosteriorV1,
 )
-from causal4d.bpt_belief import BPTBeliefExportConfig, build_twin_belief_from_replays
+from causal4d.bpt_belief import (
+    BPTBeliefExportConfig,
+    build_twin_belief_from_replays,
+)
 from causal4d.contracts import build_causal_context
 
 

--- a/tests/test_bpt_belief_provider_usage.py
+++ b/tests/test_bpt_belief_provider_usage.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+import causal4d.bpt_belief as belief_module
+from bayesian_phystwin.causal4d_belief_provider_v1 import (
+    FixedBayesianAnchorConfigV1,
+    RobustEndpointPosteriorV1,
+)
+from causal4d.bpt_belief import BPTBeliefExportConfig, build_twin_belief_from_replays
+from causal4d.contracts import build_causal_context
+
+
+def test_belief_export_validates_and_uses_fixed_anchor_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    received: dict[str, Any] = {}
+
+    def require_provider():
+        events.append("validate-provider")
+        return object()
+
+    def infer_endpoint(
+        residual_m: np.ndarray,
+        valid: np.ndarray,
+        *,
+        end_frame: int,
+        config: FixedBayesianAnchorConfigV1,
+    ) -> RobustEndpointPosteriorV1:
+        events.append("infer-endpoint")
+        received["residual"] = residual_m.copy()
+        received["valid"] = valid.copy()
+        received["end_frame"] = end_frame
+        received["config"] = config
+        return RobustEndpointPosteriorV1(
+            mean_m=np.asarray([[0.002, 0.0, 0.0]]),
+            variance_m2=np.asarray([4e-6]),
+            final_nominal_probability=np.asarray([0.8]),
+            update_count=np.asarray([2], dtype=np.int64),
+        )
+
+    monkeypatch.setattr(
+        belief_module,
+        "require_bayesian_phystwin_belief_provider",
+        require_provider,
+    )
+    monkeypatch.setattr(
+        belief_module,
+        "infer_fixed_bayesian_anchor_endpoint",
+        infer_endpoint,
+    )
+    monkeypatch.setattr(
+        belief_module,
+        "build_lift_map",
+        lambda *args, **kwargs: (
+            np.asarray([[0]], dtype=np.int64),
+            np.asarray([[1.0]]),
+        ),
+    )
+
+    frame_count = 4
+    intervention_frame = 3
+    observed = np.zeros((frame_count, 1, 3), dtype=float)
+    replay = np.zeros((1, frame_count, 2, 3), dtype=float)
+    replay[:, :, 1] = replay[:, :, 0]
+    velocity = np.zeros_like(replay)
+    valid = np.ones((frame_count, 1), dtype=bool)
+    actions = np.zeros((frame_count, 1, 3), dtype=float)
+    context = build_causal_context(
+        protocol_id="belief-provider-v1",
+        case_id="synthetic",
+        observations=observed,
+        observed_actions=actions,
+        counterfactual_actions=actions,
+        intervention_frame=intervention_frame,
+    )
+    settings = BPTBeliefExportConfig(interpolation_neighbors=1)
+
+    belief = build_twin_belief_from_replays(
+        context=context,
+        replay_positions_m=replay,
+        replay_velocities_mps=velocity,
+        observed_positions_m=observed,
+        observed_valid=valid,
+        theta=np.asarray([[0.0]]),
+        theta_names=("parameter",),
+        weights=np.asarray([1.0]),
+        config=settings,
+    )
+
+    assert events == ["validate-provider", "infer-endpoint"]
+    assert received["end_frame"] == intervention_frame
+    assert received["residual"].shape == (intervention_frame, 1, 3)
+    assert received["valid"].shape == (intervention_frame, 1)
+    assert received["config"] == settings.fixed_anchor_config()
+    assert belief.metadata["particle_update_counts"] == [2]
+    assert belief.metadata["particle_mean_final_inlier_probability"] == [0.8]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"process_std_m": float("nan")},
+        {"observation_std_m": float("inf")},
+        {"interpolation_neighbors": True},
+        {"maximum_discrepancy_m": float("nan")},
+    ],
+)
+def test_belief_export_config_rejects_nonfinite_or_boolean_settings(
+    kwargs: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError):
+        BPTBeliefExportConfig(**kwargs)

--- a/tests/test_bpt_provider_import_boundary.py
+++ b/tests/test_bpt_provider_import_boundary.py
@@ -13,6 +13,7 @@ ALLOWED_BAYESIAN_PHYSTWIN_MODULES = frozenset(
     {
         "bayesian_phystwin.causal4d_artifacts_v1",
         "bayesian_phystwin.causal4d_artifacts_v2",
+        "bayesian_phystwin.causal4d_belief_provider_v1",
         "bayesian_phystwin.causal4d_graph_provider_v1",
         "bayesian_phystwin.causal4d_provider_v1",
         "bayesian_phystwin.causal4d_provider_v2",


### PR DESCRIPTION
## Summary

- add a dedicated Causal4D compatibility contract for `bayesian_phystwin.causal4d_belief_provider_v1`;
- validate provider identity, package range, fixed-anchor capabilities, inference role, and both artifact schema versions before residual inference;
- replace the belief exporter's direct use of the historical `robust_random_walk_endpoint` surface with `infer_fixed_bayesian_anchor_endpoint` and immutable `FixedBayesianAnchorConfigV1` / `RobustEndpointPosteriorV1` contracts;
- keep the historical provider-v1 import only for the separate released self-collision compatibility lookup;
- reject non-finite fixed-anchor settings, Boolean interpolation counts, and non-finite discrepancy caps;
- extend the Bayesian-PhysTwin import allowlist, contract regressions, provider-use ordering tests, and boundary documentation.

## Root cause

Bayesian-PhysTwin already exposed a narrow NumPy-only fixed-anchor provider, but Causal4D's production belief exporter still imported the endpoint implementation and frozen hyperparameter constants from the broad scientific compatibility provider. This meant the new capability manifest was not independently validated and the Causal4D AST boundary could not distinguish fixed-anchor inference from unrelated historical operations.

## Compatibility and scientific boundary

- The five frozen fixed-anchor defaults are sourced from Bayesian-PhysTwin's immutable V1 configuration and remain numerically unchanged.
- The same causal prefix, residuals, robust endpoint computation, lifting rule, discrepancy cap, and exact separation between readout discrepancy and physical state are preserved.
- Existing frozen pins and milestone artifacts are not modified.
- This is provider-boundary and input-validation hardening, not new empirical evidence or a changed causal method.

## Validation included

- manifest acceptance, missing-capability, artifact-version, metadata-identity, and wrong-provider regressions;
- explicit validation-before-inference and causal-prefix forwarding checks;
- immutable provider DTO consumption checks;
- non-finite and Boolean configuration regressions;
- exhaustive versioned-import boundary coverage.

GitHub Actions should run the repository's full Python 3.10/3.12/3.14, provider-integration, package, installed-artifact, result-bundle, and frozen-manifest gates.