### PR TITLE
Add fail-closed pre-acquisition readiness gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,22 @@ independent-execution calibration. Primary-method development is frozen for
 this result; another discrepancy mechanism, semantic component, planner, or
 public-data branch cannot replace it.
 
-After scaffolding the acquisition dataset, seal the exact clean Causal4D commit,
+The v4 amendment itself remains immutable. After scaffolding the acquisition
+dataset, create its separate operational evidence records:
+
+```bash
+causal4d protocol readiness scaffold \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1
+```
+
+Complete and seal the source-panel, actuator, support/gravity, and
+nonconfirmatory dry-run gates. Then seal the exact clean Causal4D commit,
 Bayesian-PhysTwin pin, protocol files, analysis boundary, and reporting contract:
 
 ```bash
 causal4d-real-experiment-freeze seal \
-  . \
+  /opt/causal4d-frozen \
   /data/causal4d-sloth-multi-action-v1/method_freeze.json \
   --frozen-by "<operator-or-principal-investigator>"
 ```
@@ -168,6 +178,27 @@ causal4d-real-experiment-freeze attest \
   /data/causal4d-sloth-multi-action-v1/method_freeze_validation.json \
   --verified-by "<independent-verifier>"
 ```
+
+Seal the software-environment gate after that attestation, then require a
+hash-verified readiness decision before confirmatory execution 1:
+
+```bash
+causal4d protocol readiness status \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  --verify-file-hashes \
+  --require-ready \
+  --output-json \
+  /data/causal4d-sloth-multi-action-v1/preacquisition-readiness.json
+```
+
+The readiness gate binds the 12-run source panel, actuator synchronization,
+support/gravity registration, the nonconfirmatory end-to-end dry run, the
+method freeze, exact Causal4D/Bayesian-PhysTwin package artifacts, and an
+explicit Prob4D used-or-unused declaration. It refuses readiness when any
+confirmatory manifest already exists. See
+[docs/causal4d_preacquisition_readiness.md](docs/causal4d_preacquisition_readiness.md)
+for its evidence and exit-code contracts.
 
 Track acquisition progress without counting templates as evidence:
 

--- a/docs/causal4d_preacquisition_readiness.md
+++ b/docs/causal4d_preacquisition_readiness.md
@@ -1,0 +1,159 @@
+# Pre-acquisition readiness attestation
+
+The registered v4 amendment defines the order of work before the 36-run
+confirmatory experiment, but its Boolean collection gate is intentionally frozen
+at `false`. It is a preregistration artifact, not a mutable checklist.
+
+`causal4d protocol readiness` adds a separate, evidence-derived decision layer.
+It never rewrites the v2, v3, or v4 protocol files. The first confirmatory
+execution is permitted only when every prerequisite and operational gate below
+validates from immutable, checksummed evidence.
+
+## Decision contract
+
+The readiness status distinguishes three states:
+
+- **ready**: all evidence validates, all file hashes were checked, the registered
+  chronology is respected, and no confirmatory manifest exists;
+- **valid but incomplete**: the evidence tree is internally consistent, but one
+  or more required artifacts are absent or still templates;
+- **invalid**: present evidence is malformed or contradictory, an operational
+  approval postdates the method freeze, or confirmatory collection already
+  started before the gate opened.
+
+With `--require-ready`, these states use exit codes `0`, `3`, and `2`,
+respectively. This lets an acquisition launcher fail closed without confusing an
+ordinary incomplete setup with corrupt evidence.
+
+## Filesystem contract
+
+Scaffolding creates five non-overwriting templates below the dataset root:
+
+```text
+preacquisition/
+├── signature_panel.json
+├── actuator_sync.json
+├── support_registration.json
+├── end_to_end_dry_run.json
+├── software_environment.json
+└── source_panel/executions/<execution-id>/manifest.template.json
+```
+
+Each gate record binds the locked protocol and v4 amendment, its underlying
+files, completion and approval timestamps, the no-target-outcomes boundary, and
+a canonical SHA-256 digest. The scaffold also writes one source-panel manifest
+template per registered execution; operators promote completed copies to
+`manifest.json` at the corresponding paths. `seal-gate` verifies all bound files
+before replacing the completed gate template atomically. A sealed gate cannot be
+resealed. Evidence descriptors use the same relative-path contract throughout:
+
+```json
+{"path": "relative/file", "sha256": "<64 lowercase hex>", "bytes": 123}
+```
+
+### Signature panel
+
+The signature gate requires the exact 12 v2 source-panel execution IDs in their
+registered order and 12 independent reset/grasp sessions. Every bound
+`SourcePanelExecutionManifest` must state that it is complete, source-only,
+outside all confirmatory folds, included without quality-gate failures, and did
+not use target outcomes. Its artifact descriptors are hash-verified.
+
+### Actuator synchronization
+
+The actuator gate requires one checksummed
+`ActuatorRealizationCalibration` artifact for every source-panel execution. It
+checks the locked PyRecEst version, the source/dry-run information boundary,
+hardware-timestamp authority, artifact identity, and the registered maximum
+RGB-D/actuator synchronization error.
+
+### Support and gravity registration
+
+The support gate records the locked world frame, measured gravity vector,
+support geometry, registration closure error, and the threshold chosen by the
+pre-acquisition calibration procedure. The registration file must be included in
+the gate's evidence descriptors.
+
+### End-to-end dry run
+
+The dry-run gate requires a nonconfirmatory execution ID and successful exercise
+of all registered stages:
+
+```text
+synchronized_acquisition
+observation_prefix_build
+intervention_abduction
+held_out_prediction
+artifact_hash_validation
+status_generation
+```
+
+The dry run may not reuse a confirmatory execution ID or use target outcomes.
+
+### Software lineage
+
+The software-environment gate is sealed after the method freeze. It binds:
+
+- the exact method-freeze and independent-attestation file hashes;
+- the frozen Causal4D and Bayesian-PhysTwin commits;
+- package versions and SHA-256 descriptors for the installed wheel or equivalent
+  immutable distribution artifact;
+- an explicit Prob4D declaration. When Prob4D supplies claim-bearing
+  observations, its commit, version, distribution, and observation-contract
+  version are required. When it is not used, the record must say so and give a
+  reason;
+- the actual observation producer and Python runtime identity.
+
+This makes the executed bytes and observation producer explicit without changing
+the registered scientific method.
+
+## Workflow
+
+Create templates after scaffolding the registered dataset:
+
+```bash
+causal4d protocol readiness scaffold \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1
+```
+
+Complete each JSON template and its referenced evidence, then seal it. Operational
+source-panel gates must be completed and approved before the method freeze. For
+example:
+
+```bash
+causal4d protocol readiness seal-gate \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  signature_panel_complete \
+  --approved-by "<reviewer>"
+```
+
+Seal the software environment after `method_freeze.json` and its independent
+attestation validate:
+
+```bash
+causal4d protocol readiness seal-gate \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  software_environment_locked \
+  --approved-by "<independent-verifier>"
+```
+
+Finally, require a hash-verified ready decision before execution 1:
+
+```bash
+causal4d protocol readiness status \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  --verify-file-hashes \
+  --require-ready \
+  --output-json \
+  /data/causal4d-sloth-multi-action-v1/preacquisition-readiness.json
+```
+
+The resulting status includes the derived collection flags, prerequisite and gate
+validation details, confirmatory-manifest counts, blockers, and its own canonical
+SHA-256 digest. Only `ready=true` and
+`first_confirmatory_execution_allowed=true` authorize the first confirmatory
+execution.

--- a/docs/causal4d_real_experiment_milestone.md
+++ b/docs/causal4d_real_experiment_milestone.md
@@ -57,17 +57,49 @@ Every such change must be logged with its commit and reason.
 ## Freeze and acquisition workflow
 
 Start from a clean checkout of the commit intended for acquisition. Scaffold the
-non-overwriting dataset first, then write the freeze manifest into that dataset:
+non-overwriting dataset and readiness evidence first:
 
 ```bash
 causal4d-real-protocol scaffold \
   configs/causal4d/sloth_multi_action_v1.json \
   /data/causal4d-sloth-multi-action-v1
 
+causal4d protocol readiness scaffold \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1
+```
+
+Complete and seal the source-panel, actuator, support/gravity, and
+nonconfirmatory dry-run gates. These operational approvals must predate the
+method freeze. Then write and independently attest the freeze manifest:
+
+```bash
 causal4d-real-experiment-freeze seal \
-  . \
+  /opt/causal4d-frozen \
   /data/causal4d-sloth-multi-action-v1/method_freeze.json \
   --frozen-by "<operator-or-principal-investigator>"
+
+causal4d-real-experiment-freeze attest \
+  /data/causal4d-sloth-multi-action-v1/method_freeze.json \
+  configs/causal4d/sloth_multi_action_v1.json \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1/method_freeze_validation.json \
+  --verified-by "<independent-verifier>"
+```
+
+After the attestation, seal the software-environment gate. It binds the exact
+freeze and attestation hashes, Causal4D and Bayesian-PhysTwin package artifacts,
+the observation producer, and an explicit Prob4D used-or-unused declaration.
+Finally, require the hash-verified readiness decision:
+
+```bash
+causal4d protocol readiness status \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  --verify-file-hashes \
+  --require-ready \
+  --output-json \
+  /data/causal4d-sloth-multi-action-v1/preacquisition-readiness.json
 ```
 
 Before every acquisition session, verify that the checkout still matches the
@@ -76,8 +108,8 @@ sealed commit and that no locked file has drifted:
 ```bash
 causal4d-real-experiment-freeze validate \
   /data/causal4d-sloth-multi-action-v1/method_freeze.json \
-  . \
-  --expected-causal4d-commit "$(git rev-parse HEAD)"
+  /opt/causal4d-frozen \
+  --expected-causal4d-commit "$(git -C /opt/causal4d-frozen rev-parse HEAD)"
 ```
 
 The seal command refuses a dirty Git worktree. Freeze schema v2 records file
@@ -89,6 +121,12 @@ execution-block score, calibration unit, fold count, finite rank, and
 non-claims. A manifest that substitutes the older coordinate-pooled calibration
 command fails validation.
 
+The separate readiness status does not mutate that freeze or the v4 amendment.
+It derives the collection decision from the registered prerequisite validators,
+checksummed operational records, software lineage, chronology, and zero
+confirmatory manifests. See
+[causal4d_preacquisition_readiness.md](causal4d_preacquisition_readiness.md).
+
 ## Execution checkpoints
 
 ### 1. Readiness gate
@@ -98,9 +136,15 @@ Before confirmatory execution 1:
 - pass the versioned pre-acquisition amendment;
 - register the physical object and all three canonical contact-node sets;
 - pass the slip go/no-go pilot;
-- verify camera/controller calibration and shared-clock synchronization;
+- complete the exact 12-execution, 12-independent-session source panel;
+- validate commanded versus measured actuation;
+- validate support, gravity, camera/controller, and shared-clock registration;
+- pass one nonconfirmatory end-to-end dry run;
 - seal and independently validate `method_freeze.json`;
-- confirm that no confirmatory target outcome has been inspected.
+- bind the exact software distributions and observation producer;
+- confirm that no confirmatory manifest or target outcome exists; and
+- obtain `first_confirmatory_execution_allowed=true` from
+  `causal4d protocol readiness status --verify-file-hashes --require-ready`.
 
 ### 2. Confirmatory acquisition
 

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -18,8 +18,16 @@ causal4d benchmark counterfactual --output-dir runs/counterfactual
 causal4d benchmark latent-contact --output-dir runs/latent-contact
 causal4d protocol real validate-protocol configs/causal4d/sloth_multi_action_v1.json
 causal4d protocol freeze validate method_freeze.json protocol.json checkout/
+causal4d protocol readiness status checkout/ dataset/ --verify-file-hashes
 causal4d evidence observation-lineage validate observation.npz twin_belief.npz
 ```
+
+`protocol readiness` is the fail-closed gate before confirmatory collection. It
+scaffolds non-overwriting operational evidence templates, seals one completed
+gate after hash validation, and derives whether execution 1 is permitted. With
+`--require-ready`, exit code `0` means ready, `3` means valid but incomplete, and
+`2` means malformed or contradictory evidence. See
+[the readiness contract](causal4d_preacquisition_readiness.md).
 
 Command modules are imported only after a route is selected. Therefore root
 help, version reporting, and registry inspection stay independent of optional

--- a/src/causal4d/cli/command_registry.py
+++ b/src/causal4d/cli/command_registry.py
@@ -91,6 +91,12 @@ GROUPED_COMMANDS = (
         legacy_name="causal4d-preacquisition-protocol-v4",
     ),
     CommandSpec(
+        route=("protocol", "readiness"),
+        target="causal4d.cli.preacquisition_readiness:main",
+        summary="Verify evidence-bound readiness before confirmatory collection.",
+        lifecycle="stable",
+    ),
+    CommandSpec(
         route=("evidence", "observation-lineage"),
         target="causal4d.cli.observation_lineage:main",
         summary="Validate or bind observation provenance.",

--- a/src/causal4d/cli/preacquisition_readiness.py
+++ b/src/causal4d/cli/preacquisition_readiness.py
@@ -1,0 +1,108 @@
+"""Scaffold, seal, and verify pre-acquisition readiness evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+
+from causal4d.preacquisition_readiness import (
+    GATE_PATHS,
+    build_preacquisition_readiness,
+    scaffold_preacquisition_readiness,
+    seal_preacquisition_gate,
+    write_preacquisition_readiness,
+)
+
+
+_VALID_BUT_INCOMPLETE = 3
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    scaffold = subparsers.add_parser(
+        "scaffold",
+        help="write incomplete evidence templates without overwriting existing files",
+    )
+    scaffold.add_argument("repository_root")
+    scaffold.add_argument("dataset_root")
+
+    seal = subparsers.add_parser(
+        "seal-gate",
+        help="validate and atomically seal one completed operational gate",
+    )
+    seal.add_argument("repository_root")
+    seal.add_argument("dataset_root")
+    seal.add_argument("gate_id", choices=tuple(GATE_PATHS))
+    seal.add_argument("--approved-by", required=True)
+    seal.add_argument("--approved-at-utc")
+
+    status = subparsers.add_parser(
+        "status",
+        help="derive whether the first confirmatory execution is permitted",
+    )
+    status.add_argument("repository_root")
+    status.add_argument("dataset_root")
+    status.add_argument("--output-json")
+    status.add_argument("--verify-file-hashes", action="store_true")
+    status.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="return exit code 3 when evidence is valid but incomplete",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "scaffold":
+            result = scaffold_preacquisition_readiness(
+                args.repository_root,
+                args.dataset_root,
+            )
+        elif args.command == "seal-gate":
+            result = seal_preacquisition_gate(
+                args.repository_root,
+                args.dataset_root,
+                args.gate_id,
+                approved_by=args.approved_by,
+                approved_at_utc=args.approved_at_utc,
+            )
+        else:
+            result = build_preacquisition_readiness(
+                args.repository_root,
+                args.dataset_root,
+                verify_file_hashes=args.verify_file_hashes,
+            )
+            if args.output_json:
+                write_preacquisition_readiness(args.output_json, result)
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        print(
+            json.dumps(
+                {
+                    "valid": False,
+                    "ready": False,
+                    "passed": False,
+                    "error": str(error),
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 2
+
+    print(json.dumps(result, indent=2, sort_keys=True, allow_nan=False))
+    if args.command != "status":
+        return 0
+    if not result["valid"]:
+        return 2
+    if args.require_ready and not result["ready"]:
+        return _VALID_BUT_INCOMPLETE
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d/preacquisition_gate_validation.py
+++ b/src/causal4d/preacquisition_gate_validation.py
@@ -1,0 +1,524 @@
+"""Validation and atomic sealing for pre-acquisition gate evidence."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import tempfile
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from causal4d.preacquisition_readiness_contracts import (
+    GATE_EVIDENCE_ARTIFACT_KIND,
+    GATE_EVIDENCE_SCHEMA_VERSION,
+    GATE_PATHS,
+    OPERATIONAL_GATES_BEFORE_FREEZE,
+    REQUIRED_DRY_RUN_STAGES,
+    _finite_number,
+    _is_hex_digest,
+    _parse_utc_timestamp,
+    _read_json_mapping,
+    _require,
+    _sha256_file,
+    _validate_descriptor,
+    _validate_descriptor_list,
+    gate_evidence_sha256,
+    load_registered_preacquisition_chain,
+)
+from causal4d.preacquisition_source_validation import (
+    _validate_actuator_sync,
+    _validate_signature_panel,
+)
+from causal4d.real_evidence_contract_v2 import build_real_evidence_status
+
+def _validate_common_gate(
+    protocol: Mapping[str, Any],
+    v4: Mapping[str, Any],
+    gate: Mapping[str, Any],
+    *,
+    gate_id: str,
+    dataset_root: Path,
+    verify_file_hashes: bool,
+) -> tuple[Mapping[str, Any], set[str], datetime]:
+    _require(
+        gate.get("schema_version") == GATE_EVIDENCE_SCHEMA_VERSION,
+        f"unsupported gate schema: {gate_id}",
+    )
+    _require(
+        gate.get("artifact_kind") == GATE_EVIDENCE_ARTIFACT_KIND,
+        f"unexpected gate artifact kind: {gate_id}",
+    )
+    _require(gate.get("gate_id") == gate_id, f"gate id mismatch: {gate_id}")
+    _require(gate.get("status") == "passed", f"gate is not passed: {gate_id}")
+    _require(
+        gate.get("protocol_id") == protocol["protocol_id"],
+        f"gate protocol mismatch: {gate_id}",
+    )
+    _require(
+        gate.get("protocol_design_sha256") == protocol["design_sha256"],
+        f"gate protocol digest mismatch: {gate_id}",
+    )
+    _require(
+        gate.get("preacquisition_plan_id") == v4["plan_id"],
+        f"gate v4 plan mismatch: {gate_id}",
+    )
+    _require(
+        gate.get("preacquisition_amendment_sha256") == v4["amendment_sha256"],
+        f"gate v4 digest mismatch: {gate_id}",
+    )
+    _require(
+        gate.get("locked_before_confirmatory_collection") is True,
+        f"gate was not locked before collection: {gate_id}",
+    )
+    _require(
+        gate.get("target_outcomes_used") is False,
+        f"target outcomes entered gate evidence: {gate_id}",
+    )
+    completed_at = _parse_utc_timestamp(
+        gate.get("completed_at_utc"),
+        name=f"{gate_id} completed_at_utc",
+    )
+    approval = gate.get("approval")
+    _require(isinstance(approval, Mapping), f"gate approval is invalid: {gate_id}")
+    _require(approval.get("approved") is True, f"gate approval is missing: {gate_id}")
+    _require(
+        isinstance(approval.get("approver_id"), str)
+        and bool(str(approval["approver_id"]).strip()),
+        f"gate approver is missing: {gate_id}",
+    )
+    approved_at = _parse_utc_timestamp(
+        approval.get("approved_at_utc"),
+        name=f"{gate_id} approved_at_utc",
+    )
+    _require(approved_at >= completed_at, f"gate approval predates completion: {gate_id}")
+    _require(
+        gate.get("artifact_sha256") == gate_evidence_sha256(gate),
+        f"gate digest mismatch: {gate_id}",
+    )
+    checks = gate.get("checks")
+    _require(isinstance(checks, Mapping), f"gate checks are invalid: {gate_id}")
+    evidence_paths = _validate_descriptor_list(
+        dataset_root,
+        gate.get("evidence"),
+        name=f"{gate_id}.evidence",
+        verify_file_hashes=verify_file_hashes,
+    )
+    return checks, evidence_paths, approved_at
+
+
+def _validate_support_registration(
+    checks: Mapping[str, Any],
+    evidence_paths: set[str],
+) -> None:
+    for field in (
+        "support_geometry_registered",
+        "gravity_registered",
+        "quality_gate_passed",
+    ):
+        _require(checks.get(field) is True, f"support registration failed: {field}")
+    _require(
+        isinstance(checks.get("world_frame_id"), str)
+        and bool(str(checks["world_frame_id"]).strip()),
+        "support world frame is missing",
+    )
+    vector = checks.get("gravity_vector_mps2")
+    _require(isinstance(vector, list) and len(vector) == 3, "gravity vector is invalid")
+    gravity = [_finite_number(value, name="gravity component") for value in vector]
+    magnitude = math.sqrt(sum(value * value for value in gravity))
+    _require(8.0 <= magnitude <= 11.5, "gravity magnitude fails the physical sanity gate")
+    closure = _finite_number(
+        checks.get("registration_closure_error_m"),
+        name="support registration closure error",
+    )
+    threshold = _finite_number(
+        checks.get("maximum_registration_closure_error_m"),
+        name="support registration closure threshold",
+    )
+    _require(closure >= 0.0 and threshold > 0.0, "support closure values are invalid")
+    _require(closure <= threshold, "support registration closure error exceeds its gate")
+    relative = checks.get("registration_file")
+    _require(
+        isinstance(relative, str) and relative in evidence_paths,
+        "support registration file is not bound as evidence",
+    )
+
+
+def _validate_dry_run(
+    protocol: Mapping[str, Any],
+    checks: Mapping[str, Any],
+    evidence_paths: set[str],
+) -> None:
+    _require(checks.get("nonconfirmatory") is True, "dry run is not nonconfirmatory")
+    _require(
+        checks.get("target_outcomes_used") is False,
+        "target outcomes entered the dry run",
+    )
+    _require(
+        checks.get("frozen_entrypoints_exercised") is True,
+        "dry run did not exercise the frozen entrypoints",
+    )
+    execution_id = checks.get("execution_id")
+    _require(isinstance(execution_id, str) and bool(execution_id), "dry-run id is missing")
+    confirmatory_ids = {
+        str(execution["execution_id"]) for execution in protocol["executions"]
+    }
+    _require(execution_id not in confirmatory_ids, "dry run reuses a confirmatory id")
+    stages = checks.get("pipeline_stages")
+    _require(isinstance(stages, Mapping), "dry-run stage map is invalid")
+    _require(
+        set(stages) == set(REQUIRED_DRY_RUN_STAGES),
+        "dry-run stage set differs from the registered readiness contract",
+    )
+    _require(all(stages[name] is True for name in REQUIRED_DRY_RUN_STAGES), "dry run failed")
+    relative = checks.get("output_manifest")
+    _require(
+        isinstance(relative, str) and relative in evidence_paths,
+        "dry-run output manifest is not bound as evidence",
+    )
+
+
+def _validate_distribution_descriptor(
+    dataset_root: Path,
+    value: Any,
+    *,
+    name: str,
+    evidence_paths: set[str],
+    verify_file_hashes: bool,
+) -> None:
+    _require(isinstance(value, Mapping), f"{name} distribution descriptor is invalid")
+    path = _validate_descriptor(
+        dataset_root,
+        value,
+        name=f"{name} distribution",
+        verify_file_hashes=verify_file_hashes,
+    )
+    _require(path in evidence_paths, f"{name} distribution is not bound as evidence")
+
+
+def _validate_software_environment(
+    checks: Mapping[str, Any],
+    evidence_paths: set[str],
+    *,
+    dataset_root: Path,
+    prerequisites: Mapping[str, Mapping[str, Any]],
+    verify_file_hashes: bool,
+) -> None:
+    freeze = prerequisites["method_freeze"]
+    _require(freeze.get("valid") is True, "software lock requires a valid method freeze")
+    _require(
+        checks.get("method_freeze_sha256") == freeze.get("sha256"),
+        "software lock binds a different method freeze",
+    )
+    attestation = prerequisites["method_freeze_validation"]
+    _require(
+        attestation.get("valid") is True,
+        "software lock requires an independently attested method freeze",
+    )
+    _require(
+        checks.get("method_freeze_validation_sha256") == attestation.get("sha256"),
+        "software lock binds a different freeze attestation",
+    )
+    for name, commit_field in (
+        ("causal4d", "causal4d_commit_sha"),
+        ("bayesian_phystwin", "bayesian_phystwin_commit_sha"),
+    ):
+        package = checks.get(name)
+        _require(isinstance(package, Mapping), f"{name} software lock is missing")
+        _require(
+            package.get("commit_sha") == freeze.get(commit_field),
+            f"{name} commit differs from the method freeze",
+        )
+        _require(
+            isinstance(package.get("version"), str) and bool(package["version"]),
+            f"{name} package version is missing",
+        )
+        _validate_distribution_descriptor(
+            dataset_root,
+            package.get("distribution"),
+            name=name,
+            evidence_paths=evidence_paths,
+            verify_file_hashes=verify_file_hashes,
+        )
+    prob4d = checks.get("prob4d")
+    _require(isinstance(prob4d, Mapping), "Prob4D software declaration is missing")
+    _require(isinstance(prob4d.get("used"), bool), "Prob4D used flag is invalid")
+    if prob4d["used"]:
+        _require(_is_hex_digest(prob4d.get("commit_sha"), 40), "Prob4D commit is invalid")
+        _require(
+            isinstance(prob4d.get("version"), str) and bool(prob4d["version"]),
+            "Prob4D version is missing",
+        )
+        _require(
+            isinstance(prob4d.get("observation_contract_version"), str)
+            and bool(prob4d["observation_contract_version"]),
+            "Prob4D observation contract is missing",
+        )
+        _validate_distribution_descriptor(
+            dataset_root,
+            prob4d.get("distribution"),
+            name="prob4d",
+            evidence_paths=evidence_paths,
+            verify_file_hashes=verify_file_hashes,
+        )
+    else:
+        _require(
+            isinstance(prob4d.get("reason"), str) and bool(prob4d["reason"].strip()),
+            "the unused Prob4D declaration needs a reason",
+        )
+    producer = checks.get("observation_producer")
+    _require(isinstance(producer, Mapping), "observation producer declaration is missing")
+    for field in ("name", "version", "artifact_contract"):
+        _require(
+            isinstance(producer.get(field), str) and bool(producer[field].strip()),
+            f"observation producer {field} is missing",
+        )
+    python = checks.get("python")
+    _require(isinstance(python, Mapping), "Python environment declaration is missing")
+    for field in ("version", "implementation", "platform"):
+        _require(
+            isinstance(python.get(field), str) and bool(python[field].strip()),
+            f"Python environment {field} is missing",
+        )
+
+
+def _validate_gate_file(
+    gate_id: str,
+    path: Path,
+    *,
+    protocol: Mapping[str, Any],
+    v2: Mapping[str, Any],
+    v4: Mapping[str, Any],
+    dataset_root: Path,
+    prerequisites: Mapping[str, Mapping[str, Any]],
+    verify_file_hashes: bool,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "gate_id": gate_id,
+        "path": str(path.resolve()),
+        "present": path.is_file(),
+        "template": False,
+        "valid": False,
+        "approved_at_utc": None,
+        "error": None,
+    }
+    if not result["present"]:
+        result["error"] = "gate evidence is missing"
+        return result
+    try:
+        gate = _read_json_mapping(path, name=f"{gate_id} gate")
+        if gate.get("status") == "template":
+            _require(
+                gate.get("schema_version") == GATE_EVIDENCE_SCHEMA_VERSION,
+                "unsupported gate template schema",
+            )
+            _require(
+                gate.get("artifact_kind") == GATE_EVIDENCE_ARTIFACT_KIND,
+                "unexpected gate template kind",
+            )
+            _require(gate.get("gate_id") == gate_id, "gate template id mismatch")
+            _require(
+                gate.get("protocol_id") == protocol["protocol_id"],
+                "gate template protocol id mismatch",
+            )
+            _require(
+                gate.get("protocol_design_sha256") == protocol["design_sha256"],
+                "gate template protocol mismatch",
+            )
+            _require(
+                gate.get("preacquisition_plan_id") == v4["plan_id"],
+                "gate template v4 plan mismatch",
+            )
+            _require(
+                gate.get("preacquisition_amendment_sha256") == v4["amendment_sha256"],
+                "gate template v4 mismatch",
+            )
+            _require(
+                gate.get("artifact_sha256") is None,
+                "gate template already contains an artifact digest",
+            )
+            _require(isinstance(gate.get("checks"), Mapping), "gate template checks are invalid")
+            _require(isinstance(gate.get("evidence"), list), "gate template evidence is invalid")
+            approval = gate.get("approval")
+            _require(
+                isinstance(approval, Mapping) and approval.get("approved") is False,
+                "gate template approval is invalid",
+            )
+            result["template"] = True
+            result["error"] = "gate evidence is still a template"
+            return result
+        checks, evidence_paths, approved_at = _validate_common_gate(
+            protocol,
+            v4,
+            gate,
+            gate_id=gate_id,
+            dataset_root=dataset_root,
+            verify_file_hashes=verify_file_hashes,
+        )
+        if gate_id == "signature_panel_complete":
+            _validate_signature_panel(
+                protocol,
+                v2,
+                v4,
+                checks,
+                evidence_paths,
+                dataset_root=dataset_root,
+                verify_file_hashes=verify_file_hashes,
+            )
+        elif gate_id == "actuator_sync_passed":
+            _validate_actuator_sync(
+                protocol,
+                v2,
+                checks,
+                evidence_paths,
+                dataset_root=dataset_root,
+            )
+        elif gate_id == "support_registration_passed":
+            _validate_support_registration(checks, evidence_paths)
+        elif gate_id == "end_to_end_dry_run_passed":
+            _validate_dry_run(protocol, checks, evidence_paths)
+        elif gate_id == "software_environment_locked":
+            _validate_software_environment(
+                checks,
+                evidence_paths,
+                dataset_root=dataset_root,
+                prerequisites=prerequisites,
+                verify_file_hashes=verify_file_hashes,
+            )
+        else:
+            raise KeyError(gate_id)
+        result["valid"] = True
+        result["approved_at_utc"] = gate["approval"]["approved_at_utc"]
+        result["artifact_sha256"] = gate["artifact_sha256"]
+        result["sha256"], result["bytes"] = _sha256_file(path)
+    except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+        message = str(error).strip()
+        result["error"] = f"{type(error).__name__}: {message}" if message else type(error).__name__
+    return result
+
+
+def seal_preacquisition_gate(
+    repository_root: str | Path,
+    dataset_root: str | Path,
+    gate_id: str,
+    *,
+    approved_by: str,
+    approved_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Seal one completed gate after validating all bound evidence hashes."""
+
+    _require(gate_id in GATE_PATHS, f"unknown pre-acquisition gate: {gate_id}")
+    protocol, v2, _, v4 = load_registered_preacquisition_chain(repository_root)
+    root = Path(dataset_root)
+    path = root / GATE_PATHS[gate_id]
+    gate = _read_json_mapping(path, name=f"{gate_id} gate")
+    _require(gate.get("status") == "template", "gate evidence is already sealed")
+    _require(
+        gate.get("artifact_sha256") is None,
+        "gate template already contains an artifact digest",
+    )
+    _require(
+        gate.get("target_outcomes_used") is False,
+        "target_outcomes_used must be explicitly false before sealing",
+    )
+    approver = str(approved_by).strip()
+    _require(bool(approver), "approved_by is required")
+    _parse_utc_timestamp(gate.get("completed_at_utc"), name="gate completed_at_utc")
+    approved_at = approved_at_utc or datetime.now(timezone.utc).isoformat()
+    _parse_utc_timestamp(approved_at, name="gate approved_at_utc")
+    gate["status"] = "passed"
+    gate["locked_before_confirmatory_collection"] = True
+    gate["approval"] = {
+        "approved": True,
+        "approver_id": approver,
+        "approved_at_utc": approved_at,
+    }
+    gate["artifact_sha256"] = gate_evidence_sha256(gate)
+
+    real_status = build_real_evidence_status(
+        protocol,
+        root,
+        repository_root=repository_root,
+        verify_file_hashes=True,
+    )
+    _require(
+        int(real_status.get("manifest_executions", 0)) == 0
+        and int(real_status.get("acquired_executions", 0)) == 0
+        and int(real_status.get("validated_executions", 0)) == 0,
+        "confirmatory collection has already started",
+    )
+    freeze = real_status["prerequisites"]["method_freeze"]
+    if gate_id in OPERATIONAL_GATES_BEFORE_FREEZE and freeze.get("valid"):
+        _require(
+            _parse_utc_timestamp(approved_at, name="gate approved_at_utc")
+            <= _parse_utc_timestamp(
+                freeze.get("frozen_at_utc"),
+                name="method freeze frozen_at_utc",
+            ),
+            "operational gate approval postdates the method freeze",
+        )
+    if gate_id == "software_environment_locked":
+        attestation = real_status["prerequisites"]["method_freeze_validation"]
+        _require(
+            freeze.get("valid") is True and attestation.get("valid") is True,
+            "software environment requires a valid, independently attested freeze",
+        )
+        approved = _parse_utc_timestamp(approved_at, name="gate approved_at_utc")
+        _require(
+            approved
+            >= _parse_utc_timestamp(
+                freeze.get("frozen_at_utc"),
+                name="method freeze frozen_at_utc",
+            ),
+            "software environment approval predates the method freeze",
+        )
+        _require(
+            approved
+            >= _parse_utc_timestamp(
+                attestation.get("verified_at_utc"),
+                name="method freeze verified_at_utc",
+            ),
+            "software environment approval predates the freeze attestation",
+        )
+    # Validate the in-memory candidate before replacing the operator template.
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".candidate",
+        dir=path.parent,
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(
+                json.dumps(gate, indent=2, sort_keys=True, allow_nan=False) + "\n"
+            )
+            handle.flush()
+            os.fsync(handle.fileno())
+        candidate = _validate_gate_file(
+            gate_id,
+            temporary,
+            protocol=protocol,
+            v2=v2,
+            v4=v4,
+            dataset_root=root,
+            prerequisites=real_status["prerequisites"],
+            verify_file_hashes=True,
+        )
+        _require(candidate["valid"] is True, str(candidate["error"]))
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+    return {
+        **candidate,
+        "path": str(path.resolve()),
+        "passed": True,
+    }
+
+
+__all__ = [
+    "_validate_gate_file",
+    "seal_preacquisition_gate",
+]

--- a/src/causal4d/preacquisition_gate_validation.py
+++ b/src/causal4d/preacquisition_gate_validation.py
@@ -34,6 +34,7 @@ from causal4d.preacquisition_source_validation import (
 )
 from causal4d.real_evidence_contract_v2 import build_real_evidence_status
 
+
 def _validate_common_gate(
     protocol: Mapping[str, Any],
     v4: Mapping[str, Any],
@@ -93,7 +94,9 @@ def _validate_common_gate(
         approval.get("approved_at_utc"),
         name=f"{gate_id} approved_at_utc",
     )
-    _require(approved_at >= completed_at, f"gate approval predates completion: {gate_id}")
+    _require(
+        approved_at >= completed_at, f"gate approval predates completion: {gate_id}"
+    )
     _require(
         gate.get("artifact_sha256") == gate_evidence_sha256(gate),
         f"gate digest mismatch: {gate_id}",
@@ -128,7 +131,9 @@ def _validate_support_registration(
     _require(isinstance(vector, list) and len(vector) == 3, "gravity vector is invalid")
     gravity = [_finite_number(value, name="gravity component") for value in vector]
     magnitude = math.sqrt(sum(value * value for value in gravity))
-    _require(8.0 <= magnitude <= 11.5, "gravity magnitude fails the physical sanity gate")
+    _require(
+        8.0 <= magnitude <= 11.5, "gravity magnitude fails the physical sanity gate"
+    )
     closure = _finite_number(
         checks.get("registration_closure_error_m"),
         name="support registration closure error",
@@ -138,7 +143,9 @@ def _validate_support_registration(
         name="support registration closure threshold",
     )
     _require(closure >= 0.0 and threshold > 0.0, "support closure values are invalid")
-    _require(closure <= threshold, "support registration closure error exceeds its gate")
+    _require(
+        closure <= threshold, "support registration closure error exceeds its gate"
+    )
     relative = checks.get("registration_file")
     _require(
         isinstance(relative, str) and relative in evidence_paths,
@@ -161,7 +168,9 @@ def _validate_dry_run(
         "dry run did not exercise the frozen entrypoints",
     )
     execution_id = checks.get("execution_id")
-    _require(isinstance(execution_id, str) and bool(execution_id), "dry-run id is missing")
+    _require(
+        isinstance(execution_id, str) and bool(execution_id), "dry-run id is missing"
+    )
     confirmatory_ids = {
         str(execution["execution_id"]) for execution in protocol["executions"]
     }
@@ -172,7 +181,9 @@ def _validate_dry_run(
         set(stages) == set(REQUIRED_DRY_RUN_STAGES),
         "dry-run stage set differs from the registered readiness contract",
     )
-    _require(all(stages[name] is True for name in REQUIRED_DRY_RUN_STAGES), "dry run failed")
+    _require(
+        all(stages[name] is True for name in REQUIRED_DRY_RUN_STAGES), "dry run failed"
+    )
     relative = checks.get("output_manifest")
     _require(
         isinstance(relative, str) and relative in evidence_paths,
@@ -207,7 +218,9 @@ def _validate_software_environment(
     verify_file_hashes: bool,
 ) -> None:
     freeze = prerequisites["method_freeze"]
-    _require(freeze.get("valid") is True, "software lock requires a valid method freeze")
+    _require(
+        freeze.get("valid") is True, "software lock requires a valid method freeze"
+    )
     _require(
         checks.get("method_freeze_sha256") == freeze.get("sha256"),
         "software lock binds a different method freeze",
@@ -246,7 +259,9 @@ def _validate_software_environment(
     _require(isinstance(prob4d, Mapping), "Prob4D software declaration is missing")
     _require(isinstance(prob4d.get("used"), bool), "Prob4D used flag is invalid")
     if prob4d["used"]:
-        _require(_is_hex_digest(prob4d.get("commit_sha"), 40), "Prob4D commit is invalid")
+        _require(
+            _is_hex_digest(prob4d.get("commit_sha"), 40), "Prob4D commit is invalid"
+        )
         _require(
             isinstance(prob4d.get("version"), str) and bool(prob4d["version"]),
             "Prob4D version is missing",
@@ -269,7 +284,9 @@ def _validate_software_environment(
             "the unused Prob4D declaration needs a reason",
         )
     producer = checks.get("observation_producer")
-    _require(isinstance(producer, Mapping), "observation producer declaration is missing")
+    _require(
+        isinstance(producer, Mapping), "observation producer declaration is missing"
+    )
     for field in ("name", "version", "artifact_contract"):
         _require(
             isinstance(producer.get(field), str) and bool(producer[field].strip()),
@@ -339,8 +356,14 @@ def _validate_gate_file(
                 gate.get("artifact_sha256") is None,
                 "gate template already contains an artifact digest",
             )
-            _require(isinstance(gate.get("checks"), Mapping), "gate template checks are invalid")
-            _require(isinstance(gate.get("evidence"), list), "gate template evidence is invalid")
+            _require(
+                isinstance(gate.get("checks"), Mapping),
+                "gate template checks are invalid",
+            )
+            _require(
+                isinstance(gate.get("evidence"), list),
+                "gate template evidence is invalid",
+            )
             approval = gate.get("approval")
             _require(
                 isinstance(approval, Mapping) and approval.get("approved") is False,
@@ -395,7 +418,9 @@ def _validate_gate_file(
         result["sha256"], result["bytes"] = _sha256_file(path)
     except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
         message = str(error).strip()
-        result["error"] = f"{type(error).__name__}: {message}" if message else type(error).__name__
+        result["error"] = (
+            f"{type(error).__name__}: {message}" if message else type(error).__name__
+        )
     return result
 
 

--- a/src/causal4d/preacquisition_readiness.py
+++ b/src/causal4d/preacquisition_readiness.py
@@ -31,6 +31,7 @@ from causal4d.preacquisition_readiness_contracts import (
 )
 from causal4d.real_evidence_contract_v2 import build_real_evidence_status
 
+
 def scaffold_preacquisition_readiness(
     repository_root: str | Path,
     dataset_root: str | Path,
@@ -174,7 +175,9 @@ def evaluate_preacquisition_readiness(
                 name="software_environment_locked approved_at_utc",
             )
             if approved < frozen_at:
-                chronology_blockers.append("software_environment_predates_method_freeze")
+                chronology_blockers.append(
+                    "software_environment_predates_method_freeze"
+                )
             if attestation.get("valid"):
                 verified_at = _parse_utc_timestamp(
                     attestation.get("verified_at_utc"),
@@ -205,23 +208,23 @@ def evaluate_preacquisition_readiness(
             "valid", False
         ),
         "actuator_sync_passed": gate_results["actuator_sync_passed"]["valid"],
-        "support_registration_passed": gate_results[
-            "support_registration_passed"
-        ]["valid"],
-        "end_to_end_dry_run_passed": gate_results[
-            "end_to_end_dry_run_passed"
-        ]["valid"],
+        "support_registration_passed": gate_results["support_registration_passed"][
+            "valid"
+        ],
+        "end_to_end_dry_run_passed": gate_results["end_to_end_dry_run_passed"]["valid"],
         "analysis_code_frozen": bool(
             prerequisites["method_freeze"].get("valid")
             and prerequisites["method_freeze_validation"].get("valid")
         ),
-        "software_environment_locked": gate_results[
-            "software_environment_locked"
-        ]["valid"],
+        "software_environment_locked": gate_results["software_environment_locked"][
+            "valid"
+        ],
     }
     ready = not blockers and all(flags.values())
     flags["first_confirmatory_execution_allowed"] = ready
-    valid = not malformed_prerequisites and not malformed_gates and not chronology_blockers
+    valid = (
+        not malformed_prerequisites and not malformed_gates and not chronology_blockers
+    )
     valid = bool(valid and collection_not_started)
 
     status: dict[str, Any] = {
@@ -291,9 +294,7 @@ def write_preacquisition_readiness(
 
     output = Path(path)
     output.parent.mkdir(parents=True, exist_ok=True)
-    payload = json.dumps(
-        dict(status), indent=2, sort_keys=True, allow_nan=False
-    ) + "\n"
+    payload = json.dumps(dict(status), indent=2, sort_keys=True, allow_nan=False) + "\n"
     descriptor, temporary_name = tempfile.mkstemp(
         prefix=f".{output.name}.", suffix=".tmp", dir=output.parent
     )

--- a/src/causal4d/preacquisition_readiness.py
+++ b/src/causal4d/preacquisition_readiness.py
@@ -1,0 +1,330 @@
+"""Fail-closed readiness decision for the registered physical experiment."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from causal4d.preacquisition_gate_validation import (
+    _validate_gate_file,
+    seal_preacquisition_gate as seal_preacquisition_gate,
+)
+from causal4d.preacquisition_readiness_contracts import (
+    GATE_EVIDENCE_ARTIFACT_KIND as GATE_EVIDENCE_ARTIFACT_KIND,
+    GATE_EVIDENCE_SCHEMA_VERSION as GATE_EVIDENCE_SCHEMA_VERSION,
+    GATE_PATHS,
+    OPERATIONAL_GATES_BEFORE_FREEZE,
+    READINESS_ARTIFACT_KIND,
+    READINESS_SCHEMA_VERSION,
+    SOURCE_PANEL_MANIFEST_PATH as SOURCE_PANEL_MANIFEST_PATH,
+    SOURCE_PANEL_MANIFEST_TEMPLATE_PATH,
+    _parse_utc_timestamp,
+    gate_evidence_sha256 as gate_evidence_sha256,
+    gate_evidence_template,
+    load_registered_preacquisition_chain,
+    readiness_status_sha256,
+    source_panel_execution_manifest_template,
+)
+from causal4d.real_evidence_contract_v2 import build_real_evidence_status
+
+def scaffold_preacquisition_readiness(
+    repository_root: str | Path,
+    dataset_root: str | Path,
+) -> dict[str, Any]:
+    """Write incomplete gate templates without overwriting operator evidence."""
+
+    protocol, v2, _, v4 = load_registered_preacquisition_chain(repository_root)
+    root = Path(dataset_root)
+    created: list[str] = []
+    existing: list[str] = []
+    for gate_id, relative in GATE_PATHS.items():
+        path = root / relative
+        if path.exists():
+            existing.append(relative)
+            continue
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                gate_evidence_template(gate_id, protocol, v2, v4),
+                indent=2,
+                sort_keys=True,
+                allow_nan=False,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        created.append(relative)
+    source_executions = v2["preacquisition_signature_panel"]["executions"]
+    for execution in source_executions:
+        relative = SOURCE_PANEL_MANIFEST_TEMPLATE_PATH.format(
+            execution_id=execution["execution_id"]
+        )
+        path = root / relative
+        if path.exists():
+            existing.append(relative)
+            continue
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                source_panel_execution_manifest_template(execution, protocol, v4),
+                indent=2,
+                sort_keys=True,
+                allow_nan=False,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        created.append(relative)
+    return {
+        "passed": True,
+        "dataset_root": str(root.resolve()),
+        "created": created,
+        "existing": existing,
+    }
+
+
+def evaluate_preacquisition_readiness(
+    protocol: Mapping[str, Any],
+    v2: Mapping[str, Any],
+    v4: Mapping[str, Any],
+    dataset_root: str | Path,
+    real_status: Mapping[str, Any],
+    *,
+    verify_file_hashes: bool,
+) -> dict[str, Any]:
+    """Derive all collection gates from validated artifacts and chronology."""
+
+    root = Path(dataset_root)
+    prerequisites = real_status["prerequisites"]
+    gate_results = {
+        gate_id: _validate_gate_file(
+            gate_id,
+            root / relative,
+            protocol=protocol,
+            v2=v2,
+            v4=v4,
+            dataset_root=root,
+            prerequisites=prerequisites,
+            verify_file_hashes=verify_file_hashes,
+        )
+        for gate_id, relative in GATE_PATHS.items()
+    }
+
+    prerequisite_names = (
+        "dataset_protocol",
+        "acquisition_schedule",
+        "object_registration",
+        "slip_pilot",
+        "timebase_calibration",
+        "contact_registration",
+        "method_freeze",
+        "method_freeze_validation",
+    )
+    missing_prerequisites = [
+        name for name in prerequisite_names if not prerequisites[name].get("present")
+    ]
+    malformed_prerequisites = [
+        name
+        for name in prerequisite_names
+        if prerequisites[name].get("present") and not prerequisites[name].get("valid")
+    ]
+    missing_or_template_gates = [
+        gate_id
+        for gate_id, result in gate_results.items()
+        if not result["present"] or result["template"]
+    ]
+    malformed_gates = [
+        gate_id
+        for gate_id, result in gate_results.items()
+        if result["present"] and not result["template"] and not result["valid"]
+    ]
+
+    manifest_count = int(real_status.get("manifest_executions", 0))
+    acquired_count = int(real_status.get("acquired_executions", 0))
+    validated_count = int(real_status.get("validated_executions", 0))
+    collection_not_started = manifest_count == acquired_count == validated_count == 0
+
+    chronology_blockers: list[str] = []
+    freeze = prerequisites["method_freeze"]
+    if freeze.get("valid"):
+        frozen_at = _parse_utc_timestamp(
+            freeze.get("frozen_at_utc"), name="method freeze frozen_at_utc"
+        )
+        for gate_id in OPERATIONAL_GATES_BEFORE_FREEZE:
+            approved_at = gate_results[gate_id].get("approved_at_utc")
+            if approved_at is not None:
+                approved = _parse_utc_timestamp(
+                    approved_at, name=f"{gate_id} approved_at_utc"
+                )
+                if approved > frozen_at:
+                    chronology_blockers.append(
+                        f"method_freeze_precedes_operational_gate:{gate_id}"
+                    )
+        software_approved_at = gate_results["software_environment_locked"].get(
+            "approved_at_utc"
+        )
+        attestation = prerequisites["method_freeze_validation"]
+        if software_approved_at is not None:
+            approved = _parse_utc_timestamp(
+                software_approved_at,
+                name="software_environment_locked approved_at_utc",
+            )
+            if approved < frozen_at:
+                chronology_blockers.append("software_environment_predates_method_freeze")
+            if attestation.get("valid"):
+                verified_at = _parse_utc_timestamp(
+                    attestation.get("verified_at_utc"),
+                    name="method freeze verified_at_utc",
+                )
+                if approved < verified_at:
+                    chronology_blockers.append(
+                        "software_environment_predates_freeze_attestation"
+                    )
+
+    blockers: list[str] = []
+    blockers.extend(f"prerequisite:{name}" for name in missing_prerequisites)
+    blockers.extend(f"prerequisite_invalid:{name}" for name in malformed_prerequisites)
+    blockers.extend(f"gate:{name}" for name in missing_or_template_gates)
+    blockers.extend(f"gate_invalid:{name}" for name in malformed_gates)
+    blockers.extend(chronology_blockers)
+    if not verify_file_hashes:
+        blockers.append("file_hashes_not_verified")
+    if not collection_not_started:
+        blockers.append("confirmatory_collection_already_started")
+
+    flags = {
+        "signature_panel_complete": gate_results["signature_panel_complete"]["valid"],
+        "contact_registration_approved": prerequisites["contact_registration"].get(
+            "valid", False
+        ),
+        "slip_pilot_passed_or_versioned_out": prerequisites["slip_pilot"].get(
+            "valid", False
+        ),
+        "actuator_sync_passed": gate_results["actuator_sync_passed"]["valid"],
+        "support_registration_passed": gate_results[
+            "support_registration_passed"
+        ]["valid"],
+        "end_to_end_dry_run_passed": gate_results[
+            "end_to_end_dry_run_passed"
+        ]["valid"],
+        "analysis_code_frozen": bool(
+            prerequisites["method_freeze"].get("valid")
+            and prerequisites["method_freeze_validation"].get("valid")
+        ),
+        "software_environment_locked": gate_results[
+            "software_environment_locked"
+        ]["valid"],
+    }
+    ready = not blockers and all(flags.values())
+    flags["first_confirmatory_execution_allowed"] = ready
+    valid = not malformed_prerequisites and not malformed_gates and not chronology_blockers
+    valid = bool(valid and collection_not_started)
+
+    status: dict[str, Any] = {
+        "schema_version": READINESS_SCHEMA_VERSION,
+        "artifact_kind": READINESS_ARTIFACT_KIND,
+        "protocol_id": protocol["protocol_id"],
+        "protocol_design_sha256": protocol["design_sha256"],
+        "preacquisition_plan_id": v4["plan_id"],
+        "preacquisition_amendment_sha256": v4["amendment_sha256"],
+        "dataset_root": str(root.resolve()),
+        "verify_file_hashes": verify_file_hashes,
+        "prerequisites": {
+            name: dict(prerequisites[name]) for name in prerequisite_names
+        },
+        "operational_gates": gate_results,
+        "collection_gate": flags,
+        "confirmatory_collection": {
+            "manifest_executions": manifest_count,
+            "acquired_executions": acquired_count,
+            "validated_executions": validated_count,
+            "not_started": collection_not_started,
+        },
+        "missing_prerequisites": missing_prerequisites,
+        "malformed_prerequisites": malformed_prerequisites,
+        "missing_or_template_gates": missing_or_template_gates,
+        "malformed_gates": malformed_gates,
+        "chronology_blockers": chronology_blockers,
+        "blockers": blockers,
+        "valid": valid,
+        "ready": ready,
+        "passed": ready,
+    }
+    status["status_sha256"] = readiness_status_sha256(status)
+    return status
+
+
+def build_preacquisition_readiness(
+    repository_root: str | Path,
+    dataset_root: str | Path,
+    *,
+    verify_file_hashes: bool = False,
+) -> dict[str, Any]:
+    """Load the registered chain and derive a final collection decision."""
+
+    protocol, v2, _, v4 = load_registered_preacquisition_chain(repository_root)
+    real_status = build_real_evidence_status(
+        protocol,
+        dataset_root,
+        repository_root=repository_root,
+        verify_file_hashes=verify_file_hashes,
+    )
+    return evaluate_preacquisition_readiness(
+        protocol,
+        v2,
+        v4,
+        dataset_root,
+        real_status,
+        verify_file_hashes=verify_file_hashes,
+    )
+
+
+def write_preacquisition_readiness(
+    path: str | Path,
+    status: Mapping[str, Any],
+) -> Path:
+    """Atomically write one deterministic readiness snapshot."""
+
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(
+        dict(status), indent=2, sort_keys=True, allow_nan=False
+    ) + "\n"
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{output.name}.", suffix=".tmp", dir=output.parent
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, output)
+    finally:
+        if os.path.exists(temporary_name):
+            os.unlink(temporary_name)
+    return output
+
+
+__all__ = [
+    "GATE_EVIDENCE_ARTIFACT_KIND",
+    "GATE_EVIDENCE_SCHEMA_VERSION",
+    "GATE_PATHS",
+    "READINESS_ARTIFACT_KIND",
+    "READINESS_SCHEMA_VERSION",
+    "SOURCE_PANEL_MANIFEST_PATH",
+    "SOURCE_PANEL_MANIFEST_TEMPLATE_PATH",
+    "build_preacquisition_readiness",
+    "evaluate_preacquisition_readiness",
+    "gate_evidence_sha256",
+    "gate_evidence_template",
+    "load_registered_preacquisition_chain",
+    "readiness_status_sha256",
+    "scaffold_preacquisition_readiness",
+    "seal_preacquisition_gate",
+    "source_panel_execution_manifest_template",
+    "write_preacquisition_readiness",
+]

--- a/src/causal4d/preacquisition_readiness_contracts.py
+++ b/src/causal4d/preacquisition_readiness_contracts.py
@@ -1,0 +1,378 @@
+"""Schemas, templates, and shared utilities for acquisition readiness."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from causal4d.preacquisition_protocol_v4 import load_v4_chain
+
+READINESS_SCHEMA_VERSION = 1
+GATE_EVIDENCE_SCHEMA_VERSION = 1
+READINESS_ARTIFACT_KIND = "PreacquisitionReadinessStatus"
+GATE_EVIDENCE_ARTIFACT_KIND = "PreacquisitionGateEvidence"
+
+PROTOCOL_PATH = "configs/causal4d/sloth_multi_action_v1.json"
+PREACQUISITION_V2_PATH = "configs/causal4d/sloth_preacquisition_v2.json"
+PREACQUISITION_V3_PATH = "configs/causal4d/sloth_preacquisition_v3.json"
+PREACQUISITION_V4_PATH = "configs/causal4d/sloth_preacquisition_v4.json"
+MECHANISM_GATE_EVIDENCE_PATH = (
+    "runs/causal4d_preacquisition_v4/mechanism_gate_controls.json"
+)
+
+GATE_PATHS = {
+    "signature_panel_complete": "preacquisition/signature_panel.json",
+    "actuator_sync_passed": "preacquisition/actuator_sync.json",
+    "support_registration_passed": "preacquisition/support_registration.json",
+    "end_to_end_dry_run_passed": "preacquisition/end_to_end_dry_run.json",
+    "software_environment_locked": "preacquisition/software_environment.json",
+}
+
+SOURCE_PANEL_MANIFEST_PATH = (
+    "preacquisition/source_panel/executions/{execution_id}/manifest.json"
+)
+SOURCE_PANEL_MANIFEST_TEMPLATE_PATH = (
+    "preacquisition/source_panel/executions/{execution_id}/manifest.template.json"
+)
+
+REQUIRED_DRY_RUN_STAGES = (
+    "synchronized_acquisition",
+    "observation_prefix_build",
+    "intervention_abduction",
+    "held_out_prediction",
+    "artifact_hash_validation",
+    "status_generation",
+)
+OPERATIONAL_GATES_BEFORE_FREEZE = (
+    "signature_panel_complete",
+    "actuator_sync_passed",
+    "support_registration_passed",
+    "end_to_end_dry_run_passed",
+)
+_SHA40 = frozenset("0123456789abcdef")
+_SHA64 = _SHA40
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _canonical_sha256(values: Mapping[str, Any], *, omitted_field: str) -> str:
+    payload = deepcopy(dict(values))
+    payload.pop(omitted_field, None)
+    serialized = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def gate_evidence_sha256(values: Mapping[str, Any]) -> str:
+    """Return the digest that seals one operational gate record."""
+
+    return _canonical_sha256(values, omitted_field="artifact_sha256")
+
+
+def readiness_status_sha256(values: Mapping[str, Any]) -> str:
+    """Return the digest that binds one final readiness snapshot."""
+
+    return _canonical_sha256(values, omitted_field="status_sha256")
+
+
+def _is_hex_digest(value: Any, length: int) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == length
+        and all(character in _SHA64 for character in value)
+    )
+
+
+def _safe_relative_path(value: Any, *, name: str) -> Path:
+    _require(isinstance(value, str) and bool(value), f"{name} path is missing")
+    path = Path(value)
+    _require(
+        not path.is_absolute() and ".." not in path.parts,
+        f"{name} path is unsafe",
+    )
+    return path
+
+
+def _sha256_file(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+            size += len(block)
+    return digest.hexdigest(), size
+
+
+def _reject_json_constant(value: str) -> Any:
+    raise ValueError(f"non-finite JSON constant is forbidden: {value}")
+
+
+def _read_json_mapping(path: Path, *, name: str) -> dict[str, Any]:
+    payload = json.loads(
+        path.read_text(encoding="utf-8"),
+        parse_constant=_reject_json_constant,
+    )
+    _require(isinstance(payload, Mapping), f"{name} must be a JSON object")
+    return dict(payload)
+
+
+def _parse_utc_timestamp(value: Any, *, name: str) -> datetime:
+    _require(isinstance(value, str) and bool(value), f"{name} is missing")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(f"{name} is not ISO 8601") from error
+    _require(parsed.tzinfo is not None, f"{name} must include a timezone")
+    _require(parsed.utcoffset() == timezone.utc.utcoffset(parsed), f"{name} must be UTC")
+    return parsed
+
+
+def _finite_number(value: Any, *, name: str) -> float:
+    _require(
+        isinstance(value, (int, float)) and not isinstance(value, bool),
+        f"{name} must be numeric",
+    )
+    result = float(value)
+    _require(math.isfinite(result), f"{name} must be finite")
+    return result
+
+
+def _validate_descriptor(
+    dataset_root: Path,
+    descriptor: Mapping[str, Any],
+    *,
+    name: str,
+    verify_file_hashes: bool,
+) -> str:
+    relative = _safe_relative_path(descriptor.get("path"), name=name)
+    _require(_is_hex_digest(descriptor.get("sha256"), 64), f"{name} SHA-256 is invalid")
+    byte_count = descriptor.get("bytes")
+    _require(
+        isinstance(byte_count, int) and not isinstance(byte_count, bool) and byte_count >= 0,
+        f"{name} byte count is invalid",
+    )
+    if verify_file_hashes:
+        path = dataset_root / relative
+        _require(path.is_file(), f"{name} file is missing: {relative.as_posix()}")
+        digest, size = _sha256_file(path)
+        _require(digest == descriptor["sha256"], f"{name} checksum mismatch")
+        _require(size == byte_count, f"{name} byte count mismatch")
+    return relative.as_posix()
+
+
+def _validate_descriptor_list(
+    dataset_root: Path,
+    values: Any,
+    *,
+    name: str,
+    verify_file_hashes: bool,
+) -> set[str]:
+    _require(isinstance(values, list) and bool(values), f"{name} must be a nonempty list")
+    paths: set[str] = set()
+    for index, descriptor in enumerate(values):
+        _require(isinstance(descriptor, Mapping), f"{name}[{index}] is invalid")
+        path = _validate_descriptor(
+            dataset_root,
+            descriptor,
+            name=f"{name}[{index}]",
+            verify_file_hashes=verify_file_hashes,
+        )
+        _require(path not in paths, f"{name} contains a duplicate path: {path}")
+        paths.add(path)
+    return paths
+
+
+def _expected_source_panel(v2: Mapping[str, Any]) -> tuple[list[str], list[str]]:
+    executions = list(v2["preacquisition_signature_panel"]["executions"])
+    execution_ids = [str(execution["execution_id"]) for execution in executions]
+    session_ids = [str(execution["session_id"]) for execution in executions]
+    _require(len(execution_ids) == 12, "registered source panel must contain 12 executions")
+    _require(len(set(execution_ids)) == 12, "registered source execution ids are not unique")
+    _require(len(set(session_ids)) == 12, "registered source sessions are not independent")
+    return execution_ids, session_ids
+
+
+def source_panel_execution_manifest_template(
+    execution: Mapping[str, Any],
+    protocol: Mapping[str, Any],
+    v4: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return one explicitly incomplete source-panel execution record."""
+
+    execution_id = str(execution["execution_id"])
+    session_id = str(execution["session_id"])
+    _require(bool(execution_id) and bool(session_id), "source execution ids are missing")
+    return {
+        "schema_version": 1,
+        "artifact_kind": "SourcePanelExecutionManifest",
+        "status": "template",
+        "protocol_id": protocol["protocol_id"],
+        "protocol_design_sha256": protocol["design_sha256"],
+        "preacquisition_plan_id": v4["plan_id"],
+        "preacquisition_amendment_sha256": v4["amendment_sha256"],
+        "execution_id": execution_id,
+        "session_id": session_id,
+        "fresh_reset_and_fresh_grasp": True,
+        "confirmatory_fold_member": False,
+        "target_outcomes_used": False,
+        "included": None,
+        "quality_gate_failures": [],
+        "started_at_utc": None,
+        "ended_at_utc": None,
+        "artifacts": [],
+    }
+
+
+def _template_checks(
+    gate_id: str,
+    protocol: Mapping[str, Any],
+    v2: Mapping[str, Any],
+) -> dict[str, Any]:
+    execution_ids, session_ids = _expected_source_panel(v2)
+    if gate_id == "signature_panel_complete":
+        return {
+            "execution_ids": execution_ids,
+            "session_ids": session_ids,
+            "independent_session_count": 12,
+            "source_only": True,
+            "manifest_files": {
+                identifier: SOURCE_PANEL_MANIFEST_PATH.format(execution_id=identifier)
+                for identifier in execution_ids
+            },
+        }
+    if gate_id == "actuator_sync_passed":
+        return {
+            "commanded_vs_measured_validated": None,
+            "hardware_timestamps_authoritative": True,
+            "maximum_measured_rgbd_actuator_sync_error_ms": None,
+            "maximum_allowed_rgbd_actuator_sync_error_ms": protocol["quality_gates"][
+                "maximum_rgbd_actuator_sync_error_ms"
+            ],
+            "calibration_files": {identifier: None for identifier in execution_ids},
+            "calibration_artifact_ids": {},
+        }
+    if gate_id == "support_registration_passed":
+        return {
+            "support_geometry_registered": None,
+            "gravity_registered": None,
+            "quality_gate_passed": None,
+            "world_frame_id": None,
+            "gravity_vector_mps2": None,
+            "registration_closure_error_m": None,
+            "maximum_registration_closure_error_m": None,
+            "registration_file": None,
+        }
+    if gate_id == "end_to_end_dry_run_passed":
+        return {
+            "nonconfirmatory": True,
+            "target_outcomes_used": False,
+            "frozen_entrypoints_exercised": None,
+            "execution_id": None,
+            "pipeline_stages": {name: False for name in REQUIRED_DRY_RUN_STAGES},
+            "output_manifest": None,
+        }
+    if gate_id == "software_environment_locked":
+        return {
+            "method_freeze_sha256": None,
+            "method_freeze_validation_sha256": None,
+            "causal4d": {
+                "commit_sha": None,
+                "version": None,
+                "distribution": {"path": None, "sha256": None, "bytes": None},
+            },
+            "bayesian_phystwin": {
+                "commit_sha": None,
+                "version": None,
+                "distribution": {"path": None, "sha256": None, "bytes": None},
+            },
+            "prob4d": {"used": False, "reason": None},
+            "observation_producer": {
+                "name": None,
+                "version": None,
+                "artifact_contract": None,
+            },
+            "python": {"version": None, "implementation": None, "platform": None},
+        }
+    raise KeyError(gate_id)
+
+
+def gate_evidence_template(
+    gate_id: str,
+    protocol: Mapping[str, Any],
+    v2: Mapping[str, Any],
+    v4: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return an explicitly incomplete evidence-bound gate template."""
+
+    _require(gate_id in GATE_PATHS, f"unknown pre-acquisition gate: {gate_id}")
+    return {
+        "schema_version": GATE_EVIDENCE_SCHEMA_VERSION,
+        "artifact_kind": GATE_EVIDENCE_ARTIFACT_KIND,
+        "gate_id": gate_id,
+        "protocol_id": protocol["protocol_id"],
+        "protocol_design_sha256": protocol["design_sha256"],
+        "preacquisition_plan_id": v4["plan_id"],
+        "preacquisition_amendment_sha256": v4["amendment_sha256"],
+        "status": "template",
+        "completed_at_utc": None,
+        "locked_before_confirmatory_collection": None,
+        "target_outcomes_used": None,
+        "checks": _template_checks(gate_id, protocol, v2),
+        "evidence": [],
+        "approval": {
+            "approved": False,
+            "approver_id": None,
+            "approved_at_utc": None,
+        },
+        "artifact_sha256": None,
+    }
+
+
+def load_registered_preacquisition_chain(
+    repository_root: str | Path,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Load and validate the immutable protocol-v2-v3-v4 chain."""
+
+    root = Path(repository_root)
+    return load_v4_chain(
+        root / PROTOCOL_PATH,
+        root / PREACQUISITION_V2_PATH,
+        root / PREACQUISITION_V3_PATH,
+        root / MECHANISM_GATE_EVIDENCE_PATH,
+        root / PREACQUISITION_V4_PATH,
+    )
+
+
+__all__ = [
+    "GATE_EVIDENCE_ARTIFACT_KIND",
+    "GATE_EVIDENCE_SCHEMA_VERSION",
+    "GATE_PATHS",
+    "MECHANISM_GATE_EVIDENCE_PATH",
+    "OPERATIONAL_GATES_BEFORE_FREEZE",
+    "PREACQUISITION_V2_PATH",
+    "PREACQUISITION_V3_PATH",
+    "PREACQUISITION_V4_PATH",
+    "PROTOCOL_PATH",
+    "READINESS_ARTIFACT_KIND",
+    "READINESS_SCHEMA_VERSION",
+    "REQUIRED_DRY_RUN_STAGES",
+    "SOURCE_PANEL_MANIFEST_PATH",
+    "SOURCE_PANEL_MANIFEST_TEMPLATE_PATH",
+    "gate_evidence_sha256",
+    "gate_evidence_template",
+    "load_registered_preacquisition_chain",
+    "readiness_status_sha256",
+    "source_panel_execution_manifest_template",
+]

--- a/src/causal4d/preacquisition_readiness_contracts.py
+++ b/src/causal4d/preacquisition_readiness_contracts.py
@@ -58,6 +58,7 @@ OPERATIONAL_GATES_BEFORE_FREEZE = (
 _SHA40 = frozenset("0123456789abcdef")
 _SHA64 = _SHA40
 
+
 def _require(condition: bool, message: str) -> None:
     if not condition:
         raise ValueError(message)
@@ -135,7 +136,9 @@ def _parse_utc_timestamp(value: Any, *, name: str) -> datetime:
     except ValueError as error:
         raise ValueError(f"{name} is not ISO 8601") from error
     _require(parsed.tzinfo is not None, f"{name} must include a timezone")
-    _require(parsed.utcoffset() == timezone.utc.utcoffset(parsed), f"{name} must be UTC")
+    _require(
+        parsed.utcoffset() == timezone.utc.utcoffset(parsed), f"{name} must be UTC"
+    )
     return parsed
 
 
@@ -160,7 +163,9 @@ def _validate_descriptor(
     _require(_is_hex_digest(descriptor.get("sha256"), 64), f"{name} SHA-256 is invalid")
     byte_count = descriptor.get("bytes")
     _require(
-        isinstance(byte_count, int) and not isinstance(byte_count, bool) and byte_count >= 0,
+        isinstance(byte_count, int)
+        and not isinstance(byte_count, bool)
+        and byte_count >= 0,
         f"{name} byte count is invalid",
     )
     if verify_file_hashes:
@@ -179,7 +184,9 @@ def _validate_descriptor_list(
     name: str,
     verify_file_hashes: bool,
 ) -> set[str]:
-    _require(isinstance(values, list) and bool(values), f"{name} must be a nonempty list")
+    _require(
+        isinstance(values, list) and bool(values), f"{name} must be a nonempty list"
+    )
     paths: set[str] = set()
     for index, descriptor in enumerate(values):
         _require(isinstance(descriptor, Mapping), f"{name}[{index}] is invalid")
@@ -198,9 +205,15 @@ def _expected_source_panel(v2: Mapping[str, Any]) -> tuple[list[str], list[str]]
     executions = list(v2["preacquisition_signature_panel"]["executions"])
     execution_ids = [str(execution["execution_id"]) for execution in executions]
     session_ids = [str(execution["session_id"]) for execution in executions]
-    _require(len(execution_ids) == 12, "registered source panel must contain 12 executions")
-    _require(len(set(execution_ids)) == 12, "registered source execution ids are not unique")
-    _require(len(set(session_ids)) == 12, "registered source sessions are not independent")
+    _require(
+        len(execution_ids) == 12, "registered source panel must contain 12 executions"
+    )
+    _require(
+        len(set(execution_ids)) == 12, "registered source execution ids are not unique"
+    )
+    _require(
+        len(set(session_ids)) == 12, "registered source sessions are not independent"
+    )
     return execution_ids, session_ids
 
 
@@ -213,7 +226,9 @@ def source_panel_execution_manifest_template(
 
     execution_id = str(execution["execution_id"])
     session_id = str(execution["session_id"])
-    _require(bool(execution_id) and bool(session_id), "source execution ids are missing")
+    _require(
+        bool(execution_id) and bool(session_id), "source execution ids are missing"
+    )
     return {
         "schema_version": 1,
         "artifact_kind": "SourcePanelExecutionManifest",

--- a/src/causal4d/preacquisition_source_validation.py
+++ b/src/causal4d/preacquisition_source_validation.py
@@ -1,0 +1,232 @@
+"""Validation for source-panel and actuator readiness evidence."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from causal4d.preacquisition_readiness_contracts import (
+    _canonical_sha256,
+    _expected_source_panel,
+    _finite_number,
+    _parse_utc_timestamp,
+    _read_json_mapping,
+    _require,
+    _safe_relative_path,
+    _validate_descriptor_list,
+)
+
+def _validate_source_execution_manifest(
+    dataset_root: Path,
+    relative: str,
+    *,
+    protocol: Mapping[str, Any],
+    v4: Mapping[str, Any],
+    execution_id: str,
+    session_id: str,
+    verify_file_hashes: bool,
+) -> None:
+    path = dataset_root / _safe_relative_path(relative, name="source execution manifest")
+    manifest = _read_json_mapping(path, name="source execution manifest")
+    _require(manifest.get("schema_version") == 1, "unsupported source execution schema")
+    _require(
+        manifest.get("artifact_kind") == "SourcePanelExecutionManifest",
+        "unexpected source execution artifact kind",
+    )
+    _require(manifest.get("status") == "complete", "source execution is not complete")
+    _require(
+        manifest.get("protocol_id") == protocol["protocol_id"],
+        "source execution protocol mismatch",
+    )
+    _require(
+        manifest.get("protocol_design_sha256") == protocol["design_sha256"],
+        "source execution protocol digest mismatch",
+    )
+    _require(
+        manifest.get("preacquisition_plan_id") == v4["plan_id"],
+        "source execution v4 plan mismatch",
+    )
+    _require(
+        manifest.get("preacquisition_amendment_sha256") == v4["amendment_sha256"],
+        "source execution v4 digest mismatch",
+    )
+    _require(manifest.get("execution_id") == execution_id, "source execution id mismatch")
+    _require(manifest.get("session_id") == session_id, "source session id mismatch")
+    _require(
+        manifest.get("fresh_reset_and_fresh_grasp") is True,
+        "source execution did not use a fresh reset and grasp",
+    )
+    _require(
+        manifest.get("confirmatory_fold_member") is False,
+        "source execution entered a confirmatory fold",
+    )
+    _require(
+        manifest.get("target_outcomes_used") is False,
+        "target outcomes entered a source execution",
+    )
+    _require(manifest.get("included") is True, "source execution is not included")
+    _require(
+        manifest.get("quality_gate_failures") == [],
+        "source execution has quality-gate failures",
+    )
+    started = _parse_utc_timestamp(
+        manifest.get("started_at_utc"), name="source execution started_at_utc"
+    )
+    ended = _parse_utc_timestamp(
+        manifest.get("ended_at_utc"), name="source execution ended_at_utc"
+    )
+    _require(ended >= started, "source execution ends before it starts")
+    _validate_descriptor_list(
+        dataset_root,
+        manifest.get("artifacts"),
+        name=f"source execution {execution_id} artifacts",
+        verify_file_hashes=verify_file_hashes,
+    )
+
+
+def _validate_signature_panel(
+    protocol: Mapping[str, Any],
+    v2: Mapping[str, Any],
+    v4: Mapping[str, Any],
+    checks: Mapping[str, Any],
+    evidence_paths: set[str],
+    *,
+    dataset_root: Path,
+    verify_file_hashes: bool,
+) -> None:
+    expected_execution_ids, expected_session_ids = _expected_source_panel(v2)
+    manifest_files = checks.get("manifest_files")
+    _require(isinstance(manifest_files, Mapping), "source-panel manifest map is invalid")
+    _require(
+        set(manifest_files) == set(expected_execution_ids)
+        and len(manifest_files) == len(expected_execution_ids),
+        "source-panel manifest map differs from the registered execution set",
+    )
+    _require(
+        checks.get("execution_ids") == expected_execution_ids,
+        "source-panel execution ids differ from the registered panel",
+    )
+    _require(
+        checks.get("session_ids") == expected_session_ids,
+        "source-panel session ids differ from the registered panel",
+    )
+    _require(
+        checks.get("independent_session_count") == 12,
+        "source panel must contain 12 independent sessions",
+    )
+    _require(checks.get("source_only") is True, "source panel is not source-only")
+    for execution_id, session_id in zip(
+        expected_execution_ids, expected_session_ids, strict=True
+    ):
+        relative = manifest_files.get(execution_id)
+        _require(
+            isinstance(relative, str) and relative in evidence_paths,
+            f"source execution manifest is not bound as evidence: {execution_id}",
+        )
+        _validate_source_execution_manifest(
+            dataset_root,
+            relative,
+            protocol=protocol,
+            v4=v4,
+            execution_id=execution_id,
+            session_id=session_id,
+            verify_file_hashes=verify_file_hashes,
+        )
+
+
+def _validate_actuator_calibration(
+    dataset_root: Path,
+    relative: str,
+    *,
+    execution_id: str,
+) -> str:
+    path = dataset_root / _safe_relative_path(relative, name="actuator calibration")
+    artifact = _read_json_mapping(path, name="actuator calibration")
+    _require(artifact.get("schema_version") == 1, "unsupported actuator schema")
+    _require(
+        artifact.get("artifact_kind") == "ActuatorRealizationCalibration",
+        "unexpected actuator artifact kind",
+    )
+    _require(artifact.get("execution_id") == execution_id, "actuator execution id mismatch")
+    _require(artifact.get("pyrecest_version") == "2.4.1", "wrong PyRecEst version")
+    boundary = artifact.get("information_boundary")
+    _require(isinstance(boundary, Mapping), "actuator information boundary is invalid")
+    for field in (
+        "source_or_dry_run_only",
+        "hardware_timestamps_authoritative",
+    ):
+        _require(boundary.get(field) is True, f"actuator boundary failed: {field}")
+    _require(
+        boundary.get("target_outcomes_used") is False,
+        "target outcomes entered actuator calibration",
+    )
+    _require(
+        artifact.get("artifact_id")
+        == _canonical_sha256(artifact, omitted_field="artifact_id"),
+        "actuator artifact digest mismatch",
+    )
+    return str(artifact["artifact_id"])
+
+
+def _validate_actuator_sync(
+    protocol: Mapping[str, Any],
+    v2: Mapping[str, Any],
+    checks: Mapping[str, Any],
+    evidence_paths: set[str],
+    *,
+    dataset_root: Path,
+) -> None:
+    expected_execution_ids, _ = _expected_source_panel(v2)
+    calibration_files = checks.get("calibration_files")
+    _require(isinstance(calibration_files, Mapping), "actuator calibration map is invalid")
+    _require(
+        set(calibration_files) == set(expected_execution_ids)
+        and len(calibration_files) == len(expected_execution_ids),
+        "actuator calibration map differs from the source-panel execution set",
+    )
+    _require(
+        checks.get("commanded_vs_measured_validated") is True,
+        "commanded-versus-measured actuation was not validated",
+    )
+    _require(
+        checks.get("hardware_timestamps_authoritative") is True,
+        "hardware timestamps are not authoritative",
+    )
+    measured = _finite_number(
+        checks.get("maximum_measured_rgbd_actuator_sync_error_ms"),
+        name="maximum measured RGB-D/actuator synchronization error",
+    )
+    maximum = float(protocol["quality_gates"]["maximum_rgbd_actuator_sync_error_ms"])
+    declared_maximum = _finite_number(
+        checks.get("maximum_allowed_rgbd_actuator_sync_error_ms"),
+        name="declared maximum RGB-D/actuator synchronization error",
+    )
+    _require(
+        declared_maximum == maximum,
+        "declared actuator synchronization gate differs from the protocol",
+    )
+    _require(measured >= 0.0, "measured synchronization error must be nonnegative")
+    _require(measured <= maximum, "actuator synchronization exceeds the locked gate")
+    artifact_ids: dict[str, str] = {}
+    for execution_id in expected_execution_ids:
+        relative = calibration_files.get(execution_id)
+        _require(
+            isinstance(relative, str) and relative in evidence_paths,
+            f"actuator calibration is not bound as evidence: {execution_id}",
+        )
+        artifact_ids[execution_id] = _validate_actuator_calibration(
+            dataset_root,
+            relative,
+            execution_id=execution_id,
+        )
+    _require(
+        checks.get("calibration_artifact_ids") == artifact_ids,
+        "actuator artifact-id map differs from the calibrated files",
+    )
+
+
+__all__ = [
+    "_validate_actuator_sync",
+    "_validate_signature_panel",
+]

--- a/src/causal4d/preacquisition_source_validation.py
+++ b/src/causal4d/preacquisition_source_validation.py
@@ -17,6 +17,7 @@ from causal4d.preacquisition_readiness_contracts import (
     _validate_descriptor_list,
 )
 
+
 def _validate_source_execution_manifest(
     dataset_root: Path,
     relative: str,
@@ -27,7 +28,9 @@ def _validate_source_execution_manifest(
     session_id: str,
     verify_file_hashes: bool,
 ) -> None:
-    path = dataset_root / _safe_relative_path(relative, name="source execution manifest")
+    path = dataset_root / _safe_relative_path(
+        relative, name="source execution manifest"
+    )
     manifest = _read_json_mapping(path, name="source execution manifest")
     _require(manifest.get("schema_version") == 1, "unsupported source execution schema")
     _require(
@@ -51,7 +54,9 @@ def _validate_source_execution_manifest(
         manifest.get("preacquisition_amendment_sha256") == v4["amendment_sha256"],
         "source execution v4 digest mismatch",
     )
-    _require(manifest.get("execution_id") == execution_id, "source execution id mismatch")
+    _require(
+        manifest.get("execution_id") == execution_id, "source execution id mismatch"
+    )
     _require(manifest.get("session_id") == session_id, "source session id mismatch")
     _require(
         manifest.get("fresh_reset_and_fresh_grasp") is True,
@@ -97,7 +102,9 @@ def _validate_signature_panel(
 ) -> None:
     expected_execution_ids, expected_session_ids = _expected_source_panel(v2)
     manifest_files = checks.get("manifest_files")
-    _require(isinstance(manifest_files, Mapping), "source-panel manifest map is invalid")
+    _require(
+        isinstance(manifest_files, Mapping), "source-panel manifest map is invalid"
+    )
     _require(
         set(manifest_files) == set(expected_execution_ids)
         and len(manifest_files) == len(expected_execution_ids),
@@ -148,7 +155,9 @@ def _validate_actuator_calibration(
         artifact.get("artifact_kind") == "ActuatorRealizationCalibration",
         "unexpected actuator artifact kind",
     )
-    _require(artifact.get("execution_id") == execution_id, "actuator execution id mismatch")
+    _require(
+        artifact.get("execution_id") == execution_id, "actuator execution id mismatch"
+    )
     _require(artifact.get("pyrecest_version") == "2.4.1", "wrong PyRecEst version")
     boundary = artifact.get("information_boundary")
     _require(isinstance(boundary, Mapping), "actuator information boundary is invalid")
@@ -179,7 +188,9 @@ def _validate_actuator_sync(
 ) -> None:
     expected_execution_ids, _ = _expected_source_panel(v2)
     calibration_files = checks.get("calibration_files")
-    _require(isinstance(calibration_files, Mapping), "actuator calibration map is invalid")
+    _require(
+        isinstance(calibration_files, Mapping), "actuator calibration map is invalid"
+    )
     _require(
         set(calibration_files) == set(expected_execution_ids)
         and len(calibration_files) == len(expected_execution_ids),

--- a/tests/test_preacquisition_readiness.py
+++ b/tests/test_preacquisition_readiness.py
@@ -57,9 +57,7 @@ def _prerequisites(*, frozen_at: str = "2026-07-30T12:00:00Z") -> dict:
         "method_freeze",
         "method_freeze_validation",
     )
-    values = {
-        name: {"present": True, "valid": True, "error": None} for name in names
-    }
+    values = {name: {"present": True, "valid": True, "error": None} for name in names}
     values["method_freeze"].update(
         {
             "frozen_at_utc": frozen_at,
@@ -225,9 +223,7 @@ def test_signature_gate_validates_all_bound_source_manifests(tmp_path: Path) -> 
     evidence = []
     for execution in v2["preacquisition_signature_panel"]["executions"]:
         execution_id = execution["execution_id"]
-        manifest_relative = SOURCE_PANEL_MANIFEST_PATH.format(
-            execution_id=execution_id
-        )
+        manifest_relative = SOURCE_PANEL_MANIFEST_PATH.format(execution_id=execution_id)
         data_relative = (
             f"preacquisition/source_panel/executions/{execution_id}/measurement.bin"
         )
@@ -290,9 +286,9 @@ def test_software_gate_binds_freeze_attestation_and_distributions(
     gate = gate_evidence_template("software_environment_locked", protocol, v2, v4)
     gate["checks"] = {
         "method_freeze_sha256": prerequisites["method_freeze"]["sha256"],
-        "method_freeze_validation_sha256": prerequisites[
-            "method_freeze_validation"
-        ]["sha256"],
+        "method_freeze_validation_sha256": prerequisites["method_freeze_validation"][
+            "sha256"
+        ],
         "causal4d": {
             "commit_sha": prerequisites["method_freeze"]["causal4d_commit_sha"],
             "version": "0.4.1",
@@ -464,9 +460,7 @@ def test_require_ready_exit_codes(monkeypatch, capsys, status, expected) -> None
         lambda *args, **kwargs: dict(status),
     )
 
-    result = readiness_cli.main(
-        ["status", "repository", "dataset", "--require-ready"]
-    )
+    result = readiness_cli.main(["status", "repository", "dataset", "--require-ready"])
 
     assert result == expected
     assert json.loads(capsys.readouterr().out)["ready"] is status["ready"]

--- a/tests/test_preacquisition_readiness.py
+++ b/tests/test_preacquisition_readiness.py
@@ -1,0 +1,509 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+import causal4d.preacquisition_gate_validation as gate_validation_module
+import causal4d.preacquisition_readiness as readiness_module
+from causal4d.cli import preacquisition_readiness as readiness_cli
+from causal4d.preacquisition_readiness import (
+    GATE_PATHS,
+    SOURCE_PANEL_MANIFEST_PATH,
+    SOURCE_PANEL_MANIFEST_TEMPLATE_PATH,
+    evaluate_preacquisition_readiness,
+    gate_evidence_sha256,
+    gate_evidence_template,
+    readiness_status_sha256,
+    scaffold_preacquisition_readiness,
+    seal_preacquisition_gate,
+    source_panel_execution_manifest_template,
+)
+
+
+def _registered_values() -> tuple[dict, dict, dict]:
+    protocol = {
+        "protocol_id": "test-protocol",
+        "design_sha256": "a" * 64,
+        "executions": [],
+        "quality_gates": {"maximum_rgbd_actuator_sync_error_ms": 10.0},
+    }
+    executions = [
+        {
+            "execution_id": f"source-{index:02d}",
+            "session_id": f"session-{index:02d}",
+        }
+        for index in range(12)
+    ]
+    v2 = {"preacquisition_signature_panel": {"executions": executions}}
+    v4 = {
+        "plan_id": "test-preacquisition-v4",
+        "amendment_sha256": "b" * 64,
+    }
+    return protocol, v2, v4
+
+
+def _prerequisites(*, frozen_at: str = "2026-07-30T12:00:00Z") -> dict:
+    names = (
+        "dataset_protocol",
+        "acquisition_schedule",
+        "object_registration",
+        "slip_pilot",
+        "timebase_calibration",
+        "contact_registration",
+        "method_freeze",
+        "method_freeze_validation",
+    )
+    values = {
+        name: {"present": True, "valid": True, "error": None} for name in names
+    }
+    values["method_freeze"].update(
+        {
+            "frozen_at_utc": frozen_at,
+            "sha256": "c" * 64,
+            "causal4d_commit_sha": "d" * 40,
+            "bayesian_phystwin_commit_sha": "e" * 40,
+        }
+    )
+    values["method_freeze_validation"].update(
+        {
+            "verified_at_utc": "2026-07-30T12:05:00Z",
+            "sha256": "f" * 64,
+        }
+    )
+    return values
+
+
+def _real_status(**overrides: int) -> dict:
+    status = {
+        "prerequisites": _prerequisites(),
+        "manifest_executions": 0,
+        "acquired_executions": 0,
+        "validated_executions": 0,
+    }
+    status.update(overrides)
+    return status
+
+
+def _gate_result(
+    gate_id: str,
+    *,
+    valid: bool = True,
+    template: bool = False,
+    approved_at: str = "2026-07-30T11:00:00Z",
+) -> dict:
+    return {
+        "gate_id": gate_id,
+        "path": f"/data/{GATE_PATHS[gate_id]}",
+        "present": True,
+        "template": template,
+        "valid": valid,
+        "approved_at_utc": approved_at if valid else None,
+        "error": None if valid else "incomplete",
+    }
+
+
+def _descriptor(root: Path, relative: str) -> dict:
+    path = root / relative
+    payload = path.read_bytes()
+    return {
+        "path": relative,
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "bytes": len(payload),
+    }
+
+
+def _seal_gate_payload(gate: dict) -> dict:
+    gate["status"] = "passed"
+    gate["completed_at_utc"] = "2026-07-30T10:00:00Z"
+    gate["locked_before_confirmatory_collection"] = True
+    gate["target_outcomes_used"] = False
+    gate["approval"] = {
+        "approved": True,
+        "approver_id": "reviewer",
+        "approved_at_utc": "2026-07-30T10:05:00Z",
+    }
+    gate["artifact_sha256"] = gate_evidence_sha256(gate)
+    return gate
+
+
+def _patch_gate_results(monkeypatch, overrides: dict[str, dict] | None = None) -> None:
+    results = {gate_id: _gate_result(gate_id) for gate_id in GATE_PATHS}
+    results["software_environment_locked"] = _gate_result(
+        "software_environment_locked",
+        approved_at="2026-07-30T12:10:00Z",
+    )
+    results.update(overrides or {})
+
+    def validate(gate_id, *args, **kwargs):
+        del args, kwargs
+        return deepcopy(results[gate_id])
+
+    monkeypatch.setattr(readiness_module, "_validate_gate_file", validate)
+
+
+def test_gate_template_binds_the_exact_registered_source_panel() -> None:
+    protocol, v2, v4 = _registered_values()
+    template = gate_evidence_template(
+        "signature_panel_complete",
+        protocol,
+        v2,
+        v4,
+    )
+
+    assert template["status"] == "template"
+    assert template["checks"]["execution_ids"] == [
+        f"source-{index:02d}" for index in range(12)
+    ]
+    assert template["checks"]["independent_session_count"] == 12
+    assert template["checks"]["manifest_files"]["source-00"] == (
+        SOURCE_PANEL_MANIFEST_PATH.format(execution_id="source-00")
+    )
+    assert template["artifact_sha256"] is None
+
+
+def test_source_execution_template_preserves_the_registered_boundary() -> None:
+    protocol, _, v4 = _registered_values()
+    manifest = source_panel_execution_manifest_template(
+        {"execution_id": "source-00", "session_id": "session-00"},
+        protocol,
+        v4,
+    )
+
+    assert manifest["status"] == "template"
+    assert manifest["protocol_design_sha256"] == protocol["design_sha256"]
+    assert manifest["preacquisition_amendment_sha256"] == v4["amendment_sha256"]
+    assert manifest["fresh_reset_and_fresh_grasp"] is True
+    assert manifest["confirmatory_fold_member"] is False
+    assert manifest["target_outcomes_used"] is False
+    assert manifest["included"] is None
+
+
+def test_scaffold_writes_gates_and_source_manifest_templates(
+    monkeypatch, tmp_path: Path
+) -> None:
+    protocol, v2, v4 = _registered_values()
+    monkeypatch.setattr(
+        readiness_module,
+        "load_registered_preacquisition_chain",
+        lambda repository_root: (protocol, v2, {}, v4),
+    )
+
+    first = scaffold_preacquisition_readiness(tmp_path, tmp_path)
+    second = scaffold_preacquisition_readiness(tmp_path, tmp_path)
+
+    assert len(first["created"]) == len(GATE_PATHS) + 12
+    assert first["existing"] == []
+    assert second["created"] == []
+    assert len(second["existing"]) == len(GATE_PATHS) + 12
+    source_template = tmp_path / SOURCE_PANEL_MANIFEST_TEMPLATE_PATH.format(
+        execution_id="source-00"
+    )
+    assert json.loads(source_template.read_text(encoding="utf-8"))["status"] == (
+        "template"
+    )
+
+
+def test_gate_digest_changes_when_evidence_changes() -> None:
+    protocol, v2, v4 = _registered_values()
+    gate = gate_evidence_template("support_registration_passed", protocol, v2, v4)
+    gate["status"] = "passed"
+    gate["checks"]["world_frame_id"] = "world"
+    first = gate_evidence_sha256(gate)
+    gate["checks"]["world_frame_id"] = "world-revised"
+    second = gate_evidence_sha256(gate)
+
+    assert first != second
+
+
+def test_signature_gate_validates_all_bound_source_manifests(tmp_path: Path) -> None:
+    protocol, v2, v4 = _registered_values()
+    gate = gate_evidence_template("signature_panel_complete", protocol, v2, v4)
+    evidence = []
+    for execution in v2["preacquisition_signature_panel"]["executions"]:
+        execution_id = execution["execution_id"]
+        manifest_relative = SOURCE_PANEL_MANIFEST_PATH.format(
+            execution_id=execution_id
+        )
+        data_relative = (
+            f"preacquisition/source_panel/executions/{execution_id}/measurement.bin"
+        )
+        data_path = tmp_path / data_relative
+        data_path.parent.mkdir(parents=True, exist_ok=True)
+        data_path.write_bytes(execution_id.encode("utf-8"))
+        manifest = source_panel_execution_manifest_template(execution, protocol, v4)
+        manifest.update(
+            {
+                "status": "complete",
+                "included": True,
+                "started_at_utc": "2026-07-30T09:00:00Z",
+                "ended_at_utc": "2026-07-30T09:01:00Z",
+                "artifacts": [_descriptor(tmp_path, data_relative)],
+            }
+        )
+        manifest_path = tmp_path / manifest_relative
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(
+            json.dumps(manifest, sort_keys=True, allow_nan=False),
+            encoding="utf-8",
+        )
+        evidence.append(_descriptor(tmp_path, manifest_relative))
+    gate["evidence"] = evidence
+    _seal_gate_payload(gate)
+    gate_path = tmp_path / GATE_PATHS["signature_panel_complete"]
+    gate_path.parent.mkdir(parents=True, exist_ok=True)
+    gate_path.write_text(
+        json.dumps(gate, sort_keys=True, allow_nan=False), encoding="utf-8"
+    )
+
+    result = readiness_module._validate_gate_file(
+        "signature_panel_complete",
+        gate_path,
+        protocol=protocol,
+        v2=v2,
+        v4=v4,
+        dataset_root=tmp_path,
+        prerequisites={},
+        verify_file_hashes=True,
+    )
+
+    assert result["valid"] is True
+    assert result["error"] is None
+
+
+def test_software_gate_binds_freeze_attestation_and_distributions(
+    tmp_path: Path,
+) -> None:
+    protocol, v2, v4 = _registered_values()
+    paths = {
+        "causal4d": "software/causal4d-0.4.1.whl",
+        "bayesian_phystwin": "software/bayesian_phystwin-0.4.0.whl",
+    }
+    for name, relative in paths.items():
+        path = tmp_path / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(f"{name}-wheel".encode("utf-8"))
+    prerequisites = _prerequisites()
+    gate = gate_evidence_template("software_environment_locked", protocol, v2, v4)
+    gate["checks"] = {
+        "method_freeze_sha256": prerequisites["method_freeze"]["sha256"],
+        "method_freeze_validation_sha256": prerequisites[
+            "method_freeze_validation"
+        ]["sha256"],
+        "causal4d": {
+            "commit_sha": prerequisites["method_freeze"]["causal4d_commit_sha"],
+            "version": "0.4.1",
+            "distribution": _descriptor(tmp_path, paths["causal4d"]),
+        },
+        "bayesian_phystwin": {
+            "commit_sha": prerequisites["method_freeze"][
+                "bayesian_phystwin_commit_sha"
+            ],
+            "version": "0.4.0",
+            "distribution": _descriptor(tmp_path, paths["bayesian_phystwin"]),
+        },
+        "prob4d": {
+            "used": False,
+            "reason": "registered physical sensors provide the observations",
+        },
+        "observation_producer": {
+            "name": "registered-rgbd-pipeline",
+            "version": "1",
+            "artifact_contract": "Causal4DObservationV1",
+        },
+        "python": {
+            "version": "3.11.9",
+            "implementation": "CPython",
+            "platform": "linux-x86_64",
+        },
+    }
+    gate["evidence"] = [
+        _descriptor(tmp_path, paths["causal4d"]),
+        _descriptor(tmp_path, paths["bayesian_phystwin"]),
+    ]
+    _seal_gate_payload(gate)
+    gate["approval"]["approved_at_utc"] = "2026-07-30T12:10:00Z"
+    gate["completed_at_utc"] = "2026-07-30T12:06:00Z"
+    gate["artifact_sha256"] = gate_evidence_sha256(gate)
+    gate_path = tmp_path / GATE_PATHS["software_environment_locked"]
+    gate_path.parent.mkdir(parents=True, exist_ok=True)
+    gate_path.write_text(
+        json.dumps(gate, sort_keys=True, allow_nan=False), encoding="utf-8"
+    )
+
+    result = readiness_module._validate_gate_file(
+        "software_environment_locked",
+        gate_path,
+        protocol=protocol,
+        v2=v2,
+        v4=v4,
+        dataset_root=tmp_path,
+        prerequisites=prerequisites,
+        verify_file_hashes=True,
+    )
+
+    assert result["valid"] is True
+    assert result["error"] is None
+
+
+def test_readiness_opens_only_when_every_artifact_gate_passes(
+    monkeypatch, tmp_path: Path
+) -> None:
+    protocol, v2, v4 = _registered_values()
+    _patch_gate_results(monkeypatch)
+
+    status = evaluate_preacquisition_readiness(
+        protocol,
+        v2,
+        v4,
+        tmp_path,
+        _real_status(),
+        verify_file_hashes=True,
+    )
+
+    assert status["valid"] is True
+    assert status["ready"] is True
+    assert status["collection_gate"]["first_confirmatory_execution_allowed"] is True
+    assert status["blockers"] == []
+    assert status["status_sha256"] == readiness_status_sha256(status)
+
+
+def test_template_gate_is_valid_but_not_ready(monkeypatch, tmp_path: Path) -> None:
+    protocol, v2, v4 = _registered_values()
+    _patch_gate_results(
+        monkeypatch,
+        {
+            "end_to_end_dry_run_passed": _gate_result(
+                "end_to_end_dry_run_passed",
+                valid=False,
+                template=True,
+            )
+        },
+    )
+
+    status = evaluate_preacquisition_readiness(
+        protocol,
+        v2,
+        v4,
+        tmp_path,
+        _real_status(),
+        verify_file_hashes=True,
+    )
+
+    assert status["valid"] is True
+    assert status["ready"] is False
+    assert status["missing_or_template_gates"] == ["end_to_end_dry_run_passed"]
+    assert "gate:end_to_end_dry_run_passed" in status["blockers"]
+
+
+def test_confirmatory_manifest_before_readiness_is_invalid(
+    monkeypatch, tmp_path: Path
+) -> None:
+    protocol, v2, v4 = _registered_values()
+    _patch_gate_results(monkeypatch)
+
+    status = evaluate_preacquisition_readiness(
+        protocol,
+        v2,
+        v4,
+        tmp_path,
+        _real_status(manifest_executions=1),
+        verify_file_hashes=True,
+    )
+
+    assert status["valid"] is False
+    assert status["ready"] is False
+    assert "confirmatory_collection_already_started" in status["blockers"]
+
+
+def test_operational_gate_may_not_postdate_method_freeze(
+    monkeypatch, tmp_path: Path
+) -> None:
+    protocol, v2, v4 = _registered_values()
+    _patch_gate_results(
+        monkeypatch,
+        {
+            "signature_panel_complete": _gate_result(
+                "signature_panel_complete",
+                approved_at="2026-07-30T13:00:00Z",
+            )
+        },
+    )
+
+    status = evaluate_preacquisition_readiness(
+        protocol,
+        v2,
+        v4,
+        tmp_path,
+        _real_status(),
+        verify_file_hashes=True,
+    )
+
+    assert status["valid"] is False
+    assert status["ready"] is False
+    assert status["chronology_blockers"] == [
+        "method_freeze_precedes_operational_gate:signature_panel_complete"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ({"valid": True, "ready": True, "passed": True}, 0),
+        ({"valid": True, "ready": False, "passed": False}, 3),
+        ({"valid": False, "ready": False, "passed": False}, 2),
+    ],
+)
+def test_require_ready_exit_codes(monkeypatch, capsys, status, expected) -> None:
+    monkeypatch.setattr(
+        readiness_cli,
+        "build_preacquisition_readiness",
+        lambda *args, **kwargs: dict(status),
+    )
+
+    result = readiness_cli.main(
+        ["status", "repository", "dataset", "--require-ready"]
+    )
+
+    assert result == expected
+    assert json.loads(capsys.readouterr().out)["ready"] is status["ready"]
+
+
+def test_seal_refuses_to_rewrite_existing_gate(monkeypatch, tmp_path: Path) -> None:
+    protocol, v2, v4 = _registered_values()
+    monkeypatch.setattr(
+        gate_validation_module,
+        "load_registered_preacquisition_chain",
+        lambda repository_root: (protocol, v2, {}, v4),
+    )
+    path = tmp_path / GATE_PATHS["support_registration_passed"]
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "status": "passed",
+                "artifact_sha256": "f" * 64,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="already sealed"):
+        seal_preacquisition_gate(
+            tmp_path,
+            tmp_path,
+            "support_registration_passed",
+            approved_by="reviewer",
+        )
+
+
+def test_grouped_readiness_route_is_registered() -> None:
+    from causal4d.cli.command_registry import find_command
+
+    command = find_command("protocol/readiness")
+    assert command.lifecycle == "stable"
+    assert command.legacy_name is None
+    assert command.target.endswith("preacquisition_readiness:main")


### PR DESCRIPTION
## Summary

- add an evidence-derived `causal4d protocol readiness` workflow without mutating the frozen v2, v3, or v4 protocol artifacts
- validate and hash-bind the exact 12-execution source panel, actuator realization and synchronization, support/gravity registration, and a nonconfirmatory end-to-end dry run
- bind the method freeze, independent freeze attestation, Causal4D and Bayesian-PhysTwin distribution artifacts, observation producer, Python runtime, and an explicit Prob4D used-or-unused declaration
- enforce chronology: operational approvals precede the method freeze, while the software environment is locked only after the freeze and its independent attestation
- refuse readiness once any confirmatory manifest exists
- expose fail-closed status semantics: `0` ready, `3` valid but incomplete, and `2` malformed or contradictory evidence

## Scientific boundary

This is acquisition-only tooling. It does not change recorded signals, quality gates, target IDs, the information boundary, registered analysis, or any immutable milestone artifact. Target outcomes remain forbidden from all source-panel and readiness evidence.

## Validation

- `python -m compileall -q src tests`
- `15 passed` in `tests/test_preacquisition_readiness.py`
- Ruff lint and exact Ruff formatting
- mypy checks for stable contracts and CI utilities
- core suite on Python 3.10, 3.11, 3.12, 3.13, and 3.14
- exact declared dependency-floor environment on Python 3.10
- wheel and sdist build plus all installed CLI help checks
- frozen milestone inventory and checksums
- deterministic result-bundle production, archival, and clean consumption
- pinned Bayesian-PhysTwin provider integration
- both GitHub Actions workflows green at `0e2505da993e01ffc08bc65601ad30ff0cc35c79`
- server-side comparison confirms two commits, 11 intended files, and no unrelated changes

## Operational order

1. scaffold the registered dataset and readiness templates
2. complete and seal source-panel, actuator, support/gravity, and dry-run gates
3. seal and independently attest the method freeze
4. bind the exact software environment
5. require `first_confirmatory_execution_allowed=true` with file-hash verification before execution 1
