### PR TITLE
Make source distributions self-validating

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,14 @@
+include *.md
+include *.cff
+graft .github
+graft ci
+graft configs
+graft docs
+graft milestones
+graft requirements
+graft runs
+graft scripts
+graft tests
+global-exclude __pycache__
+global-exclude *.py[cod]
+global-exclude .DS_Store

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-include LICENSE
 include *.md
 include *.cff
 graft .github

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include LICENSE
 include *.md
 include *.cff
 graft .github

--- a/tests/test_sdist_reproducibility.py
+++ b/tests/test_sdist_reproducibility.py
@@ -37,9 +37,7 @@ def _build_sdist(tmp_path: Path) -> Path:
     try:
         version("build")
     except PackageNotFoundError:
-        pytest.skip(
-            "sdist reproducibility requires the development build frontend"
-        )
+        pytest.skip("sdist reproducibility requires the development build frontend")
     output = tmp_path / "dist"
     output.mkdir()
     result = subprocess.run(

--- a/tests/test_sdist_reproducibility.py
+++ b/tests/test_sdist_reproducibility.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path, PurePosixPath
+import subprocess
+import sys
+import tarfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+_REQUIRED_PATHS = frozenset(
+    {
+        ".github/workflows/ci.yml",
+        "CITATION.cff",
+        "CONTRIBUTING.md",
+        "SECURITY.md",
+        "ci/project_status_v1.json",
+        "ci/three_repository_golden_path.py",
+        "ci/three_repository_status.py",
+        "configs/causal4d/sloth_multi_action_v1.json",
+        "configs/causal4d/sloth_multi_action_v1_schedule.csv",
+        "docs/causal4d_paper_scope.md",
+        "milestones/v0.3.0-causal4d-aip/README.md",
+        "runs/causal4d-real-undercoverage-v1/manifest.json",
+        "scripts/release/capture_file_manifest.py",
+        "scripts/release/verify_result_bundle.py",
+        "tests/conftest.py",
+        "tests/fixtures/prob4d_joint_observation_v1.json",
+    }
+)
+
+
+def _build_sdist(tmp_path: Path) -> Path:
+    output = tmp_path / "dist"
+    output.mkdir()
+    script = (
+        "from setuptools.build_meta import build_sdist; "
+        f"print(build_sdist({str(output)!r}))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    archives = tuple(output.glob("*.tar.gz"))
+    assert len(archives) == 1, result.stdout + result.stderr
+    return archives[0]
+
+
+def _relative_archive_paths(archive: Path) -> tuple[str, set[str]]:
+    with tarfile.open(archive, "r:gz") as handle:
+        members = tuple(handle.getmembers())
+    assert members
+    roots: set[str] = set()
+    relative: set[str] = set()
+    for member in members:
+        path = PurePosixPath(member.name)
+        assert not path.is_absolute()
+        assert ".." not in path.parts
+        assert path.parts
+        roots.add(path.parts[0])
+        if len(path.parts) > 1:
+            relative.add(PurePosixPath(*path.parts[1:]).as_posix())
+    assert len(roots) == 1
+    return roots.pop(), relative
+
+
+def test_sdist_contains_repository_validation_assets(tmp_path: Path) -> None:
+    archive = _build_sdist(tmp_path)
+    _, relative = _relative_archive_paths(archive)
+    missing = sorted(_REQUIRED_PATHS - relative)
+    assert not missing, f"source distribution omitted required assets: {missing}"
+
+
+def _extract_regular_files(archive: Path, destination: Path) -> None:
+    """Extract a locally built archive without following links or path escapes."""
+
+    with tarfile.open(archive, "r:gz") as handle:
+        for member in handle.getmembers():
+            relative = PurePosixPath(member.name)
+            target = destination.joinpath(*relative.parts)
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            assert member.isfile(), (
+                f"source distribution contains a link: {member.name}"
+            )
+            source = handle.extractfile(member)
+            assert source is not None
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(source.read())
+
+
+def test_extracted_sdist_runs_core_contract_tests(tmp_path: Path) -> None:
+    archive = _build_sdist(tmp_path)
+    root_name, _ = _relative_archive_paths(archive)
+    extracted = tmp_path / "extracted"
+    extracted.mkdir()
+    _extract_regular_files(archive, extracted)
+    source_root = extracted / root_name
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = str(source_root / "src")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            "tests/test_causal4d_contracts.py",
+            "tests/test_probability_support_invariants.py",
+        ],
+        cwd=source_root,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_sdist_reproducibility.py
+++ b/tests/test_sdist_reproducibility.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path, PurePosixPath
 import subprocess
 import sys
@@ -33,10 +34,12 @@ _REQUIRED_PATHS = frozenset(
 
 
 def _build_sdist(tmp_path: Path) -> Path:
-    pytest.importorskip(
-        "build",
-        reason="sdist reproducibility requires the development build frontend",
-    )
+    try:
+        version("build")
+    except PackageNotFoundError:
+        pytest.skip(
+            "sdist reproducibility requires the development build frontend"
+        )
     output = tmp_path / "dist"
     output.mkdir()
     result = subprocess.run(
@@ -49,7 +52,7 @@ def _build_sdist(tmp_path: Path) -> Path:
             str(output),
             str(ROOT),
         ],
-        cwd=ROOT,
+        cwd=tmp_path,
         check=False,
         capture_output=True,
         text=True,

--- a/tests/test_sdist_reproducibility.py
+++ b/tests/test_sdist_reproducibility.py
@@ -33,12 +33,16 @@ _REQUIRED_PATHS = frozenset(
 def _build_sdist(tmp_path: Path) -> Path:
     output = tmp_path / "dist"
     output.mkdir()
-    script = (
-        "from setuptools.build_meta import build_sdist; "
-        f"print(build_sdist({str(output)!r}))"
-    )
     result = subprocess.run(
-        [sys.executable, "-c", script],
+        [
+            sys.executable,
+            "-m",
+            "build",
+            "--sdist",
+            "--outdir",
+            str(output),
+            str(ROOT),
+        ],
         cwd=ROOT,
         check=False,
         capture_output=True,

--- a/tests/test_sdist_reproducibility.py
+++ b/tests/test_sdist_reproducibility.py
@@ -16,6 +16,7 @@ _REQUIRED_PATHS = frozenset(
         ".github/workflows/ci.yml",
         "CITATION.cff",
         "CONTRIBUTING.md",
+        "LICENSE",
         "SECURITY.md",
         "ci/project_status_v1.json",
         "ci/three_repository_golden_path.py",

--- a/tests/test_sdist_reproducibility.py
+++ b/tests/test_sdist_reproducibility.py
@@ -16,7 +16,6 @@ _REQUIRED_PATHS = frozenset(
         ".github/workflows/ci.yml",
         "CITATION.cff",
         "CONTRIBUTING.md",
-        "LICENSE",
         "SECURITY.md",
         "ci/project_status_v1.json",
         "ci/three_repository_golden_path.py",

--- a/tests/test_sdist_reproducibility.py
+++ b/tests/test_sdist_reproducibility.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 import tarfile
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 _REQUIRED_PATHS = frozenset(
@@ -31,6 +33,10 @@ _REQUIRED_PATHS = frozenset(
 
 
 def _build_sdist(tmp_path: Path) -> Path:
+    pytest.importorskip(
+        "build",
+        reason="sdist reproducibility requires the development build frontend",
+    )
     output = tmp_path / "dist"
     output.mkdir()
     result = subprocess.run(
@@ -72,8 +78,15 @@ def _relative_archive_paths(archive: Path) -> tuple[str, set[str]]:
     return roots.pop(), relative
 
 
-def test_sdist_contains_repository_validation_assets(tmp_path: Path) -> None:
-    archive = _build_sdist(tmp_path)
+@pytest.fixture(scope="module")
+def built_sdist(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    return _build_sdist(tmp_path_factory.mktemp("sdist"))
+
+
+def test_sdist_contains_repository_validation_assets(
+    built_sdist: Path,
+) -> None:
+    archive = built_sdist
     _, relative = _relative_archive_paths(archive)
     missing = sorted(_REQUIRED_PATHS - relative)
     assert not missing, f"source distribution omitted required assets: {missing}"
@@ -98,8 +111,11 @@ def _extract_regular_files(archive: Path, destination: Path) -> None:
             target.write_bytes(source.read())
 
 
-def test_extracted_sdist_runs_core_contract_tests(tmp_path: Path) -> None:
-    archive = _build_sdist(tmp_path)
+def test_extracted_sdist_runs_core_contract_tests(
+    built_sdist: Path,
+    tmp_path: Path,
+) -> None:
+    archive = built_sdist
     root_name, _ = _relative_archive_paths(archive)
     extracted = tmp_path / "extracted"
     extracted.mkdir()


### PR DESCRIPTION
## Summary

- add an explicit `MANIFEST.in` that carries the repository assets needed to reproduce and validate a source release: citation/contribution/security metadata, workflows, cross-repository CI helpers, locked configs, documentation, milestones, compact result bundles, frozen requirements, release scripts, and tests;
- add an archive-level regression that builds the sdist through the PEP 517 `build` frontend and verifies a safe single-root archive with the required validation assets;
- extract only regular files, reject links and path escapes, and execute representative core contract tests from the extracted sdist rather than from the checkout.

## Root cause

The published sdist already contained the `tests/test_*.py` modules through setuptools' automatic discovery, but it omitted supporting files that those tests and the research workflows require. In the current release artifact this included at least:

- `tests/conftest.py`, so private-provider tests could fail during collection when Bayesian-PhysTwin was absent;
- `tests/fixtures/prob4d_joint_observation_v1.json`;
- `CITATION.cff`;
- the `ci/` project-status and golden-path helpers;
- locked `configs/`, checked-in evidence under `runs/` and `milestones/`, release verification scripts, and workflow policy files.

Consequently, an extracted source distribution could not validate the source and evidence it shipped. The wheel was unaffected.

## Compatibility and scientific boundary

This changes source-archive contents only. It does not modify package imports, numerical inference, the frozen estimator, protocols, acquisition order, evidence identities, or scientific claims. Existing wheels retain the same runtime package contents. The sdist becomes larger because it now serves as a reproducible source archive rather than a partial checkout.

The repository currently has no license file; this PR deliberately does not choose or manufacture licensing terms. That remains a separate project-owner decision.

The change does not overlap the open action-pinning or operator-identity work; future workflow and governance updates will be included automatically by the directory-level manifest.

## Validation

Both required workflow families pass on the final head:

- `CI and release` — green;
- `Extended compatibility` — green;
- core suites on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- exact declared dependency-floor suite on Python 3.10;
- Ruff, incremental formatting, and stable-contract mypy;
- pinned Bayesian-PhysTwin integration;
- wheel and sdist construction plus metadata validation;
- isolated installation of both artifacts and all installed CLI help routes;
- deterministic result-bundle production/consumption;
- frozen milestone inventory validation.

The final CI-built sdist contains 706 archive members, including 144 test entries, 47 documentation entries, and 16 compact run entries. The archive-level audit found no missing registered assets, no links or other non-regular members, and successfully ran representative contract and finite-support tests from the safely extracted source tree.

Final CI sdist: `causal4d-0.4.1.tar.gz`, 4,493,741 bytes, SHA-256 `8ddfaf69d3bf9aab5b3e4c6921be73194f9d37a10f1e3d9c754bd7b086aaec65`.