### PR TITLE
Harden multiview camera geometry contracts

### DIFF
--- a/docs/camera_geometry_contract.md
+++ b/docs/camera_geometry_contract.md
@@ -1,0 +1,50 @@
+# Camera Geometry Contract
+
+Causal4D's public multiview utilities treat camera calibration as an explicit
+input contract. A matrix with the right shape is not automatically a valid
+camera model.
+
+## Pinhole intrinsics
+
+`causal4d.camera_geometry.validate_pinhole_intrinsics` requires:
+
+- a finite `3 x 3` matrix;
+- positive horizontal and vertical focal lengths; and
+- the homogeneous row `[0, 0, 1]`.
+
+The principal point and skew are retained as calibrated. The validator returns
+an owned read-only array so later caller-side mutation cannot change an active
+projection calculation.
+
+## Rigid extrinsics
+
+`validate_se3_transform` requires a finite homogeneous `4 x 4` transform with:
+
+- final row `[0, 0, 0, 1]`;
+- an orthonormal rotation block; and
+- rotation determinant `+1`.
+
+Scale, shear, and reflections are rejected rather than accepted by a generic
+matrix inverse. `invert_se3_transform` validates the input and uses the exact
+rigid inverse
+
+```text
+R_inv = R^T
+
+t_inv = -R^T t
+```
+
+instead of treating the calibration as an arbitrary affine matrix.
+
+## Consumers
+
+The contract is applied before projection in:
+
+- the source-only SAM2 cross-view reliability audit;
+- adaptive multiview visual-hull carving; and
+- thin-rope Gaussian-splat geometry diagnostics.
+
+Malformed calibration fails before a reliability score, hull, or splat-quality
+result is emitted. This is input and numerical hardening only. It does not
+change a frozen scientific method or provide new reconstruction, calibration,
+or physical-prediction evidence.

--- a/src/causal4d/camera_geometry.py
+++ b/src/causal4d/camera_geometry.py
@@ -1,0 +1,117 @@
+"""Validated pinhole-camera and rigid-transform primitives."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from causal4d.immutable_array import readonly_array
+
+
+_DEFAULT_RIGID_ATOL = 1e-5
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def validate_pinhole_intrinsics(
+    values: Any,
+    *,
+    name: str = "camera intrinsics",
+) -> np.ndarray:
+    """Return an owned read-only pinhole calibration matrix.
+
+    The function accepts finite ``3 x 3`` matrices with positive focal lengths
+    and the standard homogeneous row ``[0, 0, 1]``. Principal points and skew
+    remain unconstrained because cropping and calibrated skew are valid inputs.
+    """
+
+    intrinsics = readonly_array(values, dtype=np.float64)
+    _require(intrinsics.shape == (3, 3), f"{name} must have shape (3, 3)")
+    _require(np.all(np.isfinite(intrinsics)), f"{name} must be finite")
+    _require(
+        intrinsics[0, 0] > 0.0 and intrinsics[1, 1] > 0.0,
+        f"{name} focal lengths must be positive",
+    )
+    _require(
+        np.allclose(
+            intrinsics[2],
+            np.asarray([0.0, 0.0, 1.0]),
+            rtol=0.0,
+            atol=1e-12,
+        ),
+        f"{name} must use homogeneous row [0, 0, 1]",
+    )
+    return intrinsics
+
+
+def validate_se3_transform(
+    values: Any,
+    *,
+    name: str = "rigid transform",
+    atol: float = _DEFAULT_RIGID_ATOL,
+) -> np.ndarray:
+    """Return an owned read-only homogeneous transform in ``SE(3)``.
+
+    Scale, shear, reflections, malformed homogeneous rows, and non-finite values
+    are rejected. The tolerance applies to rotation orthogonality and unit
+    determinant checks.
+    """
+
+    _require(np.isfinite(atol) and atol > 0.0, "SE(3) tolerance must be positive")
+    transform = readonly_array(values, dtype=np.float64)
+    _require(transform.shape == (4, 4), f"{name} must have shape (4, 4)")
+    _require(np.all(np.isfinite(transform)), f"{name} must be finite")
+    _require(
+        np.allclose(
+            transform[3],
+            np.asarray([0.0, 0.0, 0.0, 1.0]),
+            rtol=0.0,
+            atol=atol,
+        ),
+        f"{name} must use homogeneous row [0, 0, 0, 1]",
+    )
+    rotation = transform[:3, :3]
+    _require(
+        np.allclose(
+            rotation.T @ rotation,
+            np.eye(3),
+            rtol=0.0,
+            atol=atol,
+        ),
+        f"{name} rotation must be orthonormal",
+    )
+    determinant = float(np.linalg.det(rotation))
+    _require(
+        np.isclose(determinant, 1.0, rtol=0.0, atol=5.0 * atol),
+        f"{name} rotation must have determinant +1",
+    )
+    return transform
+
+
+def invert_se3_transform(
+    values: Any,
+    *,
+    name: str = "rigid transform",
+    atol: float = _DEFAULT_RIGID_ATOL,
+) -> np.ndarray:
+    """Validate and invert an ``SE(3)`` transform analytically."""
+
+    transform = validate_se3_transform(values, name=name, atol=atol)
+    rotation = transform[:3, :3]
+    translation = transform[:3, 3]
+    inverse = np.eye(4, dtype=np.float64)
+    inverse[:3, :3] = rotation.T
+    inverse[:3, 3] = -(rotation.T @ translation)
+    inverse.setflags(write=False)
+    return inverse
+
+
+__all__ = [
+    "invert_se3_transform",
+    "validate_pinhole_intrinsics",
+    "validate_se3_transform",
+]

--- a/src/causal4d_public/deform360_sam2_views.py
+++ b/src/causal4d_public/deform360_sam2_views.py
@@ -11,6 +11,12 @@ from typing import Any, Mapping, Sequence
 
 import numpy as np
 
+from causal4d.camera_geometry import (
+    invert_se3_transform,
+    validate_pinhole_intrinsics,
+    validate_se3_transform,
+)
+
 from .deform360_sam2 import (
     PINNED_SAM2_CHECKPOINT_SHA256,
     PINNED_SAM2_CHECKPOINT_URL,
@@ -162,11 +168,17 @@ def multiview_mask_consistency(
     )
 
     centers = []
+    world_to_camera_by_camera: dict[str, np.ndarray] = {}
     for camera in cameras:
-        transform = np.asarray(camera_to_world_by_camera[camera], dtype=np.float64)
-        _require(transform.shape == (4, 4), f"invalid extrinsics for {camera}")
-        _require(np.isfinite(transform).all(), f"non-finite extrinsics for {camera}")
-        centers.append(transform[:3, 3])
+        camera_to_world = validate_se3_transform(
+            camera_to_world_by_camera[camera],
+            name=f"extrinsics for {camera}",
+        )
+        centers.append(camera_to_world[:3, 3])
+        world_to_camera_by_camera[camera] = invert_se3_transform(
+            camera_to_world,
+            name=f"extrinsics for {camera}",
+        )
     center = np.mean(centers, axis=0)
     axis = np.linspace(
         -cfg.cube_half_extent_m,
@@ -183,11 +195,11 @@ def multiview_mask_consistency(
         mask = np.asarray(masks_by_camera[camera], dtype=bool)
         _require(mask.ndim == 2, f"mask for {camera} must be 2D")
         height, width = mask.shape
-        intrinsics = np.asarray(intrinsics_by_camera[camera], dtype=np.float64)
-        _require(intrinsics.shape == (3, 3), f"invalid intrinsics for {camera}")
-        world_to_camera = np.linalg.inv(
-            np.asarray(camera_to_world_by_camera[camera], dtype=np.float64)
+        intrinsics = validate_pinhole_intrinsics(
+            intrinsics_by_camera[camera],
+            name=f"intrinsics for {camera}",
         )
+        world_to_camera = world_to_camera_by_camera[camera]
         points = grid @ world_to_camera[:3, :3].T + world_to_camera[:3, 3]
         depth = points[:, 2]
         in_front = depth > 1e-6

--- a/src/causal4d_public/deform360_splat_probe.py
+++ b/src/causal4d_public/deform360_splat_probe.py
@@ -12,6 +12,11 @@ from typing import Any, Mapping, Sequence
 
 import numpy as np
 
+from causal4d.camera_geometry import (
+    invert_se3_transform,
+    validate_pinhole_intrinsics,
+)
+
 from .deform360 import Deform360ProtocolConfig
 from .deform360_sam2_prefix import select_source_locked_prefix_cameras
 
@@ -155,13 +160,14 @@ def gaussian_splat_geometry_diagnostics(
         mask = np.asarray(masks_by_camera[camera], dtype=bool)
         _require(mask.ndim == 2, f"mask for {camera} must be two-dimensional")
         height, width = mask.shape
-        intrinsics = np.asarray(intrinsics_by_camera[camera], dtype=np.float64)
-        camera_to_world = np.asarray(
-            camera_to_world_by_camera[camera], dtype=np.float64
+        intrinsics = validate_pinhole_intrinsics(
+            intrinsics_by_camera[camera],
+            name=f"intrinsics for {camera}",
         )
-        _require(intrinsics.shape == (3, 3), f"invalid intrinsics for {camera}")
-        _require(camera_to_world.shape == (4, 4), f"invalid extrinsics for {camera}")
-        world_to_camera = np.linalg.inv(camera_to_world)
+        world_to_camera = invert_se3_transform(
+            camera_to_world_by_camera[camera],
+            name=f"extrinsics for {camera}",
+        )
         points_camera = positions @ world_to_camera[:3, :3].T + world_to_camera[:3, 3]
         depth = points_camera[:, 2]
         in_front = depth > 1e-6

--- a/src/causal4d_public/deform360_visual_hull.py
+++ b/src/causal4d_public/deform360_visual_hull.py
@@ -8,6 +8,11 @@ from typing import Any, Mapping
 
 import numpy as np
 
+from causal4d.camera_geometry import (
+    invert_se3_transform,
+    validate_pinhole_intrinsics,
+)
+
 
 def _require(condition: bool, message: str) -> None:
     if not condition:
@@ -133,13 +138,14 @@ def carve_candidate_points(
         mask = np.asarray(masks_by_camera[camera], dtype=bool)
         _require(mask.ndim == 2, f"mask for {camera} must be two-dimensional")
         height, width = mask.shape
-        intrinsics = np.asarray(intrinsics_by_camera[camera], dtype=np.float64)
-        camera_to_world = np.asarray(
-            camera_to_world_by_camera[camera], dtype=np.float64
+        intrinsics = validate_pinhole_intrinsics(
+            intrinsics_by_camera[camera],
+            name=f"intrinsics for {camera}",
         )
-        _require(intrinsics.shape == (3, 3), f"invalid intrinsics for {camera}")
-        _require(camera_to_world.shape == (4, 4), f"invalid extrinsics for {camera}")
-        world_to_camera = np.linalg.inv(camera_to_world)
+        world_to_camera = invert_se3_transform(
+            camera_to_world_by_camera[camera],
+            name=f"extrinsics for {camera}",
+        )
         camera_points = points @ world_to_camera[:3, :3].T + world_to_camera[:3, 3]
         depth = camera_points[:, 2]
         in_front = depth > 1e-6

--- a/tests/test_camera_geometry.py
+++ b/tests/test_camera_geometry.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from causal4d.camera_geometry import (
+    invert_se3_transform,
+    validate_pinhole_intrinsics,
+    validate_se3_transform,
+)
+from causal4d_public.deform360_sam2_views import (
+    CrossViewMaskReliabilityConfig,
+    multiview_mask_consistency,
+)
+from causal4d_public.deform360_splat_probe import (
+    ThinRopeSplatProbeConfig,
+    gaussian_splat_geometry_diagnostics,
+)
+from causal4d_public.deform360_visual_hull import carve_candidate_points
+
+
+def _camera_intrinsics() -> np.ndarray:
+    return np.asarray(
+        [
+            [40.0, 0.0, 16.0],
+            [0.0, 40.0, 16.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+
+
+def _camera_to_world() -> np.ndarray:
+    angle = 0.37
+    cosine = np.cos(angle)
+    sine = np.sin(angle)
+    transform = np.eye(4)
+    transform[:3, :3] = np.asarray(
+        [
+            [cosine, -sine, 0.0],
+            [sine, cosine, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    transform[:3, 3] = np.asarray([0.1, -0.2, 0.3])
+    return transform
+
+
+def test_rigid_transform_is_owned_read_only_and_inverted_analytically() -> None:
+    source = _camera_to_world()
+    original = source.copy()
+
+    validated = validate_se3_transform(source)
+    inverse = invert_se3_transform(source)
+
+    source[0, 3] = 99.0
+    assert validated[0, 3] == pytest.approx(original[0, 3])
+    assert np.allclose(inverse, np.linalg.inv(original), rtol=0.0, atol=1e-12)
+    assert validated.flags.writeable is False
+    assert inverse.flags.writeable is False
+    with pytest.raises(ValueError, match="read-only"):
+        validated[0, 0] = 2.0
+
+
+@pytest.mark.parametrize(
+    ("transform", "message"),
+    [
+        (np.diag([1.01, 1.0, 1.0, 1.0]), "orthonormal"),
+        (np.diag([-1.0, 1.0, 1.0, 1.0]), "determinant"),
+        (
+            np.asarray(
+                [
+                    [1.0, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                    [0.0, 0.0, 1.0, 0.0],
+                    [0.0, 0.0, 0.1, 1.0],
+                ]
+            ),
+            "homogeneous row",
+        ),
+    ],
+)
+def test_rigid_transform_rejects_non_se3_matrices(
+    transform: np.ndarray,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        validate_se3_transform(transform)
+
+
+def test_pinhole_intrinsics_reject_invalid_calibration() -> None:
+    intrinsics = validate_pinhole_intrinsics(_camera_intrinsics())
+    assert intrinsics.flags.writeable is False
+
+    negative_focal = _camera_intrinsics()
+    negative_focal[0, 0] = -1.0
+    with pytest.raises(ValueError, match="focal lengths"):
+        validate_pinhole_intrinsics(negative_focal)
+
+    bad_row = _camera_intrinsics()
+    bad_row[2, 0] = 0.1
+    with pytest.raises(ValueError, match="homogeneous row"):
+        validate_pinhole_intrinsics(bad_row)
+
+
+def test_public_multiview_paths_reject_scaled_extrinsics() -> None:
+    intrinsics = _camera_intrinsics()
+    valid = np.eye(4)
+    scaled = np.eye(4)
+    scaled[0, 0] = 1.01
+
+    masks3 = {
+        "a": np.ones((32, 32), dtype=bool),
+        "b": np.ones((32, 32), dtype=bool),
+        "c": np.ones((32, 32), dtype=bool),
+    }
+    intrinsics3 = {camera: intrinsics for camera in masks3}
+    extrinsics3 = {"a": valid, "b": valid, "c": scaled}
+    with pytest.raises(ValueError, match="orthonormal"):
+        multiview_mask_consistency(
+            masks3,
+            intrinsics3,
+            extrinsics3,
+            CrossViewMaskReliabilityConfig(
+                voxel_resolution=16,
+                minimum_consensus_votes=2,
+                minimum_leave_one_out_recall=0.0,
+            ),
+        )
+
+    points = np.column_stack(
+        (
+            np.linspace(-0.1, 0.1, 20),
+            np.zeros(20),
+            np.ones(20),
+        )
+    )
+    masks2 = {"a": masks3["a"], "b": masks3["b"]}
+    intrinsics2 = {"a": intrinsics, "b": intrinsics}
+    extrinsics2 = {"a": valid, "b": scaled}
+    with pytest.raises(ValueError, match="orthonormal"):
+        carve_candidate_points(
+            points,
+            masks2,
+            intrinsics2,
+            extrinsics2,
+            consensus_fraction_of_peak=0.5,
+            minimum_consensus_votes=2,
+        )
+
+    with pytest.raises(ValueError, match="orthonormal"):
+        gaussian_splat_geometry_diagnostics(
+            points,
+            opacity=np.ones(len(points)),
+            masks_by_camera=masks2,
+            intrinsics_by_camera=intrinsics2,
+            camera_to_world_by_camera=extrinsics2,
+            config=ThinRopeSplatProbeConfig(
+                minimum_camera_count=2,
+                minimum_gaussian_count=1,
+            ),
+        )


### PR DESCRIPTION
## Summary

- add shared, NumPy-only validation for pinhole intrinsics and homogeneous `SE(3)` transforms
- reject scale, shear, reflections, malformed homogeneous rows, non-finite calibration, and nonpositive focal lengths
- replace generic matrix inversion with the analytic rigid inverse in the SAM2 view audit, adaptive visual hull, and splat geometry diagnostics
- return owned read-only calibration arrays so caller-side mutation cannot change an active projection
- add adversarial and integration tests for valid inverses and fail-closed public multiview paths
- document the camera geometry contract and its non-claim boundary

## Motivation

The public multiview paths previously checked mainly matrix shapes and then used `numpy.linalg.inv`. A finite `4 x 4` affine matrix can still contain scale, shear, or reflection and silently produce plausible-looking but invalid projections. These paths now admit only rigid camera calibration and fail before emitting reliability, hull, or splat-QA evidence.

## Scientific boundary

This is input validation and numerical hardening only. It does not change frozen estimators, protocols, evidence artifacts, target-access boundaries, or reported results.

## Validation

Repository CI should exercise:

- Ruff lint and incremental formatting
- core tests on all supported Python versions
- exact dependency-floor tests
- wheel/sdist installation and CLI help
- deterministic result-bundle and frozen-manifest checks
- pinned Bayesian-PhysTwin integration

The new targeted tests cover ownership/immutability, analytic inverse parity, invalid scale/reflection/homogeneous rows, invalid pinhole calibration, and fail-closed behavior in all three public projection consumers.