### PR TITLE
Add predeclared, source-verified real-result interpretation

### DIFF
--- a/configs/causal4d/real_analysis_manifest_v1.template.json
+++ b/configs/causal4d/real_analysis_manifest_v1.template.json
@@ -1,0 +1,12 @@
+{
+  "analysis_id": null,
+  "artifact_kind": "Causal4DRegisteredRealAnalysisManifestTemplate",
+  "method_freeze_sha256": null,
+  "optional_branches_may_change_primary_analysis": false,
+  "preacquisition_amendment_sha256": "0e167538a7824e5ec053031d8359d4e9b4ff89ad61a85666400a86c2a88ac42f",
+  "primary_analysis_locked": false,
+  "protocol_design_sha256": "6d61f2bea96af0ba04faaf3476990b58cd87e0a9c826420c254a012dec647968",
+  "protocol_id": "causal4d-sloth-multi-action-v1",
+  "schema_version": 1,
+  "target_outcomes_may_select_method_or_hyperparameters": false
+}

--- a/configs/causal4d/real_result_gate_summary_v1.template.json
+++ b/configs/causal4d/real_result_gate_summary_v1.template.json
@@ -1,0 +1,18 @@
+{
+  "analysis_manifest_sha256": null,
+  "artifact_kind": "Causal4DRealResultGateSummaryTemplate",
+  "evidence_status": "incomplete",
+  "execution_block_calibration": "not_estimable",
+  "factual_continuation": "not_estimable",
+  "method_freeze_sha256": null,
+  "new_contact_transfer": "not_estimable",
+  "oracle_diagnosis": "not_estimable",
+  "preacquisition_amendment_sha256": "0e167538a7824e5ec053031d8359d4e9b4ff89ad61a85666400a86c2a88ac42f",
+  "preregistered_exclusion_count": 0,
+  "protocol_design_sha256": "6d61f2bea96af0ba04faaf3476990b58cd87e0a9c826420c254a012dec647968",
+  "protocol_id": "causal4d-sloth-multi-action-v1",
+  "same_grasp_transfer": "not_estimable",
+  "schema_version": 1,
+  "target_informed_selection": null,
+  "technical_failure_count": 0
+}

--- a/docs/causal4d_real_result_interpretation.md
+++ b/docs/causal4d_real_result_interpretation.md
@@ -1,0 +1,127 @@
+# Predeclared interpretation of the real Causal4D result
+
+## Purpose
+
+The 36-execution same-object protocol can produce several scientifically useful
+outcomes. Those outcomes must not be combined after target access into a broader
+claim than the registered gates support.
+
+`causal4d evidence interpret-real-result` applies one versioned interpretation
+tree to the completed gate summary. It reads **gate decisions and provenance,
+not raw target metrics**. The output is recomputable, content-addressed, and
+fails validation if a headline, supported claim, limitation, or next action is
+edited by hand.
+
+This reporting contract does not change the estimator, protocol, thresholds,
+folds, exclusion policy, or target outcomes. It fixes how their registered gate
+results may be described.
+
+## Bound inputs
+
+A gate summary identifies:
+
+- protocol `causal4d-sloth-multi-action-v1` and its exact design SHA-256;
+- the final v4 pre-acquisition amendment SHA-256;
+- the sealed method-freeze SHA-256;
+- the registered analysis-manifest SHA-256;
+- complete versus incomplete evidence status;
+- factual-continuation, same-grasp-transfer, new-contact-transfer, and
+  execution-block-calibration gate results;
+- the preregistered oracle diagnosis;
+- technical-failure and preregistered-exclusion counts; and
+- whether target-informed method or threshold selection occurred.
+
+Every primary gate is one of `passed`, `failed`, or `not_estimable`. The oracle
+diagnosis is one of `intervention_headroom`, `model_discrepancy_dominant`,
+`mixed`, or `not_estimable`.
+
+## Decision tree
+
+The tree is evaluated in this order:
+
+| Result pattern | Classification | Permitted headline |
+| --- | --- | --- |
+| Target-informed selection occurred | `confirmatory_boundary_violated` | No confirmatory claim; report the violation and issue a new protocol. |
+| Evidence registry incomplete | `incomplete_evidence` | No confirmatory claim; retain missing, failed, and excluded executions. |
+| Factual-continuation gate fails | `primary_chain_not_supported` | Negative primary result; transfer or calibration cannot rescue it. |
+| Factual, same-grasp, new-contact, and calibration gates pass | `full_chain_supported` | Complete registered evidence chain passes, bounded to this protocol. |
+| Factual and both transfer gates pass; calibration fails | `transfer_supported_calibration_limited` | Transfer is supported, but no calibrated-risk or hardware-safety claim. |
+| Factual and both transfer gates pass; calibration not estimable | `transfer_supported_calibration_unresolved` | Bounded transfer evidence with unresolved independent-execution calibration. |
+| Factual and same-grasp pass; new-contact fails | `persistent_transfer_only` | Persistent realized actuation transfers; fresh-contact/event transfer does not. |
+| Factual and new-contact pass; same-grasp fails | `incoherent_transfer_pattern` | Report the inconsistent arms separately; no general transfer claim. |
+| Factual passes; both transfer gates fail | `factual_only` | Prefix-conditioned factual prediction improves; transfer is unsupported. |
+| Factual passes; at least one transfer endpoint is not estimable | `partial_transfer_evidence` | Report the estimable subset without inferring the complete chain. |
+
+A passed calibration gate does not rescue failed factual or transfer gates.
+Oracle diagnostics add mandatory limitations and a post-reporting research
+focus; they cannot change the primary classification.
+
+## Input format
+
+```json
+{
+  "schema_version": 1,
+  "artifact_kind": "Causal4DRealResultGateSummary",
+  "protocol_id": "causal4d-sloth-multi-action-v1",
+  "protocol_design_sha256": "6d61f2bea96af0ba04faaf3476990b58cd87e0a9c826420c254a012dec647968",
+  "preacquisition_amendment_sha256": "0e167538a7824e5ec053031d8359d4e9b4ff89ad61a85666400a86c2a88ac42f",
+  "method_freeze_sha256": "<64 lowercase hex>",
+  "analysis_manifest_sha256": "<64 lowercase hex>",
+  "evidence_status": "complete",
+  "factual_continuation": "passed",
+  "same_grasp_transfer": "passed",
+  "new_contact_transfer": "failed",
+  "execution_block_calibration": "failed",
+  "oracle_diagnosis": "model_discrepancy_dominant",
+  "technical_failure_count": 0,
+  "preregistered_exclusion_count": 0,
+  "target_informed_selection": false
+}
+```
+
+The gate summary should be generated from the registered analysis and evidence
+registry. It is not an opportunity to redefine thresholds or manually choose a
+more favorable qualitative label.
+
+An explicitly invalid operator template is available at
+`configs/causal4d/real_result_gate_summary_v1.template.json`. It must be copied,
+completed, and changed to artifact kind `Causal4DRealResultGateSummary`; the
+template itself cannot pass validation.
+
+## Command
+
+```bash
+causal4d evidence interpret-real-result \
+  /data/causal4d-sloth-multi-action-v1/real-result-gates.json \
+  /data/causal4d-sloth-multi-action-v1/real-result-interpretation.json \
+  --require-complete
+```
+
+The output contains:
+
+- the exact gate and provenance identities;
+- the matched rule and stable classification ID;
+- paper status: `positive`, `bounded_positive`, `negative`, or `incomplete`;
+- supported claims;
+- mandatory limitations;
+- globally prohibited claims;
+- the next action allowed by the registered result; and
+- SHA-256 identities for the interpretation contract and result.
+
+The command returns exit code `3` with `--require-complete` when the resulting
+paper status is `incomplete`. Existing output is not overwritten unless
+`--overwrite` is supplied.
+
+## Non-claims retained for every outcome
+
+The interpretation artifact always prohibits:
+
+- individual-level real counterfactual ground truth;
+- an overall state-of-the-art claim beyond the registered same-object protocol;
+- calibration of the raw physical-posterior covariance;
+- general robot-execution safety or hardware-control success;
+- Prob4D physical-prediction benefit without its separate prospective test; and
+- real contact recovery without independent contact instrumentation.
+
+A negative or bounded result is complete scientific evidence. It must not be
+retuned on the same target executions.

--- a/docs/causal4d_real_result_interpretation.md
+++ b/docs/causal4d_real_result_interpretation.md
@@ -12,6 +12,11 @@ not raw target metrics**. The output is recomputable, content-addressed, and
 fails validation if a headline, supported claim, limitation, or next action is
 edited by hand.
 
+The public command also opens and verifies the concrete sealed method-freeze and
+registered-analysis files whose SHA-256 values appear in the gate summary. A
+well-formed 64-hex string without the corresponding source artifact is therefore
+not sufficient to publish an interpretation.
+
 This reporting contract does not change the estimator, protocol, thresholds,
 folds, exclusion policy, or target outcomes. It fixes how their registered gate
 results may be described.
@@ -35,6 +40,48 @@ Every primary gate is one of `passed`, `failed`, or `not_estimable`. The oracle
 diagnosis is one of `intervention_headroom`, `model_discrepancy_dominant`,
 `mixed`, or `not_estimable`.
 
+## Source-artifact verification
+
+Before applying the decision tree, the command requires two ordinary,
+non-symlinked JSON files.
+
+### Sealed method freeze
+
+The file supplied through `--method-freeze` must:
+
+- have the exact SHA-256 recorded by the gate summary;
+- use the current method-freeze schema and milestone ID;
+- be explicitly sealed before confirmatory collection;
+- record that target outcomes had not been observed at freeze time;
+- bind the same protocol and v4 amendment as the gate summary; and
+- prohibit target-informed method selection and optional-branch replacement of
+  the primary analysis.
+
+The independent freeze-validation command remains responsible for checking the
+complete deployed checkout and every locked file. The interpretation command
+adds a second, local check that the exact sealed file being cited is present and
+internally consistent.
+
+### Registered analysis manifest
+
+The file supplied through `--analysis-manifest` must use artifact kind
+`Causal4DRegisteredRealAnalysisManifest`, bind the same protocol, amendment, and
+method-freeze digest, and state that:
+
+```text
+primary_analysis_locked = true
+target_outcomes_may_select_method_or_hyperparameters = false
+optional_branches_may_change_primary_analysis = false
+```
+
+An intentionally invalid template is checked in at
+`configs/causal4d/real_analysis_manifest_v1.template.json`. It must be completed
+and promoted from the `...Template` artifact kind before target access.
+
+The command publishes a sibling `*.sources.json` record containing the verified
+file sizes and SHA-256 values plus its own canonical digest. This record contains
+no workstation-local path and can be compared after archive relocation.
+
 ## Decision tree
 
 The tree is evaluated in this order:
@@ -56,7 +103,7 @@ A passed calibration gate does not rescue failed factual or transfer gates.
 Oracle diagnostics add mandatory limitations and a post-reporting research
 focus; they cannot change the primary classification.
 
-## Input format
+## Gate-summary format
 
 ```json
 {
@@ -94,10 +141,18 @@ template itself cannot pass validation.
 causal4d evidence interpret-real-result \
   /data/causal4d-sloth-multi-action-v1/real-result-gates.json \
   /data/causal4d-sloth-multi-action-v1/real-result-interpretation.json \
+  --method-freeze \
+  /data/causal4d-sloth-multi-action-v1/method_freeze.json \
+  --analysis-manifest \
+  /data/causal4d-sloth-multi-action-v1/registered-analysis.json \
   --require-complete
 ```
 
-The output contains:
+By default the source-verification record is written beside the interpretation as
+`real-result-interpretation.sources.json`. Use
+`--source-verification-output <path>` to choose another location.
+
+The interpretation output contains:
 
 - the exact gate and provenance identities;
 - the matched rule and stable classification ID;
@@ -109,8 +164,8 @@ The output contains:
 - SHA-256 identities for the interpretation contract and result.
 
 The command returns exit code `3` with `--require-complete` when the resulting
-paper status is `incomplete`. Existing output is not overwritten unless
-`--overwrite` is supplied.
+paper status is `incomplete`. Neither the interpretation nor its source record is
+overwritten unless `--overwrite` is supplied.
 
 ## Non-claims retained for every outcome
 

--- a/src/causal4d/cli/command_registry.py
+++ b/src/causal4d/cli/command_registry.py
@@ -104,6 +104,12 @@ GROUPED_COMMANDS = (
         legacy_name="causal4d-observation-lineage",
     ),
     CommandSpec(
+        route=("evidence", "interpret-real-result"),
+        target="causal4d.cli.real_result_interpretation:main",
+        summary="Apply the preregistered real-result interpretation tree.",
+        lifecycle="stable",
+    ),
+    CommandSpec(
         route=("calibration", "real"),
         target="causal4d.cli.real_calibration:main",
         summary="Fit or evaluate real predictive calibration.",

--- a/src/causal4d/cli/real_result_interpretation.py
+++ b/src/causal4d/cli/real_result_interpretation.py
@@ -7,17 +7,28 @@ import json
 from pathlib import Path
 from typing import Sequence
 
+from causal4d.atomic_io import atomic_write_json
 from causal4d.real_result_interpretation import (
     RealResultGateSummary,
     interpret_real_result,
     write_real_result_interpretation,
 )
+from causal4d.real_result_source_verification import verify_real_result_sources
+
+
+def _default_verification_path(output: Path) -> Path:
+    suffix = output.suffix
+    stem = output.name[: -len(suffix)] if suffix else output.name
+    return output.with_name(f"{stem}.sources.json")
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("gate_summary", type=Path)
     parser.add_argument("output", type=Path)
+    parser.add_argument("--method-freeze", type=Path, required=True)
+    parser.add_argument("--analysis-manifest", type=Path, required=True)
+    parser.add_argument("--source-verification-output", type=Path)
     parser.add_argument("--overwrite", action="store_true")
     parser.add_argument("--require-complete", action="store_true")
     arguments = parser.parse_args(argv)
@@ -26,13 +37,43 @@ def main(argv: Sequence[str] | None = None) -> int:
     if not isinstance(payload, dict):
         parser.error("gate summary JSON must contain an object")
     gates = RealResultGateSummary.from_dict(payload)
+    verification = verify_real_result_sources(
+        gates,
+        method_freeze_path=arguments.method_freeze,
+        analysis_manifest_path=arguments.analysis_manifest,
+    )
+    verification_output = (
+        arguments.source_verification_output
+        or _default_verification_path(arguments.output)
+    )
+    if verification_output.resolve() == arguments.output.resolve():
+        parser.error("source-verification output must differ from interpretation output")
+    if not arguments.overwrite:
+        existing = [
+            str(path)
+            for path in (arguments.output, verification_output)
+            if path.exists()
+        ]
+        if existing:
+            raise FileExistsError(
+                "real-result evidence output already exists: " + ", ".join(existing)
+            )
+
     interpretation = interpret_real_result(gates)
+    atomic_write_json(
+        verification_output,
+        verification,
+        overwrite=arguments.overwrite,
+    )
     write_real_result_interpretation(
         arguments.output,
         interpretation,
         overwrite=arguments.overwrite,
     )
-    print(json.dumps(interpretation.as_dict(), indent=2, sort_keys=True))
+    console = interpretation.as_dict()
+    console["source_verification"] = verification
+    console["source_verification_path"] = str(verification_output)
+    print(json.dumps(console, indent=2, sort_keys=True))
     if arguments.require_complete and interpretation.paper_status == "incomplete":
         return 3
     return 0

--- a/src/causal4d/cli/real_result_interpretation.py
+++ b/src/causal4d/cli/real_result_interpretation.py
@@ -47,7 +47,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         or _default_verification_path(arguments.output)
     )
     if verification_output.resolve() == arguments.output.resolve():
-        parser.error("source-verification output must differ from interpretation output")
+        parser.error(
+            "source-verification output must differ from interpretation output"
+        )
     if not arguments.overwrite:
         existing = [
             str(path)

--- a/src/causal4d/cli/real_result_interpretation.py
+++ b/src/causal4d/cli/real_result_interpretation.py
@@ -1,0 +1,42 @@
+"""Create the preregistered interpretation of real-experiment gate outcomes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from causal4d.real_result_interpretation import (
+    RealResultGateSummary,
+    interpret_real_result,
+    write_real_result_interpretation,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("gate_summary", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--require-complete", action="store_true")
+    arguments = parser.parse_args(argv)
+
+    payload = json.loads(arguments.gate_summary.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        parser.error("gate summary JSON must contain an object")
+    gates = RealResultGateSummary.from_dict(payload)
+    interpretation = interpret_real_result(gates)
+    write_real_result_interpretation(
+        arguments.output,
+        interpretation,
+        overwrite=arguments.overwrite,
+    )
+    print(json.dumps(interpretation.as_dict(), indent=2, sort_keys=True))
+    if arguments.require_complete and interpretation.paper_status == "incomplete":
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d/real_result_interpretation.py
+++ b/src/causal4d/real_result_interpretation.py
@@ -241,8 +241,7 @@ class RealResultGateSummary:
             name="preacquisition_amendment_sha256",
         )
         _require(
-            self.preacquisition_amendment_sha256
-            == EXPECTED_PREACQUISITION_SHA256,
+            self.preacquisition_amendment_sha256 == EXPECTED_PREACQUISITION_SHA256,
             "gate summary amendment digest does not match locked v4 amendment",
         )
         _sha256(self.method_freeze_sha256, name="method_freeze_sha256")
@@ -276,9 +275,7 @@ class RealResultGateSummary:
         return {
             "protocol_id": self.protocol_id,
             "protocol_design_sha256": self.protocol_design_sha256,
-            "preacquisition_amendment_sha256": (
-                self.preacquisition_amendment_sha256
-            ),
+            "preacquisition_amendment_sha256": (self.preacquisition_amendment_sha256),
             "method_freeze_sha256": self.method_freeze_sha256,
             "analysis_manifest_sha256": self.analysis_manifest_sha256,
             "evidence_status": self.evidence_status,
@@ -473,15 +470,9 @@ def validate_real_result_interpretation(
         method_freeze_sha256=str(gates_payload["method_freeze_sha256"]),
         analysis_manifest_sha256=str(gates_payload["analysis_manifest_sha256"]),
         evidence_status=cast(EvidenceStatus, gates_payload["evidence_status"]),
-        factual_continuation=cast(
-            GateStatus, gates_payload["factual_continuation"]
-        ),
-        same_grasp_transfer=cast(
-            GateStatus, gates_payload["same_grasp_transfer"]
-        ),
-        new_contact_transfer=cast(
-            GateStatus, gates_payload["new_contact_transfer"]
-        ),
+        factual_continuation=cast(GateStatus, gates_payload["factual_continuation"]),
+        same_grasp_transfer=cast(GateStatus, gates_payload["same_grasp_transfer"]),
+        new_contact_transfer=cast(GateStatus, gates_payload["new_contact_transfer"]),
         execution_block_calibration=cast(
             GateStatus, gates_payload["execution_block_calibration"]
         ),

--- a/src/causal4d/real_result_interpretation.py
+++ b/src/causal4d/real_result_interpretation.py
@@ -1,0 +1,539 @@
+"""Predeclared interpretation contract for the confirmatory real experiment."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from causal4d.atomic_io import atomic_write_json
+
+INTERPRETATION_SCHEMA_VERSION = 1
+INTERPRETATION_CONTRACT_ID = "causal4d-real-result-interpretation-v1"
+EXPECTED_PROTOCOL_ID = "causal4d-sloth-multi-action-v1"
+EXPECTED_PROTOCOL_DESIGN_SHA256 = (
+    "6d61f2bea96af0ba04faaf3476990b58cd87e0a9c826420c254a012dec647968"
+)
+EXPECTED_PREACQUISITION_SHA256 = (
+    "0e167538a7824e5ec053031d8359d4e9b4ff89ad61a85666400a86c2a88ac42f"
+)
+
+GateStatus = Literal["passed", "failed", "not_estimable"]
+EvidenceStatus = Literal["complete", "incomplete"]
+OracleDiagnosis = Literal[
+    "intervention_headroom",
+    "model_discrepancy_dominant",
+    "mixed",
+    "not_estimable",
+]
+PaperStatus = Literal["positive", "bounded_positive", "negative", "incomplete"]
+
+_GATE_STATUSES = {"passed", "failed", "not_estimable"}
+_EVIDENCE_STATUSES = {"complete", "incomplete"}
+_ORACLE_DIAGNOSES = {
+    "intervention_headroom",
+    "model_discrepancy_dominant",
+    "mixed",
+    "not_estimable",
+}
+
+_PROHIBITED_CLAIMS = (
+    "individual-level real counterfactual ground truth",
+    "overall state of the art beyond the registered same-object protocol",
+    "calibration of the raw physical-posterior covariance",
+    "general robot-execution safety or hardware-control success",
+    "Prob4D benefit without its separate prospective experiment",
+    "real contact recovery without independent contact instrumentation",
+)
+
+_CONTRACT_DESCRIPTOR = {
+    "schema_version": INTERPRETATION_SCHEMA_VERSION,
+    "contract_id": INTERPRETATION_CONTRACT_ID,
+    "protocol_id": EXPECTED_PROTOCOL_ID,
+    "protocol_design_sha256": EXPECTED_PROTOCOL_DESIGN_SHA256,
+    "preacquisition_amendment_sha256": EXPECTED_PREACQUISITION_SHA256,
+    "primary_gate_order": [
+        "factual_continuation",
+        "same_grasp_transfer",
+        "new_contact_transfer",
+        "execution_block_calibration",
+    ],
+    "prohibited_claims": list(_PROHIBITED_CLAIMS),
+}
+
+_RULES: dict[str, dict[str, Any]] = {
+    "confirmatory_boundary_violated": {
+        "paper_status": "incomplete",
+        "headline": "The target-informed selection boundary was violated.",
+        "claims": (),
+        "next_action": (
+            "Report the violation and issue a new protocol before reanalysis."
+        ),
+    },
+    "incomplete_evidence": {
+        "paper_status": "incomplete",
+        "headline": "The confirmatory evidence registry is incomplete.",
+        "claims": (),
+        "next_action": (
+            "Complete or explicitly report the registered evidence without "
+            "replacing missing or failed executions."
+        ),
+    },
+    "primary_chain_not_supported": {
+        "paper_status": "negative",
+        "headline": "The factual-continuation gate does not pass.",
+        "claims": (),
+        "next_action": (
+            "Report the negative result and use only preregistered oracle "
+            "diagnostics to localize the failure."
+        ),
+    },
+    "full_chain_supported": {
+        "paper_status": "positive",
+        "headline": "The complete registered Causal4D evidence chain passes.",
+        "claims": (
+            "Factual continuation and persistent/event-specific transfer pass.",
+            (
+                "Execution-block calibration supports the registered nominal "
+                "coverage statement under its finite-sample assumptions."
+            ),
+        ),
+        "next_action": (
+            "Freeze the evidence bundle and keep the claim bounded to the "
+            "registered object, actions, contacts, and calibration design."
+        ),
+    },
+    "transfer_supported_calibration_limited": {
+        "paper_status": "bounded_positive",
+        "headline": "Factual and transfer gates pass, but calibration fails.",
+        "claims": (
+            "Factual continuation and persistent/event-specific transfer pass.",
+        ),
+        "next_action": (
+            "Report the transfer result with the calibration limitation; do not "
+            "make a calibrated-risk or hardware-safety claim."
+        ),
+    },
+    "transfer_supported_calibration_unresolved": {
+        "paper_status": "incomplete",
+        "headline": "Transfer passes, but calibration is not estimable.",
+        "claims": (
+            "Factual continuation and persistent/event-specific transfer pass.",
+        ),
+        "next_action": (
+            "Report bounded transfer evidence and retain the unresolved "
+            "independent-execution calibration endpoint."
+        ),
+    },
+    "persistent_transfer_only": {
+        "paper_status": "bounded_positive",
+        "headline": "Same-grasp transfer passes, but new-contact transfer fails.",
+        "claims": (
+            "Persistent realized-actuation information transfers within grasp.",
+        ),
+        "next_action": (
+            "Report the contact/event-transfer failure and do not claim that a "
+            "fresh kappa resolves new-contact interventions."
+        ),
+    },
+    "incoherent_transfer_pattern": {
+        "paper_status": "bounded_positive",
+        "headline": "New-contact transfer passes without same-grasp transfer.",
+        "claims": ("The registered new-contact arm shows bounded improvement.",),
+        "next_action": (
+            "Report the inconsistent arms separately; do not make a general "
+            "realized-intervention transfer claim."
+        ),
+    },
+    "factual_only": {
+        "paper_status": "bounded_positive",
+        "headline": "Factual continuation passes, but both transfer gates fail.",
+        "claims": (
+            "Prefix-conditioned factual continuation improves under the protocol.",
+        ),
+        "next_action": (
+            "Do not describe the realized-intervention posterior as transferable "
+            "across actions or contacts."
+        ),
+    },
+    "partial_transfer_evidence": {
+        "paper_status": "incomplete",
+        "headline": "At least one transfer endpoint is not estimable.",
+        "claims": ("Factual continuation passes under the protocol.",),
+        "next_action": (
+            "Report every non-estimable endpoint without inferring the complete "
+            "transfer chain from the available subset."
+        ),
+    },
+}
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _sha256(value: str, *, name: str) -> str:
+    _require(
+        len(value) == 64
+        and all(character in "0123456789abcdef" for character in value),
+        f"{name} must be a lowercase SHA-256 digest",
+    )
+    return value
+
+
+def _nonnegative_integer(value: Any, *, name: str) -> int:
+    _require(
+        isinstance(value, int) and not isinstance(value, bool) and value >= 0,
+        f"{name} must be a nonnegative integer",
+    )
+    return value
+
+
+def _canonical_sha256(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def interpretation_contract_sha256() -> str:
+    return _canonical_sha256(_CONTRACT_DESCRIPTOR)
+
+
+@dataclass(frozen=True)
+class RealResultGateSummary:
+    """Registered gate outcomes and provenance for one confirmatory analysis."""
+
+    protocol_id: str
+    protocol_design_sha256: str
+    preacquisition_amendment_sha256: str
+    method_freeze_sha256: str
+    analysis_manifest_sha256: str
+    evidence_status: EvidenceStatus
+    factual_continuation: GateStatus
+    same_grasp_transfer: GateStatus
+    new_contact_transfer: GateStatus
+    execution_block_calibration: GateStatus
+    oracle_diagnosis: OracleDiagnosis = "not_estimable"
+    technical_failure_count: int = 0
+    preregistered_exclusion_count: int = 0
+    target_informed_selection: bool = False
+
+    def __post_init__(self) -> None:
+        _require(
+            self.protocol_id == EXPECTED_PROTOCOL_ID,
+            "gate summary targets an unexpected protocol",
+        )
+        _sha256(self.protocol_design_sha256, name="protocol_design_sha256")
+        _require(
+            self.protocol_design_sha256 == EXPECTED_PROTOCOL_DESIGN_SHA256,
+            "gate summary protocol digest does not match the locked design",
+        )
+        _sha256(
+            self.preacquisition_amendment_sha256,
+            name="preacquisition_amendment_sha256",
+        )
+        _require(
+            self.preacquisition_amendment_sha256
+            == EXPECTED_PREACQUISITION_SHA256,
+            "gate summary amendment digest does not match locked v4 amendment",
+        )
+        _sha256(self.method_freeze_sha256, name="method_freeze_sha256")
+        _sha256(self.analysis_manifest_sha256, name="analysis_manifest_sha256")
+        _require(self.evidence_status in _EVIDENCE_STATUSES, "unknown evidence status")
+        for name, value in (
+            ("factual_continuation", self.factual_continuation),
+            ("same_grasp_transfer", self.same_grasp_transfer),
+            ("new_contact_transfer", self.new_contact_transfer),
+            ("execution_block_calibration", self.execution_block_calibration),
+        ):
+            _require(value in _GATE_STATUSES, f"unknown {name} status")
+        _require(
+            self.oracle_diagnosis in _ORACLE_DIAGNOSES,
+            "unknown oracle diagnosis",
+        )
+        _nonnegative_integer(
+            self.technical_failure_count,
+            name="technical_failure_count",
+        )
+        _nonnegative_integer(
+            self.preregistered_exclusion_count,
+            name="preregistered_exclusion_count",
+        )
+        _require(
+            isinstance(self.target_informed_selection, bool),
+            "target_informed_selection must be Boolean",
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "protocol_id": self.protocol_id,
+            "protocol_design_sha256": self.protocol_design_sha256,
+            "preacquisition_amendment_sha256": (
+                self.preacquisition_amendment_sha256
+            ),
+            "method_freeze_sha256": self.method_freeze_sha256,
+            "analysis_manifest_sha256": self.analysis_manifest_sha256,
+            "evidence_status": self.evidence_status,
+            "factual_continuation": self.factual_continuation,
+            "same_grasp_transfer": self.same_grasp_transfer,
+            "new_contact_transfer": self.new_contact_transfer,
+            "execution_block_calibration": self.execution_block_calibration,
+            "oracle_diagnosis": self.oracle_diagnosis,
+            "technical_failure_count": self.technical_failure_count,
+            "preregistered_exclusion_count": self.preregistered_exclusion_count,
+            "target_informed_selection": self.target_informed_selection,
+        }
+
+    @classmethod
+    def from_dict(cls, values: Mapping[str, Any]) -> RealResultGateSummary:
+        _require(values.get("schema_version") == 1, "unsupported gate-summary schema")
+        _require(
+            values.get("artifact_kind") == "Causal4DRealResultGateSummary",
+            "unexpected gate-summary artifact kind",
+        )
+        return cls(
+            protocol_id=str(values["protocol_id"]),
+            protocol_design_sha256=str(values["protocol_design_sha256"]),
+            preacquisition_amendment_sha256=str(
+                values["preacquisition_amendment_sha256"]
+            ),
+            method_freeze_sha256=str(values["method_freeze_sha256"]),
+            analysis_manifest_sha256=str(values["analysis_manifest_sha256"]),
+            evidence_status=cast(EvidenceStatus, values["evidence_status"]),
+            factual_continuation=cast(GateStatus, values["factual_continuation"]),
+            same_grasp_transfer=cast(GateStatus, values["same_grasp_transfer"]),
+            new_contact_transfer=cast(GateStatus, values["new_contact_transfer"]),
+            execution_block_calibration=cast(
+                GateStatus, values["execution_block_calibration"]
+            ),
+            oracle_diagnosis=cast(
+                OracleDiagnosis, values.get("oracle_diagnosis", "not_estimable")
+            ),
+            technical_failure_count=_nonnegative_integer(
+                values.get("technical_failure_count", 0),
+                name="technical_failure_count",
+            ),
+            preregistered_exclusion_count=_nonnegative_integer(
+                values.get("preregistered_exclusion_count", 0),
+                name="preregistered_exclusion_count",
+            ),
+            target_informed_selection=values.get("target_informed_selection", False),
+        )
+
+
+@dataclass(frozen=True)
+class RealResultInterpretation:
+    gates: RealResultGateSummary
+    rule_id: str
+    paper_status: PaperStatus
+    headline: str
+    supported_claims: tuple[str, ...]
+    required_limitations: tuple[str, ...]
+    prohibited_claims: tuple[str, ...]
+    next_action: str
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": INTERPRETATION_SCHEMA_VERSION,
+            "artifact_kind": "Causal4DRealResultInterpretation",
+            "interpretation_contract_id": INTERPRETATION_CONTRACT_ID,
+            "interpretation_contract_sha256": interpretation_contract_sha256(),
+            "gates": self.gates.as_dict(),
+            "rule_id": self.rule_id,
+            "classification": self.rule_id,
+            "paper_status": self.paper_status,
+            "headline": self.headline,
+            "supported_claims": list(self.supported_claims),
+            "required_limitations": list(self.required_limitations),
+            "prohibited_claims": list(self.prohibited_claims),
+            "next_action": self.next_action,
+        }
+
+    @property
+    def result_sha256(self) -> str:
+        return _canonical_sha256(self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        payload = self._payload()
+        payload["result_sha256"] = self.result_sha256
+        return payload
+
+
+def _select_rule(gates: RealResultGateSummary) -> str:
+    if gates.target_informed_selection:
+        return "confirmatory_boundary_violated"
+    if gates.evidence_status == "incomplete":
+        return "incomplete_evidence"
+    if gates.factual_continuation != "passed":
+        return "primary_chain_not_supported"
+    same_grasp = gates.same_grasp_transfer
+    new_contact = gates.new_contact_transfer
+    calibration = gates.execution_block_calibration
+    if same_grasp == "passed" and new_contact == "passed":
+        if calibration == "passed":
+            return "full_chain_supported"
+        if calibration == "failed":
+            return "transfer_supported_calibration_limited"
+        return "transfer_supported_calibration_unresolved"
+    if same_grasp == "passed" and new_contact == "failed":
+        return "persistent_transfer_only"
+    if same_grasp == "failed" and new_contact == "passed":
+        return "incoherent_transfer_pattern"
+    if same_grasp == "failed" and new_contact == "failed":
+        return "factual_only"
+    return "partial_transfer_evidence"
+
+
+def _limitations(gates: RealResultGateSummary, rule_id: str) -> tuple[str, ...]:
+    values = [
+        (
+            "The real result is held-out interventional prediction from matched "
+            "initial conditions, not individual counterfactual ground truth."
+        ),
+        "The claim is bounded to the registered same-object protocol.",
+        (
+            "Semantic, planning, and public-data branches cannot rescue a failed "
+            "primary gate."
+        ),
+    ]
+    if gates.technical_failure_count:
+        values.append(
+            f"The report retains {gates.technical_failure_count} technical failures."
+        )
+    if gates.preregistered_exclusion_count:
+        values.append(
+            "The report retains "
+            f"{gates.preregistered_exclusion_count} preregistered exclusions."
+        )
+    if gates.oracle_diagnosis == "model_discrepancy_dominant":
+        values.append(
+            "The oracle diagnosis attributes dominant remaining headroom to "
+            "physical/model discrepancy rather than proposal width."
+        )
+    elif gates.oracle_diagnosis == "intervention_headroom":
+        values.append(
+            "The oracle diagnosis leaves material intervention-inference or "
+            "proposal-support headroom."
+        )
+    elif gates.oracle_diagnosis == "mixed":
+        values.append("The oracle diagnosis does not isolate one failure source.")
+    if (
+        gates.execution_block_calibration == "passed"
+        and rule_id != "full_chain_supported"
+    ):
+        values.append(
+            "Passing calibration does not rescue a failed factual or transfer gate."
+        )
+    return tuple(values)
+
+
+def interpret_real_result(gates: RealResultGateSummary) -> RealResultInterpretation:
+    """Apply the locked tree without reading raw target outcomes."""
+
+    rule_id = _select_rule(gates)
+    rule = _RULES[rule_id]
+    return RealResultInterpretation(
+        gates=gates,
+        rule_id=rule_id,
+        paper_status=cast(PaperStatus, rule["paper_status"]),
+        headline=str(rule["headline"]),
+        supported_claims=tuple(rule["claims"]),
+        required_limitations=_limitations(gates, rule_id),
+        prohibited_claims=_PROHIBITED_CLAIMS,
+        next_action=str(rule["next_action"]),
+    )
+
+
+def validate_real_result_interpretation(
+    payload: Mapping[str, Any],
+) -> RealResultInterpretation:
+    """Recompute the artifact and reject any edited interpretation."""
+
+    _require(payload.get("schema_version") == 1, "unsupported interpretation schema")
+    _require(
+        payload.get("artifact_kind") == "Causal4DRealResultInterpretation",
+        "unexpected interpretation artifact kind",
+    )
+    gates_payload = payload.get("gates")
+    _require(isinstance(gates_payload, Mapping), "interpretation gates are missing")
+    gates = RealResultGateSummary(
+        protocol_id=str(gates_payload["protocol_id"]),
+        protocol_design_sha256=str(gates_payload["protocol_design_sha256"]),
+        preacquisition_amendment_sha256=str(
+            gates_payload["preacquisition_amendment_sha256"]
+        ),
+        method_freeze_sha256=str(gates_payload["method_freeze_sha256"]),
+        analysis_manifest_sha256=str(gates_payload["analysis_manifest_sha256"]),
+        evidence_status=cast(EvidenceStatus, gates_payload["evidence_status"]),
+        factual_continuation=cast(
+            GateStatus, gates_payload["factual_continuation"]
+        ),
+        same_grasp_transfer=cast(
+            GateStatus, gates_payload["same_grasp_transfer"]
+        ),
+        new_contact_transfer=cast(
+            GateStatus, gates_payload["new_contact_transfer"]
+        ),
+        execution_block_calibration=cast(
+            GateStatus, gates_payload["execution_block_calibration"]
+        ),
+        oracle_diagnosis=cast(OracleDiagnosis, gates_payload["oracle_diagnosis"]),
+        technical_failure_count=_nonnegative_integer(
+            gates_payload["technical_failure_count"],
+            name="technical_failure_count",
+        ),
+        preregistered_exclusion_count=_nonnegative_integer(
+            gates_payload["preregistered_exclusion_count"],
+            name="preregistered_exclusion_count",
+        ),
+        target_informed_selection=gates_payload["target_informed_selection"],
+    )
+    expected = interpret_real_result(gates)
+    _require(
+        dict(payload) == expected.as_dict(),
+        "serialized interpretation differs from the locked decision tree",
+    )
+    return expected
+
+
+def load_real_result_interpretation(
+    path: str | Path,
+) -> RealResultInterpretation:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    _require(isinstance(payload, Mapping), "interpretation JSON must be an object")
+    return validate_real_result_interpretation(payload)
+
+
+def write_real_result_interpretation(
+    path: str | Path,
+    interpretation: RealResultInterpretation,
+    *,
+    overwrite: bool = False,
+) -> Path:
+    output = Path(path)
+    atomic_write_json(output, interpretation.as_dict(), overwrite=overwrite)
+    return output
+
+
+__all__ = [
+    "EXPECTED_PREACQUISITION_SHA256",
+    "EXPECTED_PROTOCOL_DESIGN_SHA256",
+    "EXPECTED_PROTOCOL_ID",
+    "INTERPRETATION_CONTRACT_ID",
+    "INTERPRETATION_SCHEMA_VERSION",
+    "RealResultGateSummary",
+    "RealResultInterpretation",
+    "interpret_real_result",
+    "interpretation_contract_sha256",
+    "load_real_result_interpretation",
+    "validate_real_result_interpretation",
+    "write_real_result_interpretation",
+]

--- a/src/causal4d/real_result_source_verification.py
+++ b/src/causal4d/real_result_source_verification.py
@@ -12,13 +12,9 @@ from causal4d.real_experiment_freeze import MILESTONE_ID, SCHEMA_VERSION
 from causal4d.real_result_interpretation import RealResultGateSummary
 
 REGISTERED_ANALYSIS_SCHEMA_VERSION: Final = 1
-REGISTERED_ANALYSIS_ARTIFACT_KIND: Final = (
-    "Causal4DRegisteredRealAnalysisManifest"
-)
+REGISTERED_ANALYSIS_ARTIFACT_KIND: Final = "Causal4DRegisteredRealAnalysisManifest"
 SOURCE_VERIFICATION_SCHEMA_VERSION: Final = 1
-SOURCE_VERIFICATION_ARTIFACT_KIND: Final = (
-    "Causal4DRealResultSourceVerification"
-)
+SOURCE_VERIFICATION_ARTIFACT_KIND: Final = "Causal4DRealResultSourceVerification"
 
 
 def _require(condition: bool, message: str) -> None:
@@ -99,15 +95,13 @@ def _validate_method_freeze(
         "method freeze lacks pre-acquisition provenance",
     )
     _require(
-        preacquisition.get("amendment_sha256")
-        == gates.preacquisition_amendment_sha256,
+        preacquisition.get("amendment_sha256") == gates.preacquisition_amendment_sha256,
         "method freeze amendment digest differs from the gate summary",
     )
     analysis = payload.get("analysis_contract")
     _require(isinstance(analysis, Mapping), "method freeze lacks an analysis contract")
     _require(
-        analysis.get("target_outcomes_may_select_method_or_hyperparameters")
-        is False,
+        analysis.get("target_outcomes_may_select_method_or_hyperparameters") is False,
         "method freeze permits target-informed analysis selection",
     )
     _require(
@@ -151,8 +145,7 @@ def _validate_registered_analysis(
         "registered analysis manifest does not lock the primary analysis",
     )
     _require(
-        payload.get("target_outcomes_may_select_method_or_hyperparameters")
-        is False,
+        payload.get("target_outcomes_may_select_method_or_hyperparameters") is False,
         "registered analysis manifest permits target-informed selection",
     )
     _require(
@@ -202,9 +195,7 @@ def verify_real_result_sources(
         "artifact_kind": SOURCE_VERIFICATION_ARTIFACT_KIND,
         "protocol_id": gates.protocol_id,
         "protocol_design_sha256": gates.protocol_design_sha256,
-        "preacquisition_amendment_sha256": (
-            gates.preacquisition_amendment_sha256
-        ),
+        "preacquisition_amendment_sha256": (gates.preacquisition_amendment_sha256),
         "method_freeze": method_descriptor,
         "registered_analysis_manifest": analysis_descriptor,
     }

--- a/src/causal4d/real_result_source_verification.py
+++ b/src/causal4d/real_result_source_verification.py
@@ -1,0 +1,266 @@
+"""Verify the concrete source artifacts bound by a real-result gate summary."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Final
+
+from causal4d.real_experiment_freeze import MILESTONE_ID, SCHEMA_VERSION
+from causal4d.real_result_interpretation import RealResultGateSummary
+
+REGISTERED_ANALYSIS_SCHEMA_VERSION: Final = 1
+REGISTERED_ANALYSIS_ARTIFACT_KIND: Final = (
+    "Causal4DRegisteredRealAnalysisManifest"
+)
+SOURCE_VERIFICATION_SCHEMA_VERSION: Final = 1
+SOURCE_VERIFICATION_ARTIFACT_KIND: Final = (
+    "Causal4DRealResultSourceVerification"
+)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _canonical_sha256(values: Mapping[str, Any], *, omitted_field: str) -> str:
+    payload = dict(values)
+    payload.pop(omitted_field, None)
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _artifact_descriptor(path: str | Path, *, name: str) -> dict[str, object]:
+    source = Path(path)
+    _require(not source.is_symlink(), f"{name} must not be a symlink")
+    _require(source.is_file(), f"{name} is not a regular file")
+    digest = hashlib.sha256()
+    byte_count = 0
+    try:
+        with source.open("rb") as handle:
+            for block in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(block)
+                byte_count += len(block)
+    except OSError as error:
+        raise ValueError(f"cannot read {name}") from error
+    return {
+        "sha256": digest.hexdigest(),
+        "bytes": byte_count,
+    }
+
+
+def _read_json_object(path: str | Path, *, name: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"{name} must be readable JSON") from error
+    _require(isinstance(payload, Mapping), f"{name} must contain a JSON object")
+    return dict(payload)
+
+
+def _validate_method_freeze(
+    payload: Mapping[str, Any],
+    gates: RealResultGateSummary,
+) -> None:
+    _require(
+        payload.get("schema_version") == SCHEMA_VERSION,
+        "method freeze uses an unsupported schema",
+    )
+    _require(
+        payload.get("milestone_id") == MILESTONE_ID,
+        "method freeze targets another milestone",
+    )
+    _require(payload.get("status") == "sealed", "method freeze is not sealed")
+    _require(
+        payload.get("locked_before_confirmatory_collection") is True,
+        "method freeze was not locked before confirmatory collection",
+    )
+    _require(
+        payload.get("target_outcomes_observed_at_freeze") is False,
+        "method freeze records target access before locking",
+    )
+    protocol = payload.get("protocol")
+    _require(isinstance(protocol, Mapping), "method freeze lacks protocol provenance")
+    _require(
+        protocol.get("design_sha256") == gates.protocol_design_sha256,
+        "method freeze protocol digest differs from the gate summary",
+    )
+    preacquisition = payload.get("preacquisition")
+    _require(
+        isinstance(preacquisition, Mapping),
+        "method freeze lacks pre-acquisition provenance",
+    )
+    _require(
+        preacquisition.get("amendment_sha256")
+        == gates.preacquisition_amendment_sha256,
+        "method freeze amendment digest differs from the gate summary",
+    )
+    analysis = payload.get("analysis_contract")
+    _require(isinstance(analysis, Mapping), "method freeze lacks an analysis contract")
+    _require(
+        analysis.get("target_outcomes_may_select_method_or_hyperparameters")
+        is False,
+        "method freeze permits target-informed analysis selection",
+    )
+    _require(
+        analysis.get("optional_branches_may_change_primary_analysis") is False,
+        "method freeze permits optional branches to change the primary analysis",
+    )
+
+
+def _validate_registered_analysis(
+    payload: Mapping[str, Any],
+    gates: RealResultGateSummary,
+) -> None:
+    _require(
+        payload.get("schema_version") == REGISTERED_ANALYSIS_SCHEMA_VERSION,
+        "registered analysis manifest uses an unsupported schema",
+    )
+    _require(
+        payload.get("artifact_kind") == REGISTERED_ANALYSIS_ARTIFACT_KIND,
+        "unexpected registered analysis artifact kind",
+    )
+    analysis_id = payload.get("analysis_id")
+    _require(
+        isinstance(analysis_id, str) and bool(analysis_id.strip()),
+        "registered analysis manifest lacks analysis_id",
+    )
+    for field, expected in (
+        ("protocol_id", gates.protocol_id),
+        ("protocol_design_sha256", gates.protocol_design_sha256),
+        (
+            "preacquisition_amendment_sha256",
+            gates.preacquisition_amendment_sha256,
+        ),
+        ("method_freeze_sha256", gates.method_freeze_sha256),
+    ):
+        _require(
+            payload.get(field) == expected,
+            f"registered analysis manifest {field} differs from the gate summary",
+        )
+    _require(
+        payload.get("primary_analysis_locked") is True,
+        "registered analysis manifest does not lock the primary analysis",
+    )
+    _require(
+        payload.get("target_outcomes_may_select_method_or_hyperparameters")
+        is False,
+        "registered analysis manifest permits target-informed selection",
+    )
+    _require(
+        payload.get("optional_branches_may_change_primary_analysis") is False,
+        "registered analysis manifest permits optional-branch rescue",
+    )
+
+
+def verify_real_result_sources(
+    gates: RealResultGateSummary,
+    *,
+    method_freeze_path: str | Path,
+    analysis_manifest_path: str | Path,
+) -> dict[str, Any]:
+    """Verify exact files and their protocol bindings before interpretation."""
+
+    method_descriptor = _artifact_descriptor(
+        method_freeze_path,
+        name="method freeze",
+    )
+    _require(
+        method_descriptor["sha256"] == gates.method_freeze_sha256,
+        "method-freeze file SHA-256 differs from the gate summary",
+    )
+    method_payload = _read_json_object(
+        method_freeze_path,
+        name="method freeze",
+    )
+    _validate_method_freeze(method_payload, gates)
+
+    analysis_descriptor = _artifact_descriptor(
+        analysis_manifest_path,
+        name="registered analysis manifest",
+    )
+    _require(
+        analysis_descriptor["sha256"] == gates.analysis_manifest_sha256,
+        "analysis-manifest file SHA-256 differs from the gate summary",
+    )
+    analysis_payload = _read_json_object(
+        analysis_manifest_path,
+        name="registered analysis manifest",
+    )
+    _validate_registered_analysis(analysis_payload, gates)
+
+    result: dict[str, Any] = {
+        "schema_version": SOURCE_VERIFICATION_SCHEMA_VERSION,
+        "artifact_kind": SOURCE_VERIFICATION_ARTIFACT_KIND,
+        "protocol_id": gates.protocol_id,
+        "protocol_design_sha256": gates.protocol_design_sha256,
+        "preacquisition_amendment_sha256": (
+            gates.preacquisition_amendment_sha256
+        ),
+        "method_freeze": method_descriptor,
+        "registered_analysis_manifest": analysis_descriptor,
+    }
+    result["verification_sha256"] = _canonical_sha256(
+        result,
+        omitted_field="verification_sha256",
+    )
+    return result
+
+
+def validate_real_result_source_verification(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate the portable source-verification record without reopening files."""
+
+    _require(
+        payload.get("schema_version") == SOURCE_VERIFICATION_SCHEMA_VERSION,
+        "unsupported source-verification schema",
+    )
+    _require(
+        payload.get("artifact_kind") == SOURCE_VERIFICATION_ARTIFACT_KIND,
+        "unexpected source-verification artifact kind",
+    )
+    for field in ("protocol_id", "protocol_design_sha256", "preacquisition_amendment_sha256"):
+        value = payload.get(field)
+        _require(isinstance(value, str) and bool(value), f"{field} is missing")
+    for field in ("method_freeze", "registered_analysis_manifest"):
+        descriptor = payload.get(field)
+        _require(isinstance(descriptor, Mapping), f"{field} descriptor is missing")
+        digest = descriptor.get("sha256")
+        byte_count = descriptor.get("bytes")
+        _require(
+            isinstance(digest, str)
+            and len(digest) == 64
+            and all(character in "0123456789abcdef" for character in digest),
+            f"{field} SHA-256 is invalid",
+        )
+        _require(
+            isinstance(byte_count, int)
+            and not isinstance(byte_count, bool)
+            and byte_count > 0,
+            f"{field} byte count is invalid",
+        )
+    expected = _canonical_sha256(payload, omitted_field="verification_sha256")
+    _require(
+        payload.get("verification_sha256") == expected,
+        "source-verification SHA-256 mismatch",
+    )
+    return dict(payload)
+
+
+__all__ = [
+    "REGISTERED_ANALYSIS_ARTIFACT_KIND",
+    "REGISTERED_ANALYSIS_SCHEMA_VERSION",
+    "SOURCE_VERIFICATION_ARTIFACT_KIND",
+    "SOURCE_VERIFICATION_SCHEMA_VERSION",
+    "validate_real_result_source_verification",
+    "verify_real_result_sources",
+]

--- a/src/causal4d/real_result_source_verification.py
+++ b/src/causal4d/real_result_source_verification.py
@@ -228,7 +228,11 @@ def validate_real_result_source_verification(
         payload.get("artifact_kind") == SOURCE_VERIFICATION_ARTIFACT_KIND,
         "unexpected source-verification artifact kind",
     )
-    for field in ("protocol_id", "protocol_design_sha256", "preacquisition_amendment_sha256"):
+    for field in (
+        "protocol_id",
+        "protocol_design_sha256",
+        "preacquisition_amendment_sha256",
+    ):
         value = payload.get(field)
         _require(isinstance(value, str) and bool(value), f"{field} is missing")
     for field in ("method_freeze", "registered_analysis_manifest"):

--- a/tests/test_causal4d_command_registry.py
+++ b/tests/test_causal4d_command_registry.py
@@ -17,7 +17,11 @@ from causal4d.cli.command_registry import (
 def test_grouped_registry_has_unique_routes_and_legacy_names() -> None:
     commands = grouped_commands()
     assert len({command.route for command in commands}) == len(commands)
-    legacy = [command.legacy_name for command in commands]
+    legacy = [
+        command.legacy_name
+        for command in commands
+        if command.legacy_name is not None
+    ]
     assert len(set(legacy)) == len(legacy)
     assert find_command("benchmark/counterfactual").target.endswith(
         "counterfactual_benchmark:main"

--- a/tests/test_causal4d_command_registry.py
+++ b/tests/test_causal4d_command_registry.py
@@ -18,9 +18,7 @@ def test_grouped_registry_has_unique_routes_and_legacy_names() -> None:
     commands = grouped_commands()
     assert len({command.route for command in commands}) == len(commands)
     legacy = [
-        command.legacy_name
-        for command in commands
-        if command.legacy_name is not None
+        command.legacy_name for command in commands if command.legacy_name is not None
     ]
     assert len(set(legacy)) == len(legacy)
     assert find_command("benchmark/counterfactual").target.endswith(

--- a/tests/test_real_result_interpretation.py
+++ b/tests/test_real_result_interpretation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from itertools import product
 import json
 from pathlib import Path
@@ -8,6 +9,7 @@ import pytest
 
 from causal4d.cli.command_registry import find_command
 from causal4d.cli.real_result_interpretation import main as interpretation_main
+from causal4d.real_experiment_freeze import MILESTONE_ID, SCHEMA_VERSION
 from causal4d.real_result_interpretation import (
     EXPECTED_PREACQUISITION_SHA256,
     EXPECTED_PROTOCOL_DESIGN_SHA256,
@@ -17,6 +19,10 @@ from causal4d.real_result_interpretation import (
     load_real_result_interpretation,
     validate_real_result_interpretation,
     write_real_result_interpretation,
+)
+from causal4d.real_result_source_verification import (
+    REGISTERED_ANALYSIS_ARTIFACT_KIND,
+    validate_real_result_source_verification,
 )
 
 _DIGEST = "1" * 64
@@ -50,6 +56,55 @@ def _gate_payload(**changes) -> dict[str, object]:
         "artifact_kind": "Causal4DRealResultGateSummary",
         **gates.as_dict(),
     }
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_registered_sources(
+    tmp_path: Path,
+) -> tuple[Path, Path, str, str]:
+    freeze_path = tmp_path / "method-freeze.json"
+    freeze_payload = {
+        "schema_version": SCHEMA_VERSION,
+        "milestone_id": MILESTONE_ID,
+        "status": "sealed",
+        "locked_before_confirmatory_collection": True,
+        "target_outcomes_observed_at_freeze": False,
+        "protocol": {"design_sha256": EXPECTED_PROTOCOL_DESIGN_SHA256},
+        "preacquisition": {
+            "amendment_sha256": EXPECTED_PREACQUISITION_SHA256
+        },
+        "analysis_contract": {
+            "target_outcomes_may_select_method_or_hyperparameters": False,
+            "optional_branches_may_change_primary_analysis": False,
+        },
+    }
+    freeze_path.write_text(
+        json.dumps(freeze_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    freeze_sha = _sha256(freeze_path)
+
+    analysis_path = tmp_path / "registered-analysis.json"
+    analysis_payload = {
+        "schema_version": 1,
+        "artifact_kind": REGISTERED_ANALYSIS_ARTIFACT_KIND,
+        "analysis_id": "causal4d-real-analysis-unit",
+        "protocol_id": EXPECTED_PROTOCOL_ID,
+        "protocol_design_sha256": EXPECTED_PROTOCOL_DESIGN_SHA256,
+        "preacquisition_amendment_sha256": EXPECTED_PREACQUISITION_SHA256,
+        "method_freeze_sha256": freeze_sha,
+        "primary_analysis_locked": True,
+        "target_outcomes_may_select_method_or_hyperparameters": False,
+        "optional_branches_may_change_primary_analysis": False,
+    }
+    analysis_path.write_text(
+        json.dumps(analysis_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return freeze_path, analysis_path, freeze_sha, _sha256(analysis_path)
 
 
 def test_grouped_cli_registers_the_interpretation_contract() -> None:
@@ -154,25 +209,56 @@ def test_interpretation_round_trip_and_tamper_detection(tmp_path: Path) -> None:
         write_real_result_interpretation(path, result)
 
 
-def test_cli_writes_artifact_and_can_fail_closed_on_incomplete(
+def test_cli_verifies_sources_and_can_fail_closed_on_incomplete(
     tmp_path: Path,
     capsys,
 ) -> None:
+    freeze_path, analysis_path, freeze_sha, analysis_sha = (
+        _write_registered_sources(tmp_path)
+    )
     input_path = tmp_path / "gates.json"
     output_path = tmp_path / "interpretation.json"
     input_path.write_text(
-        json.dumps(_gate_payload(), indent=2, sort_keys=True) + "\n",
+        json.dumps(
+            _gate_payload(
+                method_freeze_sha256=freeze_sha,
+                analysis_manifest_sha256=analysis_sha,
+            ),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
         encoding="utf-8",
     )
-    assert interpretation_main([str(input_path), str(output_path)]) == 0
+    arguments = [
+        str(input_path),
+        str(output_path),
+        "--method-freeze",
+        str(freeze_path),
+        "--analysis-manifest",
+        str(analysis_path),
+    ]
+    assert interpretation_main(arguments) == 0
     assert load_real_result_interpretation(output_path).paper_status == "positive"
-    assert json.loads(capsys.readouterr().out)["rule_id"] == "full_chain_supported"
+    verification_path = tmp_path / "interpretation.sources.json"
+    verification = validate_real_result_source_verification(
+        json.loads(verification_path.read_text(encoding="utf-8"))
+    )
+    console = json.loads(capsys.readouterr().out)
+    assert console["rule_id"] == "full_chain_supported"
+    assert console["source_verification"]["verification_sha256"] == (
+        verification["verification_sha256"]
+    )
 
     incomplete_input = tmp_path / "incomplete.json"
     incomplete_output = tmp_path / "incomplete-result.json"
     incomplete_input.write_text(
         json.dumps(
-            _gate_payload(evidence_status="incomplete"),
+            _gate_payload(
+                evidence_status="incomplete",
+                method_freeze_sha256=freeze_sha,
+                analysis_manifest_sha256=analysis_sha,
+            ),
             indent=2,
             sort_keys=True,
         )
@@ -184,6 +270,10 @@ def test_cli_writes_artifact_and_can_fail_closed_on_incomplete(
             [
                 str(incomplete_input),
                 str(incomplete_output),
+                "--method-freeze",
+                str(freeze_path),
+                "--analysis-manifest",
+                str(analysis_path),
                 "--require-complete",
             ]
         )
@@ -191,16 +281,55 @@ def test_cli_writes_artifact_and_can_fail_closed_on_incomplete(
     )
 
 
-def test_checked_in_template_cannot_pass_as_evidence() -> None:
-    template_path = (
-        Path(__file__).parents[1]
-        / "configs"
-        / "causal4d"
-        / "real_result_gate_summary_v1.template.json"
+def test_cli_rejects_source_hash_drift(tmp_path: Path) -> None:
+    freeze_path, analysis_path, freeze_sha, analysis_sha = (
+        _write_registered_sources(tmp_path)
     )
-    payload = json.loads(template_path.read_text(encoding="utf-8"))
+    gates_path = tmp_path / "gates.json"
+    gates_path.write_text(
+        json.dumps(
+            _gate_payload(
+                method_freeze_sha256=freeze_sha,
+                analysis_manifest_sha256=analysis_sha,
+            )
+        ),
+        encoding="utf-8",
+    )
+    analysis_path.write_text(
+        analysis_path.read_text(encoding="utf-8") + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="analysis-manifest file SHA-256"):
+        interpretation_main(
+            [
+                str(gates_path),
+                str(tmp_path / "interpretation.json"),
+                "--method-freeze",
+                str(freeze_path),
+                "--analysis-manifest",
+                str(analysis_path),
+            ]
+        )
+
+
+def test_checked_in_templates_cannot_pass_as_evidence() -> None:
+    root = Path(__file__).parents[1] / "configs" / "causal4d"
+    gate_payload = json.loads(
+        (root / "real_result_gate_summary_v1.template.json").read_text(
+            encoding="utf-8"
+        )
+    )
     with pytest.raises(ValueError, match="artifact kind"):
-        RealResultGateSummary.from_dict(payload)
+        RealResultGateSummary.from_dict(gate_payload)
+
+    analysis_payload = json.loads(
+        (root / "real_analysis_manifest_v1.template.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert analysis_payload["artifact_kind"].endswith("Template")
+    assert analysis_payload["primary_analysis_locked"] is False
 
 
 def test_gate_summary_rejects_wrong_frozen_protocol_identity() -> None:

--- a/tests/test_real_result_interpretation.py
+++ b/tests/test_real_result_interpretation.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from itertools import product
+import json
+from pathlib import Path
+
+import pytest
+
+from causal4d.cli.command_registry import find_command
+from causal4d.cli.real_result_interpretation import main as interpretation_main
+from causal4d.real_result_interpretation import (
+    EXPECTED_PREACQUISITION_SHA256,
+    EXPECTED_PROTOCOL_DESIGN_SHA256,
+    EXPECTED_PROTOCOL_ID,
+    RealResultGateSummary,
+    interpret_real_result,
+    load_real_result_interpretation,
+    validate_real_result_interpretation,
+    write_real_result_interpretation,
+)
+
+_DIGEST = "1" * 64
+
+
+def _gates(**changes) -> RealResultGateSummary:
+    values = {
+        "protocol_id": EXPECTED_PROTOCOL_ID,
+        "protocol_design_sha256": EXPECTED_PROTOCOL_DESIGN_SHA256,
+        "preacquisition_amendment_sha256": EXPECTED_PREACQUISITION_SHA256,
+        "method_freeze_sha256": _DIGEST,
+        "analysis_manifest_sha256": "2" * 64,
+        "evidence_status": "complete",
+        "factual_continuation": "passed",
+        "same_grasp_transfer": "passed",
+        "new_contact_transfer": "passed",
+        "execution_block_calibration": "passed",
+        "oracle_diagnosis": "not_estimable",
+        "technical_failure_count": 0,
+        "preregistered_exclusion_count": 0,
+        "target_informed_selection": False,
+    }
+    values.update(changes)
+    return RealResultGateSummary(**values)
+
+
+def _gate_payload(**changes) -> dict[str, object]:
+    gates = _gates(**changes)
+    return {
+        "schema_version": 1,
+        "artifact_kind": "Causal4DRealResultGateSummary",
+        **gates.as_dict(),
+    }
+
+
+def test_grouped_cli_registers_the_interpretation_contract() -> None:
+    command = find_command("evidence/interpret-real-result")
+    assert command.target.endswith("real_result_interpretation:main")
+    assert command.lifecycle == "stable"
+
+
+def test_full_chain_requires_all_primary_gates_and_calibration() -> None:
+    result = interpret_real_result(_gates())
+    assert result.rule_id == "full_chain_supported"
+    assert result.paper_status == "positive"
+    assert len(result.supported_claims) == 2
+    assert "individual-level real counterfactual" in result.prohibited_claims[0]
+
+
+def test_transfer_without_calibration_is_a_bounded_positive_result() -> None:
+    result = interpret_real_result(_gates(execution_block_calibration="failed"))
+    assert result.rule_id == "transfer_supported_calibration_limited"
+    assert result.paper_status == "bounded_positive"
+    assert all("calibration supports" not in claim for claim in result.supported_claims)
+
+
+def test_same_grasp_success_does_not_rescue_new_contact_failure() -> None:
+    result = interpret_real_result(_gates(new_contact_transfer="failed"))
+    assert result.rule_id == "persistent_transfer_only"
+    assert result.paper_status == "bounded_positive"
+    assert "new-contact transfer fails" in result.headline
+
+
+def test_factual_gain_does_not_imply_transfer() -> None:
+    result = interpret_real_result(
+        _gates(
+            same_grasp_transfer="failed",
+            new_contact_transfer="failed",
+            execution_block_calibration="passed",
+        )
+    )
+    assert result.rule_id == "factual_only"
+    assert any("does not rescue" in value for value in result.required_limitations)
+
+
+def test_failed_factual_gate_preempts_other_positive_results() -> None:
+    result = interpret_real_result(_gates(factual_continuation="failed"))
+    assert result.rule_id == "primary_chain_not_supported"
+    assert result.paper_status == "negative"
+    assert result.supported_claims == ()
+
+
+def test_incomplete_evidence_and_target_selection_preempt_gate_values() -> None:
+    incomplete = interpret_real_result(_gates(evidence_status="incomplete"))
+    assert incomplete.rule_id == "incomplete_evidence"
+    assert incomplete.paper_status == "incomplete"
+
+    violated = interpret_real_result(_gates(target_informed_selection=True))
+    assert violated.rule_id == "confirmatory_boundary_violated"
+    assert violated.paper_status == "incomplete"
+
+
+def test_oracle_and_failure_accounting_are_mandatory_limitations() -> None:
+    result = interpret_real_result(
+        _gates(
+            oracle_diagnosis="model_discrepancy_dominant",
+            technical_failure_count=2,
+            preregistered_exclusion_count=3,
+        )
+    )
+    limitations = " ".join(result.required_limitations)
+    assert "model discrepancy" in limitations
+    assert "2 technical failures" in limitations
+    assert "3 preregistered exclusions" in limitations
+
+
+def test_every_gate_combination_has_a_deterministic_interpretation() -> None:
+    statuses = ("passed", "failed", "not_estimable")
+    for values in product(statuses, repeat=4):
+        gates = _gates(
+            factual_continuation=values[0],
+            same_grasp_transfer=values[1],
+            new_contact_transfer=values[2],
+            execution_block_calibration=values[3],
+        )
+        first = interpret_real_result(gates)
+        second = interpret_real_result(gates)
+        assert first.as_dict() == second.as_dict()
+        assert len(first.result_sha256) == 64
+
+
+def test_interpretation_round_trip_and_tamper_detection(tmp_path: Path) -> None:
+    result = interpret_real_result(_gates())
+    path = tmp_path / "interpretation.json"
+    write_real_result_interpretation(path, result)
+    restored = load_real_result_interpretation(path)
+    assert restored.as_dict() == result.as_dict()
+
+    tampered = json.loads(path.read_text(encoding="utf-8"))
+    tampered["headline"] = "broader claim"
+    with pytest.raises(ValueError, match="differs from the locked decision tree"):
+        validate_real_result_interpretation(tampered)
+
+    with pytest.raises(FileExistsError):
+        write_real_result_interpretation(path, result)
+
+
+def test_cli_writes_artifact_and_can_fail_closed_on_incomplete(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    input_path = tmp_path / "gates.json"
+    output_path = tmp_path / "interpretation.json"
+    input_path.write_text(
+        json.dumps(_gate_payload(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    assert interpretation_main([str(input_path), str(output_path)]) == 0
+    assert load_real_result_interpretation(output_path).paper_status == "positive"
+    assert json.loads(capsys.readouterr().out)["rule_id"] == "full_chain_supported"
+
+    incomplete_input = tmp_path / "incomplete.json"
+    incomplete_output = tmp_path / "incomplete-result.json"
+    incomplete_input.write_text(
+        json.dumps(
+            _gate_payload(evidence_status="incomplete"),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    assert (
+        interpretation_main(
+            [
+                str(incomplete_input),
+                str(incomplete_output),
+                "--require-complete",
+            ]
+        )
+        == 3
+    )
+
+
+def test_checked_in_template_cannot_pass_as_evidence() -> None:
+    template_path = (
+        Path(__file__).parents[1]
+        / "configs"
+        / "causal4d"
+        / "real_result_gate_summary_v1.template.json"
+    )
+    payload = json.loads(template_path.read_text(encoding="utf-8"))
+    with pytest.raises(ValueError, match="artifact kind"):
+        RealResultGateSummary.from_dict(payload)
+
+
+def test_gate_summary_rejects_wrong_frozen_protocol_identity() -> None:
+    with pytest.raises(ValueError, match="locked design"):
+        _gates(protocol_design_sha256="0" * 64)
+    with pytest.raises(ValueError, match="locked v4 amendment"):
+        _gates(preacquisition_amendment_sha256="0" * 64)

--- a/tests/test_real_result_interpretation.py
+++ b/tests/test_real_result_interpretation.py
@@ -73,9 +73,7 @@ def _write_registered_sources(
         "locked_before_confirmatory_collection": True,
         "target_outcomes_observed_at_freeze": False,
         "protocol": {"design_sha256": EXPECTED_PROTOCOL_DESIGN_SHA256},
-        "preacquisition": {
-            "amendment_sha256": EXPECTED_PREACQUISITION_SHA256
-        },
+        "preacquisition": {"amendment_sha256": EXPECTED_PREACQUISITION_SHA256},
         "analysis_contract": {
             "target_outcomes_may_select_method_or_hyperparameters": False,
             "optional_branches_may_change_primary_analysis": False,
@@ -213,8 +211,8 @@ def test_cli_verifies_sources_and_can_fail_closed_on_incomplete(
     tmp_path: Path,
     capsys,
 ) -> None:
-    freeze_path, analysis_path, freeze_sha, analysis_sha = (
-        _write_registered_sources(tmp_path)
+    freeze_path, analysis_path, freeze_sha, analysis_sha = _write_registered_sources(
+        tmp_path
     )
     input_path = tmp_path / "gates.json"
     output_path = tmp_path / "interpretation.json"
@@ -246,8 +244,9 @@ def test_cli_verifies_sources_and_can_fail_closed_on_incomplete(
     )
     console = json.loads(capsys.readouterr().out)
     assert console["rule_id"] == "full_chain_supported"
-    assert console["source_verification"]["verification_sha256"] == (
-        verification["verification_sha256"]
+    assert (
+        console["source_verification"]["verification_sha256"]
+        == (verification["verification_sha256"])
     )
 
     incomplete_input = tmp_path / "incomplete.json"
@@ -282,8 +281,8 @@ def test_cli_verifies_sources_and_can_fail_closed_on_incomplete(
 
 
 def test_cli_rejects_source_hash_drift(tmp_path: Path) -> None:
-    freeze_path, analysis_path, freeze_sha, analysis_sha = (
-        _write_registered_sources(tmp_path)
+    freeze_path, analysis_path, freeze_sha, analysis_sha = _write_registered_sources(
+        tmp_path
     )
     gates_path = tmp_path / "gates.json"
     gates_path.write_text(
@@ -316,17 +315,13 @@ def test_cli_rejects_source_hash_drift(tmp_path: Path) -> None:
 def test_checked_in_templates_cannot_pass_as_evidence() -> None:
     root = Path(__file__).parents[1] / "configs" / "causal4d"
     gate_payload = json.loads(
-        (root / "real_result_gate_summary_v1.template.json").read_text(
-            encoding="utf-8"
-        )
+        (root / "real_result_gate_summary_v1.template.json").read_text(encoding="utf-8")
     )
     with pytest.raises(ValueError, match="artifact kind"):
         RealResultGateSummary.from_dict(gate_payload)
 
     analysis_payload = json.loads(
-        (root / "real_analysis_manifest_v1.template.json").read_text(
-            encoding="utf-8"
-        )
+        (root / "real_analysis_manifest_v1.template.json").read_text(encoding="utf-8")
     )
     assert analysis_payload["artifact_kind"].endswith("Template")
     assert analysis_payload["primary_analysis_locked"] is False

--- a/tests/test_real_result_source_verification.py
+++ b/tests/test_real_result_source_verification.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from causal4d.real_experiment_freeze import MILESTONE_ID, SCHEMA_VERSION
+from causal4d.real_result_interpretation import (
+    EXPECTED_PREACQUISITION_SHA256,
+    EXPECTED_PROTOCOL_DESIGN_SHA256,
+    EXPECTED_PROTOCOL_ID,
+    RealResultGateSummary,
+)
+from causal4d.real_result_source_verification import (
+    REGISTERED_ANALYSIS_ARTIFACT_KIND,
+    validate_real_result_source_verification,
+    verify_real_result_sources,
+)
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> str:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _source_pair(
+    tmp_path: Path,
+    *,
+    freeze_protocol_sha256: str = EXPECTED_PROTOCOL_DESIGN_SHA256,
+) -> tuple[Path, Path, RealResultGateSummary]:
+    freeze_path = tmp_path / "method-freeze.json"
+    freeze_sha = _write_json(
+        freeze_path,
+        {
+            "schema_version": SCHEMA_VERSION,
+            "milestone_id": MILESTONE_ID,
+            "status": "sealed",
+            "locked_before_confirmatory_collection": True,
+            "target_outcomes_observed_at_freeze": False,
+            "protocol": {"design_sha256": freeze_protocol_sha256},
+            "preacquisition": {
+                "amendment_sha256": EXPECTED_PREACQUISITION_SHA256
+            },
+            "analysis_contract": {
+                "target_outcomes_may_select_method_or_hyperparameters": False,
+                "optional_branches_may_change_primary_analysis": False,
+            },
+        },
+    )
+    analysis_path = tmp_path / "analysis.json"
+    analysis_sha = _write_json(
+        analysis_path,
+        {
+            "schema_version": 1,
+            "artifact_kind": REGISTERED_ANALYSIS_ARTIFACT_KIND,
+            "analysis_id": "registered-real-analysis-v1",
+            "protocol_id": EXPECTED_PROTOCOL_ID,
+            "protocol_design_sha256": EXPECTED_PROTOCOL_DESIGN_SHA256,
+            "preacquisition_amendment_sha256": EXPECTED_PREACQUISITION_SHA256,
+            "method_freeze_sha256": freeze_sha,
+            "primary_analysis_locked": True,
+            "target_outcomes_may_select_method_or_hyperparameters": False,
+            "optional_branches_may_change_primary_analysis": False,
+        },
+    )
+    gates = RealResultGateSummary(
+        protocol_id=EXPECTED_PROTOCOL_ID,
+        protocol_design_sha256=EXPECTED_PROTOCOL_DESIGN_SHA256,
+        preacquisition_amendment_sha256=EXPECTED_PREACQUISITION_SHA256,
+        method_freeze_sha256=freeze_sha,
+        analysis_manifest_sha256=analysis_sha,
+        evidence_status="complete",
+        factual_continuation="passed",
+        same_grasp_transfer="passed",
+        new_contact_transfer="passed",
+        execution_block_calibration="passed",
+    )
+    return freeze_path, analysis_path, gates
+
+
+def test_source_verification_is_portable_and_tamper_evident(tmp_path: Path) -> None:
+    freeze_path, analysis_path, gates = _source_pair(tmp_path)
+
+    verification = verify_real_result_sources(
+        gates,
+        method_freeze_path=freeze_path,
+        analysis_manifest_path=analysis_path,
+    )
+
+    restored = validate_real_result_source_verification(verification)
+    assert restored["method_freeze"]["sha256"] == gates.method_freeze_sha256
+    assert "path" not in restored["method_freeze"]
+
+    tampered = json.loads(json.dumps(verification))
+    tampered["method_freeze"]["bytes"] += 1
+    with pytest.raises(ValueError, match="source-verification SHA-256 mismatch"):
+        validate_real_result_source_verification(tampered)
+
+
+def test_source_verification_rejects_method_freeze_protocol_drift(
+    tmp_path: Path,
+) -> None:
+    freeze_path, analysis_path, gates = _source_pair(
+        tmp_path,
+        freeze_protocol_sha256="0" * 64,
+    )
+
+    with pytest.raises(ValueError, match="protocol digest differs"):
+        verify_real_result_sources(
+            gates,
+            method_freeze_path=freeze_path,
+            analysis_manifest_path=analysis_path,
+        )
+
+
+def test_source_verification_rejects_symlinked_source(tmp_path: Path) -> None:
+    freeze_path, analysis_path, gates = _source_pair(tmp_path)
+    link = tmp_path / "analysis-link.json"
+    try:
+        link.symlink_to(analysis_path)
+    except OSError:
+        pytest.skip("symlinks are unavailable on this platform")
+
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        verify_real_result_sources(
+            gates,
+            method_freeze_path=freeze_path,
+            analysis_manifest_path=link,
+        )

--- a/tests/test_real_result_source_verification.py
+++ b/tests/test_real_result_source_verification.py
@@ -43,9 +43,7 @@ def _source_pair(
             "locked_before_confirmatory_collection": True,
             "target_outcomes_observed_at_freeze": False,
             "protocol": {"design_sha256": freeze_protocol_sha256},
-            "preacquisition": {
-                "amendment_sha256": EXPECTED_PREACQUISITION_SHA256
-            },
+            "preacquisition": {"amendment_sha256": EXPECTED_PREACQUISITION_SHA256},
             "analysis_contract": {
                 "target_outcomes_may_select_method_or_hyperparameters": False,
                 "optional_branches_may_change_primary_analysis": False,


### PR DESCRIPTION
## Summary

- add a versioned, deterministic interpretation tree for the locked 36-execution real experiment;
- classify factual, same-grasp, new-contact, and execution-block-calibration gate combinations without reading raw target metrics;
- generate a tamper-evident interpretation artifact containing permitted claims, mandatory limitations, prohibited claims, and the next scientifically allowed action;
- require the public command to open and verify the exact sealed method-freeze and registered-analysis files cited by the gate summary;
- publish a separate portable `*.sources.json` record binding source-file SHA-256 values and byte counts;
- reject symlinked source files, source hash drift, protocol/amendment mismatches, unlocked analysis, target-informed selection, and optional-branch replacement of the primary analysis;
- add intentionally invalid gate-summary and registered-analysis templates that cannot be mistaken for completed evidence;
- add the stable grouped command `causal4d evidence interpret-real-result`.

## Why

The registered physical experiment can yield a full positive result, a bounded transfer result, a calibration limitation, a factual-only result, or a negative primary result. Without a frozen interpretation contract, individual passing arms could be combined after target access into a broader claim than the preregistered evidence chain supports.

This change makes the reporting boundary machine-verifiable. In particular:

- calibration cannot rescue a failed factual or transfer gate;
- same-grasp success cannot be described as successful new-contact transfer;
- a factual-continuation improvement cannot be promoted to a general realized-intervention transfer claim;
- target-informed method or threshold selection invalidates confirmatory interpretation;
- technical failures and preregistered exclusions remain explicit limitations;
- oracle diagnostics can localize remaining headroom but cannot change the primary gate classification;
- arbitrary well-formed 64-hex strings are no longer sufficient provenance: the cited source artifacts must exist, hash-match, and bind the same locked protocol.

## Source verification

`causal4d evidence interpret-real-result` now requires:

```text
--method-freeze <sealed method_freeze.json>
--analysis-manifest <registered analysis JSON>
```

The registered analysis must bind the protocol, v4 amendment, and method-freeze digest and state:

```text
primary_analysis_locked = true
target_outcomes_may_select_method_or_hyperparameters = false
optional_branches_may_change_primary_analysis = false
```

The source-verification record is path-independent and content-addressed. Full deployed-checkout validation remains the responsibility of the independent method-freeze attestation; this command verifies the exact source files cited by the result interpretation.

## Scientific boundary

This PR changes no estimator, posterior, intervention support, protocol, acquisition order, information boundary, quality gate, fold, calibration threshold, exclusion policy, or target result. It only fixes the allowed interpretation and concrete provenance of the already registered gate outcomes.

## Validation

- all `3^4 = 81` primary gate combinations have deterministic, content-addressed outputs;
- source-file hash drift, symlinks, protocol drift, and tampered interpretations fail closed;
- Ruff lint and exact formatting passed;
- stable-contract mypy passed;
- core suites passed on Python 3.10, 3.12, 3.14, plus extended Python 3.11 and 3.13;
- exact declared dependency-floor suite passed;
- wheel and source-distribution builds passed;
- isolated installed wheel and sdist CLI checks passed;
- frozen milestone, deterministic bundle, and pinned Bayesian-PhysTwin integration checks passed;
- both GitHub Actions workflows are green on head `a644edbf918d7ea3a12fb330a709ab25368b85ae`.