### PR TITLE
Add secret-free pinned BayesianPhysTwin wheel integration

### DIFF
--- a/.github/workflows/public-pinned-bpt.yml
+++ b/.github/workflows/public-pinned-bpt.yml
@@ -1,0 +1,180 @@
+name: Public pinned BayesianPhysTwin integration
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/public-pinned-bpt.yml"
+      - "requirements/ci/bayesian-phystwin-provider-v1.sha"
+      - "scripts/ci/read_bpt_pin.py"
+      - "scripts/ci/run_bpt_integration_tests.py"
+      - "src/**"
+      - "tests/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/public-pinned-bpt.yml"
+      - "requirements/ci/bayesian-phystwin-provider-v1.sha"
+      - "scripts/ci/read_bpt_pin.py"
+      - "scripts/ci/run_bpt_integration_tests.py"
+      - "src/**"
+      - "tests/**"
+  workflow_dispatch:
+  schedule:
+    - cron: "23 4 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: public-pinned-bpt-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  installed-wheel:
+    name: Pinned BPT installed-wheel boundary
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out Causal4D
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: causal4d
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: causal4d/pyproject.toml
+
+      - name: Read exact BayesianPhysTwin pin
+        id: pin
+        working-directory: causal4d
+        run: echo "sha=$(python scripts/ci/read_bpt_pin.py)" >> "$GITHUB_OUTPUT"
+
+      - name: Check out public pinned BayesianPhysTwin
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/BayesianPhysTwin
+          ref: ${{ steps.pin.outputs.sha }}
+          path: bayesian-phystwin
+          persist-credentials: false
+
+      - name: Record exact clean revisions
+        id: revisions
+        shell: bash
+        run: |
+          for repository in causal4d bayesian-phystwin; do
+            test -z "$(git -C "$repository" status --porcelain=v1 --untracked-files=all)"
+          done
+          echo "causal4d=$(git -C causal4d rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "bpt=$(git -C bayesian-phystwin rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Build both wheels
+        shell: bash
+        run: |
+          python -m pip install --upgrade build pip
+          wheelhouse="$RUNNER_TEMP/public-pinned-bpt-wheelhouse"
+          mkdir -p "$wheelhouse"
+          python -m build --wheel --outdir "$wheelhouse" causal4d
+          python -m build --wheel --outdir "$wheelhouse" bayesian-phystwin
+          test "$(find "$wheelhouse" -maxdepth 1 -name '*.whl' | wc -l)" -eq 2
+          (
+            cd "$wheelhouse"
+            sha256sum ./*.whl | sort
+          ) | tee "$RUNNER_TEMP/public-pinned-bpt-wheel-sha256.txt"
+
+      - name: Install wheels in a clean virtual environment
+        shell: bash
+        run: |
+          venv="$RUNNER_TEMP/public-pinned-bpt-venv"
+          wheelhouse="$RUNNER_TEMP/public-pinned-bpt-wheelhouse"
+          python -m venv "$venv"
+          "$venv/bin/python" -m pip install --upgrade pip
+          mapfile -t wheels < <(find "$wheelhouse" -maxdepth 1 -name '*.whl' -print | sort)
+          "$venv/bin/python" -m pip install "${wheels[@]}" pytest opencv-python-headless
+          "$venv/bin/python" -m pip check
+
+      - name: Reject checkout-resolved imports
+        shell: bash
+        run: |
+          cd "$RUNNER_TEMP"
+          env -u PYTHONPATH \
+            CAUSAL4D_CHECKOUT="$GITHUB_WORKSPACE/causal4d" \
+            BPT_CHECKOUT="$GITHUB_WORKSPACE/bayesian-phystwin" \
+            "$RUNNER_TEMP/public-pinned-bpt-venv/bin/python" - <<'PY'
+          import os
+          from pathlib import Path
+
+          import bayesian_phystwin
+          import causal4d
+
+          roots = (
+              Path(os.environ["CAUSAL4D_CHECKOUT"]).resolve(),
+              Path(os.environ["BPT_CHECKOUT"]).resolve(),
+          )
+          for module in (causal4d, bayesian_phystwin):
+              origin = Path(module.__file__).resolve()
+              if any(origin.is_relative_to(root) for root in roots):
+                  raise SystemExit(f"{module.__name__} resolved from checkout: {origin}")
+              print(module.__name__, origin)
+          PY
+
+      - name: Run pinned provider contract tests against installed wheels
+        shell: bash
+        env:
+          CAUSAL4D_REQUIRE_BPT_PROVIDER: "1"
+        run: |
+          cd "$RUNNER_TEMP"
+          env -u PYTHONPATH \
+            "$RUNNER_TEMP/public-pinned-bpt-venv/bin/python" -m pytest -ra \
+              --import-mode=importlib \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_bpt_graph_provider_integration.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_bpt_provider_integration.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_causal4d_bpt_belief.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_causal4d_molmo_acceptance.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_causal4d_molmo_adapter.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_causal4d_phystwin_backend.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_causal4d_real_calibration.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_causal4d_real_oracle_audit.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_causal4d_rest_geometry.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_causal4d_rest_geometry_protocol.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_causal4d_rest_geometry_transfer.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_discrepancy_localization_aggregate.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_phystwin_propagated_state.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_phystwin_resumable.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_replay_provider_contract.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_rollout_cache.py"
+
+      - name: Publish revision and wheel identities
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### Public pinned BayesianPhysTwin integration"
+            echo
+            echo "- Causal4D: \`${{ steps.revisions.outputs.causal4d }}\`"
+            echo "- BayesianPhysTwin: \`${{ steps.revisions.outputs.bpt }}\`"
+            if [[ -f "$RUNNER_TEMP/public-pinned-bpt-wheel-sha256.txt" ]]; then
+              echo
+              echo "#### Wheel SHA-256 identities"
+              echo '```text'
+              cat "$RUNNER_TEMP/public-pinned-bpt-wheel-sha256.txt"
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload wheel identities
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: public-pinned-bpt-wheel-identities
+          path: ${{ runner.temp }}/public-pinned-bpt-wheel-sha256.txt
+          if-no-files-found: warn
+          retention-days: 7

--- a/tests/test_public_pinned_bpt_workflow_policy.py
+++ b/tests/test_public_pinned_bpt_workflow_policy.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[1]
+    / ".github"
+    / "workflows"
+    / "public-pinned-bpt.yml"
+)
+
+
+def test_public_pinned_provider_requires_no_repository_secret() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "repository: IPS-Stuttgart/BayesianPhysTwin" in text
+    assert "ref: ${{ steps.pin.outputs.sha }}" in text
+    assert "BPT_READ_SSH_KEY" not in text
+    assert "ssh-key:" not in text
+    assert "PROB4D_READ_TOKEN" not in text
+
+
+def test_provider_boundary_uses_built_wheels_and_isolated_imports() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert text.count("python -m build --wheel") == 2
+    assert "public-pinned-bpt-venv" in text
+    assert "env -u PYTHONPATH" in text
+    assert "Reject checkout-resolved imports" in text
+    assert "origin.is_relative_to(root)" in text
+    assert "--import-mode=importlib" in text
+    assert "CAUSAL4D_REQUIRE_BPT_PROVIDER" in text
+
+
+def test_provider_revision_and_wheel_bytes_are_recorded() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "read_bpt_pin.py" in text
+    assert "git -C causal4d rev-parse HEAD" in text
+    assert "git -C bayesian-phystwin rev-parse HEAD" in text
+    assert "sha256sum ./*.whl | sort" in text
+    assert "public-pinned-bpt-wheel-sha256.txt" in text
+    assert "Upload wheel identities" in text
+
+
+def test_public_gate_runs_continuously_and_on_schedule() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "pull_request:" in text
+    assert "push:" in text
+    assert "workflow_dispatch:" in text
+    assert "schedule:" in text
+    assert "cancel-in-progress: true" in text


### PR DESCRIPTION
## What changed

- add a required public checkout path for the exact BayesianPhysTwin revision pinned by Causal4D;
- build Causal4D and BayesianPhysTwin as wheels and install only those artifacts into a fresh virtual environment;
- reject imports that resolve from either source checkout;
- run the existing BPT-facing Causal4D contract suite with `PYTHONPATH` unset and pytest importlib mode;
- record exact repository revisions and SHA-256 identities for both wheels;
- add workflow-policy regression tests that prohibit deploy-key and token dependencies.

## Why

The pinned provider boundary still depended on `BPT_READ_SSH_KEY`, even though `IPS-Stuttgart/BayesianPhysTwin` is publicly readable. That allowed a missing secret to skip meaningful integration coverage. This workflow makes the public provider boundary executable for ordinary organization pull requests, forked pull requests, pushes, manual runs, and the weekly compatibility check.

## Validation

The workflow is self-testing through `tests/test_public_pinned_bpt_workflow_policy.py`. Opening this PR also exercises the new installed-wheel job against the exact pinned provider revision.

## Scope

This adds the secret-free installed-wheel gate without changing scientific code, provider schemas, frozen evidence, or the existing credentialed three-repository workflow.