### PR TITLE
Pin the release-publishing action to an immutable revision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,6 @@ jobs:
           name: python-distributions
           path: dist
       - name: Publish release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: dist/*


### PR DESCRIPTION
## Summary

Pin `softprops/action-gh-release` in the contents-write release job to the exact commit currently referenced by the repository's `v2` ref:

```text
3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
```

Keep the `# v2` annotation so Dependabot can continue proposing reviewed updates after #90.

## Why

The release job can write GitHub release contents. Resolving a mutable major-version ref at execution time creates an avoidable supply-chain boundary. An immutable commit identity ensures that the reviewed action implementation is the one that executes.

## Validation

The resolved `v2` ref was checked directly against `softprops/action-gh-release` before applying the pin. Normal CI validates workflow syntax, packaging, installed artifacts, CLI help, bundles, provider integration, and the frozen manifest.

## Scientific boundary

This changes only the identity of a release-publishing dependency. No package source, protocol, evidence, estimator, calibration, or scientific result changes.