### PR TITLE
Fix aggregate direction-angle reproduction tolerance

### DIFF
--- a/.github/workflows/workstation2-evaluation.yml
+++ b/.github/workflows/workstation2-evaluation.yml
@@ -7,11 +7,13 @@ on:
       - ".github/workflows/workstation2-evaluation.yml"
       - ".github/workflows/optional-integrations.yml"
       - "scripts/ci/compare_result_bundles.py"
+      - "scripts/ci/result_bundle_compare_*.py"
       - "scripts/ci/reproduction_manifest_runtime.py"
       - "scripts/ci/reproduction_manifest_validation.py"
       - "scripts/ci/result_bundle_identity.py"
       - "scripts/ci/write_reproduction_manifest.py"
       - "scripts/ci/workstation2_gpu_qualification.py"
+      - "tests/test_result_bundle*.py"
       - "tests/test_workstation2_cache_policy.py"
   workflow_dispatch:
     inputs:

--- a/scripts/ci/result_bundle_compare_values.py
+++ b/scripts/ci/result_bundle_compare_values.py
@@ -12,6 +12,7 @@ _SUCCESS_GATE_THRESHOLD_PATH = re.compile(
     r"^success_gates\.json\.gates\[\d+\]\.threshold$"
 )
 _DIRECTION_ANGLE_FIELD = "direction_error_deg"
+_DIRECTION_ANGLE_AGGREGATE_FIELD = f"mean_{_DIRECTION_ANGLE_FIELD}"
 _ALLOWED_CONTACT_AGGREGATE_DIAGNOSTICS = frozenset(
     {
         "mean_joint_positive_support_size",
@@ -105,8 +106,9 @@ class Comparison:
 
 
 def _is_direction_angle_path(path: str) -> bool:
-    return path.endswith(f".{_DIRECTION_ANGLE_FIELD}") or path.endswith(
-        f"field={_DIRECTION_ANGLE_FIELD}"
+    return any(
+        path.endswith(f".{field}") or path.endswith(f"field={field}")
+        for field in (_DIRECTION_ANGLE_FIELD, _DIRECTION_ANGLE_AGGREGATE_FIELD)
     )
 
 

--- a/tests/test_result_bundle_aggregate_angle_tolerance.py
+++ b/tests/test_result_bundle_aggregate_angle_tolerance.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+from result_bundle_test_support import (
+    _copy_bundle,
+    _read_json,
+    _refresh_result_manifest,
+    _run_comparison,
+    _write_bundle,
+    _write_json,
+)
+
+
+def _set_mean_direction_error(bundle: Path, value: float) -> None:
+    summary = _read_json(bundle / "summary.json")
+    summary["aggregate"] = {
+        "interventions": [
+            {
+                "method": "latent_contact",
+                "mean_direction_error_deg": value,
+            }
+        ]
+    }
+    _write_json(bundle / "summary.json", summary)
+    _refresh_result_manifest(bundle)
+
+
+def test_aggregate_direction_angle_uses_declared_tolerance(tmp_path: Path) -> None:
+    expected = tmp_path / "expected"
+    within = tmp_path / "within"
+    beyond = tmp_path / "beyond"
+    expected_value = 0.15694540479337696
+    observed_workstation2_delta = 1.2074182697257333e-6
+    _write_bundle(expected)
+    _set_mean_direction_error(expected, expected_value)
+    _copy_bundle(expected, within)
+    _copy_bundle(expected, beyond)
+
+    _set_mean_direction_error(within, expected_value + observed_workstation2_delta)
+    _set_mean_direction_error(beyond, expected_value + 2.1e-6)
+
+    within_process, within_report = _run_comparison(expected, within, tmp_path)
+    beyond_process, beyond_report = _run_comparison(expected, beyond, tmp_path)
+
+    assert within_process.returncode == 0
+    assert within_report["semantic_match"] is True
+    assert math.isclose(
+        within_report["maximum_direction_angle_difference_deg"],
+        observed_workstation2_delta,
+        rel_tol=0.0,
+        abs_tol=1e-15,
+    )
+    assert beyond_process.returncode == 2
+    assert beyond_report["semantic_match"] is False
+    assert any(
+        "mean_direction_error_deg" in mismatch
+        for mismatch in beyond_report["mismatches"]
+    )

--- a/tests/test_workstation2_cache_policy.py
+++ b/tests/test_workstation2_cache_policy.py
@@ -19,3 +19,5 @@ def test_workstation2_uses_isolated_grouped_reproduction_path() -> None:
     assert text.count("scripts/ci/write_reproduction_manifest.py") >= 2
     assert "--actual-reproduction-manifest" in text
     assert "--require-actual-reproduction-manifest" in text
+    assert '"scripts/ci/result_bundle_compare_*.py"' in text
+    assert '"tests/test_result_bundle*.py"' in text


### PR DESCRIPTION
## Summary

- apply the already-declared `2e-6` degree conditioning tolerance to both row-level `direction_error_deg` and aggregate `mean_direction_error_deg` values;
- add a regression using the exact magnitude observed on workstation2, while retaining rejection just beyond the declared tolerance;
- make modular comparator implementations and their focused tests trigger the workstation2 reproduction workflow;
- add a workflow-policy regression so future comparator refactors cannot bypass the self-hosted evidence path.

## Root cause

PR #119 declared a narrow absolute tolerance for `direction_error_deg`, because near-zero angles computed through `arccos` amplify machine-level cosine differences. The comparator recognized row-level `.direction_error_deg` and CSV `field=direction_error_deg`, but not the aggregate summary field `.mean_direction_error_deg`.

When self-hosted run `30886792116` eventually executed, it regenerated the frozen bundle successfully and passed every frozen scientific gate, but reported seven semantic mismatches in aggregate mean direction angles. Every one was below the declared `2e-6` degree tolerance; the maximum was `1.2074182697257333e-6`. This was an implementation mismatch between the declared comparison contract and its path classifier, not scientific drift.

The workstation2 workflow path filter also named only the CLI wrapper, not the modular `result_bundle_compare_*.py` implementation files, so a comparator-only repair could otherwise miss the end-to-end reproduction job.

## Scientific boundary

- no tolerance value is changed;
- no estimator, likelihood, posterior, calibration, threshold, success-gate decision, frozen payload, or physical-evidence status is changed;
- byte identity remains false and explicitly reported across numerical stacks;
- the repair only makes the version-2 semantic comparator honor its existing field-specific contract for the corresponding aggregate statistic.

## Validation

Requested validation:

- focused within/beyond aggregate-angle regressions;
- existing adversarial result-bundle comparison suite;
- Ruff formatting, lint, and CI-utility mypy;
- complete hosted compatibility matrix;
- workstation2 regeneration of seeds `0:5`, requiring `semantic_match=true` while preserving `all_payload_bytes_match=false` and the recorded runtime sidecar.

The PR remains draft until the hosted checks and self-hosted reproduction report their results.