### PR TITLE
Complete MIT license metadata on current main

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,6 +5,7 @@ message: >-
 title: Causal4D
 type: software
 version: 0.5.0
+license: MIT
 authors:
   - family-names: Pfaff
     given-names: Florian

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,8 +133,13 @@ promotion. When a change is maintenance-only, state that boundary explicitly.
 
 ## Licensing
 
-Causal4D is distributed under the MIT License in `LICENSE`. Contributions are
-accepted for inclusion under those terms. Do not replace the repository license or
-apply different terms to datasets, checkpoints, evidence bundles, or paper assets
-without an explicit maintainer and, where applicable, institutional rights-holder
-decision.
+Causal4D source code and associated project documentation are distributed under
+the [MIT License](LICENSE). Unless agreed otherwise in writing before submission,
+contributions accepted into this repository are provided under the same license.
+By submitting a contribution, you represent that you have the right to provide it
+under those terms.
+
+Identify third-party code, data, checkpoints, or other assets explicitly. Their
+licenses and attribution requirements must permit the proposed use; the Causal4D
+MIT License does not relicense external material. See
+[docs/licensing.md](docs/licensing.md) for the complete repository licensing scope.

--- a/README.md
+++ b/README.md
@@ -260,3 +260,11 @@ runs/                  small checked-in diagnostic result bundles
 scripts/remote/        reproducible remote execution wrappers
 tests/                 unit, protocol, parity, and artifact-boundary tests
 ```
+
+## License
+
+Causal4D software and its associated project documentation are available under the
+[MIT License](LICENSE). Third-party datasets, model checkpoints, provider
+repositories, and externally sourced artifacts retain their own terms and are not
+relicensed by this repository. See [docs/licensing.md](docs/licensing.md) for the
+scope, historical-version policy, contribution terms, and citation boundary.

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -1,0 +1,42 @@
+# Licensing
+
+Causal4D software and its associated project documentation are distributed under
+the [MIT License](../LICENSE).
+
+The repository maintainer selected the MIT License for the current Causal4D
+repository and successor releases on 4 August 2026. This records the licensing
+choice; it does not transfer copyright or change the ownership of individual
+contributions.
+
+## Scope
+
+Unless a file states different terms, the Causal4D source code and project
+documentation authored for this repository are covered by the root `LICENSE`.
+The license permits use, copying, modification, distribution, sublicensing, and
+sale subject to preservation of the copyright and permission notices.
+
+The MIT License does **not** relicense third-party material. In particular,
+external datasets, model checkpoints, copied or generated artifacts derived from
+external sources, and separately obtained provider repositories remain subject to
+their own licenses, access conditions, and citation requirements. Consult the
+metadata and upstream source associated with each such artifact before reuse.
+
+Frozen tags, milestone directories, result bundles, and requirement locks remain
+historical records and are not rewritten merely to add a license notice. For a
+historical version, use the license included with the exact version obtained.
+References to external repositories or datasets inside frozen evidence are
+provenance records, not grants of rights to those external materials.
+
+## Contributions
+
+Unless agreed otherwise in writing before submission, contributions accepted into
+Causal4D are provided under the same MIT License. By opening a contribution, the
+contributor represents that they have the right to submit it under those terms.
+Third-party code or assets must be identified explicitly and must have terms
+compatible with their proposed use in this repository.
+
+## Citation
+
+Licensing and scholarly attribution are separate. Reuse permitted by the MIT
+License should still cite the software, paper, dataset, or frozen milestone used in
+research. The current software citation is defined in [`CITATION.cff`](../CITATION.cff).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,21 @@ requires-python = ">=3.10"
 authors = [
   { name = "Florian Pfaff" },
 ]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Typing :: Typed",
+]
 dependencies = [
   "numpy>=1.24",
   "packaging>=23",

--- a/tests/test_citation_metadata.py
+++ b/tests/test_citation_metadata.py
@@ -14,9 +14,10 @@ def _required_scalar(text: str, key: str) -> str:
     return match.group(1).strip().strip("\"'")
 
 
-def test_citation_metadata_matches_package_version_and_repository() -> None:
+def test_citation_metadata_matches_package_version_repository_and_license() -> None:
     citation = (ROOT / "CITATION.cff").read_text(encoding="utf-8")
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    license_text = (ROOT / "LICENSE").read_text(encoding="utf-8")
     version_match = re.search(r'(?m)^version = "([^"]+)"$', pyproject)
     assert version_match is not None
 
@@ -24,12 +25,34 @@ def test_citation_metadata_matches_package_version_and_repository() -> None:
     assert _required_scalar(citation, "title") == "Causal4D"
     assert _required_scalar(citation, "type") == "software"
     assert _required_scalar(citation, "version") == version_match.group(1)
+    assert _required_scalar(citation, "license") == "MIT"
     assert _required_scalar(citation, "repository-code") == (
+        "https://github.com/IPS-Stuttgart/Causal4D"
+    )
+    assert _required_scalar(citation, "url") == (
         "https://github.com/IPS-Stuttgart/Causal4D"
     )
     assert "family-names: Pfaff" in citation
     assert "given-names: Florian" in citation
+    assert 'license = { file = "LICENSE" }' in pyproject
+    assert '"License :: OSI Approved :: MIT License"' in pyproject
     assert (
         'Citation = "https://github.com/IPS-Stuttgart/Causal4D/blob/main/CITATION.cff"'
     ) in pyproject
+    assert 'Repository = "https://github.com/IPS-Stuttgart/Causal4D"' in pyproject
+    assert license_text.startswith("MIT License\n")
+    assert "Copyright (c) 2026 Florian Pfaff" in license_text
     assert "\t" not in citation
+
+
+def test_current_documentation_explains_the_license_scope() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    licensing = (ROOT / "docs" / "licensing.md").read_text(encoding="utf-8")
+
+    assert "## License" in readme
+    assert "[MIT License](LICENSE)" in readme
+    assert "## Licensing" in contributing
+    assert "[MIT License](LICENSE)" in contributing
+    assert "third-party material" in licensing
+    assert "Frozen tags" in licensing


### PR DESCRIPTION
## Summary

- declare `license: MIT` in `CITATION.cff`;
- add the MIT Trove classifier and supported Python classifiers to package metadata;
- document the repository-authored, third-party-material, historical-artifact, contribution, and citation boundaries;
- link the license scope from the README and contribution guide;
- extend metadata regressions so citation, package, documentation, and root-license declarations cannot silently diverge.

## Conflict resolution

This is a clean rebuild of #115 directly on Causal4D 0.5.0 `main`. It preserves the newer single-executable CLI consolidation, current `IPS-Stuttgart` repository identities, provider-transfer fixes, and current package version. It intentionally omits repository-name and version edits from the old branch that are already present on `main`.

## Compatibility and scientific boundary

Documentation, licensing, citation, and package metadata only. No estimator, likelihood, command route, registered protocol, frozen milestone, target-access rule, evidence artifact, threshold, or scientific claim changes.

## Validation

The focused six-file diff includes metadata and documentation regressions. GitHub Actions on this current-main branch are authoritative.

Supersedes #115 and completes #88.