### PR TITLE
Fix self-hosted provider validation and cache overhead

### DIFF
--- a/.github/workflows/self-hosted-evaluation.yml
+++ b/.github/workflows/self-hosted-evaluation.yml
@@ -46,7 +46,6 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-          cache: pip
 
       - name: Create isolated environment
         shell: bash
@@ -176,53 +175,41 @@ jobs:
             --output-dir self-hosted-evaluation/results \
             | tee self-hosted-evaluation/evaluation.log
 
-      - name: Detect private Bayesian-PhysTwin credential
+      - name: Require private BayesianPhysTwin credential
         if: ${{ inputs.run_bpt }}
-        id: access
         shell: bash
         env:
-          BPT_READ_TOKEN: ${{ secrets.BPT_READ_TOKEN }}
+          BPT_READ_SSH_KEY: ${{ secrets.BPT_READ_SSH_KEY }}
         run: |
-          if [[ -n "${BPT_READ_TOKEN}" ]]; then
-            echo "enabled=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "enabled=false" >> "${GITHUB_OUTPUT}"
-            echo "::warning::BPT_READ_TOKEN is absent; provider checks were skipped."
+          if [[ -z "${BPT_READ_SSH_KEY}" ]]; then
+            echo "::error::BPT_READ_SSH_KEY is absent; provider checks were requested and cannot run."
+            exit 1
           fi
+          echo "BayesianPhysTwin read credential is configured."
 
       - name: Read exact Bayesian-PhysTwin provider pin
-        if: steps.access.outputs.enabled == 'true'
+        if: ${{ inputs.run_bpt }}
         id: pin
         run: echo "sha=$(python scripts/ci/read_bpt_pin.py)" >> "${GITHUB_OUTPUT}"
 
       - name: Check out pinned Bayesian-PhysTwin
-        if: steps.access.outputs.enabled == 'true'
-        id: bpt_checkout
-        continue-on-error: true
+        if: ${{ inputs.run_bpt }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: IPS-Stuttgart/BayesianPhysTwin
           ref: ${{ steps.pin.outputs.sha }}
-          token: ${{ secrets.BPT_READ_TOKEN }}
+          ssh-key: ${{ secrets.BPT_READ_SSH_KEY }}
           path: _bpt
           persist-credentials: false
 
-      - name: Report unavailable Bayesian-PhysTwin access
-        if: >-
-          steps.access.outputs.enabled == 'true' &&
-          steps.bpt_checkout.outcome != 'success'
-        shell: bash
-        run: |
-          echo "::warning::BPT_READ_TOKEN could not read IPS-Stuttgart/BayesianPhysTwin; provider checks were skipped."
-
       - name: Install pinned Bayesian-PhysTwin
-        if: steps.bpt_checkout.outcome == 'success'
+        if: ${{ inputs.run_bpt }}
         run: |
           python -m pip install -e ./_bpt
           python -m pip check
 
       - name: Run pinned provider integration tests
-        if: steps.bpt_checkout.outcome == 'success'
+        if: ${{ inputs.run_bpt }}
         shell: bash
         run: |
           set -o pipefail

--- a/tests/test_self_hosted_evaluation_workflow_policy.py
+++ b/tests/test_self_hosted_evaluation_workflow_policy.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[1]
+    / ".github"
+    / "workflows"
+    / "self-hosted-evaluation.yml"
+)
+
+
+def test_requested_provider_validation_uses_ssh_and_fails_closed() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Require private BayesianPhysTwin credential" in text
+    assert "BPT_READ_SSH_KEY: ${{ secrets.BPT_READ_SSH_KEY }}" in text
+    assert "ssh-key: ${{ secrets.BPT_READ_SSH_KEY }}" in text
+    assert "provider checks were requested and cannot run" in text
+    assert text.count("if: ${{ inputs.run_bpt }}") >= 5
+    assert "BPT_READ_TOKEN" not in text
+    assert "continue-on-error: true" not in text
+    assert "Report unavailable Bayesian-PhysTwin access" not in text
+
+
+def test_self_hosted_gpu_stack_does_not_use_actions_pip_cache() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "cache: pip" not in text
+    assert 'python -m pip install -e ".[dev,warp]"' in text


### PR DESCRIPTION
## Root cause

The referenced self-hosted evaluation completed green even though the requested BayesianPhysTwin provider validation did not run:

- `BPT_READ_TOKEN` was present but returned HTTP 403 for `IPS-Stuttgart/BayesianPhysTwin`.
- The checkout was `continue-on-error`, so the provider integration steps were silently skipped.
- `actions/setup-python` cached the full pip download cache, including the CUDA/PyTorch stack, causing a failed 6.6 GB restore and another 6.6 GB cache upload.

## Fix

- Use the repository's established read-only `BPT_READ_SSH_KEY` deploy-key secret for BayesianPhysTwin checkout.
- Fail closed when `run_bpt=true`: a missing credential or failed checkout now fails the workflow instead of producing a misleading green result.
- Remove the Actions pip cache from this persistent self-hosted GPU runner; the runner-local pip cache remains available without blob transfers.
- Add workflow policy tests preventing token fallback, `continue-on-error`, and CUDA pip-cache reintroduction.

## Verification

- Workflow YAML parsed successfully.
- Branch is based on current `main` and changes only the self-hosted workflow plus its policy test.
- The policy assertions cover the credential, fail-closed, and cache behavior.