### PR TITLE
Add acquisition flight recorder and operational doctor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,20 +119,20 @@ jobs:
       - name: Detect private-repository credential
         id: access
         env:
-          BPT_READ_TOKEN: ${{ secrets.BPT_READ_TOKEN }}
+          BPT_READ_SSH_KEY: ${{ secrets.BPT_READ_SSH_KEY }}
         run: |
-          if [[ -n "${BPT_READ_TOKEN}" ]]; then
+          if [[ -n "${BPT_READ_SSH_KEY}" ]]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::BPT_READ_TOKEN is not configured; pinned private-repository integration was not exercised."
+            echo "::warning::BPT_READ_SSH_KEY is not configured; pinned private-repository integration was not exercised."
             echo "### Pinned Bayesian-PhysTwin integration" >> "$GITHUB_STEP_SUMMARY"
-            echo "Skipped because the repository secret \`BPT_READ_TOKEN\` is absent." >> "$GITHUB_STEP_SUMMARY"
+            echo "Skipped because the repository secret \`BPT_READ_SSH_KEY\` is absent." >> "$GITHUB_STEP_SUMMARY"
           fi
       - name: Require private-provider integration for releases
         if: startsWith(github.ref, 'refs/tags/v') && steps.access.outputs.enabled != 'true'
         run: |
-          echo "::error::Release tags require BPT_READ_TOKEN and an executed pinned-provider integration."
+          echo "::error::Release tags require BPT_READ_SSH_KEY and an executed pinned-provider integration."
           exit 1
       - name: Read exact Bayesian-PhysTwin pin
         if: steps.access.outputs.enabled == 'true'
@@ -142,9 +142,9 @@ jobs:
         if: steps.access.outputs.enabled == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repository: FlorianPfaff/Bayesian-PhysTwin
+          repository: IPS-Stuttgart/BayesianPhysTwin
           ref: ${{ steps.pin.outputs.sha }}
-          token: ${{ secrets.BPT_READ_TOKEN }}
+          ssh-key: ${{ secrets.BPT_READ_SSH_KEY }}
           path: _bpt
           persist-credentials: false
       - name: Install Causal4D and pinned provider

--- a/docs/causal4d_acquisition_flight_recorder.md
+++ b/docs/causal4d_acquisition_flight_recorder.md
@@ -1,0 +1,236 @@
+# Acquisition doctor and flight recorder
+
+The acquisition tooling protects the locked 36-execution experiment from
+operational failures without changing the estimator, protocol, split, exclusion
+rules, analysis, or scientific thresholds.
+
+It has three surfaces:
+
+```text
+causal4d protocol acquisition doctor ...
+causal4d protocol acquisition snapshot ...
+causal4d protocol acquisition journal ...
+```
+
+All outputs explicitly state `target_outcomes_used=false`. Journal payloads and
+health snapshots reject target-error, held-out-metric, coverage, NLL, Chamfer,
+and oracle-result fields. The tooling is therefore suitable for collection
+health and recovery, not target-informed method selection.
+
+## Pre-session doctor
+
+Run the doctor immediately before every session from the exact deployed
+checkout:
+
+```bash
+causal4d protocol acquisition doctor \
+  configs/causal4d/sloth_multi_action_v1.json \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  --minimum-free-gib 100 \
+  --write-probe-mib 64 \
+  --minimum-write-mib-s 100 \
+  --output-json \
+  /data/causal4d-sloth-multi-action-v1/operator/doctor-latest.json \
+  --overwrite \
+  --require-ready
+```
+
+The doctor fails closed when:
+
+- the checkout is dirty or differs from `method_freeze.json`;
+- any locked method file differs from the freeze;
+- the sealed pre-acquisition readiness report is absent, invalid, or did not
+  permit execution 1;
+- the dataset or journal traverses a symlink;
+- free space or measured synchronous write throughput is below the operator
+  threshold;
+- the registered evidence status or any referenced artifact hash is invalid;
+- validated execution manifests do not form the locked acquisition prefix;
+- the next execution or session directory was not scaffolded; or
+- the next session journal is already sealed while an execution remains
+  incomplete.
+
+An existing valid, unsealed journal is reported as a warning rather than erased.
+It blocks `--require-ready` until the operator reviews the chain and explicitly
+reruns the doctor with `--allow-resume`. The doctor verifies that the journal
+identifies the registered protocol and current session, that its terminal
+execution events agree with hash-validated manifests, and that any active
+execution is the next locked execution. The doctor never overwrites evidence and
+its temporary write probe is created with exclusive, no-follow semantics,
+fsynced, and deleted.
+
+With `--require-ready`, exit codes follow the other operational gates:
+
+| Code | Meaning |
+| ---: | --- |
+| `0` | Ready to record, or all registered executions are complete. |
+| `2` | Invalid or contradictory operational state. |
+| `3` | Valid invocation, but collection is blocked or requires review. |
+
+## Live health snapshots
+
+Hardware-specific capture processes can periodically publish a small JSON
+snapshot and ask Causal4D to evaluate it:
+
+```bash
+causal4d protocol acquisition snapshot health.json \
+  --maximum-heartbeat-age-s 2 \
+  --maximum-clock-offset-ms 5 \
+  --maximum-dropped-frames 0 \
+  --minimum-free-gib 100 \
+  --minimum-write-mib-s 100 \
+  --require-healthy
+```
+
+A snapshot has this shape:
+
+```json
+{
+  "schema_version": 1,
+  "artifact_kind": "Causal4DAcquisitionHealthSnapshot",
+  "protocol_id": "causal4d-sloth-multi-action-v1",
+  "session_id": "sloth-v1-c1-s6",
+  "execution_id": "sloth-v1-c1-s6-e1",
+  "captured_at_utc": "2026-08-03T08:00:00+00:00",
+  "target_outcomes_used": false,
+  "streams": {
+    "rgbd": {
+      "required": true,
+      "alive": true,
+      "heartbeat_age_s": 0.12,
+      "dropped_frames": 0,
+      "clock_offset_ms": 1.4
+    },
+    "actuator": {
+      "required": true,
+      "alive": true,
+      "heartbeat_age_s": 0.03,
+      "dropped_frames": 0,
+      "clock_offset_ms": -0.8
+    }
+  },
+  "storage": {
+    "free_bytes": 500000000000,
+    "write_mib_s": 420.0
+  }
+}
+```
+
+Required dead or stale streams, dropped-frame excess, clock-offset excess, low
+free space, or low write rate produce a failed decision. Optional unhealthy
+streams produce warnings. The capture system decides whether to stop safely; the
+snapshot checker does not issue actuator commands.
+
+## Append-only session journal
+
+The journal is JSON Lines with one canonical JSON object per event. Every event
+contains:
+
+- protocol, session, and optional execution identities;
+- a contiguous sequence number;
+- UTC and monotonic timestamps;
+- an event type and source;
+- finite JSON operational payload;
+- the previous event SHA-256; and
+- its own canonical SHA-256.
+
+The first event must be `session_started`. Append operations use an exclusive
+file lock on POSIX, `O_APPEND`, `O_NOFOLLOW` where available, `flush`, and
+`fsync`. Existing bytes are never rewritten.
+
+Start a journal:
+
+```bash
+causal4d protocol acquisition journal append \
+  /data/causal4d-sloth-multi-action-v1/sessions/sloth-v1-c1-s6/acquisition.jsonl \
+  session_started \
+  --protocol-id causal4d-sloth-multi-action-v1 \
+  --session-id sloth-v1-c1-s6 \
+  --source acquisition-supervisor
+```
+
+Append an execution transition or a health sample:
+
+```bash
+causal4d protocol acquisition journal append \
+  /data/causal4d-sloth-multi-action-v1/sessions/sloth-v1-c1-s6/acquisition.jsonl \
+  execution_started \
+  --protocol-id causal4d-sloth-multi-action-v1 \
+  --session-id sloth-v1-c1-s6 \
+  --execution-id sloth-v1-c1-s6-e1 \
+  --source controller
+```
+
+Payloads are supplied as a separate JSON object:
+
+```bash
+causal4d protocol acquisition journal append \
+  SESSION/acquisition.jsonl stream_heartbeat \
+  --protocol-id causal4d-sloth-multi-action-v1 \
+  --session-id sloth-v1-c1-s6 \
+  --execution-id sloth-v1-c1-s6-e1 \
+  --source rgbd-recorder \
+  --payload-json heartbeat.json
+```
+
+Use coarse operational events or periodic heartbeats. Raw sensor samples remain
+in their registered artifacts and should not be duplicated into JSONL.
+
+Validate at any time:
+
+```bash
+causal4d protocol acquisition journal validate SESSION/acquisition.jsonl
+```
+
+Finish with exactly one terminal disposition:
+
+```bash
+causal4d protocol acquisition journal append \
+  SESSION/acquisition.jsonl session_completed \
+  --protocol-id causal4d-sloth-multi-action-v1 \
+  --session-id sloth-v1-c1-s6 \
+  --source acquisition-supervisor
+
+causal4d protocol acquisition journal seal \
+  SESSION/acquisition.jsonl \
+  --sealed-by operator.primary
+```
+
+For a technical failure, use `session_aborted` instead of pretending the session
+completed. The deterministic seal is written as
+`acquisition.jsonl.seal.json`. It binds the journal byte count, journal SHA-256,
+final event SHA-256, event count, execution IDs, session outcome, signer, and
+seal time. After a terminal event or seal, further appends fail.
+
+Revalidate an archived journal and seal together:
+
+```bash
+causal4d protocol acquisition journal validate \
+  SESSION/acquisition.jsonl \
+  --require-sealed
+```
+
+## Recovery policy
+
+A crash may leave a valid unsealed journal. Do not delete or replace it.
+
+1. Run `journal validate` and the pre-session doctor.
+2. Record `recovery_started` with the detected process and artifact state.
+3. Resume only hardware streams whose registered artifacts support safe append or
+   create a new preregistered technical-failure record.
+4. Record `recovery_completed`.
+5. Rerun the doctor with `--allow-resume` after reviewing the validated chain.
+6. Complete or abort the session explicitly, then seal.
+
+A corrupt journal is operational evidence of a failed acquisition path. It is
+not silently repaired. Preserve the bytes, record the technical failure, and
+follow the registered replacement/exclusion policy.
+
+## Scientific boundary
+
+The doctor, snapshots, journals, and seals are operational provenance. They do
+not increment the acquired or validated execution count, change inclusion, tune
+thresholds, inspect held-out outcomes, or support a physical-prediction claim.
+Only the registered execution/session manifests and evidence-status validator
+establish the confirmatory evidence count.

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -8,6 +8,7 @@ causal4d --help
 causal4d --version
 causal4d commands list
 causal4d commands list --json --include-legacy
+causal4d commands validate --json --require-installed
 ```
 
 The grouped routes cover the stable benchmark, protocol, evidence, and
@@ -19,6 +20,7 @@ causal4d benchmark latent-contact --output-dir runs/latent-contact
 causal4d protocol real validate-protocol configs/causal4d/sloth_multi_action_v1.json
 causal4d protocol freeze validate method_freeze.json protocol.json checkout/
 causal4d protocol readiness status checkout/ dataset/ --verify-file-hashes
+causal4d protocol acquisition doctor protocol.json checkout/ dataset/
 causal4d evidence observation-lineage validate observation.npz twin_belief.npz
 ```
 
@@ -29,9 +31,15 @@ gate after hash validation, and derives whether execution 1 is permitted. With
 `2` means malformed or contradictory evidence. See
 [the readiness contract](causal4d_preacquisition_readiness.md).
 
+`protocol acquisition` adds the method-neutral pre-session doctor, live health
+snapshot evaluator, and append-only, hash-chained session journal. It verifies
+the frozen checkout, sealed readiness, storage, locked acquisition order, and
+journal recovery state without reading target outcomes. See
+[the acquisition flight recorder](causal4d_acquisition_flight_recorder.md).
+
 Command modules are imported only after a route is selected. Therefore root
-help, version reporting, and registry inspection stay independent of optional
-Bayesian-PhysTwin, Warp, vision, and GPU dependencies.
+help, version reporting, registry inspection, and registry validation stay
+independent of optional Bayesian-PhysTwin, Warp, vision, and GPU dependencies.
 
 ## Registry and migration
 
@@ -42,6 +50,13 @@ extras, and historical executable name. Inspect one entry with:
 causal4d commands describe protocol/real
 causal4d commands migrate causal4d-real-protocol
 ```
+
+`commands validate` compares every grouped historical mapping with the installed
+wheel's `console_scripts` metadata without importing command modules. It fails
+when a grouped historical executable is missing or maps to a different Python
+target, and reports the still-ungrouped compatibility surface. In a source-only
+checkout it reports that no installed distribution was found; use
+`--require-installed` in wheel/sdist and release checks.
 
 `commands migrate` reports the preferred grouped spelling without changing the
 historical executable. To invoke an installed compatibility entry point through

--- a/src/causal4d/acquisition_doctor.py
+++ b/src/causal4d/acquisition_doctor.py
@@ -98,9 +98,7 @@ def build_acquisition_doctor_report(
     )
     collection_complete = next_execution is None and not failures
     ready_to_record = (
-        next_execution is not None
-        and not failures
-        and not journal_requires_review
+        next_execution is not None and not failures and not journal_requires_review
     )
     report: dict[str, Any] = {
         "schema_version": 1,

--- a/src/causal4d/acquisition_doctor.py
+++ b/src/causal4d/acquisition_doctor.py
@@ -1,0 +1,135 @@
+"""Fail-closed pre-session acquisition doctor."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from causal4d.acquisition_flight_common import (
+    DOCTOR_REPORT_KIND,
+    _assert_no_symlink_components,
+    _canonical_sha256,
+    _require,
+    _utc_now,
+)
+from causal4d.acquisition_doctor_environment import (
+    frozen_checkout_check,
+    protocol_schedule,
+    readiness_check,
+    storage_checks,
+)
+from causal4d.acquisition_doctor_progress import (
+    evidence_check,
+    manifest_check,
+    next_execution_checks,
+)
+from causal4d.acquisition_doctor_support import DoctorThresholds
+
+
+def build_acquisition_doctor_report(
+    protocol: Mapping[str, Any],
+    repository_root: str | Path,
+    dataset_root: str | Path,
+    *,
+    readiness_path: str | Path | None = None,
+    method_freeze_path: str | Path | None = None,
+    thresholds: DoctorThresholds | None = None,
+    perform_write_probe: bool = True,
+    allow_resume: bool = False,
+) -> dict[str, Any]:
+    """Run method-neutral pre-session checks and identify the next execution."""
+
+    settings = thresholds or DoctorThresholds()
+    repository = Path(repository_root)
+    dataset = Path(dataset_root)
+    _assert_no_symlink_components(repository, name="repository root")
+    _assert_no_symlink_components(dataset, name="dataset root")
+    _require(repository.is_dir(), "repository root must exist")
+    _require(dataset.is_dir(), "dataset root must exist")
+
+    protocol_id, design_sha, executions, schedule_check = protocol_schedule(protocol)
+    checks = [
+        schedule_check,
+        frozen_checkout_check(repository, dataset, method_freeze_path),
+        readiness_check(protocol, dataset, readiness_path),
+        *storage_checks(
+            dataset,
+            settings,
+            perform_write_probe=perform_write_probe,
+        ),
+    ]
+    evidence, completed, malformed, present = evidence_check(
+        protocol,
+        repository,
+        dataset,
+    )
+    checks.append(evidence)
+    manifests, next_execution = manifest_check(
+        executions,
+        completed,
+        malformed,
+        present,
+    )
+    checks.append(manifests)
+    next_checks, next_summary, journal_requires_review = next_execution_checks(
+        protocol_id,
+        executions,
+        completed,
+        next_execution,
+        dataset,
+        allow_resume=allow_resume,
+    )
+    checks.extend(next_checks)
+
+    failures = [check for check in checks if check["status"] == "fail"]
+    warnings = [check for check in checks if check["status"] == "warn"]
+    invalid_check_ids = {
+        "frozen_checkout",
+        "sealed_readiness",
+        "real_evidence_status",
+        "execution_manifests",
+        "session_journal",
+    }
+    valid = not any(
+        check["status"] == "fail" and check["check_id"] in invalid_check_ids
+        for check in checks
+    )
+    collection_complete = next_execution is None and not failures
+    ready_to_record = (
+        next_execution is not None
+        and not failures
+        and not journal_requires_review
+    )
+    report: dict[str, Any] = {
+        "schema_version": 1,
+        "artifact_kind": DOCTOR_REPORT_KIND,
+        "generated_at_utc": _utc_now(),
+        "protocol_id": protocol_id,
+        "protocol_design_sha256": design_sha,
+        "repository_root": str(repository.resolve()),
+        "dataset_root": str(dataset.resolve()),
+        "thresholds": asdict(settings),
+        "resume_acknowledged": allow_resume,
+        "checks": checks,
+        "failure_count": len(failures),
+        "warning_count": len(warnings),
+        "completed_executions": len(completed),
+        "total_executions": len(executions),
+        "next_execution": next_summary,
+        "ready_to_record": ready_to_record,
+        "collection_complete": collection_complete,
+        "valid": valid,
+        "passed": ready_to_record or collection_complete,
+        "target_outcomes_used": False,
+    }
+    report["report_sha256"] = _canonical_sha256(report, omitted="report_sha256")
+    return report
+
+
+__all__ = [
+    "DOCTOR_REPORT_KIND",
+    "DoctorThresholds",
+    "build_acquisition_doctor_report",
+]

--- a/src/causal4d/acquisition_doctor_environment.py
+++ b/src/causal4d/acquisition_doctor_environment.py
@@ -1,0 +1,185 @@
+"""Environment, freeze, readiness, and storage checks for acquisition."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+import shutil
+from typing import Any
+
+from causal4d.acquisition_flight_common import _is_sha256, _require
+from causal4d.acquisition_doctor_support import (
+    CheckStatus,
+    DoctorThresholds,
+    _doctor_check,
+    _load_json_object,
+    _measure_write_rate,
+    _validate_readiness_report,
+)
+
+
+def protocol_schedule(
+    protocol: Mapping[str, Any],
+) -> tuple[str, str, list[Mapping[str, Any]], dict[str, Any]]:
+    protocol_id = protocol.get("protocol_id")
+    design_sha = protocol.get("design_sha256")
+    _require(
+        isinstance(protocol_id, str) and bool(protocol_id),
+        "protocol_id is missing",
+    )
+    _require(_is_sha256(design_sha), "protocol design_sha256 is invalid")
+    executions = sorted(
+        list(protocol.get("executions", [])),
+        key=lambda item: int(item["acquisition_execution_index"]),
+    )
+    _require(executions, "protocol contains no executions")
+    expected_indices = list(range(len(executions)))
+    actual_indices = [int(item["acquisition_execution_index"]) for item in executions]
+    _require(
+        actual_indices == expected_indices,
+        "protocol execution order is not contiguous",
+    )
+    check = _doctor_check(
+        "protocol_schedule",
+        "pass",
+        "Protocol execution order is contiguous.",
+        execution_count=len(executions),
+    )
+    return protocol_id, str(design_sha), executions, check
+
+
+def frozen_checkout_check(
+    repository: Path,
+    dataset: Path,
+    method_freeze_path: str | Path | None,
+) -> dict[str, Any]:
+    freeze_path = Path(method_freeze_path or dataset / "method_freeze.json")
+    try:
+        from causal4d.real_experiment_freeze import (
+            load_method_freeze_manifest,
+            validate_method_freeze_manifest,
+            validate_repository_checkout,
+        )
+
+        freeze = load_method_freeze_manifest(freeze_path)
+        freeze_validation = validate_method_freeze_manifest(
+            freeze,
+            repository,
+            verify_files=True,
+        )
+        checkout = validate_repository_checkout(freeze, repository)
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        return _doctor_check(
+            "frozen_checkout",
+            "fail",
+            f"Frozen checkout validation failed: {error}",
+            method_freeze_path=str(freeze_path),
+        )
+    return _doctor_check(
+        "frozen_checkout",
+        "pass",
+        "Checkout and locked files match the method freeze.",
+        method_freeze_path=str(freeze_path),
+        freeze_validation=freeze_validation,
+        checkout=checkout,
+    )
+
+
+def readiness_check(
+    protocol: Mapping[str, Any],
+    dataset: Path,
+    readiness_path: str | Path | None,
+) -> dict[str, Any]:
+    readiness_file = Path(readiness_path or dataset / "preacquisition-readiness.json")
+    try:
+        readiness = _validate_readiness_report(
+            _load_json_object(readiness_file, name="pre-acquisition readiness report"),
+            protocol,
+        )
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        return _doctor_check(
+            "sealed_readiness",
+            "fail",
+            f"Sealed readiness validation failed: {error}",
+            readiness_path=str(readiness_file),
+        )
+    relocated = Path(str(readiness.get("dataset_root", dataset))) != dataset.resolve()
+    return _doctor_check(
+        "sealed_readiness",
+        "warn" if relocated else "pass",
+        (
+            "Readiness evidence is valid; dataset path differs because the archive "
+            "was relocated."
+            if relocated
+            else "Readiness evidence is valid and permits confirmatory collection."
+        ),
+        readiness_path=str(readiness_file),
+        evidence_sha256=readiness["evidence_sha256"],
+        relocated=relocated,
+    )
+
+
+def storage_checks(
+    dataset: Path,
+    settings: DoctorThresholds,
+    *,
+    perform_write_probe: bool,
+) -> list[dict[str, Any]]:
+    checks: list[dict[str, Any]] = []
+    usage = shutil.disk_usage(dataset)
+    capacity_status: CheckStatus = (
+        "pass" if usage.free >= settings.minimum_free_bytes else "fail"
+    )
+    checks.append(
+        _doctor_check(
+            "storage_capacity",
+            capacity_status,
+            (
+                "Free storage meets the configured threshold."
+                if capacity_status == "pass"
+                else "Free storage is below the configured threshold."
+            ),
+            free_bytes=usage.free,
+            minimum_free_bytes=settings.minimum_free_bytes,
+        )
+    )
+
+    if perform_write_probe and settings.write_probe_bytes > 0:
+        try:
+            write_rate = _measure_write_rate(dataset, settings.write_probe_bytes)
+        except (OSError, ValueError) as error:
+            checks.append(
+                _doctor_check(
+                    "storage_write_probe",
+                    "fail",
+                    f"Storage write probe failed: {error}",
+                    write_probe_bytes=settings.write_probe_bytes,
+                )
+            )
+        else:
+            write_status: CheckStatus = (
+                "pass" if write_rate >= settings.minimum_write_mib_s else "fail"
+            )
+            checks.append(
+                _doctor_check(
+                    "storage_write_probe",
+                    write_status,
+                    (
+                        "Storage write rate meets the configured threshold."
+                        if write_status == "pass"
+                        else "Storage write rate is below the configured threshold."
+                    ),
+                    write_mib_s=write_rate,
+                    minimum_write_mib_s=settings.minimum_write_mib_s,
+                    write_probe_bytes=settings.write_probe_bytes,
+                )
+            )
+    else:
+        checks.append(
+            _doctor_check(
+                "storage_write_probe",
+                "skipped",
+                "Storage write probe was disabled.",
+            )
+        )
+    return checks

--- a/src/causal4d/acquisition_doctor_progress.py
+++ b/src/causal4d/acquisition_doctor_progress.py
@@ -1,0 +1,300 @@
+"""Evidence, execution-order, and recovery checks for acquisition."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from causal4d.acquisition_flight_common import _require, journal_seal_path
+from causal4d.acquisition_journal import validate_acquisition_journal
+from causal4d.acquisition_doctor_support import (
+    _doctor_check,
+    _execution_progress_from_status,
+)
+
+
+def evidence_check(
+    protocol: Mapping[str, Any],
+    repository: Path,
+    dataset: Path,
+) -> tuple[dict[str, Any], list[str], list[dict[str, Any]], list[str]]:
+    try:
+        from causal4d.real_evidence_contract_v2 import build_real_evidence_status
+
+        evidence_status = build_real_evidence_status(
+            protocol,
+            dataset,
+            repository_root=repository,
+            verify_file_hashes=True,
+        )
+        completed, malformed, present = _execution_progress_from_status(
+            protocol,
+            evidence_status,
+        )
+        prerequisites = evidence_status.get("prerequisites")
+        _require(
+            isinstance(prerequisites, Mapping),
+            "real evidence status lacks prerequisites",
+        )
+        invalid_prerequisites = [
+            str(name)
+            for name, result in prerequisites.items()
+            if not isinstance(result, Mapping) or result.get("valid") is not True
+        ]
+        structural_errors = {
+            "invalid_prerequisites": invalid_prerequisites,
+            "invalid_session_ids": list(
+                evidence_status.get("invalid_session_ids", [])
+            ),
+            "unexpected_execution_directories": list(
+                evidence_status.get("unexpected_execution_directories", [])
+            ),
+            "unexpected_session_directories": list(
+                evidence_status.get("unexpected_session_directories", [])
+            ),
+        }
+        structural_errors = {
+            key: value for key, value in structural_errors.items() if value
+        }
+        _require(
+            evidence_status.get("file_hashes_requested") is True,
+            "real evidence status omitted file hash verification",
+        )
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        return (
+            _doctor_check(
+                "real_evidence_status",
+                "fail",
+                f"Registered evidence validation failed: {error}",
+            ),
+            [],
+            [],
+            [],
+        )
+    return (
+        _doctor_check(
+            "real_evidence_status",
+            "fail" if structural_errors else "pass",
+            (
+                "Registered evidence has invalid prerequisites or directories."
+                if structural_errors
+                else "Registered evidence and referenced file hashes validate."
+            ),
+            specified_executions=evidence_status["specified_executions"],
+            manifest_executions=evidence_status["manifest_executions"],
+            acquired_executions=evidence_status["acquired_executions"],
+            validated_executions=evidence_status["validated_executions"],
+            structural_errors=structural_errors,
+        ),
+        completed,
+        malformed,
+        present,
+    )
+
+
+def manifest_check(
+    executions: Sequence[Mapping[str, Any]],
+    completed: list[str],
+    malformed: list[dict[str, Any]],
+    present: list[str],
+) -> tuple[dict[str, Any], Mapping[str, Any] | None]:
+    completed_set = set(completed)
+    next_execution = next(
+        (
+            execution
+            for execution in executions
+            if execution["execution_id"] not in completed_set
+        ),
+        None,
+    )
+    if malformed:
+        return (
+            _doctor_check(
+                "execution_manifests",
+                "fail",
+                "One or more execution manifests are present but not explicitly "
+                "complete.",
+                malformed=malformed,
+            ),
+            next_execution,
+        )
+    expected_prefix = [
+        str(execution["execution_id"]) for execution in executions[: len(completed)]
+    ]
+    if completed != expected_prefix:
+        return (
+            _doctor_check(
+                "execution_manifests",
+                "fail",
+                "Completed execution manifests do not form the locked acquisition "
+                "prefix.",
+                completed=completed,
+                expected_prefix=expected_prefix,
+                present=present,
+            ),
+            next_execution,
+        )
+    return (
+        _doctor_check(
+            "execution_manifests",
+            "pass",
+            "Completed execution manifests form the locked acquisition prefix.",
+            completed_executions=len(completed),
+            total_executions=len(executions),
+        ),
+        next_execution,
+    )
+
+
+def next_execution_checks(
+    protocol_id: str,
+    executions: Sequence[Mapping[str, Any]],
+    completed: list[str],
+    next_execution: Mapping[str, Any] | None,
+    dataset: Path,
+    *,
+    allow_resume: bool,
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None, bool]:
+    checks: list[dict[str, Any]] = []
+    if next_execution is None:
+        checks.append(
+            _doctor_check(
+                "next_execution",
+                "pass",
+                "All registered executions have complete manifests.",
+            )
+        )
+        return checks, None, False
+
+    next_summary = {
+        key: next_execution[key]
+        for key in (
+            "acquisition_execution_index",
+            "execution_id",
+            "session_id",
+            "pair_order",
+            "contact_region_id",
+            "command_profile_id",
+            "realization_condition_id",
+            "replicate_block",
+        )
+        if key in next_execution
+    }
+    execution_root = dataset / "executions" / str(next_execution["execution_id"])
+    session_root = dataset / "sessions" / str(next_execution["session_id"])
+    if execution_root.is_dir() and session_root.is_dir():
+        checks.append(
+            _doctor_check(
+                "next_execution",
+                "pass",
+                "Next execution and session directories are scaffolded.",
+                next_execution=next_summary,
+                execution_root=str(execution_root),
+                session_root=str(session_root),
+            )
+        )
+    else:
+        checks.append(
+            _doctor_check(
+                "next_execution",
+                "fail",
+                "Next execution or session directory is missing.",
+                next_execution=next_summary,
+                execution_root=str(execution_root),
+                execution_root_present=execution_root.is_dir(),
+                session_root=str(session_root),
+                session_root_present=session_root.is_dir(),
+            )
+        )
+
+    journal_requires_review = False
+    journal = session_root / "acquisition.jsonl"
+    seal = journal_seal_path(journal)
+    if seal.exists():
+        checks.append(
+            _doctor_check(
+                "session_journal",
+                "fail",
+                "The next session journal is already sealed although an execution "
+                "is incomplete.",
+                journal_path=str(journal),
+                seal_path=str(seal),
+            )
+        )
+    elif journal.exists():
+        try:
+            validation = validate_acquisition_journal(journal)
+            expected_session_id = str(next_execution["session_id"])
+            expected_execution_ids = {
+                str(execution["execution_id"])
+                for execution in executions
+                if str(execution["session_id"]) == expected_session_id
+            }
+            completed_session_ids = {
+                identifier
+                for identifier in completed
+                if identifier in expected_execution_ids
+            }
+            terminal_journal_ids = set(
+                validation["completed_execution_ids"]
+            ) | set(validation["aborted_execution_ids"])
+            _require(
+                validation["protocol_id"] == protocol_id,
+                "session journal protocol differs from the registered protocol",
+            )
+            _require(
+                validation["session_id"] == expected_session_id,
+                "session journal identifies the wrong session",
+            )
+            _require(
+                set(validation["seen_execution_ids"]) <= expected_execution_ids,
+                "session journal names an execution outside this session",
+            )
+            _require(
+                terminal_journal_ids == completed_session_ids,
+                "session journal terminal executions differ from validated manifests",
+            )
+            active_execution_id = validation["active_execution_id"]
+            _require(
+                active_execution_id is None
+                or active_execution_id == next_execution["execution_id"],
+                "session journal has the wrong active execution",
+            )
+        except (OSError, TypeError, ValueError) as error:
+            checks.append(
+                _doctor_check(
+                    "session_journal",
+                    "fail",
+                    f"Existing session journal is invalid: {error}",
+                    journal_path=str(journal),
+                )
+            )
+        else:
+            journal_requires_review = not allow_resume
+            checks.append(
+                _doctor_check(
+                    "session_journal",
+                    "warn",
+                    (
+                        "An unsealed session journal exists and resume was explicitly "
+                        "acknowledged."
+                        if allow_resume
+                        else "An unsealed session journal exists; review it and rerun "
+                        "with --allow-resume before recording."
+                    ),
+                    journal_path=str(journal),
+                    resume_acknowledged=allow_resume,
+                    validation=validation,
+                )
+            )
+    else:
+        checks.append(
+            _doctor_check(
+                "session_journal",
+                "pass",
+                "No prior journal bytes exist for the next session.",
+                journal_path=str(journal),
+            )
+        )
+    return checks, next_summary, journal_requires_review

--- a/src/causal4d/acquisition_doctor_progress.py
+++ b/src/causal4d/acquisition_doctor_progress.py
@@ -44,9 +44,7 @@ def evidence_check(
         ]
         structural_errors = {
             "invalid_prerequisites": invalid_prerequisites,
-            "invalid_session_ids": list(
-                evidence_status.get("invalid_session_ids", [])
-            ),
+            "invalid_session_ids": list(evidence_status.get("invalid_session_ids", [])),
             "unexpected_execution_directories": list(
                 evidence_status.get("unexpected_execution_directories", [])
             ),
@@ -236,9 +234,9 @@ def next_execution_checks(
                 for identifier in completed
                 if identifier in expected_execution_ids
             }
-            terminal_journal_ids = set(
-                validation["completed_execution_ids"]
-            ) | set(validation["aborted_execution_ids"])
+            terminal_journal_ids = set(validation["completed_execution_ids"]) | set(
+                validation["aborted_execution_ids"]
+            )
             _require(
                 validation["protocol_id"] == protocol_id,
                 "session journal protocol differs from the registered protocol",

--- a/src/causal4d/acquisition_doctor_support.py
+++ b/src/causal4d/acquisition_doctor_support.py
@@ -1,0 +1,186 @@
+"""Shared checks for the fail-closed acquisition doctor."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import time
+from typing import Any, Literal
+import uuid
+
+from causal4d.acquisition_flight_common import (
+    _assert_json_value,
+    _assert_ordinary_file_or_missing,
+    _require,
+)
+
+CheckStatus = Literal["pass", "warn", "fail", "skipped"]
+
+
+@dataclass(frozen=True)
+class DoctorThresholds:
+    minimum_free_bytes: int = 20 * 1024**3
+    write_probe_bytes: int = 8 * 1024**2
+    minimum_write_mib_s: float = 25.0
+
+    def __post_init__(self) -> None:
+        _require(self.minimum_free_bytes >= 0, "minimum_free_bytes must be nonnegative")
+        _require(self.write_probe_bytes >= 0, "write_probe_bytes must be nonnegative")
+        _require(
+            self.minimum_write_mib_s >= 0.0,
+            "minimum_write_mib_s must be nonnegative",
+        )
+
+
+def _doctor_check(
+    check_id: str,
+    status: CheckStatus,
+    message: str,
+    **details: Any,
+) -> dict[str, Any]:
+    return {"check_id": check_id, "status": status, "message": message, **details}
+
+
+def _measure_write_rate(directory: Path, byte_count: int) -> float:
+    if byte_count == 0:
+        return 0.0
+    path = directory / f".causal4d-write-probe-{uuid.uuid4().hex}.tmp"
+    _assert_ordinary_file_or_missing(path, name="write probe")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    block = b"\0" * min(1024 * 1024, byte_count)
+    written = 0
+    start = time.perf_counter()
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        while written < byte_count:
+            chunk = block[: min(len(block), byte_count - written)]
+            count = os.write(descriptor, chunk)
+            _require(count > 0, "storage write probe made no forward progress")
+            written += count
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+        path.unlink(missing_ok=True)
+    elapsed = max(time.perf_counter() - start, 1e-9)
+    return (written / 1024**2) / elapsed
+
+
+def _load_json_object(path: Path, *, name: str) -> dict[str, Any]:
+    _assert_ordinary_file_or_missing(path, name=name)
+    _require(path.is_file(), f"{name} does not exist")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    _require(isinstance(payload, Mapping), f"{name} must be a JSON object")
+    _assert_json_value(payload, name=name)
+    return dict(payload)
+
+
+def _execution_progress_from_status(
+    protocol: Mapping[str, Any],
+    evidence_status: Mapping[str, Any],
+) -> tuple[list[str], list[dict[str, Any]], list[str]]:
+    raw_results = evidence_status.get("executions")
+    _require(isinstance(raw_results, list), "real evidence status lacks executions")
+    by_id: dict[str, Mapping[str, Any]] = {}
+    for raw in raw_results:
+        _require(isinstance(raw, Mapping), "execution status must be an object")
+        identifier = str(raw.get("execution_id", ""))
+        _require(bool(identifier), "execution status lacks execution_id")
+        _require(identifier not in by_id, f"duplicate execution status: {identifier}")
+        by_id[identifier] = raw
+
+    completed: list[str] = []
+    malformed: list[dict[str, Any]] = []
+    present: list[str] = []
+    executions = sorted(
+        protocol.get("executions", []),
+        key=lambda item: int(item["acquisition_execution_index"]),
+    )
+    expected_ids = [str(execution["execution_id"]) for execution in executions]
+    _require(
+        set(by_id) == set(expected_ids),
+        "real evidence status execution set differs from the protocol",
+    )
+    for identifier in expected_ids:
+        result = by_id[identifier]
+        manifest_present = result.get("manifest_present") is True
+        acquired = result.get("acquired") is True
+        validated = result.get("validated") is True
+        _require(
+            not acquired or manifest_present,
+            f"acquired execution lacks a manifest: {identifier}",
+        )
+        _require(
+            not validated or acquired,
+            f"validated execution is not acquired: {identifier}",
+        )
+        if manifest_present:
+            present.append(identifier)
+        if validated:
+            completed.append(identifier)
+        elif manifest_present:
+            malformed.append(
+                {
+                    "execution_id": identifier,
+                    "acquisition_status": result.get("acquisition_status"),
+                    "error": result.get("error"),
+                }
+            )
+    return completed, malformed, present
+
+
+def _validate_readiness_report(
+    report: Mapping[str, Any],
+    protocol: Mapping[str, Any],
+) -> dict[str, Any]:
+    from causal4d.preacquisition_readiness_contracts import (
+        READINESS_ARTIFACT_KIND,
+        READINESS_SCHEMA_VERSION,
+        readiness_evidence_sha256,
+        readiness_status_sha256,
+    )
+
+    values = dict(report)
+    _require(
+        values.get("schema_version") == READINESS_SCHEMA_VERSION,
+        "wrong readiness schema",
+    )
+    _require(
+        values.get("artifact_kind") == READINESS_ARTIFACT_KIND,
+        "wrong readiness kind",
+    )
+    _require(
+        values.get("protocol_id") == protocol.get("protocol_id"),
+        "readiness protocol mismatch",
+    )
+    _require(
+        values.get("protocol_design_sha256") == protocol.get("design_sha256"),
+        "readiness protocol digest mismatch",
+    )
+    _require(
+        values.get("verify_file_hashes") is True,
+        "readiness omitted file hash checks",
+    )
+    _require(values.get("valid") is True, "readiness report is invalid")
+    _require(values.get("ready") is True, "readiness report did not pass")
+    gate = values.get("collection_gate")
+    _require(isinstance(gate, Mapping), "readiness collection gate is missing")
+    _require(
+        gate.get("first_confirmatory_execution_allowed") is True,
+        "readiness did not permit the first confirmatory execution",
+    )
+    _require(
+        values.get("evidence_sha256") == readiness_evidence_sha256(values),
+        "readiness portable evidence checksum mismatch",
+    )
+    _require(
+        values.get("status_sha256") == readiness_status_sha256(values),
+        "readiness status checksum mismatch",
+    )
+    return values

--- a/src/causal4d/acquisition_flight_common.py
+++ b/src/causal4d/acquisition_flight_common.py
@@ -1,0 +1,149 @@
+"""Shared safety and content-addressing utilities for acquisition operations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+JOURNAL_SCHEMA_VERSION = 1
+JOURNAL_EVENT_KIND = "Causal4DAcquisitionJournalEvent"
+JOURNAL_SEAL_KIND = "Causal4DAcquisitionJournalSeal"
+HEALTH_SNAPSHOT_KIND = "Causal4DAcquisitionHealthSnapshot"
+DOCTOR_REPORT_KIND = "Causal4DAcquisitionDoctorReport"
+
+_FORBIDDEN_OUTCOME_KEYS = frozenset(
+    {
+        "target_outcomes",
+        "target_metrics",
+        "held_out_metrics",
+        "prediction_error",
+        "coordinate_rmse_m",
+        "track_error_m",
+        "chamfer_distance_m",
+        "negative_log_likelihood",
+        "nll",
+        "coverage",
+        "oracle_error",
+    }
+)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _is_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _canonical_sha256(value: Mapping[str, Any], *, omitted: str) -> str:
+    payload = dict(value)
+    payload.pop(omitted, None)
+    return hashlib.sha256(_canonical_json_bytes(payload)).hexdigest()
+
+
+def _sha256_file(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+            size += len(block)
+    return digest.hexdigest(), size
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _fsync_directory(path: Path) -> None:
+    if os.name != "posix":
+        return
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _parse_utc(value: Any, *, name: str) -> datetime:
+    _require(isinstance(value, str) and bool(value), f"{name} is missing")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(f"{name} is not ISO 8601") from error
+    _require(parsed.tzinfo is not None, f"{name} must include a timezone")
+    _require(
+        parsed.utcoffset() == timezone.utc.utcoffset(parsed),
+        f"{name} must be UTC",
+    )
+    return parsed
+
+
+def _assert_json_value(value: Any, *, name: str) -> None:
+    try:
+        _canonical_json_bytes(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{name} must be finite JSON") from error
+
+
+def _walk_mapping_keys(value: Any) -> Sequence[str]:
+    keys: list[str] = []
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            keys.append(str(key))
+            keys.extend(_walk_mapping_keys(child))
+    elif isinstance(value, (list, tuple)):
+        for child in value:
+            keys.extend(_walk_mapping_keys(child))
+    return keys
+
+
+def _reject_target_outcomes(value: Any) -> None:
+    forbidden = sorted(
+        key
+        for key in _walk_mapping_keys(value)
+        if key.lower() in _FORBIDDEN_OUTCOME_KEYS
+    )
+    _require(
+        not forbidden,
+        "acquisition operations must not contain target-outcome fields: "
+        + ", ".join(forbidden),
+    )
+
+
+def _assert_no_symlink_components(path: Path, *, name: str) -> None:
+    candidate = path.absolute()
+    for component in (candidate, *candidate.parents):
+        if component.is_symlink():
+            raise ValueError(f"{name} contains a symlink component: {component}")
+
+
+def _assert_ordinary_file_or_missing(path: Path, *, name: str) -> None:
+    _assert_no_symlink_components(path, name=name)
+    if path.exists():
+        _require(path.is_file(), f"{name} must be an ordinary file")
+
+
+def journal_seal_path(journal_path: str | Path) -> Path:
+    journal = Path(journal_path)
+    return journal.with_name(f"{journal.name}.seal.json")

--- a/src/causal4d/acquisition_flight_recorder.py
+++ b/src/causal4d/acquisition_flight_recorder.py
@@ -1,0 +1,41 @@
+"""Public acquisition doctor, health, and flight-recorder surface."""
+
+from causal4d.acquisition_doctor import (
+    DOCTOR_REPORT_KIND,
+    DoctorThresholds,
+    build_acquisition_doctor_report,
+)
+from causal4d.acquisition_health import (
+    HEALTH_SNAPSHOT_KIND,
+    HealthThresholds,
+    evaluate_health_snapshot,
+)
+from causal4d.acquisition_journal import (
+    JOURNAL_EVENT_KIND,
+    JOURNAL_SCHEMA_VERSION,
+    JOURNAL_SEAL_KIND,
+    append_journal_event,
+    build_journal_event,
+    journal_seal_path,
+    seal_acquisition_journal,
+    validate_acquisition_journal,
+    validate_acquisition_journal_seal,
+)
+
+__all__ = [
+    "DOCTOR_REPORT_KIND",
+    "HEALTH_SNAPSHOT_KIND",
+    "JOURNAL_EVENT_KIND",
+    "JOURNAL_SCHEMA_VERSION",
+    "JOURNAL_SEAL_KIND",
+    "DoctorThresholds",
+    "HealthThresholds",
+    "append_journal_event",
+    "build_acquisition_doctor_report",
+    "build_journal_event",
+    "evaluate_health_snapshot",
+    "journal_seal_path",
+    "seal_acquisition_journal",
+    "validate_acquisition_journal",
+    "validate_acquisition_journal_seal",
+]

--- a/src/causal4d/acquisition_health.py
+++ b/src/causal4d/acquisition_health.py
@@ -15,6 +15,7 @@ from causal4d.acquisition_flight_common import (
     _require,
 )
 
+
 @dataclass(frozen=True)
 class HealthThresholds:
     """Operational watchdog thresholds; not scientific acceptance thresholds."""
@@ -178,7 +179,6 @@ def evaluate_health_snapshot(
         "passed": passed,
         "target_outcomes_used": False,
     }
-
 
 
 __all__ = [

--- a/src/causal4d/acquisition_health.py
+++ b/src/causal4d/acquisition_health.py
@@ -1,0 +1,188 @@
+"""Method-neutral live acquisition-health decisions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+import math
+from typing import Any
+
+from causal4d.acquisition_flight_common import (
+    HEALTH_SNAPSHOT_KIND,
+    _assert_json_value,
+    _parse_utc,
+    _reject_target_outcomes,
+    _require,
+)
+
+@dataclass(frozen=True)
+class HealthThresholds:
+    """Operational watchdog thresholds; not scientific acceptance thresholds."""
+
+    maximum_heartbeat_age_s: float = 2.0
+    maximum_clock_offset_ms: float = 5.0
+    maximum_dropped_frames: int = 0
+    minimum_free_bytes: int = 20 * 1024**3
+    minimum_write_mib_s: float = 25.0
+
+    def __post_init__(self) -> None:
+        _require(
+            self.maximum_heartbeat_age_s > 0.0,
+            "heartbeat threshold must be positive",
+        )
+        _require(
+            self.maximum_clock_offset_ms >= 0.0,
+            "clock threshold must be nonnegative",
+        )
+        _require(
+            isinstance(self.maximum_dropped_frames, int)
+            and not isinstance(self.maximum_dropped_frames, bool)
+            and self.maximum_dropped_frames >= 0,
+            "dropped-frame threshold must be a nonnegative integer",
+        )
+        _require(self.minimum_free_bytes >= 0, "minimum_free_bytes must be nonnegative")
+        _require(
+            self.minimum_write_mib_s >= 0.0,
+            "minimum_write_mib_s must be nonnegative",
+        )
+
+
+def _finite_number(value: Any, *, name: str, minimum: float | None = None) -> float:
+    _require(
+        isinstance(value, (int, float)) and not isinstance(value, bool),
+        f"{name} must be numeric",
+    )
+    result = float(value)
+    _require(math.isfinite(result), f"{name} must be finite")
+    if minimum is not None:
+        _require(result >= minimum, f"{name} must be at least {minimum}")
+    return result
+
+
+def evaluate_health_snapshot(
+    snapshot: Mapping[str, Any],
+    *,
+    thresholds: HealthThresholds | None = None,
+) -> dict[str, Any]:
+    """Evaluate a live collection-health snapshot without reading target metrics."""
+
+    settings = thresholds or HealthThresholds()
+    values = dict(snapshot)
+    _assert_json_value(values, name="health snapshot")
+    _reject_target_outcomes(values)
+    _require(values.get("schema_version") == 1, "unsupported health snapshot schema")
+    _require(values.get("artifact_kind") == HEALTH_SNAPSHOT_KIND, "wrong snapshot kind")
+    _require(
+        values.get("target_outcomes_used") is False,
+        "snapshot used target outcomes",
+    )
+    for field in ("protocol_id", "session_id"):
+        _require(
+            isinstance(values.get(field), str) and bool(values[field].strip()),
+            f"snapshot {field} must be nonempty",
+        )
+    _parse_utc(values.get("captured_at_utc"), name="captured_at_utc")
+    streams = values.get("streams")
+    _require(
+        isinstance(streams, Mapping) and bool(streams),
+        "snapshot streams are missing",
+    )
+    failures: list[str] = []
+    warnings: list[str] = []
+    stream_results: dict[str, Any] = {}
+    for stream_id, raw in sorted(streams.items(), key=lambda item: str(item[0])):
+        _require(isinstance(raw, Mapping), f"stream {stream_id} must be an object")
+        stream = dict(raw)
+        required = stream.get("required", True)
+        alive = stream.get("alive")
+        _require(
+            isinstance(required, bool),
+            f"stream {stream_id}.required must be boolean",
+        )
+        _require(isinstance(alive, bool), f"stream {stream_id}.alive must be boolean")
+        heartbeat = _finite_number(
+            stream.get("heartbeat_age_s"),
+            name=f"stream {stream_id}.heartbeat_age_s",
+            minimum=0.0,
+        )
+        dropped = stream.get("dropped_frames", 0)
+        _require(
+            isinstance(dropped, int) and not isinstance(dropped, bool) and dropped >= 0,
+            f"stream {stream_id}.dropped_frames must be nonnegative integer",
+        )
+        clock_offset = stream.get("clock_offset_ms")
+        if clock_offset is not None:
+            clock_offset = _finite_number(
+                clock_offset,
+                name=f"stream {stream_id}.clock_offset_ms",
+            )
+        issues = []
+        if required and not alive:
+            issues.append("required_stream_not_alive")
+        if required and heartbeat > settings.maximum_heartbeat_age_s:
+            issues.append("required_stream_heartbeat_stale")
+        if required and dropped > settings.maximum_dropped_frames:
+            issues.append("dropped_frame_limit_exceeded")
+        if (
+            required
+            and clock_offset is not None
+            and abs(clock_offset) > settings.maximum_clock_offset_ms
+        ):
+            issues.append("clock_offset_limit_exceeded")
+        if issues:
+            failures.extend(f"stream:{stream_id}:{issue}" for issue in issues)
+        elif not required and (
+            not alive or heartbeat > settings.maximum_heartbeat_age_s
+        ):
+            warnings.append(f"optional_stream:{stream_id}:unhealthy")
+        stream_results[str(stream_id)] = {
+            "required": required,
+            "alive": alive,
+            "heartbeat_age_s": heartbeat,
+            "dropped_frames": dropped,
+            "clock_offset_ms": clock_offset,
+            "issues": issues,
+        }
+
+    storage = values.get("storage")
+    _require(isinstance(storage, Mapping), "snapshot storage is missing")
+    free_bytes = storage.get("free_bytes")
+    _require(
+        isinstance(free_bytes, int)
+        and not isinstance(free_bytes, bool)
+        and free_bytes >= 0,
+        "storage.free_bytes must be a nonnegative integer",
+    )
+    write_rate = _finite_number(
+        storage.get("write_mib_s"),
+        name="storage.write_mib_s",
+        minimum=0.0,
+    )
+    if free_bytes < settings.minimum_free_bytes:
+        failures.append("storage:free_space_below_threshold")
+    if write_rate < settings.minimum_write_mib_s:
+        failures.append("storage:write_rate_below_threshold")
+    passed = not failures
+    return {
+        "schema_version": 1,
+        "artifact_kind": "Causal4DAcquisitionHealthDecision",
+        "protocol_id": values["protocol_id"],
+        "session_id": values["session_id"],
+        "execution_id": values.get("execution_id"),
+        "captured_at_utc": values["captured_at_utc"],
+        "thresholds": asdict(settings),
+        "streams": stream_results,
+        "storage": {"free_bytes": free_bytes, "write_mib_s": write_rate},
+        "failures": failures,
+        "warnings": warnings,
+        "passed": passed,
+        "target_outcomes_used": False,
+    }
+
+
+
+__all__ = [
+    "HEALTH_SNAPSHOT_KIND",
+    "HealthThresholds",
+    "evaluate_health_snapshot",
+]

--- a/src/causal4d/acquisition_journal.py
+++ b/src/causal4d/acquisition_journal.py
@@ -1,0 +1,29 @@
+"""Public append-only acquisition journal surface."""
+
+from causal4d.acquisition_flight_common import (
+    JOURNAL_EVENT_KIND,
+    JOURNAL_SCHEMA_VERSION,
+    JOURNAL_SEAL_KIND,
+    journal_seal_path,
+)
+from causal4d.acquisition_journal_io import (
+    append_journal_event,
+    validate_acquisition_journal,
+)
+from causal4d.acquisition_journal_model import build_journal_event
+from causal4d.acquisition_journal_seal import (
+    seal_acquisition_journal,
+    validate_acquisition_journal_seal,
+)
+
+__all__ = [
+    "JOURNAL_EVENT_KIND",
+    "JOURNAL_SCHEMA_VERSION",
+    "JOURNAL_SEAL_KIND",
+    "append_journal_event",
+    "build_journal_event",
+    "journal_seal_path",
+    "seal_acquisition_journal",
+    "validate_acquisition_journal",
+    "validate_acquisition_journal_seal",
+]

--- a/src/causal4d/acquisition_journal_io.py
+++ b/src/causal4d/acquisition_journal_io.py
@@ -115,9 +115,7 @@ def append_journal_event(
                     "completed_execution_ids": list(
                         validation["completed_execution_ids"]
                     ),
-                    "aborted_execution_ids": list(
-                        validation["aborted_execution_ids"]
-                    ),
+                    "aborted_execution_ids": list(validation["aborted_execution_ids"]),
                 }
                 _require(
                     last["event_type"] not in _FINAL_EVENT_TYPES,

--- a/src/causal4d/acquisition_journal_io.py
+++ b/src/causal4d/acquisition_journal_io.py
@@ -1,0 +1,247 @@
+"""Durable append and validation for the acquisition journal."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from causal4d.acquisition_flight_common import (
+    JOURNAL_SCHEMA_VERSION,
+    _assert_no_symlink_components,
+    _assert_ordinary_file_or_missing,
+    _canonical_json_bytes,
+    _fsync_directory,
+    _require,
+    _sha256_file,
+    journal_seal_path,
+)
+from causal4d.acquisition_journal_model import (
+    _FINAL_EVENT_TYPES,
+    _advance_journal_state,
+    _empty_journal_state,
+    _journal_state,
+    _validate_event_shape,
+    build_journal_event,
+)
+
+
+def _last_nonempty_line(handle: Any) -> str | None:
+    handle.seek(0, os.SEEK_END)
+    position = handle.tell()
+    if position == 0:
+        return None
+    block_size = 8192
+    data = b""
+    while position > 0:
+        read_size = min(block_size, position)
+        position -= read_size
+        handle.seek(position)
+        data = handle.read(read_size) + data
+        lines = data.splitlines()
+        complete_lines = lines if position == 0 else lines[1:]
+        for line in reversed(complete_lines):
+            if not line.strip():
+                continue
+            try:
+                return line.decode("utf-8")
+            except UnicodeDecodeError as error:
+                raise ValueError("journal ends with invalid UTF-8") from error
+    return None
+
+
+def append_journal_event(
+    journal_path: str | Path,
+    *,
+    protocol_id: str,
+    session_id: str,
+    event_type: str,
+    source: str,
+    execution_id: str | None = None,
+    payload: Mapping[str, Any] | None = None,
+    recorded_at_utc: str | None = None,
+    monotonic_ns: int | None = None,
+) -> dict[str, Any]:
+    """Append one fsync'ed, hash-chained event without replacing prior bytes."""
+
+    path = Path(journal_path)
+    seal = journal_seal_path(path)
+    _assert_ordinary_file_or_missing(path, name="acquisition journal")
+    _assert_ordinary_file_or_missing(seal, name="acquisition journal seal")
+    _require(not seal.exists(), "acquisition journal is sealed")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _assert_no_symlink_components(path.parent, name="acquisition journal parent")
+
+    flags = os.O_RDWR | os.O_APPEND | os.O_CREAT
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags, 0o640)
+    try:
+        with os.fdopen(descriptor, "r+b") as handle:
+            try:
+                import fcntl
+            except ImportError:  # pragma: no cover - Windows fallback
+                fcntl = None
+            if fcntl is not None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            _require(not seal.exists(), "acquisition journal is sealed")
+            last_line = _last_nonempty_line(handle)
+            if last_line is None:
+                sequence = 0
+                previous = None
+                state = _empty_journal_state()
+            else:
+                validation = validate_acquisition_journal(path)
+                try:
+                    last = _validate_event_shape(json.loads(last_line))
+                except json.JSONDecodeError as error:
+                    raise ValueError("journal ends with invalid JSON") from error
+                _require(
+                    last["event_sha256"] == validation["final_event_sha256"],
+                    "journal tail differs from the validated hash chain",
+                )
+                _require(last["protocol_id"] == protocol_id, "journal protocol changed")
+                _require(last["session_id"] == session_id, "journal session changed")
+                sequence = int(last["sequence"]) + 1
+                previous = str(last["event_sha256"])
+                state = {
+                    "active_execution_id": validation["active_execution_id"],
+                    "recovery_active": validation["recovery_active"],
+                    "seen_execution_ids": list(validation["seen_execution_ids"]),
+                    "completed_execution_ids": list(
+                        validation["completed_execution_ids"]
+                    ),
+                    "aborted_execution_ids": list(
+                        validation["aborted_execution_ids"]
+                    ),
+                }
+                _require(
+                    last["event_type"] not in _FINAL_EVENT_TYPES,
+                    "cannot append after a terminal session event",
+                )
+                if monotonic_ns is not None:
+                    _require(
+                        monotonic_ns >= int(last["monotonic_ns"]),
+                        "journal monotonic clock moved backward",
+                    )
+            event = build_journal_event(
+                protocol_id=protocol_id,
+                session_id=session_id,
+                execution_id=execution_id,
+                event_type=event_type,
+                source=source,
+                sequence=sequence,
+                previous_event_sha256=previous,
+                payload=payload,
+                recorded_at_utc=recorded_at_utc,
+                monotonic_ns=monotonic_ns,
+            )
+            _advance_journal_state(state, event, event_index=sequence)
+            handle.seek(0, os.SEEK_END)
+            handle.write(_canonical_json_bytes(event) + b"\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+            if fcntl is not None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except Exception:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        raise
+    _fsync_directory(path.parent)
+    return event
+
+
+def validate_acquisition_journal(journal_path: str | Path) -> dict[str, Any]:
+    """Validate every event, the hash chain, and the session-level invariants."""
+
+    path = Path(journal_path)
+    _assert_ordinary_file_or_missing(path, name="acquisition journal")
+    _require(path.is_file(), "acquisition journal does not exist")
+    events: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            _require(bool(line.strip()), f"blank journal line at {line_number}")
+            try:
+                event = _validate_event_shape(json.loads(line))
+            except json.JSONDecodeError as error:
+                raise ValueError(
+                    f"invalid journal JSON at line {line_number}"
+                ) from error
+            if not events:
+                _require(event["sequence"] == 0, "journal must begin at sequence zero")
+                _require(
+                    event["previous_event_sha256"] is None,
+                    "first journal event must not have a predecessor",
+                )
+                _require(
+                    event["event_type"] == "session_started",
+                    "journal must begin with session_started",
+                )
+            else:
+                previous = events[-1]
+                _require(
+                    event["sequence"] == previous["sequence"] + 1,
+                    f"journal sequence gap at line {line_number}",
+                )
+                _require(
+                    event["previous_event_sha256"] == previous["event_sha256"],
+                    f"journal hash-chain mismatch at line {line_number}",
+                )
+                _require(
+                    event["protocol_id"] == previous["protocol_id"],
+                    "journal protocol changed",
+                )
+                _require(
+                    event["session_id"] == previous["session_id"],
+                    "journal session changed",
+                )
+                _require(
+                    event["monotonic_ns"] >= previous["monotonic_ns"],
+                    f"monotonic clock moved backward at line {line_number}",
+                )
+                _require(
+                    previous["event_type"] not in _FINAL_EVENT_TYPES,
+                    "journal contains events after terminal session event",
+                )
+            events.append(event)
+    _require(events, "acquisition journal is empty")
+    state = _journal_state(events)
+    digest, size = _sha256_file(path)
+    first = events[0]
+    last = events[-1]
+    execution_ids = sorted(
+        {
+            str(event["execution_id"])
+            for event in events
+            if event.get("execution_id") is not None
+        }
+    )
+    return {
+        "schema_version": JOURNAL_SCHEMA_VERSION,
+        "artifact_kind": "Causal4DAcquisitionJournalValidation",
+        "valid": True,
+        "protocol_id": first["protocol_id"],
+        "session_id": first["session_id"],
+        "event_count": len(events),
+        "execution_ids": execution_ids,
+        "seen_execution_ids": list(state["seen_execution_ids"]),
+        "completed_execution_ids": list(state["completed_execution_ids"]),
+        "aborted_execution_ids": list(state["aborted_execution_ids"]),
+        "active_execution_id": state["active_execution_id"],
+        "recovery_active": state["recovery_active"],
+        "first_event_type": first["event_type"],
+        "last_event_type": last["event_type"],
+        "first_recorded_at_utc": first["recorded_at_utc"],
+        "last_recorded_at_utc": last["recorded_at_utc"],
+        "final_event_sha256": last["event_sha256"],
+        "journal_sha256": digest,
+        "journal_bytes": size,
+        "terminal": last["event_type"] in _FINAL_EVENT_TYPES,
+        "target_outcomes_used": False,
+    }

--- a/src/causal4d/acquisition_journal_model.py
+++ b/src/causal4d/acquisition_journal_model.py
@@ -1,0 +1,223 @@
+"""Schema and state machine for the acquisition flight-recorder journal."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import time
+from typing import Any, Literal
+
+from causal4d.acquisition_flight_common import (
+    JOURNAL_EVENT_KIND,
+    JOURNAL_SCHEMA_VERSION,
+    _assert_json_value,
+    _canonical_sha256,
+    _is_sha256,
+    _parse_utc,
+    _reject_target_outcomes,
+    _require,
+    _utc_now,
+)
+
+JournalOutcome = Literal["completed", "aborted"]
+
+_ALLOWED_EVENT_TYPES = frozenset(
+    {
+        "session_started",
+        "execution_started",
+        "stream_heartbeat",
+        "clock_offset_sample",
+        "storage_sample",
+        "technical_warning",
+        "technical_failure",
+        "operator_note",
+        "artifact_closed",
+        "execution_completed",
+        "execution_aborted",
+        "recovery_started",
+        "recovery_completed",
+        "session_completed",
+        "session_aborted",
+    }
+)
+_FINAL_EVENT_TYPES: dict[str, JournalOutcome] = {
+    "session_completed": "completed",
+    "session_aborted": "aborted",
+}
+
+
+def _validate_event_shape(event: Mapping[str, Any]) -> dict[str, Any]:
+    payload = dict(event)
+    _require(
+        payload.get("schema_version") == JOURNAL_SCHEMA_VERSION,
+        "unsupported journal event schema",
+    )
+    _require(payload.get("artifact_kind") == JOURNAL_EVENT_KIND, "wrong event kind")
+    for field in ("protocol_id", "session_id", "event_type", "source"):
+        _require(
+            isinstance(payload.get(field), str) and bool(payload[field].strip()),
+            f"journal event {field} must be nonempty",
+        )
+    _require(
+        payload["event_type"] in _ALLOWED_EVENT_TYPES,
+        f"unsupported journal event type: {payload['event_type']}",
+    )
+    execution_id = payload.get("execution_id")
+    _require(
+        execution_id is None
+        or (isinstance(execution_id, str) and bool(execution_id.strip())),
+        "execution_id must be null or nonempty",
+    )
+    sequence = payload.get("sequence")
+    _require(
+        isinstance(sequence, int) and not isinstance(sequence, bool) and sequence >= 0,
+        "journal sequence must be a nonnegative integer",
+    )
+    monotonic_ns = payload.get("monotonic_ns")
+    _require(
+        isinstance(monotonic_ns, int)
+        and not isinstance(monotonic_ns, bool)
+        and monotonic_ns >= 0,
+        "journal monotonic_ns must be a nonnegative integer",
+    )
+    _parse_utc(payload.get("recorded_at_utc"), name="recorded_at_utc")
+    previous = payload.get("previous_event_sha256")
+    _require(
+        previous is None or _is_sha256(previous),
+        "previous_event_sha256 must be null or lowercase SHA-256",
+    )
+    _require(
+        isinstance(payload.get("payload"), Mapping),
+        "event payload must be an object",
+    )
+    _assert_json_value(payload["payload"], name="event payload")
+    _reject_target_outcomes(payload["payload"])
+    event_sha = payload.get("event_sha256")
+    _require(_is_sha256(event_sha), "event_sha256 must be lowercase SHA-256")
+    _require(
+        event_sha == _canonical_sha256(payload, omitted="event_sha256"),
+        "journal event checksum mismatch",
+    )
+    return payload
+
+
+def _empty_journal_state() -> dict[str, Any]:
+    return {
+        "active_execution_id": None,
+        "recovery_active": False,
+        "seen_execution_ids": [],
+        "completed_execution_ids": [],
+        "aborted_execution_ids": [],
+    }
+
+
+def _advance_journal_state(
+    state: dict[str, Any],
+    event: Mapping[str, Any],
+    *,
+    event_index: int,
+) -> None:
+    event_type = str(event["event_type"])
+    execution_id = event.get("execution_id")
+    if event_index == 0:
+        _require(
+            event_type == "session_started",
+            "journal must begin with session_started",
+        )
+        _require(execution_id is None, "session_started must not name an execution")
+        return
+
+    _require(event_type != "session_started", "session_started may appear only once")
+    active = state["active_execution_id"]
+    if event_type == "execution_started":
+        _require(execution_id is not None, "execution_started requires execution_id")
+        _require(active is None, "another execution is already active")
+        _require(
+            execution_id not in state["seen_execution_ids"],
+            "an execution may not be restarted under the same registered ID",
+        )
+        state["seen_execution_ids"].append(execution_id)
+        state["active_execution_id"] = execution_id
+        return
+
+    if event_type in {"execution_completed", "execution_aborted"}:
+        _require(execution_id is not None, f"{event_type} requires execution_id")
+        _require(active is not None, f"{event_type} requires an active execution")
+        _require(execution_id == active, f"{event_type} names the wrong execution")
+        destination = (
+            "completed_execution_ids"
+            if event_type == "execution_completed"
+            else "aborted_execution_ids"
+        )
+        state[destination].append(execution_id)
+        state["active_execution_id"] = None
+        return
+
+    if event_type == "recovery_started":
+        _require(not state["recovery_active"], "recovery is already active")
+        state["recovery_active"] = True
+        return
+
+    if event_type == "recovery_completed":
+        _require(state["recovery_active"], "recovery_completed lacks recovery_started")
+        state["recovery_active"] = False
+        return
+
+    if event_type in _FINAL_EVENT_TYPES:
+        _require(execution_id is None, f"{event_type} must not name an execution")
+        _require(active is None, "session cannot end while an execution is active")
+        _require(
+            not state["recovery_active"],
+            "session cannot end while recovery is active",
+        )
+        if event_type == "session_completed":
+            _require(
+                bool(state["completed_execution_ids"]),
+                "session_completed requires at least one completed execution",
+            )
+        return
+
+    if execution_id is not None:
+        _require(
+            execution_id in state["seen_execution_ids"],
+            "journal event names an execution that was not started",
+        )
+
+
+def _journal_state(events: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    state = _empty_journal_state()
+    for event_index, event in enumerate(events):
+        _advance_journal_state(state, event, event_index=event_index)
+    return state
+
+
+def build_journal_event(
+    *,
+    protocol_id: str,
+    session_id: str,
+    event_type: str,
+    source: str,
+    sequence: int,
+    previous_event_sha256: str | None,
+    execution_id: str | None = None,
+    payload: Mapping[str, Any] | None = None,
+    recorded_at_utc: str | None = None,
+    monotonic_ns: int | None = None,
+) -> dict[str, Any]:
+    """Build one content-addressed event for an append-only acquisition journal."""
+
+    event: dict[str, Any] = {
+        "schema_version": JOURNAL_SCHEMA_VERSION,
+        "artifact_kind": JOURNAL_EVENT_KIND,
+        "protocol_id": protocol_id,
+        "session_id": session_id,
+        "execution_id": execution_id,
+        "sequence": sequence,
+        "recorded_at_utc": recorded_at_utc or _utc_now(),
+        "monotonic_ns": time.monotonic_ns() if monotonic_ns is None else monotonic_ns,
+        "event_type": event_type,
+        "source": source,
+        "payload": dict(payload or {}),
+        "previous_event_sha256": previous_event_sha256,
+    }
+    event["event_sha256"] = _canonical_sha256(event, omitted="event_sha256")
+    return _validate_event_shape(event)

--- a/src/causal4d/acquisition_journal_seal.py
+++ b/src/causal4d/acquisition_journal_seal.py
@@ -1,0 +1,136 @@
+"""Exactly-once sealing for acquisition journals."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from causal4d.atomic_io import atomic_write_json
+from causal4d.acquisition_flight_common import (
+    JOURNAL_SCHEMA_VERSION,
+    JOURNAL_SEAL_KIND,
+    _assert_ordinary_file_or_missing,
+    _canonical_sha256,
+    _is_sha256,
+    _parse_utc,
+    _require,
+    _utc_now,
+    journal_seal_path,
+)
+from causal4d.acquisition_journal_io import validate_acquisition_journal
+from causal4d.acquisition_journal_model import _FINAL_EVENT_TYPES
+
+
+def seal_acquisition_journal(
+    journal_path: str | Path,
+    *,
+    sealed_by: str,
+    sealed_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Seal a terminal journal exactly once with a portable content identity."""
+
+    _require(
+        isinstance(sealed_by, str) and bool(sealed_by.strip()),
+        "sealed_by must be nonempty",
+    )
+    journal = Path(journal_path)
+    seal_path = journal_seal_path(journal)
+    _assert_ordinary_file_or_missing(journal, name="acquisition journal")
+    _require(journal.is_file(), "acquisition journal does not exist")
+    _assert_ordinary_file_or_missing(seal_path, name="acquisition journal seal")
+    _require(not seal_path.exists(), "acquisition journal seal already exists")
+    flags = os.O_RDONLY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(journal, flags)
+    with os.fdopen(descriptor, "rb") as handle:
+        try:
+            import fcntl
+        except ImportError:  # pragma: no cover - Windows fallback
+            fcntl = None
+        if fcntl is not None:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        _require(not seal_path.exists(), "acquisition journal seal already exists")
+        validation = validate_acquisition_journal(journal)
+        last_event_type = str(validation["last_event_type"])
+        _require(
+            last_event_type in _FINAL_EVENT_TYPES,
+            "journal must end with session_completed or session_aborted before sealing",
+        )
+        timestamp = sealed_at_utc or _utc_now()
+        _parse_utc(timestamp, name="sealed_at_utc")
+        seal: dict[str, Any] = {
+            "schema_version": JOURNAL_SCHEMA_VERSION,
+            "artifact_kind": JOURNAL_SEAL_KIND,
+            "status": "sealed",
+            "protocol_id": validation["protocol_id"],
+            "session_id": validation["session_id"],
+            "execution_ids": validation["execution_ids"],
+            "event_count": validation["event_count"],
+            "journal_sha256": validation["journal_sha256"],
+            "journal_bytes": validation["journal_bytes"],
+            "final_event_sha256": validation["final_event_sha256"],
+            "session_outcome": _FINAL_EVENT_TYPES[last_event_type],
+            "sealed_by": sealed_by.strip(),
+            "sealed_at_utc": timestamp,
+            "target_outcomes_used": False,
+        }
+        seal["seal_sha256"] = _canonical_sha256(seal, omitted="seal_sha256")
+        atomic_write_json(seal_path, seal, overwrite=False)
+        if fcntl is not None:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    return seal
+
+
+def validate_acquisition_journal_seal(journal_path: str | Path) -> dict[str, Any]:
+    """Reopen the deterministic seal and prove that journal bytes did not change."""
+
+    journal = Path(journal_path)
+    seal_path = journal_seal_path(journal)
+    _assert_ordinary_file_or_missing(seal_path, name="acquisition journal seal")
+    _require(seal_path.is_file(), "acquisition journal seal does not exist")
+    payload = json.loads(seal_path.read_text(encoding="utf-8"))
+    _require(isinstance(payload, Mapping), "journal seal must be a JSON object")
+    seal = dict(payload)
+    _require(seal.get("schema_version") == JOURNAL_SCHEMA_VERSION, "wrong seal schema")
+    _require(seal.get("artifact_kind") == JOURNAL_SEAL_KIND, "wrong seal kind")
+    _require(seal.get("status") == "sealed", "journal seal is not sealed")
+    _require(
+        seal.get("target_outcomes_used") is False,
+        "journal seal used target outcomes",
+    )
+    _parse_utc(seal.get("sealed_at_utc"), name="sealed_at_utc")
+    _require(
+        isinstance(seal.get("sealed_by"), str) and bool(seal["sealed_by"].strip()),
+        "journal seal signer is missing",
+    )
+    _require(_is_sha256(seal.get("seal_sha256")), "invalid seal SHA-256")
+    _require(
+        seal["seal_sha256"] == _canonical_sha256(seal, omitted="seal_sha256"),
+        "journal seal checksum mismatch",
+    )
+    validation = validate_acquisition_journal(journal)
+    for field in (
+        "protocol_id",
+        "session_id",
+        "execution_ids",
+        "event_count",
+        "journal_sha256",
+        "journal_bytes",
+        "final_event_sha256",
+    ):
+        _require(
+            seal.get(field) == validation.get(field),
+            f"journal seal {field} mismatch",
+        )
+    expected_outcome = _FINAL_EVENT_TYPES.get(str(validation["last_event_type"]))
+    _require(
+        seal.get("session_outcome") == expected_outcome,
+        "journal outcome mismatch",
+    )
+    return {**seal, "valid": True, "seal_path": str(seal_path)}

--- a/src/causal4d/cli/acquisition_operations.py
+++ b/src/causal4d/cli/acquisition_operations.py
@@ -1,0 +1,218 @@
+"""Operate the method-neutral acquisition doctor and flight recorder."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+from causal4d.acquisition_flight_recorder import (
+    DoctorThresholds,
+    HealthThresholds,
+    append_journal_event,
+    build_acquisition_doctor_report,
+    evaluate_health_snapshot,
+    seal_acquisition_journal,
+    validate_acquisition_journal,
+    validate_acquisition_journal_seal,
+)
+from causal4d.atomic_io import atomic_write_json
+from causal4d.real_protocol import validate_protocol
+
+
+def _json_object(path: Path, *, name: str) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{name} must contain a JSON object")
+    return payload
+
+
+def _gib(value: str | float) -> int:
+    amount = float(value)
+    if amount < 0.0:
+        raise argparse.ArgumentTypeError("GiB values must be nonnegative")
+    return int(amount * 1024**3)
+
+
+def _mib(value: str | float) -> int:
+    amount = float(value)
+    if amount < 0.0:
+        raise argparse.ArgumentTypeError("MiB values must be nonnegative")
+    return int(amount * 1024**2)
+
+
+def _add_doctor(subparsers: Any) -> None:
+    parser = subparsers.add_parser(
+        "doctor",
+        help="verify the frozen checkout, readiness, storage, and next execution",
+    )
+    parser.add_argument("protocol_json", type=Path)
+    parser.add_argument("repository_root", type=Path)
+    parser.add_argument("dataset_root", type=Path)
+    parser.add_argument("--readiness-json", type=Path)
+    parser.add_argument("--method-freeze", type=Path)
+    parser.add_argument("--minimum-free-gib", type=_gib, default=_gib(20.0))
+    parser.add_argument("--write-probe-mib", type=_mib, default=_mib(8.0))
+    parser.add_argument("--minimum-write-mib-s", type=float, default=25.0)
+    parser.add_argument("--skip-write-probe", action="store_true")
+    parser.add_argument("--output-json", type=Path)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--allow-resume", action="store_true")
+    parser.add_argument("--require-ready", action="store_true")
+
+
+def _add_journal(subparsers: Any) -> None:
+    journal = subparsers.add_parser(
+        "journal",
+        help="append, validate, or seal a hash-chained acquisition journal",
+    )
+    operations = journal.add_subparsers(dest="journal_command", required=True)
+
+    append = operations.add_parser("append", help="append one fsync'ed journal event")
+    append.add_argument("journal", type=Path)
+    append.add_argument("event_type")
+    append.add_argument("--protocol-id", required=True)
+    append.add_argument("--session-id", required=True)
+    append.add_argument("--execution-id")
+    append.add_argument("--source", required=True)
+    append.add_argument("--payload-json", type=Path)
+    append.add_argument("--recorded-at-utc")
+    append.add_argument("--monotonic-ns", type=int)
+
+    validate = operations.add_parser("validate", help="validate the entire hash chain")
+    validate.add_argument("journal", type=Path)
+    validate.add_argument("--require-sealed", action="store_true")
+
+    seal = operations.add_parser("seal", help="seal a terminal journal exactly once")
+    seal.add_argument("journal", type=Path)
+    seal.add_argument("--sealed-by", required=True)
+    seal.add_argument("--sealed-at-utc")
+
+
+def _add_snapshot(subparsers: Any) -> None:
+    snapshot = subparsers.add_parser(
+        "snapshot",
+        help="evaluate one live collection-health snapshot",
+    )
+    snapshot.add_argument("snapshot_json", type=Path)
+    snapshot.add_argument("--maximum-heartbeat-age-s", type=float, default=2.0)
+    snapshot.add_argument("--maximum-clock-offset-ms", type=float, default=5.0)
+    snapshot.add_argument("--maximum-dropped-frames", type=int, default=0)
+    snapshot.add_argument("--minimum-free-gib", type=_gib, default=_gib(20.0))
+    snapshot.add_argument("--minimum-write-mib-s", type=float, default=25.0)
+    snapshot.add_argument("--require-healthy", action="store_true")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    _add_doctor(subparsers)
+    _add_journal(subparsers)
+    _add_snapshot(subparsers)
+    return parser
+
+
+def _doctor(arguments: argparse.Namespace) -> int:
+    protocol = _json_object(arguments.protocol_json, name="protocol")
+    validate_protocol(protocol)
+    thresholds = DoctorThresholds(
+        minimum_free_bytes=arguments.minimum_free_gib,
+        write_probe_bytes=arguments.write_probe_mib,
+        minimum_write_mib_s=arguments.minimum_write_mib_s,
+    )
+    report = build_acquisition_doctor_report(
+        protocol,
+        arguments.repository_root,
+        arguments.dataset_root,
+        readiness_path=arguments.readiness_json,
+        method_freeze_path=arguments.method_freeze,
+        thresholds=thresholds,
+        perform_write_probe=not arguments.skip_write_probe,
+        allow_resume=arguments.allow_resume,
+    )
+    if arguments.output_json is not None:
+        atomic_write_json(
+            arguments.output_json,
+            report,
+            overwrite=arguments.overwrite,
+        )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if not report["valid"]:
+        return 2
+    if arguments.require_ready and not report["passed"]:
+        return 3
+    return 0
+
+
+def _journal(arguments: argparse.Namespace) -> int:
+    if arguments.journal_command == "append":
+        payload = (
+            {}
+            if arguments.payload_json is None
+            else _json_object(arguments.payload_json, name="journal payload")
+        )
+        result = append_journal_event(
+            arguments.journal,
+            protocol_id=arguments.protocol_id,
+            session_id=arguments.session_id,
+            execution_id=arguments.execution_id,
+            event_type=arguments.event_type,
+            source=arguments.source,
+            payload=payload,
+            recorded_at_utc=arguments.recorded_at_utc,
+            monotonic_ns=arguments.monotonic_ns,
+        )
+    elif arguments.journal_command == "validate":
+        result = (
+            validate_acquisition_journal_seal(arguments.journal)
+            if arguments.require_sealed
+            else validate_acquisition_journal(arguments.journal)
+        )
+    elif arguments.journal_command == "seal":
+        result = seal_acquisition_journal(
+            arguments.journal,
+            sealed_by=arguments.sealed_by,
+            sealed_at_utc=arguments.sealed_at_utc,
+        )
+    else:  # pragma: no cover - argparse prevents this branch
+        raise RuntimeError(f"unsupported journal command: {arguments.journal_command}")
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def _snapshot(arguments: argparse.Namespace) -> int:
+    snapshot = _json_object(arguments.snapshot_json, name="health snapshot")
+    result = evaluate_health_snapshot(
+        snapshot,
+        thresholds=HealthThresholds(
+            maximum_heartbeat_age_s=arguments.maximum_heartbeat_age_s,
+            maximum_clock_offset_ms=arguments.maximum_clock_offset_ms,
+            maximum_dropped_frames=arguments.maximum_dropped_frames,
+            minimum_free_bytes=arguments.minimum_free_gib,
+            minimum_write_mib_s=arguments.minimum_write_mib_s,
+        ),
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if arguments.require_healthy and not result["passed"]:
+        return 3
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = build_parser().parse_args(argv)
+    try:
+        if arguments.command == "doctor":
+            return _doctor(arguments)
+        if arguments.command == "journal":
+            return _journal(arguments)
+        if arguments.command == "snapshot":
+            return _snapshot(arguments)
+    except (FileExistsError, OSError, TypeError, ValueError) as error:
+        print(json.dumps({"passed": False, "error": str(error)}, indent=2))
+        return 2
+    raise RuntimeError(f"unsupported acquisition operation: {arguments.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d/cli/command_registry.py
+++ b/src/causal4d/cli/command_registry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 import importlib.metadata
-from typing import Literal
+from typing import Any, Literal
 
 Lifecycle = Literal["stable", "diagnostic", "experimental", "legacy"]
 
@@ -97,6 +97,12 @@ GROUPED_COMMANDS = (
         lifecycle="stable",
     ),
     CommandSpec(
+        route=("protocol", "acquisition"),
+        target="causal4d.cli.acquisition_operations:main",
+        summary="Run the acquisition doctor, watchdog, and append-only journal.",
+        lifecycle="stable",
+    ),
+    CommandSpec(
         route=("evidence", "observation-lineage"),
         target="causal4d.cli.observation_lineage:main",
         summary="Validate or bind observation provenance.",
@@ -156,26 +162,44 @@ def grouped_commands() -> tuple[CommandSpec, ...]:
     return GROUPED_COMMANDS
 
 
-def installed_legacy_commands() -> tuple[CommandSpec, ...]:
-    """Discover legacy scripts without importing their target modules."""
-
+def _installed_console_scripts() -> dict[str, str] | None:
     try:
         distribution = importlib.metadata.distribution("causal4d")
     except importlib.metadata.PackageNotFoundError:
-        return ()
-    commands = []
+        return None
+    scripts: dict[str, str] = {}
+    duplicates: list[str] = []
     for entry_point in distribution.entry_points:
         if entry_point.group != "console_scripts":
             continue
-        if not entry_point.name.startswith("causal4d-"):
+        if entry_point.name in scripts:
+            duplicates.append(entry_point.name)
+        scripts[entry_point.name] = entry_point.value
+    if duplicates:
+        raise RuntimeError(
+            "installed console script names are duplicated: "
+            + ", ".join(sorted(set(duplicates)))
+        )
+    return scripts
+
+
+def installed_legacy_commands() -> tuple[CommandSpec, ...]:
+    """Discover legacy scripts without importing their target modules."""
+
+    scripts = _installed_console_scripts()
+    if scripts is None:
+        return ()
+    commands = []
+    for name, target in scripts.items():
+        if not name.startswith("causal4d-"):
             continue
         commands.append(
             CommandSpec(
-                route=("legacy", entry_point.name.removeprefix("causal4d-")),
-                target=entry_point.value,
-                summary=f"Compatibility route for {entry_point.name}.",
+                route=("legacy", name.removeprefix("causal4d-")),
+                target=target,
+                summary=f"Compatibility route for {name}.",
                 lifecycle="legacy",
-                legacy_name=entry_point.name,
+                legacy_name=name,
             )
         )
     return tuple(sorted(commands, key=lambda command: command.route))
@@ -186,6 +210,63 @@ def command_inventory(*, include_legacy: bool = False) -> tuple[CommandSpec, ...
     if include_legacy:
         commands.extend(installed_legacy_commands())
     return tuple(commands)
+
+
+def validate_runtime_command_inventory(
+    *,
+    require_installed: bool = False,
+) -> dict[str, Any]:
+    """Check grouped legacy mappings against installed console-script metadata.
+
+    This validation imports no command target modules. It prevents a grouped
+    route from silently drifting away from the historical executable retained by
+    a frozen manifest, while reporting the still-ungrouped compatibility surface.
+    """
+
+    commands = grouped_commands()
+    scripts = _installed_console_scripts()
+    installed = scripts is not None
+    missing: list[str] = []
+    mismatched: list[dict[str, str]] = []
+    grouped_legacy = {
+        command.legacy_name: command
+        for command in commands
+        if command.legacy_name is not None
+    }
+    if scripts is not None:
+        for legacy_name, command in grouped_legacy.items():
+            target = scripts.get(legacy_name)
+            if target is None:
+                missing.append(legacy_name)
+            elif target != command.target:
+                mismatched.append(
+                    {
+                        "legacy_name": legacy_name,
+                        "registered_target": command.target,
+                        "installed_target": target,
+                    }
+                )
+        ungrouped = sorted(
+            name
+            for name in scripts
+            if name.startswith("causal4d-") and name not in grouped_legacy
+        )
+    else:
+        ungrouped = []
+    valid = not missing and not mismatched and (installed or not require_installed)
+    return {
+        "schema_version": 1,
+        "artifact_kind": "Causal4DCommandInventoryValidation",
+        "valid": valid,
+        "installed_distribution_present": installed,
+        "require_installed": require_installed,
+        "grouped_route_count": len(commands),
+        "grouped_legacy_count": len(grouped_legacy),
+        "missing_grouped_legacy_executables": sorted(missing),
+        "target_mismatches": mismatched,
+        "ungrouped_legacy_executables": ungrouped,
+        "ungrouped_legacy_count": len(ungrouped),
+    }
 
 
 def find_command(name: str, *, include_legacy: bool = True) -> CommandSpec:

--- a/src/causal4d/cli/root.py
+++ b/src/causal4d/cli/root.py
@@ -14,6 +14,7 @@ from causal4d.cli.command_registry import (
     command_inventory,
     find_command,
     grouped_commands,
+    validate_runtime_command_inventory,
 )
 
 
@@ -30,7 +31,7 @@ def _root_help() -> str:
         groups.setdefault(command.route[0], []).append(command)
     lines = [
         "usage: causal4d <group> <command> [arguments]",
-        "       causal4d commands {list,describe,migrate} ...",
+        "       causal4d commands {list,describe,migrate,validate} ...",
         "       causal4d legacy <historical-suffix> [arguments]",
         "",
         "Grouped command surface for Causal4D. Command modules are imported lazily.",
@@ -49,6 +50,7 @@ def _root_help() -> str:
             "  commands list [--json] [--include-legacy]",
             "  commands describe <route-or-legacy-name> [--json]",
             "  commands migrate <historical-executable> [--json]",
+            "  commands validate [--json] [--require-installed]",
             "",
             "Use 'causal4d <group> <command> --help' for command-specific help.",
         )
@@ -142,10 +144,39 @@ def _commands_migrate(arguments: Sequence[str]) -> int:
     return 0
 
 
+def _commands_validate(arguments: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(prog="causal4d commands validate")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--require-installed", action="store_true")
+    parsed = parser.parse_args(arguments)
+    report = validate_runtime_command_inventory(
+        require_installed=parsed.require_installed
+    )
+    if parsed.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        state = "valid" if report["valid"] else "invalid"
+        print(f"command inventory: {state}")
+        print(f"grouped routes: {report['grouped_route_count']}")
+        print(f"installed distribution: {report['installed_distribution_present']}")
+        print(f"ungrouped legacy executables: {report['ungrouped_legacy_count']}")
+        missing = report["missing_grouped_legacy_executables"]
+        if missing:
+            print("missing grouped legacy executables: " + ", ".join(missing))
+        mismatches = report["target_mismatches"]
+        for mismatch in mismatches:
+            print(
+                "target mismatch: "
+                f"{mismatch['legacy_name']} -> {mismatch['installed_target']} "
+                f"(registered {mismatch['registered_target']})"
+            )
+    return 0 if report["valid"] else 2
+
+
 def _commands(arguments: Sequence[str]) -> int:
     if not arguments or arguments[0] in {"-h", "--help"}:
         print(
-            "usage: causal4d commands {list,describe,migrate} ...\n\n"
+            "usage: causal4d commands {list,describe,migrate,validate} ...\n\n"
             "Inspect the typed command registry and legacy migrations."
         )
         return 0
@@ -156,6 +187,8 @@ def _commands(arguments: Sequence[str]) -> int:
         return _commands_describe(remaining)
     if operation == "migrate":
         return _commands_migrate(remaining)
+    if operation == "validate":
+        return _commands_validate(remaining)
     raise SystemExit(f"unknown commands operation: {operation}")
 
 

--- a/tests/test_acquisition_flight_recorder.py
+++ b/tests/test_acquisition_flight_recorder.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from causal4d.acquisition_flight_recorder import (
+    HEALTH_SNAPSHOT_KIND,
+    DoctorThresholds,
+    HealthThresholds,
+    append_journal_event,
+    build_acquisition_doctor_report,
+    evaluate_health_snapshot,
+    journal_seal_path,
+    seal_acquisition_journal,
+    validate_acquisition_journal,
+    validate_acquisition_journal_seal,
+)
+
+
+UTC = "2026-08-03T08:00:00+00:00"
+
+
+def _append(
+    path: Path,
+    event_type: str,
+    monotonic_ns: int,
+    *,
+    execution_id: str | None = None,
+    payload: dict[str, object] | None = None,
+):
+    return append_journal_event(
+        path,
+        protocol_id="protocol-v1",
+        session_id="session-1",
+        execution_id=execution_id,
+        event_type=event_type,
+        source="test",
+        payload=payload,
+        recorded_at_utc=UTC,
+        monotonic_ns=monotonic_ns,
+    )
+
+
+def test_journal_round_trip_seal_and_non_overwrite(tmp_path: Path) -> None:
+    journal = tmp_path / "acquisition.jsonl"
+    first = _append(journal, "session_started", 10)
+    second = _append(journal, "execution_started", 20, execution_id="execution-1")
+    _append(journal, "execution_completed", 30, execution_id="execution-1")
+    _append(journal, "session_completed", 40)
+
+    assert first["sequence"] == 0
+    assert second["previous_event_sha256"] == first["event_sha256"]
+    validation = validate_acquisition_journal(journal)
+    assert validation["event_count"] == 4
+    assert validation["terminal"] is True
+    assert validation["execution_ids"] == ["execution-1"]
+
+    seal = seal_acquisition_journal(
+        journal,
+        sealed_by="operator.primary",
+        sealed_at_utc=UTC,
+    )
+    assert seal["session_outcome"] == "completed"
+    assert journal_seal_path(journal).is_file()
+    assert validate_acquisition_journal_seal(journal)["valid"] is True
+
+    with pytest.raises(ValueError, match="sealed"):
+        _append(journal, "operator_note", 50)
+    with pytest.raises(ValueError, match="already exists"):
+        seal_acquisition_journal(journal, sealed_by="operator.primary")
+
+
+def test_journal_rejects_invalid_execution_state_transitions(
+    tmp_path: Path,
+) -> None:
+    journal = tmp_path / "acquisition.jsonl"
+    _append(journal, "session_started", 10)
+
+    with pytest.raises(ValueError, match="requires an active execution"):
+        _append(
+            journal,
+            "execution_completed",
+            20,
+            execution_id="execution-1",
+        )
+    with pytest.raises(ValueError, match="was not started"):
+        _append(
+            journal,
+            "stream_heartbeat",
+            25,
+            execution_id="execution-1",
+        )
+
+    _append(journal, "execution_started", 30, execution_id="execution-1")
+    with pytest.raises(ValueError, match="while an execution is active"):
+        _append(journal, "session_aborted", 40)
+    _append(journal, "execution_aborted", 50, execution_id="execution-1")
+
+    with pytest.raises(ValueError, match="may not be restarted"):
+        _append(journal, "execution_started", 60, execution_id="execution-1")
+    _append(journal, "session_aborted", 70)
+    validation = validate_acquisition_journal(journal)
+    assert validation["aborted_execution_ids"] == ["execution-1"]
+    assert validation["active_execution_id"] is None
+
+
+def test_journal_append_handles_events_larger_than_tail_read_block(
+    tmp_path: Path,
+) -> None:
+    journal = tmp_path / "acquisition.jsonl"
+    _append(
+        journal,
+        "session_started",
+        10,
+        payload={"operator_note": "x" * 12_000},
+    )
+    appended = _append(journal, "operator_note", 20, payload={"note": "continued"})
+
+    assert appended["sequence"] == 1
+    validation = validate_acquisition_journal(journal)
+    assert validation["event_count"] == 2
+    assert validation["last_event_type"] == "operator_note"
+
+
+def test_journal_rejects_broken_symlink_target(tmp_path: Path) -> None:
+    journal = tmp_path / "acquisition.jsonl"
+    try:
+        journal.symlink_to(tmp_path / "missing.jsonl")
+    except OSError as error:  # pragma: no cover - symlinks unavailable
+        pytest.skip(f"symlinks unavailable: {error}")
+
+    with pytest.raises(ValueError, match="symlink component"):
+        _append(journal, "session_started", 10)
+
+
+def test_journal_detects_tampering_and_target_outcomes(tmp_path: Path) -> None:
+    journal = tmp_path / "acquisition.jsonl"
+    _append(journal, "session_started", 10)
+    _append(journal, "operator_note", 20, payload={"note": "camera restarted"})
+    lines = journal.read_text(encoding="utf-8").splitlines()
+    tampered = json.loads(lines[1])
+    tampered["payload"]["note"] = "edited after collection"
+    lines[1] = json.dumps(tampered, sort_keys=True, separators=(",", ":"))
+    journal.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="checksum mismatch"):
+        validate_acquisition_journal(journal)
+
+    clean = tmp_path / "clean.jsonl"
+    _append(clean, "session_started", 10)
+    with pytest.raises(ValueError, match="target-outcome"):
+        _append(
+            clean,
+            "operator_note",
+            20,
+            payload={"target_metrics": {"track_error_m": 0.01}},
+        )
+
+
+def test_health_snapshot_fails_closed_on_stream_and_storage_faults() -> None:
+    snapshot = {
+        "schema_version": 1,
+        "artifact_kind": HEALTH_SNAPSHOT_KIND,
+        "protocol_id": "protocol-v1",
+        "session_id": "session-1",
+        "execution_id": "execution-1",
+        "captured_at_utc": UTC,
+        "target_outcomes_used": False,
+        "streams": {
+            "rgbd": {
+                "required": True,
+                "alive": True,
+                "heartbeat_age_s": 0.2,
+                "dropped_frames": 0,
+                "clock_offset_ms": 1.5,
+            },
+            "force_torque": {
+                "required": False,
+                "alive": False,
+                "heartbeat_age_s": 4.0,
+                "dropped_frames": 0,
+            },
+        },
+        "storage": {"free_bytes": 1000, "write_mib_s": 100.0},
+    }
+    thresholds = HealthThresholds(
+        minimum_free_bytes=500,
+        minimum_write_mib_s=50.0,
+    )
+    healthy = evaluate_health_snapshot(snapshot, thresholds=thresholds)
+    assert healthy["passed"] is True
+    assert healthy["warnings"] == ["optional_stream:force_torque:unhealthy"]
+
+    snapshot["streams"]["rgbd"]["dropped_frames"] = 1
+    snapshot["storage"]["free_bytes"] = 100
+    failed = evaluate_health_snapshot(snapshot, thresholds=thresholds)
+    assert failed["passed"] is False
+    assert "stream:rgbd:dropped_frame_limit_exceeded" in failed["failures"]
+    assert "storage:free_space_below_threshold" in failed["failures"]
+
+
+def _protocol() -> dict[str, object]:
+    digest = "a" * 64
+    return {
+        "protocol_id": "protocol-v1",
+        "design_sha256": digest,
+        "executions": [
+            {
+                "acquisition_execution_index": 0,
+                "execution_id": "execution-1",
+                "session_id": "session-1",
+                "pair_order": 0,
+                "contact_region_id": "contact-1",
+                "command_profile_id": "command-1",
+                "realization_condition_id": "nominal",
+                "replicate_block": 0,
+            },
+            {
+                "acquisition_execution_index": 1,
+                "execution_id": "execution-2",
+                "session_id": "session-1",
+                "pair_order": 1,
+                "contact_region_id": "contact-1",
+                "command_profile_id": "command-2",
+                "realization_condition_id": "nominal",
+                "replicate_block": 0,
+            },
+        ],
+    }
+
+
+def _install_doctor_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    freeze = SimpleNamespace(
+        load_method_freeze_manifest=lambda path: {"status": "sealed"},
+        validate_method_freeze_manifest=lambda manifest, root, verify_files: {
+            "passed": True
+        },
+        validate_repository_checkout=lambda manifest, root: {
+            "commit_sha": "b" * 40,
+            "dirty_worktree": False,
+        },
+    )
+    readiness = SimpleNamespace(
+        READINESS_ARTIFACT_KIND="Readiness",
+        READINESS_SCHEMA_VERSION=1,
+        readiness_evidence_sha256=lambda values: "evidence",
+        readiness_status_sha256=lambda values: "status",
+    )
+    monkeypatch.setitem(sys.modules, "causal4d.real_experiment_freeze", freeze)
+    monkeypatch.setitem(
+        sys.modules,
+        "causal4d.preacquisition_readiness_contracts",
+        readiness,
+    )
+
+    def build_status(
+        protocol,
+        dataset_root,
+        *,
+        repository_root,
+        verify_file_hashes,
+    ):
+        results = []
+        for execution in protocol["executions"]:
+            identifier = execution["execution_id"]
+            path = Path(dataset_root) / "executions" / identifier / "manifest.json"
+            present = path.is_file()
+            payload = json.loads(path.read_text()) if present else {}
+            acquired = payload.get("acquisition_status") == "complete"
+            results.append(
+                {
+                    "execution_id": identifier,
+                    "manifest_present": present,
+                    "acquisition_status": payload.get("acquisition_status"),
+                    "acquired": acquired,
+                    "validated": acquired,
+                    "error": None if acquired or not present else "incomplete",
+                }
+            )
+        return {
+            "specified_executions": len(results),
+            "manifest_executions": sum(item["manifest_present"] for item in results),
+            "acquired_executions": sum(item["acquired"] for item in results),
+            "validated_executions": sum(item["validated"] for item in results),
+            "file_hashes_requested": verify_file_hashes,
+            "prerequisites": {"dataset_protocol": {"valid": True}},
+            "invalid_session_ids": [],
+            "unexpected_execution_directories": [],
+            "unexpected_session_directories": [],
+            "executions": results,
+        }
+
+    evidence = SimpleNamespace(build_real_evidence_status=build_status)
+    monkeypatch.setitem(sys.modules, "causal4d.real_evidence_contract_v2", evidence)
+
+
+def _doctor_tree(tmp_path: Path) -> tuple[Path, Path]:
+    repository = tmp_path / "repository"
+    dataset = tmp_path / "dataset"
+    repository.mkdir()
+    dataset.mkdir()
+    (dataset / "method_freeze.json").write_text("{}\n", encoding="utf-8")
+    readiness = {
+        "schema_version": 1,
+        "artifact_kind": "Readiness",
+        "protocol_id": "protocol-v1",
+        "protocol_design_sha256": "a" * 64,
+        "verify_file_hashes": True,
+        "valid": True,
+        "ready": True,
+        "collection_gate": {"first_confirmatory_execution_allowed": True},
+        "dataset_root": str(dataset.resolve()),
+        "evidence_sha256": "evidence",
+        "status_sha256": "status",
+    }
+    (dataset / "preacquisition-readiness.json").write_text(
+        json.dumps(readiness), encoding="utf-8"
+    )
+    for execution in ("execution-1", "execution-2"):
+        (dataset / "executions" / execution).mkdir(parents=True)
+    (dataset / "sessions" / "session-1").mkdir(parents=True)
+    return repository, dataset
+
+
+def test_doctor_identifies_next_execution_and_rejects_out_of_order_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_doctor_stubs(monkeypatch)
+    repository, dataset = _doctor_tree(tmp_path)
+    settings = DoctorThresholds(
+        minimum_free_bytes=0,
+        write_probe_bytes=0,
+        minimum_write_mib_s=0.0,
+    )
+    report = build_acquisition_doctor_report(
+        _protocol(),
+        repository,
+        dataset,
+        thresholds=settings,
+        perform_write_probe=False,
+    )
+    assert report["passed"] is True
+    assert report["next_execution"]["execution_id"] == "execution-1"
+
+    (dataset / "executions" / "execution-2" / "manifest.json").write_text(
+        json.dumps({"acquisition_status": "complete"}),
+        encoding="utf-8",
+    )
+    invalid = build_acquisition_doctor_report(
+        _protocol(),
+        repository,
+        dataset,
+        thresholds=settings,
+        perform_write_probe=False,
+    )
+    assert invalid["passed"] is False
+    assert any(
+        check["check_id"] == "execution_manifests" and check["status"] == "fail"
+        for check in invalid["checks"]
+    )
+
+
+def test_doctor_requires_explicit_resume_acknowledgement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_doctor_stubs(monkeypatch)
+    repository, dataset = _doctor_tree(tmp_path)
+    journal = dataset / "sessions" / "session-1" / "acquisition.jsonl"
+    _append(journal, "session_started", 10)
+    settings = DoctorThresholds(
+        minimum_free_bytes=0,
+        write_probe_bytes=0,
+        minimum_write_mib_s=0.0,
+    )
+
+    blocked = build_acquisition_doctor_report(
+        _protocol(),
+        repository,
+        dataset,
+        thresholds=settings,
+        perform_write_probe=False,
+    )
+    assert blocked["valid"] is True
+    assert blocked["passed"] is False
+    assert blocked["resume_acknowledged"] is False
+
+    acknowledged = build_acquisition_doctor_report(
+        _protocol(),
+        repository,
+        dataset,
+        thresholds=settings,
+        perform_write_probe=False,
+        allow_resume=True,
+    )
+    assert acknowledged["passed"] is True
+    assert acknowledged["resume_acknowledged"] is True

--- a/tests/test_causal4d_command_registry.py
+++ b/tests/test_causal4d_command_registry.py
@@ -123,9 +123,7 @@ def test_runtime_inventory_detects_missing_or_mismatched_grouped_legacy(
     )
     report = validate_runtime_command_inventory(require_installed=True)
     assert report["valid"] is False
-    assert report["missing_grouped_legacy_executables"] == [
-        "causal4d-real-calibration"
-    ]
+    assert report["missing_grouped_legacy_executables"] == ["causal4d-real-calibration"]
     assert report["target_mismatches"][0]["legacy_name"] == "causal4d-real-protocol"
     assert report["ungrouped_legacy_executables"] == [
         "causal4d-unmapped-research-command"
@@ -146,9 +144,7 @@ def test_commands_validate_reports_source_checkout_without_install(
     report = json.loads(capsys.readouterr().out)
     assert report["installed_distribution_present"] is False
     assert report["valid"] is True
-    assert root.main(
-        ["commands", "validate", "--json", "--require-installed"]
-    ) == 2
+    assert root.main(["commands", "validate", "--json", "--require-installed"]) == 2
 
 
 def test_command_spec_rejects_invalid_routes() -> None:

--- a/tests/test_causal4d_command_registry.py
+++ b/tests/test_causal4d_command_registry.py
@@ -11,6 +11,7 @@ from causal4d.cli.command_registry import (
     CommandSpec,
     find_command,
     grouped_commands,
+    validate_runtime_command_inventory,
 )
 
 
@@ -24,13 +25,16 @@ def test_grouped_registry_has_unique_routes_and_legacy_names() -> None:
     assert find_command("benchmark/counterfactual").target.endswith(
         "counterfactual_benchmark:main"
     )
+    assert find_command("protocol/acquisition").target.endswith(
+        "acquisition_operations:main"
+    )
 
 
 def test_root_help_and_inventory_do_not_import_command_modules(capsys) -> None:
     assert root.main(["--help"]) == 0
     help_output = capsys.readouterr().out
     assert "usage: causal4d" in help_output
-    assert "benchmark" in help_output
+    assert "acquisition" in help_output
 
     assert root.main(["commands", "list", "--json"]) == 0
     inventory = json.loads(capsys.readouterr().out)
@@ -49,9 +53,9 @@ def test_grouped_route_forwards_remaining_arguments(monkeypatch) -> None:
         "import_module",
         lambda name: SimpleNamespace(main=command_main),
     )
-    result = root.main(["benchmark", "counterfactual", "--output-dir", "result"])
+    result = root.main(["protocol", "acquisition", "doctor", "protocol.json"])
     assert result == 7
-    assert received == ["--output-dir", "result"]
+    assert received == ["doctor", "protocol.json"]
 
 
 def test_no_argument_main_receives_passthrough_via_sys_argv(monkeypatch) -> None:
@@ -85,6 +89,66 @@ def test_describe_and_migrate_report_compatibility_route(capsys) -> None:
     assert root.main(["commands", "migrate", "causal4d-real-protocol", "--json"]) == 0
     migration = json.loads(capsys.readouterr().out)
     assert migration["route"] == ["protocol", "real"]
+
+
+def test_runtime_inventory_detects_missing_or_mismatched_grouped_legacy(
+    monkeypatch,
+) -> None:
+    entry_points = []
+    for command in grouped_commands():
+        if command.legacy_name is None:
+            continue
+        target = command.target
+        if command.legacy_name == "causal4d-real-protocol":
+            target = "wrong.module:main"
+        if command.legacy_name == "causal4d-real-calibration":
+            continue
+        entry_points.append(
+            SimpleNamespace(
+                group="console_scripts",
+                name=command.legacy_name,
+                value=target,
+            )
+        )
+    entry_points.append(
+        SimpleNamespace(
+            group="console_scripts",
+            name="causal4d-unmapped-research-command",
+            value="module:main",
+        )
+    )
+    monkeypatch.setattr(
+        "causal4d.cli.command_registry.importlib.metadata.distribution",
+        lambda name: SimpleNamespace(entry_points=entry_points),
+    )
+    report = validate_runtime_command_inventory(require_installed=True)
+    assert report["valid"] is False
+    assert report["missing_grouped_legacy_executables"] == [
+        "causal4d-real-calibration"
+    ]
+    assert report["target_mismatches"][0]["legacy_name"] == "causal4d-real-protocol"
+    assert report["ungrouped_legacy_executables"] == [
+        "causal4d-unmapped-research-command"
+    ]
+
+
+def test_commands_validate_reports_source_checkout_without_install(
+    monkeypatch, capsys
+) -> None:
+    def missing(name):
+        raise root.metadata.PackageNotFoundError
+
+    monkeypatch.setattr(
+        "causal4d.cli.command_registry.importlib.metadata.distribution",
+        missing,
+    )
+    assert root.main(["commands", "validate", "--json"]) == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["installed_distribution_present"] is False
+    assert report["valid"] is True
+    assert root.main(
+        ["commands", "validate", "--json", "--require-installed"]
+    ) == 2
 
 
 def test_command_spec_rejects_invalid_routes() -> None:

--- a/tests/test_release_workflow_policy.py
+++ b/tests/test_release_workflow_policy.py
@@ -11,4 +11,4 @@ def test_tag_release_requires_private_provider_integration() -> None:
     assert "Require private-provider integration for releases" in text
     assert "startsWith(github.ref, 'refs/tags/v')" in text
     assert "steps.access.outputs.enabled != 'true'" in text
-    assert "Release tags require BPT_READ_TOKEN" in text
+    assert "Release tags require BPT_READ_SSH_KEY" in text


### PR DESCRIPTION
## Summary

- add a method-neutral pre-session doctor that binds the exact frozen checkout, sealed readiness, full registered evidence/hash status, locked execution order, storage capacity, and measured write throughput;
- add a live operational-health evaluator for stream liveness, heartbeat age, frame drops, clock offsets, free space, and write throughput;
- add an append-only, fsync'd, hash-chained acquisition journal with execution/recovery state-machine validation and exactly-once terminal sealing;
- reject target-outcome and held-out metric fields throughout operational artifacts;
- add the stable grouped route `causal4d protocol acquisition` and a lazy `causal4d commands validate` check for installed historical-entry-point drift;
- document session startup, watchdog, journal, sealing, and crash-recovery procedures;
- add adversarial tests for tampering, invalid state transitions, broken symlinks, large events, out-of-order manifests, explicit resume acknowledgement, and CLI metadata drift.

## Why

The registered 36-execution physical experiment is no longer software-blocked, but each execution is operationally expensive and must remain auditable after recorder, storage, clock, or process failures. This change adds fail-closed collection operations without introducing another estimator or changing the preregistered analysis.

## Scientific boundary

Operational provenance only. The estimator, registered 36-execution protocol, acquisition schedule, information boundary, splits, exclusion policy, calibration method, reporting thresholds, and scientific claim status are unchanged. The journal, doctor, health snapshots, and seals do not count as physical executions and do not inspect target outcomes. Every new operational artifact records `target_outcomes_used=false`.

## Validation

Local validation on the final source tree rebased onto `225d615dd941f08423b189a3aa83ccf4a15efc4b`:

- complete test suite: **593 passed, 13 skipped**;
- source and test byte-compilation passed;
- focused acquisition and command-registry tests passed.

GitHub Actions on head `feb88c752e4a0aad81e4941f12951ffd0f9c2ee4`:

- Extended compatibility: passed;
- Ruff, incremental formatting, and stable-contract mypy: passed;
- core suites on Python 3.10, 3.12, and 3.14: passed;
- wheel and sdist build and metadata validation: passed;
- isolated wheel/sdist installation and complete CLI-help surface: passed;
- deterministic result-bundle and frozen-milestone checks: passed;
- pinned Bayesian-PhysTwin integration: passed against canonical repository `IPS-Stuttgart/BayesianPhysTwin` at exact revision `695f7d7b949988052d8bd83ac7ac91620d1c6bb1`; **74 integration tests passed** after migrating checkout authentication to a dedicated read-only deploy key.

All required GitHub Actions checks pass on the current head.