### PR TITLE
Run controlled and CUDA evaluation on workstation2

### DIFF
--- a/.github/workflows/optional-integrations.yml
+++ b/.github/workflows/optional-integrations.yml
@@ -61,7 +61,7 @@ jobs:
             tests/test_deform360_visual_hull.py
 
   bpt-vision:
-    name: Bayesian-PhysTwin OpenCV collection
+    name: BayesianPhysTwin OpenCV collection
     runs-on: ubuntu-latest
     steps:
       - name: Check out Causal4D
@@ -73,34 +73,33 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-      - name: Detect private-repository credential
+      - name: Detect private-repository deploy key
         id: access
         env:
-          BPT_READ_TOKEN: ${{ secrets.BPT_READ_TOKEN }}
+          BPT_READ_SSH_KEY: ${{ secrets.BPT_READ_SSH_KEY }}
         run: |
-          if [[ -n "${BPT_READ_TOKEN}" ]]; then
+          if [[ -n "${BPT_READ_SSH_KEY}" ]]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::BPT_READ_TOKEN is absent; BPT OpenCV collection was not exercised."
+            echo "::warning::BPT_READ_SSH_KEY is absent; BPT OpenCV collection was not exercised."
           fi
       - name: Read exact provider pin
         if: steps.access.outputs.enabled == 'true'
         id: pin
         run: echo "sha=$(python scripts/ci/read_bpt_pin.py)" >> "$GITHUB_OUTPUT"
-      - name: Check out pinned Bayesian-PhysTwin
+      - name: Check out pinned BayesianPhysTwin
         if: steps.access.outputs.enabled == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repository: FlorianPfaff/Bayesian-PhysTwin
+          repository: IPS-Stuttgart/BayesianPhysTwin
           ref: ${{ steps.pin.outputs.sha }}
-          token: ${{ secrets.BPT_READ_TOKEN }}
+          ssh-key: ${{ secrets.BPT_READ_SSH_KEY }}
           path: _bpt
           persist-credentials: false
       - name: Install BPT tests with explicit vision runtime
         if: steps.access.outputs.enabled == 'true'
-        run: |
-          python -m pip install -e "./_bpt[dev]" opencv-python
+        run: python -m pip install -e "./_bpt[dev]" opencv-python
       - name: Run BPT tests that collect OpenCV modules
         if: steps.access.outputs.enabled == 'true'
         run: |
@@ -121,28 +120,28 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-      - name: Detect private-repository credential
+      - name: Detect private-repository deploy key
         id: access
         env:
-          BPT_READ_TOKEN: ${{ secrets.BPT_READ_TOKEN }}
+          BPT_READ_SSH_KEY: ${{ secrets.BPT_READ_SSH_KEY }}
         run: |
-          if [[ -n "${BPT_READ_TOKEN}" ]]; then
+          if [[ -n "${BPT_READ_SSH_KEY}" ]]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::BPT_READ_TOKEN is absent; Warp/provider integration was not exercised."
+            echo "::warning::BPT_READ_SSH_KEY is absent; Warp/provider integration was not exercised."
           fi
       - name: Read exact provider pin
         if: steps.access.outputs.enabled == 'true'
         id: pin
         run: echo "sha=$(python scripts/ci/read_bpt_pin.py)" >> "$GITHUB_OUTPUT"
-      - name: Check out pinned Bayesian-PhysTwin
+      - name: Check out pinned BayesianPhysTwin
         if: steps.access.outputs.enabled == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repository: FlorianPfaff/Bayesian-PhysTwin
+          repository: IPS-Stuttgart/BayesianPhysTwin
           ref: ${{ steps.pin.outputs.sha }}
-          token: ${{ secrets.BPT_READ_TOKEN }}
+          ssh-key: ${{ secrets.BPT_READ_SSH_KEY }}
           path: _bpt
           persist-credentials: false
       - name: Install Warp CPU stack
@@ -174,7 +173,7 @@ jobs:
   gpu:
     name: CUDA / Warp self-hosted smoke
     if: github.event_name == 'workflow_dispatch' && inputs.run_gpu
-    runs-on: [self-hosted, linux, x64, gpu]
+    runs-on: [self-hosted, Linux, X64, nvidia-smi]
     steps:
       - name: Check out Causal4D
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -184,19 +183,19 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-      - name: Require private-repository credential
+      - name: Require private-repository deploy key
         env:
-          BPT_READ_TOKEN: ${{ secrets.BPT_READ_TOKEN }}
-        run: test -n "${BPT_READ_TOKEN}"
+          BPT_READ_SSH_KEY: ${{ secrets.BPT_READ_SSH_KEY }}
+        run: test -n "${BPT_READ_SSH_KEY}"
       - name: Read exact provider pin
         id: pin
         run: echo "sha=$(python scripts/ci/read_bpt_pin.py)" >> "$GITHUB_OUTPUT"
-      - name: Check out pinned Bayesian-PhysTwin
+      - name: Check out pinned BayesianPhysTwin
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repository: FlorianPfaff/Bayesian-PhysTwin
+          repository: IPS-Stuttgart/BayesianPhysTwin
           ref: ${{ steps.pin.outputs.sha }}
-          token: ${{ secrets.BPT_READ_TOKEN }}
+          ssh-key: ${{ secrets.BPT_READ_SSH_KEY }}
           path: _bpt
           persist-credentials: false
       - name: Install GPU integration stack

--- a/.github/workflows/workstation2-evaluation.yml
+++ b/.github/workflows/workstation2-evaluation.yml
@@ -1,0 +1,277 @@
+name: Workstation2 GPU evaluation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/workstation2-evaluation.yml"
+      - ".github/workflows/optional-integrations.yml"
+      - "scripts/ci/compare_result_bundles.py"
+      - "scripts/ci/workstation2_gpu_qualification.py"
+  workflow_dispatch:
+    inputs:
+      cuda_visible_devices:
+        description: CUDA device list exposed to Torch and Warp
+        required: false
+        default: "0"
+        type: string
+      extended_seeds:
+        description: Independent diagnostic seed range
+        required: false
+        default: "100:120"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: workstation2-evaluation-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+  CUDA_VISIBLE_DEVICES: ${{ inputs.cuda_visible_devices || '0' }}
+  EXTENDED_SEEDS: ${{ inputs.extended_seeds || '100:120' }}
+
+jobs:
+  evaluate:
+    name: CUDA qualification and controlled replication
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    timeout-minutes: 180
+    steps:
+      - name: Check out Causal4D
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Record runner and NVIDIA environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p outputs/workstation2
+          {
+            echo "runner_name=${RUNNER_NAME}"
+            echo "runner_os=${RUNNER_OS}"
+            echo "runner_arch=${RUNNER_ARCH}"
+            echo "cuda_visible_devices=${CUDA_VISIBLE_DEVICES}"
+            echo "git_commit=${GITHUB_SHA}"
+            uname -a
+          } | tee outputs/workstation2/runner.txt
+          nvidia-smi -L | tee outputs/workstation2/nvidia-smi-L.txt
+          nvidia-smi \
+            --query-gpu=index,name,uuid,driver_version,memory.total,compute_cap \
+            --format=csv,noheader \
+            | tee outputs/workstation2/nvidia-smi.csv
+
+      - name: Install isolated GPU evaluation environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m venv .workstation2-venv
+          .workstation2-venv/bin/python -m pip install --upgrade pip
+          .workstation2-venv/bin/python -m pip install -e ".[dev,warp]"
+          .workstation2-venv/bin/python -m pip check
+          .workstation2-venv/bin/python -m pip freeze --all \
+            > outputs/workstation2/pip-freeze.txt
+
+      - name: Qualify Torch and Warp on CUDA
+        shell: bash
+        run: |
+          .workstation2-venv/bin/python \
+            scripts/ci/workstation2_gpu_qualification.py \
+            --output outputs/workstation2/gpu-qualification.json
+
+      - name: Reproduce frozen controlled latent-contact result
+        shell: bash
+        run: |
+          set -euo pipefail
+          .workstation2-venv/bin/causal4d-latent-contact-benchmark \
+            --output-dir outputs/workstation2/frozen-controlled \
+            --seeds 0:5 \
+            --frames 56 \
+            --training-repeats 2 \
+            --parameter-grid-count 5 \
+            --contact-parameter-particles 12 \
+            --observation-fraction 0.20 \
+            --observation-noise-mm 1.5 \
+            --require-gates \
+            | tee outputs/workstation2/frozen-controlled-console.json
+          .workstation2-venv/bin/python scripts/ci/verify_result_bundle.py \
+            outputs/workstation2/frozen-controlled/manifest.json
+          .workstation2-venv/bin/python scripts/ci/compare_result_bundles.py \
+            milestones/v0.3.0-causal4d-aip/results/controlled \
+            outputs/workstation2/frozen-controlled \
+            --output outputs/workstation2/frozen-bundle-comparison.json
+
+      - name: Run independent-seed controlled replication
+        shell: bash
+        run: |
+          set -euo pipefail
+          .workstation2-venv/bin/causal4d-latent-contact-benchmark \
+            --output-dir outputs/workstation2/independent-seeds \
+            --seeds "${EXTENDED_SEEDS}" \
+            --frames 56 \
+            --training-repeats 2 \
+            --parameter-grid-count 5 \
+            --contact-parameter-particles 12 \
+            --observation-fraction 0.20 \
+            --observation-noise-mm 1.5 \
+            | tee outputs/workstation2/independent-seeds-console.json
+          .workstation2-venv/bin/python scripts/ci/verify_result_bundle.py \
+            outputs/workstation2/independent-seeds/manifest.json
+
+      - name: Summarize evaluation evidence
+        shell: bash
+        run: |
+          .workstation2-venv/bin/python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path("outputs/workstation2")
+          qualification = json.loads(
+              (root / "gpu-qualification.json").read_text(encoding="utf-8")
+          )
+          comparison = json.loads(
+              (root / "frozen-bundle-comparison.json").read_text(encoding="utf-8")
+          )
+          frozen = json.loads(
+              (root / "frozen-controlled/summary.json").read_text(encoding="utf-8")
+          )
+          independent = json.loads(
+              (root / "independent-seeds/summary.json").read_text(encoding="utf-8")
+          )
+          summary = {
+              "schema_version": 1,
+              "artifact_kind": "Causal4DWorkstation2EvaluationSummary",
+              "repository": os.environ["GITHUB_REPOSITORY"],
+              "commit": os.environ["GITHUB_SHA"],
+              "runner_name": os.environ.get("RUNNER_NAME"),
+              "independent_seed_specification": os.environ["EXTENDED_SEEDS"],
+              "gpu_qualification_passed": qualification["passed"],
+              "gpu": qualification["gpu"],
+              "frozen_payload_bytes_match": comparison["all_payload_bytes_match"],
+              "frozen_semantic_match": comparison["semantic_match"],
+              "frozen_maximum_absolute_difference": comparison[
+                  "maximum_absolute_difference"
+              ],
+              "frozen_maximum_direction_angle_difference_deg": comparison[
+                  "maximum_direction_angle_difference_deg"
+              ],
+              "frozen_success_gates": frozen["success_gates"],
+              "frozen_aggregate": frozen["aggregate"],
+              "independent_success_gates": independent["success_gates"],
+              "independent_aggregate": independent["aggregate"],
+              "claim_boundary": (
+                  "The seeds 0:5 run is an independent-runner semantic "
+                  "reproduction of the frozen controlled artifact. Serialized "
+                  "byte equality is reported separately. Seeds 100:120 are a "
+                  "diagnostic replication and do not change the frozen method, "
+                  "registered real experiment, or paper claim."
+              ),
+          }
+          (root / "evaluation-summary.json").write_text(
+              json.dumps(summary, indent=2, sort_keys=True, allow_nan=False)
+              + "\n",
+              encoding="utf-8",
+          )
+          print(json.dumps(summary, indent=2, sort_keys=True, allow_nan=False))
+          PY
+
+      - name: Detect BayesianPhysTwin deploy key
+        id: bpt_access
+        env:
+          BPT_READ_SSH_KEY: ${{ secrets.BPT_READ_SSH_KEY }}
+        run: |
+          if [[ -n "${BPT_READ_SSH_KEY}" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "BPT_READ_SSH_KEY absent; provider integration skipped." \
+              | tee outputs/workstation2/bpt-provider-skip.txt
+          fi
+
+      - name: Read exact BayesianPhysTwin pin
+        if: steps.bpt_access.outputs.enabled == 'true'
+        id: bpt_pin
+        run: |
+          echo "sha=$(.workstation2-venv/bin/python scripts/ci/read_bpt_pin.py)" \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Check out pinned BayesianPhysTwin
+        if: steps.bpt_access.outputs.enabled == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/BayesianPhysTwin
+          ref: ${{ steps.bpt_pin.outputs.sha }}
+          ssh-key: ${{ secrets.BPT_READ_SSH_KEY }}
+          path: _bpt
+          persist-credentials: false
+
+      - name: Run pinned provider integration on workstation2
+        if: steps.bpt_access.outputs.enabled == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          .workstation2-venv/bin/python -m pip install -e ./_bpt
+          .workstation2-venv/bin/python -m pip check
+          .workstation2-venv/bin/python scripts/ci/run_bpt_integration_tests.py \
+            | tee outputs/workstation2/bpt-provider-integration.txt
+
+      - name: Publish job summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### Workstation2 Causal4D evaluation"
+            echo
+            echo "- Runner: \`${RUNNER_NAME}\`"
+            echo "- CUDA devices requested: \`${CUDA_VISIBLE_DEVICES}\`"
+            echo "- Independent seeds: \`${EXTENDED_SEEDS}\`"
+            if [[ -f outputs/workstation2/evaluation-summary.json ]]; then
+              .workstation2-venv/bin/python - <<'PY'
+          import json
+          from pathlib import Path
+
+          summary = json.loads(
+              Path("outputs/workstation2/evaluation-summary.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          print(f"- GPU qualification: `{summary['gpu_qualification_passed']}`")
+          print(f"- Frozen semantic match: `{summary['frozen_semantic_match']}`")
+          print(f"- Frozen byte match: `{summary['frozen_payload_bytes_match']}`")
+          print(
+              "- Independent gates passed: "
+              f"`{summary['independent_success_gates']['overall_passed']}`"
+          )
+          PY
+            else
+              echo "- Evaluation stopped before the final summary."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload complete evaluation artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: workstation2-causal4d-evaluation
+          path: outputs/workstation2/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Remove isolated evaluation environment
+        if: always()
+        run: rm -rf .workstation2-venv _bpt

--- a/scripts/ci/compare_result_bundles.py
+++ b/scripts/ci/compare_result_bundles.py
@@ -1,0 +1,387 @@
+"""Compare result bundles bytewise and with strict numeric semantics."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Sequence
+
+
+_JSON_FILES = ("protocol.json", "success_gates.json", "summary.json")
+_CSV_FILES = ("contact_recovery.csv", "fold_calibration.csv", "interventions.csv")
+_FLOAT_TEXT = re.compile(
+    r"^[+-]?(?:(?:\d+\.\d*|\.\d+)(?:[eE][+-]?\d+)?|\d+[eE][+-]?\d+)$"
+)
+_DIRECTION_ANGLE_SUFFIX = "direction_error_deg"
+
+
+@dataclass
+class Comparison:
+    """Accumulate strict semantic differences and floating-point drift."""
+
+    mismatches: list[str] = field(default_factory=list)
+    numeric_comparisons: int = 0
+    maximum_absolute_difference: float = 0.0
+    maximum_relative_difference: float = 0.0
+    maximum_direction_angle_difference_deg: float = 0.0
+
+    def compare_number(
+        self,
+        expected: float,
+        actual: float,
+        *,
+        path: str,
+        relative_tolerance: float,
+        absolute_tolerance: float,
+        direction_angle_tolerance_deg: float,
+    ) -> None:
+        self.numeric_comparisons += 1
+        if math.isnan(expected) or math.isnan(actual):
+            if not (math.isnan(expected) and math.isnan(actual)):
+                self.mismatches.append(
+                    f"{path}: expected {expected!r}, received {actual!r}"
+                )
+            return
+        if math.isinf(expected) or math.isinf(actual):
+            if expected != actual:
+                self.mismatches.append(
+                    f"{path}: expected {expected!r}, received {actual!r}"
+                )
+            return
+        absolute = abs(actual - expected)
+        denominator = max(abs(expected), abs(actual), absolute_tolerance)
+        relative = absolute / denominator
+        self.maximum_absolute_difference = max(
+            self.maximum_absolute_difference, absolute
+        )
+        self.maximum_relative_difference = max(
+            self.maximum_relative_difference, relative
+        )
+        effective_absolute_tolerance = absolute_tolerance
+        if path.endswith(_DIRECTION_ANGLE_SUFFIX):
+            self.maximum_direction_angle_difference_deg = max(
+                self.maximum_direction_angle_difference_deg,
+                absolute,
+            )
+            effective_absolute_tolerance = max(
+                effective_absolute_tolerance,
+                direction_angle_tolerance_deg,
+            )
+        if not math.isclose(
+            expected,
+            actual,
+            rel_tol=relative_tolerance,
+            abs_tol=effective_absolute_tolerance,
+        ):
+            self.mismatches.append(
+                f"{path}: expected {expected!r}, received {actual!r}; "
+                f"absolute difference {absolute:.17g}"
+            )
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _compare_json_value(
+    expected: Any,
+    actual: Any,
+    *,
+    path: str,
+    comparison: Comparison,
+    relative_tolerance: float,
+    absolute_tolerance: float,
+    direction_angle_tolerance_deg: float,
+) -> None:
+    if _is_number(expected) and _is_number(actual):
+        comparison.compare_number(
+            float(expected),
+            float(actual),
+            path=path,
+            relative_tolerance=relative_tolerance,
+            absolute_tolerance=absolute_tolerance,
+            direction_angle_tolerance_deg=direction_angle_tolerance_deg,
+        )
+        return
+    if type(expected) is not type(actual):
+        comparison.mismatches.append(
+            f"{path}: type differs ({type(expected).__name__} versus "
+            f"{type(actual).__name__})"
+        )
+        return
+    if isinstance(expected, dict):
+        expected_keys = set(expected)
+        actual_keys = set(actual)
+        if expected_keys != actual_keys:
+            missing = sorted(expected_keys - actual_keys)
+            extra = sorted(actual_keys - expected_keys)
+            comparison.mismatches.append(
+                f"{path}: object keys differ; missing={missing!r}, extra={extra!r}"
+            )
+        for key in sorted(expected_keys & actual_keys):
+            _compare_json_value(
+                expected[key],
+                actual[key],
+                path=f"{path}.{key}",
+                comparison=comparison,
+                relative_tolerance=relative_tolerance,
+                absolute_tolerance=absolute_tolerance,
+                direction_angle_tolerance_deg=direction_angle_tolerance_deg,
+            )
+        return
+    if isinstance(expected, list):
+        if len(expected) != len(actual):
+            comparison.mismatches.append(
+                f"{path}: list length differs ({len(expected)} versus {len(actual)})"
+            )
+        for index, (expected_item, actual_item) in enumerate(
+            zip(expected, actual, strict=False)
+        ):
+            _compare_json_value(
+                expected_item,
+                actual_item,
+                path=f"{path}[{index}]",
+                comparison=comparison,
+                relative_tolerance=relative_tolerance,
+                absolute_tolerance=absolute_tolerance,
+                direction_angle_tolerance_deg=direction_angle_tolerance_deg,
+            )
+        return
+    if expected != actual:
+        comparison.mismatches.append(
+            f"{path}: expected {expected!r}, received {actual!r}"
+        )
+
+
+def _read_csv(path: Path) -> tuple[list[str], list[dict[str, str]]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            raise ValueError(f"CSV has no header: {path}")
+        return list(reader.fieldnames), list(reader)
+
+
+def _numeric_text(value: str) -> bool:
+    return bool(_FLOAT_TEXT.fullmatch(value.strip()))
+
+
+def _structured_json_text(value: str) -> bool:
+    stripped = value.strip()
+    return len(stripped) >= 2 and stripped[0] in "[{" and stripped[-1] in "]}"
+
+
+def _compare_csv(
+    expected_path: Path,
+    actual_path: Path,
+    *,
+    comparison: Comparison,
+    relative_tolerance: float,
+    absolute_tolerance: float,
+    direction_angle_tolerance_deg: float,
+) -> None:
+    expected_fields, expected_rows = _read_csv(expected_path)
+    actual_fields, actual_rows = _read_csv(actual_path)
+    label = expected_path.name
+    if expected_fields != actual_fields:
+        comparison.mismatches.append(
+            f"{label}: header differs ({expected_fields!r} versus {actual_fields!r})"
+        )
+        return
+    if len(expected_rows) != len(actual_rows):
+        comparison.mismatches.append(
+            f"{label}: row count differs ({len(expected_rows)} versus "
+            f"{len(actual_rows)})"
+        )
+    for row_index, (expected_row, actual_row) in enumerate(
+        zip(expected_rows, actual_rows, strict=False), start=2
+    ):
+        for field_name in expected_fields:
+            expected = expected_row[field_name]
+            actual = actual_row[field_name]
+            if expected == actual:
+                continue
+            path = f"{label}:row={row_index}:field={field_name}"
+            if _numeric_text(expected) and _numeric_text(actual):
+                comparison.compare_number(
+                    float(expected),
+                    float(actual),
+                    path=path,
+                    relative_tolerance=relative_tolerance,
+                    absolute_tolerance=absolute_tolerance,
+                    direction_angle_tolerance_deg=direction_angle_tolerance_deg,
+                )
+            elif _structured_json_text(expected) and _structured_json_text(actual):
+                try:
+                    expected_value = json.loads(expected)
+                    actual_value = json.loads(actual)
+                except json.JSONDecodeError:
+                    comparison.mismatches.append(
+                        f"{path}: expected {expected!r}, received {actual!r}"
+                    )
+                else:
+                    _compare_json_value(
+                        expected_value,
+                        actual_value,
+                        path=path,
+                        comparison=comparison,
+                        relative_tolerance=relative_tolerance,
+                        absolute_tolerance=absolute_tolerance,
+                        direction_angle_tolerance_deg=direction_angle_tolerance_deg,
+                    )
+            else:
+                comparison.mismatches.append(
+                    f"{path}: expected {expected!r}, received {actual!r}"
+                )
+
+
+def _compare_file(
+    expected_path: Path,
+    actual_path: Path,
+    *,
+    comparison: Comparison,
+    relative_tolerance: float,
+    absolute_tolerance: float,
+    direction_angle_tolerance_deg: float,
+) -> dict[str, Any]:
+    if not expected_path.is_file():
+        comparison.mismatches.append(f"missing expected file: {expected_path}")
+        return {"present": False}
+    if not actual_path.is_file():
+        comparison.mismatches.append(f"missing actual file: {actual_path}")
+        return {"present": False}
+    expected_bytes = expected_path.read_bytes()
+    actual_bytes = actual_path.read_bytes()
+    record = {
+        "present": True,
+        "byte_identical": expected_bytes == actual_bytes,
+        "expected_bytes": len(expected_bytes),
+        "actual_bytes": len(actual_bytes),
+        "expected_sha256": _sha256(expected_path),
+        "actual_sha256": _sha256(actual_path),
+    }
+    if expected_path.suffix == ".json":
+        expected = json.loads(expected_bytes)
+        actual = json.loads(actual_bytes)
+        _compare_json_value(
+            expected,
+            actual,
+            path=expected_path.name,
+            comparison=comparison,
+            relative_tolerance=relative_tolerance,
+            absolute_tolerance=absolute_tolerance,
+            direction_angle_tolerance_deg=direction_angle_tolerance_deg,
+        )
+    elif expected_path.suffix == ".csv":
+        _compare_csv(
+            expected_path,
+            actual_path,
+            comparison=comparison,
+            relative_tolerance=relative_tolerance,
+            absolute_tolerance=absolute_tolerance,
+            direction_angle_tolerance_deg=direction_angle_tolerance_deg,
+        )
+    else:
+        raise ValueError(f"unsupported comparison file: {expected_path}")
+    return record
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare a regenerated deterministic result bundle with an archived "
+            "bundle, preserving byte mismatch as a diagnostic while failing on "
+            "semantic drift."
+        )
+    )
+    parser.add_argument("expected_dir")
+    parser.add_argument("actual_dir")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--relative-tolerance", type=float, default=2e-12)
+    parser.add_argument("--absolute-tolerance", type=float, default=2e-15)
+    parser.add_argument(
+        "--direction-angle-tolerance-deg",
+        type=float,
+        default=2e-6,
+        help=(
+            "Absolute tolerance for direction angles near zero, where arccos "
+            "amplifies machine-level cosine differences."
+        ),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    tolerances = (
+        args.relative_tolerance,
+        args.absolute_tolerance,
+        args.direction_angle_tolerance_deg,
+    )
+    if any(value < 0.0 for value in tolerances):
+        raise ValueError("comparison tolerances must be nonnegative")
+    expected_dir = Path(args.expected_dir).resolve()
+    actual_dir = Path(args.actual_dir).resolve()
+    comparison = Comparison()
+    file_records: dict[str, Any] = {}
+    for file_name in (*_JSON_FILES, *_CSV_FILES):
+        file_records[file_name] = _compare_file(
+            expected_dir / file_name,
+            actual_dir / file_name,
+            comparison=comparison,
+            relative_tolerance=args.relative_tolerance,
+            absolute_tolerance=args.absolute_tolerance,
+            direction_angle_tolerance_deg=args.direction_angle_tolerance_deg,
+        )
+    report = {
+        "schema_version": 1,
+        "artifact_kind": "Causal4DResultBundleComparison",
+        "expected_dir": str(expected_dir),
+        "actual_dir": str(actual_dir),
+        "relative_tolerance": args.relative_tolerance,
+        "absolute_tolerance": args.absolute_tolerance,
+        "direction_angle_tolerance_deg": args.direction_angle_tolerance_deg,
+        "all_payload_bytes_match": all(
+            record.get("byte_identical") is True for record in file_records.values()
+        ),
+        "semantic_match": not comparison.mismatches,
+        "numeric_comparisons": comparison.numeric_comparisons,
+        "maximum_absolute_difference": comparison.maximum_absolute_difference,
+        "maximum_relative_difference": comparison.maximum_relative_difference,
+        "maximum_direction_angle_difference_deg": (
+            comparison.maximum_direction_angle_difference_deg
+        ),
+        "mismatch_count": len(comparison.mismatches),
+        "mismatches": comparison.mismatches[:100],
+        "files": file_records,
+        "claim_boundary": (
+            "Byte equality is reported separately from strict numeric and "
+            "structural equivalence. A field-specific near-zero angle tolerance "
+            "handles arccos conditioning and is never used to revise a gate."
+        ),
+    }
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(report, indent=2, sort_keys=True, allow_nan=False))
+    return 0 if report["semantic_match"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/workstation2_gpu_qualification.py
+++ b/scripts/ci/workstation2_gpu_qualification.py
@@ -1,0 +1,213 @@
+"""Qualify a self-hosted CUDA/Warp runner with deterministic shared-memory IO."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import time
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import torch
+import warp as wp
+
+
+@wp.kernel
+def _saxpy_kernel(
+    x: wp.array(dtype=wp.float32),  # type: ignore[valid-type]
+    y: wp.array(dtype=wp.float32),  # type: ignore[valid-type]
+    output: wp.array(dtype=wp.float32),  # type: ignore[valid-type]
+    alpha: float,
+) -> None:
+    index = wp.tid()
+    output[index] = alpha * x[index] + y[index]
+
+
+def _sha256_array(values: np.ndarray) -> str:
+    array = np.ascontiguousarray(values)
+    digest = hashlib.sha256()
+    digest.update(array.dtype.str.encode("ascii"))
+    digest.update(json.dumps(array.shape, separators=(",", ":")).encode("ascii"))
+    digest.update(array.view(np.uint8))
+    return digest.hexdigest()
+
+
+def _throughput_gb_s(elements: int, iterations: int, seconds: float) -> float:
+    transferred_bytes = elements * iterations * 3 * np.dtype(np.float32).itemsize
+    return transferred_bytes / seconds / 1e9
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run deterministic Torch and Warp CUDA qualification."
+    )
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--elements", type=int, default=4_000_000)
+    parser.add_argument("--iterations", type=int, default=30)
+    parser.add_argument("--warmup-iterations", type=int, default=3)
+    parser.add_argument("--alpha", type=float, default=1.25)
+    parser.add_argument("--maximum-error", type=float, default=2e-6)
+    return parser
+
+
+def run_qualification(args: argparse.Namespace) -> dict[str, Any]:
+    if args.elements < 1:
+        raise ValueError("elements must be positive")
+    if args.iterations < 1 or args.warmup_iterations < 0:
+        raise ValueError("iteration counts are invalid")
+    if not torch.cuda.is_available():
+        raise RuntimeError("PyTorch cannot see a CUDA device")
+
+    torch.use_deterministic_algorithms(True)
+    torch.cuda.set_device(0)
+    torch_device = torch.device("cuda:0")
+    properties = torch.cuda.get_device_properties(torch_device)
+
+    wp.init()
+    cuda_devices = wp.get_cuda_devices()
+    if not cuda_devices:
+        raise RuntimeError("Warp cannot see a CUDA device")
+    warp_device = cuda_devices[0]
+    wp.set_device(warp_device)
+
+    index = torch.arange(args.elements, device=torch_device, dtype=torch.float32)
+    x = torch.sin(index * 0.001)
+    y = torch.cos(index * 0.0007)
+    output = torch.empty_like(x)
+    reference = torch.add(y, x, alpha=args.alpha)
+
+    wp_x = wp.from_torch(x, dtype=wp.float32)
+    wp_y = wp.from_torch(y, dtype=wp.float32)
+    wp_output = wp.from_torch(output, dtype=wp.float32)
+
+    for _ in range(args.warmup_iterations):
+        wp.launch(
+            _saxpy_kernel,
+            dim=args.elements,
+            inputs=[wp_x, wp_y, wp_output, args.alpha],
+            device=warp_device,
+        )
+    wp.synchronize()
+
+    started = time.perf_counter()
+    for _ in range(args.iterations):
+        wp.launch(
+            _saxpy_kernel,
+            dim=args.elements,
+            inputs=[wp_x, wp_y, wp_output, args.alpha],
+            device=warp_device,
+        )
+    wp.synchronize()
+    warp_seconds = time.perf_counter() - started
+
+    maximum_error = float(torch.max(torch.abs(output - reference)).item())
+    first_output = output.detach().cpu().numpy().copy()
+    first_sha256 = _sha256_array(first_output)
+
+    output.fill_(float("nan"))
+    wp.launch(
+        _saxpy_kernel,
+        dim=args.elements,
+        inputs=[wp_x, wp_y, wp_output, args.alpha],
+        device=warp_device,
+    )
+    wp.synchronize()
+    second_output = output.detach().cpu().numpy().copy()
+    second_sha256 = _sha256_array(second_output)
+
+    torch_output = torch.empty_like(x)
+    for _ in range(args.warmup_iterations):
+        torch.add(y, x, alpha=args.alpha, out=torch_output)
+    torch.cuda.synchronize()
+    started = time.perf_counter()
+    for _ in range(args.iterations):
+        torch.add(y, x, alpha=args.alpha, out=torch_output)
+    torch.cuda.synchronize()
+    torch_seconds = time.perf_counter() - started
+    torch_maximum_error = float(torch.max(torch.abs(torch_output - reference)).item())
+
+    passed = bool(
+        maximum_error <= args.maximum_error
+        and torch_maximum_error <= args.maximum_error
+        and first_sha256 == second_sha256
+    )
+    result = {
+        "schema_version": 1,
+        "artifact_kind": "Causal4DWorkstation2GpuQualification",
+        "passed": passed,
+        "runner": {
+            "name": os.environ.get("RUNNER_NAME"),
+            "os": os.environ.get("RUNNER_OS"),
+            "architecture": os.environ.get("RUNNER_ARCH"),
+            "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
+        },
+        "platform": {
+            "python": platform.python_version(),
+            "implementation": platform.python_implementation(),
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+        },
+        "gpu": {
+            "name": properties.name,
+            "compute_capability": [properties.major, properties.minor],
+            "total_memory_bytes": properties.total_memory,
+            "torch_version": torch.__version__,
+            "torch_cuda_version": torch.version.cuda,
+            "warp_version": wp.__version__,
+            "warp_cuda_devices": [str(device) for device in cuda_devices],
+        },
+        "configuration": {
+            "elements": args.elements,
+            "iterations": args.iterations,
+            "warmup_iterations": args.warmup_iterations,
+            "alpha": args.alpha,
+            "maximum_error": args.maximum_error,
+        },
+        "correctness": {
+            "warp_maximum_absolute_error": maximum_error,
+            "torch_maximum_absolute_error": torch_maximum_error,
+            "first_output_sha256": first_sha256,
+            "second_output_sha256": second_sha256,
+            "repeat_is_bit_identical": first_sha256 == second_sha256,
+        },
+        "performance": {
+            "warp_seconds": warp_seconds,
+            "warp_effective_gb_s": _throughput_gb_s(
+                args.elements, args.iterations, warp_seconds
+            ),
+            "torch_seconds": torch_seconds,
+            "torch_effective_gb_s": _throughput_gb_s(
+                args.elements, args.iterations, torch_seconds
+            ),
+            "torch_peak_allocated_bytes": torch.cuda.max_memory_allocated(),
+            "torch_peak_reserved_bytes": torch.cuda.max_memory_reserved(),
+        },
+        "claim_boundary": (
+            "Hardware and numerical-runtime qualification only; this is not an "
+            "accuracy, calibration, physical-prediction, or intervention result."
+        ),
+    }
+    if not passed:
+        raise RuntimeError(f"GPU qualification failed: {result['correctness']}")
+    return result
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    result = run_qualification(args)
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(result, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(result, indent=2, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- route the optional GPU integration to runner labels `self-hosted`, `Linux`, `X64`, and `nvidia-smi`;
- use the transferred `IPS-Stuttgart/BayesianPhysTwin` repository and its read-only SSH deploy key;
- add a same-repository-only workstation2 evaluation workflow;
- qualify the NVIDIA, PyTorch, and Warp runtime with deterministic zero-copy Torch/Warp computation;
- reproduce the frozen five-seed latent-contact result, reporting strict numerical/structural equivalence separately from serialized-byte equality;
- run a separate controlled diagnostic replication on seeds `100:120` and archive its complete result bundle;
- preserve the frozen estimator, real protocol, target IDs, gates, calibration, and paper claim.

## Evaluation boundary

The seeds `0:5` run is an independent-runner reproduction of the frozen controlled result. The comparator fails on substantive structural or numeric drift. It gives `direction_error_deg` a field-specific `2e-6` degree tolerance because near-zero angles computed through `arccos` amplify machine-level cosine differences; this tolerance is not used by any scientific gate. Raw byte equality remains a separate diagnostic.

The seeds `100:120` run is diagnostic controlled replication only. No physical or target data are read, and its outcome cannot revise the frozen method or the registered 36-execution experiment.

## Self-hosted runner safety

The pull-request trigger is path-limited and requires the PR head repository to equal the base repository. Fork pull requests cannot execute code on workstation2. Manual dispatch remains available after merge.

## Outputs

The 30-day workflow artifact includes runner and NVIDIA metadata, pip environment, deterministic CUDA correctness and throughput results, the frozen reproduction and comparison, the independent-seed bundle and gate summary, and the pinned BayesianPhysTwin integration output when the deploy key is configured.
