### PR TITLE
Harden preacquisition provenance validation

### DIFF
--- a/src/causal4d/preacquisition_gate_validation.py
+++ b/src/causal4d/preacquisition_gate_validation.py
@@ -44,8 +44,9 @@ def _validate_common_gate(
     dataset_root: Path,
     verify_file_hashes: bool,
 ) -> tuple[Mapping[str, Any], set[str], datetime]:
+    schema_version = gate.get("schema_version")
     _require(
-        gate.get("schema_version") == GATE_EVIDENCE_SCHEMA_VERSION,
+        type(schema_version) is int and schema_version == GATE_EVIDENCE_SCHEMA_VERSION,
         f"unsupported gate schema: {gate_id}",
     )
     _require(
@@ -384,8 +385,10 @@ def _validate_gate_file(
     try:
         gate = _read_json_mapping(path, name=f"{gate_id} gate")
         if gate.get("status") == "template":
+            schema_version = gate.get("schema_version")
             _require(
-                gate.get("schema_version") == GATE_EVIDENCE_SCHEMA_VERSION,
+                type(schema_version) is int
+                and schema_version == GATE_EVIDENCE_SCHEMA_VERSION,
                 "unsupported gate template schema",
             )
             _require(
@@ -438,7 +441,7 @@ def _validate_gate_file(
             verify_file_hashes=verify_file_hashes,
         )
         if gate_id == "signature_panel_complete":
-            _validate_signature_panel(
+            result["source_panel_evidence_sha256"] = _validate_signature_panel(
                 protocol,
                 v2,
                 v4,
@@ -505,8 +508,11 @@ def seal_preacquisition_gate(
         gate.get("target_outcomes_used") is False,
         "target_outcomes_used must be explicitly false before sealing",
     )
-    approver = str(approved_by).strip()
-    _require(bool(approver), "approved_by is required")
+    _require(
+        isinstance(approved_by, str) and bool(approved_by.strip()),
+        "approved_by must be a nonempty string",
+    )
+    approver = approved_by.strip()
     _parse_utc_timestamp(gate.get("completed_at_utc"), name="gate completed_at_utc")
     approved_at = approved_at_utc or datetime.now(timezone.utc).isoformat()
     _parse_utc_timestamp(approved_at, name="gate approved_at_utc")
@@ -525,10 +531,21 @@ def seal_preacquisition_gate(
         repository_root=repository_root,
         verify_file_hashes=True,
     )
+    collection_counts = {
+        name: real_status.get(name, 0)
+        for name in (
+            "manifest_executions",
+            "acquired_executions",
+            "validated_executions",
+        )
+    }
+    for name, value in collection_counts.items():
+        _require(
+            type(value) is int and value >= 0,
+            f"{name} must be a nonnegative integer",
+        )
     _require(
-        int(real_status.get("manifest_executions", 0)) == 0
-        and int(real_status.get("acquired_executions", 0)) == 0
-        and int(real_status.get("validated_executions", 0)) == 0,
+        all(value == 0 for value in collection_counts.values()),
         "confirmatory collection has already started",
     )
     freeze = real_status["prerequisites"]["method_freeze"]

--- a/src/causal4d/preacquisition_readiness.py
+++ b/src/causal4d/preacquisition_readiness.py
@@ -214,9 +214,20 @@ def evaluate_preacquisition_readiness(
         and not result["valid"]
     ]
 
-    manifest_count = int(real_status.get("manifest_executions", 0))
-    acquired_count = int(real_status.get("acquired_executions", 0))
-    validated_count = int(real_status.get("validated_executions", 0))
+    collection_counts = {
+        name: real_status.get(name, 0)
+        for name in (
+            "manifest_executions",
+            "acquired_executions",
+            "validated_executions",
+        )
+    }
+    for name, value in collection_counts.items():
+        if type(value) is not int or value < 0:
+            raise ValueError(f"{name} must be a nonnegative integer")
+    manifest_count = collection_counts["manifest_executions"]
+    acquired_count = collection_counts["acquired_executions"]
+    validated_count = collection_counts["validated_executions"]
     collection_not_started = manifest_count == acquired_count == validated_count == 0
 
     chronology_blockers: list[str] = []

--- a/src/causal4d/preacquisition_readiness_contracts.py
+++ b/src/causal4d/preacquisition_readiness_contracts.py
@@ -148,9 +148,23 @@ def _reject_json_constant(value: str) -> Any:
     raise ValueError(f"non-finite JSON constant is forbidden: {value}")
 
 
+def _object_without_duplicate_json_keys(
+    pairs: list[tuple[str, Any]],
+) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        _require(
+            key not in value,
+            f"duplicate JSON object key is forbidden: {key!r}",
+        )
+        value[key] = item
+    return value
+
+
 def _read_json_mapping(path: Path, *, name: str) -> dict[str, Any]:
     payload = json.loads(
         path.read_text(encoding="utf-8"),
+        object_pairs_hook=_object_without_duplicate_json_keys,
         parse_constant=_reject_json_constant,
     )
     _require(isinstance(payload, Mapping), f"{name} must be a JSON object")
@@ -249,18 +263,49 @@ def _validate_descriptor_list(
     return paths
 
 
-def _expected_source_panel(v2: Mapping[str, Any]) -> tuple[list[str], list[str]]:
-    executions = list(v2["preacquisition_signature_panel"]["executions"])
-    execution_ids = [str(execution["execution_id"]) for execution in executions]
-    session_ids = [str(execution["session_id"]) for execution in executions]
+def _expected_source_panel(
+    v2: Mapping[str, Any],
+) -> tuple[list[str], list[str]]:
+    panel = v2.get("preacquisition_signature_panel")
     _require(
-        len(execution_ids) == 12, "registered source panel must contain 12 executions"
+        isinstance(panel, Mapping),
+        "registered source panel is missing",
+    )
+    raw_executions = panel.get("executions")
+    _require(
+        isinstance(raw_executions, list),
+        "registered source executions are missing",
+    )
+    execution_ids: list[str] = []
+    session_ids: list[str] = []
+    for index, execution in enumerate(raw_executions):
+        _require(
+            isinstance(execution, Mapping),
+            f"registered source execution {index} is invalid",
+        )
+        execution_id = execution.get("execution_id")
+        session_id = execution.get("session_id")
+        _require(
+            isinstance(execution_id, str) and bool(execution_id.strip()),
+            f"registered source execution {index} id is invalid",
+        )
+        _require(
+            isinstance(session_id, str) and bool(session_id.strip()),
+            f"registered source execution {index} session id is invalid",
+        )
+        execution_ids.append(execution_id)
+        session_ids.append(session_id)
+    _require(
+        len(execution_ids) == 12,
+        "registered source panel must contain 12 executions",
     )
     _require(
-        len(set(execution_ids)) == 12, "registered source execution ids are not unique"
+        len(set(execution_ids)) == 12,
+        "registered source execution ids are not unique",
     )
     _require(
-        len(set(session_ids)) == 12, "registered source sessions are not independent"
+        len(set(session_ids)) == 12,
+        "registered source sessions are not independent",
     )
     return execution_ids, session_ids
 
@@ -272,10 +317,14 @@ def source_panel_execution_manifest_template(
 ) -> dict[str, Any]:
     """Return one explicitly incomplete source-panel execution record."""
 
-    execution_id = str(execution["execution_id"])
-    session_id = str(execution["session_id"])
+    execution_id = execution.get("execution_id")
+    session_id = execution.get("session_id")
     _require(
-        bool(execution_id) and bool(session_id), "source execution ids are missing"
+        isinstance(execution_id, str)
+        and bool(execution_id.strip())
+        and isinstance(session_id, str)
+        and bool(session_id.strip()),
+        "source execution ids are missing or invalid",
     )
     return {
         "schema_version": 1,

--- a/src/causal4d/preacquisition_source_panel_control.py
+++ b/src/causal4d/preacquisition_source_panel_control.py
@@ -69,8 +69,7 @@ def _registered_source_executions(
         "source-panel execution order differs from the registered panel",
     )
     _require(
-        [str(value.get("session_id")) for value in executions]
-        == expected_sessions,
+        [str(value.get("session_id")) for value in executions] == expected_sessions,
         "source-panel session order differs from the registered panel",
     )
     return executions
@@ -125,9 +124,7 @@ def _execution_status(
 ) -> dict[str, Any]:
     execution_id = str(execution["execution_id"])
     session_id = str(execution["session_id"])
-    manifest_relative = SOURCE_PANEL_MANIFEST_PATH.format(
-        execution_id=execution_id
-    )
+    manifest_relative = SOURCE_PANEL_MANIFEST_PATH.format(execution_id=execution_id)
     template_relative = SOURCE_PANEL_MANIFEST_TEMPLATE_PATH.format(
         execution_id=execution_id
     )
@@ -200,15 +197,16 @@ def _unexpected_execution_directories(
     return sorted(unexpected)
 
 
-def build_source_panel_status(
-    repository_root: str | Path,
+def _build_registered_source_panel_status(
+    protocol: Mapping[str, Any],
+    v2: Mapping[str, Any],
+    v4: Mapping[str, Any],
     dataset_root: str | Path,
     *,
     verify_file_hashes: bool = False,
 ) -> dict[str, Any]:
-    """Validate source-panel progress and identify the next physical execution."""
+    """Validate source-panel progress against an already loaded registration."""
 
-    protocol, v2, _, v4 = load_registered_preacquisition_chain(repository_root)
     root = _resolved_dataset_root(dataset_root)
     executions = _registered_source_executions(v2)
     profiles = _registered_profiles(v2)
@@ -235,14 +233,10 @@ def build_source_panel_status(
         if result["template_valid"] is False
     ]
     missing_ids = [
-        result["execution_id"]
-        for result in results
-        if not result["manifest_present"]
+        result["execution_id"] for result in results if not result["manifest_present"]
     ]
     missing_template_ids = [
-        result["execution_id"]
-        for result in results
-        if not result["template_present"]
+        result["execution_id"] for result in results if not result["template_present"]
     ]
     expected_prefix = expected_ids[: len(valid_ids)]
     out_of_order = valid_ids != expected_prefix
@@ -252,9 +246,7 @@ def build_source_panel_status(
     )
 
     next_execution: dict[str, Any] | None = None
-    for index, (execution, result) in enumerate(
-        zip(executions, results, strict=True)
-    ):
+    for index, (execution, result) in enumerate(zip(executions, results, strict=True)):
         if result["valid"]:
             continue
         profile_id = str(execution["command_profile_id"])
@@ -299,9 +291,7 @@ def build_source_panel_status(
         or out_of_order
     )
     complete = bool(
-        valid
-        and verify_file_hashes
-        and len(valid_ids) == len(expected_ids)
+        valid and verify_file_hashes and len(valid_ids) == len(expected_ids)
     )
     status: dict[str, Any] = {
         "schema_version": SOURCE_PANEL_STATUS_SCHEMA_VERSION,
@@ -335,6 +325,24 @@ def build_source_panel_status(
     status["evidence_sha256"] = source_panel_evidence_sha256(status)
     status["status_sha256"] = source_panel_status_sha256(status)
     return status
+
+
+def build_source_panel_status(
+    repository_root: str | Path,
+    dataset_root: str | Path,
+    *,
+    verify_file_hashes: bool = False,
+) -> dict[str, Any]:
+    """Validate source-panel progress and identify the next physical execution."""
+
+    protocol, v2, _, v4 = load_registered_preacquisition_chain(repository_root)
+    return _build_registered_source_panel_status(
+        protocol,
+        v2,
+        v4,
+        dataset_root,
+        verify_file_hashes=verify_file_hashes,
+    )
 
 
 def write_source_panel_status(
@@ -406,9 +414,7 @@ def publish_source_panel_manifest(
         payload.get("session_id") == session_id,
         "source-panel manifest names the wrong session",
     )
-    manifest_relative = SOURCE_PANEL_MANIFEST_PATH.format(
-        execution_id=execution_id
-    )
+    manifest_relative = SOURCE_PANEL_MANIFEST_PATH.format(execution_id=execution_id)
     final_path = root / manifest_relative
     _assert_ordinary_file_or_missing(final_path, name="source-panel manifest")
     _require(not final_path.exists(), "source-panel manifest already exists")

--- a/src/causal4d/preacquisition_source_validation.py
+++ b/src/causal4d/preacquisition_source_validation.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from causal4d.preacquisition_readiness_contracts import (
+    SOURCE_PANEL_MANIFEST_PATH,
     _canonical_sha256,
     _expected_source_panel,
     _finite_number,
@@ -32,7 +33,11 @@ def _validate_source_execution_manifest(
         relative, name="source execution manifest"
     )
     manifest = _read_json_mapping(path, name="source execution manifest")
-    _require(manifest.get("schema_version") == 1, "unsupported source execution schema")
+    schema_version = manifest.get("schema_version")
+    _require(
+        type(schema_version) is int and schema_version == 1,
+        "unsupported source execution schema",
+    )
     _require(
         manifest.get("artifact_kind") == "SourcePanelExecutionManifest",
         "unexpected source execution artifact kind",
@@ -99,15 +104,23 @@ def _validate_signature_panel(
     *,
     dataset_root: Path,
     verify_file_hashes: bool,
-) -> None:
+) -> str:
+    from causal4d.preacquisition_source_panel_control import (
+        _build_registered_source_panel_status,
+    )
+
     expected_execution_ids, expected_session_ids = _expected_source_panel(v2)
+    expected_manifest_files = {
+        execution_id: SOURCE_PANEL_MANIFEST_PATH.format(execution_id=execution_id)
+        for execution_id in expected_execution_ids
+    }
     manifest_files = checks.get("manifest_files")
     _require(
-        isinstance(manifest_files, Mapping), "source-panel manifest map is invalid"
+        isinstance(manifest_files, Mapping),
+        "source-panel manifest map is invalid",
     )
     _require(
-        set(manifest_files) == set(expected_execution_ids)
-        and len(manifest_files) == len(expected_execution_ids),
+        dict(manifest_files) == expected_manifest_files,
         "source-panel manifest map differs from the registered execution set",
     )
     _require(
@@ -118,17 +131,25 @@ def _validate_signature_panel(
         checks.get("session_ids") == expected_session_ids,
         "source-panel session ids differ from the registered panel",
     )
+    independent_session_count = checks.get("independent_session_count")
     _require(
-        checks.get("independent_session_count") == 12,
+        type(independent_session_count) is int
+        and independent_session_count == len(expected_session_ids),
         "source panel must contain 12 independent sessions",
     )
-    _require(checks.get("source_only") is True, "source panel is not source-only")
+    _require(
+        checks.get("source_only") is True,
+        "source panel is not source-only",
+    )
     for execution_id, session_id in zip(
-        expected_execution_ids, expected_session_ids, strict=True
+        expected_execution_ids,
+        expected_session_ids,
+        strict=True,
     ):
         relative = manifest_files.get(execution_id)
         _require(
-            isinstance(relative, str) and relative in evidence_paths,
+            relative == expected_manifest_files[execution_id]
+            and relative in evidence_paths,
             f"source execution manifest is not bound as evidence: {execution_id}",
         )
         _validate_source_execution_manifest(
@@ -141,6 +162,39 @@ def _validate_signature_panel(
             verify_file_hashes=verify_file_hashes,
         )
 
+    status = _build_registered_source_panel_status(
+        protocol,
+        v2,
+        v4,
+        dataset_root,
+        verify_file_hashes=verify_file_hashes,
+    )
+    blockers = status.get("blockers")
+    blocker_text = (
+        ", ".join(str(value) for value in blockers)
+        if isinstance(blockers, list)
+        else "unknown blocker"
+    )
+    _require(
+        status.get("valid") is True,
+        f"source-panel status is invalid: {blocker_text}",
+    )
+    _require(
+        status.get("validated_executions") == len(expected_execution_ids),
+        "source panel is incomplete",
+    )
+    if verify_file_hashes:
+        _require(
+            status.get("complete") is True,
+            f"source panel is not hash-verified and complete: {blocker_text}",
+        )
+    evidence_sha256 = status.get("evidence_sha256")
+    _require(
+        isinstance(evidence_sha256, str) and len(evidence_sha256) == 64,
+        "source-panel evidence digest is invalid",
+    )
+    return evidence_sha256
+
 
 def _validate_actuator_calibration(
     dataset_root: Path,
@@ -150,7 +204,11 @@ def _validate_actuator_calibration(
 ) -> str:
     path = dataset_root / _safe_relative_path(relative, name="actuator calibration")
     artifact = _read_json_mapping(path, name="actuator calibration")
-    _require(artifact.get("schema_version") == 1, "unsupported actuator schema")
+    schema_version = artifact.get("schema_version")
+    _require(
+        type(schema_version) is int and schema_version == 1,
+        "unsupported actuator schema",
+    )
     _require(
         artifact.get("artifact_kind") == "ActuatorRealizationCalibration",
         "unexpected actuator artifact kind",

--- a/tests/test_preacquisition_provenance_hardening.py
+++ b/tests/test_preacquisition_provenance_hardening.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+import causal4d.preacquisition_gate_validation as gate_validation
+import causal4d.preacquisition_readiness_contracts as contracts
+from causal4d.preacquisition_readiness import (
+    GATE_PATHS,
+    gate_evidence_sha256,
+    gate_evidence_template,
+)
+from causal4d.preacquisition_readiness_contracts import (
+    SOURCE_PANEL_MANIFEST_PATH,
+    SOURCE_PANEL_MANIFEST_TEMPLATE_PATH,
+    source_panel_execution_manifest_template,
+)
+from causal4d.preacquisition_source_validation import (
+    _validate_source_execution_manifest,
+)
+
+
+def _registered_values() -> tuple[dict, dict, dict]:
+    protocol = {
+        "protocol_id": "test-protocol",
+        "design_sha256": "a" * 64,
+        "executions": [],
+        "quality_gates": {"maximum_rgbd_actuator_sync_error_ms": 10.0},
+    }
+    profile = {"id": "test-profile", "amplitude_m": 0.08}
+    executions = [
+        {
+            "execution_id": f"source-{index:02d}",
+            "session_id": f"session-{index:02d}",
+            "command_profile_id": profile["id"],
+            "contact_region_id": "upper_torso",
+            "realization_condition_id": "nominal",
+            "replicate": index + 1,
+            "fresh_reset_and_fresh_grasp": True,
+            "confirmatory_fold_member": False,
+        }
+        for index in range(12)
+    ]
+    v2 = {
+        "preacquisition_signature_panel": {
+            "executions": executions,
+            "profiles": [profile],
+        }
+    }
+    v4 = {
+        "plan_id": "test-preacquisition-v4",
+        "amendment_sha256": "b" * 64,
+    }
+    return protocol, v2, v4
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _descriptor(root: Path, relative: str) -> dict:
+    payload = (root / relative).read_bytes()
+    return {
+        "path": relative,
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "bytes": len(payload),
+    }
+
+
+def _scaffold_complete_panel(
+    root: Path,
+    protocol: dict,
+    v2: dict,
+    v4: dict,
+) -> list[dict]:
+    evidence: list[dict] = []
+    executions = v2["preacquisition_signature_panel"]["executions"]
+    for execution in executions:
+        execution_id = execution["execution_id"]
+        template = source_panel_execution_manifest_template(
+            execution,
+            protocol,
+            v4,
+        )
+        template_relative = SOURCE_PANEL_MANIFEST_TEMPLATE_PATH.format(
+            execution_id=execution_id
+        )
+        _write_json(root / template_relative, template)
+        artifact_relative = (
+            f"preacquisition/source_panel/executions/{execution_id}/measurement.bin"
+        )
+        artifact_path = root / artifact_relative
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        artifact_path.write_bytes(execution_id.encode("utf-8"))
+        manifest = deepcopy(template)
+        manifest.update(
+            {
+                "status": "complete",
+                "included": True,
+                "started_at_utc": "2026-07-30T09:00:00Z",
+                "ended_at_utc": "2026-07-30T09:01:00Z",
+                "artifacts": [_descriptor(root, artifact_relative)],
+            }
+        )
+        manifest_relative = SOURCE_PANEL_MANIFEST_PATH.format(execution_id=execution_id)
+        _write_json(root / manifest_relative, manifest)
+        evidence.append(_descriptor(root, manifest_relative))
+    return evidence
+
+
+def _signature_gate(
+    root: Path,
+    protocol: dict,
+    v2: dict,
+    v4: dict,
+    *,
+    sealed: bool,
+) -> dict:
+    gate = gate_evidence_template(
+        "signature_panel_complete",
+        protocol,
+        v2,
+        v4,
+    )
+    gate["completed_at_utc"] = "2026-07-30T10:00:00Z"
+    gate["target_outcomes_used"] = False
+    gate["evidence"] = _scaffold_complete_panel(
+        root,
+        protocol,
+        v2,
+        v4,
+    )
+    if sealed:
+        gate["status"] = "passed"
+        gate["locked_before_confirmatory_collection"] = True
+        gate["approval"] = {
+            "approved": True,
+            "approver_id": "reviewer",
+            "approved_at_utc": "2026-07-30T10:05:00Z",
+        }
+        gate["artifact_sha256"] = gate_evidence_sha256(gate)
+    return gate
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '{"value": 1, "value": 2}',
+        '{"outer": {"value": 1, "value": 2}}',
+    ],
+)
+def test_acquisition_json_rejects_duplicate_keys(
+    tmp_path: Path,
+    payload: str,
+) -> None:
+    path = tmp_path / "duplicate.json"
+    path.write_text(payload, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        contracts._read_json_mapping(path, name="duplicate fixture")
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("execution_id", 1),
+        ("session_id", True),
+    ],
+)
+def test_registered_source_ids_reject_coercible_values(
+    field: str,
+    value: object,
+) -> None:
+    _, v2, _ = _registered_values()
+    v2["preacquisition_signature_panel"]["executions"][0][field] = value
+
+    with pytest.raises(ValueError, match="id is invalid"):
+        contracts._expected_source_panel(v2)
+
+
+@pytest.mark.parametrize("schema_version", [True, 1.0])
+def test_source_manifest_schema_requires_an_exact_integer(
+    tmp_path: Path,
+    schema_version: object,
+) -> None:
+    protocol, v2, v4 = _registered_values()
+    execution = v2["preacquisition_signature_panel"]["executions"][0]
+    _scaffold_complete_panel(tmp_path, protocol, v2, v4)
+    relative = SOURCE_PANEL_MANIFEST_PATH.format(execution_id=execution["execution_id"])
+    path = tmp_path / relative
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    manifest["schema_version"] = schema_version
+    _write_json(path, manifest)
+
+    with pytest.raises(
+        ValueError,
+        match="unsupported source execution schema",
+    ):
+        _validate_source_execution_manifest(
+            tmp_path,
+            relative,
+            protocol=protocol,
+            v4=v4,
+            execution_id=execution["execution_id"],
+            session_id=execution["session_id"],
+            verify_file_hashes=False,
+        )
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ["delete", "alter", "directory", "symlink"],
+)
+def test_signature_gate_revalidates_registered_templates(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    protocol, v2, v4 = _registered_values()
+    gate = _signature_gate(
+        tmp_path,
+        protocol,
+        v2,
+        v4,
+        sealed=True,
+    )
+    execution_id = v2["preacquisition_signature_panel"]["executions"][0]["execution_id"]
+    template = tmp_path / SOURCE_PANEL_MANIFEST_TEMPLATE_PATH.format(
+        execution_id=execution_id
+    )
+    if mutation == "delete":
+        template.unlink()
+    elif mutation == "alter":
+        payload = json.loads(template.read_text(encoding="utf-8"))
+        payload["included"] = True
+        _write_json(template, payload)
+    elif mutation == "directory":
+        template.unlink()
+        template.mkdir()
+    else:
+        replacement_id = v2["preacquisition_signature_panel"]["executions"][1][
+            "execution_id"
+        ]
+        replacement = tmp_path / SOURCE_PANEL_MANIFEST_TEMPLATE_PATH.format(
+            execution_id=replacement_id
+        )
+        template.unlink()
+        try:
+            template.symlink_to(replacement)
+        except OSError:
+            pytest.skip("symlinks are unavailable on this platform")
+
+    gate_path = tmp_path / GATE_PATHS["signature_panel_complete"]
+    _write_json(gate_path, gate)
+    result = gate_validation._validate_gate_file(
+        "signature_panel_complete",
+        gate_path,
+        protocol=protocol,
+        v2=v2,
+        v4=v4,
+        dataset_root=tmp_path,
+        prerequisites={},
+        verify_file_hashes=True,
+    )
+
+    assert result["valid"] is False
+    assert "source-panel status is invalid" in str(result["error"])
+
+
+def test_signature_gate_rejects_unexpected_execution_directory(
+    tmp_path: Path,
+) -> None:
+    protocol, v2, v4 = _registered_values()
+    gate = _signature_gate(
+        tmp_path,
+        protocol,
+        v2,
+        v4,
+        sealed=True,
+    )
+    unexpected = (
+        tmp_path
+        / "preacquisition"
+        / "source_panel"
+        / "executions"
+        / "unregistered-execution"
+    )
+    unexpected.mkdir(parents=True)
+    gate_path = tmp_path / GATE_PATHS["signature_panel_complete"]
+    _write_json(gate_path, gate)
+
+    result = gate_validation._validate_gate_file(
+        "signature_panel_complete",
+        gate_path,
+        protocol=protocol,
+        v2=v2,
+        v4=v4,
+        dataset_root=tmp_path,
+        prerequisites={},
+        verify_file_hashes=True,
+    )
+
+    assert result["valid"] is False
+    assert "unexpected_execution_directory" in str(result["error"])
+
+
+def test_signature_gate_binds_portable_source_panel_digest(
+    tmp_path: Path,
+) -> None:
+    protocol, v2, v4 = _registered_values()
+    gate = _signature_gate(
+        tmp_path,
+        protocol,
+        v2,
+        v4,
+        sealed=True,
+    )
+    gate_path = tmp_path / GATE_PATHS["signature_panel_complete"]
+    _write_json(gate_path, gate)
+
+    result = gate_validation._validate_gate_file(
+        "signature_panel_complete",
+        gate_path,
+        protocol=protocol,
+        v2=v2,
+        v4=v4,
+        dataset_root=tmp_path,
+        prerequisites={},
+        verify_file_hashes=True,
+    )
+
+    assert result["valid"] is True
+    assert len(result["source_panel_evidence_sha256"]) == 64
+
+
+def test_signature_gate_rejects_float_session_count(
+    tmp_path: Path,
+) -> None:
+    protocol, v2, v4 = _registered_values()
+    gate = _signature_gate(
+        tmp_path,
+        protocol,
+        v2,
+        v4,
+        sealed=True,
+    )
+    gate["checks"]["independent_session_count"] = 12.0
+    gate["artifact_sha256"] = gate_evidence_sha256(gate)
+    gate_path = tmp_path / GATE_PATHS["signature_panel_complete"]
+    _write_json(gate_path, gate)
+
+    result = gate_validation._validate_gate_file(
+        "signature_panel_complete",
+        gate_path,
+        protocol=protocol,
+        v2=v2,
+        v4=v4,
+        dataset_root=tmp_path,
+        prerequisites={},
+        verify_file_hashes=True,
+    )
+
+    assert result["valid"] is False
+    assert "12 independent sessions" in str(result["error"])
+
+
+def test_sealing_refuses_a_deleted_registered_template(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    protocol, v2, v4 = _registered_values()
+    gate = _signature_gate(
+        tmp_path,
+        protocol,
+        v2,
+        v4,
+        sealed=False,
+    )
+    execution_id = v2["preacquisition_signature_panel"]["executions"][0]["execution_id"]
+    template = tmp_path / SOURCE_PANEL_MANIFEST_TEMPLATE_PATH.format(
+        execution_id=execution_id
+    )
+    template.unlink()
+    gate_path = tmp_path / GATE_PATHS["signature_panel_complete"]
+    _write_json(gate_path, gate)
+    monkeypatch.setattr(
+        gate_validation,
+        "load_registered_preacquisition_chain",
+        lambda repository_root: (protocol, v2, {}, v4),
+    )
+    monkeypatch.setattr(
+        gate_validation,
+        "build_real_evidence_status",
+        lambda *args, **kwargs: {
+            "prerequisites": {"method_freeze": {"valid": False}},
+            "manifest_executions": 0,
+            "acquired_executions": 0,
+            "validated_executions": 0,
+        },
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="source-panel status is invalid",
+    ):
+        gate_validation.seal_preacquisition_gate(
+            tmp_path,
+            tmp_path,
+            "signature_panel_complete",
+            approved_by="reviewer",
+            approved_at_utc="2026-07-30T10:05:00Z",
+        )
+
+    retained = json.loads(gate_path.read_text(encoding="utf-8"))
+    assert retained["status"] == "template"
+    assert retained["artifact_sha256"] is None

--- a/tests/test_preacquisition_readiness.py
+++ b/tests/test_preacquisition_readiness.py
@@ -37,10 +37,16 @@ def _registered_values() -> tuple[dict, dict, dict]:
         {
             "execution_id": f"source-{index:02d}",
             "session_id": f"session-{index:02d}",
+            "command_profile_id": "test-profile",
         }
         for index in range(12)
     ]
-    v2 = {"preacquisition_signature_panel": {"executions": executions}}
+    v2 = {
+        "preacquisition_signature_panel": {
+            "executions": executions,
+            "profiles": [{"id": "test-profile"}],
+        }
+    }
     v4 = {
         "plan_id": "test-preacquisition-v4",
         "amendment_sha256": "b" * 64,
@@ -281,7 +287,21 @@ def test_signature_gate_validates_all_bound_source_manifests(tmp_path: Path) -> 
         data_path = tmp_path / data_relative
         data_path.parent.mkdir(parents=True, exist_ok=True)
         data_path.write_bytes(execution_id.encode("utf-8"))
-        manifest = source_panel_execution_manifest_template(execution, protocol, v4)
+        template = source_panel_execution_manifest_template(
+            execution,
+            protocol,
+            v4,
+        )
+        template_relative = SOURCE_PANEL_MANIFEST_TEMPLATE_PATH.format(
+            execution_id=execution_id
+        )
+        template_path = tmp_path / template_relative
+        template_path.parent.mkdir(parents=True, exist_ok=True)
+        template_path.write_text(
+            json.dumps(template, sort_keys=True, allow_nan=False),
+            encoding="utf-8",
+        )
+        manifest = deepcopy(template)
         manifest.update(
             {
                 "status": "complete",
@@ -319,6 +339,7 @@ def test_signature_gate_validates_all_bound_source_manifests(tmp_path: Path) -> 
 
     assert result["valid"] is True
     assert result["error"] is None
+    assert len(result["source_panel_evidence_sha256"]) == 64
 
 
 def test_software_gate_binds_freeze_attestation_and_distributions(
@@ -485,6 +506,23 @@ def test_confirmatory_manifest_before_readiness_is_invalid(
     assert status["valid"] is False
     assert status["ready"] is False
     assert "confirmatory_collection_already_started" in status["blockers"]
+
+
+def test_readiness_rejects_noninteger_confirmatory_counts(
+    monkeypatch, tmp_path: Path
+) -> None:
+    protocol, v2, v4 = _registered_values()
+    _patch_gate_results(monkeypatch)
+
+    with pytest.raises(ValueError, match="manifest_executions"):
+        evaluate_preacquisition_readiness(
+            protocol,
+            v2,
+            v4,
+            tmp_path,
+            _real_status(manifest_executions=0.0),
+            verify_file_hashes=True,
+        )
 
 
 def test_operational_gate_may_not_postdate_method_freeze(


### PR DESCRIPTION
## Summary

- make `signature_panel_complete` reuse the registered source-panel status contract during sealing and every later readiness evaluation;
- revalidate all 12 immutable worksheet templates, the exact registered execution inventory, prefix completion, unexpected execution directories, final manifests, and referenced artifact hashes;
- bind the portable source-panel `evidence_sha256` into derived gate/readiness evidence;
- reject duplicate JSON object keys and coercible acquisition-critical values, including Boolean/float schema versions, float session counts, non-string registered IDs, non-string approvers, and non-integer confirmatory counts;
- add adversarial regressions for deleted, altered, directory-replaced, and symlinked templates, unexpected directories, nested duplicate keys, exact-type semantics, and failed sealing without overwriting the template gate.

## Root cause

The acquisition-time source-panel status path enforced template and inventory integrity, while final gate validation independently checked only the completed manifest map and manifest contents. A valid gate could therefore be sealed, or remain readiness-valid, after a registered worksheet was removed or modified. The shared JSON loader also rejected non-finite numbers but accepted duplicate keys, and several coercion/equality checks admitted semantically ambiguous JSON values.

## Scientific boundary

No estimator, likelihood, posterior, intervention support, registered protocol, threshold, exclusion, split, target identity, or evidence-count changes. The physical confirmatory state remains `0/36` until genuine registered executions are acquired and validated.

## Validation

Self-hosted `workstation2` run `30898787597` passed on the final implementation before publication:

- Ruff formatting and focused lint: passed;
- focused readiness/source-panel/adversarial suite: **48 passed**;
- `git diff --check`: passed;
- branch rebuilt from current `main` and reduced to one implementation commit (`6dfa041bd8559965d3f12df686f5f18cd80c3c83`).

The PR remains draft until the normal hosted compatibility and packaging checks complete on this exact head.