### PR TITLE
Harden runbook checks for compound shell commands

### DIFF
--- a/scripts/ci/check_acquisition_runbook_commands.py
+++ b/scripts/ci/check_acquisition_runbook_commands.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Reject stale or unknown Causal4D commands in acquisition-critical runbooks.
+
+Causal4D 0.5 installs one ``causal4d`` executable. Historical
+``causal4d-*`` executables remain migration metadata only. This check parses
+shell command blocks in the operator-facing acquisition runbooks and verifies
+that every Causal4D invocation uses either a registered grouped route or one of
+the small command-registry management routes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shlex
+import sys
+from collections.abc import Iterable, Iterator, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SOURCE_ROOT = REPOSITORY_ROOT / "src"
+if str(SOURCE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SOURCE_ROOT))
+
+from causal4d.cli.command_registry import (  # noqa: E402
+    PRIMARY_EXECUTABLE,
+    grouped_commands,
+)
+
+ACQUISITION_RUNBOOKS = (
+    Path("README.md"),
+    Path("docs/causal4d_preacquisition_readiness.md"),
+    Path("docs/causal4d_real_experiment_milestone.md"),
+    Path("docs/causal4d_real_evidence_status.md"),
+)
+
+SHELL_FENCE_LANGUAGES = frozenset({"bash", "console", "sh", "shell", "zsh"})
+COMMAND_MANAGEMENT_ROUTES = frozenset({"describe", "list", "migrate", "validate"})
+LEGACY_EXECUTABLE_PATTERN = re.compile(r"^causal4d-[A-Za-z0-9][A-Za-z0-9_-]*$")
+SHELL_ASSIGNMENT_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
+SHELL_WRAPPERS = frozenset({"command", "env", "sudo", "time"})
+
+
+@dataclass(frozen=True)
+class RunbookCommandIssue:
+    """One invalid command found in an operator-facing Markdown runbook."""
+
+    path: Path
+    line: int
+    command: str
+    message: str
+
+    def render(self) -> str:
+        return f"{self.path}:{self.line}: {self.message}: {self.command}"
+
+
+def _shell_fenced_blocks(text: str) -> Iterator[tuple[int, tuple[str, ...]]]:
+    """Yield shell-fenced Markdown blocks as ``(first_line, lines)`` pairs."""
+
+    fence_character: str | None = None
+    fence_length = 0
+    block_start = 0
+    block_lines: list[str] = []
+
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if fence_character is None:
+            match = re.match(r"^(`{3,}|~{3,})\s*([^\s`]*)", stripped)
+            if match is None:
+                continue
+            language = match.group(2).lower()
+            if language not in SHELL_FENCE_LANGUAGES:
+                continue
+            marker = match.group(1)
+            fence_character = marker[0]
+            fence_length = len(marker)
+            block_start = line_number + 1
+            block_lines = []
+            continue
+
+        closing = fence_character * fence_length
+        if stripped.startswith(closing):
+            yield block_start, tuple(block_lines)
+            fence_character = None
+            fence_length = 0
+            block_start = 0
+            block_lines = []
+            continue
+        block_lines.append(line)
+
+    if fence_character is not None:
+        yield block_start, tuple(block_lines)
+
+
+def _logical_shell_commands(
+    block_start: int,
+    lines: Sequence[str],
+) -> Iterator[tuple[int, str]]:
+    """Join backslash continuations and return executable shell commands."""
+
+    command_parts: list[str] = []
+    command_start = block_start
+
+    for offset, raw_line in enumerate(lines):
+        line_number = block_start + offset
+        stripped = raw_line.strip()
+        if stripped.startswith("$ "):
+            stripped = stripped[2:].lstrip()
+
+        if not command_parts and (not stripped or stripped.startswith("#")):
+            continue
+        if not command_parts:
+            command_start = line_number
+
+        continued = stripped.endswith("\\")
+        if continued:
+            stripped = stripped[:-1].rstrip()
+        command_parts.append(stripped)
+
+        if continued:
+            continue
+        command = " ".join(part for part in command_parts if part).strip()
+        if command:
+            yield command_start, command
+        command_parts = []
+
+    if command_parts:
+        command = " ".join(part for part in command_parts if part).strip()
+        if command:
+            yield command_start, command
+
+
+def _command_tokens(command: str) -> tuple[str, ...]:
+    try:
+        tokens = list(shlex.split(command, comments=True, posix=True))
+    except ValueError:
+        return ()
+
+    while tokens:
+        first = tokens[0]
+        if SHELL_ASSIGNMENT_PATTERN.fullmatch(first):
+            tokens.pop(0)
+            continue
+        if first in SHELL_WRAPPERS:
+            tokens.pop(0)
+            if first == "env":
+                while tokens and SHELL_ASSIGNMENT_PATTERN.fullmatch(tokens[0]):
+                    tokens.pop(0)
+            continue
+        break
+    return tuple(tokens)
+
+
+def _validate_causal4d_command(
+    path: Path,
+    line: int,
+    command: str,
+) -> RunbookCommandIssue | None:
+    tokens = _command_tokens(command)
+    if not tokens:
+        return None
+
+    executable = tokens[0]
+    if LEGACY_EXECUTABLE_PATTERN.fullmatch(executable):
+        return RunbookCommandIssue(
+            path=path,
+            line=line,
+            command=command,
+            message=(
+                "removed historical executable; use its grouped `causal4d` route"
+            ),
+        )
+    if executable != PRIMARY_EXECUTABLE:
+        return None
+
+    arguments = tokens[1:]
+    if not arguments:
+        return RunbookCommandIssue(
+            path=path,
+            line=line,
+            command=command,
+            message="missing grouped route or option",
+        )
+    if arguments[0].startswith("-"):
+        return None
+
+    if arguments[0] == "commands":
+        if len(arguments) < 2 or arguments[1] not in COMMAND_MANAGEMENT_ROUTES:
+            return RunbookCommandIssue(
+                path=path,
+                line=line,
+                command=command,
+                message="unknown command-registry management route",
+            )
+        return None
+
+    routes = sorted(
+        (spec.route for spec in grouped_commands()),
+        key=len,
+        reverse=True,
+    )
+    if any(arguments[: len(route)] == route for route in routes):
+        return None
+    return RunbookCommandIssue(
+        path=path,
+        line=line,
+        command=command,
+        message="unknown grouped Causal4D route",
+    )
+
+
+def validate_markdown(
+    path: Path,
+    text: str,
+) -> tuple[RunbookCommandIssue, ...]:
+    """Validate Causal4D commands in shell-fenced blocks from one document."""
+
+    issues: list[RunbookCommandIssue] = []
+    for block_start, lines in _shell_fenced_blocks(text):
+        for line, command in _logical_shell_commands(block_start, lines):
+            issue = _validate_causal4d_command(path, line, command)
+            if issue is not None:
+                issues.append(issue)
+    return tuple(issues)
+
+
+def validate_paths(
+    repository_root: Path = REPOSITORY_ROOT,
+    paths: Iterable[Path] = ACQUISITION_RUNBOOKS,
+) -> tuple[RunbookCommandIssue, ...]:
+    """Validate every configured acquisition runbook below ``repository_root``."""
+
+    issues: list[RunbookCommandIssue] = []
+    for relative_path in paths:
+        document_path = repository_root / relative_path
+        if not document_path.is_file():
+            issues.append(
+                RunbookCommandIssue(
+                    path=relative_path,
+                    line=1,
+                    command="",
+                    message="configured acquisition runbook is missing",
+                )
+            )
+            continue
+        text = document_path.read_text(encoding="utf-8")
+        issues.extend(validate_markdown(relative_path, text))
+    return tuple(issues)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        help="Runbook paths relative to --repository-root (defaults to the locked set).",
+    )
+    parser.add_argument(
+        "--repository-root",
+        type=Path,
+        default=REPOSITORY_ROOT,
+        help="Repository checkout containing the runbooks and src/ tree.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    paths = tuple(args.paths) if args.paths else ACQUISITION_RUNBOOKS
+    issues = validate_paths(args.repository_root.resolve(), paths)
+    for issue in issues:
+        print(issue.render(), file=sys.stderr)
+    if issues:
+        print(
+            f"acquisition runbook command validation failed with {len(issues)} issue(s)",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"validated Causal4D commands in {len(paths)} acquisition runbook(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_acquisition_runbook_commands.py
+++ b/scripts/ci/check_acquisition_runbook_commands.py
@@ -39,7 +39,33 @@ SHELL_FENCE_LANGUAGES = frozenset({"bash", "console", "sh", "shell", "zsh"})
 COMMAND_MANAGEMENT_ROUTES = frozenset({"describe", "list", "migrate", "validate"})
 LEGACY_EXECUTABLE_PATTERN = re.compile(r"^causal4d-[A-Za-z0-9][A-Za-z0-9_-]*$")
 SHELL_ASSIGNMENT_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
-SHELL_WRAPPERS = frozenset({"command", "env", "sudo", "time"})
+SHELL_CONTROL_PATTERN = re.compile(r"^[;&|()]+$")
+SHELL_PREFIX_KEYWORDS = frozenset({"!", "{", "do", "elif", "else", "if", "then", "until", "while"})
+
+_ENV_OPTIONS_WITH_VALUES = frozenset(
+    {"-C", "--chdir", "-S", "--split-string", "-u", "--unset"}
+)
+_SUDO_OPTIONS_WITH_VALUES = frozenset(
+    {
+        "-C",
+        "--close-from",
+        "-g",
+        "--group",
+        "-h",
+        "--host",
+        "-p",
+        "--prompt",
+        "-r",
+        "--role",
+        "-t",
+        "--type",
+        "-T",
+        "--command-timeout",
+        "-u",
+        "--user",
+    }
+)
+_TIME_OPTIONS_WITH_VALUES = frozenset({"-f", "--format", "-o", "--output"})
 
 
 @dataclass(frozen=True)
@@ -131,37 +157,95 @@ def _logical_shell_commands(
             yield command_start, command
 
 
-def _command_tokens(command: str) -> tuple[str, ...]:
+def _simple_shell_commands(command: str) -> tuple[tuple[str, ...], ...]:
+    """Split one logical line at unquoted shell control operators."""
+
     try:
-        tokens = list(shlex.split(command, comments=True, posix=True))
+        lexer = shlex.shlex(
+            command,
+            posix=True,
+            punctuation_chars=";&|()",
+        )
+        lexer.whitespace_split = True
+        lexer.commenters = "#"
+        tokens = list(lexer)
     except ValueError:
         return ()
 
-    while tokens:
-        first = tokens[0]
-        if SHELL_ASSIGNMENT_PATTERN.fullmatch(first):
-            tokens.pop(0)
+    commands: list[tuple[str, ...]] = []
+    current: list[str] = []
+    for token in tokens:
+        if SHELL_CONTROL_PATTERN.fullmatch(token):
+            if current:
+                commands.append(tuple(current))
+                current = []
             continue
-        if first in SHELL_WRAPPERS:
+        current.append(token)
+    if current:
+        commands.append(tuple(current))
+    return tuple(commands)
+
+
+def _consume_options(
+    tokens: list[str],
+    options_with_values: frozenset[str],
+) -> None:
+    while tokens and tokens[0].startswith("-"):
+        option = tokens.pop(0)
+        if option == "--":
+            return
+        name, separator, _ = option.partition("=")
+        if not separator and name in options_with_values and tokens:
             tokens.pop(0)
-            if first == "env":
-                while tokens and SHELL_ASSIGNMENT_PATTERN.fullmatch(tokens[0]):
-                    tokens.pop(0)
+
+
+def _command_tokens(tokens: Sequence[str]) -> tuple[str, ...]:
+    """Remove shell prefixes and wrappers from one simple command."""
+
+    values = list(tokens)
+    while values:
+        first = values[0]
+        if SHELL_ASSIGNMENT_PATTERN.fullmatch(first) or first in SHELL_PREFIX_KEYWORDS:
+            values.pop(0)
+            continue
+        if first == "env":
+            values.pop(0)
+            _consume_options(values, _ENV_OPTIONS_WITH_VALUES)
+            while values and SHELL_ASSIGNMENT_PATTERN.fullmatch(values[0]):
+                values.pop(0)
+            continue
+        if first == "sudo":
+            values.pop(0)
+            _consume_options(values, _SUDO_OPTIONS_WITH_VALUES)
+            while values and SHELL_ASSIGNMENT_PATTERN.fullmatch(values[0]):
+                values.pop(0)
+            continue
+        if first == "time":
+            values.pop(0)
+            _consume_options(values, _TIME_OPTIONS_WITH_VALUES)
+            continue
+        if first == "command":
+            values.pop(0)
+            if values and values[0] in {"-v", "-V"}:
+                return ()
+            while values and values[0] in {"-p", "--"}:
+                values.pop(0)
             continue
         break
-    return tuple(tokens)
+    return tuple(values)
 
 
-def _validate_causal4d_command(
+def _validate_causal4d_tokens(
     path: Path,
     line: int,
     command: str,
+    tokens: Sequence[str],
 ) -> RunbookCommandIssue | None:
-    tokens = _command_tokens(command)
-    if not tokens:
+    normalized = _command_tokens(tokens)
+    if not normalized:
         return None
 
-    executable = tokens[0]
+    executable = normalized[0]
     if LEGACY_EXECUTABLE_PATTERN.fullmatch(executable):
         return RunbookCommandIssue(
             path=path,
@@ -172,7 +256,7 @@ def _validate_causal4d_command(
     if executable != PRIMARY_EXECUTABLE:
         return None
 
-    arguments = tokens[1:]
+    arguments = normalized[1:]
     if not arguments:
         return RunbookCommandIssue(
             path=path,
@@ -208,6 +292,19 @@ def _validate_causal4d_command(
     )
 
 
+def _validate_causal4d_command(
+    path: Path,
+    line: int,
+    command: str,
+) -> tuple[RunbookCommandIssue, ...]:
+    issues: list[RunbookCommandIssue] = []
+    for tokens in _simple_shell_commands(command):
+        issue = _validate_causal4d_tokens(path, line, command, tokens)
+        if issue is not None:
+            issues.append(issue)
+    return tuple(issues)
+
+
 def validate_markdown(
     path: Path,
     text: str,
@@ -217,9 +314,7 @@ def validate_markdown(
     issues: list[RunbookCommandIssue] = []
     for block_start, lines in _shell_fenced_blocks(text):
         for line, command in _logical_shell_commands(block_start, lines):
-            issue = _validate_causal4d_command(path, line, command)
-            if issue is not None:
-                issues.append(issue)
+            issues.extend(_validate_causal4d_command(path, line, command))
     return tuple(issues)
 
 

--- a/scripts/ci/check_acquisition_runbook_commands.py
+++ b/scripts/ci/check_acquisition_runbook_commands.py
@@ -167,9 +167,7 @@ def _validate_causal4d_command(
             path=path,
             line=line,
             command=command,
-            message=(
-                "removed historical executable; use its grouped `causal4d` route"
-            ),
+            message=("removed historical executable; use its grouped `causal4d` route"),
         )
     if executable != PRIMARY_EXECUTABLE:
         return None

--- a/tests/test_acquisition_runbook_commands.py
+++ b/tests/test_acquisition_runbook_commands.py
@@ -36,6 +36,10 @@ CHECKER = _load_checker()
         "causal4d calibration execution-block evaluate folds.json",
         "causal4d commands migrate causal4d-real-protocol",
         "env MODE=confirmatory causal4d protocol real validate-dataset protocol.json data",
+        "sudo -n -u operator causal4d protocol real status protocol.json data",
+        "time -p causal4d protocol readiness status /opt/causal4d /data/evidence",
+        "command -p causal4d protocol freeze validate method.json /opt/causal4d",
+        "command -v causal4d",
         "causal4d --help",
     ],
 )
@@ -55,11 +59,48 @@ causal4d-real-protocol status protocol.json evidence
     assert "removed historical executable" in issues[0].message
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "echo ready && causal4d-real-protocol status protocol.json evidence",
+        "printf '%s\\n' ready | causal4d-real-experiment-freeze seal root freeze.json",
+        "if ! causal4d-real-protocol status protocol.json evidence; then exit 1; fi",
+        "sudo -u operator causal4d-real-protocol status protocol.json evidence",
+        "env -u TOKEN MODE=test causal4d-real-protocol status protocol.json evidence",
+        "time -p causal4d-real-protocol status protocol.json evidence",
+    ],
+)
+def test_removed_executable_is_rejected_in_compound_or_wrapped_commands(
+    command: str,
+) -> None:
+    text = f"```bash\n{command}\n```\n"
+    issues = CHECKER.validate_markdown(Path("runbook.md"), text)
+    assert len(issues) == 1
+    assert "removed historical executable" in issues[0].message
+
+
 def test_unknown_grouped_route_is_rejected() -> None:
     text = """```console
 $ causal4d protocol definitely-not-a-route --help
 ```
 """
+    issues = CHECKER.validate_markdown(Path("runbook.md"), text)
+    assert len(issues) == 1
+    assert "unknown grouped Causal4D route" in issues[0].message
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "echo ready; causal4d protocol definitely-not-a-route --help",
+        "true || sudo -n causal4d protocol definitely-not-a-route --help",
+        "printf ready | time -p causal4d protocol definitely-not-a-route --help",
+    ],
+)
+def test_unknown_route_is_rejected_in_compound_or_wrapped_commands(
+    command: str,
+) -> None:
+    text = f"```bash\n{command}\n```\n"
     issues = CHECKER.validate_markdown(Path("runbook.md"), text)
     assert len(issues) == 1
     assert "unknown grouped Causal4D route" in issues[0].message
@@ -88,10 +129,12 @@ causal4d-real-experiment-freeze seal \\
     assert issues[0].line == 3
 
 
-def test_non_causal4d_commands_are_ignored() -> None:
+def test_non_causal4d_commands_and_literal_arguments_are_ignored() -> None:
     text = """```bash
 python -m pip install -e .
 git rev-parse HEAD
+echo causal4d-real-protocol
+causal4d commands migrate causal4d-real-protocol
 ```
 """
     assert CHECKER.validate_markdown(Path("runbook.md"), text) == ()

--- a/tests/test_acquisition_runbook_commands.py
+++ b/tests/test_acquisition_runbook_commands.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+CHECKER_PATH = REPOSITORY_ROOT / "scripts/ci/check_acquisition_runbook_commands.py"
+
+
+def _load_checker() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "check_acquisition_runbook_commands",
+        CHECKER_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+CHECKER = _load_checker()
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "causal4d protocol real status /tmp/protocol.json /tmp/evidence",
+        "causal4d protocol readiness status /opt/causal4d /data/evidence",
+        "causal4d protocol freeze validate method_freeze.json /opt/causal4d",
+        "causal4d calibration execution-block evaluate folds.json",
+        "causal4d commands migrate causal4d-real-protocol",
+        "env MODE=confirmatory causal4d protocol real validate-dataset protocol.json data",
+        "causal4d --help",
+    ],
+)
+def test_current_grouped_commands_are_accepted(command: str) -> None:
+    text = f"```bash\n{command}\n```\n"
+    assert CHECKER.validate_markdown(Path("runbook.md"), text) == ()
+
+
+def test_removed_historical_executable_is_rejected() -> None:
+    text = """```bash
+causal4d-real-protocol status protocol.json evidence
+```
+"""
+    issues = CHECKER.validate_markdown(Path("runbook.md"), text)
+    assert len(issues) == 1
+    assert issues[0].line == 2
+    assert "removed historical executable" in issues[0].message
+
+
+def test_unknown_grouped_route_is_rejected() -> None:
+    text = """```console
+$ causal4d protocol definitely-not-a-route --help
+```
+"""
+    issues = CHECKER.validate_markdown(Path("runbook.md"), text)
+    assert len(issues) == 1
+    assert "unknown grouped Causal4D route" in issues[0].message
+
+
+def test_unknown_command_management_route_is_rejected() -> None:
+    text = """```sh
+causal4d commands silently-rewrite-history
+```
+"""
+    issues = CHECKER.validate_markdown(Path("runbook.md"), text)
+    assert len(issues) == 1
+    assert "unknown command-registry management route" in issues[0].message
+
+
+def test_backslash_continuation_reports_the_first_command_line() -> None:
+    text = """```bash
+# Old command copied from a pre-0.5 checklist.
+causal4d-real-experiment-freeze seal \\
+  /opt/causal4d \\
+  method_freeze.json
+```
+"""
+    issues = CHECKER.validate_markdown(Path("runbook.md"), text)
+    assert len(issues) == 1
+    assert issues[0].line == 3
+
+
+def test_non_causal4d_commands_are_ignored() -> None:
+    text = """```bash
+python -m pip install -e .
+git rev-parse HEAD
+```
+"""
+    assert CHECKER.validate_markdown(Path("runbook.md"), text) == ()
+
+
+def test_acquisition_critical_runbooks_use_current_commands() -> None:
+    assert CHECKER.validate_paths(REPOSITORY_ROOT) == ()


### PR DESCRIPTION
## Summary

- split each logical runbook line at unquoted shell control operators and validate every simple command;
- reject removed `causal4d-*` executables and unknown grouped routes after `&&`, `||`, `;`, pipes, and subshell boundaries;
- unwrap common `env`, `sudo`, `time`, and invoking `command` forms, including options that consume values;
- recognize shell prefixes such as `if`, `!`, `then`, `while`, and brace groups;
- keep literal migration-name arguments and non-Causal4D commands admissible;
- add adversarial regressions for compound lines, wrappers, query-only `command -v`, and false-positive avoidance.

## Why

Merged PR #129 validated the first command in each logical shell line. A stale removed executable or unknown grouped route later in a compound command could therefore evade the check, for example after `&&` or a pipe. Acquisition runbooks should fail closed regardless of ordinary shell composition.

## Boundary

Operator-safety validation only. No estimator, protocol, schedule, evidence, frozen artifact, threshold, or scientific claim changes.

## Validation requested

- focused runbook checker tests;
- Ruff lint and formatting;
- current repository CI and compatibility suites.
