### PR TITLE
Repair private-provider CI after repository transfer

### DIFF
--- a/.github/workflows/bayesian-phystwin-provider-compatibility.yml
+++ b/.github/workflows/bayesian-phystwin-provider-compatibility.yml
@@ -68,7 +68,7 @@ on:
   workflow_dispatch:
     inputs:
       bpt_ref:
-        description: Bayesian-PhysTwin revision to test
+        description: BayesianPhysTwin revision to test
         required: false
         default: main
       prob4d_ref:
@@ -108,8 +108,8 @@ jobs:
               echo "This check is not allowed to pass by skipping its private repositories."
               echo "Configure a least-privilege token with read access to:"
               echo
-              echo "- \`FlorianPfaff/Bayesian-PhysTwin\`;"
-              echo "- \`FlorianPfaff/Prob4D\`."
+              echo "- \`IPS-Stuttgart/BayesianPhysTwin\`;"
+              echo "- \`IPS-Stuttgart/Prob4D\`."
             } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
@@ -149,10 +149,10 @@ jobs:
           path: causal4d
           persist-credentials: false
 
-      - name: Check out Bayesian-PhysTwin
+      - name: Check out BayesianPhysTwin
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repository: FlorianPfaff/Bayesian-PhysTwin
+          repository: IPS-Stuttgart/BayesianPhysTwin
           ref: ${{ inputs.bpt_ref || 'main' }}
           token: ${{ secrets.BPT_READ_TOKEN }}
           path: bayesian-phystwin
@@ -161,7 +161,7 @@ jobs:
       - name: Check out Prob4D
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repository: FlorianPfaff/Prob4D
+          repository: IPS-Stuttgart/Prob4D
           ref: ${{ inputs.prob4d_ref || 'main' }}
           token: ${{ secrets.BPT_READ_TOKEN }}
           path: prob4d

--- a/.github/workflows/bayesian-phystwin-provider-compatibility.yml
+++ b/.github/workflows/bayesian-phystwin-provider-compatibility.yml
@@ -94,26 +94,33 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      PRIVATE_REPOSITORY_READ_TOKEN: ${{ secrets.BPT_READ_TOKEN }}
+      BPT_READ_SSH_KEY: ${{ secrets.BPT_READ_SSH_KEY }}
+      PROB4D_READ_SSH_KEY: ${{ secrets.PROB4D_READ_SSH_KEY }}
     steps:
-      - name: Enforce private-repository credential
+      - name: Enforce private-repository deploy keys
+        shell: bash
         run: |
-          if [[ -z "${PRIVATE_REPOSITORY_READ_TOKEN}" ]]; then
-            echo "::error::BPT_READ_TOKEN is not configured; the required three-repository golden path cannot run."
+          missing=()
+          [[ -n "${BPT_READ_SSH_KEY}" ]] || missing+=("BPT_READ_SSH_KEY")
+          [[ -n "${PROB4D_READ_SSH_KEY}" ]] || missing+=("PROB4D_READ_SSH_KEY")
+          if (( ${#missing[@]} )); then
+            echo "::error::Required private-repository deploy keys are absent: ${missing[*]}"
             {
               echo "### Three-repository installed-wheel compatibility"
               echo
-              echo "**Failed:** the repository secret \`BPT_READ_TOKEN\` is absent."
+              echo "**Failed:** required read-only deploy-key secrets are absent."
               echo
               echo "This check is not allowed to pass by skipping its private repositories."
-              echo "Configure a least-privilege token with read access to:"
+              echo "Configure repository-scoped read-only deploy keys and store their private keys as:"
               echo
-              echo "- \`IPS-Stuttgart/BayesianPhysTwin\`;"
-              echo "- \`IPS-Stuttgart/Prob4D\`."
+              echo "- \`BPT_READ_SSH_KEY\` for \`IPS-Stuttgart/BayesianPhysTwin\`;"
+              echo "- \`PROB4D_READ_SSH_KEY\` for \`IPS-Stuttgart/Prob4D\`."
+              echo
+              echo "Missing in this run: \`${missing[*]}\`."
             } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
-          echo "Private-repository credential is configured."
+          echo "Both private-provider deploy keys are configured."
 
   external-pull-request:
     name: External PR cannot access private providers
@@ -140,8 +147,6 @@ jobs:
     if: needs.credential-gate.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    env:
-      PRIVATE_REPOSITORY_READ_TOKEN: ${{ secrets.BPT_READ_TOKEN }}
     steps:
       - name: Check out Causal4D
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -154,7 +159,7 @@ jobs:
         with:
           repository: IPS-Stuttgart/BayesianPhysTwin
           ref: ${{ inputs.bpt_ref || 'main' }}
-          token: ${{ secrets.BPT_READ_TOKEN }}
+          ssh-key: ${{ secrets.BPT_READ_SSH_KEY }}
           path: bayesian-phystwin
           persist-credentials: false
 
@@ -163,7 +168,7 @@ jobs:
         with:
           repository: IPS-Stuttgart/Prob4D
           ref: ${{ inputs.prob4d_ref || 'main' }}
-          token: ${{ secrets.BPT_READ_TOKEN }}
+          ssh-key: ${{ secrets.PROB4D_READ_SSH_KEY }}
           path: prob4d
           persist-credentials: false
 

--- a/.github/workflows/self-hosted-evaluation.yml
+++ b/.github/workflows/self-hosted-evaluation.yml
@@ -13,7 +13,7 @@ on:
           - standard
           - full
       run_bpt:
-        description: Run the pinned Bayesian-PhysTwin provider checks
+        description: Run the pinned BayesianPhysTwin provider checks
         required: true
         default: true
         type: boolean
@@ -176,46 +176,46 @@ jobs:
             --output-dir self-hosted-evaluation/results \
             | tee self-hosted-evaluation/evaluation.log
 
-      - name: Detect private Bayesian-PhysTwin credential
+      - name: Detect private BayesianPhysTwin deploy key
         if: ${{ inputs.run_bpt }}
         id: access
         shell: bash
         env:
-          BPT_READ_TOKEN: ${{ secrets.BPT_READ_TOKEN }}
+          BPT_READ_SSH_KEY: ${{ secrets.BPT_READ_SSH_KEY }}
         run: |
-          if [[ -n "${BPT_READ_TOKEN}" ]]; then
+          if [[ -n "${BPT_READ_SSH_KEY}" ]]; then
             echo "enabled=true" >> "${GITHUB_OUTPUT}"
           else
             echo "enabled=false" >> "${GITHUB_OUTPUT}"
-            echo "::warning::BPT_READ_TOKEN is absent; provider checks were skipped."
+            echo "::warning::BPT_READ_SSH_KEY is absent; provider checks were skipped."
           fi
 
-      - name: Read exact Bayesian-PhysTwin provider pin
+      - name: Read exact BayesianPhysTwin provider pin
         if: steps.access.outputs.enabled == 'true'
         id: pin
         run: echo "sha=$(python scripts/ci/read_bpt_pin.py)" >> "${GITHUB_OUTPUT}"
 
-      - name: Check out pinned Bayesian-PhysTwin
+      - name: Check out pinned BayesianPhysTwin
         if: steps.access.outputs.enabled == 'true'
         id: bpt_checkout
         continue-on-error: true
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repository: IPS-Stuttgart/Bayesian-PhysTwin
+          repository: IPS-Stuttgart/BayesianPhysTwin
           ref: ${{ steps.pin.outputs.sha }}
-          token: ${{ secrets.BPT_READ_TOKEN }}
+          ssh-key: ${{ secrets.BPT_READ_SSH_KEY }}
           path: _bpt
           persist-credentials: false
 
-      - name: Report unavailable Bayesian-PhysTwin access
+      - name: Report unavailable BayesianPhysTwin access
         if: >-
           steps.access.outputs.enabled == 'true' &&
           steps.bpt_checkout.outcome != 'success'
         shell: bash
         run: |
-          echo "::warning::BPT_READ_TOKEN could not read IPS-Stuttgart/Bayesian-PhysTwin; provider checks were skipped."
+          echo "::warning::BPT_READ_SSH_KEY could not read IPS-Stuttgart/BayesianPhysTwin; provider checks were skipped."
 
-      - name: Install pinned Bayesian-PhysTwin
+      - name: Install pinned BayesianPhysTwin
         if: steps.bpt_checkout.outcome == 'success'
         run: |
           python -m pip install -e ./_bpt

--- a/.github/workflows/self-hosted-evaluation.yml
+++ b/.github/workflows/self-hosted-evaluation.yml
@@ -176,29 +176,24 @@ jobs:
             --output-dir self-hosted-evaluation/results \
             | tee self-hosted-evaluation/evaluation.log
 
-      - name: Detect private BayesianPhysTwin deploy key
+      - name: Require private BayesianPhysTwin deploy key
         if: ${{ inputs.run_bpt }}
-        id: access
         shell: bash
         env:
           BPT_READ_SSH_KEY: ${{ secrets.BPT_READ_SSH_KEY }}
         run: |
-          if [[ -n "${BPT_READ_SSH_KEY}" ]]; then
-            echo "enabled=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "enabled=false" >> "${GITHUB_OUTPUT}"
-            echo "::warning::BPT_READ_SSH_KEY is absent; provider checks were skipped."
+          if [[ -z "${BPT_READ_SSH_KEY}" ]]; then
+            echo "::error::run_bpt=true requires BPT_READ_SSH_KEY."
+            exit 1
           fi
 
       - name: Read exact BayesianPhysTwin provider pin
-        if: steps.access.outputs.enabled == 'true'
+        if: ${{ inputs.run_bpt }}
         id: pin
         run: echo "sha=$(python scripts/ci/read_bpt_pin.py)" >> "${GITHUB_OUTPUT}"
 
       - name: Check out pinned BayesianPhysTwin
-        if: steps.access.outputs.enabled == 'true'
-        id: bpt_checkout
-        continue-on-error: true
+        if: ${{ inputs.run_bpt }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: IPS-Stuttgart/BayesianPhysTwin
@@ -207,22 +202,14 @@ jobs:
           path: _bpt
           persist-credentials: false
 
-      - name: Report unavailable BayesianPhysTwin access
-        if: >-
-          steps.access.outputs.enabled == 'true' &&
-          steps.bpt_checkout.outcome != 'success'
-        shell: bash
-        run: |
-          echo "::warning::BPT_READ_SSH_KEY could not read IPS-Stuttgart/BayesianPhysTwin; provider checks were skipped."
-
       - name: Install pinned BayesianPhysTwin
-        if: steps.bpt_checkout.outcome == 'success'
+        if: ${{ inputs.run_bpt }}
         run: |
           python -m pip install -e ./_bpt
           python -m pip check
 
       - name: Run pinned provider integration tests
-        if: steps.bpt_checkout.outcome == 'success'
+        if: ${{ inputs.run_bpt }}
         shell: bash
         run: |
           set -o pipefail

--- a/ci/three_repository_common.py
+++ b/ci/three_repository_common.py
@@ -11,6 +11,10 @@ from pathlib import Path
 
 import numpy as np
 
+CAUSAL4D_REPOSITORY = "IPS-Stuttgart/Causal4D"
+BAYESIAN_PHYSTWIN_REPOSITORY = "IPS-Stuttgart/BayesianPhysTwin"
+PROB4D_REPOSITORY = "IPS-Stuttgart/Prob4D"
+
 EXPECTED_OBSERVATION_ARTIFACT_ID = (
     "2a1f24acd2dd741155eb5333c92a37f615e1f0578b7f55cb9df0d34c52af8640"
 )

--- a/ci/three_repository_golden_path.py
+++ b/ci/three_repository_golden_path.py
@@ -1,4 +1,4 @@
-"""Installed-wheel golden path for Prob4D, Bayesian-PhysTwin, and Causal4D.
+"""Installed-wheel golden path for Prob4D, BayesianPhysTwin, and Causal4D.
 
 The runner is copied outside every source checkout before execution. It accepts
 only data and exact repository revisions from those checkouts; all Python imports
@@ -13,7 +13,13 @@ import os
 from pathlib import Path
 from typing import Any
 
-from three_repository_common import installed_package_origins, require
+from three_repository_common import (
+    BAYESIAN_PHYSTWIN_REPOSITORY,
+    CAUSAL4D_REPOSITORY,
+    PROB4D_REPOSITORY,
+    installed_package_origins,
+    require,
+)
 from three_repository_manifest import run_evidence_manifest_checks
 from three_repository_observation import (
     fixture_artifact,
@@ -102,9 +108,9 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         "package_origins": origins,
         "project_status": project_status,
         "repository_revisions": {
-            "FlorianPfaff/Prob4D": args.prob4d_revision,
-            "FlorianPfaff/Bayesian-PhysTwin": args.bpt_revision,
-            "FlorianPfaff/Causal4D": args.causal4d_revision,
+            PROB4D_REPOSITORY: args.prob4d_revision,
+            BAYESIAN_PHYSTWIN_REPOSITORY: args.bpt_revision,
+            CAUSAL4D_REPOSITORY: args.causal4d_revision,
         },
         "observation_artifact_id": restored_prob4d.artifact_id,
         "prob4d_provider_manifest": prob4d_manifest,

--- a/ci/three_repository_manifest.py
+++ b/ci/three_repository_manifest.py
@@ -7,7 +7,12 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any, Callable
 
-from three_repository_common import require
+from three_repository_common import (
+    BAYESIAN_PHYSTWIN_REPOSITORY,
+    CAUSAL4D_REPOSITORY,
+    PROB4D_REPOSITORY,
+    require,
+)
 
 
 def _expect_failure(label: str, operation: Callable[[], Any]) -> dict[str, str]:
@@ -71,18 +76,18 @@ def run_evidence_manifest_checks(
 
     manifest = RunManifestV2(
         run_id="three-repository-installed-wheel-golden-path",
-        repository="FlorianPfaff/Causal4D",
+        repository=CAUSAL4D_REPOSITORY,
         revision=revisions["causal4d"],
         dirty=False,
         related_repositories=(
             RepositoryState(
-                repository="FlorianPfaff/Prob4D",
+                repository=PROB4D_REPOSITORY,
                 revision=revisions["prob4d"],
                 dirty=False,
                 role="observation",
             ),
             RepositoryState(
-                repository="FlorianPfaff/Bayesian-PhysTwin",
+                repository=BAYESIAN_PHYSTWIN_REPOSITORY,
                 revision=revisions["bayesian-phystwin"],
                 dirty=False,
                 role="upstream",

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -2,15 +2,15 @@
 
 Causal4D separates its lightweight contracts from private-provider and
 hardware integrations. This keeps a base installation testable while still
-detecting drift at the Prob4D and Bayesian-PhysTwin boundaries.
+detecting drift at the Prob4D and BayesianPhysTwin boundaries.
 
 ## Required pull-request checks
 
 `CI and release` runs the following independent jobs:
 
-- **Core-only** installs `.[dev]` without Bayesian-PhysTwin, OpenCV, PyTorch, or
+- **Core-only** installs `.[dev]` without BayesianPhysTwin, OpenCV, PyTorch, or
   Warp and executes the default test suite on Python 3.10, 3.12, and 3.14.
-- **Pinned Bayesian-PhysTwin integration** checks out the exact provider-API
+- **Pinned BayesianPhysTwin integration** checks out the exact provider-API
   revision recorded in `requirements/ci/bayesian-phystwin-provider-v1.sha` and
   runs the BPT-facing Causal4D tests. The normal `phystwin` extra remains the
   supported `>=0.4,<0.5` development range.
@@ -31,19 +31,21 @@ Ruff-formatted without forcing unrelated historical files into the same change.
 
 ## Private repository access
 
-Configure the least-privilege repository secret `BPT_READ_TOKEN` with read
-access to both private repositories:
+Use repository-scoped, read-only SSH deploy keys for the two private providers.
+Add each public key as a read-only deploy key to its provider repository and
+store the corresponding private key as a Causal4D repository secret:
 
-- `FlorianPfaff/Bayesian-PhysTwin`;
-- `FlorianPfaff/Prob4D`.
+- `BPT_READ_SSH_KEY` for `IPS-Stuttgart/BayesianPhysTwin`;
+- `PROB4D_READ_SSH_KEY` for `IPS-Stuttgart/Prob4D`.
 
-The historical secret name is retained so existing repository configuration
-does not need to change. Trusted same-repository pull requests, pushes,
-scheduled runs, and manual dispatches now **fail** when the secret is absent.
-The three-repository workflow is not allowed to report success after skipping
-its checkouts, wheel builds, and compatibility tests.
+The keys are intentionally separate because GitHub deploy keys are scoped to one
+repository. This avoids a broad personal access token and makes provider access
+revocable independently. Trusted same-repository pull requests, pushes,
+scheduled runs, and manual dispatches fail when either key required by the
+three-repository workflow is absent. The workflow is not allowed to report
+success after skipping its checkouts, wheel builds, and compatibility tests.
 
-Tag releases also fail in the main CI workflow when the credential is absent,
+Tag releases also fail in the main CI workflow when `BPT_READ_SSH_KEY` is absent,
 so a skipped pinned-provider job cannot authorize release publication.
 
 GitHub does not expose repository secrets to pull requests from external forks.
@@ -55,15 +57,16 @@ passing installed-wheel golden path before merge.
 ## Three-repository installed-wheel golden path
 
 `.github/workflows/bayesian-phystwin-provider-compatibility.yml` is the terminal
-Prob4D -> Bayesian-PhysTwin -> Causal4D compatibility check. It runs on relevant
+Prob4D -> BayesianPhysTwin -> Causal4D compatibility check. It runs on relevant
 same-repository pull requests and pushes, can be dispatched with explicit BPT
 and Prob4D revisions, and runs weekly against both private repositories' `main`
 branches.
 
 The workflow begins with a separate credential gate. For trusted events, a
-missing `BPT_READ_TOKEN` is a hard configuration failure and prevents a false
-green result. Only an external-fork pull request can use the explicitly labelled
-unavailable path, because GitHub withholds repository secrets by design.
+missing `BPT_READ_SSH_KEY` or `PROB4D_READ_SSH_KEY` is a hard configuration
+failure and prevents a false green result. Only an external-fork pull request can
+use the explicitly labelled unavailable path, because GitHub withholds
+repository secrets by design.
 
 The installed-wheel job records the exact clean revision of every checkout,
 builds one wheel for each repository, records each wheel's SHA-256 identity, and
@@ -79,7 +82,7 @@ The compatibility path:
 
 1. reconstructs the deterministic Prob4D joint-gauge observation fixture and
    checks its fixed content address;
-2. lets Bayesian-PhysTwin independently validate causal lineage, adapt the
+2. lets BayesianPhysTwin independently validate causal lineage, adapt the
    observation to a gauge-aware batch, and execute a deterministic update;
 3. asserts that conditional local covariance is passed unchanged while the
    shared low-rank gauge root remains an explicit nuisance, preventing
@@ -111,7 +114,7 @@ formed:
 1. Prob4D's strict loader requires an explicit causal stream contract v2, the
    sequential joint gauge tree, canonical shared factors, both calibration IDs,
    and independently verified runtime provenance;
-2. Bayesian-PhysTwin's claim-bearing adapter validates the producer statement,
+2. BayesianPhysTwin's claim-bearing adapter validates the producer statement,
    full cross-window covariance, calibration completeness, and fallback policy
    before constructing the innovation, then executes the deterministic guarded
    update twice and requires exact parity;
@@ -151,22 +154,22 @@ expected rejection.
 core job:
 
 - hosted CPU vision/OpenCV tests run weekly;
-- BPT OpenCV collection and Warp CPU tests run separately when the private token
-  is configured;
-- the CUDA/Warp job is manual and targets a self-hosted runner carrying the
-  labels `self-hosted`, `linux`, `x64`, and `gpu`.
+- BPT OpenCV collection and Warp CPU tests run separately when
+  `BPT_READ_SSH_KEY` is configured;
+- the CUDA/Warp job is manual and targets the self-hosted runner carrying the
+  labels `self-hosted`, `Linux`, `X64`, and `nvidia-smi`.
 
-The manual GPU job additionally requires the same `BPT_READ_TOKEN` secret.
+The manual GPU job additionally requires `BPT_READ_SSH_KEY`.
 
 ## Reproducing the wheel boundary locally
 
 The workflow is the canonical executable specification because it can read the
 two private repositories. A local equivalent requires checkouts of all three
-repositories and a token is not needed once they are available:
+repositories and no credential once they are locally available:
 
 ```bash
 python -m build --wheel --outdir /tmp/three-repo-wheels Prob4D
-python -m build --wheel --outdir /tmp/three-repo-wheels Bayesian-PhysTwin
+python -m build --wheel --outdir /tmp/three-repo-wheels BayesianPhysTwin
 python -m build --wheel --outdir /tmp/three-repo-wheels Causal4D
 python -m venv /tmp/three-repo-venv
 /tmp/three-repo-venv/bin/python -m pip install /tmp/three-repo-wheels/*.whl

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -159,7 +159,11 @@ core job:
 - the CUDA/Warp job is manual and targets the self-hosted runner carrying the
   labels `self-hosted`, `Linux`, `X64`, and `nvidia-smi`.
 
-The manual GPU job additionally requires `BPT_READ_SSH_KEY`.
+The manual GPU job additionally requires `BPT_READ_SSH_KEY`. The separate
+`Self-hosted research evaluation` workflow defaults `run_bpt=true`; when that
+input is selected, a missing key, failed checkout, or failed provider test fails
+the job. Set `run_bpt=false` explicitly to run only the provider-independent
+GPU diagnostics.
 
 ## Reproducing the wheel boundary locally
 

--- a/tests/test_three_repository_workflow_policy.py
+++ b/tests/test_three_repository_workflow_policy.py
@@ -72,6 +72,16 @@ def test_transferred_repository_locations_are_used_consistently() -> None:
     assert "FlorianPfaff/" not in golden_path
 
 
+def test_requested_self_hosted_provider_coverage_cannot_degrade_to_a_skip() -> None:
+    text = SELF_HOSTED_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Require private BayesianPhysTwin deploy key" in text
+    assert "run_bpt=true requires BPT_READ_SSH_KEY" in text
+    assert "continue-on-error: true" not in text
+    assert "provider checks were skipped" not in text
+    assert text.count("if: ${{ inputs.run_bpt }}") >= 5
+
+
 def test_strict_claim_bearing_path_is_mandatory_and_fail_closed() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
 

--- a/tests/test_three_repository_workflow_policy.py
+++ b/tests/test_three_repository_workflow_policy.py
@@ -5,7 +5,10 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = (
-    ROOT / ".github" / "workflows" / "bayesian-phystwin-provider-compatibility.yml"
+    ROOT
+    / ".github"
+    / "workflows"
+    / "bayesian-phystwin-provider-compatibility.yml"
 )
 COMMON = ROOT / "ci" / "three_repository_common.py"
 MANIFEST = ROOT / "ci" / "three_repository_manifest.py"

--- a/tests/test_three_repository_workflow_policy.py
+++ b/tests/test_three_repository_workflow_policy.py
@@ -5,10 +5,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = (
-    ROOT
-    / ".github"
-    / "workflows"
-    / "bayesian-phystwin-provider-compatibility.yml"
+    ROOT / ".github" / "workflows" / "bayesian-phystwin-provider-compatibility.yml"
 )
 COMMON = ROOT / "ci" / "three_repository_common.py"
 MANIFEST = ROOT / "ci" / "three_repository_manifest.py"

--- a/tests/test_three_repository_workflow_policy.py
+++ b/tests/test_three_repository_workflow_policy.py
@@ -7,6 +7,7 @@ ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = (
     ROOT / ".github" / "workflows" / "bayesian-phystwin-provider-compatibility.yml"
 )
+SELF_HOSTED_WORKFLOW = ROOT / ".github" / "workflows" / "self-hosted-evaluation.yml"
 COMMON = ROOT / "ci" / "three_repository_common.py"
 MANIFEST = ROOT / "ci" / "three_repository_manifest.py"
 GOLDEN_PATH = ROOT / "ci" / "three_repository_golden_path.py"
@@ -17,10 +18,22 @@ def test_trusted_events_cannot_pass_by_skipping_private_repositories() -> None:
 
     assert "credential-gate:" in text
     assert "Require private-repository read access" in text
+    assert "Enforce private-repository deploy keys" in text
     assert "exit 1" in text
     assert "needs: credential-gate" in text
     assert "steps.access.outputs.enabled" not in text
-    assert "the required three-repository golden path cannot run" in text
+    assert "This check is not allowed to pass" in text
+
+
+def test_private_provider_checkouts_use_repository_scoped_deploy_keys() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "BPT_READ_SSH_KEY: ${{ secrets.BPT_READ_SSH_KEY }}" in text
+    assert "PROB4D_READ_SSH_KEY: ${{ secrets.PROB4D_READ_SSH_KEY }}" in text
+    assert "ssh-key: ${{ secrets.BPT_READ_SSH_KEY }}" in text
+    assert "ssh-key: ${{ secrets.PROB4D_READ_SSH_KEY }}" in text
+    assert "BPT_READ_TOKEN" not in text
+    assert "token: ${{ secrets." not in text
 
 
 def test_external_fork_limitation_is_separate_and_explicit() -> None:
@@ -34,6 +47,7 @@ def test_external_fork_limitation_is_separate_and_explicit() -> None:
 
 def test_transferred_repository_locations_are_used_consistently() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
+    self_hosted = SELF_HOSTED_WORKFLOW.read_text(encoding="utf-8")
     common = COMMON.read_text(encoding="utf-8")
     manifest = MANIFEST.read_text(encoding="utf-8")
     golden_path = GOLDEN_PATH.read_text(encoding="utf-8")
@@ -48,6 +62,10 @@ def test_transferred_repository_locations_are_used_consistently() -> None:
 
     assert "repository: IPS-Stuttgart/BayesianPhysTwin" in workflow
     assert "repository: IPS-Stuttgart/Prob4D" in workflow
+    assert "repository: IPS-Stuttgart/BayesianPhysTwin" in self_hosted
+    assert "ssh-key: ${{ secrets.BPT_READ_SSH_KEY }}" in self_hosted
+    assert "BPT_READ_TOKEN" not in self_hosted
+    assert "IPS-Stuttgart/Bayesian-PhysTwin" not in self_hosted
     assert "FlorianPfaff/Bayesian-PhysTwin" not in workflow
     assert "FlorianPfaff/Prob4D" not in workflow
     assert "FlorianPfaff/Causal4D" not in manifest

--- a/tests/test_three_repository_workflow_policy.py
+++ b/tests/test_three_repository_workflow_policy.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from pathlib import Path
 
 
+ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = (
-    Path(__file__).resolve().parents[1]
-    / ".github"
-    / "workflows"
-    / "bayesian-phystwin-provider-compatibility.yml"
+    ROOT / ".github" / "workflows" / "bayesian-phystwin-provider-compatibility.yml"
 )
+COMMON = ROOT / "ci" / "three_repository_common.py"
+MANIFEST = ROOT / "ci" / "three_repository_manifest.py"
+GOLDEN_PATH = ROOT / "ci" / "three_repository_golden_path.py"
 
 
 def test_trusted_events_cannot_pass_by_skipping_private_repositories() -> None:
@@ -29,6 +30,28 @@ def test_external_fork_limitation_is_separate_and_explicit() -> None:
     assert "External PR cannot access private providers" in text
     assert "github.event.pull_request.head.repo.full_name != github.repository" in text
     assert "maintainers must run the installed-wheel golden path" in text
+
+
+def test_transferred_repository_locations_are_used_consistently() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    common = COMMON.read_text(encoding="utf-8")
+    manifest = MANIFEST.read_text(encoding="utf-8")
+    golden_path = GOLDEN_PATH.read_text(encoding="utf-8")
+
+    current_repositories = (
+        "IPS-Stuttgart/Causal4D",
+        "IPS-Stuttgart/BayesianPhysTwin",
+        "IPS-Stuttgart/Prob4D",
+    )
+    for repository in current_repositories:
+        assert repository in common
+
+    assert "repository: IPS-Stuttgart/BayesianPhysTwin" in workflow
+    assert "repository: IPS-Stuttgart/Prob4D" in workflow
+    assert "FlorianPfaff/Bayesian-PhysTwin" not in workflow
+    assert "FlorianPfaff/Prob4D" not in workflow
+    assert "FlorianPfaff/Causal4D" not in manifest
+    assert "FlorianPfaff/" not in golden_path
 
 
 def test_strict_claim_bearing_path_is_mandatory_and_fail_closed() -> None:


### PR DESCRIPTION
Superseded by the current transferred-repository compatibility workflow on `main` and the external configuration issue #117.

This older branch is conflict-blocked and assumes a terminal credential posture before the repository-scoped Prob4D deploy key is configured. Current CI already uses the transferred `IPS-Stuttgart/BayesianPhysTwin` and `IPS-Stuttgart/Prob4D` identities, probes private access explicitly, executes the available Causal4D/BayesianPhysTwin coverage, records a controlled unavailable gate on continuous events, and remains fail-closed for scheduled/manual terminal validation.

Do not revive or merge this stale branch. Configure `PROB4D_READ_SSH_KEY` as tracked in #117, then update the current workflow on a fresh branch only if the repository chooses the deploy-key implementation over the existing fine-grained token input.