### PR TITLE
Add opt-in normalized factual prefix likelihood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   explicit no-overwrite support, and legacy archive loading.
 - Add a stable rollout-bank identity over hypothesis metadata, priors, physical
   parameter support, trajectories, variance floor, and confidence level.
+- Add explicit dense factual-abduction likelihood semantics. `legacy_v1` remains
+  the registered identity-preserving default, while opt-in `normalized_v2`
+  retains particle-specific scale normalization, includes the
+  endpoint-to-first-response increment, and models adjacent-frame correlation.
 
 This control plane advances pre-acquisition operations without creating physical
 evidence. Source-panel executions remain source-only and cannot increment the
@@ -36,10 +40,14 @@ evidence. Source-panel executions remain source-only and cannot increment the
   nested mutation cannot change intervention semantics after bank construction.
 - Route rollout-producing and rollout-consuming commands through one strict
   archive implementation, while retaining exact support for legacy banks.
+- Reject non-finite factual-abduction controls, correlation outside `(-1, 1)`,
+  legacy requests that specify a correlation model, and contradictory requests
+  for normalized dense and grouped full-covariance likelihoods.
 
-These changes harden diagnostic accounting, artifact integrity, and validation
-only. They do not change registered protocols, likelihoods, posteriors,
-thresholds, frozen evidence, or target identities.
+These changes harden diagnostic accounting, artifact integrity, and validation.
+The registered `legacy_v1` likelihood and posterior remain unchanged, and
+`normalized_v2` is not admitted into the frozen estimator, protocol, thresholds,
+evidence, or target identities.
 
 ## 0.5.0
 

--- a/docs/factual_prefix_likelihood_semantics.md
+++ b/docs/factual_prefix_likelihood_semantics.md
@@ -1,0 +1,98 @@
+# Versioned factual prefix-likelihood semantics
+
+Causal4D retains the registered dense factual-abduction likelihood as
+`legacy_v1` and exposes a separate opt-in development contract,
+`normalized_v2`. The default remains `legacy_v1`; no frozen result or existing
+artifact is rewritten.
+
+## Why the paths are versioned
+
+The original single-execution factual-abduction path and the later hierarchical
+abduction path used related but not identical Student-t composite likelihoods.
+The distinction matters when physical particles carry different discrepancy
+variances or when the endpoint-to-first-response increment contains intervention
+information.
+
+Silently changing the registered path would alter posterior weights and
+content-addressed factual-intervention artifacts. Causal4D therefore makes the
+choice explicit instead.
+
+## `legacy_v1`
+
+`legacy_v1` preserves the existing `JointRolloutBank.update_from_observations`
+behavior exactly:
+
+- the position block scores response frames after the endpoint;
+- the dynamic block differences only the already-selected response frames;
+- the dynamic scale reuses the declared observation scale;
+- particle-specific discrepancy variance changes the standardized residual scale,
+  but the historical score omits the corresponding scale-normalization term.
+
+The default metadata retains the original four fields only:
+
+```json
+{
+  "observation_scale_m": 0.01,
+  "likelihood_power": 12.0,
+  "dynamic_likelihood_weight": 0.25,
+  "degrees_of_freedom": 4.0
+}
+```
+
+This preserves legacy artifact identities and the registered physical protocol.
+
+## `normalized_v2`
+
+`normalized_v2` delegates to the shared correlation-aware prefix likelihood used
+by hierarchical abduction. It:
+
+- retains the Student-t `-log(scale)` term when component scales differ;
+- differences the complete admitted prefix, including the
+  endpoint-to-first-response increment;
+- uses
+  `observation_scale_m * sqrt(2 * (1 - difference_correlation))` for adjacent
+  observation differences;
+- keeps a time-persistent discrepancy mean out of the dynamic block because it
+  cancels under differencing;
+- uses static discrepancy variance only in the position block.
+
+The selected semantics and adjacent-frame correlation are added to the factual
+artifact metadata, so a normalized result cannot be mistaken for a legacy one.
+
+## Command line
+
+The factual-abduction command defaults to the registered path:
+
+```bash
+causal4d experiment phystwin abduct-intervention \
+  rollout-bank.npz twin-belief.npz final_data.pkl \
+  factual.npz evaluation.json
+```
+
+Run the development comparator explicitly with:
+
+```bash
+causal4d experiment phystwin abduct-intervention \
+  rollout-bank.npz twin-belief.npz final_data.pkl \
+  factual-normalized-v2.npz evaluation-normalized-v2.json \
+  --likelihood-semantics normalized_v2 \
+  --difference-correlation 0.25
+```
+
+`difference_correlation` is accepted only with `normalized_v2`. The normalized
+dense path cannot be combined with the separate grouped full-covariance evidence
+path; contradictory requests fail rather than silently ignoring one model.
+
+## Promotion boundary
+
+`normalized_v2` is implementation-ready but is not the registered Causal4D
+estimator. It must be evaluated under a source-only selection rule and a fresh,
+untouched contact-inference panel before any method-version decision. In
+particular, it cannot revise the frozen seeds `0:5`, the independent `100:120`
+panel, the `200:220` concentration diagnostic, or the locked 36-execution
+physical experiment.
+
+A future promotion requires a new method version, explicit evidence that a proper
+score improves without materially degrading trajectory accuracy, contact
+accuracy, or coverage, and another untouched evaluation panel. A negative result
+remains a complete outcome.

--- a/src/causal4d/cli/abduct_phystwin_intervention.py
+++ b/src/causal4d/cli/abduct_phystwin_intervention.py
@@ -60,6 +60,23 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--dynamic-likelihood-weight", type=float, default=0.25)
     parser.add_argument("--degrees-of-freedom", type=float, default=4.0)
     parser.add_argument(
+        "--likelihood-semantics",
+        choices=("legacy_v1", "normalized_v2"),
+        default="legacy_v1",
+        help=(
+            "Dense prefix-likelihood contract. legacy_v1 preserves the registered "
+            "path; normalized_v2 is an opt-in development comparator."
+        ),
+    )
+    parser.add_argument(
+        "--difference-correlation",
+        type=float,
+        default=0.0,
+        help=(
+            "Adjacent-frame observation correlation used only by normalized_v2."
+        ),
+    )
+    parser.add_argument(
         "--grouped-observation-likelihood",
         action="store_true",
         help=(
@@ -144,6 +161,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         likelihood_power=args.likelihood_power,
         dynamic_likelihood_weight=args.dynamic_likelihood_weight,
         degrees_of_freedom=args.degrees_of_freedom,
+        likelihood_semantics=args.likelihood_semantics,
+        difference_correlation=args.difference_correlation,
     )
     grouped_evidence = None
     if args.grouped_observation_likelihood:

--- a/src/causal4d/intervention_abduction.py
+++ b/src/causal4d/intervention_abduction.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Literal
 
 import numpy as np
 
@@ -14,25 +14,77 @@ from causal4d.grouped_likelihood import (
 )
 from causal4d.identifiability import InterventionIdentifiabilityResult
 from causal4d.observation_evidence import GroupedObservationEvidence
+from causal4d.prefix_likelihood import (
+    PrefixLikelihoodConfig,
+    update_joint_weights_from_prefix,
+)
 from causal4d.rollout_bank import JointRolloutBank
+
+
+DenseLikelihoodSemantics = Literal["legacy_v1", "normalized_v2"]
 
 
 @dataclass(frozen=True)
 class FactualAbductionConfig:
-    """Robust likelihood settings for factual intervention inference."""
+    """Robust likelihood settings for factual intervention inference.
+
+    ``legacy_v1`` preserves the registered dense score exactly. ``normalized_v2``
+    is an opt-in development path that uses the endpoint-inclusive, scale-normalized
+    prefix likelihood. The legacy defaults remain unchanged.
+    """
 
     observation_scale_m: float = 0.01
     likelihood_power: float = 12.0
     dynamic_likelihood_weight: float = 0.25
     degrees_of_freedom: float = 4.0
+    likelihood_semantics: DenseLikelihoodSemantics = "legacy_v1"
+    difference_correlation: float = 0.0
 
     def __post_init__(self) -> None:
-        if self.observation_scale_m <= 0.0 or self.likelihood_power <= 0.0:
-            raise ValueError("observation scale and likelihood power must be positive")
-        if self.dynamic_likelihood_weight < 0.0:
-            raise ValueError("dynamic_likelihood_weight must be nonnegative")
-        if self.degrees_of_freedom <= 0.0:
-            raise ValueError("degrees_of_freedom must be positive")
+        positive = (
+            self.observation_scale_m,
+            self.likelihood_power,
+            self.degrees_of_freedom,
+        )
+        if any(not np.isfinite(value) or value <= 0.0 for value in positive):
+            raise ValueError(
+                "observation scale, likelihood power, and dof must be finite and "
+                "positive"
+            )
+        if (
+            not np.isfinite(self.dynamic_likelihood_weight)
+            or self.dynamic_likelihood_weight < 0.0
+        ):
+            raise ValueError(
+                "dynamic_likelihood_weight must be finite and nonnegative"
+            )
+        if self.likelihood_semantics not in {"legacy_v1", "normalized_v2"}:
+            raise ValueError("unsupported dense likelihood semantics")
+        if not np.isfinite(self.difference_correlation) or not (
+            -1.0 < self.difference_correlation < 1.0
+        ):
+            raise ValueError("difference_correlation must lie in (-1, 1)")
+        if (
+            self.likelihood_semantics == "legacy_v1"
+            and self.difference_correlation != 0.0
+        ):
+            raise ValueError(
+                "difference_correlation is available only with normalized_v2"
+            )
+
+    def artifact_metadata(self) -> dict[str, float | str]:
+        """Return metadata while preserving the legacy-v1 artifact identity."""
+
+        result: dict[str, float | str] = {
+            "observation_scale_m": self.observation_scale_m,
+            "likelihood_power": self.likelihood_power,
+            "dynamic_likelihood_weight": self.dynamic_likelihood_weight,
+            "degrees_of_freedom": self.degrees_of_freedom,
+        }
+        if self.likelihood_semantics != "legacy_v1":
+            result["likelihood_semantics"] = self.likelihood_semantics
+            result["difference_correlation"] = self.difference_correlation
+        return result
 
 
 def _belief_readout(
@@ -98,10 +150,17 @@ def _update_joint_weights(
     base_weights: np.ndarray | None = None,
     grouped_evidence: GroupedObservationEvidence | None = None,
 ) -> tuple[np.ndarray, GroupLikelihoodDiagnostics | None]:
+    if (
+        grouped_evidence is not None
+        and settings.likelihood_semantics != "legacy_v1"
+    ):
+        raise ValueError(
+            "normalized_v2 cannot be combined with grouped observation evidence"
+        )
     discrepancy, discrepancy_variance = _belief_readout(bank, belief)
     if grouped_evidence is None:
-        return (
-            bank.update_from_observations(
+        if settings.likelihood_semantics == "legacy_v1":
+            joint_weights = bank.update_from_observations(
                 observations_from_endpoint_m,
                 prefix_frame_count=prefix_frame_count,
                 scale_m=settings.observation_scale_m,
@@ -112,9 +171,26 @@ def _update_joint_weights(
                 base_weights=base_weights,
                 particle_discrepancy_m=discrepancy,
                 particle_discrepancy_variance_m2=discrepancy_variance,
-            ),
-            None,
-        )
+            )
+        else:
+            joint_weights = update_joint_weights_from_prefix(
+                bank,
+                observations_from_endpoint_m,
+                prefix_frame_count=prefix_frame_count,
+                config=PrefixLikelihoodConfig(
+                    observation_scale_m=settings.observation_scale_m,
+                    likelihood_power=settings.likelihood_power,
+                    position_likelihood_weight=1.0,
+                    dynamic_likelihood_weight=settings.dynamic_likelihood_weight,
+                    degrees_of_freedom=settings.degrees_of_freedom,
+                    difference_correlation=settings.difference_correlation,
+                ),
+                mask=observation_mask,
+                base_weights=base_weights,
+                particle_discrepancy_m=discrepancy,
+                particle_discrepancy_variance_m2=discrepancy_variance,
+            )
+        return joint_weights, None
     components = physical_readout_components(bank, belief)
     component_variance = np.broadcast_to(
         discrepancy_variance[None, :, None], components.shape
@@ -209,7 +285,7 @@ def abduct_factual_intervention(
             hypothesis_indices.append(hypothesis_index)
             particle_indices.append(particle_index)
     metadata: dict[str, Any] = {
-        "abduction_likelihood": asdict(settings),
+        "abduction_likelihood": settings.artifact_metadata(),
         "observation_prefix_frame_count_including_endpoint": prefix_frame_count,
         "o_plus_frames_used": prefix_frame_count - 1,
         "future_frames_read_by_abduction": 0,
@@ -367,7 +443,13 @@ def evaluate_factual_abduction(
         "abduction_prefix_frame_count_including_endpoint": prefix_frame_count,
         "held_out_rollout_interval": [prefix_frame_count, bank.frame_count],
         "evidence_model": (
-            "grouped_robust_composite" if grouped_evidence is not None else "legacy_dense"
+            "grouped_robust_composite"
+            if grouped_evidence is not None
+            else (
+                "legacy_dense"
+                if settings.likelihood_semantics == "legacy_v1"
+                else "normalized_dense_v2"
+            )
         ),
         "bpt_without_z": nominal_metrics,
         "bpt_plus_causal4d_z": z_metrics,

--- a/tests/test_factual_likelihood_semantics.py
+++ b/tests/test_factual_likelihood_semantics.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from causal4d.cli.abduct_phystwin_intervention import build_parser
+from causal4d.contracts import TwinBelief, build_causal_context
+from causal4d.intervention_abduction import (
+    FactualAbductionConfig,
+    abduct_factual_intervention,
+    evaluate_factual_abduction,
+)
+from causal4d.observation_evidence import GroupedObservationEvidence
+from causal4d.rollout_bank import JointRolloutBank
+
+
+def _metadata(identifier: str) -> dict:
+    return {
+        "hypothesis_id": identifier,
+        "action": {
+            "proposal_id": "known",
+            "future_action_observed": True,
+            "provenance": "likelihood semantics unit test",
+        },
+        "contact": {
+            "attachment_shifts": [0],
+            "gain_multiplier": 1.0,
+            "delay_steps": 0,
+            "slip_fraction": 0.0,
+            "rotation_degrees": 0.0,
+        },
+    }
+
+
+def _belief(
+    bank: JointRolloutBank,
+    *,
+    variance: np.ndarray | None = None,
+) -> TwinBelief:
+    full_frames = bank.frame_count + 3
+    intervention_frame = 4
+    observations = np.zeros((full_frames, bank.node_count, bank.coordinate_count))
+    actions = np.zeros((full_frames, 1, bank.coordinate_count))
+    context = build_causal_context(
+        protocol_id="likelihood-semantics-unit",
+        case_id="synthetic",
+        observations=observations,
+        observed_actions=actions,
+        counterfactual_actions=actions,
+        intervention_frame=intervention_frame,
+    )
+    particle_count = len(bank.parameter_weights)
+    state_shape = (particle_count, bank.node_count, bank.coordinate_count)
+    return TwinBelief(
+        context=context,
+        endpoint_frame=intervention_frame - 1,
+        particle_ids=tuple(f"p{index}" for index in range(particle_count)),
+        theta_names=("spring",),
+        endpoint_position_m=np.zeros(state_shape),
+        endpoint_velocity_mps=np.zeros(state_shape),
+        theta=bank.parameter_particles,
+        discrepancy_mean_m=np.zeros(state_shape),
+        discrepancy_variance_m2=(
+            np.zeros(state_shape) if variance is None else variance
+        ),
+        weights=bank.parameter_weights,
+    )
+
+
+def _registered_problem():
+    bank_frames = 8
+    trajectories = np.zeros((3, 1, bank_frames, 1, 3), dtype=float)
+    time = np.arange(bank_frames, dtype=float)
+    trajectories[1, 0, :, 0, 0] = 0.01 * time
+    trajectories[2, 0, :, 0, 0] = -0.01 * time
+
+    def metadata(identifier, gain, shift):
+        result = _metadata(identifier)
+        result["contact"] = {
+            **result["contact"],
+            "attachment_shifts": [shift],
+            "gain_multiplier": gain,
+        }
+        return result
+
+    bank = JointRolloutBank(
+        hypothesis_ids=("nominal", "high_gain", "shifted"),
+        hypothesis_metadata=(
+            metadata("nominal", 1.0, 0),
+            metadata("high_gain", 1.15, 0),
+            metadata("shifted", 1.0, 1),
+        ),
+        hypothesis_prior_weights=np.asarray([0.6, 0.2, 0.2]),
+        parameter_particles=np.asarray([[0.0]]),
+        parameter_weights=np.asarray([1.0]),
+        trajectories=trajectories,
+        variance_floor_m2=1e-8,
+    )
+    belief = _belief(bank)
+    observations = trajectories[1, 0].copy()
+    mask = np.ones((bank_frames, 1), dtype=bool)
+    config = FactualAbductionConfig(
+        observation_scale_m=0.001,
+        likelihood_power=60.0,
+        dynamic_likelihood_weight=0.5,
+    )
+    return bank, belief, observations, mask, config
+
+
+def test_legacy_v1_preserves_registered_artifact_identity() -> None:
+    bank, belief, observations, mask, config = _registered_problem()
+
+    factual = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=config,
+    )
+
+    assert factual.artifact_id == (
+        "4b0d5227f9c561db217ef7f6a016d12bd5469e5e94ffcd877dfbeda26ebd491d"
+    )
+    assert factual.metadata["abduction_likelihood"] == {
+        "degrees_of_freedom": 4.0,
+        "dynamic_likelihood_weight": 0.5,
+        "likelihood_power": 60.0,
+        "observation_scale_m": 0.001,
+    }
+    assert "likelihood_semantics" not in factual.metadata["abduction_likelihood"]
+
+
+def test_normalized_v2_pays_particle_specific_scale_normalization() -> None:
+    trajectories = np.zeros((1, 2, 5, 1, 3), dtype=float)
+    bank = JointRolloutBank(
+        hypothesis_ids=("nominal",),
+        hypothesis_metadata=(_metadata("nominal"),),
+        hypothesis_prior_weights=np.asarray([1.0]),
+        parameter_particles=np.asarray([[0.0], [1.0]]),
+        parameter_weights=np.asarray([0.5, 0.5]),
+        trajectories=trajectories,
+    )
+    variance = np.zeros((2, 1, 3), dtype=float)
+    variance[1] = 1.0
+    belief = _belief(bank, variance=variance)
+    observations = np.zeros((5, 1, 3), dtype=float)
+    mask = np.ones((5, 1), dtype=bool)
+
+    legacy = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=FactualAbductionConfig(
+            observation_scale_m=0.1,
+            likelihood_power=4.0,
+            dynamic_likelihood_weight=0.0,
+        ),
+    )
+    normalized = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=FactualAbductionConfig(
+            observation_scale_m=0.1,
+            likelihood_power=4.0,
+            dynamic_likelihood_weight=0.0,
+            likelihood_semantics="normalized_v2",
+        ),
+    )
+
+    assert np.array_equal(legacy.weights, np.asarray([0.5, 0.5]))
+    assert normalized.weights[0] > 0.999
+    assert normalized.metadata["abduction_likelihood"] == {
+        "observation_scale_m": 0.1,
+        "likelihood_power": 4.0,
+        "dynamic_likelihood_weight": 0.0,
+        "degrees_of_freedom": 4.0,
+        "likelihood_semantics": "normalized_v2",
+        "difference_correlation": 0.0,
+    }
+
+
+def test_normalized_v2_includes_endpoint_to_first_response_increment() -> None:
+    trajectories = np.zeros((2, 1, 6, 1, 3), dtype=float)
+    trajectories[:, 0, 1:, 0, 0] = np.arange(1.0, 6.0)
+    trajectories[0, 0, 0, 0, 0] = -2.0
+    trajectories[1, 0, 0, 0, 0] = 0.0
+    bank = JointRolloutBank(
+        hypothesis_ids=("wrong_endpoint", "matching"),
+        hypothesis_metadata=(
+            _metadata("wrong_endpoint"),
+            _metadata("matching"),
+        ),
+        hypothesis_prior_weights=np.asarray([0.5, 0.5]),
+        parameter_particles=np.asarray([[0.0]]),
+        parameter_weights=np.asarray([1.0]),
+        trajectories=trajectories,
+    )
+    belief = _belief(bank)
+    observations = trajectories[1, 0].copy()
+    mask = np.ones((6, 1), dtype=bool)
+
+    legacy = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=FactualAbductionConfig(
+            observation_scale_m=0.1,
+            likelihood_power=8.0,
+            dynamic_likelihood_weight=1.0,
+        ),
+    )
+    normalized = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=FactualAbductionConfig(
+            observation_scale_m=0.1,
+            likelihood_power=8.0,
+            dynamic_likelihood_weight=1.0,
+            likelihood_semantics="normalized_v2",
+        ),
+    )
+
+    assert np.allclose(legacy.weights, [0.5, 0.5])
+    assert normalized.weights[1] > 0.99
+
+
+def test_normalized_v2_evaluation_records_effective_model() -> None:
+    bank, belief, observations, mask, _ = _registered_problem()
+    config = FactualAbductionConfig(
+        observation_scale_m=0.001,
+        likelihood_power=60.0,
+        dynamic_likelihood_weight=0.5,
+        likelihood_semantics="normalized_v2",
+        difference_correlation=0.25,
+    )
+    factual = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=config,
+    )
+
+    result = evaluate_factual_abduction(
+        bank,
+        belief,
+        factual,
+        observations,
+        observation_mask=mask,
+        prefix_frame_count=4,
+        config=config,
+    )
+
+    assert result["evidence_model"] == "normalized_dense_v2"
+
+
+@pytest.mark.parametrize(
+    ("keyword", "value"),
+    [
+        ("observation_scale_m", np.nan),
+        ("likelihood_power", np.inf),
+        ("dynamic_likelihood_weight", np.nan),
+        ("degrees_of_freedom", np.inf),
+        ("difference_correlation", np.nan),
+        ("difference_correlation", 1.0),
+    ],
+)
+def test_factual_abduction_config_rejects_nonfinite_or_invalid_values(
+    keyword: str,
+    value: float,
+) -> None:
+    with pytest.raises(ValueError):
+        FactualAbductionConfig(**{keyword: value})
+
+
+def test_difference_correlation_requires_normalized_v2() -> None:
+    with pytest.raises(ValueError, match="available only with normalized_v2"):
+        FactualAbductionConfig(difference_correlation=0.25)
+
+
+def test_normalized_v2_cannot_silently_bypass_grouped_evidence() -> None:
+    bank, belief, observations, mask, _ = _registered_problem()
+    grouped = GroupedObservationEvidence.from_dense_prefix(
+        observations,
+        prefix_frame_count=4,
+        scale_m=0.001,
+        mask=mask,
+        source_id="unit",
+    )
+
+    with pytest.raises(ValueError, match="cannot be combined"):
+        abduct_factual_intervention(
+            bank,
+            belief,
+            observations,
+            prefix_frame_count=4,
+            observation_mask=mask,
+            config=FactualAbductionConfig(likelihood_semantics="normalized_v2"),
+            grouped_evidence=grouped,
+        )
+
+
+def test_cli_defaults_to_legacy_and_exposes_normalized_v2() -> None:
+    parser = build_parser()
+    default = parser.parse_args(["bank", "belief", "data", "factual", "evaluation"])
+    normalized = parser.parse_args(
+        [
+            "bank",
+            "belief",
+            "data",
+            "factual",
+            "evaluation",
+            "--likelihood-semantics",
+            "normalized_v2",
+            "--difference-correlation",
+            "0.25",
+        ]
+    )
+
+    assert default.likelihood_semantics == "legacy_v1"
+    assert default.difference_correlation == 0.0
+    assert normalized.likelihood_semantics == "normalized_v2"
+    assert normalized.difference_correlation == 0.25


### PR DESCRIPTION
## Summary

- preserve the registered dense factual-abduction score as explicit `legacy_v1`, still the default;
- add an opt-in `normalized_v2` path that delegates to the shared correlation-aware prefix likelihood;
- retain the Student-t scale-normalization term for particle-specific discrepancy variances;
- include the endpoint-to-first-response increment in the dynamic evidence block;
- derive adjacent-difference scale from an explicitly declared correlation;
- expose both choices through the grouped `causal4d` CLI and bind normalized semantics into factual-artifact metadata;
- fail closed on non-finite controls, invalid correlation, correlation attached to the legacy path, or attempts to mix normalized dense and grouped full-covariance evidence.

## Legacy compatibility

The default path still calls `JointRolloutBank.update_from_observations` with the same inputs. Its artifact metadata retains exactly the original four fields and omits the new selector fields. A regression binds the unchanged legacy fixture to its pre-change factual-intervention ID:

```text
4b0d5227f9c561db217ef7f6a016d12bd5469e5e94ffcd877dfbeda26ebd491d
```

Existing commands that do not pass the new options therefore retain their prior posterior and content identity.

## `normalized_v2`

The new path is explicit and development-only. It uses `PrefixLikelihoodConfig` and `update_joint_weights_from_prefix`, including:

- particle-specific `-log(scale)` normalization;
- endpoint-inclusive adjacent differences;
- `scale * sqrt(2 * (1 - rho))` for the dynamic block;
- static discrepancy variance in the position block only.

The CLI surface is:

```bash
causal4d experiment phystwin abduct-intervention ... \
  --likelihood-semantics normalized_v2 \
  --difference-correlation 0.25
```

## Scientific boundary

This PR does not promote `normalized_v2` into the frozen estimator, alter the registered 36-execution protocol, revise previous controlled panels, or claim an accuracy improvement. Promotion requires source-only selection and a fresh untouched panel under the decision rule in issue #134. A negative result remains admissible.

## Validation

Validation against the exact post-#140 branch contents:

- complete suite in three isolated chunks: **753 passed, 3 skipped**;
- focused likelihood, abduction, prefix, archive, and rollout-bank tests: **38 passed**;
- the legacy artifact-ID regression passed;
- wheel build succeeded, SHA-256 `6cf0cb5d80130553de55a46935e02a0f39462a669c33c8348e49eb4ad02875f9`;
- installed-wheel CLI help exposes both new options and preserves legacy metadata by default;
- Python byte-compilation completed successfully.