### PR TITLE
Default CPU diagnostics to GitHub-hosted runners

### DIFF
--- a/.github/workflows/contact-posterior-concentration.yml
+++ b/.github/workflows/contact-posterior-concentration.yml
@@ -11,6 +11,14 @@ on:
       - "tests/test_contact_concentration_diagnostic.py"
   workflow_dispatch:
     inputs:
+      runner:
+        description: Runner type
+        required: true
+        default: github-hosted
+        type: choice
+        options:
+          - github-hosted
+          - self-hosted
       seeds:
         description: Fresh diagnostic seed range
         required: false
@@ -42,7 +50,12 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    runs-on: >-
+      ${{
+        inputs.runner == 'self-hosted' &&
+        fromJSON('["self-hosted","Linux","X64","nvidia-smi"]') ||
+        'ubuntu-latest'
+      }}
     timeout-minutes: 240
     steps:
       - name: Check out Causal4D
@@ -56,6 +69,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install isolated diagnostic environment
         shell: bash

--- a/.github/workflows/contact-posterior-concentration.yml
+++ b/.github/workflows/contact-posterior-concentration.yml
@@ -65,12 +65,19 @@ jobs:
           persist-credentials: false
           clean: true
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.12 with pip cache
+        if: inputs.runner != 'self-hosted'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: pyproject.toml
+
+      - name: Set up Python 3.12 without Actions cache
+        if: inputs.runner == 'self-hosted'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
 
       - name: Install isolated diagnostic environment
         shell: bash

--- a/.github/workflows/contact-posterior-diagnostics.yml
+++ b/.github/workflows/contact-posterior-diagnostics.yml
@@ -18,6 +18,14 @@ on:
       - "tests/test_contact_posterior_workflow_policy.py"
   workflow_dispatch:
     inputs:
+      runner:
+        description: Runner type
+        required: true
+        default: github-hosted
+        type: choice
+        options:
+          - github-hosted
+          - self-hosted
       seeds:
         description: Independent diagnostic seed range
         required: false
@@ -55,7 +63,12 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    runs-on: >-
+      ${{
+        inputs.runner == 'self-hosted' &&
+        fromJSON('["self-hosted","Linux","X64","nvidia-smi"]') ||
+        'ubuntu-latest'
+      }}
     timeout-minutes: 180
     steps:
       - name: Check out Causal4D
@@ -69,6 +82,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install isolated diagnostic environment
         shell: bash

--- a/.github/workflows/contact-posterior-diagnostics.yml
+++ b/.github/workflows/contact-posterior-diagnostics.yml
@@ -78,12 +78,19 @@ jobs:
           persist-credentials: false
           clean: true
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.12 with pip cache
+        if: inputs.runner != 'self-hosted'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: pyproject.toml
+
+      - name: Set up Python 3.12 without Actions cache
+        if: inputs.runner == 'self-hosted'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
 
       - name: Install isolated diagnostic environment
         shell: bash

--- a/.github/workflows/controlled-demo-video.yml
+++ b/.github/workflows/controlled-demo-video.yml
@@ -3,6 +3,14 @@ name: Controlled collaborator demo video
 on:
   workflow_dispatch:
     inputs:
+      runner:
+        description: Runner type
+        required: true
+        default: github-hosted
+        type: choice
+        options:
+          - github-hosted
+          - self-hosted
       seed:
         description: Representative controlled-case seed
         required: true
@@ -24,7 +32,12 @@ concurrency:
 jobs:
   render:
     name: Render controlled MP4, GIF, and poster
-    runs-on: [self-hosted, Linux, X64, collaborator-demo]
+    runs-on: >-
+      ${{
+        inputs.runner == 'self-hosted' &&
+        fromJSON('["self-hosted","Linux","X64","collaborator-demo"]') ||
+        'ubuntu-latest'
+      }}
     timeout-minutes: 15
     steps:
       - name: Check out Causal4D
@@ -36,6 +49,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install controlled-demo renderer
         run: |

--- a/.github/workflows/controlled-demo-video.yml
+++ b/.github/workflows/controlled-demo-video.yml
@@ -45,12 +45,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python
+      - name: Set up Python 3.12 with pip cache
+        if: inputs.runner != 'self-hosted'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: pyproject.toml
+
+      - name: Set up Python 3.12 without Actions cache
+        if: inputs.runner == 'self-hosted'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
 
       - name: Install controlled-demo renderer
         run: |

--- a/tests/test_contact_concentration_workflow_policy.py
+++ b/tests/test_contact_concentration_workflow_policy.py
@@ -7,14 +7,19 @@ ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "contact-posterior-concentration.yml"
 
 
-def test_concentration_workflow_is_read_only_and_self_hosted() -> None:
+def test_concentration_workflow_is_read_only_and_runner_selectable() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
 
     assert "permissions:\n  contents: read\n" in text
     assert "contents: write" not in text
     assert "git push" not in text
     assert "persist-credentials: false" in text
-    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
+    assert "default: github-hosted" in text
+    assert "'ubuntu-latest'" in text
+    assert (
+        "fromJSON('[\"self-hosted\",\"Linux\",\"X64\",\"nvidia-smi\"]')"
+        in text
+    )
     assert "github.event.pull_request.head.repo.full_name == github.repository" in text
     assert "workflow_dispatch:" in text
     assert "  push:" not in text

--- a/tests/test_contact_concentration_workflow_policy.py
+++ b/tests/test_contact_concentration_workflow_policy.py
@@ -25,6 +25,20 @@ def test_concentration_workflow_is_read_only_and_runner_selectable() -> None:
     assert "  push:" not in text
 
 
+def test_concentration_workflow_caches_only_on_hosted_runners() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    hosted = "      - name: Set up Python 3.12 with pip cache\n"
+    self_hosted = "      - name: Set up Python 3.12 without Actions cache\n"
+    install = "      - name: Install isolated diagnostic environment\n"
+    assert hosted in text
+    assert self_hosted in text
+    assert "        if: inputs.runner != 'self-hosted'\n" in text
+    assert "        if: inputs.runner == 'self-hosted'\n" in text
+    assert text.count("          cache: pip\n") == 1
+    assert text.index(hosted) < text.index(self_hosted) < text.index(install)
+
+
 def test_concentration_workflow_uses_fresh_registered_panel() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
 

--- a/tests/test_contact_posterior_workflow_policy.py
+++ b/tests/test_contact_posterior_workflow_policy.py
@@ -20,3 +20,17 @@ def test_contact_diagnostic_workflow_is_read_only_and_uses_grouped_cli() -> None
         "fromJSON('[\"self-hosted\",\"Linux\",\"X64\",\"nvidia-smi\"]')"
         in text
     )
+
+
+def test_contact_diagnostic_caches_only_on_hosted_runners() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    hosted = "      - name: Set up Python 3.12 with pip cache\n"
+    self_hosted = "      - name: Set up Python 3.12 without Actions cache\n"
+    install = "      - name: Install isolated diagnostic environment\n"
+    assert hosted in text
+    assert self_hosted in text
+    assert "        if: inputs.runner != 'self-hosted'\n" in text
+    assert "        if: inputs.runner == 'self-hosted'\n" in text
+    assert text.count("          cache: pip\n") == 1
+    assert text.index(hosted) < text.index(self_hosted) < text.index(install)

--- a/tests/test_contact_posterior_workflow_policy.py
+++ b/tests/test_contact_posterior_workflow_policy.py
@@ -14,4 +14,9 @@ def test_contact_diagnostic_workflow_is_read_only_and_uses_grouped_cli() -> None
     assert "\n  push:\n" not in text
     assert ".contact-diagnostic-venv/bin/causal4d benchmark latent-contact" in text
     assert "causal4d.cli.latent_contact_benchmark" not in text
-    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
+    assert "default: github-hosted" in text
+    assert "'ubuntu-latest'" in text
+    assert (
+        "fromJSON('[\"self-hosted\",\"Linux\",\"X64\",\"nvidia-smi\"]')"
+        in text
+    )

--- a/tests/test_dynamic_contact_demo.py
+++ b/tests/test_dynamic_contact_demo.py
@@ -50,6 +50,12 @@ def test_demo_workflow_uploads_all_presentation_artifacts() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
 
     assert "workflow_dispatch:" in text
+    assert "default: github-hosted" in text
+    assert "'ubuntu-latest'" in text
+    assert (
+        "fromJSON('[\"self-hosted\",\"Linux\",\"X64\",\"collaborator-demo\"]')"
+        in text
+    )
     assert "causal4d.cli.dynamic_contact_demo" in text
     assert "--require-gates" in text
     assert "causal4d_dynamic_contact_demo.mp4" in text

--- a/tests/test_dynamic_contact_demo.py
+++ b/tests/test_dynamic_contact_demo.py
@@ -64,3 +64,17 @@ def test_demo_workflow_uploads_all_presentation_artifacts() -> None:
     assert "summary.json" in text
     assert "SHA256SUMS" in text
     assert "actions/upload-artifact@" in text
+
+
+def test_demo_workflow_caches_only_on_hosted_runners() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    hosted = "      - name: Set up Python 3.12 with pip cache\n"
+    self_hosted = "      - name: Set up Python 3.12 without Actions cache\n"
+    install = "      - name: Install controlled-demo renderer\n"
+    assert hosted in text
+    assert self_hosted in text
+    assert "        if: inputs.runner != 'self-hosted'\n" in text
+    assert "        if: inputs.runner == 'self-hosted'\n" in text
+    assert text.count("          cache: pip\n") == 1
+    assert text.index(hosted) < text.index(self_hosted) < text.index(install)


### PR DESCRIPTION
## Summary

- default the contact concentration, contact posterior, and controlled demo jobs to `ubuntu-latest`;
- expose a manual `runner` choice retaining the original self-hosted label sets;
- enable the `setup-python` pip download cache only for GitHub-hosted runs;
- use a separate cache-free `setup-python` step for manual self-hosted runs, preventing the multi-gigabyte Actions cache restores previously observed on workstation2;
- add workflow-policy regressions that require the hosted default, preserve the self-hosted override, and prove that only the hosted setup step enables `cache: pip`.

## Why

All three workloads are CPU-only and use synthetic data. Recent executions completed in roughly 1–14 minutes, so consuming the scarce self-hosted GPU runner by default delayed unrelated CUDA and scientific jobs.

The first implementation enabled `setup-python` caching unconditionally. That would also have restored the remote cache on the manual self-hosted override, contradicting the repository's established workstation2 cache policy. The final implementation splits Python setup by runner type: hosted runs receive the pip download cache, while self-hosted runs rely on the runner's local environment and pip cache without Actions cache transfer.

Actual CUDA/Warp jobs in Optional integrations, Self-hosted research evaluation, and Workstation2 GPU evaluation remain self-hosted because they explicitly require CUDA devices.

## Validation

Before the cache-policy correction:

- `actionlint` 1.7.12 passed;
- `git diff --check` passed;
- 10 workflow-policy tests passed;
- 3 controlled-demo contract and numerical tests passed.

Final-head validation is running through:

- `CI and release` run `30907859540`;
- `Extended compatibility` run `30907859058`;
- hosted contact-concentration run `30907859062`;
- hosted topology-diagnostic run `30907859907`.

No estimator, protocol, dataset, threshold, frozen artifact, or scientific claim changes.