### PR TITLE
Add stage-specific provenance identities

### DIFF
--- a/docs/stage_specific_provenance.md
+++ b/docs/stage_specific_provenance.md
@@ -1,0 +1,97 @@
+# Stage-specific provenance identities
+
+Causal4D version-1 artifacts retain one complete `CausalContext` containing
+`O-`, `O+`, `u_obs`, and `u_cf`. That contract is preserved for frozen
+milestones and existing result bundles.
+
+For new provenance and future version-2 contracts, the three logically distinct
+stages can now be content-addressed independently with
+`causal4d.stage_provenance`:
+
+```text
+FactualEvidenceContext
+├── O-
+├── admitted O+ response prefix
+└── known observed command u_obs
+
+CounterfactualQueryContext
+├── do(u_cf)
+├── contact-resampling policy
+└── optional semantic/query-node specification
+
+EvaluationTarget
+└── held-out observation suffix
+```
+
+The separation prevents an unchanged factual input from receiving a different
+stage identity merely because a held-out target or alternative query changed.
+It is additive provenance infrastructure: it does not change a posterior,
+likelihood, rollout, registered analysis, or frozen artifact identifier.
+
+## Construction from version-1 contracts
+
+```python
+from causal4d.stage_provenance import (
+    build_counterfactual_query_context,
+    build_evaluation_target,
+    build_factual_evidence_context,
+    validate_stage_contexts,
+)
+
+factual_context = build_factual_evidence_context(
+    legacy_context,
+    observations,
+    observed_actions,
+    evidence_frame_stop=prefix_stop,
+)
+query_context = build_counterfactual_query_context(counterfactual_query)
+target = build_evaluation_target(
+    legacy_context,
+    observations,
+    target_frame_start=prefix_stop,
+)
+validate_stage_contexts(factual_context, query_context, target)
+```
+
+`build_factual_evidence_context` verifies `O-` and the complete known
+`u_obs` trajectory against their version-1 digests, but reads and hashes only the
+admitted `O+` prefix. It can therefore be sealed before the held-out target is
+opened.
+
+`build_counterfactual_query_context` copies only the query action, contact
+policy, language, and selected query nodes. The target-bearing version-1 context
+is deliberately not retained in the new identity.
+
+`build_evaluation_target` is called only after evaluation data are available. It
+verifies the version-1 `O+` digest and addresses exactly the held-out suffix.
+
+## Required invariants
+
+The regression tests enforce the following behavior:
+
+| Change | Factual identity | Query identity | Target identity |
+| --- | --- | --- | --- |
+| perturb held-out observations only | unchanged | unchanged | changed |
+| change only `u_cf` | unchanged | changed | unchanged |
+| perturb the admitted response prefix | changed | unchanged | unchanged |
+
+`validate_stage_contexts` additionally requires one protocol and case, an exact
+factual/target boundary, and a counterfactual action interval that covers the
+held-out target.
+
+## Adoption boundary
+
+Existing `TwinBelief`, `FactualIntervention`, `CounterfactualQuery`, and
+`PhysicalPosterior` artifact IDs remain version-1 identities. Frozen milestone
+files must not be rewritten.
+
+A future version-2 artifact family can bind:
+
+1. a `TwinBeliefV2` to pre-intervention evidence;
+2. a `FactualInterventionV2` to `FactualEvidenceContext`;
+3. a `PhysicalPosteriorV2` to the factual posterior and
+   `CounterfactualQueryContext`; and
+4. an evaluation result to the physical posterior and `EvaluationTarget`.
+
+That migration should be introduced under new schema and contract-type names,
+with explicit parity tests against the frozen version-1 numerical path.

--- a/src/causal4d/stage_provenance.py
+++ b/src/causal4d/stage_provenance.py
@@ -1,0 +1,388 @@
+"""Stage-specific provenance identities for causal inference and evaluation.
+
+The version-1 :class:`~causal4d.contracts.CausalContext` intentionally remains
+unchanged for frozen artifacts.  This module provides additive identities for a
+future contract boundary in which factual evidence, the counterfactual query,
+and the held-out evaluation target are content-addressed independently.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, ClassVar, Literal, Mapping, cast
+
+import numpy as np
+
+from causal4d.contracts import (
+    ActionWindow,
+    CausalContext,
+    CounterfactualQuery,
+    ObservationWindow,
+    array_sha256,
+)
+
+
+STAGE_PROVENANCE_SCHEMA_VERSION = 1
+
+
+def _validate_sha256(value: str, *, name: str) -> None:
+    if len(value) != 64 or any(
+        character not in "0123456789abcdef" for character in value
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+
+
+def _artifact_id(contract_type: str, payload: Mapping[str, Any]) -> str:
+    descriptor = {
+        "schema_version": STAGE_PROVENANCE_SCHEMA_VERSION,
+        "contract_type": contract_type,
+        "payload": payload,
+    }
+    encoded = json.dumps(
+        descriptor,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _require_header(values: Mapping[str, Any], *, contract_type: str) -> None:
+    if int(values.get("schema_version", -1)) != STAGE_PROVENANCE_SCHEMA_VERSION:
+        raise ValueError("unsupported stage-provenance schema version")
+    if str(values.get("contract_type", "")) != contract_type:
+        raise ValueError(f"expected stage-provenance contract {contract_type}")
+
+
+def _frame_array(values: np.ndarray, *, name: str, frame_stop: int) -> np.ndarray:
+    array = np.asarray(values)
+    if array.ndim < 1:
+        raise ValueError(f"{name} must have a frame axis")
+    if frame_stop > len(array):
+        raise ValueError(f"{name} does not cover frame {frame_stop - 1}")
+    return array
+
+
+def _require_window_digest(
+    values: np.ndarray,
+    window: ObservationWindow | ActionWindow,
+    *,
+    name: str,
+) -> None:
+    array = _frame_array(values, name=name, frame_stop=window.frame_stop)
+    digest = array_sha256(array[window.frame_start : window.frame_stop])
+    expected = (
+        window.content_sha256
+        if isinstance(window, ObservationWindow)
+        else window.trajectory_sha256
+    )
+    if digest != expected:
+        raise ValueError(f"{name} does not match the declared {name} digest")
+
+
+@dataclass(frozen=True)
+class FactualEvidenceContext:
+    """Content identity for exactly the evidence admitted by factual abduction.
+
+    This context contains the pre-intervention observation window, the admitted
+    post-intervention response prefix, and the known observed command.  It does
+    not contain the counterfactual query or the held-out observation suffix.
+    """
+
+    contract_type: ClassVar[str] = "FactualEvidenceContext"
+
+    protocol_id: str
+    o_minus: ObservationWindow
+    o_plus_prefix: ObservationWindow
+    u_obs: ActionWindow
+
+    def __post_init__(self) -> None:
+        if not self.protocol_id:
+            raise ValueError("protocol_id must be nonempty")
+        case_ids = {
+            self.o_minus.case_id,
+            self.o_plus_prefix.case_id,
+            self.u_obs.case_id,
+        }
+        if len(case_ids) != 1:
+            raise ValueError("factual evidence windows must identify the same case")
+        if self.o_minus.frame_stop > self.o_plus_prefix.frame_start:
+            raise ValueError("O- must not overlap the admitted O+ prefix")
+        if (
+            self.u_obs.frame_start > self.o_plus_prefix.frame_start
+            or self.u_obs.frame_stop < self.o_plus_prefix.frame_stop
+        ):
+            raise ValueError("u_obs must cover the admitted O+ prefix")
+
+    @property
+    def case_id(self) -> str:
+        return self.o_minus.case_id
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "protocol_id": self.protocol_id,
+            "o_minus": self.o_minus.as_dict(),
+            "o_plus_prefix": self.o_plus_prefix.as_dict(),
+            "u_obs": self.u_obs.as_dict(),
+        }
+
+    @property
+    def artifact_id(self) -> str:
+        return _artifact_id(self.contract_type, self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": STAGE_PROVENANCE_SCHEMA_VERSION,
+            "contract_type": self.contract_type,
+            **self._payload(),
+        }
+
+    @classmethod
+    def from_dict(cls, values: Mapping[str, Any]) -> FactualEvidenceContext:
+        _require_header(values, contract_type=cls.contract_type)
+        return cls(
+            protocol_id=str(values["protocol_id"]),
+            o_minus=ObservationWindow.from_dict(values["o_minus"]),
+            o_plus_prefix=ObservationWindow.from_dict(values["o_plus_prefix"]),
+            u_obs=ActionWindow.from_dict(values["u_obs"]),
+        )
+
+
+@dataclass(frozen=True)
+class CounterfactualQueryContext:
+    """Content identity for a ``do(u_cf)`` query independent of target outcomes."""
+
+    contract_type: ClassVar[str] = "CounterfactualQueryContext"
+
+    protocol_id: str
+    case_id: str
+    u_cf: ActionWindow
+    contact_policy: Literal["same_grasp", "new_contact"]
+    language: str | None = None
+    query_node_indices: tuple[int, ...] | None = None
+
+    def __post_init__(self) -> None:
+        if not self.protocol_id or not self.case_id:
+            raise ValueError("protocol_id and case_id must be nonempty")
+        if self.u_cf.case_id != self.case_id:
+            raise ValueError("u_cf must identify the query case")
+        if self.contact_policy not in {"same_grasp", "new_contact"}:
+            raise ValueError("contact_policy must be 'same_grasp' or 'new_contact'")
+        if self.query_node_indices is not None:
+            if not self.query_node_indices or any(
+                index < 0 for index in self.query_node_indices
+            ):
+                raise ValueError(
+                    "query_node_indices must be a nonempty nonnegative tuple"
+                )
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "protocol_id": self.protocol_id,
+            "case_id": self.case_id,
+            "u_cf": self.u_cf.as_dict(),
+            "contact_policy": self.contact_policy,
+            "language": self.language,
+            "query_node_indices": (
+                None
+                if self.query_node_indices is None
+                else list(self.query_node_indices)
+            ),
+        }
+
+    @property
+    def artifact_id(self) -> str:
+        return _artifact_id(self.contract_type, self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": STAGE_PROVENANCE_SCHEMA_VERSION,
+            "contract_type": self.contract_type,
+            **self._payload(),
+        }
+
+    @classmethod
+    def from_dict(cls, values: Mapping[str, Any]) -> CounterfactualQueryContext:
+        _require_header(values, contract_type=cls.contract_type)
+        nodes = values.get("query_node_indices")
+        policy = str(values["contact_policy"])
+        if policy not in {"same_grasp", "new_contact"}:
+            raise ValueError(
+                "contact_policy must be 'same_grasp' or 'new_contact'"
+            )
+        language = values.get("language")
+        return cls(
+            protocol_id=str(values["protocol_id"]),
+            case_id=str(values["case_id"]),
+            u_cf=ActionWindow.from_dict(values["u_cf"]),
+            contact_policy=cast(
+                Literal["same_grasp", "new_contact"],
+                policy,
+            ),
+            language=None if language is None else str(language),
+            query_node_indices=(
+                None if nodes is None else tuple(int(index) for index in nodes)
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class EvaluationTarget:
+    """Content identity for a held-out target independent of the tested query."""
+
+    contract_type: ClassVar[str] = "EvaluationTarget"
+
+    protocol_id: str
+    target: ObservationWindow
+
+    def __post_init__(self) -> None:
+        if not self.protocol_id:
+            raise ValueError("protocol_id must be nonempty")
+
+    @property
+    def case_id(self) -> str:
+        return self.target.case_id
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "protocol_id": self.protocol_id,
+            "target": self.target.as_dict(),
+        }
+
+    @property
+    def artifact_id(self) -> str:
+        return _artifact_id(self.contract_type, self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": STAGE_PROVENANCE_SCHEMA_VERSION,
+            "contract_type": self.contract_type,
+            **self._payload(),
+        }
+
+    @classmethod
+    def from_dict(cls, values: Mapping[str, Any]) -> EvaluationTarget:
+        _require_header(values, contract_type=cls.contract_type)
+        return cls(
+            protocol_id=str(values["protocol_id"]),
+            target=ObservationWindow.from_dict(values["target"]),
+        )
+
+
+def build_factual_evidence_context(
+    context: CausalContext,
+    observations: np.ndarray,
+    observed_actions: np.ndarray,
+    *,
+    evidence_frame_stop: int,
+) -> FactualEvidenceContext:
+    """Derive a factual identity without reading or hashing held-out observations."""
+
+    if not (
+        context.o_plus.frame_start
+        < evidence_frame_stop
+        <= context.o_plus.frame_stop
+    ):
+        raise ValueError("evidence_frame_stop must be a nonempty O+ prefix")
+    _require_window_digest(observations, context.o_minus, name="O-")
+    _require_window_digest(observed_actions, context.u_obs, name="u_obs")
+    observation_array = _frame_array(
+        observations,
+        name="observations",
+        frame_stop=evidence_frame_stop,
+    )
+    prefix = ObservationWindow(
+        case_id=context.case_id,
+        stream_id=context.o_plus.stream_id,
+        frame_start=context.o_plus.frame_start,
+        frame_stop=evidence_frame_stop,
+        content_sha256=array_sha256(
+            observation_array[context.o_plus.frame_start : evidence_frame_stop]
+        ),
+    )
+    return FactualEvidenceContext(
+        protocol_id=context.protocol_id,
+        o_minus=context.o_minus,
+        o_plus_prefix=prefix,
+        u_obs=context.u_obs,
+    )
+
+
+def build_counterfactual_query_context(
+    query: CounterfactualQuery,
+) -> CounterfactualQueryContext:
+    """Derive a query identity without retaining the V1 target-bearing context."""
+
+    nodes = (
+        None
+        if query.query_node_indices is None
+        else tuple(int(index) for index in query.query_node_indices)
+    )
+    return CounterfactualQueryContext(
+        protocol_id=query.context.protocol_id,
+        case_id=query.context.case_id,
+        u_cf=query.context.u_cf,
+        contact_policy=query.contact_policy,
+        language=query.language,
+        query_node_indices=nodes,
+    )
+
+
+def build_evaluation_target(
+    context: CausalContext,
+    observations: np.ndarray,
+    *,
+    target_frame_start: int,
+) -> EvaluationTarget:
+    """Derive the held-out target identity after the evaluation suffix is opened."""
+
+    if not (
+        context.o_plus.frame_start
+        <= target_frame_start
+        < context.o_plus.frame_stop
+    ):
+        raise ValueError("target_frame_start must leave a nonempty O+ suffix")
+    _require_window_digest(observations, context.o_plus, name="O+")
+    observation_array = _frame_array(
+        observations,
+        name="observations",
+        frame_stop=context.o_plus.frame_stop,
+    )
+    target = ObservationWindow(
+        case_id=context.case_id,
+        stream_id=context.o_plus.stream_id,
+        frame_start=target_frame_start,
+        frame_stop=context.o_plus.frame_stop,
+        content_sha256=array_sha256(
+            observation_array[target_frame_start : context.o_plus.frame_stop]
+        ),
+    )
+    return EvaluationTarget(protocol_id=context.protocol_id, target=target)
+
+
+def validate_stage_contexts(
+    factual: FactualEvidenceContext,
+    query: CounterfactualQueryContext,
+    target: EvaluationTarget,
+) -> None:
+    """Validate that independently addressed stages form one admissible chain."""
+
+    if len({factual.protocol_id, query.protocol_id, target.protocol_id}) != 1:
+        raise ValueError("stage contexts must use the same protocol")
+    if len({factual.case_id, query.case_id, target.case_id}) != 1:
+        raise ValueError("stage contexts must use the same case")
+    if factual.o_plus_prefix.frame_stop != target.target.frame_start:
+        raise ValueError("held-out target must begin at the factual evidence boundary")
+    if (
+        query.u_cf.frame_start > target.target.frame_start
+        or query.u_cf.frame_stop < target.target.frame_stop
+    ):
+        raise ValueError("u_cf must cover the held-out evaluation target")
+    for name, value in (
+        ("factual artifact_id", factual.artifact_id),
+        ("query artifact_id", query.artifact_id),
+        ("target artifact_id", target.artifact_id),
+    ):
+        _validate_sha256(value, name=name)

--- a/src/causal4d/stage_provenance.py
+++ b/src/causal4d/stage_provenance.py
@@ -209,9 +209,7 @@ class CounterfactualQueryContext:
         nodes = values.get("query_node_indices")
         policy = str(values["contact_policy"])
         if policy not in {"same_grasp", "new_contact"}:
-            raise ValueError(
-                "contact_policy must be 'same_grasp' or 'new_contact'"
-            )
+            raise ValueError("contact_policy must be 'same_grasp' or 'new_contact'")
         language = values.get("language")
         return cls(
             protocol_id=str(values["protocol_id"]),
@@ -281,9 +279,7 @@ def build_factual_evidence_context(
     """Derive a factual identity without reading or hashing held-out observations."""
 
     if not (
-        context.o_plus.frame_start
-        < evidence_frame_stop
-        <= context.o_plus.frame_stop
+        context.o_plus.frame_start < evidence_frame_stop <= context.o_plus.frame_stop
     ):
         raise ValueError("evidence_frame_stop must be a nonempty O+ prefix")
     _require_window_digest(observations, context.o_minus, name="O-")
@@ -339,9 +335,7 @@ def build_evaluation_target(
     """Derive the held-out target identity after the evaluation suffix is opened."""
 
     if not (
-        context.o_plus.frame_start
-        <= target_frame_start
-        < context.o_plus.frame_stop
+        context.o_plus.frame_start <= target_frame_start < context.o_plus.frame_stop
     ):
         raise ValueError("target_frame_start must leave a nonempty O+ suffix")
     _require_window_digest(observations, context.o_plus, name="O+")

--- a/src/causal4d/stage_provenance.py
+++ b/src/causal4d/stage_provenance.py
@@ -367,6 +367,8 @@ def validate_stage_contexts(
         raise ValueError("stage contexts must use the same protocol")
     if len({factual.case_id, query.case_id, target.case_id}) != 1:
         raise ValueError("stage contexts must use the same case")
+    if factual.o_plus_prefix.stream_id != target.target.stream_id:
+        raise ValueError("held-out target must continue the factual observation stream")
     if factual.o_plus_prefix.frame_stop != target.target.frame_start:
         raise ValueError("held-out target must begin at the factual evidence boundary")
     if (

--- a/tests/test_stage_provenance.py
+++ b/tests/test_stage_provenance.py
@@ -1,3 +1,5 @@
+from dataclasses import replace
+
 import numpy as np
 import pytest
 
@@ -242,3 +244,27 @@ def test_stage_chain_rejects_a_target_with_the_wrong_boundary() -> None:
 
     with pytest.raises(ValueError, match="factual evidence boundary"):
         validate_stage_contexts(factual, query, target)
+
+
+def test_stage_chain_rejects_a_target_from_another_observation_stream() -> None:
+    observations, actions, counterfactual = _arrays()
+    context = _context(observations, actions, counterfactual)
+    factual = build_factual_evidence_context(
+        context,
+        observations,
+        actions,
+        evidence_frame_stop=6,
+    )
+    query = build_counterfactual_query_context(_query(context, counterfactual))
+    target = build_evaluation_target(
+        context,
+        observations,
+        target_frame_start=6,
+    )
+    changed_target = replace(
+        target,
+        target=replace(target.target, stream_id="other-observation-stream"),
+    )
+
+    with pytest.raises(ValueError, match="factual observation stream"):
+        validate_stage_contexts(factual, query, changed_target)

--- a/tests/test_stage_provenance.py
+++ b/tests/test_stage_provenance.py
@@ -1,0 +1,244 @@
+import numpy as np
+import pytest
+
+from causal4d.contracts import CounterfactualQuery, build_causal_context
+from causal4d.stage_provenance import (
+    CounterfactualQueryContext,
+    EvaluationTarget,
+    FactualEvidenceContext,
+    build_counterfactual_query_context,
+    build_evaluation_target,
+    build_factual_evidence_context,
+    validate_stage_contexts,
+)
+
+
+def _arrays() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    observations = np.arange(8 * 2 * 3, dtype=np.float64).reshape(8, 2, 3)
+    actions = np.arange(8 * 1 * 3, dtype=np.float64).reshape(8, 1, 3)
+    counterfactual = actions.copy()
+    counterfactual[4:, :, 0] *= -1.0
+    return observations, actions, counterfactual
+
+
+def _context(
+    observations: np.ndarray,
+    actions: np.ndarray,
+    counterfactual: np.ndarray,
+):
+    return build_causal_context(
+        protocol_id="stage-provenance-unit",
+        case_id="unit-case",
+        observations=observations,
+        observed_actions=actions,
+        counterfactual_actions=counterfactual,
+        intervention_frame=4,
+    )
+
+
+def _query(context, counterfactual: np.ndarray) -> CounterfactualQuery:
+    return CounterfactualQuery(
+        context=context,
+        controller_points_m=counterfactual[4:],
+        horizon_frames=4,
+        contact_policy="new_contact",
+        source_factual_intervention_id="a" * 64,
+        language="move the free endpoint",
+        query_node_indices=np.asarray([0, 2]),
+    )
+
+
+def test_held_out_suffix_changes_only_the_evaluation_target_identity() -> None:
+    observations, actions, counterfactual = _arrays()
+    changed = observations.copy()
+    changed[6:] += 1000.0
+
+    context = _context(observations, actions, counterfactual)
+    changed_context = _context(changed, actions, counterfactual)
+
+    factual = build_factual_evidence_context(
+        context,
+        observations,
+        actions,
+        evidence_frame_stop=6,
+    )
+    changed_factual = build_factual_evidence_context(
+        changed_context,
+        changed,
+        actions,
+        evidence_frame_stop=6,
+    )
+    query = build_counterfactual_query_context(_query(context, counterfactual))
+    changed_query = build_counterfactual_query_context(
+        _query(changed_context, counterfactual)
+    )
+    target = build_evaluation_target(
+        context,
+        observations,
+        target_frame_start=6,
+    )
+    changed_target = build_evaluation_target(
+        changed_context,
+        changed,
+        target_frame_start=6,
+    )
+
+    assert factual.artifact_id == changed_factual.artifact_id
+    assert query.artifact_id == changed_query.artifact_id
+    assert target.artifact_id != changed_target.artifact_id
+    validate_stage_contexts(factual, query, target)
+    validate_stage_contexts(changed_factual, changed_query, changed_target)
+
+
+def test_alternative_query_changes_only_the_query_identity() -> None:
+    observations, actions, counterfactual = _arrays()
+    alternative = counterfactual.copy()
+    alternative[4:, :, 1] += 0.25
+
+    context = _context(observations, actions, counterfactual)
+    alternative_context = _context(observations, actions, alternative)
+
+    factual = build_factual_evidence_context(
+        context,
+        observations,
+        actions,
+        evidence_frame_stop=6,
+    )
+    alternative_factual = build_factual_evidence_context(
+        alternative_context,
+        observations,
+        actions,
+        evidence_frame_stop=6,
+    )
+    query = build_counterfactual_query_context(_query(context, counterfactual))
+    alternative_query = build_counterfactual_query_context(
+        _query(alternative_context, alternative)
+    )
+    target = build_evaluation_target(
+        context,
+        observations,
+        target_frame_start=6,
+    )
+    alternative_target = build_evaluation_target(
+        alternative_context,
+        observations,
+        target_frame_start=6,
+    )
+
+    assert factual.artifact_id == alternative_factual.artifact_id
+    assert query.artifact_id != alternative_query.artifact_id
+    assert target.artifact_id == alternative_target.artifact_id
+
+
+def test_admitted_prefix_changes_only_the_factual_identity() -> None:
+    observations, actions, counterfactual = _arrays()
+    changed = observations.copy()
+    changed[5] += 10.0
+
+    context = _context(observations, actions, counterfactual)
+    changed_context = _context(changed, actions, counterfactual)
+    factual = build_factual_evidence_context(
+        context,
+        observations,
+        actions,
+        evidence_frame_stop=6,
+    )
+    changed_factual = build_factual_evidence_context(
+        changed_context,
+        changed,
+        actions,
+        evidence_frame_stop=6,
+    )
+    target = build_evaluation_target(
+        context,
+        observations,
+        target_frame_start=6,
+    )
+    changed_target = build_evaluation_target(
+        changed_context,
+        changed,
+        target_frame_start=6,
+    )
+
+    assert factual.artifact_id != changed_factual.artifact_id
+    assert target.artifact_id == changed_target.artifact_id
+
+
+def test_builders_reject_arrays_that_disagree_with_the_v1_context() -> None:
+    observations, actions, counterfactual = _arrays()
+    context = _context(observations, actions, counterfactual)
+
+    wrong_observations = observations.copy()
+    wrong_observations[0] += 1.0
+    with pytest.raises(ValueError, match="declared O- digest"):
+        build_factual_evidence_context(
+            context,
+            wrong_observations,
+            actions,
+            evidence_frame_stop=6,
+        )
+
+    wrong_actions = actions.copy()
+    wrong_actions[7] += 1.0
+    with pytest.raises(ValueError, match="declared u_obs digest"):
+        build_factual_evidence_context(
+            context,
+            observations,
+            wrong_actions,
+            evidence_frame_stop=6,
+        )
+
+    wrong_target = observations.copy()
+    wrong_target[7] += 1.0
+    with pytest.raises(ValueError, match=r"declared O\+ digest"):
+        build_evaluation_target(
+            context,
+            wrong_target,
+            target_frame_start=6,
+        )
+
+
+def test_stage_contexts_round_trip_and_validate_as_one_chain() -> None:
+    observations, actions, counterfactual = _arrays()
+    context = _context(observations, actions, counterfactual)
+    factual = build_factual_evidence_context(
+        context,
+        observations,
+        actions,
+        evidence_frame_stop=6,
+    )
+    query = build_counterfactual_query_context(_query(context, counterfactual))
+    target = build_evaluation_target(
+        context,
+        observations,
+        target_frame_start=6,
+    )
+
+    restored_factual = FactualEvidenceContext.from_dict(factual.as_dict())
+    restored_query = CounterfactualQueryContext.from_dict(query.as_dict())
+    restored_target = EvaluationTarget.from_dict(target.as_dict())
+
+    assert restored_factual.artifact_id == factual.artifact_id
+    assert restored_query.artifact_id == query.artifact_id
+    assert restored_target.artifact_id == target.artifact_id
+    validate_stage_contexts(restored_factual, restored_query, restored_target)
+
+
+def test_stage_chain_rejects_a_target_with_the_wrong_boundary() -> None:
+    observations, actions, counterfactual = _arrays()
+    context = _context(observations, actions, counterfactual)
+    factual = build_factual_evidence_context(
+        context,
+        observations,
+        actions,
+        evidence_frame_stop=6,
+    )
+    query = build_counterfactual_query_context(_query(context, counterfactual))
+    target = build_evaluation_target(
+        context,
+        observations,
+        target_frame_start=5,
+    )
+
+    with pytest.raises(ValueError, match="factual evidence boundary"):
+        validate_stage_contexts(factual, query, target)


### PR DESCRIPTION
## Summary

- add independently content-addressed `FactualEvidenceContext`, `CounterfactualQueryContext`, and `EvaluationTarget` contracts;
- derive those identities from existing version-1 Causal4D contracts without rewriting frozen artifacts;
- ensure factual provenance reads and hashes only `O-`, the admitted `O+` prefix, and known `u_obs`;
- add chain validation for protocol, case, observation-stream continuity, factual/target boundary, and counterfactual-action coverage;
- document a compatibility-preserving migration path for future version-2 artifacts.

## Why

The version-1 `CausalContext` intentionally contains `O-`, complete `O+`, `u_obs`, and `u_cf`. That remains preserved for frozen milestones, but a legacy artifact identity can consequently change when only a held-out target or alternative query changes. The new additive identities make each information stage explicit without changing inference arrays, likelihoods, rollouts, registered analyses, or existing artifact IDs.

## Invariants covered

The regression suite verifies that:

- perturbing only held-out observations changes only the target identity;
- changing only `u_cf` changes only the query identity;
- perturbing the admitted response prefix changes only the factual identity;
- supplied arrays must match the declared version-1 observation and action digests;
- serialized stage identities round-trip with stable content addresses;
- incompatible stage boundaries fail closed;
- a target from another observation stream cannot be attached merely because its case and frame boundary match.

## Scientific boundary

This is provenance and contract infrastructure only. It does not modify the frozen v0.3.0 path, the preregistered 36-execution method, target access, posterior computation, physical simulation, or claim status.

## Validation

- Ruff lint and exact formatting;
- mypy on stable contracts and CI utilities;
- core suite on Python 3.10, 3.12, and 3.14;
- extended compatibility on Python 3.11 and 3.13;
- exact dependency-floor, distribution, installed-CLI, bundle, frozen-milestone, and pinned Bayesian-PhysTwin checks.
