### PR TITLE
Harden claim-bearing JSON and contact posterior metrics

### DIFF
--- a/src/causal4d/contact_metrics.py
+++ b/src/causal4d/contact_metrics.py
@@ -45,21 +45,54 @@ def _weighted_crps(probabilities: dict[float | int, float], truth: float) -> flo
     return first - second
 
 
+def _credible_set(
+    probabilities: dict[Value, float],
+    confidence_level: float,
+    *,
+    close_boundary_ties: bool = False,
+) -> set[Value]:
+    ordered = sorted(
+        probabilities.items(), key=lambda item: item[1], reverse=True
+    )
+    cumulative = 0.0
+    selected: set[Value] = set()
+    boundary_probability: float | None = None
+    for value, probability in ordered:
+        selected.add(value)
+        cumulative += probability
+        if cumulative >= confidence_level:
+            boundary_probability = probability
+            break
+    if close_boundary_ties and boundary_probability is not None:
+        for value, probability in ordered[len(selected) :]:
+            if not np.isclose(
+                probability,
+                boundary_probability,
+                rtol=1e-12,
+                atol=1e-15,
+            ):
+                break
+            selected.add(value)
+    return selected
+
+
 def _credible_set_coverage(
     probabilities: dict[Value, float],
     truth: Value,
     confidence_level: float,
 ) -> bool:
-    cumulative = 0.0
-    selected: set[Value] = set()
-    for value, probability in sorted(
-        probabilities.items(), key=lambda item: item[1], reverse=True
-    ):
-        selected.add(value)
-        cumulative += probability
-        if cumulative >= confidence_level:
-            break
-    return truth in selected
+    return truth in _credible_set(probabilities, confidence_level)
+
+
+def _categorical_entropy(probabilities: dict[Value, float]) -> tuple[float, float]:
+    positive = np.asarray(
+        [probability for probability in probabilities.values() if probability > 0.0]
+    )
+    entropy = -float(np.sum(positive * np.log(positive)))
+    normalized = (
+        entropy / np.log(len(probabilities)) if len(probabilities) > 1 else 0.0
+    )
+    return entropy, float(normalized)
 
 
 def _continuous_metrics(
@@ -97,8 +130,14 @@ def contact_recovery_metrics(
 
     states = tuple(states)
     weights = np.asarray(weights, dtype=float)
-    if weights.shape != (len(states),) or not np.isclose(np.sum(weights), 1.0):
-        raise ValueError("contact weights must align with states and sum to one")
+    if not states or weights.shape != (len(states),):
+        raise ValueError("contact weights must align with a nonempty state support")
+    if not np.all(np.isfinite(weights)) or np.any(weights < 0.0):
+        raise ValueError("contact weights must be finite and nonnegative")
+    if not np.isclose(np.sum(weights), 1.0, atol=1e-10, rtol=1e-10):
+        raise ValueError("contact weights must sum to one")
+    if not np.isfinite(confidence_level) or not 0.0 < confidence_level < 1.0:
+        raise ValueError("confidence_level must be finite and in (0, 1)")
 
     node_probabilities = _group_probabilities(
         states, weights, lambda state: state.contact_nodes
@@ -119,6 +158,23 @@ def contact_recovery_metrics(
     node_map, node_confidence = max(
         node_probabilities.items(), key=lambda item: item[1]
     )
+    node_map_set = tuple(
+        nodes
+        for nodes, probability in sorted(node_probabilities.items())
+        if np.isclose(
+            probability,
+            node_confidence,
+            rtol=1e-12,
+            atol=1e-15,
+        )
+    )
+    node_credible_set = _credible_set(node_probabilities, confidence_level)
+    node_tie_closed_credible_set = _credible_set(
+        node_probabilities,
+        confidence_level,
+        close_boundary_ties=True,
+    )
+    node_entropy, node_normalized_entropy = _categorical_entropy(node_probabilities)
     node_brier = float(
         sum(
             (probability - float(nodes == truth.contact_nodes)) ** 2
@@ -136,16 +192,28 @@ def contact_recovery_metrics(
         "node_map": ";".join(map(str, node_map)),
         "node_correct": bool(node_map == truth.contact_nodes),
         "node_confidence": float(node_confidence),
+        "node_map_set": "|".join(
+            ";".join(map(str, nodes)) for nodes in node_map_set
+        ),
+        "node_map_set_size": len(node_map_set),
+        "node_truth_in_map_set": truth.contact_nodes in node_map_set,
+        "node_support_size": len(node_probabilities),
+        "node_entropy": node_entropy,
+        "node_normalized_entropy": node_normalized_entropy,
         "node_truth_probability": float(
             node_probabilities.get(truth.contact_nodes, 0.0)
         ),
         "node_brier": node_brier,
-        "node_credible_covered": _credible_set_coverage(
-            node_probabilities, truth.contact_nodes, confidence_level
+        "node_credible_covered": truth.contact_nodes in node_credible_set,
+        "node_credible_set_size": len(node_credible_set),
+        "node_tie_closed_credible_covered": (
+            truth.contact_nodes in node_tie_closed_credible_set
         ),
+        "node_tie_closed_credible_set_size": len(node_tie_closed_credible_set),
         "delay_map": int(delay_map),
         "delay_map_correct": bool(delay_map == truth.delay_steps),
         "delay_map_confidence": float(delay_confidence),
+        "joint_positive_support_size": int(np.count_nonzero(positive)),
         "joint_effective_sample_size": float(1.0 / np.sum(np.square(weights))),
         "joint_normalized_entropy": float(
             entropy / np.log(weights.size) if weights.size > 1 else 0.0
@@ -198,60 +266,77 @@ def aggregate_contact_recovery(
     for (setting, world), selected in sorted(groups.items()):
         node_accuracy = float(np.mean([float(row["node_correct"]) for row in selected]))
         node_confidence = float(np.mean([row["node_confidence"] for row in selected]))
-        output.append(
-            {
-                "setting": setting,
-                "world_condition": world,
-                "case_count": len(selected),
-                "object_count": len({row["object"] for row in selected}),
-                "node_accuracy": node_accuracy,
-                "mean_node_confidence": node_confidence,
-                "node_calibration_error": abs(node_confidence - node_accuracy),
-                "mean_node_truth_probability": float(
-                    np.mean([row["node_truth_probability"] for row in selected])
-                ),
-                "mean_node_brier": float(
-                    np.mean([row["node_brier"] for row in selected])
-                ),
-                "node_credible_coverage": float(
-                    np.mean([float(row["node_credible_covered"]) for row in selected])
-                ),
-                "mean_gain_absolute_error": float(
-                    np.mean([row["gain_absolute_error"] for row in selected])
-                ),
-                "gain_coverage": float(
-                    np.mean([float(row["gain_covered"]) for row in selected])
-                ),
-                "mean_gain_crps": float(
-                    np.mean([row["gain_crps"] for row in selected])
-                ),
-                "delay_map_accuracy": float(
-                    np.mean([float(row["delay_map_correct"]) for row in selected])
-                ),
-                "mean_delay_absolute_error": float(
-                    np.mean([row["delay_absolute_error"] for row in selected])
-                ),
-                "delay_coverage": float(
-                    np.mean([float(row["delay_covered"]) for row in selected])
-                ),
-                "mean_delay_crps": float(
-                    np.mean([row["delay_crps"] for row in selected])
-                ),
-                "mean_slip_absolute_error": float(
-                    np.mean([row["slip_absolute_error"] for row in selected])
-                ),
-                "slip_coverage": float(
-                    np.mean([float(row["slip_covered"]) for row in selected])
-                ),
-                "mean_rotation_absolute_error_deg": float(
-                    np.mean([row["rotation_deg_absolute_error"] for row in selected])
-                ),
-                "rotation_coverage": float(
-                    np.mean([float(row["rotation_deg_covered"]) for row in selected])
-                ),
-                "mean_joint_effective_sample_size": float(
-                    np.mean([row["joint_effective_sample_size"] for row in selected])
-                ),
-            }
-        )
+        aggregate: dict[str, Any] = {
+            "setting": setting,
+            "world_condition": world,
+            "case_count": len(selected),
+            "object_count": len({row["object"] for row in selected}),
+            "node_accuracy": node_accuracy,
+            "mean_node_confidence": node_confidence,
+            "node_calibration_error": abs(node_confidence - node_accuracy),
+            "mean_node_truth_probability": float(
+                np.mean([row["node_truth_probability"] for row in selected])
+            ),
+            "mean_node_brier": float(
+                np.mean([row["node_brier"] for row in selected])
+            ),
+            "node_credible_coverage": float(
+                np.mean([float(row["node_credible_covered"]) for row in selected])
+            ),
+            "mean_gain_absolute_error": float(
+                np.mean([row["gain_absolute_error"] for row in selected])
+            ),
+            "gain_coverage": float(
+                np.mean([float(row["gain_covered"]) for row in selected])
+            ),
+            "mean_gain_crps": float(
+                np.mean([row["gain_crps"] for row in selected])
+            ),
+            "delay_map_accuracy": float(
+                np.mean([float(row["delay_map_correct"]) for row in selected])
+            ),
+            "mean_delay_absolute_error": float(
+                np.mean([row["delay_absolute_error"] for row in selected])
+            ),
+            "delay_coverage": float(
+                np.mean([float(row["delay_covered"]) for row in selected])
+            ),
+            "mean_delay_crps": float(
+                np.mean([row["delay_crps"] for row in selected])
+            ),
+            "mean_slip_absolute_error": float(
+                np.mean([row["slip_absolute_error"] for row in selected])
+            ),
+            "slip_coverage": float(
+                np.mean([float(row["slip_covered"]) for row in selected])
+            ),
+            "mean_rotation_absolute_error_deg": float(
+                np.mean([row["rotation_deg_absolute_error"] for row in selected])
+            ),
+            "rotation_coverage": float(
+                np.mean([float(row["rotation_deg_covered"]) for row in selected])
+            ),
+            "mean_joint_effective_sample_size": float(
+                np.mean([row["joint_effective_sample_size"] for row in selected])
+            ),
+        }
+        diagnostic_fields = {
+            "node_map_set_coverage": "node_truth_in_map_set",
+            "mean_node_map_set_size": "node_map_set_size",
+            "mean_node_credible_set_size": "node_credible_set_size",
+            "node_tie_closed_credible_coverage": (
+                "node_tie_closed_credible_covered"
+            ),
+            "mean_node_tie_closed_credible_set_size": (
+                "node_tie_closed_credible_set_size"
+            ),
+            "mean_node_normalized_entropy": "node_normalized_entropy",
+            "mean_joint_positive_support_size": "joint_positive_support_size",
+        }
+        for output_name, row_name in diagnostic_fields.items():
+            if all(row_name in row for row in selected):
+                aggregate[output_name] = float(
+                    np.mean([float(row[row_name]) for row in selected])
+                )
+        output.append(aggregate)
     return output

--- a/src/causal4d/contact_metrics.py
+++ b/src/causal4d/contact_metrics.py
@@ -51,9 +51,7 @@ def _credible_set(
     *,
     close_boundary_ties: bool = False,
 ) -> set[Value]:
-    ordered = sorted(
-        probabilities.items(), key=lambda item: item[1], reverse=True
-    )
+    ordered = sorted(probabilities.items(), key=lambda item: item[1], reverse=True)
     cumulative = 0.0
     selected: set[Value] = set()
     boundary_probability: float | None = None
@@ -89,9 +87,7 @@ def _categorical_entropy(probabilities: dict[Value, float]) -> tuple[float, floa
         [probability for probability in probabilities.values() if probability > 0.0]
     )
     entropy = -float(np.sum(positive * np.log(positive)))
-    normalized = (
-        entropy / np.log(len(probabilities)) if len(probabilities) > 1 else 0.0
-    )
+    normalized = entropy / np.log(len(probabilities)) if len(probabilities) > 1 else 0.0
     return entropy, float(normalized)
 
 
@@ -192,9 +188,7 @@ def contact_recovery_metrics(
         "node_map": ";".join(map(str, node_map)),
         "node_correct": bool(node_map == truth.contact_nodes),
         "node_confidence": float(node_confidence),
-        "node_map_set": "|".join(
-            ";".join(map(str, nodes)) for nodes in node_map_set
-        ),
+        "node_map_set": "|".join(";".join(map(str, nodes)) for nodes in node_map_set),
         "node_map_set_size": len(node_map_set),
         "node_truth_in_map_set": truth.contact_nodes in node_map_set,
         "node_support_size": len(node_probabilities),
@@ -277,9 +271,7 @@ def aggregate_contact_recovery(
             "mean_node_truth_probability": float(
                 np.mean([row["node_truth_probability"] for row in selected])
             ),
-            "mean_node_brier": float(
-                np.mean([row["node_brier"] for row in selected])
-            ),
+            "mean_node_brier": float(np.mean([row["node_brier"] for row in selected])),
             "node_credible_coverage": float(
                 np.mean([float(row["node_credible_covered"]) for row in selected])
             ),
@@ -289,9 +281,7 @@ def aggregate_contact_recovery(
             "gain_coverage": float(
                 np.mean([float(row["gain_covered"]) for row in selected])
             ),
-            "mean_gain_crps": float(
-                np.mean([row["gain_crps"] for row in selected])
-            ),
+            "mean_gain_crps": float(np.mean([row["gain_crps"] for row in selected])),
             "delay_map_accuracy": float(
                 np.mean([float(row["delay_map_correct"]) for row in selected])
             ),
@@ -301,9 +291,7 @@ def aggregate_contact_recovery(
             "delay_coverage": float(
                 np.mean([float(row["delay_covered"]) for row in selected])
             ),
-            "mean_delay_crps": float(
-                np.mean([row["delay_crps"] for row in selected])
-            ),
+            "mean_delay_crps": float(np.mean([row["delay_crps"] for row in selected])),
             "mean_slip_absolute_error": float(
                 np.mean([row["slip_absolute_error"] for row in selected])
             ),
@@ -324,9 +312,7 @@ def aggregate_contact_recovery(
             "node_map_set_coverage": "node_truth_in_map_set",
             "mean_node_map_set_size": "node_map_set_size",
             "mean_node_credible_set_size": "node_credible_set_size",
-            "node_tie_closed_credible_coverage": (
-                "node_tie_closed_credible_covered"
-            ),
+            "node_tie_closed_credible_coverage": ("node_tie_closed_credible_covered"),
             "mean_node_tie_closed_credible_set_size": (
                 "node_tie_closed_credible_set_size"
             ),

--- a/src/causal4d/immutable_json.py
+++ b/src/causal4d/immutable_json.py
@@ -17,6 +17,19 @@ def plain_json(value: Any) -> Any:
     return value
 
 
+def _require_string_mapping_keys(value: Any) -> None:
+    """Reject JSON objects whose Python keys would be coerced by ``json``."""
+
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError("JSON object keys must be strings")
+            _require_string_mapping_keys(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            _require_string_mapping_keys(item)
+
+
 class _FrozenDict(dict):
     """A JSON object that preserves ``dict`` compatibility but rejects mutation."""
 
@@ -106,14 +119,15 @@ def validated_json_mapping(
 ) -> Mapping[str, Any]:
     """Normalize a mapping as finite JSON and recursively freeze its containers.
 
-    The normalization preserves the historical Causal4D semantics: tuples become
-    JSON arrays, mapping keys are normalized by the JSON encoder, and non-finite
-    or unsupported values fail closed.  The returned containers still satisfy
-    ordinary ``isinstance(value, dict/list)`` checks, while ``copy.copy`` and
-    ``copy.deepcopy`` yield independent mutable JSON data.
+    Tuples become JSON arrays. Object keys must already be strings so the JSON
+    encoder cannot silently coerce a key or collapse distinct Python identities.
+    Non-finite and unsupported values fail closed. The returned containers still
+    satisfy ordinary ``isinstance(value, dict/list)`` checks, while ``copy.copy``
+    and ``copy.deepcopy`` yield independent mutable JSON data.
     """
 
     try:
+        _require_string_mapping_keys(values)
         normalized = json.loads(
             json.dumps(plain_json(values), sort_keys=True, allow_nan=False)
         )

--- a/src/causal4d/stage_provenance.py
+++ b/src/causal4d/stage_provenance.py
@@ -115,9 +115,7 @@ def _observation_window_from_dict(
     )
 
 
-def _action_window_from_dict(
-    values: Mapping[str, Any], *, name: str
-) -> ActionWindow:
+def _action_window_from_dict(values: Mapping[str, Any], *, name: str) -> ActionWindow:
     _require_exact_fields(
         values,
         fields={

--- a/src/causal4d/stage_provenance.py
+++ b/src/causal4d/stage_provenance.py
@@ -49,10 +49,118 @@ def _artifact_id(contract_type: str, payload: Mapping[str, Any]) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _require_header(values: Mapping[str, Any], *, contract_type: str) -> None:
-    if int(values.get("schema_version", -1)) != STAGE_PROVENANCE_SCHEMA_VERSION:
+def _require_exact_fields(
+    values: Mapping[str, Any],
+    *,
+    fields: set[str],
+    name: str,
+) -> None:
+    if not isinstance(values, Mapping):
+        raise ValueError(f"{name} must be a JSON object")
+    if any(not isinstance(key, str) for key in values):
+        raise ValueError(f"{name} keys must be strings")
+    actual = set(values)
+    missing = sorted(fields - actual)
+    unexpected = sorted(actual - fields)
+    if missing or unexpected:
+        raise ValueError(
+            f"{name} fields do not match the schema; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+
+
+def _require_string(values: Mapping[str, Any], key: str, *, name: str) -> str:
+    value = values[key]
+    if not isinstance(value, str):
+        raise ValueError(f"{name}.{key} must be a string")
+    return value
+
+
+def _require_integer(values: Mapping[str, Any], key: str, *, name: str) -> int:
+    value = values[key]
+    if type(value) is not int:
+        raise ValueError(f"{name}.{key} must be an integer")
+    return value
+
+
+def _require_mapping(
+    values: Mapping[str, Any], key: str, *, name: str
+) -> Mapping[str, Any]:
+    value = values[key]
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name}.{key} must be a JSON object")
+    return value
+
+
+def _observation_window_from_dict(
+    values: Mapping[str, Any], *, name: str
+) -> ObservationWindow:
+    _require_exact_fields(
+        values,
+        fields={
+            "case_id",
+            "stream_id",
+            "frame_start",
+            "frame_stop",
+            "content_sha256",
+        },
+        name=name,
+    )
+    return ObservationWindow(
+        case_id=_require_string(values, "case_id", name=name),
+        stream_id=_require_string(values, "stream_id", name=name),
+        frame_start=_require_integer(values, "frame_start", name=name),
+        frame_stop=_require_integer(values, "frame_stop", name=name),
+        content_sha256=_require_string(values, "content_sha256", name=name),
+    )
+
+
+def _action_window_from_dict(
+    values: Mapping[str, Any], *, name: str
+) -> ActionWindow:
+    _require_exact_fields(
+        values,
+        fields={
+            "action_id",
+            "case_id",
+            "frame_start",
+            "frame_stop",
+            "trajectory_sha256",
+            "provenance",
+        },
+        name=name,
+    )
+    return ActionWindow(
+        action_id=_require_string(values, "action_id", name=name),
+        case_id=_require_string(values, "case_id", name=name),
+        frame_start=_require_integer(values, "frame_start", name=name),
+        frame_stop=_require_integer(values, "frame_stop", name=name),
+        trajectory_sha256=_require_string(
+            values,
+            "trajectory_sha256",
+            name=name,
+        ),
+        provenance=_require_string(values, "provenance", name=name),
+    )
+
+
+def _require_header(
+    values: Mapping[str, Any],
+    *,
+    contract_type: str,
+    payload_fields: set[str],
+) -> None:
+    name = f"stage-provenance {contract_type}"
+    _require_exact_fields(
+        values,
+        fields={"schema_version", "contract_type", *payload_fields},
+        name=name,
+    )
+    if _require_integer(values, "schema_version", name=name) != (
+        STAGE_PROVENANCE_SCHEMA_VERSION
+    ):
         raise ValueError("unsupported stage-provenance schema version")
-    if str(values.get("contract_type", "")) != contract_type:
+    if _require_string(values, "contract_type", name=name) != contract_type:
         raise ValueError(f"expected stage-provenance contract {contract_type}")
 
 
@@ -141,12 +249,26 @@ class FactualEvidenceContext:
 
     @classmethod
     def from_dict(cls, values: Mapping[str, Any]) -> FactualEvidenceContext:
-        _require_header(values, contract_type=cls.contract_type)
+        _require_header(
+            values,
+            contract_type=cls.contract_type,
+            payload_fields={"protocol_id", "o_minus", "o_plus_prefix", "u_obs"},
+        )
+        name = f"stage-provenance {cls.contract_type}"
         return cls(
-            protocol_id=str(values["protocol_id"]),
-            o_minus=ObservationWindow.from_dict(values["o_minus"]),
-            o_plus_prefix=ObservationWindow.from_dict(values["o_plus_prefix"]),
-            u_obs=ActionWindow.from_dict(values["u_obs"]),
+            protocol_id=_require_string(values, "protocol_id", name=name),
+            o_minus=_observation_window_from_dict(
+                _require_mapping(values, "o_minus", name=name),
+                name=f"{name}.o_minus",
+            ),
+            o_plus_prefix=_observation_window_from_dict(
+                _require_mapping(values, "o_plus_prefix", name=name),
+                name=f"{name}.o_plus_prefix",
+            ),
+            u_obs=_action_window_from_dict(
+                _require_mapping(values, "u_obs", name=name),
+                name=f"{name}.u_obs",
+            ),
         )
 
 
@@ -205,24 +327,51 @@ class CounterfactualQueryContext:
 
     @classmethod
     def from_dict(cls, values: Mapping[str, Any]) -> CounterfactualQueryContext:
-        _require_header(values, contract_type=cls.contract_type)
-        nodes = values.get("query_node_indices")
-        policy = str(values["contact_policy"])
+        _require_header(
+            values,
+            contract_type=cls.contract_type,
+            payload_fields={
+                "protocol_id",
+                "case_id",
+                "u_cf",
+                "contact_policy",
+                "language",
+                "query_node_indices",
+            },
+        )
+        name = f"stage-provenance {cls.contract_type}"
+        policy = _require_string(values, "contact_policy", name=name)
         if policy not in {"same_grasp", "new_contact"}:
             raise ValueError("contact_policy must be 'same_grasp' or 'new_contact'")
-        language = values.get("language")
+        language = values["language"]
+        if language is not None and not isinstance(language, str):
+            raise ValueError(f"{name}.language must be null or a string")
+        raw_nodes = values["query_node_indices"]
+        if raw_nodes is None:
+            nodes = None
+        else:
+            if not isinstance(raw_nodes, list):
+                raise ValueError(
+                    f"{name}.query_node_indices must be null or a JSON array"
+                )
+            if any(type(index) is not int for index in raw_nodes):
+                raise ValueError(
+                    f"{name}.query_node_indices must contain only integers"
+                )
+            nodes = tuple(raw_nodes)
         return cls(
-            protocol_id=str(values["protocol_id"]),
-            case_id=str(values["case_id"]),
-            u_cf=ActionWindow.from_dict(values["u_cf"]),
+            protocol_id=_require_string(values, "protocol_id", name=name),
+            case_id=_require_string(values, "case_id", name=name),
+            u_cf=_action_window_from_dict(
+                _require_mapping(values, "u_cf", name=name),
+                name=f"{name}.u_cf",
+            ),
             contact_policy=cast(
                 Literal["same_grasp", "new_contact"],
                 policy,
             ),
-            language=None if language is None else str(language),
-            query_node_indices=(
-                None if nodes is None else tuple(int(index) for index in nodes)
-            ),
+            language=language,
+            query_node_indices=nodes,
         )
 
 
@@ -262,10 +411,18 @@ class EvaluationTarget:
 
     @classmethod
     def from_dict(cls, values: Mapping[str, Any]) -> EvaluationTarget:
-        _require_header(values, contract_type=cls.contract_type)
+        _require_header(
+            values,
+            contract_type=cls.contract_type,
+            payload_fields={"protocol_id", "target"},
+        )
+        name = f"stage-provenance {cls.contract_type}"
         return cls(
-            protocol_id=str(values["protocol_id"]),
-            target=ObservationWindow.from_dict(values["target"]),
+            protocol_id=_require_string(values, "protocol_id", name=name),
+            target=_observation_window_from_dict(
+                _require_mapping(values, "target", name=name),
+                name=f"{name}.target",
+            ),
         )
 
 

--- a/tests/test_contact_metrics.py
+++ b/tests/test_contact_metrics.py
@@ -1,0 +1,88 @@
+import numpy as np
+import pytest
+
+from causal4d.contact_inference import ContactState
+from causal4d.contact_metrics import (
+    aggregate_contact_recovery,
+    contact_recovery_metrics,
+)
+
+
+def _state(node: int) -> ContactState:
+    return ContactState(
+        contact_nodes=(node,),
+        gain_multiplier=1.0,
+        delay_steps=0,
+        slip_fraction=0.0,
+        rotation_radians=0.0,
+    )
+
+
+@pytest.mark.parametrize(
+    "weights",
+    (
+        np.asarray([1.1, -0.1]),
+        np.asarray([np.nan, np.nan]),
+        np.asarray([np.inf, -np.inf]),
+    ),
+)
+def test_contact_recovery_rejects_invalid_probability_support(
+    weights: np.ndarray,
+) -> None:
+    states = (_state(0), _state(1))
+
+    with pytest.raises(ValueError, match="finite and nonnegative"):
+        contact_recovery_metrics(
+            states,
+            weights,
+            states[0],
+            confidence_level=0.9,
+        )
+
+
+def test_contact_recovery_rejects_invalid_confidence_level() -> None:
+    states = (_state(0), _state(1))
+
+    for confidence_level in (0.0, 1.0, float("nan")):
+        with pytest.raises(ValueError, match="confidence_level"):
+            contact_recovery_metrics(
+                states,
+                np.asarray([0.5, 0.5]),
+                states[0],
+                confidence_level=confidence_level,
+            )
+
+
+def test_contact_recovery_reports_tie_aware_diagnostics() -> None:
+    states = (_state(0), _state(1))
+    result = contact_recovery_metrics(
+        states,
+        np.asarray([0.5, 0.5]),
+        states[1],
+        confidence_level=0.5,
+    )
+
+    assert result["node_map"] == "0"
+    assert not result["node_correct"]
+    assert result["node_map_set"] == "0|1"
+    assert result["node_map_set_size"] == 2
+    assert result["node_truth_in_map_set"]
+    assert result["node_credible_set_size"] == 1
+    assert not result["node_credible_covered"]
+    assert result["node_tie_closed_credible_set_size"] == 2
+    assert result["node_tie_closed_credible_covered"]
+    assert result["node_normalized_entropy"] == pytest.approx(1.0)
+
+    aggregate = aggregate_contact_recovery(
+        [
+            {
+                **result,
+                "object": "symmetric_graph",
+                "setting": "online_adaptation",
+                "world_condition": "shifted_contact",
+            }
+        ]
+    )[0]
+    assert aggregate["node_map_set_coverage"] == 1.0
+    assert aggregate["node_tie_closed_credible_coverage"] == 1.0
+    assert aggregate["mean_node_normalized_entropy"] == pytest.approx(1.0)

--- a/tests/test_immutable_json.py
+++ b/tests/test_immutable_json.py
@@ -1,4 +1,5 @@
 import copy
+from typing import Any
 
 import pytest
 
@@ -52,3 +53,16 @@ def test_validated_json_mapping_rejects_nonfinite_and_non_json_values() -> None:
         validated_json_mapping({"bad": float("nan")})
     with pytest.raises(ValueError, match="finite JSON"):
         validated_json_mapping({"bad": object()})
+
+
+def test_validated_json_mapping_rejects_non_string_object_keys() -> None:
+    top_level: dict[Any, Any] = {1: "integer-key"}
+    nested: dict[Any, Any] = {"valid": [{False: "boolean-key"}]}
+    colliding_after_json_coercion: dict[Any, Any] = {
+        1: "integer-key",
+        "1": "string-key",
+    }
+
+    for values in (top_level, nested, colliding_after_json_coercion):
+        with pytest.raises(ValueError, match="finite JSON"):
+            validated_json_mapping(values)

--- a/tests/test_stage_provenance_strict_loading.py
+++ b/tests/test_stage_provenance_strict_loading.py
@@ -1,0 +1,116 @@
+from copy import deepcopy
+
+import pytest
+
+from causal4d.stage_provenance import (
+    CounterfactualQueryContext,
+    EvaluationTarget,
+    FactualEvidenceContext,
+)
+
+
+def _observation_window(*, start: int, stop: int) -> dict[str, object]:
+    return {
+        "case_id": "strict-case",
+        "stream_id": "object_points_m",
+        "frame_start": start,
+        "frame_stop": stop,
+        "content_sha256": "a" * 64,
+    }
+
+
+def _action_window(*, start: int, stop: int) -> dict[str, object]:
+    return {
+        "action_id": "u",
+        "case_id": "strict-case",
+        "frame_start": start,
+        "frame_stop": stop,
+        "trajectory_sha256": "b" * 64,
+        "provenance": "unit test",
+    }
+
+
+def _query_values() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "contract_type": "CounterfactualQueryContext",
+        "protocol_id": "strict-protocol",
+        "case_id": "strict-case",
+        "u_cf": _action_window(start=4, stop=8),
+        "contact_policy": "new_contact",
+        "language": None,
+        "query_node_indices": [0, 2],
+    }
+
+
+def test_query_context_rejects_values_that_would_be_coerced() -> None:
+    valid = _query_values()
+    restored = CounterfactualQueryContext.from_dict(valid)
+    assert restored.query_node_indices == (0, 2)
+
+    invalid_values: list[tuple[dict[str, object], str]] = []
+
+    boolean_schema = deepcopy(valid)
+    boolean_schema["schema_version"] = True
+    invalid_values.append((boolean_schema, "must be an integer"))
+
+    null_protocol = deepcopy(valid)
+    null_protocol["protocol_id"] = None
+    invalid_values.append((null_protocol, "must be a string"))
+
+    fractional_nodes = deepcopy(valid)
+    fractional_nodes["query_node_indices"] = [0, 2.5]
+    invalid_values.append((fractional_nodes, "contain only integers"))
+
+    boolean_nodes = deepcopy(valid)
+    boolean_nodes["query_node_indices"] = [0, True]
+    invalid_values.append((boolean_nodes, "contain only integers"))
+
+    tuple_nodes = deepcopy(valid)
+    tuple_nodes["query_node_indices"] = (0, 2)
+    invalid_values.append((tuple_nodes, "must be null or a JSON array"))
+
+    fractional_frame = deepcopy(valid)
+    assert isinstance(fractional_frame["u_cf"], dict)
+    fractional_frame["u_cf"]["frame_start"] = 4.5
+    invalid_values.append((fractional_frame, "must be an integer"))
+
+    unknown_field = deepcopy(valid)
+    unknown_field["unregistered"] = "value"
+    invalid_values.append((unknown_field, "fields do not match the schema"))
+
+    for values, message in invalid_values:
+        with pytest.raises(ValueError, match=message):
+            CounterfactualQueryContext.from_dict(values)
+
+
+def test_factual_and_target_contexts_require_exact_nested_schemas() -> None:
+    factual = {
+        "schema_version": 1,
+        "contract_type": "FactualEvidenceContext",
+        "protocol_id": "strict-protocol",
+        "o_minus": _observation_window(start=0, stop=4),
+        "o_plus_prefix": _observation_window(start=4, stop=6),
+        "u_obs": _action_window(start=0, stop=8),
+    }
+    target = {
+        "schema_version": 1,
+        "contract_type": "EvaluationTarget",
+        "protocol_id": "strict-protocol",
+        "target": _observation_window(start=6, stop=8),
+    }
+
+    assert FactualEvidenceContext.from_dict(factual).case_id == "strict-case"
+    assert EvaluationTarget.from_dict(target).case_id == "strict-case"
+
+    malformed_factual = deepcopy(factual)
+    assert isinstance(malformed_factual["o_minus"], dict)
+    malformed_factual["o_minus"]["frame_start"] = False
+    with pytest.raises(ValueError, match="must be an integer"):
+        FactualEvidenceContext.from_dict(malformed_factual)
+
+    malformed_target = deepcopy(target)
+    assert isinstance(malformed_target["target"], dict)
+    malformed_target["target"]["unexpected"] = 1
+    with pytest.raises(ValueError, match="fields do not match the schema"):
+        EvaluationTarget.from_dict(malformed_target)


### PR DESCRIPTION
## Summary

- reject non-string JSON object keys before canonicalization so Python keys cannot be silently coerced or collapsed by the JSON encoder;
- make stage-specific factual-evidence, counterfactual-query, and held-out-target loaders require exact schema fields and exact JSON types;
- reject booleans as integers, fractional frame/node indices, non-array node lists, unknown fields, and string-coercible null values;
- preserve recursive immutability, tuple-to-array metadata normalization, and all valid existing artifact identities;
- require contact posterior weights to be nonempty, aligned, finite, nonnegative, and normalized;
- require a finite confidence level strictly inside `(0, 1)`;
- add tie-aware node-MAP and credible-set diagnostics, categorical entropy, and positive-support accounting without replacing the registered exact-node metrics;
- aggregate the new diagnostics when present while retaining compatibility with historical rows that do not contain them;
- add adversarial regressions for JSON-key collisions, coercive provenance payloads, negative/NaN/infinite posterior weights, invalid confidence levels, and graph-symmetry ties.

## Root cause

`json.dumps` accepts selected non-string mapping keys and coerces them to strings. That allowed distinct Python inputs such as `1` and `"1"` to lose their original identity during content-addressed metadata normalization.

The stage-provenance loaders used `str(...)`, `int(...)`, and permissive `.get(...)` calls. Malformed values such as `schema_version=True`, `protocol_id=None`, or `query_node_indices=[2.5]` could therefore be accepted after coercion, and unknown fields were silently ignored.

`contact_recovery_metrics` previously checked only shape and total mass. A vector such as `[1.1, -0.1]` could therefore reach entropy, Brier-score, and credible-set calculations because it sums to one. Equal-probability node hypotheses were also represented only by the insertion-order MAP and legacy credible set, which is insufficient for diagnosing topology symmetry.

## Compatibility and scientific boundary

- Valid existing inputs retain their previous artifact identities and metric values.
- The registered `node_map`, `node_correct`, `node_credible_covered`, gates, estimator, likelihood, calibration, and frozen milestone artifacts are unchanged.
- New diagnostics are additive and explicitly do not revise or rescue the frozen five-seed result.
- Historical aggregate rows remain accepted; additive aggregate fields are emitted only when their corresponding row diagnostics exist.
- The stricter loaders reject only malformed, ambiguous, or schema-inconsistent stage-provenance payloads.

## Validation

Authoritative GitHub Actions on head `cc03e852f701a31477471130bfb066f15007a6c7`:

- `CI and release` run 559: **passed**;
- `Extended compatibility` run 193: **passed**;
- Ruff lint, Ruff formatting, and stable-contract mypy: passed;
- core suites on Python 3.10, 3.12, and 3.14: passed;
- pinned BayesianPhysTwin integration: passed;
- deterministic bundle production, verification, archival, and clean consumption: passed;
- frozen milestone inventory and checked-in checksums: passed;
- wheel and source-distribution builds and metadata validation: passed;
- isolated wheel and sdist installations, including all CLI help checks: passed.

Focused adversarial coverage includes non-string and colliding JSON keys, coercive stage-provenance types and fields, negative/NaN/infinite posterior weights, invalid confidence levels, and equal-probability contact-node ties.

Related to #113.