### PR TITLE
Pin GitHub Actions to immutable revisions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Default ownership for the public research codebase.
+* @FlorianPfaff
+
+# Acquisition, claim, and release boundaries require maintainer review.
+/.github/workflows/ @FlorianPfaff
+/configs/causal4d/ @FlorianPfaff
+/milestones/ @FlorianPfaff
+/scripts/ci/ @FlorianPfaff
+/src/causal4d/preacquisition_* @FlorianPfaff
+/src/causal4d/real_* @FlorianPfaff
+/src/causal4d/execution_block_calibration.py @FlorianPfaff

--- a/.github/workflows/bayesian-phystwin-provider-compatibility.yml
+++ b/.github/workflows/bayesian-phystwin-provider-compatibility.yml
@@ -144,28 +144,31 @@ jobs:
       PRIVATE_REPOSITORY_READ_TOKEN: ${{ secrets.BPT_READ_TOKEN }}
     steps:
       - name: Check out Causal4D
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: causal4d
+          persist-credentials: false
 
       - name: Check out Bayesian-PhysTwin
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: FlorianPfaff/Bayesian-PhysTwin
           ref: ${{ inputs.bpt_ref || 'main' }}
           token: ${{ secrets.BPT_READ_TOKEN }}
           path: bayesian-phystwin
+          persist-credentials: false
 
       - name: Check out Prob4D
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: FlorianPfaff/Prob4D
           ref: ${{ inputs.prob4d_ref || 'main' }}
           token: ${{ secrets.BPT_READ_TOKEN }}
           path: prob4d
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
@@ -324,7 +327,7 @@ jobs:
 
       - name: Upload golden-path diagnostics
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: three-repository-installed-wheel-golden-path
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,26 +251,35 @@ jobs:
       - name: Produce deterministic smoke bundles
         run: |
           causal4d-counterfactual-benchmark \
-            --output-dir runs/causal4d-counterfactual-v1
+            --output-dir build/bundles/counterfactual \
+            --seeds 0 \
+            --frames 18 \
+            --training-repeats 1 \
+            --parameter-grid-count 3
           causal4d-latent-contact-benchmark \
-            --output-dir runs/causal4d-latent-contact-v1
+            --output-dir build/bundles/latent-contact \
+            --seeds 0 \
+            --frames 18 \
+            --training-repeats 1 \
+            --parameter-grid-count 3 \
+            --contact-parameter-particles 4
       - name: Verify produced bundles
         run: |
           python scripts/ci/verify_result_bundle.py \
-            runs/causal4d-counterfactual-v1/manifest.json
+            build/bundles/counterfactual/manifest.json
           python scripts/ci/verify_result_bundle.py \
-            runs/causal4d-latent-contact-v1/manifest.json
+            build/bundles/latent-contact/manifest.json
       - name: Archive and consume bundles in a clean location
         run: |
           mkdir -p build/archives build/consumed
-          tar -C runs -czf build/archives/counterfactual.tar.gz causal4d-counterfactual-v1
-          tar -C runs -czf build/archives/latent-contact.tar.gz causal4d-latent-contact-v1
+          tar -C build/bundles -czf build/archives/counterfactual.tar.gz counterfactual
+          tar -C build/bundles -czf build/archives/latent-contact.tar.gz latent-contact
           tar -C build/consumed -xzf build/archives/counterfactual.tar.gz
           tar -C build/consumed -xzf build/archives/latent-contact.tar.gz
           python scripts/ci/verify_result_bundle.py \
-            build/consumed/causal4d-counterfactual-v1/manifest.json
+            build/consumed/counterfactual/manifest.json
           python scripts/ci/verify_result_bundle.py \
-            build/consumed/causal4d-latent-contact-v1/manifest.json
+            build/consumed/latent-contact/manifest.json
       - name: Upload smoke bundles
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Python 3.10
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
           cache: pip
@@ -71,9 +72,11 @@ jobs:
         python-version: ["3.10", "3.12", "3.14"]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -95,7 +98,7 @@ jobs:
             --junitxml="pytest-core-${{ matrix.python-version }}.xml"
       - name: Upload pytest report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pytest-core-${{ matrix.python-version }}
           path: pytest-core-${{ matrix.python-version }}.xml
@@ -105,9 +108,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Causal4D
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
@@ -135,12 +140,13 @@ jobs:
         run: echo "sha=$(python scripts/ci/read_bpt_pin.py)" >> "$GITHUB_OUTPUT"
       - name: Check out pinned Bayesian-PhysTwin
         if: steps.access.outputs.enabled == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: FlorianPfaff/Bayesian-PhysTwin
           ref: ${{ steps.pin.outputs.sha }}
           token: ${{ secrets.BPT_READ_TOKEN }}
           path: _bpt
+          persist-credentials: false
       - name: Install Causal4D and pinned provider
         if: steps.access.outputs.enabled == 'true'
         run: |
@@ -156,9 +162,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
@@ -169,7 +177,7 @@ jobs:
       - name: Validate distribution metadata
         run: python -m twine check dist/*
       - name: Upload distributions
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: python-distributions
           path: dist/
@@ -184,13 +192,15 @@ jobs:
         kind: [wheel, sdist]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Download distributions
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-distributions
           path: dist
@@ -228,9 +238,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
@@ -239,37 +251,28 @@ jobs:
       - name: Produce deterministic smoke bundles
         run: |
           causal4d-counterfactual-benchmark \
-            --output-dir build/bundles/counterfactual \
-            --seeds 0 \
-            --frames 18 \
-            --training-repeats 1 \
-            --parameter-grid-count 3
+            --output-dir runs/causal4d-counterfactual-v1
           causal4d-latent-contact-benchmark \
-            --output-dir build/bundles/latent-contact \
-            --seeds 0 \
-            --frames 18 \
-            --training-repeats 1 \
-            --parameter-grid-count 3 \
-            --contact-parameter-particles 4
+            --output-dir runs/causal4d-latent-contact-v1
       - name: Verify produced bundles
         run: |
           python scripts/ci/verify_result_bundle.py \
-            build/bundles/counterfactual/manifest.json
+            runs/causal4d-counterfactual-v1/manifest.json
           python scripts/ci/verify_result_bundle.py \
-            build/bundles/latent-contact/manifest.json
+            runs/causal4d-latent-contact-v1/manifest.json
       - name: Archive and consume bundles in a clean location
         run: |
           mkdir -p build/archives build/consumed
-          tar -C build/bundles -czf build/archives/counterfactual.tar.gz counterfactual
-          tar -C build/bundles -czf build/archives/latent-contact.tar.gz latent-contact
+          tar -C runs -czf build/archives/counterfactual.tar.gz causal4d-counterfactual-v1
+          tar -C runs -czf build/archives/latent-contact.tar.gz causal4d-latent-contact-v1
           tar -C build/consumed -xzf build/archives/counterfactual.tar.gz
           tar -C build/consumed -xzf build/archives/latent-contact.tar.gz
           python scripts/ci/verify_result_bundle.py \
-            build/consumed/counterfactual/manifest.json
+            build/consumed/causal4d-counterfactual-v1/manifest.json
           python scripts/ci/verify_result_bundle.py \
-            build/consumed/latent-contact/manifest.json
+            build/consumed/causal4d-latent-contact-v1/manifest.json
       - name: Upload smoke bundles
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: result-bundle-smoke
           path: build/archives/*.tar.gz
@@ -279,9 +282,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Validate frozen inventory and checked-in checksums
@@ -298,11 +303,11 @@ jobs:
       contents: write
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-distributions
           path: dist
       - name: Publish release assets
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: dist/*

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -29,9 +29,11 @@ jobs:
         python-version: ["3.11", "3.13"]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -53,7 +55,7 @@ jobs:
             --junitxml="pytest-extended-${{ matrix.python-version }}.xml"
       - name: Upload pytest report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pytest-extended-${{ matrix.python-version }}
           path: pytest-extended-${{ matrix.python-version }}.xml
@@ -63,9 +65,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Python 3.10
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
           cache: pip
@@ -142,7 +146,7 @@ jobs:
           PY
       - name: Upload floor-environment evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: minimum-dependency-evidence
           path: |

--- a/.github/workflows/optional-integrations.yml
+++ b/.github/workflows/optional-integrations.yml
@@ -28,9 +28,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
@@ -63,9 +65,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Causal4D
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
@@ -86,12 +90,13 @@ jobs:
         run: echo "sha=$(python scripts/ci/read_bpt_pin.py)" >> "$GITHUB_OUTPUT"
       - name: Check out pinned Bayesian-PhysTwin
         if: steps.access.outputs.enabled == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: FlorianPfaff/Bayesian-PhysTwin
           ref: ${{ steps.pin.outputs.sha }}
           token: ${{ secrets.BPT_READ_TOKEN }}
           path: _bpt
+          persist-credentials: false
       - name: Install BPT tests with explicit vision runtime
         if: steps.access.outputs.enabled == 'true'
         run: |
@@ -108,9 +113,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Causal4D
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
@@ -131,12 +138,13 @@ jobs:
         run: echo "sha=$(python scripts/ci/read_bpt_pin.py)" >> "$GITHUB_OUTPUT"
       - name: Check out pinned Bayesian-PhysTwin
         if: steps.access.outputs.enabled == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: FlorianPfaff/Bayesian-PhysTwin
           ref: ${{ steps.pin.outputs.sha }}
           token: ${{ secrets.BPT_READ_TOKEN }}
           path: _bpt
+          persist-credentials: false
       - name: Install Warp CPU stack
         if: steps.access.outputs.enabled == 'true'
         run: |
@@ -169,9 +177,11 @@ jobs:
     runs-on: [self-hosted, linux, x64, gpu]
     steps:
       - name: Check out Causal4D
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Require private-repository credential
@@ -182,12 +192,13 @@ jobs:
         id: pin
         run: echo "sha=$(python scripts/ci/read_bpt_pin.py)" >> "$GITHUB_OUTPUT"
       - name: Check out pinned Bayesian-PhysTwin
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: FlorianPfaff/Bayesian-PhysTwin
           ref: ${{ steps.pin.outputs.sha }}
           token: ${{ secrets.BPT_READ_TOKEN }}
           path: _bpt
+          persist-credentials: false
       - name: Install GPU integration stack
         run: |
           python -m pip install -e ".[dev,vision,warp]"

--- a/.github/workflows/quality-failure-diagnostics.yml
+++ b/.github/workflows/quality-failure-diagnostics.yml
@@ -22,11 +22,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out the failed revision
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
       - name: Set up Python 3.10
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
           cache: pip
@@ -45,7 +46,7 @@ jobs:
           exit 0
       - name: Upload focused diagnostics
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: quality-failure-diagnostics-${{ github.event.workflow_run.id }}
           path: |

--- a/tests/test_github_action_pins.py
+++ b/tests/test_github_action_pins.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_ROOT = ROOT / ".github" / "workflows"
+_USES_LINE = re.compile(
+    r"^\s*(?:-\s*)?uses:\s*(?P<value>[^#\s]+)\s*(?:#\s*(?P<comment>.+))?$"
+)
+_FULL_COMMIT = re.compile(r"^[0-9a-f]{40}$")
+_VERSION_COMMENT = re.compile(r"^v[0-9]+(?:\.[0-9]+){0,2}(?:[-+][A-Za-z0-9.-]+)?$")
+
+
+def _pin_errors(text: str, *, source: str) -> list[str]:
+    errors: list[str] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        match = _USES_LINE.match(line)
+        if match is None:
+            continue
+        value = match.group("value").strip("\"'")
+        if value.startswith(("./", "docker://")):
+            continue
+        if "@" not in value:
+            errors.append(f"{source}:{line_number}: external action has no ref: {value}")
+            continue
+        action, ref = value.rsplit("@", 1)
+        if "/" not in action or not _FULL_COMMIT.fullmatch(ref):
+            errors.append(
+                f"{source}:{line_number}: external action must use a full "
+                f"lowercase commit SHA: {value}"
+            )
+        comment = (match.group("comment") or "").strip().split(maxsplit=1)[0:1]
+        if not comment or _VERSION_COMMENT.fullmatch(comment[0]) is None:
+            errors.append(
+                f"{source}:{line_number}: immutable action pin needs a version "
+                f"annotation such as '# v7': {value}"
+            )
+    return errors
+
+
+def test_every_external_github_action_is_immutably_pinned() -> None:
+    workflow_files = sorted(WORKFLOW_ROOT.glob("*.yml")) + sorted(
+        WORKFLOW_ROOT.glob("*.yaml")
+    )
+    assert workflow_files, "no GitHub Actions workflows found"
+
+    errors: list[str] = []
+    for path in workflow_files:
+        errors.extend(
+            _pin_errors(
+                path.read_text(encoding="utf-8"),
+                source=path.relative_to(ROOT).as_posix(),
+            )
+        )
+    assert not errors, "\n".join(errors)
+
+
+def test_pin_policy_rejects_tags_branches_and_short_shas() -> None:
+    text = "\n".join(
+        (
+            "- uses: actions/checkout@v7",
+            "- uses: owner/action@main",
+            "- uses: owner/action@0123456789abcdef # v1",
+        )
+    )
+    errors = _pin_errors(text, source="fixture.yml")
+
+    assert len(errors) == 5
+    assert all("fixture.yml" in error for error in errors)
+
+
+def test_pin_policy_allows_local_docker_and_annotated_commit_uses() -> None:
+    text = "\n".join(
+        (
+            "- uses: ./local-action",
+            "- uses: docker://python:3.12",
+            "- uses: owner/action@0123456789abcdef0123456789abcdef01234567 # v1.2.3",
+        )
+    )
+
+    assert _pin_errors(text, source="fixture.yml") == []

--- a/tests/test_github_action_pins.py
+++ b/tests/test_github_action_pins.py
@@ -10,9 +10,7 @@ _USES_LINE = re.compile(
     r"^\s*(?:-\s*)?uses:\s*(?P<value>[^#\s]+)\s*(?:#\s*(?P<comment>.+))?$"
 )
 _FULL_COMMIT = re.compile(r"^[0-9a-f]{40}$")
-_VERSION_COMMENT = re.compile(
-    r"^v[0-9]+(?:\.[0-9]+){0,2}(?:[-+][A-Za-z0-9.-]+)?$"
-)
+_VERSION_COMMENT = re.compile(r"^v[0-9]+(?:\.[0-9]+){0,2}(?:[-+][A-Za-z0-9.-]+)?$")
 
 
 def _pin_errors(text: str, *, source: str) -> list[str]:

--- a/tests/test_github_action_pins.py
+++ b/tests/test_github_action_pins.py
@@ -10,7 +10,9 @@ _USES_LINE = re.compile(
     r"^\s*(?:-\s*)?uses:\s*(?P<value>[^#\s]+)\s*(?:#\s*(?P<comment>.+))?$"
 )
 _FULL_COMMIT = re.compile(r"^[0-9a-f]{40}$")
-_VERSION_COMMENT = re.compile(r"^v[0-9]+(?:\.[0-9]+){0,2}(?:[-+][A-Za-z0-9.-]+)?$")
+_VERSION_COMMENT = re.compile(
+    r"^v[0-9]+(?:\.[0-9]+){0,2}(?:[-+][A-Za-z0-9.-]+)?$"
+)
 
 
 def _pin_errors(text: str, *, source: str) -> list[str]:
@@ -23,7 +25,9 @@ def _pin_errors(text: str, *, source: str) -> list[str]:
         if value.startswith(("./", "docker://")):
             continue
         if "@" not in value:
-            errors.append(f"{source}:{line_number}: external action has no ref: {value}")
+            errors.append(
+                f"{source}:{line_number}: external action has no ref: {value}"
+            )
             continue
         action, ref = value.rsplit("@", 1)
         if "/" not in action or not _FULL_COMMIT.fullmatch(ref):
@@ -72,11 +76,12 @@ def test_pin_policy_rejects_tags_branches_and_short_shas() -> None:
 
 
 def test_pin_policy_allows_local_docker_and_annotated_commit_uses() -> None:
+    pinned = "0123456789abcdef0123456789abcdef01234567"
     text = "\n".join(
         (
             "- uses: ./local-action",
             "- uses: docker://python:3.12",
-            "- uses: owner/action@0123456789abcdef0123456789abcdef01234567 # v1.2.3",
+            f"- uses: owner/action@{pinned} # v1.2.3",
         )
     )
 


### PR DESCRIPTION
## Summary

- pin every external GitHub Action in all workflows to a reviewed 40-character commit SHA
- upgrade `actions/checkout` to v7.0.1, `actions/setup-python` to v7, and `softprops/action-gh-release` to v3.0.2 while retaining current artifact-action majors
- disable persisted checkout credentials because no workflow pushes through the checked-out repositories
- add a repository-wide regression test that rejects tags, branches, short SHAs, and unannotated external action pins
- add `CODEOWNERS` coverage for workflow, acquisition, milestone, and release-critical paths

This consolidates and supersedes Dependabot PRs #91, #92, and #93.

## Scientific boundary

Supply-chain and review-policy hardening only. The estimator, registered protocols, acquisition schedule, result-bundle smoke configuration, evidence contracts, and scientific claim status are unchanged.

## Validation

- **CI and release** run 475 passed: Ruff, exact formatting, mypy, core suites on Python 3.10/3.12/3.14, pinned Bayesian-PhysTwin integration, wheel and sdist builds, installed-artifact CLI help, deterministic result bundles, and frozen milestone verification
- **Extended compatibility** run 109 passed: core suites on Python 3.11/3.13 and the exact declared dependency-floor environment on Python 3.10
- **Three-repository installed-wheel compatibility** run 98 passed: credential gate, clean wheel builds for Prob4D/Bayesian-PhysTwin/Causal4D, strict provider-v2 admission, and cross-repository contract tests
- cumulative comparison against `main` contains only the five workflow files, `CODEOWNERS`, and the immutable-action pin policy test
