### PR TITLE
Bind cross-repository versions to project claim status

### DIFF
--- a/ci/project_status_v1.json
+++ b/ci/project_status_v1.json
@@ -1,0 +1,34 @@
+{
+  "claim_status": "controlled_passed_real_pending",
+  "empirical_status": {
+    "controlled_counterfactual": "passed",
+    "independent_execution_calibration": "pending",
+    "prob4d_to_bayesian_phystwin": "prospective_pending",
+    "same_object_multi_action_real": "pending",
+    "semantic_reweighting": "not_admitted"
+  },
+  "non_claims": [
+    "same-object multi-action real validation is not yet complete",
+    "independent-execution calibration is not yet established",
+    "Prob4D has not yet shown held-out physical-prediction benefit",
+    "semantic reweighting is not admitted into the primary method"
+  ],
+  "packages": {
+    "bayesian-phystwin": {
+      "role": "uncertain_physical_twin",
+      "supported_versions": ">=0.4,<0.5"
+    },
+    "causal4d": {
+      "required_version": "0.4.1",
+      "role": "realized_intervention_abduction_and_prediction"
+    },
+    "prob4d": {
+      "role": "optional_probabilistic_observation_feeder",
+      "supported_versions": ">=0.3,<0.4"
+    }
+  },
+  "primary_next_milestone": "same_object_multi_action_real_protocol",
+  "schema_version": 1,
+  "snapshot_date": "2026-07-31",
+  "status_id": "causal4d-project-status-v1"
+}

--- a/ci/three_repository_golden_path.py
+++ b/ci/three_repository_golden_path.py
@@ -22,6 +22,7 @@ from three_repository_observation import (
     run_rejection_corpus,
 )
 from three_repository_rollout import run_causal4d_rollout
+from three_repository_status import validate_installed_stack_status
 
 
 def _require_runner_outside_checkouts(checkout_roots: tuple[Path, ...]) -> None:
@@ -36,13 +37,19 @@ def _require_runner_outside_checkouts(checkout_roots: tuple[Path, ...]) -> None:
 
 def run(args: argparse.Namespace) -> dict[str, Any]:
     fixture_path = Path(args.prob4d_fixture).resolve()
+    project_status_path = Path(args.project_status).resolve()
     output_path = Path(args.output).resolve()
     checkout_roots = tuple(Path(value).resolve() for value in args.checkout_root)
     require(fixture_path.is_file(), f"fixture does not exist: {fixture_path}")
+    require(
+        project_status_path.is_file(),
+        f"project status does not exist: {project_status_path}",
+    )
     require(checkout_roots, "at least one checkout root must be supplied")
     require(os.environ.get("PYTHONPATH") in {None, ""}, "PYTHONPATH must be unset")
     _require_runner_outside_checkouts(checkout_roots)
     origins = installed_package_origins(checkout_roots)
+    project_status = validate_installed_stack_status(project_status_path)
 
     workdir = output_path.parent / "three-repository-golden-work"
     workdir.mkdir(parents=True, exist_ok=True)
@@ -86,6 +93,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         "status": "passed",
         "schema_version": 1,
         "package_origins": origins,
+        "project_status": project_status,
         "repository_revisions": {
             "FlorianPfaff/Prob4D": args.prob4d_revision,
             "FlorianPfaff/Bayesian-PhysTwin": args.bpt_revision,
@@ -109,6 +117,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--prob4d-fixture", required=True)
+    parser.add_argument("--project-status", required=True)
     parser.add_argument("--prob4d-revision", required=True)
     parser.add_argument("--bpt-revision", required=True)
     parser.add_argument("--causal4d-revision", required=True)

--- a/ci/three_repository_golden_path.py
+++ b/ci/three_repository_golden_path.py
@@ -35,6 +35,13 @@ def _require_runner_outside_checkouts(checkout_roots: tuple[Path, ...]) -> None:
         raise RuntimeError(f"golden-path runner is inside a checkout: {runner}")
 
 
+def _default_project_status() -> str:
+    workspace = os.environ.get("GITHUB_WORKSPACE")
+    if workspace:
+        return str(Path(workspace) / "causal4d" / "ci" / "project_status_v1.json")
+    return "ci/project_status_v1.json"
+
+
 def run(args: argparse.Namespace) -> dict[str, Any]:
     fixture_path = Path(args.prob4d_fixture).resolve()
     project_status_path = Path(args.project_status).resolve()
@@ -117,7 +124,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--prob4d-fixture", required=True)
-    parser.add_argument("--project-status", required=True)
+    parser.add_argument("--project-status", default=_default_project_status())
     parser.add_argument("--prob4d-revision", required=True)
     parser.add_argument("--bpt-revision", required=True)
     parser.add_argument("--causal4d-revision", required=True)

--- a/ci/three_repository_status.py
+++ b/ci/three_repository_status.py
@@ -49,7 +49,9 @@ def _specifier(value: Any, *, name: str) -> str:
     try:
         SpecifierSet(text)
     except InvalidSpecifier as error:
-        raise RuntimeError(f"{name} is not a valid version specifier: {text}") from error
+        raise RuntimeError(
+            f"{name} is not a valid version specifier: {text}"
+        ) from error
     return text
 
 
@@ -89,13 +91,13 @@ def load_project_status(path: Path) -> dict[str, Any]:
         "the decisive same-object real protocol is no longer the next milestone",
     )
     try:
-        date.fromisoformat(_nonempty_text(status.get("snapshot_date"), name="snapshot_date"))
+        date.fromisoformat(
+            _nonempty_text(status.get("snapshot_date"), name="snapshot_date")
+        )
     except ValueError as error:
         raise RuntimeError("snapshot_date must use ISO YYYY-MM-DD format") from error
 
-    empirical = dict(
-        _mapping(status.get("empirical_status"), name="empirical_status")
-    )
+    empirical = dict(_mapping(status.get("empirical_status"), name="empirical_status"))
     require(
         empirical == _EXPECTED_EMPIRICAL_STATUS,
         "empirical status changed without updating the versioned status contract",

--- a/ci/three_repository_status.py
+++ b/ci/three_repository_status.py
@@ -1,0 +1,222 @@
+"""Validate the machine-readable Causal4D cross-repository project status."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+import hashlib
+import importlib.metadata
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion, Version
+
+from three_repository_common import require
+
+
+_EXPECTED_STATUS_ID = "causal4d-project-status-v1"
+_EXPECTED_CLAIM_STATUS = "controlled_passed_real_pending"
+_EXPECTED_NEXT_MILESTONE = "same_object_multi_action_real_protocol"
+_EXPECTED_EMPIRICAL_STATUS = {
+    "controlled_counterfactual": "passed",
+    "independent_execution_calibration": "pending",
+    "prob4d_to_bayesian_phystwin": "prospective_pending",
+    "same_object_multi_action_real": "pending",
+    "semantic_reweighting": "not_admitted",
+}
+_EXPECTED_PACKAGE_ROLES = {
+    "bayesian-phystwin": "uncertain_physical_twin",
+    "causal4d": "realized_intervention_abduction_and_prediction",
+    "prob4d": "optional_probabilistic_observation_feeder",
+}
+
+
+def _mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    require(isinstance(value, dict), f"{name} must be a JSON object")
+    return value
+
+
+def _nonempty_text(value: Any, *, name: str) -> str:
+    text = str(value).strip()
+    require(bool(text), f"{name} must be nonempty")
+    return text
+
+
+def _specifier(value: Any, *, name: str) -> str:
+    text = _nonempty_text(value, name=name)
+    try:
+        SpecifierSet(text)
+    except InvalidSpecifier as error:
+        raise RuntimeError(f"{name} is not a valid version specifier: {text}") from error
+    return text
+
+
+def _version(value: Any, *, name: str) -> str:
+    text = _nonempty_text(value, name=name)
+    try:
+        Version(text)
+    except InvalidVersion as error:
+        raise RuntimeError(f"{name} is not a valid version: {text}") from error
+    return text
+
+
+def _canonical_sha256(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def load_project_status(path: Path) -> dict[str, Any]:
+    """Load and fail closed on unsupported or claim-inflating status records."""
+
+    require(path.is_file(), f"project status does not exist: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    status = dict(_mapping(payload, name="project status"))
+    require(status.get("schema_version") == 1, "unsupported project-status schema")
+    require(status.get("status_id") == _EXPECTED_STATUS_ID, "unexpected status_id")
+    require(
+        status.get("claim_status") == _EXPECTED_CLAIM_STATUS,
+        "project status overstates or changes the registered claim boundary",
+    )
+    require(
+        status.get("primary_next_milestone") == _EXPECTED_NEXT_MILESTONE,
+        "the decisive same-object real protocol is no longer the next milestone",
+    )
+    try:
+        date.fromisoformat(_nonempty_text(status.get("snapshot_date"), name="snapshot_date"))
+    except ValueError as error:
+        raise RuntimeError("snapshot_date must use ISO YYYY-MM-DD format") from error
+
+    empirical = dict(
+        _mapping(status.get("empirical_status"), name="empirical_status")
+    )
+    require(
+        empirical == _EXPECTED_EMPIRICAL_STATUS,
+        "empirical status changed without updating the versioned status contract",
+    )
+
+    packages = dict(_mapping(status.get("packages"), name="packages"))
+    require(
+        set(packages) == set(_EXPECTED_PACKAGE_ROLES),
+        "project status must describe exactly Causal4D, Bayesian-PhysTwin, and Prob4D",
+    )
+    for package_name, expected_role in _EXPECTED_PACKAGE_ROLES.items():
+        record = _mapping(packages[package_name], name=f"packages.{package_name}")
+        require(
+            record.get("role") == expected_role,
+            f"packages.{package_name}.role changed",
+        )
+    causal4d_record = _mapping(packages["causal4d"], name="packages.causal4d")
+    _version(
+        causal4d_record.get("required_version"),
+        name="packages.causal4d.required_version",
+    )
+    for package_name in ("bayesian-phystwin", "prob4d"):
+        record = _mapping(packages[package_name], name=f"packages.{package_name}")
+        _specifier(
+            record.get("supported_versions"),
+            name=f"packages.{package_name}.supported_versions",
+        )
+
+    non_claims = status.get("non_claims")
+    require(
+        isinstance(non_claims, list) and len(non_claims) >= 4,
+        "project status must retain its explicit non-claims",
+    )
+    require(
+        all(isinstance(value, str) and value.strip() for value in non_claims),
+        "project-status non-claims must be nonempty strings",
+    )
+    return status
+
+
+def validate_causal4d_status(path: Path) -> dict[str, Any]:
+    """Validate Causal4D's installed version and provider range against status."""
+
+    import causal4d
+    from causal4d.provider_contract import BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE
+
+    status = load_project_status(path)
+    packages = _mapping(status["packages"], name="packages")
+    causal4d_record = _mapping(packages["causal4d"], name="packages.causal4d")
+    required_causal4d = _version(
+        causal4d_record["required_version"],
+        name="packages.causal4d.required_version",
+    )
+    installed_causal4d = importlib.metadata.version("causal4d")
+    require(
+        installed_causal4d == required_causal4d,
+        "installed Causal4D version differs from the project-status contract",
+    )
+    require(
+        causal4d.__version__ == required_causal4d,
+        "causal4d.__version__ differs from the project-status contract",
+    )
+
+    bpt_record = _mapping(
+        packages["bayesian-phystwin"],
+        name="packages.bayesian-phystwin",
+    )
+    supported_bpt = _specifier(
+        bpt_record["supported_versions"],
+        name="packages.bayesian-phystwin.supported_versions",
+    )
+    require(
+        supported_bpt == BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE,
+        "Bayesian-PhysTwin compatibility range drifted from provider_contract.py",
+    )
+    return {
+        "claim_status": status["claim_status"],
+        "empirical_status": status["empirical_status"],
+        "primary_next_milestone": status["primary_next_milestone"],
+        "status_id": status["status_id"],
+        "status_sha256": _canonical_sha256(status),
+        "versions": {"causal4d": installed_causal4d},
+    }
+
+
+def validate_installed_stack_status(path: Path) -> dict[str, Any]:
+    """Validate all three installed wheels against the shared status contract."""
+
+    summary = validate_causal4d_status(path)
+    status = load_project_status(path)
+    packages = _mapping(status["packages"], name="packages")
+    versions = {
+        package_name: importlib.metadata.version(package_name)
+        for package_name in ("bayesian-phystwin", "causal4d", "prob4d")
+    }
+    for package_name in ("bayesian-phystwin", "prob4d"):
+        record = _mapping(packages[package_name], name=f"packages.{package_name}")
+        supported = _specifier(
+            record["supported_versions"],
+            name=f"packages.{package_name}.supported_versions",
+        )
+        require(
+            Version(versions[package_name]) in SpecifierSet(supported),
+            f"installed {package_name} {versions[package_name]} is outside {supported}",
+        )
+    summary["versions"] = versions
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--status", type=Path, required=True)
+    parser.add_argument("--installed-stack", action="store_true")
+    arguments = parser.parse_args()
+    validator = (
+        validate_installed_stack_status
+        if arguments.installed_stack
+        else validate_causal4d_status
+    )
+    print(json.dumps(validator(arguments.status.resolve()), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/project_status_contract.md
+++ b/docs/project_status_contract.md
@@ -1,0 +1,59 @@
+# Cross-repository project-status contract
+
+`ci/project_status_v1.json` is the machine-readable development status shared by
+the Causal4D, Bayesian-PhysTwin, and Prob4D installed-wheel path. It records two
+different kinds of information that must not be conflated:
+
+1. package-version compatibility needed to execute the current development
+   stack; and
+2. the empirical claim boundary supported by completed experiments.
+
+The current contract records:
+
+- Causal4D `0.4.1`;
+- Bayesian-PhysTwin compatibility `>=0.4,<0.5`;
+- Prob4D development compatibility `>=0.3,<0.4`;
+- a passed controlled counterfactual result;
+- pending same-object multi-action validation and independent-execution
+  calibration;
+- a pending prospective Prob4D-to-Bayesian-PhysTwin experiment; and
+- semantic reweighting as not admitted into the primary method.
+
+## Automated checks
+
+`ci/three_repository_status.py` fails closed when:
+
+- Causal4D package metadata and `causal4d.__version__` disagree with the status
+  contract;
+- the recorded Bayesian-PhysTwin range differs from
+  `BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE`;
+- an installed Bayesian-PhysTwin or Prob4D wheel lies outside its recorded
+  development range;
+- the status record changes the decisive next milestone;
+- a pending empirical result is promoted without versioning the contract; or
+- explicit non-claims are removed.
+
+The ordinary core test suite validates Causal4D and its provider range. The
+private installed-wheel golden path additionally validates all three installed
+distributions and writes the status ID, canonical SHA-256 digest, package
+versions, next milestone, claim status, and empirical status into its JSON
+summary.
+
+The runner resolves the record from
+`$GITHUB_WORKSPACE/causal4d/ci/project_status_v1.json` in GitHub Actions and from
+`ci/project_status_v1.json` when launched at the repository root. No source
+checkout is imported; the package-version checks run against the three built and
+installed wheels.
+
+## Update policy
+
+A package release may update its version or compatibility range without changing
+the empirical status. Conversely, a scientific claim may change only when the
+corresponding locked experiment is complete and reported. Either change must be
+made explicitly in the versioned status record and must pass the same installed
+stack checks.
+
+This contract does not replace exact commit pins used by frozen milestones or
+method-freeze manifests. It is the ordinary-development compatibility and claim
+status, while frozen experiments continue to bind exact revisions, artifacts,
+and checksums.

--- a/tests/test_three_repository_project_status.py
+++ b/tests/test_three_repository_project_status.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CI_ROOT = ROOT / "ci"
+STATUS = CI_ROOT / "project_status_v1.json"
+GOLDEN_PATH = CI_ROOT / "three_repository_golden_path.py"
+if str(CI_ROOT) not in sys.path:
+    sys.path.insert(0, str(CI_ROOT))
+
+from three_repository_status import validate_causal4d_status  # noqa: E402
+
+
+def _write_status(tmp_path: Path, mutation) -> Path:
+    payload = json.loads(STATUS.read_text(encoding="utf-8"))
+    mutation(payload)
+    path = tmp_path / "project-status.json"
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_project_status_matches_causal4d_and_provider_contract() -> None:
+    summary = validate_causal4d_status(STATUS)
+
+    assert summary["status_id"] == "causal4d-project-status-v1"
+    assert summary["claim_status"] == "controlled_passed_real_pending"
+    assert summary["versions"] == {"causal4d": "0.4.1"}
+    assert len(summary["status_sha256"]) == 64
+
+
+def test_project_status_rejects_claim_inflation(tmp_path: Path) -> None:
+    path = _write_status(
+        tmp_path,
+        lambda payload: payload.__setitem__("claim_status", "real_confirmed"),
+    )
+
+    with pytest.raises(RuntimeError, match="overstates"):
+        validate_causal4d_status(path)
+
+
+def test_project_status_rejects_provider_range_drift(tmp_path: Path) -> None:
+    def mutate(payload) -> None:
+        payload["packages"]["bayesian-phystwin"]["supported_versions"] = ">=0.5,<0.6"
+
+    path = _write_status(tmp_path, mutate)
+    with pytest.raises(RuntimeError, match="compatibility range drifted"):
+        validate_causal4d_status(path)
+
+
+def test_project_status_rejects_causal4d_version_drift(tmp_path: Path) -> None:
+    def mutate(payload) -> None:
+        payload["packages"]["causal4d"]["required_version"] = "9.0.0"
+
+    path = _write_status(tmp_path, mutate)
+    with pytest.raises(RuntimeError, match="installed Causal4D version differs"):
+        validate_causal4d_status(path)
+
+
+def test_installed_wheel_golden_path_binds_project_status() -> None:
+    text = GOLDEN_PATH.read_text(encoding="utf-8")
+
+    assert "validate_installed_stack_status" in text
+    assert '"project_status": project_status' in text
+    assert "project_status_v1.json" in text


### PR DESCRIPTION
## Summary

- add a machine-readable project-status contract for Causal4D, Bayesian-PhysTwin, and Prob4D;
- validate Causal4D's package version and Bayesian-PhysTwin compatibility range in the ordinary core suite;
- validate all three installed wheel versions in the private golden path;
- bind the status ID, canonical digest, versions, next milestone, empirical states, and non-claim boundary into the golden-path summary;
- reject claim inflation, removed non-claims, package drift, or a changed decisive milestone.

## Current boundary

The contract records the controlled counterfactual result as passed while keeping the same-object multi-action real experiment, independent-execution calibration, and prospective Prob4D-to-Bayesian-PhysTwin experiment pending. Semantic reweighting remains not admitted.

## Engineering boundary

This is CI, provenance, and documentation infrastructure. It does not alter inference, providers, registered analysis, frozen artifacts, or empirical evidence. Exact frozen revisions remain governed by existing milestone and method-freeze manifests.

## Validation

- Ruff lint and exact formatting for all golden-path scripts;
- project-status tests for valid status, claim inflation, Causal4D version drift, and Bayesian-PhysTwin range drift;
- core suite on Python 3.10, 3.12, and 3.14;
- extended compatibility on Python 3.11 and 3.13;
- exact declared dependency floors;
- wheel and source-distribution builds and all installed CLI help checks;
- frozen milestone and deterministic result-bundle validation;
- pinned Bayesian-PhysTwin integration;
- three clean Prob4D, Bayesian-PhysTwin, and Causal4D wheels built and installed in an isolated environment;
- installed versions accepted by the status contract;
- complete Prob4D -> Bayesian-PhysTwin -> Causal4D golden path, strict provider-v2 admission, and cross-repository contract suite.
