### PR TITLE
Add fail-closed factorized multi-contact path beliefs

### DIFF
--- a/docs/causal4d_dynamic_contact_paths.md
+++ b/docs/causal4d_dynamic_contact_paths.md
@@ -123,3 +123,11 @@ A real integration should:
 The extension should not delay the registered 36-execution acquisition. It is a
 specific candidate for the already observed contact-onset failure, not a reason
 to reopen unrestricted architecture search on exhausted cases.
+
+## Multiple contact channels
+
+The single-contact API remains unchanged. Independently changing left/right or
+support contacts are represented by the factorized joint path support in
+[`causal4d_multi_contact_paths.md`](causal4d_multi_contact_paths.md). That
+extension preserves one-contact behavior, tracks joint retained mass, and
+requires one continuous simulator trajectory for every retained joint schedule.

--- a/docs/causal4d_multi_contact_paths.md
+++ b/docs/causal4d_multi_contact_paths.md
@@ -47,7 +47,7 @@ enumerator, apart from the added contact axis and named joint path identifier.
 Setting all transition hazards to zero returns one all-inactive joint path with
 unit mass for any number of contacts.
 
-## Continuous simulation boundary
+## Continuous simulation and identity boundary
 
 `MultiContactPathBank` associates each complete joint schedule with one
 trajectory of shape `(T, N, C)`. The trajectory must be produced by one
@@ -76,21 +76,44 @@ bank = MultiContactPathBank.from_prior(
     prior,
     trajectories_m,                 # shape (K, T, N, 3)
     base_variance_m2=base_variance,
+    replay_result_identity=provider_result_identity,
+    frame_times_s=frame_times_s,
 )
 ```
 
-The bank and prior expose the same deterministic `schedule_identity`. The
-identity covers contact names, path identifiers, complete regime schedules,
-normalized prior weights, retained mass, and an explicit schema version. A
-future BayesianPhysTwin provider contract can therefore bind a replay result to
-the exact schedule support without depending on Causal4D internals.
+The schedule and rollout identities are deliberately separate:
 
-## Prefix-only posterior inference
+- `schedule_identity` binds contact names, path identifiers, complete regime
+  schedules, normalized prior weights, and retained prior mass;
+- `rollout_identity` additionally binds the replay-result identity, explicit
+  timebase, trajectory bytes, and conditional-variance bytes.
+
+Changing a trajectory, variance tensor, replay identity, or timebase changes the
+rollout identity even when the schedule remains unchanged. Equal arrays with
+different NumPy memory layouts retain the same identity. This supplies a narrow
+content boundary for a future BayesianPhysTwin scheduled-replay provider without
+pretending that an arbitrary caller-supplied replay identifier is independently
+verified. Claim-bearing use can require both a replay-result identity and a
+strictly increasing explicit timebase.
+
+## Prefix-only normalized likelihood
 
 `infer_multi_contact_posterior` performs robust Student-t reweighting using only
 frames before `prefix_frame_count`. The known future activation sequence is part
 of the intervention query and may be used for prior generation and uncertainty
 propagation. Future object observations are never read.
+
+For a residual `r`, scale `s`, and degrees of freedom `nu`, the compared score
+retains the heteroscedastic normalization term:
+
+```text
+-log(s) - (nu + 1) / 2 * log(1 + r^2 / (nu * s^2)).
+```
+
+The `-log(s)` term is required because conditional uncertainty differs between
+contact paths. Omitting it would allow a path to improve its likelihood merely
+by inflating its variance. Constants that are shared by all compared paths are
+omitted.
 
 The posterior returns:
 
@@ -100,13 +123,46 @@ The posterior returns:
 - per-contact switch probabilities;
 - the probability that any contact switches at each frame;
 - an active-contact probability for each contact and frame;
-- the exact schedule identity and retained prior mass in metadata.
+- schedule and rollout identities; and
+- retained-support and omitted-posterior diagnostics.
 
 Changing held-out observations leaves weights and predictive moments byte-exact.
 The test suite also checks contact-label permutation symmetry when the complete
 joint support is retained.
 
-## Intervention-conditioned uncertainty
+## Retained-support admission and exact static fallback
+
+Renormalizing a narrow retained beam must not silently turn it into complete
+support. `MultiContactInferencePolicy` can require all of the following:
+
+```python
+from causal4d.multi_contact import MultiContactInferencePolicy
+
+policy = MultiContactInferencePolicy(
+    minimum_retained_prior_mass=0.95,
+    maximum_omitted_posterior_mass=0.05,
+    require_replay_binding=True,
+)
+```
+
+The omitted-posterior bound combines the retained prior mass, the exact retained
+average likelihood, and a conservative upper bound on the likelihood of any
+omitted path. It therefore can be stricter or less conservative than a prior-mass
+threshold alone while remaining independent of held-out observations.
+
+When a configured gate fails, inference raises
+`MultiContactInferenceRejectedError` unless the caller supplies
+`static_fallback_bank`. The fallback must contain exactly one rollout, retain
+unit mass, use the same dimensions and contact identifiers, and keep every
+contact regime constant over time. The returned posterior then uses that static
+trajectory exactly and records the rejected schedule, rollout, mass bound, and
+fallback identities in recursively immutable metadata.
+
+The default policy leaves the development API permissive. A claim-bearing
+protocol must freeze nontrivial thresholds and an exact fallback before target
+access.
+
+## Intervention-conditioned uncertainty and intervals
 
 Conditional variance accumulates uncertainty for every contact transition, not
 merely for a collapsed global state:
@@ -124,20 +180,29 @@ array with shape `(G, T)` contributes the sum of squared per-contact distances.
 Setting all inflation coefficients to zero preserves the supplied conditional
 variance exactly.
 
+Marginal credible intervals are computed as quantiles of the conditional
+Gaussian path mixture. They are not formed as `mean +/- z * standard deviation`,
+which can place interval mass in the low-density gap between separated contact
+modes. The posterior still reports the law-of-total-variance moment for summary
+and calibration diagnostics.
+
 ## Current limitations
 
 This implementation deliberately does not claim calibrated real-data contact
 prediction. The contact chains are independent in the prior and currently use
 the single-contact Markov transition parameterization. It does not yet provide
 source-fitted duration distributions, cross-gripper transition coupling, tactile
-label construction, or a BayesianPhysTwin dynamic-schedule replay capability.
+label construction, contact-point migration, continuous force-transmission
+parameters, or a BayesianPhysTwin dynamic-schedule replay capability.
 
 The next evidence-bearing steps are therefore:
 
-1. fit transition and duration parameters on source interactions only;
+1. fit transition, duration, and force-transmission parameters on source
+   interactions only;
 2. add an additive BayesianPhysTwin provider capability that executes one
-   continuous rollout per schedule identity;
-3. evaluate contact onset, offset, calibration, retained support mass, and
-   held-out trajectory prediction on a prospectively reserved Deform360 cohort;
-4. retain exact fallback to the frozen static operator when support or
-   calibration gates fail.
+   continuous rollout per schedule and returns a verified replay-result identity;
+3. freeze support thresholds and the exact static fallback before target access;
+4. evaluate contact onset, offset, calibration, retained support mass, and
+   held-out trajectory prediction on a prospectively reserved cohort; and
+5. retain exact fallback to the frozen static operator when support, replay
+   binding, or calibration gates fail.

--- a/docs/causal4d_multi_contact_paths.md
+++ b/docs/causal4d_multi_contact_paths.md
@@ -1,0 +1,143 @@
+# Factorized Multi-Contact Path Beliefs
+
+## Status and scope
+
+This is an experimental, backend-neutral extension of the dynamic contact-path
+model. It does not modify any frozen Causal4D estimator, registered physical
+protocol, or claim-bearing result. Its purpose is to remove a concrete modeling
+restriction in the existing development prototype: one global contact regime
+cannot represent independently changing left/right gripper contacts.
+
+The implementation supports an arbitrary number of named contact channels. A
+channel can represent a gripper, a support contact, or another independently
+realized force-transmission path. The current prior factorizes across channels;
+coupled contact mechanics are represented by the continuously simulated joint
+trajectory, not by splicing marginal rollouts.
+
+## Joint path enumeration
+
+For contact channels `g = 1, ..., G`, the prior is
+
+```text
+p(kappa_1:T) = product_g p(kappa_g,1:T | a_g,1:T).
+```
+
+Each marginal path support is generated with the existing
+`enumerate_contact_paths` implementation and can use its own
+`ContactTransitionConfig`. `enumerate_multi_contact_paths` then extracts the
+highest-probability joint products with a deterministic best-first heap. It does
+not construct the full Cartesian product.
+
+For a retained marginal mass `m_g` and selected normalized product mass `s`, the
+reported joint mass is
+
+```text
+retained_prior_mass = s * product_g m_g.
+```
+
+This accounts for both marginal beam pruning and joint top-k pruning. The optional
+`minimum_joint_probability` threshold is evaluated against the original prior
+mass, before retained joint weights are renormalized. Increasing
+`maximum_joint_paths` cannot reduce the retained mass; this invariant is tested.
+The returned object also records the marginal path indices and the size of the
+unpruned Cartesian support for auditing.
+
+A one-contact call is exactly equivalent to the existing single-contact
+enumerator, apart from the added contact axis and named joint path identifier.
+Setting all transition hazards to zero returns one all-inactive joint path with
+unit mass for any number of contacts.
+
+## Continuous simulation boundary
+
+`MultiContactPathBank` associates each complete joint schedule with one
+trajectory of shape `(T, N, C)`. The trajectory must be produced by one
+continuous simulator execution for that schedule. It must not be assembled by
+splicing independently simulated contact segments, because that would generally
+break state, velocity, and internal-stress continuity.
+
+Use `MultiContactPathBank.from_prior` after a simulator has executed every
+retained schedule:
+
+```python
+from causal4d.multi_contact import (
+    MultiContactEnumerationConfig,
+    MultiContactPathBank,
+    enumerate_multi_contact_paths,
+)
+
+prior = enumerate_multi_contact_paths(
+    command_activation,             # shape (G, T)
+    contact_ids=("left", "right"),
+    transition_configs=(left_config, right_config),
+    config=MultiContactEnumerationConfig(maximum_joint_paths=128),
+)
+
+bank = MultiContactPathBank.from_prior(
+    prior,
+    trajectories_m,                 # shape (K, T, N, 3)
+    base_variance_m2=base_variance,
+)
+```
+
+The bank and prior expose the same deterministic `schedule_identity`. The
+identity covers contact names, path identifiers, complete regime schedules,
+normalized prior weights, retained mass, and an explicit schema version. A
+future BayesianPhysTwin provider contract can therefore bind a replay result to
+the exact schedule support without depending on Causal4D internals.
+
+## Prefix-only posterior inference
+
+`infer_multi_contact_posterior` performs robust Student-t reweighting using only
+frames before `prefix_frame_count`. The known future activation sequence is part
+of the intervention query and may be used for prior generation and uncertainty
+propagation. Future object observations are never read.
+
+The posterior returns:
+
+- joint path weights and predictive trajectory moments;
+- per-contact, per-frame probabilities for inactive, sticking, slipping, and
+  detached regimes;
+- per-contact switch probabilities;
+- the probability that any contact switches at each frame;
+- an active-contact probability for each contact and frame;
+- the exact schedule identity and retained prior mass in metadata.
+
+Changing held-out observations leaves weights and predictive moments byte-exact.
+The test suite also checks contact-label permutation symmetry when the complete
+joint support is retained.
+
+## Intervention-conditioned uncertainty
+
+Conditional variance accumulates uncertainty for every contact transition, not
+merely for a collapsed global state:
+
+```text
+V_k(t) = V_k(0)
+       + q_switch * cumulative_number_of_contact_switches_k(t)
+       + q_command * cumulative_sum_g delta(a_g,t)^2
+       + q_ood * cumulative_ood_energy(t).
+```
+
+Thus simultaneous or staggered bimanual contact changes contribute separately.
+A global OOD distance with shape `(T,)` is counted once, while a contact-specific
+array with shape `(G, T)` contributes the sum of squared per-contact distances.
+Setting all inflation coefficients to zero preserves the supplied conditional
+variance exactly.
+
+## Current limitations
+
+This implementation deliberately does not claim calibrated real-data contact
+prediction. The contact chains are independent in the prior and currently use
+the single-contact Markov transition parameterization. It does not yet provide
+source-fitted duration distributions, cross-gripper transition coupling, tactile
+label construction, or a BayesianPhysTwin dynamic-schedule replay capability.
+
+The next evidence-bearing steps are therefore:
+
+1. fit transition and duration parameters on source interactions only;
+2. add an additive BayesianPhysTwin provider capability that executes one
+   continuous rollout per schedule identity;
+3. evaluate contact onset, offset, calibration, retained support mass, and
+   held-out trajectory prediction on a prospectively reserved Deform360 cohort;
+4. retain exact fallback to the frozen static operator when support or
+   calibration gates fail.

--- a/src/causal4d/_multi_contact_common.py
+++ b/src/causal4d/_multi_contact_common.py
@@ -1,0 +1,163 @@
+"""Shared validation and content-identity helpers for multi-contact paths."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from numbers import Real
+from typing import Any, Sequence
+
+import numpy as np
+
+from causal4d.immutable_array import readonly_array, readonly_integer_array
+
+
+MULTI_CONTACT_SCHEDULE_SCHEMA_VERSION = "causal4d.multi_contact_schedule.v1"
+
+
+def readonly(values: Any, *, dtype: Any = None) -> np.ndarray:
+    """Return a defensive, immutable NumPy copy."""
+
+    return readonly_array(values, dtype=dtype)
+
+
+def real_array(
+    values: Any,
+    *,
+    name: str,
+    require_finite: bool = True,
+) -> np.ndarray:
+    """Return owned real-valued data without Boolean or string coercion."""
+
+    raw = np.asarray(values)
+    if raw.dtype.kind not in {"i", "u", "f"}:
+        raise ValueError(f"{name} must contain real numbers")
+    result = raw.astype(float, copy=True)
+    if require_finite and not np.all(np.isfinite(result)):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def integer_array(
+    values: Any,
+    *,
+    name: str,
+    dtype: Any = np.int64,
+) -> np.ndarray:
+    """Return immutable integer data without truncating or coercing inputs."""
+
+    exact = readonly_integer_array(values, name=name)
+    return readonly(exact, dtype=dtype)
+
+
+def normalized_weights(values: Any, *, name: str) -> np.ndarray:
+    """Validate and normalize a finite nonnegative weight vector."""
+
+    weights = real_array(values, name=name)
+    if weights.ndim != 1 or len(weights) == 0:
+        raise ValueError(f"{name} must be a nonempty vector")
+    if np.any(weights < 0.0):
+        raise ValueError(f"{name} must be nonnegative")
+    total = float(np.sum(weights))
+    if total <= 0.0:
+        raise ValueError(f"{name} must have positive mass")
+    tolerance = 16.0 * np.finfo(float).eps * max(1, len(weights))
+    normalized = weights if abs(total - 1.0) <= tolerance else weights / total
+    return readonly(normalized)
+
+
+def probability_mass(value: object, *, name: str) -> float:
+    """Validate one finite probability mass, allowing only round-off above one."""
+
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real probability mass")
+    result = float(value)
+    if not np.isfinite(result) or not 0.0 < result <= 1.0 + 1e-12:
+        raise ValueError(f"{name} must lie in (0, 1]")
+    return min(result, 1.0)
+
+
+def activation_matrix(
+    values: Any,
+    *,
+    contact_count: int | None = None,
+    frame_count: int | None = None,
+    name: str = "command_activation",
+) -> np.ndarray:
+    """Validate a single- or multi-contact activation schedule."""
+
+    activation = real_array(values, name=name)
+    if activation.ndim == 1:
+        activation = activation[None, :]
+    if activation.ndim != 2 or min(activation.shape) < 1:
+        raise ValueError(f"{name} must have shape (G, T) or (T,)")
+    if contact_count is not None and activation.shape[0] != contact_count:
+        raise ValueError(f"{name} must identify every contact channel")
+    if frame_count is not None and activation.shape[1] != frame_count:
+        raise ValueError(f"{name} must match the rollout frame count")
+    if np.any((activation < 0.0) | (activation > 1.0)):
+        raise ValueError(f"{name} must lie in [0, 1]")
+    return activation
+
+
+def validated_contact_ids(
+    values: Sequence[str] | None,
+    contact_count: int,
+) -> tuple[str, ...]:
+    """Return nonempty unique contact identifiers without string coercion."""
+
+    if contact_count < 1:
+        raise ValueError("contact paths must identify at least one contact channel")
+    if values is None:
+        return tuple(f"contact-{index}" for index in range(contact_count))
+    return validate_identifiers(
+        values,
+        expected_count=contact_count,
+        name="contact_ids",
+    )
+
+
+def validate_identifiers(
+    values: Sequence[str],
+    *,
+    expected_count: int,
+    name: str,
+) -> tuple[str, ...]:
+    """Validate and freeze identifiers against their support size."""
+
+    if expected_count < 1 or isinstance(values, (str, bytes)):
+        raise ValueError(f"{name} must be nonempty unique strings")
+    result = tuple(values)
+    if len(result) != expected_count or any(
+        type(value) is not str or not value for value in result
+    ) or len(set(result)) != expected_count:
+        raise ValueError(f"{name} must be nonempty unique strings")
+    return result
+
+
+def schedule_identity(
+    contact_ids: tuple[str, ...],
+    path_ids: tuple[str, ...],
+    regime_paths: np.ndarray,
+    weights: np.ndarray,
+    retained_prior_mass: float,
+) -> str:
+    """Return a stable SHA-256 identity for one retained schedule support."""
+
+    payload = {
+        "schema_version": MULTI_CONTACT_SCHEDULE_SCHEMA_VERSION,
+        "contact_ids": list(contact_ids),
+        "path_ids": list(path_ids),
+        "regime_paths": np.asarray(regime_paths, dtype=np.int8).tolist(),
+        "weights_hex": [
+            float(value).hex() for value in np.asarray(weights, dtype=float)
+        ],
+        "retained_prior_mass_hex": float(retained_prior_mass).hex(),
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()

--- a/src/causal4d/_multi_contact_common.py
+++ b/src/causal4d/_multi_contact_common.py
@@ -47,7 +47,16 @@ def integer_array(
     """Return immutable integer data without truncating or coercing inputs."""
 
     exact = readonly_integer_array(values, name=name)
-    return readonly(exact, dtype=dtype)
+    target_dtype = np.dtype(dtype)
+    if target_dtype.kind not in {"i", "u"}:
+        raise ValueError(f"{name} target dtype must be integral")
+    if exact.size:
+        limits = np.iinfo(target_dtype)
+        if int(np.min(exact)) < limits.min or int(np.max(exact)) > limits.max:
+            raise ValueError(
+                f"{name} contains an integer outside {target_dtype.name} range"
+            )
+    return readonly(exact, dtype=target_dtype)
 
 
 def normalized_weights(values: Any, *, name: str) -> np.ndarray:

--- a/src/causal4d/_multi_contact_common.py
+++ b/src/causal4d/_multi_contact_common.py
@@ -137,9 +137,11 @@ def validate_identifiers(
     if expected_count < 1 or isinstance(values, (str, bytes)):
         raise ValueError(f"{name} must be nonempty unique strings")
     result = tuple(values)
-    if len(result) != expected_count or any(
-        type(value) is not str or not value for value in result
-    ) or len(set(result)) != expected_count:
+    if (
+        len(result) != expected_count
+        or any(type(value) is not str or not value for value in result)
+        or len(set(result)) != expected_count
+    ):
         raise ValueError(f"{name} must be nonempty unique strings")
     return result
 

--- a/src/causal4d/_multi_contact_inference.py
+++ b/src/causal4d/_multi_contact_inference.py
@@ -41,9 +41,7 @@ class MultiContactPathBank:
     retained_prior_mass: float = 1.0
 
     def __post_init__(self) -> None:
-        trajectories = readonly(
-            real_array(self.trajectories_m, name="trajectories_m")
-        )
+        trajectories = readonly(real_array(self.trajectories_m, name="trajectories_m"))
         paths = integer_array(
             self.regime_paths,
             name="regime_paths",
@@ -322,9 +320,7 @@ def multi_contact_conditioned_variance(
     cumulative_switches = np.cumsum(np.sum(switches, axis=1), axis=1)
     command_change = np.zeros_like(activation)
     command_change[:, 1:] = np.diff(activation, axis=1)
-    cumulative_command_energy = np.cumsum(
-        np.sum(np.square(command_change), axis=0)
-    )
+    cumulative_command_energy = np.cumsum(np.sum(np.square(command_change), axis=0))
     cumulative_ood_energy = np.cumsum(ood_frame_energy)
     increment = (
         settings.switch_variance_m2 * cumulative_switches
@@ -364,8 +360,10 @@ def _student_t_mean_log_score(
     degrees_of_freedom: float,
 ) -> np.ndarray:
     standardized = residual / scale_m
-    terms = -0.5 * (degrees_of_freedom + 1.0) * np.log1p(
-        np.square(standardized) / degrees_of_freedom
+    terms = (
+        -0.5
+        * (degrees_of_freedom + 1.0)
+        * np.log1p(np.square(standardized) / degrees_of_freedom)
     )
     valid_float = np.asarray(valid, dtype=float)[None]
     count = np.sum(valid_float, axis=(1, 2, 3))
@@ -434,12 +432,10 @@ def infer_multi_contact_posterior(
         config=settings,
     )
     position_scale = np.sqrt(
-        settings.observation_scale_m**2
-        + conditional_variance[:, :prefix_frame_count]
+        settings.observation_scale_m**2 + conditional_variance[:, :prefix_frame_count]
     )
     position_score = _student_t_mean_log_score(
-        bank.trajectories_m[:, :prefix_frame_count]
-        - prefix_observations[None],
+        bank.trajectories_m[:, :prefix_frame_count] - prefix_observations[None],
         prefix_valid,
         position_scale,
         settings.degrees_of_freedom,
@@ -470,9 +466,7 @@ def infer_multi_contact_posterior(
         bank.prior_weights,
         name="multi-contact prior",
     )
-    weights = _normalized_log_weights(
-        log_prior + settings.likelihood_power * score
-    )
+    weights = _normalized_log_weights(log_prior + settings.likelihood_power * score)
     components = bank.trajectories_m
     mean = np.einsum("k,ktnc->tnc", weights, components)
     centered = components - mean[None]
@@ -494,9 +488,7 @@ def infer_multi_contact_posterior(
             bank.regime_paths == regime,
         )
     switches = np.zeros_like(bank.regime_paths, dtype=bool)
-    switches[:, :, 1:] = (
-        bank.regime_paths[:, :, 1:] != bank.regime_paths[:, :, :-1]
-    )
+    switches[:, :, 1:] = bank.regime_paths[:, :, 1:] != bank.regime_paths[:, :, :-1]
     switch_probability = np.einsum("k,kgt->gt", weights, switches)
     any_switch_probability = np.einsum(
         "k,kt->t",

--- a/src/causal4d/_multi_contact_inference.py
+++ b/src/causal4d/_multi_contact_inference.py
@@ -1,0 +1,530 @@
+"""Prefix-only Bayesian inference over joint multi-contact trajectories."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from statistics import NormalDist
+from typing import Any
+
+import numpy as np
+
+from causal4d._multi_contact_common import (
+    MULTI_CONTACT_SCHEDULE_SCHEMA_VERSION,
+    activation_matrix,
+    integer_array,
+    normalized_weights,
+    probability_mass,
+    real_array,
+    readonly,
+    schedule_identity,
+    validate_identifiers,
+)
+from causal4d._multi_contact_prior import MultiContactPathPrior
+from causal4d.dynamic_contact import (
+    CONTACT_REGIME_NAMES,
+    ContactRegime,
+    DynamicContactInferenceConfig,
+)
+from causal4d.weighting import log_weights_from_probabilities
+
+
+@dataclass(frozen=True)
+class MultiContactPathBank:
+    """Continuously simulated trajectories indexed by complete joint schedules."""
+
+    contact_ids: tuple[str, ...]
+    path_ids: tuple[str, ...]
+    regime_paths: np.ndarray
+    trajectories_m: np.ndarray
+    prior_weights: np.ndarray
+    base_variance_m2: np.ndarray | float
+    retained_prior_mass: float = 1.0
+
+    def __post_init__(self) -> None:
+        trajectories = readonly(
+            real_array(self.trajectories_m, name="trajectories_m")
+        )
+        paths = integer_array(
+            self.regime_paths,
+            name="regime_paths",
+            dtype=np.int8,
+        )
+        weights = normalized_weights(
+            self.prior_weights,
+            name="multi-contact bank weights",
+        )
+        if trajectories.ndim != 4 or trajectories.shape[-1] not in {2, 3}:
+            raise ValueError("trajectories_m must have shape (K, T, N, 2|3)")
+        path_count, frame_count, node_count, coordinate_count = trajectories.shape
+        if (
+            paths.ndim != 3
+            or paths.shape[0] != path_count
+            or paths.shape[2] != frame_count
+        ):
+            raise ValueError("regime_paths must have shape (K, G, T)")
+        contact_count = paths.shape[1]
+        if contact_count < 1:
+            raise ValueError("regime_paths must identify at least one contact")
+        contact_ids = validate_identifiers(
+            self.contact_ids,
+            expected_count=contact_count,
+            name="contact_ids",
+        )
+        path_ids = validate_identifiers(
+            self.path_ids,
+            expected_count=path_count,
+            name="path_ids",
+        )
+        if len(weights) != path_count:
+            raise ValueError("prior_weights must identify every path")
+        if np.any(paths < 0) or np.any(paths >= len(CONTACT_REGIME_NAMES)):
+            raise ValueError("regime_paths contain an unknown contact regime")
+        variance = real_array(self.base_variance_m2, name="base_variance_m2")
+        allowed_shapes = {
+            (),
+            (node_count, coordinate_count),
+            (path_count, node_count, coordinate_count),
+            (path_count, frame_count, node_count, coordinate_count),
+        }
+        if variance.shape not in allowed_shapes:
+            raise ValueError(
+                "base_variance_m2 must be scalar or have shape (N, C), "
+                "(K, N, C), or (K, T, N, C)"
+            )
+        if np.any(variance < 0.0):
+            raise ValueError("base_variance_m2 must be nonnegative")
+        retained = probability_mass(
+            self.retained_prior_mass,
+            name="retained_prior_mass",
+        )
+        object.__setattr__(self, "contact_ids", contact_ids)
+        object.__setattr__(self, "path_ids", path_ids)
+        object.__setattr__(self, "regime_paths", paths)
+        object.__setattr__(self, "trajectories_m", trajectories)
+        object.__setattr__(self, "prior_weights", weights)
+        object.__setattr__(self, "base_variance_m2", readonly(variance))
+        object.__setattr__(self, "retained_prior_mass", retained)
+
+    @property
+    def schedule_identity(self) -> str:
+        """Content identity shared with the prior used to build the bank."""
+
+        return schedule_identity(
+            self.contact_ids,
+            self.path_ids,
+            self.regime_paths,
+            self.prior_weights,
+            self.retained_prior_mass,
+        )
+
+    @classmethod
+    def from_prior(
+        cls,
+        prior: MultiContactPathPrior,
+        trajectories_m: np.ndarray,
+        *,
+        base_variance_m2: np.ndarray | float,
+    ) -> MultiContactPathBank:
+        """Attach continuous simulator trajectories to an enumerated joint prior."""
+
+        if not isinstance(prior, MultiContactPathPrior):
+            raise ValueError("prior must be a MultiContactPathPrior")
+        return cls(
+            contact_ids=prior.contact_ids,
+            path_ids=prior.path_ids,
+            regime_paths=prior.regime_paths,
+            trajectories_m=trajectories_m,
+            prior_weights=prior.weights,
+            base_variance_m2=base_variance_m2,
+            retained_prior_mass=prior.retained_prior_mass,
+        )
+
+
+@dataclass(frozen=True)
+class MultiContactPosterior:
+    """Predictive moments and per-contact regime marginals over a joint bank."""
+
+    contact_ids: tuple[str, ...]
+    path_ids: tuple[str, ...]
+    weights: np.ndarray
+    mean_m: np.ndarray
+    variance_m2: np.ndarray
+    interval_lower_m: np.ndarray
+    interval_upper_m: np.ndarray
+    conditional_variance_m2: np.ndarray
+    regime_probabilities: np.ndarray
+    switch_probability: np.ndarray
+    any_switch_probability: np.ndarray
+    evidence_frame_stop: int
+    metadata: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        weights = normalized_weights(
+            self.weights,
+            name="multi-contact posterior weights",
+        )
+        mean = readonly(real_array(self.mean_m, name="mean_m"))
+        variance = readonly(real_array(self.variance_m2, name="variance_m2"))
+        lower = readonly(real_array(self.interval_lower_m, name="interval_lower_m"))
+        upper = readonly(real_array(self.interval_upper_m, name="interval_upper_m"))
+        conditional = readonly(
+            real_array(
+                self.conditional_variance_m2,
+                name="conditional_variance_m2",
+            )
+        )
+        regime = readonly(
+            real_array(self.regime_probabilities, name="regime_probabilities")
+        )
+        switch = readonly(
+            real_array(self.switch_probability, name="switch_probability")
+        )
+        any_switch = readonly(
+            real_array(
+                self.any_switch_probability,
+                name="any_switch_probability",
+            )
+        )
+        contact_ids = validate_identifiers(
+            self.contact_ids,
+            expected_count=len(self.contact_ids),
+            name="contact_ids",
+        )
+        path_ids = validate_identifiers(
+            self.path_ids,
+            expected_count=len(weights),
+            name="path_ids",
+        )
+        if mean.ndim != 3 or mean.shape[-1] not in {2, 3}:
+            raise ValueError("posterior mean must have shape (T, N, 2|3)")
+        if (
+            variance.shape != mean.shape
+            or lower.shape != mean.shape
+            or upper.shape != mean.shape
+        ):
+            raise ValueError("posterior variance and intervals must match the mean")
+        if conditional.shape != (len(weights), *mean.shape):
+            raise ValueError("conditional variance must have shape (K, T, N, C)")
+        if regime.shape != (len(contact_ids), mean.shape[0], len(ContactRegime)):
+            raise ValueError("regime probabilities must have shape (G, T, 4)")
+        if switch.shape != (len(contact_ids), mean.shape[0]):
+            raise ValueError("switch_probability must have shape (G, T)")
+        if any_switch.shape != (mean.shape[0],):
+            raise ValueError("any_switch_probability must have shape (T,)")
+        if (
+            type(self.evidence_frame_stop) is not int
+            or not 1 <= self.evidence_frame_stop < mean.shape[0]
+        ):
+            raise ValueError(
+                "evidence_frame_stop must be an integer leaving held-out frames"
+            )
+        if np.any(variance <= 0.0) or np.any(conditional < 0.0):
+            raise ValueError("posterior variances must be positive")
+        if np.any(lower > upper):
+            raise ValueError("posterior interval lower bound exceeds upper bound")
+        if not np.allclose(np.sum(regime, axis=2), 1.0, atol=1e-10, rtol=0.0):
+            raise ValueError(
+                "regime probabilities must sum to one per contact and frame"
+            )
+        if np.any((switch < 0.0) | (switch > 1.0)) or np.any(
+            (any_switch < 0.0) | (any_switch > 1.0)
+        ):
+            raise ValueError("switch probabilities must lie in [0, 1]")
+        object.__setattr__(self, "contact_ids", contact_ids)
+        object.__setattr__(self, "path_ids", path_ids)
+        object.__setattr__(self, "weights", weights)
+        object.__setattr__(self, "mean_m", mean)
+        object.__setattr__(self, "variance_m2", variance)
+        object.__setattr__(self, "interval_lower_m", lower)
+        object.__setattr__(self, "interval_upper_m", upper)
+        object.__setattr__(self, "conditional_variance_m2", conditional)
+        object.__setattr__(self, "regime_probabilities", regime)
+        object.__setattr__(self, "switch_probability", switch)
+        object.__setattr__(self, "any_switch_probability", any_switch)
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+    @property
+    def map_path_id(self) -> str:
+        """Identifier of the maximum-posterior joint contact path."""
+
+        return self.path_ids[int(np.argmax(self.weights))]
+
+    @property
+    def active_probability(self) -> np.ndarray:
+        """Per-contact probability of sticking or slipping at every frame."""
+
+        result = (
+            self.regime_probabilities[..., ContactRegime.STICKING]
+            + self.regime_probabilities[..., ContactRegime.SLIPPING]
+        )
+        return readonly(result)
+
+
+def _base_variance_schedule(bank: MultiContactPathBank) -> np.ndarray:
+    path_count, frame_count, node_count, coordinate_count = bank.trajectories_m.shape
+    variance = np.asarray(bank.base_variance_m2, dtype=float)
+    if variance.ndim == 0:
+        return np.full(bank.trajectories_m.shape, float(variance), dtype=float)
+    if variance.shape == (node_count, coordinate_count):
+        return np.broadcast_to(
+            variance[None, None],
+            bank.trajectories_m.shape,
+        ).copy()
+    if variance.shape == (path_count, node_count, coordinate_count):
+        return np.broadcast_to(
+            variance[:, None],
+            bank.trajectories_m.shape,
+        ).copy()
+    if variance.shape == (
+        path_count,
+        frame_count,
+        node_count,
+        coordinate_count,
+    ):
+        return variance.copy()
+    raise RuntimeError("validated variance shape became unsupported")
+
+
+def multi_contact_conditioned_variance(
+    bank: MultiContactPathBank,
+    command_activation: np.ndarray,
+    *,
+    ood_distance: np.ndarray | None = None,
+    config: DynamicContactInferenceConfig | None = None,
+) -> np.ndarray:
+    """Forecast variance from all contact switches, commands, and OOD distances."""
+
+    settings = config or DynamicContactInferenceConfig()
+    contact_count = bank.regime_paths.shape[1]
+    frame_count = bank.trajectories_m.shape[1]
+    activation = activation_matrix(
+        command_activation,
+        contact_count=contact_count,
+        frame_count=frame_count,
+    )
+    if ood_distance is None:
+        ood_frame_energy = np.zeros(frame_count, dtype=float)
+    else:
+        supplied = real_array(ood_distance, name="ood_distance")
+        if supplied.shape == (frame_count,):
+            if np.any(supplied < 0.0):
+                raise ValueError("ood_distance must be nonnegative")
+            ood_frame_energy = np.square(supplied)
+        elif supplied.shape == (contact_count, frame_count):
+            if np.any(supplied < 0.0):
+                raise ValueError("ood_distance must be nonnegative")
+            ood_frame_energy = np.sum(np.square(supplied), axis=0)
+        else:
+            raise ValueError("ood_distance must have shape (T,) or (G, T)")
+
+    switches = np.zeros_like(bank.regime_paths, dtype=float)
+    switches[:, :, 1:] = bank.regime_paths[:, :, 1:] != bank.regime_paths[:, :, :-1]
+    cumulative_switches = np.cumsum(np.sum(switches, axis=1), axis=1)
+    command_change = np.zeros_like(activation)
+    command_change[:, 1:] = np.diff(activation, axis=1)
+    cumulative_command_energy = np.cumsum(
+        np.sum(np.square(command_change), axis=0)
+    )
+    cumulative_ood_energy = np.cumsum(ood_frame_energy)
+    increment = (
+        settings.switch_variance_m2 * cumulative_switches
+        + settings.command_change_variance_m2 * cumulative_command_energy[None]
+        + settings.ood_variance_m2 * cumulative_ood_energy[None]
+    )
+    return _base_variance_schedule(bank) + increment[:, :, None, None]
+
+
+def _prefix_coordinate_mask(
+    observations: np.ndarray,
+    mask: np.ndarray | None,
+    *,
+    full_shape: tuple[int, int, int],
+    prefix_frame_count: int,
+) -> np.ndarray:
+    finite = np.isfinite(observations)
+    if mask is None:
+        return finite
+    supplied = np.asarray(mask)
+    if supplied.dtype.kind != "b":
+        raise ValueError("mask must contain booleans")
+    if supplied.shape == full_shape[:2]:
+        prefix = supplied[:prefix_frame_count, :, None]
+        prefix = np.repeat(prefix, full_shape[2], axis=2)
+    elif supplied.shape == full_shape:
+        prefix = supplied[:prefix_frame_count]
+    else:
+        raise ValueError("mask must have shape (T, N) or (T, N, C)")
+    return finite & prefix
+
+
+def _student_t_mean_log_score(
+    residual: np.ndarray,
+    valid: np.ndarray,
+    scale_m: np.ndarray,
+    degrees_of_freedom: float,
+) -> np.ndarray:
+    standardized = residual / scale_m
+    terms = -0.5 * (degrees_of_freedom + 1.0) * np.log1p(
+        np.square(standardized) / degrees_of_freedom
+    )
+    valid_float = np.asarray(valid, dtype=float)[None]
+    count = np.sum(valid_float, axis=(1, 2, 3))
+    if np.any(count <= 0.0):
+        raise ValueError("multi-contact update has no valid coordinates")
+    return (
+        np.sum(
+            np.where(valid_float > 0.0, terms, 0.0),
+            axis=(1, 2, 3),
+        )
+        / count
+    )
+
+
+def _normalized_log_weights(log_weights: np.ndarray) -> np.ndarray:
+    values = np.asarray(log_weights, dtype=float)
+    maximum = float(np.max(values))
+    weights = np.exp(values - maximum)
+    total = float(np.sum(weights))
+    if not np.isfinite(total) or total <= 0.0:
+        raise RuntimeError("multi-contact posterior normalization failed")
+    return weights / total
+
+
+def infer_multi_contact_posterior(
+    bank: MultiContactPathBank,
+    observations_m: np.ndarray,
+    *,
+    prefix_frame_count: int,
+    command_activation: np.ndarray,
+    mask: np.ndarray | None = None,
+    ood_distance: np.ndarray | None = None,
+    config: DynamicContactInferenceConfig | None = None,
+) -> MultiContactPosterior:
+    """Infer a joint contact-path posterior from an observation prefix only."""
+
+    settings = config or DynamicContactInferenceConfig()
+    observations = real_array(
+        observations_m,
+        name="observations_m",
+        require_finite=False,
+    )
+    expected_shape = bank.trajectories_m.shape[1:]
+    if observations.shape != expected_shape:
+        raise ValueError(f"observations_m must have shape {expected_shape}")
+    if type(prefix_frame_count) is not int or not (
+        1 <= prefix_frame_count < expected_shape[0]
+    ):
+        raise ValueError(
+            "prefix_frame_count must be an integer leaving held-out frames"
+        )
+    prefix_observations = observations[:prefix_frame_count]
+    prefix_valid = _prefix_coordinate_mask(
+        prefix_observations,
+        mask,
+        full_shape=expected_shape,
+        prefix_frame_count=prefix_frame_count,
+    )
+    if not np.any(prefix_valid):
+        raise ValueError("multi-contact update prefix contains no valid observations")
+
+    conditional_variance = multi_contact_conditioned_variance(
+        bank,
+        command_activation,
+        ood_distance=ood_distance,
+        config=settings,
+    )
+    position_scale = np.sqrt(
+        settings.observation_scale_m**2
+        + conditional_variance[:, :prefix_frame_count]
+    )
+    position_score = _student_t_mean_log_score(
+        bank.trajectories_m[:, :prefix_frame_count]
+        - prefix_observations[None],
+        prefix_valid,
+        position_scale,
+        settings.degrees_of_freedom,
+    )
+    score = position_score
+    if settings.dynamic_likelihood_weight > 0.0 and prefix_frame_count >= 2:
+        predicted_delta = np.diff(
+            bank.trajectories_m[:, :prefix_frame_count],
+            axis=1,
+        )
+        observed_delta = np.diff(prefix_observations, axis=0)
+        delta_valid = prefix_valid[1:] & prefix_valid[:-1]
+        delta_variance = (
+            2.0 * settings.observation_scale_m**2
+            + conditional_variance[:, 1:prefix_frame_count]
+            + conditional_variance[:, : prefix_frame_count - 1]
+        )
+        if np.any(delta_valid):
+            dynamic_score = _student_t_mean_log_score(
+                predicted_delta - observed_delta[None],
+                delta_valid,
+                np.sqrt(delta_variance),
+                settings.degrees_of_freedom,
+            )
+            score = score + settings.dynamic_likelihood_weight * dynamic_score
+
+    log_prior = log_weights_from_probabilities(
+        bank.prior_weights,
+        name="multi-contact prior",
+    )
+    weights = _normalized_log_weights(
+        log_prior + settings.likelihood_power * score
+    )
+    components = bank.trajectories_m
+    mean = np.einsum("k,ktnc->tnc", weights, components)
+    centered = components - mean[None]
+    epistemic = np.einsum("k,ktnc->tnc", weights, np.square(centered))
+    conditional = np.einsum("k,ktnc->tnc", weights, conditional_variance)
+    variance = np.maximum(epistemic + conditional, np.finfo(float).tiny)
+    z_score = NormalDist().inv_cdf(0.5 * (1.0 + settings.confidence_level))
+    margin = z_score * np.sqrt(variance)
+
+    contact_count = bank.regime_paths.shape[1]
+    regime_probabilities = np.zeros(
+        (contact_count, expected_shape[0], len(ContactRegime)),
+        dtype=float,
+    )
+    for regime in ContactRegime:
+        regime_probabilities[:, :, regime] = np.einsum(
+            "k,kgt->gt",
+            weights,
+            bank.regime_paths == regime,
+        )
+    switches = np.zeros_like(bank.regime_paths, dtype=bool)
+    switches[:, :, 1:] = (
+        bank.regime_paths[:, :, 1:] != bank.regime_paths[:, :, :-1]
+    )
+    switch_probability = np.einsum("k,kgt->gt", weights, switches)
+    any_switch_probability = np.einsum(
+        "k,kt->t",
+        weights,
+        np.any(switches, axis=1),
+    )
+    return MultiContactPosterior(
+        contact_ids=bank.contact_ids,
+        path_ids=bank.path_ids,
+        weights=weights,
+        mean_m=mean,
+        variance_m2=variance,
+        interval_lower_m=mean - margin,
+        interval_upper_m=mean + margin,
+        conditional_variance_m2=conditional_variance,
+        regime_probabilities=regime_probabilities,
+        switch_probability=switch_probability,
+        any_switch_probability=any_switch_probability,
+        evidence_frame_stop=prefix_frame_count,
+        metadata={
+            "model": "factorized_multi_contact_path_bank",
+            "contact_ids": list(bank.contact_ids),
+            "contact_regimes": list(CONTACT_REGIME_NAMES),
+            "prefix_frame_count": prefix_frame_count,
+            "future_observations_read": 0,
+            "retained_prior_mass": bank.retained_prior_mass,
+            "schedule_identity": bank.schedule_identity,
+            "schedule_schema_version": MULTI_CONTACT_SCHEDULE_SCHEMA_VERSION,
+            "config": asdict(settings),
+        },
+    )

--- a/src/causal4d/_multi_contact_inference.py
+++ b/src/causal4d/_multi_contact_inference.py
@@ -69,9 +69,7 @@ def _rollout_identity(
         "trajectories_m": _array_record(trajectories_m, dtype="<f8"),
         "base_variance_m2": _array_record(base_variance_m2, dtype="<f8"),
         "frame_times_s": (
-            None
-            if frame_times_s is None
-            else _array_record(frame_times_s, dtype="<f8")
+            None if frame_times_s is None else _array_record(frame_times_s, dtype="<f8")
         ),
     }
     encoded = json.dumps(
@@ -162,9 +160,7 @@ class MultiContactPathBank:
         if self.frame_times_s is None:
             frame_times = None
         else:
-            frame_times = readonly(
-                real_array(self.frame_times_s, name="frame_times_s")
-            )
+            frame_times = readonly(real_array(self.frame_times_s, name="frame_times_s"))
             if frame_times.shape != (frame_count,):
                 raise ValueError("frame_times_s must match the rollout frame count")
             if frame_count > 1 and np.any(np.diff(frame_times) <= 0.0):
@@ -209,8 +205,7 @@ class MultiContactPathBank:
         """Whether the bank binds an external replay result and explicit timebase."""
 
         return (
-            self.replay_result_identity is not None
-            and self.frame_times_s is not None
+            self.replay_result_identity is not None and self.frame_times_s is not None
         )
 
     @classmethod
@@ -878,9 +873,7 @@ def infer_multi_contact_posterior(
     violations = _policy_violations(candidate, bank, admission)
     policy_record = {
         "minimum_retained_prior_mass": admission.minimum_retained_prior_mass,
-        "maximum_omitted_posterior_mass": (
-            admission.maximum_omitted_posterior_mass
-        ),
+        "maximum_omitted_posterior_mass": (admission.maximum_omitted_posterior_mass),
         "require_replay_binding": admission.require_replay_binding,
     }
     if not violations:

--- a/src/causal4d/_multi_contact_inference.py
+++ b/src/causal4d/_multi_contact_inference.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass
-from statistics import NormalDist
+import hashlib
+import json
+from numbers import Real
 from typing import Any
 
 import numpy as np
+from scipy.special import ndtr
 
 from causal4d._multi_contact_common import (
     MULTI_CONTACT_SCHEDULE_SCHEMA_VERSION,
@@ -20,12 +24,63 @@ from causal4d._multi_contact_common import (
     validate_identifiers,
 )
 from causal4d._multi_contact_prior import MultiContactPathPrior
+from causal4d._student_t_likelihood import student_t_mean_log_score
 from causal4d.dynamic_contact import (
     CONTACT_REGIME_NAMES,
     ContactRegime,
     DynamicContactInferenceConfig,
 )
+from causal4d.immutable_json import plain_json, validated_json_mapping
 from causal4d.weighting import log_weights_from_probabilities
+
+
+MULTI_CONTACT_ROLLOUT_SCHEMA_VERSION = "causal4d.multi_contact_rollout.v1"
+
+
+def _optional_identity(value: object, *, name: str) -> str | None:
+    if value is None:
+        return None
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a nonempty string when supplied")
+    return value
+
+
+def _array_record(values: np.ndarray, *, dtype: str) -> dict[str, Any]:
+    canonical = np.ascontiguousarray(np.asarray(values, dtype=np.dtype(dtype)))
+    return {
+        "dtype": canonical.dtype.str,
+        "shape": list(canonical.shape),
+        "sha256": hashlib.sha256(canonical.tobytes(order="C")).hexdigest(),
+    }
+
+
+def _rollout_identity(
+    *,
+    schedule_id: str,
+    trajectories_m: np.ndarray,
+    base_variance_m2: np.ndarray,
+    replay_result_identity: str | None,
+    frame_times_s: np.ndarray | None,
+) -> str:
+    payload = {
+        "schema_version": MULTI_CONTACT_ROLLOUT_SCHEMA_VERSION,
+        "schedule_identity": schedule_id,
+        "replay_result_identity": replay_result_identity,
+        "trajectories_m": _array_record(trajectories_m, dtype="<f8"),
+        "base_variance_m2": _array_record(base_variance_m2, dtype="<f8"),
+        "frame_times_s": (
+            None
+            if frame_times_s is None
+            else _array_record(frame_times_s, dtype="<f8")
+        ),
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 @dataclass(frozen=True)
@@ -39,6 +94,8 @@ class MultiContactPathBank:
     prior_weights: np.ndarray
     base_variance_m2: np.ndarray | float
     retained_prior_mass: float = 1.0
+    replay_result_identity: str | None = None
+    frame_times_s: np.ndarray | None = None
 
     def __post_init__(self) -> None:
         trajectories = readonly(real_array(self.trajectories_m, name="trajectories_m"))
@@ -77,6 +134,7 @@ class MultiContactPathBank:
             raise ValueError("prior_weights must identify every path")
         if np.any(paths < 0) or np.any(paths >= len(CONTACT_REGIME_NAMES)):
             raise ValueError("regime_paths contain an unknown contact regime")
+
         variance = real_array(self.base_variance_m2, name="base_variance_m2")
         allowed_shapes = {
             (),
@@ -91,10 +149,27 @@ class MultiContactPathBank:
             )
         if np.any(variance < 0.0):
             raise ValueError("base_variance_m2 must be nonnegative")
+
         retained = probability_mass(
             self.retained_prior_mass,
             name="retained_prior_mass",
         )
+        replay_identity: str | None = _optional_identity(
+            self.replay_result_identity,
+            name="replay_result_identity",
+        )
+        frame_times: np.ndarray | None
+        if self.frame_times_s is None:
+            frame_times = None
+        else:
+            frame_times = readonly(
+                real_array(self.frame_times_s, name="frame_times_s")
+            )
+            if frame_times.shape != (frame_count,):
+                raise ValueError("frame_times_s must match the rollout frame count")
+            if frame_count > 1 and np.any(np.diff(frame_times) <= 0.0):
+                raise ValueError("frame_times_s must be strictly increasing")
+
         object.__setattr__(self, "contact_ids", contact_ids)
         object.__setattr__(self, "path_ids", path_ids)
         object.__setattr__(self, "regime_paths", paths)
@@ -102,6 +177,8 @@ class MultiContactPathBank:
         object.__setattr__(self, "prior_weights", weights)
         object.__setattr__(self, "base_variance_m2", readonly(variance))
         object.__setattr__(self, "retained_prior_mass", retained)
+        object.__setattr__(self, "replay_result_identity", replay_identity)
+        object.__setattr__(self, "frame_times_s", frame_times)
 
     @property
     def schedule_identity(self) -> str:
@@ -115,6 +192,27 @@ class MultiContactPathBank:
             self.retained_prior_mass,
         )
 
+    @property
+    def rollout_identity(self) -> str:
+        """Bind schedule, replay result, timebase, trajectories, and variance."""
+
+        return _rollout_identity(
+            schedule_id=self.schedule_identity,
+            trajectories_m=self.trajectories_m,
+            base_variance_m2=np.asarray(self.base_variance_m2),
+            replay_result_identity=self.replay_result_identity,
+            frame_times_s=self.frame_times_s,
+        )
+
+    @property
+    def replay_bound(self) -> bool:
+        """Whether the bank binds an external replay result and explicit timebase."""
+
+        return (
+            self.replay_result_identity is not None
+            and self.frame_times_s is not None
+        )
+
     @classmethod
     def from_prior(
         cls,
@@ -122,6 +220,8 @@ class MultiContactPathBank:
         trajectories_m: np.ndarray,
         *,
         base_variance_m2: np.ndarray | float,
+        replay_result_identity: str | None = None,
+        frame_times_s: np.ndarray | None = None,
     ) -> MultiContactPathBank:
         """Attach continuous simulator trajectories to an enumerated joint prior."""
 
@@ -135,7 +235,37 @@ class MultiContactPathBank:
             prior_weights=prior.weights,
             base_variance_m2=base_variance_m2,
             retained_prior_mass=prior.retained_prior_mass,
+            replay_result_identity=replay_result_identity,
+            frame_times_s=frame_times_s,
         )
+
+
+@dataclass(frozen=True)
+class MultiContactInferencePolicy:
+    """Fail-closed support and replay-binding requirements."""
+
+    minimum_retained_prior_mass: float = 0.0
+    maximum_omitted_posterior_mass: float = 1.0
+    require_replay_binding: bool = False
+
+    def __post_init__(self) -> None:
+        for name in (
+            "minimum_retained_prior_mass",
+            "maximum_omitted_posterior_mass",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+                raise ValueError(f"{name} must be a real probability")
+            normalized = float(value)
+            if not np.isfinite(normalized) or not 0.0 <= normalized <= 1.0:
+                raise ValueError(f"{name} must lie in [0, 1]")
+            object.__setattr__(self, name, normalized)
+        if type(self.require_replay_binding) is not bool:
+            raise ValueError("require_replay_binding must be a Boolean")
+
+
+class MultiContactInferenceRejectedError(ValueError):
+    """Raised when an inference bank fails a configured admission policy."""
 
 
 @dataclass(frozen=True)
@@ -154,7 +284,7 @@ class MultiContactPosterior:
     switch_probability: np.ndarray
     any_switch_probability: np.ndarray
     evidence_frame_stop: int
-    metadata: dict[str, Any]
+    metadata: Mapping[str, Any]
 
     def __post_init__(self) -> None:
         weights = normalized_weights(
@@ -228,6 +358,10 @@ class MultiContactPosterior:
             (any_switch < 0.0) | (any_switch > 1.0)
         ):
             raise ValueError("switch probabilities must lie in [0, 1]")
+        metadata = validated_json_mapping(
+            self.metadata,
+            error_message="multi-contact posterior metadata must be finite JSON data",
+        )
         object.__setattr__(self, "contact_ids", contact_ids)
         object.__setattr__(self, "path_ids", path_ids)
         object.__setattr__(self, "weights", weights)
@@ -239,7 +373,7 @@ class MultiContactPosterior:
         object.__setattr__(self, "regime_probabilities", regime)
         object.__setattr__(self, "switch_probability", switch)
         object.__setattr__(self, "any_switch_probability", any_switch)
-        object.__setattr__(self, "metadata", dict(self.metadata))
+        object.__setattr__(self, "metadata", metadata)
 
     @property
     def map_path_id(self) -> str:
@@ -353,31 +487,6 @@ def _prefix_coordinate_mask(
     return finite & prefix
 
 
-def _student_t_mean_log_score(
-    residual: np.ndarray,
-    valid: np.ndarray,
-    scale_m: np.ndarray,
-    degrees_of_freedom: float,
-) -> np.ndarray:
-    standardized = residual / scale_m
-    terms = (
-        -0.5
-        * (degrees_of_freedom + 1.0)
-        * np.log1p(np.square(standardized) / degrees_of_freedom)
-    )
-    valid_float = np.asarray(valid, dtype=float)[None]
-    count = np.sum(valid_float, axis=(1, 2, 3))
-    if np.any(count <= 0.0):
-        raise ValueError("multi-contact update has no valid coordinates")
-    return (
-        np.sum(
-            np.where(valid_float > 0.0, terms, 0.0),
-            axis=(1, 2, 3),
-        )
-        / count
-    )
-
-
 def _normalized_log_weights(log_weights: np.ndarray) -> np.ndarray:
     values = np.asarray(log_weights, dtype=float)
     maximum = float(np.max(values))
@@ -388,19 +497,120 @@ def _normalized_log_weights(log_weights: np.ndarray) -> np.ndarray:
     return weights / total
 
 
-def infer_multi_contact_posterior(
+def _logsumexp(values: np.ndarray) -> float:
+    finite = np.asarray(values, dtype=float)
+    maximum = float(np.max(finite))
+    return maximum + float(np.log(np.sum(np.exp(finite - maximum))))
+
+
+def _omitted_posterior_mass_bound(
+    *,
+    retained_prior_mass: float,
+    log_prior: np.ndarray,
+    log_likelihood: np.ndarray,
+    settings: DynamicContactInferenceConfig,
+    dynamic_score_used: bool,
+) -> tuple[float, float, float]:
+    retained_log_average_likelihood = _logsumexp(log_prior + log_likelihood)
+    maximum_score = -float(np.log(settings.observation_scale_m))
+    if dynamic_score_used:
+        minimum_difference_scale = np.sqrt(2.0) * settings.observation_scale_m
+        maximum_score += settings.dynamic_likelihood_weight * -float(
+            np.log(minimum_difference_scale)
+        )
+    maximum_log_likelihood = settings.likelihood_power * maximum_score
+    if retained_prior_mass >= 1.0:
+        return 0.0, retained_log_average_likelihood, maximum_log_likelihood
+    retained_log_evidence = (
+        float(np.log(retained_prior_mass)) + retained_log_average_likelihood
+    )
+    omitted_log_evidence_bound = (
+        float(np.log1p(-retained_prior_mass)) + maximum_log_likelihood
+    )
+    posterior_bound = float(
+        np.exp(
+            omitted_log_evidence_bound
+            - np.logaddexp(retained_log_evidence, omitted_log_evidence_bound)
+        )
+    )
+    return (
+        min(max(posterior_bound, 0.0), 1.0),
+        retained_log_average_likelihood,
+        maximum_log_likelihood,
+    )
+
+
+def _gaussian_mixture_quantile(
+    component_means: np.ndarray,
+    component_variances: np.ndarray,
+    weights: np.ndarray,
+    probability: float,
+    *,
+    chunk_size: int = 4096,
+) -> np.ndarray:
+    if not 0.0 < probability < 1.0:
+        raise ValueError("mixture quantile probability must lie in (0, 1)")
+    means = np.asarray(component_means, dtype=float)
+    variances = np.asarray(component_variances, dtype=float)
+    if means.shape != variances.shape or means.ndim < 2:
+        raise ValueError("mixture means and variances must share shape (K, ...)")
+    flat_means = means.reshape(means.shape[0], -1)
+    flat_scales = np.sqrt(
+        np.maximum(variances.reshape(variances.shape[0], -1), np.finfo(float).tiny)
+    )
+    result = np.empty(flat_means.shape[1], dtype=float)
+    for start in range(0, flat_means.shape[1], chunk_size):
+        stop = min(start + chunk_size, flat_means.shape[1])
+        means_chunk = flat_means[:, start:stop]
+        scales_chunk = flat_scales[:, start:stop]
+        lower = np.min(means_chunk - 12.0 * scales_chunk, axis=0)
+        upper = np.max(means_chunk + 12.0 * scales_chunk, axis=0)
+        for _ in range(64):
+            midpoint = 0.5 * (lower + upper)
+            cdf = np.einsum(
+                "k,km->m",
+                weights,
+                ndtr((midpoint[None] - means_chunk) / scales_chunk),
+            )
+            lower = np.where(cdf < probability, midpoint, lower)
+            upper = np.where(cdf < probability, upper, midpoint)
+        result[start:stop] = 0.5 * (lower + upper)
+    return result.reshape(means.shape[1:])
+
+
+def _mixture_interval(
+    component_means: np.ndarray,
+    component_variances: np.ndarray,
+    weights: np.ndarray,
+    confidence_level: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    tail = 0.5 * (1.0 - confidence_level)
+    return (
+        _gaussian_mixture_quantile(
+            component_means,
+            component_variances,
+            weights,
+            tail,
+        ),
+        _gaussian_mixture_quantile(
+            component_means,
+            component_variances,
+            weights,
+            1.0 - tail,
+        ),
+    )
+
+
+def _infer_multi_contact_core(
     bank: MultiContactPathBank,
     observations_m: np.ndarray,
     *,
     prefix_frame_count: int,
     command_activation: np.ndarray,
-    mask: np.ndarray | None = None,
-    ood_distance: np.ndarray | None = None,
-    config: DynamicContactInferenceConfig | None = None,
+    mask: np.ndarray | None,
+    ood_distance: np.ndarray | None,
+    settings: DynamicContactInferenceConfig,
 ) -> MultiContactPosterior:
-    """Infer a joint contact-path posterior from an observation prefix only."""
-
-    settings = config or DynamicContactInferenceConfig()
     observations = real_array(
         observations_m,
         name="observations_m",
@@ -434,13 +644,16 @@ def infer_multi_contact_posterior(
     position_scale = np.sqrt(
         settings.observation_scale_m**2 + conditional_variance[:, :prefix_frame_count]
     )
-    position_score = _student_t_mean_log_score(
+    position_score = student_t_mean_log_score(
         bank.trajectories_m[:, :prefix_frame_count] - prefix_observations[None],
         prefix_valid,
-        position_scale,
-        settings.degrees_of_freedom,
+        scale=position_scale,
+        degrees_of_freedom=settings.degrees_of_freedom,
+        reduction_axes=(1, 2, 3),
+        empty_error="multi-contact update has no valid coordinates",
     )
     score = position_score
+    dynamic_score_used = False
     if settings.dynamic_likelihood_weight > 0.0 and prefix_frame_count >= 2:
         predicted_delta = np.diff(
             bank.trajectories_m[:, :prefix_frame_count],
@@ -454,27 +667,45 @@ def infer_multi_contact_posterior(
             + conditional_variance[:, : prefix_frame_count - 1]
         )
         if np.any(delta_valid):
-            dynamic_score = _student_t_mean_log_score(
+            dynamic_score = student_t_mean_log_score(
                 predicted_delta - observed_delta[None],
                 delta_valid,
-                np.sqrt(delta_variance),
-                settings.degrees_of_freedom,
+                scale=np.sqrt(delta_variance),
+                degrees_of_freedom=settings.degrees_of_freedom,
+                reduction_axes=(1, 2, 3),
+                empty_error="multi-contact dynamic update has no valid coordinates",
             )
             score = score + settings.dynamic_likelihood_weight * dynamic_score
+            dynamic_score_used = True
 
     log_prior = log_weights_from_probabilities(
         bank.prior_weights,
         name="multi-contact prior",
     )
-    weights = _normalized_log_weights(log_prior + settings.likelihood_power * score)
+    log_likelihood = settings.likelihood_power * score
+    weights = _normalized_log_weights(log_prior + log_likelihood)
+    omitted_bound, retained_log_likelihood, maximum_log_likelihood = (
+        _omitted_posterior_mass_bound(
+            retained_prior_mass=bank.retained_prior_mass,
+            log_prior=log_prior,
+            log_likelihood=log_likelihood,
+            settings=settings,
+            dynamic_score_used=dynamic_score_used,
+        )
+    )
+
     components = bank.trajectories_m
     mean = np.einsum("k,ktnc->tnc", weights, components)
     centered = components - mean[None]
     epistemic = np.einsum("k,ktnc->tnc", weights, np.square(centered))
     conditional = np.einsum("k,ktnc->tnc", weights, conditional_variance)
     variance = np.maximum(epistemic + conditional, np.finfo(float).tiny)
-    z_score = NormalDist().inv_cdf(0.5 * (1.0 + settings.confidence_level))
-    margin = z_score * np.sqrt(variance)
+    lower, upper = _mixture_interval(
+        components,
+        conditional_variance,
+        weights,
+        settings.confidence_level,
+    )
 
     contact_count = bank.regime_paths.shape[1]
     regime_probabilities = np.zeros(
@@ -501,8 +732,8 @@ def infer_multi_contact_posterior(
         weights=weights,
         mean_m=mean,
         variance_m2=variance,
-        interval_lower_m=mean - margin,
-        interval_upper_m=mean + margin,
+        interval_lower_m=lower,
+        interval_upper_m=upper,
         conditional_variance_m2=conditional_variance,
         regime_probabilities=regime_probabilities,
         switch_probability=switch_probability,
@@ -515,8 +746,184 @@ def infer_multi_contact_posterior(
             "prefix_frame_count": prefix_frame_count,
             "future_observations_read": 0,
             "retained_prior_mass": bank.retained_prior_mass,
+            "omitted_posterior_mass_upper_bound": omitted_bound,
+            "retained_log_average_likelihood": retained_log_likelihood,
+            "maximum_omitted_log_likelihood": maximum_log_likelihood,
             "schedule_identity": bank.schedule_identity,
             "schedule_schema_version": MULTI_CONTACT_SCHEDULE_SCHEMA_VERSION,
+            "rollout_identity": bank.rollout_identity,
+            "rollout_schema_version": MULTI_CONTACT_ROLLOUT_SCHEMA_VERSION,
+            "replay_result_identity": bank.replay_result_identity,
+            "replay_bound": bank.replay_bound,
+            "frame_times_s": (
+                None
+                if bank.frame_times_s is None
+                else np.asarray(bank.frame_times_s).tolist()
+            ),
+            "interval_method": "conditional_gaussian_mixture_quantiles",
             "config": asdict(settings),
+        },
+    )
+
+
+def _policy_violations(
+    posterior: MultiContactPosterior,
+    bank: MultiContactPathBank,
+    policy: MultiContactInferencePolicy,
+) -> list[str]:
+    violations: list[str] = []
+    if bank.retained_prior_mass + 1e-15 < policy.minimum_retained_prior_mass:
+        violations.append("retained_prior_mass_below_minimum")
+    omitted_bound = float(posterior.metadata["omitted_posterior_mass_upper_bound"])
+    if omitted_bound > policy.maximum_omitted_posterior_mass + 1e-15:
+        violations.append("omitted_posterior_mass_above_maximum")
+    if policy.require_replay_binding and not bank.replay_bound:
+        violations.append("replay_binding_required")
+    return violations
+
+
+def _validate_static_fallback(
+    candidate: MultiContactPathBank,
+    fallback: MultiContactPathBank,
+    policy: MultiContactInferencePolicy,
+) -> None:
+    if fallback.contact_ids != candidate.contact_ids:
+        raise ValueError("static fallback must use the candidate contact identifiers")
+    if fallback.trajectories_m.shape[1:] != candidate.trajectories_m.shape[1:]:
+        raise ValueError("static fallback must match candidate rollout dimensions")
+    if len(fallback.prior_weights) != 1:
+        raise ValueError("static fallback must contain exactly one rollout path")
+    if not np.array_equal(
+        fallback.regime_paths[:, :, 1:],
+        fallback.regime_paths[:, :, :-1],
+    ):
+        raise ValueError("static fallback contact regimes must not change over time")
+    if not np.isclose(
+        fallback.retained_prior_mass,
+        1.0,
+        atol=1e-12,
+        rtol=0.0,
+    ):
+        raise ValueError("static fallback must retain unit prior mass")
+    if (
+        candidate.frame_times_s is not None
+        and fallback.frame_times_s is not None
+        and not np.array_equal(candidate.frame_times_s, fallback.frame_times_s)
+    ):
+        raise ValueError("static fallback must use the candidate rollout timebase")
+    if policy.require_replay_binding and not fallback.replay_bound:
+        raise ValueError("static fallback must satisfy the replay-binding policy")
+
+
+def _with_policy_metadata(
+    posterior: MultiContactPosterior,
+    extra: Mapping[str, Any],
+) -> MultiContactPosterior:
+    metadata = plain_json(posterior.metadata)
+    metadata.update(plain_json(extra))
+    return MultiContactPosterior(
+        contact_ids=posterior.contact_ids,
+        path_ids=posterior.path_ids,
+        weights=posterior.weights,
+        mean_m=posterior.mean_m,
+        variance_m2=posterior.variance_m2,
+        interval_lower_m=posterior.interval_lower_m,
+        interval_upper_m=posterior.interval_upper_m,
+        conditional_variance_m2=posterior.conditional_variance_m2,
+        regime_probabilities=posterior.regime_probabilities,
+        switch_probability=posterior.switch_probability,
+        any_switch_probability=posterior.any_switch_probability,
+        evidence_frame_stop=posterior.evidence_frame_stop,
+        metadata=metadata,
+    )
+
+
+def infer_multi_contact_posterior(
+    bank: MultiContactPathBank,
+    observations_m: np.ndarray,
+    *,
+    prefix_frame_count: int,
+    command_activation: np.ndarray,
+    mask: np.ndarray | None = None,
+    ood_distance: np.ndarray | None = None,
+    config: DynamicContactInferenceConfig | None = None,
+    policy: MultiContactInferencePolicy | None = None,
+    static_fallback_bank: MultiContactPathBank | None = None,
+) -> MultiContactPosterior:
+    """Infer from a prefix and fail closed when retained support is inadequate.
+
+    The default policy preserves the development API. Claim-bearing callers can
+    require retained prior mass, a conservative omitted-posterior upper bound,
+    and a replay-bound rollout identity. A rejected candidate either raises or
+    returns the supplied one-path static fallback exactly.
+    """
+
+    if not isinstance(bank, MultiContactPathBank):
+        raise ValueError("bank must be a MultiContactPathBank")
+    if config is not None and not isinstance(config, DynamicContactInferenceConfig):
+        raise ValueError("config must be a DynamicContactInferenceConfig")
+    if policy is not None and not isinstance(policy, MultiContactInferencePolicy):
+        raise ValueError("policy must be a MultiContactInferencePolicy")
+    settings = config or DynamicContactInferenceConfig()
+    admission = policy or MultiContactInferencePolicy()
+    candidate = _infer_multi_contact_core(
+        bank,
+        observations_m,
+        prefix_frame_count=prefix_frame_count,
+        command_activation=command_activation,
+        mask=mask,
+        ood_distance=ood_distance,
+        settings=settings,
+    )
+    violations = _policy_violations(candidate, bank, admission)
+    policy_record = {
+        "minimum_retained_prior_mass": admission.minimum_retained_prior_mass,
+        "maximum_omitted_posterior_mass": (
+            admission.maximum_omitted_posterior_mass
+        ),
+        "require_replay_binding": admission.require_replay_binding,
+    }
+    if not violations:
+        return _with_policy_metadata(
+            candidate,
+            {
+                "inference_policy": policy_record,
+                "support_gate_passed": True,
+                "support_gate_violations": [],
+                "fallback_used": False,
+            },
+        )
+    if static_fallback_bank is None:
+        details = ", ".join(violations)
+        raise MultiContactInferenceRejectedError(
+            f"multi-contact inference policy rejected rollout bank: {details}"
+        )
+    if not isinstance(static_fallback_bank, MultiContactPathBank):
+        raise ValueError("static_fallback_bank must be a MultiContactPathBank")
+    _validate_static_fallback(bank, static_fallback_bank, admission)
+    fallback = _infer_multi_contact_core(
+        static_fallback_bank,
+        observations_m,
+        prefix_frame_count=prefix_frame_count,
+        command_activation=command_activation,
+        mask=mask,
+        ood_distance=ood_distance,
+        settings=settings,
+    )
+    return _with_policy_metadata(
+        fallback,
+        {
+            "inference_policy": policy_record,
+            "support_gate_passed": False,
+            "support_gate_violations": violations,
+            "fallback_used": True,
+            "rejected_schedule_identity": bank.schedule_identity,
+            "rejected_rollout_identity": bank.rollout_identity,
+            "rejected_retained_prior_mass": bank.retained_prior_mass,
+            "rejected_omitted_posterior_mass_upper_bound": candidate.metadata[
+                "omitted_posterior_mass_upper_bound"
+            ],
+            "fallback_schedule_identity": static_fallback_bank.schedule_identity,
+            "fallback_rollout_identity": static_fallback_bank.rollout_identity,
         },
     )

--- a/src/causal4d/_multi_contact_prior.py
+++ b/src/causal4d/_multi_contact_prior.py
@@ -44,10 +44,9 @@ class MultiContactEnumerationConfig:
     def __post_init__(self) -> None:
         if type(self.maximum_joint_paths) is not int or self.maximum_joint_paths < 1:
             raise ValueError("maximum_joint_paths must be a positive integer")
-        if (
-            isinstance(self.minimum_joint_probability, (bool, np.bool_))
-            or not isinstance(self.minimum_joint_probability, Real)
-        ):
+        if isinstance(
+            self.minimum_joint_probability, (bool, np.bool_)
+        ) or not isinstance(self.minimum_joint_probability, Real):
             raise ValueError("minimum_joint_probability must be a real probability")
         minimum = float(self.minimum_joint_probability)
         if not np.isfinite(minimum) or not 0.0 <= minimum < 1.0:

--- a/src/causal4d/_multi_contact_prior.py
+++ b/src/causal4d/_multi_contact_prior.py
@@ -1,0 +1,332 @@
+"""Factorized top-k prior enumeration for multiple contact channels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import heapq
+from math import prod
+from numbers import Real
+from typing import Sequence
+
+import numpy as np
+
+from causal4d._multi_contact_common import (
+    activation_matrix,
+    integer_array,
+    normalized_weights,
+    probability_mass,
+    real_array,
+    readonly,
+    schedule_identity,
+    validate_identifiers,
+    validated_contact_ids,
+)
+from causal4d.dynamic_contact import (
+    CONTACT_REGIME_NAMES,
+    ContactPathPrior,
+    ContactRegime,
+    ContactTransitionConfig,
+    enumerate_contact_paths,
+)
+
+
+@dataclass(frozen=True)
+class MultiContactEnumerationConfig:
+    """Controls deterministic pruning of the joint contact-path support.
+
+    ``minimum_joint_probability`` is measured in the original marginal prior,
+    before retained joint weights are renormalized.
+    """
+
+    maximum_joint_paths: int = 128
+    minimum_joint_probability: float = 0.0
+
+    def __post_init__(self) -> None:
+        if type(self.maximum_joint_paths) is not int or self.maximum_joint_paths < 1:
+            raise ValueError("maximum_joint_paths must be a positive integer")
+        if (
+            isinstance(self.minimum_joint_probability, (bool, np.bool_))
+            or not isinstance(self.minimum_joint_probability, Real)
+        ):
+            raise ValueError("minimum_joint_probability must be a real probability")
+        minimum = float(self.minimum_joint_probability)
+        if not np.isfinite(minimum) or not 0.0 <= minimum < 1.0:
+            raise ValueError("minimum_joint_probability must lie in [0, 1)")
+        object.__setattr__(self, "minimum_joint_probability", minimum)
+
+
+@dataclass(frozen=True)
+class MultiContactPathPrior:
+    """Finite top-k approximation to a factorized joint contact-path prior."""
+
+    contact_ids: tuple[str, ...]
+    path_ids: tuple[str, ...]
+    regime_paths: np.ndarray
+    weights: np.ndarray
+    retained_prior_mass: float
+    marginal_retained_prior_mass: np.ndarray
+    marginal_path_indices: np.ndarray
+    marginal_path_counts: np.ndarray
+
+    def __post_init__(self) -> None:
+        paths = integer_array(
+            self.regime_paths,
+            name="regime_paths",
+            dtype=np.int8,
+        )
+        weights = normalized_weights(self.weights, name="multi-contact path weights")
+        marginal_mass = readonly(
+            real_array(
+                self.marginal_retained_prior_mass,
+                name="marginal_retained_prior_mass",
+            )
+        )
+        indices = integer_array(
+            self.marginal_path_indices,
+            name="marginal_path_indices",
+        )
+        counts = integer_array(
+            self.marginal_path_counts,
+            name="marginal_path_counts",
+        )
+        if paths.ndim != 3 or paths.shape[0] != len(weights):
+            raise ValueError("regime_paths must have shape (K, G, T)")
+        path_count, contact_count, frame_count = paths.shape
+        if contact_count < 1 or frame_count < 1:
+            raise ValueError("contact paths must contain contacts and frames")
+        contact_ids = validate_identifiers(
+            self.contact_ids,
+            expected_count=contact_count,
+            name="contact_ids",
+        )
+        path_ids = validate_identifiers(
+            self.path_ids,
+            expected_count=path_count,
+            name="path_ids",
+        )
+        if np.any(paths < 0) or np.any(paths >= len(CONTACT_REGIME_NAMES)):
+            raise ValueError("regime_paths contain an unknown contact regime")
+        if marginal_mass.shape != (contact_count,):
+            raise ValueError("marginal retained mass must identify every contact")
+        if np.any((marginal_mass <= 0.0) | (marginal_mass > 1.0 + 1e-12)):
+            raise ValueError("marginal retained mass must lie in (0, 1]")
+        if indices.shape != (path_count, contact_count):
+            raise ValueError("marginal_path_indices must have shape (K, G)")
+        if counts.shape != (contact_count,) or np.any(counts < 1):
+            raise ValueError("marginal_path_counts must be positive per contact")
+        if np.any(indices < 0) or np.any(indices >= counts[None, :]):
+            raise ValueError("marginal path index lies outside its support")
+        retained = probability_mass(
+            self.retained_prior_mass,
+            name="retained_prior_mass",
+        )
+        if retained > float(np.prod(marginal_mass)) + 1e-12:
+            raise ValueError("joint retained mass exceeds marginal retained support")
+        object.__setattr__(self, "contact_ids", contact_ids)
+        object.__setattr__(self, "path_ids", path_ids)
+        object.__setattr__(self, "regime_paths", paths)
+        object.__setattr__(self, "weights", weights)
+        object.__setattr__(self, "retained_prior_mass", retained)
+        object.__setattr__(self, "marginal_retained_prior_mass", marginal_mass)
+        object.__setattr__(self, "marginal_path_indices", indices)
+        object.__setattr__(self, "marginal_path_counts", counts)
+
+    @property
+    def full_cartesian_path_count(self) -> int:
+        """Number of paths before the joint top-k truncation."""
+
+        return int(prod(int(value) for value in self.marginal_path_counts))
+
+    @property
+    def schedule_identity(self) -> str:
+        """Content identity for the complete retained joint schedule support."""
+
+        return schedule_identity(
+            self.contact_ids,
+            self.path_ids,
+            self.regime_paths,
+            self.weights,
+            self.retained_prior_mass,
+        )
+
+
+def _transition_configs(
+    values: ContactTransitionConfig | Sequence[ContactTransitionConfig] | None,
+    contact_count: int,
+) -> tuple[ContactTransitionConfig, ...]:
+    if values is None:
+        return tuple(ContactTransitionConfig() for _ in range(contact_count))
+    if isinstance(values, ContactTransitionConfig):
+        return (values,) * contact_count
+    try:
+        result = tuple(values)
+    except TypeError as error:
+        raise ValueError(
+            "transition_configs must identify every contact channel"
+        ) from error
+    if len(result) != contact_count or not all(
+        isinstance(value, ContactTransitionConfig) for value in result
+    ):
+        raise ValueError("transition_configs must identify every contact channel")
+    return result
+
+
+def _initial_probabilities(
+    values: np.ndarray | None,
+    contact_count: int,
+) -> tuple[np.ndarray | None, ...]:
+    if values is None:
+        return (None,) * contact_count
+    probabilities = real_array(values, name="initial_probabilities")
+    regime_count = len(ContactRegime)
+    if probabilities.shape == (regime_count,):
+        probabilities = np.broadcast_to(
+            probabilities[None, :],
+            (contact_count, regime_count),
+        )
+    if probabilities.shape != (contact_count, regime_count):
+        raise ValueError("initial_probabilities must have shape (4,) or (G, 4)")
+    return tuple(probabilities[index] for index in range(contact_count))
+
+
+def _sorted_marginal(prior: ContactPathPrior) -> ContactPathPrior:
+    order = sorted(
+        range(len(prior.weights)),
+        key=lambda index: (-float(prior.weights[index]), prior.path_ids[index]),
+    )
+    return ContactPathPrior(
+        path_ids=tuple(prior.path_ids[index] for index in order),
+        regime_paths=np.asarray(prior.regime_paths)[order],
+        weights=np.asarray(prior.weights)[order],
+        retained_prior_mass=prior.retained_prior_mass,
+    )
+
+
+def enumerate_multi_contact_paths(
+    command_activation: np.ndarray,
+    *,
+    contact_ids: Sequence[str] | None = None,
+    transition_configs: ContactTransitionConfig
+    | Sequence[ContactTransitionConfig]
+    | None = None,
+    initial_probabilities: np.ndarray | None = None,
+    config: MultiContactEnumerationConfig | None = None,
+) -> MultiContactPathPrior:
+    """Enumerate top joint paths without constructing the Cartesian product.
+
+    Contact chains are conditionally independent in the prior. Each marginal is
+    first enumerated by :func:`enumerate_contact_paths`; a best-first heap then
+    extracts the globally highest-probability products. The reported retained
+    mass accounts for both marginal beam pruning and joint top-k pruning.
+    """
+
+    if config is not None and not isinstance(config, MultiContactEnumerationConfig):
+        raise ValueError("config must be a MultiContactEnumerationConfig")
+    settings = config or MultiContactEnumerationConfig()
+    activation = activation_matrix(command_activation)
+    contact_count = activation.shape[0]
+    identifiers = validated_contact_ids(contact_ids, contact_count)
+    transitions = _transition_configs(transition_configs, contact_count)
+    initials = _initial_probabilities(initial_probabilities, contact_count)
+    marginals = tuple(
+        _sorted_marginal(
+            enumerate_contact_paths(
+                activation[index],
+                config=transitions[index],
+                initial_probabilities=initials[index],
+            )
+        )
+        for index in range(contact_count)
+    )
+    log_weights = tuple(
+        np.log(np.asarray(prior.weights, dtype=float)) for prior in marginals
+    )
+    marginal_mass = np.asarray(
+        [prior.retained_prior_mass for prior in marginals],
+        dtype=float,
+    )
+    log_marginal_support_mass = float(np.sum(np.log(marginal_mass)))
+    initial_index = (0,) * contact_count
+    initial_log_probability = float(sum(values[0] for values in log_weights))
+    heap: list[tuple[float, tuple[int, ...]]] = [
+        (-initial_log_probability, initial_index)
+    ]
+    visited = {initial_index}
+    selected_indices: list[tuple[int, ...]] = []
+    selected_log_weights: list[float] = []
+    log_minimum = (
+        float(np.log(settings.minimum_joint_probability))
+        if settings.minimum_joint_probability > 0.0
+        else -np.inf
+    )
+
+    while heap and len(selected_indices) < settings.maximum_joint_paths:
+        negative_log_probability, indices = heapq.heappop(heap)
+        log_probability = -negative_log_probability
+        if log_probability + log_marginal_support_mass < log_minimum:
+            break
+        selected_indices.append(indices)
+        selected_log_weights.append(log_probability)
+        for contact_index in range(contact_count):
+            next_path_index = indices[contact_index] + 1
+            if next_path_index >= len(marginals[contact_index].weights):
+                continue
+            neighbor = list(indices)
+            neighbor[contact_index] = next_path_index
+            neighbor_tuple = tuple(neighbor)
+            if neighbor_tuple in visited:
+                continue
+            visited.add(neighbor_tuple)
+            neighbor_log_probability = float(
+                sum(
+                    log_weights[index][path_index]
+                    for index, path_index in enumerate(neighbor_tuple)
+                )
+            )
+            heapq.heappush(heap, (-neighbor_log_probability, neighbor_tuple))
+
+    if not selected_indices:
+        raise RuntimeError("joint contact-path pruning removed all probability mass")
+    selected_logs = np.asarray(selected_log_weights, dtype=float)
+    maximum = float(np.max(selected_logs))
+    scaled_weights = np.exp(selected_logs - maximum)
+    normalized_joint_weights = scaled_weights / np.sum(scaled_weights)
+    selected_support_mass = float(np.exp(maximum) * np.sum(scaled_weights))
+    retained_prior_mass = float(
+        np.exp(log_marginal_support_mass) * selected_support_mass
+    )
+    index_array = np.asarray(selected_indices, dtype=np.int64)
+    paths = np.stack(
+        [
+            np.stack(
+                [
+                    marginals[contact_index].regime_paths[path_index]
+                    for contact_index, path_index in enumerate(indices)
+                ],
+                axis=0,
+            )
+            for indices in selected_indices
+        ],
+        axis=0,
+    )
+    path_ids = tuple(
+        ";".join(
+            f"{identifiers[contact_index]}="
+            f"{marginals[contact_index].path_ids[path_index]}"
+            for contact_index, path_index in enumerate(indices)
+        )
+        for indices in selected_indices
+    )
+    return MultiContactPathPrior(
+        contact_ids=identifiers,
+        path_ids=path_ids,
+        regime_paths=paths,
+        weights=normalized_joint_weights,
+        retained_prior_mass=retained_prior_mass,
+        marginal_retained_prior_mass=marginal_mass,
+        marginal_path_indices=index_array,
+        marginal_path_counts=np.asarray(
+            [len(prior.weights) for prior in marginals],
+            dtype=np.int64,
+        ),
+    )

--- a/src/causal4d/_student_t_likelihood.py
+++ b/src/causal4d/_student_t_likelihood.py
@@ -1,0 +1,57 @@
+"""Shared normalized Student-t scores for heteroscedastic rollout likelihoods."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def student_t_mean_log_score(
+    residual: np.ndarray,
+    valid: np.ndarray,
+    *,
+    scale: np.ndarray | float,
+    degrees_of_freedom: float,
+    reduction_axes: tuple[int, ...],
+    empty_error: str,
+) -> np.ndarray:
+    """Return a normalized mean Student-t log score.
+
+    Constants independent of the compared component are omitted. The
+    ``-log(scale)`` term is retained because conditional uncertainty may differ
+    between rollout components; omitting it would reward variance inflation.
+    """
+
+    values = np.asarray(residual, dtype=float)
+    scales = np.asarray(scale, dtype=float)
+    if (
+        not np.isfinite(degrees_of_freedom)
+        or degrees_of_freedom <= 0.0
+        or np.any(~np.isfinite(scales))
+        or np.any(scales <= 0.0)
+    ):
+        raise ValueError("Student-t scales and degrees of freedom must be positive")
+    try:
+        standardized = values / scales
+        log_scale = np.broadcast_to(np.log(scales), values.shape)
+    except ValueError as error:
+        raise ValueError("Student-t scale is not broadcastable to residuals") from error
+
+    terms = -log_scale - 0.5 * (degrees_of_freedom + 1.0) * np.log1p(
+        np.square(standardized) / degrees_of_freedom
+    )
+    valid_float = np.asarray(valid, dtype=float)
+    while valid_float.ndim < terms.ndim:
+        valid_float = valid_float[None]
+    count = np.sum(valid_float, axis=reduction_axes)
+    if np.any(count <= 0.0):
+        raise ValueError(empty_error)
+    return (
+        np.sum(
+            np.where(valid_float > 0.0, terms, 0.0),
+            axis=reduction_axes,
+        )
+        / count
+    )
+
+
+__all__ = ["student_t_mean_log_score"]

--- a/src/causal4d/multi_contact.py
+++ b/src/causal4d/multi_contact.py
@@ -1,0 +1,34 @@
+"""Factorized dynamic contact-path inference for multiple contact channels.
+
+The single-contact dynamic model represents one regime path per rollout. This
+module composes independently parameterized contact channels into a
+deterministic top-k joint path support, then performs prefix-only Bayesian
+reweighting over trajectories simulated continuously for those schedules.
+"""
+
+from __future__ import annotations
+
+from causal4d._multi_contact_common import MULTI_CONTACT_SCHEDULE_SCHEMA_VERSION
+from causal4d._multi_contact_inference import (
+    MultiContactPathBank,
+    MultiContactPosterior,
+    infer_multi_contact_posterior,
+    multi_contact_conditioned_variance,
+)
+from causal4d._multi_contact_prior import (
+    MultiContactEnumerationConfig,
+    MultiContactPathPrior,
+    enumerate_multi_contact_paths,
+)
+
+
+__all__ = [
+    "MULTI_CONTACT_SCHEDULE_SCHEMA_VERSION",
+    "MultiContactEnumerationConfig",
+    "MultiContactPathBank",
+    "MultiContactPathPrior",
+    "MultiContactPosterior",
+    "enumerate_multi_contact_paths",
+    "infer_multi_contact_posterior",
+    "multi_contact_conditioned_variance",
+]

--- a/src/causal4d/multi_contact.py
+++ b/src/causal4d/multi_contact.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 from causal4d._multi_contact_common import MULTI_CONTACT_SCHEDULE_SCHEMA_VERSION
 from causal4d._multi_contact_inference import (
+    MULTI_CONTACT_ROLLOUT_SCHEMA_VERSION,
+    MultiContactInferencePolicy,
+    MultiContactInferenceRejectedError,
     MultiContactPathBank,
     MultiContactPosterior,
     infer_multi_contact_posterior,
@@ -23,8 +26,11 @@ from causal4d._multi_contact_prior import (
 
 
 __all__ = [
+    "MULTI_CONTACT_ROLLOUT_SCHEMA_VERSION",
     "MULTI_CONTACT_SCHEDULE_SCHEMA_VERSION",
     "MultiContactEnumerationConfig",
+    "MultiContactInferencePolicy",
+    "MultiContactInferenceRejectedError",
     "MultiContactPathBank",
     "MultiContactPathPrior",
     "MultiContactPosterior",

--- a/tests/test_multi_contact.py
+++ b/tests/test_multi_contact.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+from itertools import product
+
+import numpy as np
+import pytest
+
+from causal4d.dynamic_contact import (
+    ContactRegime,
+    ContactTransitionConfig,
+    DynamicContactInferenceConfig,
+    enumerate_contact_paths,
+)
+from causal4d.multi_contact import (
+    MultiContactEnumerationConfig,
+    MultiContactPathBank,
+    enumerate_multi_contact_paths,
+    infer_multi_contact_posterior,
+    multi_contact_conditioned_variance,
+)
+
+
+def _zero_hazard_config() -> ContactTransitionConfig:
+    return ContactTransitionConfig(
+        activation_floor=0.0,
+        activation_gain=0.0,
+        slip_floor=0.0,
+        slip_change_gain=0.0,
+        release_floor=0.0,
+        release_gain=0.0,
+        slip_recovery_probability=0.0,
+        reattachment_gain=0.0,
+    )
+
+
+def _sorted_marginal(activation: np.ndarray, config: ContactTransitionConfig):
+    prior = enumerate_contact_paths(activation, config=config)
+    order = sorted(
+        range(len(prior.weights)),
+        key=lambda index: (-float(prior.weights[index]), prior.path_ids[index]),
+    )
+    return prior, order
+
+
+def test_single_contact_matches_existing_enumerator() -> None:
+    activation = np.asarray([0.0, 0.2, 0.9, 0.9, 0.1])
+    transition = ContactTransitionConfig(maximum_paths=32)
+    marginal, order = _sorted_marginal(activation, transition)
+    joint = enumerate_multi_contact_paths(
+        activation,
+        contact_ids=("left",),
+        transition_configs=transition,
+        config=MultiContactEnumerationConfig(maximum_joint_paths=32),
+    )
+    assert joint.contact_ids == ("left",)
+    assert np.array_equal(joint.regime_paths[:, 0], marginal.regime_paths[order])
+    assert np.allclose(joint.weights, marginal.weights[order])
+    assert np.isclose(joint.retained_prior_mass, marginal.retained_prior_mass)
+    assert joint.full_cartesian_path_count == len(marginal.weights)
+
+
+def test_contact_identifiers_are_fail_closed() -> None:
+    with pytest.raises(ValueError, match="nonempty unique strings"):
+        enumerate_multi_contact_paths(
+            np.zeros((2, 3)),
+            contact_ids=("left", 1),  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="positive integer"):
+        MultiContactEnumerationConfig(
+            maximum_joint_paths=True,  # type: ignore[arg-type]
+        )
+
+
+def test_zero_hazard_multi_contact_prior_is_exactly_static() -> None:
+    activation = np.ones((3, 6), dtype=float)
+    prior = enumerate_multi_contact_paths(
+        activation,
+        contact_ids=("left", "right", "support"),
+        transition_configs=_zero_hazard_config(),
+    )
+    assert prior.path_ids == (
+        "left=inactive:0-5;right=inactive:0-5;support=inactive:0-5",
+    )
+    assert np.array_equal(prior.regime_paths, np.zeros((1, 3, 6), dtype=np.int8))
+    assert np.array_equal(prior.weights, np.ones(1))
+    assert prior.retained_prior_mass == 1.0
+    assert np.array_equal(prior.marginal_retained_prior_mass, np.ones(3))
+
+
+def test_joint_top_k_matches_brute_force_and_accounts_for_retained_mass() -> None:
+    activation = np.asarray(
+        [
+            [0.0, 0.7, 0.9, 0.2],
+            [0.0, 0.1, 0.8, 0.8],
+        ]
+    )
+    transition = ContactTransitionConfig(maximum_paths=8)
+    marginals = [_sorted_marginal(row, transition) for row in activation]
+    joint = enumerate_multi_contact_paths(
+        activation,
+        transition_configs=transition,
+        config=MultiContactEnumerationConfig(maximum_joint_paths=5),
+    )
+    products = []
+    for indices in product(*(range(len(prior.weights)) for prior, _ in marginals)):
+        probability = 1.0
+        sorted_indices = []
+        for contact_index, source_index in enumerate(indices):
+            prior, order = marginals[contact_index]
+            probability *= float(prior.weights[order[source_index]])
+            sorted_indices.append(source_index)
+        products.append((probability, tuple(sorted_indices)))
+    products.sort(key=lambda item: (-item[0], item[1]))
+    expected = products[:5]
+    expected_mass = float(
+        np.prod([prior.retained_prior_mass for prior, _ in marginals])
+        * sum(probability for probability, _ in expected)
+    )
+    expected_weights = np.asarray([value for value, _ in expected], dtype=float)
+    expected_weights /= np.sum(expected_weights)
+    assert np.array_equal(
+        joint.marginal_path_indices,
+        np.asarray([indices for _, indices in expected], dtype=np.int64),
+    )
+    assert np.allclose(joint.weights, expected_weights)
+    assert np.isclose(joint.retained_prior_mass, expected_mass)
+
+
+def test_retained_mass_is_monotone_in_joint_beam_width() -> None:
+    activation = np.asarray(
+        [
+            [0.0, 0.8, 0.8, 0.1],
+            [0.0, 0.3, 0.9, 0.9],
+        ]
+    )
+    transition = ContactTransitionConfig(maximum_paths=12)
+    narrow = enumerate_multi_contact_paths(
+        activation,
+        transition_configs=transition,
+        config=MultiContactEnumerationConfig(maximum_joint_paths=3),
+    )
+    wide = enumerate_multi_contact_paths(
+        activation,
+        transition_configs=transition,
+        config=MultiContactEnumerationConfig(maximum_joint_paths=20),
+    )
+    assert narrow.retained_prior_mass <= wide.retained_prior_mass
+    assert len(narrow.weights) == 3
+    assert len(wide.weights) == 20
+    assert wide.full_cartesian_path_count > len(wide.weights)
+
+
+def test_contact_permutation_preserves_full_joint_distribution() -> None:
+    activation = np.asarray(
+        [
+            [0.0, 0.8, 0.9],
+            [0.0, 0.2, 0.7],
+        ]
+    )
+    transition = ContactTransitionConfig(maximum_paths=8)
+    first = enumerate_multi_contact_paths(
+        activation,
+        contact_ids=("left", "right"),
+        transition_configs=transition,
+        config=MultiContactEnumerationConfig(maximum_joint_paths=64),
+    )
+    second = enumerate_multi_contact_paths(
+        activation[::-1],
+        contact_ids=("right", "left"),
+        transition_configs=transition,
+        config=MultiContactEnumerationConfig(maximum_joint_paths=64),
+    )
+
+    def distribution(prior, reverse: bool):
+        result = {}
+        paths = prior.regime_paths[:, ::-1] if reverse else prior.regime_paths
+        for path, weight in zip(paths, prior.weights, strict=True):
+            result[tuple(int(value) for value in path.ravel())] = float(weight)
+        return result
+
+    assert distribution(first, False).keys() == distribution(second, True).keys()
+    for key, value in distribution(first, False).items():
+        assert np.isclose(value, distribution(second, True)[key])
+    assert np.isclose(first.retained_prior_mass, second.retained_prior_mass)
+
+
+def test_schedule_identity_is_stable_and_bank_preserves_it() -> None:
+    activation = np.asarray(
+        [
+            [0.0, 0.8, 0.8],
+            [0.0, 0.2, 0.9],
+        ]
+    )
+    prior = enumerate_multi_contact_paths(
+        activation,
+        contact_ids=("left", "right"),
+        config=MultiContactEnumerationConfig(maximum_joint_paths=12),
+    )
+    trajectories = np.zeros((len(prior.weights), 3, 1, 3), dtype=float)
+    bank = MultiContactPathBank.from_prior(
+        prior,
+        trajectories,
+        base_variance_m2=1e-6,
+    )
+    copied = enumerate_multi_contact_paths(
+        np.asfortranarray(activation),
+        contact_ids=("left", "right"),
+        config=MultiContactEnumerationConfig(maximum_joint_paths=12),
+    )
+    assert prior.schedule_identity == copied.schedule_identity
+    assert prior.schedule_identity == bank.schedule_identity
+    changed_paths = prior.regime_paths.copy()
+    changed_paths[0, 0, -1] = ContactRegime.DETACHED
+    changed = MultiContactPathBank(
+        contact_ids=prior.contact_ids,
+        path_ids=prior.path_ids,
+        regime_paths=changed_paths,
+        trajectories_m=trajectories,
+        prior_weights=prior.weights,
+        base_variance_m2=1e-6,
+        retained_prior_mass=prior.retained_prior_mass,
+    )
+    assert changed.schedule_identity != prior.schedule_identity
+
+
+def _posterior_bank() -> tuple[MultiContactPathBank, np.ndarray, np.ndarray]:
+    frame_count = 5
+    paths = np.asarray(
+        [
+            [[0, 0, 0, 0, 0], [0, 0, 0, 0, 0]],
+            [[0, 0, 1, 1, 1], [0, 0, 0, 0, 0]],
+            [[0, 0, 0, 0, 0], [0, 0, 1, 1, 1]],
+            [[0, 0, 1, 1, 1], [0, 0, 1, 1, 1]],
+        ],
+        dtype=np.int8,
+    )
+    trajectories = np.zeros((4, frame_count, 1, 3), dtype=float)
+    trajectories[1, 2:, 0, 0] = [0.01, 0.02, 0.03]
+    trajectories[2, 2:, 0, 1] = [0.01, 0.02, 0.03]
+    trajectories[3] = trajectories[1] + trajectories[2]
+    bank = MultiContactPathBank(
+        contact_ids=("left", "right"),
+        path_ids=("none", "left", "right", "both"),
+        regime_paths=paths,
+        trajectories_m=trajectories,
+        prior_weights=np.full(4, 0.25),
+        base_variance_m2=1e-8,
+    )
+    activation = np.asarray(
+        [
+            [0.0, 0.0, 1.0, 1.0, 1.0],
+            [0.0, 0.0, 1.0, 1.0, 1.0],
+        ]
+    )
+    observations = trajectories[3].copy()
+    return bank, activation, observations
+
+
+def test_prefix_inference_is_future_invariant_and_returns_contact_marginals() -> None:
+    bank, activation, observations = _posterior_bank()
+    config = DynamicContactInferenceConfig(
+        observation_scale_m=1e-4,
+        dynamic_likelihood_weight=0.0,
+        switch_variance_m2=0.0,
+        command_change_variance_m2=0.0,
+        ood_variance_m2=0.0,
+    )
+    first = infer_multi_contact_posterior(
+        bank,
+        observations,
+        prefix_frame_count=4,
+        command_activation=activation,
+        config=config,
+    )
+    perturbed = observations.copy()
+    perturbed[4] = 1e6
+    second = infer_multi_contact_posterior(
+        bank,
+        perturbed,
+        prefix_frame_count=4,
+        command_activation=activation,
+        config=config,
+    )
+    assert np.array_equal(first.weights, second.weights)
+    assert np.array_equal(first.mean_m, second.mean_m)
+    assert first.map_path_id == "both"
+    assert first.metadata["future_observations_read"] == 0
+    assert first.regime_probabilities.shape == (2, 5, 4)
+    assert np.allclose(np.sum(first.regime_probabilities, axis=2), 1.0)
+    assert np.all(first.active_probability[:, 2:] > 0.95)
+    assert np.all(first.switch_probability[:, 2] > 0.95)
+    assert first.any_switch_probability[2] > 0.99
+
+
+def test_variance_counts_each_contact_switch() -> None:
+    paths = np.asarray(
+        [[[[0], [1], [1]], [[0], [0], [1]]]],
+        dtype=np.int8,
+    ).reshape(1, 2, 3)
+    trajectories = np.zeros((1, 3, 1, 2), dtype=float)
+    bank = MultiContactPathBank(
+        contact_ids=("left", "right"),
+        path_ids=("staggered",),
+        regime_paths=paths,
+        trajectories_m=trajectories,
+        prior_weights=np.ones(1),
+        base_variance_m2=2.0,
+    )
+    config = DynamicContactInferenceConfig(
+        switch_variance_m2=1.0,
+        command_change_variance_m2=0.0,
+        ood_variance_m2=0.0,
+    )
+    variance = multi_contact_conditioned_variance(
+        bank,
+        np.zeros((2, 3)),
+        config=config,
+    )
+    expected = np.asarray([2.0, 3.0, 4.0])
+    assert np.array_equal(variance[0, :, 0, 0], expected)
+    assert np.array_equal(variance[0, :, 0, 1], expected)
+
+
+def test_numeric_contracts_reject_boolean_and_string_coercion() -> None:
+    with pytest.raises(ValueError, match="real numbers"):
+        enumerate_multi_contact_paths(
+            np.asarray([[False, True]]),
+            contact_ids=("left",),
+        )
+    with pytest.raises(ValueError, match="real numbers"):
+        enumerate_multi_contact_paths(
+            np.asarray([["0", "1"]]),
+            contact_ids=("left",),
+        )
+    with pytest.raises(ValueError, match="integers"):
+        MultiContactPathBank(
+            contact_ids=("left",),
+            path_ids=("path",),
+            regime_paths=np.asarray([[[0.0, 1.0]]]),
+            trajectories_m=np.zeros((1, 2, 1, 2)),
+            prior_weights=np.ones(1),
+            base_variance_m2=1.0,
+        )
+
+
+def test_global_ood_distance_is_not_multiplied_by_contact_count() -> None:
+    paths = np.zeros((1, 2, 3), dtype=np.int8)
+    bank = MultiContactPathBank(
+        contact_ids=("left", "right"),
+        path_ids=("static",),
+        regime_paths=paths,
+        trajectories_m=np.zeros((1, 3, 1, 2)),
+        prior_weights=np.ones(1),
+        base_variance_m2=2.0,
+    )
+    config = DynamicContactInferenceConfig(
+        switch_variance_m2=0.0,
+        command_change_variance_m2=0.0,
+        ood_variance_m2=1.0,
+    )
+    global_distance = multi_contact_conditioned_variance(
+        bank,
+        np.zeros((2, 3)),
+        ood_distance=np.asarray([1.0, 2.0, 0.0]),
+        config=config,
+    )
+    per_contact_distance = multi_contact_conditioned_variance(
+        bank,
+        np.zeros((2, 3)),
+        ood_distance=np.asarray([[1.0, 2.0, 0.0], [0.0, 0.0, 0.0]]),
+        config=config,
+    )
+    assert np.array_equal(global_distance, per_contact_distance)
+    assert np.array_equal(
+        global_distance[0, :, 0, 0],
+        np.asarray([3.0, 7.0, 7.0]),
+    )
+
+
+def test_prefix_frame_count_and_mask_are_fail_closed() -> None:
+    bank, activation, observations = _posterior_bank()
+    with pytest.raises(ValueError, match="integer leaving held-out"):
+        infer_multi_contact_posterior(
+            bank,
+            observations,
+            prefix_frame_count=True,  # type: ignore[arg-type]
+            command_activation=activation,
+        )
+    with pytest.raises(ValueError, match="mask must contain booleans"):
+        infer_multi_contact_posterior(
+            bank,
+            observations,
+            prefix_frame_count=3,
+            command_activation=activation,
+            mask=np.ones(observations.shape, dtype=int),
+        )

--- a/tests/test_multi_contact.py
+++ b/tests/test_multi_contact.py
@@ -341,6 +341,15 @@ def test_numeric_contracts_reject_boolean_and_string_coercion() -> None:
             prior_weights=np.ones(1),
             base_variance_m2=1.0,
         )
+    with pytest.raises(ValueError, match="outside int8 range"):
+        MultiContactPathBank(
+            contact_ids=("left",),
+            path_ids=("path",),
+            regime_paths=np.asarray([[[0, 256]]]),
+            trajectories_m=np.zeros((1, 2, 1, 2)),
+            prior_weights=np.ones(1),
+            base_variance_m2=1.0,
+        )
 
 
 def test_global_ood_distance_is_not_multiplied_by_contact_count() -> None:

--- a/tests/test_multi_contact_hardening.py
+++ b/tests/test_multi_contact_hardening.py
@@ -176,9 +176,7 @@ def test_omitted_posterior_bound_is_admission_relevant() -> None:
         command_activation=activation,
         config=_config(),
     )
-    omitted_bound = float(
-        posterior.metadata["omitted_posterior_mass_upper_bound"]
-    )
+    omitted_bound = float(posterior.metadata["omitted_posterior_mass_upper_bound"])
     assert 0.5 <= omitted_bound < 0.501
     with pytest.raises(
         MultiContactInferenceRejectedError,
@@ -190,9 +188,7 @@ def test_omitted_posterior_bound_is_admission_relevant() -> None:
             prefix_frame_count=2,
             command_activation=activation,
             config=_config(),
-            policy=MultiContactInferencePolicy(
-                maximum_omitted_posterior_mass=0.5
-            ),
+            policy=MultiContactInferencePolicy(maximum_omitted_posterior_mass=0.5),
         )
 
 

--- a/tests/test_multi_contact_hardening.py
+++ b/tests/test_multi_contact_hardening.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from causal4d.dynamic_contact import DynamicContactInferenceConfig
+from causal4d.multi_contact import (
+    MultiContactInferencePolicy,
+    MultiContactInferenceRejectedError,
+    MultiContactPathBank,
+    infer_multi_contact_posterior,
+)
+
+
+def _config(*, confidence_level: float = 0.90) -> DynamicContactInferenceConfig:
+    return DynamicContactInferenceConfig(
+        observation_scale_m=0.1,
+        dynamic_likelihood_weight=0.0,
+        switch_variance_m2=0.0,
+        command_change_variance_m2=0.0,
+        ood_variance_m2=0.0,
+        confidence_level=confidence_level,
+    )
+
+
+def _one_path_bank(
+    *,
+    value: float = 0.0,
+    retained_prior_mass: float = 1.0,
+    replay_result_identity: str | None = None,
+    frame_times_s: np.ndarray | None = None,
+) -> MultiContactPathBank:
+    return MultiContactPathBank(
+        contact_ids=("left",),
+        path_ids=("static",),
+        regime_paths=np.zeros((1, 1, 3), dtype=np.int8),
+        trajectories_m=np.full((1, 3, 1, 2), value, dtype=float),
+        prior_weights=np.ones(1),
+        base_variance_m2=1e-6,
+        retained_prior_mass=retained_prior_mass,
+        replay_result_identity=replay_result_identity,
+        frame_times_s=frame_times_s,
+    )
+
+
+def test_heteroscedastic_likelihood_penalizes_variance_inflation() -> None:
+    bank = MultiContactPathBank(
+        contact_ids=("left",),
+        path_ids=("precise", "inflated"),
+        regime_paths=np.zeros((2, 1, 3), dtype=np.int8),
+        trajectories_m=np.zeros((2, 3, 1, 2), dtype=float),
+        prior_weights=np.full(2, 0.5),
+        base_variance_m2=np.asarray(
+            [
+                [[0.0, 0.0]],
+                [[1.0, 1.0]],
+            ]
+        ),
+    )
+    posterior = infer_multi_contact_posterior(
+        bank,
+        np.zeros((3, 1, 2)),
+        prefix_frame_count=2,
+        command_activation=np.zeros((1, 3)),
+        config=_config(),
+    )
+    assert posterior.weights[0] > 0.90
+    assert posterior.weights[0] > posterior.weights[1]
+
+
+def test_rollout_identity_binds_trajectory_variance_replay_and_timebase() -> None:
+    times = np.asarray([0.0, 0.1, 0.2])
+    baseline = _one_path_bank(
+        replay_result_identity="provider-result-a",
+        frame_times_s=times,
+    )
+    fortran_order = MultiContactPathBank(
+        contact_ids=baseline.contact_ids,
+        path_ids=baseline.path_ids,
+        regime_paths=np.asfortranarray(baseline.regime_paths),
+        trajectories_m=np.asfortranarray(baseline.trajectories_m),
+        prior_weights=baseline.prior_weights,
+        base_variance_m2=baseline.base_variance_m2,
+        replay_result_identity="provider-result-a",
+        frame_times_s=np.asfortranarray(times),
+    )
+    changed_trajectory = _one_path_bank(
+        value=0.01,
+        replay_result_identity="provider-result-a",
+        frame_times_s=times,
+    )
+    changed_replay = _one_path_bank(
+        replay_result_identity="provider-result-b",
+        frame_times_s=times,
+    )
+    changed_variance = MultiContactPathBank(
+        contact_ids=baseline.contact_ids,
+        path_ids=baseline.path_ids,
+        regime_paths=baseline.regime_paths,
+        trajectories_m=baseline.trajectories_m,
+        prior_weights=baseline.prior_weights,
+        base_variance_m2=2e-6,
+        replay_result_identity="provider-result-a",
+        frame_times_s=times,
+    )
+    assert baseline.replay_bound
+    assert baseline.schedule_identity == changed_trajectory.schedule_identity
+    assert baseline.rollout_identity == fortran_order.rollout_identity
+    assert baseline.rollout_identity != changed_trajectory.rollout_identity
+    assert baseline.rollout_identity != changed_replay.rollout_identity
+    assert baseline.rollout_identity != changed_variance.rollout_identity
+
+
+def test_rollout_timebase_and_external_identity_are_fail_closed() -> None:
+    with pytest.raises(ValueError, match="strictly increasing"):
+        _one_path_bank(
+            replay_result_identity="provider-result",
+            frame_times_s=np.asarray([0.0, 0.2, 0.1]),
+        )
+    with pytest.raises(ValueError, match="nonempty string"):
+        _one_path_bank(
+            replay_result_identity="",
+            frame_times_s=np.asarray([0.0, 0.1, 0.2]),
+        )
+
+
+def test_retained_support_gate_raises_or_uses_exact_static_fallback() -> None:
+    candidate = _one_path_bank(value=9.0, retained_prior_mass=0.4)
+    fallback = _one_path_bank(value=2.0)
+    policy = MultiContactInferencePolicy(minimum_retained_prior_mass=0.9)
+    observations = np.zeros((3, 1, 2))
+    activation = np.zeros((1, 3))
+
+    with pytest.raises(
+        MultiContactInferenceRejectedError,
+        match="retained_prior_mass_below_minimum",
+    ):
+        infer_multi_contact_posterior(
+            candidate,
+            observations,
+            prefix_frame_count=2,
+            command_activation=activation,
+            config=_config(),
+            policy=policy,
+        )
+
+    posterior = infer_multi_contact_posterior(
+        candidate,
+        observations,
+        prefix_frame_count=2,
+        command_activation=activation,
+        config=_config(),
+        policy=policy,
+        static_fallback_bank=fallback,
+    )
+    assert np.array_equal(posterior.weights, np.ones(1))
+    assert np.array_equal(posterior.mean_m, fallback.trajectories_m[0])
+    assert posterior.metadata["fallback_used"] is True
+    assert posterior.metadata["support_gate_passed"] is False
+    assert posterior.metadata["support_gate_violations"] == [
+        "retained_prior_mass_below_minimum"
+    ]
+    assert posterior.metadata["rejected_rollout_identity"] == (
+        candidate.rollout_identity
+    )
+
+
+def test_omitted_posterior_bound_is_admission_relevant() -> None:
+    candidate = _one_path_bank(retained_prior_mass=0.5)
+    observations = np.zeros((3, 1, 2))
+    activation = np.zeros((1, 3))
+    posterior = infer_multi_contact_posterior(
+        candidate,
+        observations,
+        prefix_frame_count=2,
+        command_activation=activation,
+        config=_config(),
+    )
+    assert np.isclose(
+        posterior.metadata["omitted_posterior_mass_upper_bound"],
+        0.5,
+    )
+    with pytest.raises(
+        MultiContactInferenceRejectedError,
+        match="omitted_posterior_mass_above_maximum",
+    ):
+        infer_multi_contact_posterior(
+            candidate,
+            observations,
+            prefix_frame_count=2,
+            command_activation=activation,
+            config=_config(),
+            policy=MultiContactInferencePolicy(
+                maximum_omitted_posterior_mass=0.49
+            ),
+        )
+
+
+def test_replay_binding_can_be_required_for_admission() -> None:
+    observations = np.zeros((3, 1, 2))
+    activation = np.zeros((1, 3))
+    policy = MultiContactInferencePolicy(require_replay_binding=True)
+    with pytest.raises(
+        MultiContactInferenceRejectedError,
+        match="replay_binding_required",
+    ):
+        infer_multi_contact_posterior(
+            _one_path_bank(),
+            observations,
+            prefix_frame_count=2,
+            command_activation=activation,
+            config=_config(),
+            policy=policy,
+        )
+    admitted = infer_multi_contact_posterior(
+        _one_path_bank(
+            replay_result_identity="provider-result",
+            frame_times_s=np.asarray([0.0, 0.1, 0.2]),
+        ),
+        observations,
+        prefix_frame_count=2,
+        command_activation=activation,
+        config=_config(),
+        policy=policy,
+    )
+    assert admitted.metadata["support_gate_passed"] is True
+    assert admitted.metadata["replay_bound"] is True
+
+
+def test_intervals_are_marginal_gaussian_mixture_quantiles() -> None:
+    trajectories = np.zeros((2, 3, 1, 2), dtype=float)
+    trajectories[0, 1:, 0, 0] = -1.0
+    trajectories[1, 1:, 0, 0] = 1.0
+    bank = MultiContactPathBank(
+        contact_ids=("left",),
+        path_ids=("negative", "positive"),
+        regime_paths=np.zeros((2, 1, 3), dtype=np.int8),
+        trajectories_m=trajectories,
+        prior_weights=np.full(2, 0.5),
+        base_variance_m2=1e-6,
+    )
+    posterior = infer_multi_contact_posterior(
+        bank,
+        np.zeros((3, 1, 2)),
+        prefix_frame_count=1,
+        command_activation=np.zeros((1, 3)),
+        config=_config(),
+    )
+    lower = float(posterior.interval_lower_m[2, 0, 0])
+    upper = float(posterior.interval_upper_m[2, 0, 0])
+    assert -1.01 < lower < -0.99
+    assert 0.99 < upper < 1.01
+    assert upper - lower < 2.1
+    assert posterior.metadata["interval_method"] == (
+        "conditional_gaussian_mixture_quantiles"
+    )
+
+
+def test_posterior_metadata_is_recursively_immutable() -> None:
+    posterior = infer_multi_contact_posterior(
+        _one_path_bank(),
+        np.zeros((3, 1, 2)),
+        prefix_frame_count=2,
+        command_activation=np.zeros((1, 3)),
+        config=_config(),
+    )
+    with pytest.raises(TypeError, match="immutable"):
+        posterior.metadata["config"]["observation_scale_m"] = 4.0
+    with pytest.raises(TypeError, match="immutable"):
+        posterior.metadata["support_gate_violations"].append("tampered")
+
+
+def test_policy_numeric_contracts_reject_boolean_coercion() -> None:
+    with pytest.raises(ValueError, match="real probability"):
+        MultiContactInferencePolicy(
+            minimum_retained_prior_mass=True,  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="Boolean"):
+        MultiContactInferencePolicy(
+            require_replay_binding=np.bool_(True),  # type: ignore[arg-type]
+        )

--- a/tests/test_multi_contact_hardening.py
+++ b/tests/test_multi_contact_hardening.py
@@ -176,10 +176,10 @@ def test_omitted_posterior_bound_is_admission_relevant() -> None:
         command_activation=activation,
         config=_config(),
     )
-    assert np.isclose(
-        posterior.metadata["omitted_posterior_mass_upper_bound"],
-        0.5,
+    omitted_bound = float(
+        posterior.metadata["omitted_posterior_mass_upper_bound"]
     )
+    assert 0.5 <= omitted_bound < 0.501
     with pytest.raises(
         MultiContactInferenceRejectedError,
         match="omitted_posterior_mass_above_maximum",
@@ -191,7 +191,7 @@ def test_omitted_posterior_bound_is_admission_relevant() -> None:
             command_activation=activation,
             config=_config(),
             policy=MultiContactInferencePolicy(
-                maximum_omitted_posterior_mass=0.49
+                maximum_omitted_posterior_mass=0.5
             ),
         )
 


### PR DESCRIPTION
## Summary

This adds a backend-neutral, finite-support posterior over independently changing contact channels such as left gripper, right gripper, and support contact.

- enumerate per-contact Markov path supports and extract the globally highest-probability joint schedules with a deterministic best-first heap rather than materializing the Cartesian product;
- retain exact accounting for probability mass removed by marginal beam pruning and joint top-k pruning;
- associate every retained joint schedule with one continuously simulated trajectory, without splicing independently simulated segments;
- infer joint path weights from the permitted observation prefix and return per-contact regime, active-contact, switch, and any-switch marginals;
- use a normalized heteroscedastic Student-t score, including `-log(scale)`, so a path cannot improve its likelihood merely by inflating conditional variance;
- add marginal conditional-Gaussian-mixture quantile intervals instead of `mean +/- z * std` intervals across potentially separated contact modes;
- separate the contact-schedule identity from the rollout identity that additionally binds replay-result identity, explicit timebase, trajectory bytes, and variance bytes;
- add fail-closed retained-support admission, a conservative omitted-posterior-mass upper bound, optional replay-binding requirements, and exact one-path static fallback;
- make posterior metadata recursively immutable and retain complete admission/fallback audit records;
- add adversarial numeric, identity, support, future-invariance, fallback, multimodality, and immutability regressions.

## Correctness and safety changes

### Normalized path likelihood

For residual `r`, conditional scale `s`, and degrees of freedom `nu`, path comparison now retains

```text
-log(s) - (nu + 1) / 2 * log(1 + r^2 / (nu * s^2)).
```

Constants shared by all paths are omitted. The scale normalization is required because switch-, command-, OOD-, and path-dependent uncertainty can differ between components.

### Retained-support admission

`MultiContactInferencePolicy` can require:

- a minimum retained prior mass;
- a maximum conservative omitted posterior mass; and
- an externally bound replay-result identity plus strictly increasing timebase.

The omitted-posterior bound combines the exact retained average likelihood with an upper bound on any omitted path's likelihood. If a configured gate fails, inference raises `MultiContactInferenceRejectedError` or returns a supplied static fallback. The fallback must contain exactly one path, retain unit prior mass, match the candidate dimensions and contact identifiers, and keep every contact regime constant through time.

The default policy remains permissive for the experimental API. Any claim-bearing use must freeze nontrivial thresholds and the exact fallback before target access.

### Schedule and rollout identities

- `schedule_identity` binds contact IDs, path IDs, complete regime schedules, normalized prior weights, and retained mass.
- `rollout_identity` additionally binds the replay-result identity, frame timebase, complete trajectory bytes, and conditional-variance bytes.

The external replay-result identity remains a provider trust input; this PR does not claim that arbitrary caller-supplied identities are independently verified. A future BayesianPhysTwin scheduled-replay provider can supply that verified boundary without exposing simulator internals.

### Mixture-aware intervals

Predictive moments still use the law of total variance. Marginal intervals are now obtained by numerically inverting the conditional Gaussian path-mixture CDF, avoiding Gaussian intervals that can place most of their span in a low-density gap between contact modes.

## Compatibility and scientific boundary

- the existing single-contact implementation and controlled benchmark are unchanged;
- a one-contact joint prior reproduces the existing regime paths and weights, apart from the explicit contact axis and named joint path identifier;
- zero transition hazards still produce one exact all-inactive path with unit mass for any number of contacts;
- perturbing every held-out observation leaves posterior weights and predictive moments byte-exact;
- no frozen estimator, registered physical protocol, threshold, evidence artifact, or claim-bearing result changes;
- this does not establish calibrated real-data contact prediction, physical transfer, or BayesianPhysTwin scheduled-contact replay;
- source-fitted duration models, cross-contact transition coupling, contact-point migration, continuous force-transmission parameters, tactile-label construction, and an official scheduled-replay backend remain separate future work.

## Validation

Final branch head: `6f3269864caba809d41ecc87999da6c8f54e7cde`.

Local clean-source validation:

- adversarial hardening suite: **9 passed**;
- dynamic-contact plus complete multi-contact focused suite: **27 passed**;
- core-compatible repository suite in four isolated clean chunks: **1,013 passed, 14 expected optional/private-runtime skips**;
- Python byte compilation and Git blob identity checks for every published hardening file: passed.

GitHub Actions on the exact final head:

- `CI and release` run `31001194723`: **success**;
- `Extended compatibility` run `31001194742`: **success**;
- Ruff lint, Ruff formatting, and type checks: passed;
- core suites on Python 3.10, 3.11, 3.12, 3.13, and 3.14: passed;
- declared dependency floors: passed;
- pinned BayesianPhysTwin installed-wheel integration: passed;
- frozen milestone manifest validation: passed;
- deterministic result-bundle production, verification, archival, and consumption: passed;
- wheel and source-distribution build and metadata validation: passed;
- isolated wheel and sdist installation plus all CLI help smoke tests: passed.