### PR TITLE
Consume verified scheduled-contact replay banks

### DIFF
--- a/.github/workflows/scheduled-contact-replay-integration.yml
+++ b/.github/workflows/scheduled-contact-replay-integration.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: IPS-Stuttgart/BayesianPhysTwin
-          ref: f4b2bdbe5372e0a1fd9bf88060ce40130fde6247
+          ref: 974c4e28a41ff0b22be7fe06e34c8fe1d00c6100
           path: bayesian-phystwin
           persist-credentials: false
 

--- a/.github/workflows/scheduled-contact-replay-integration.yml
+++ b/.github/workflows/scheduled-contact-replay-integration.yml
@@ -1,0 +1,111 @@
+name: Scheduled-contact replay installed-wheel integration
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/scheduled-contact-replay-integration.yml"
+      - "docs/causal4d_multi_contact_paths.md"
+      - "src/causal4d/multi_contact.py"
+      - "src/causal4d/scheduled_contact_replay.py"
+      - "tests/test_multi_contact.py"
+      - "tests/test_multi_contact_hardening.py"
+      - "tests/test_scheduled_contact_replay_adapter.py"
+      - "tests/test_scheduled_contact_replay_workflow_policy.py"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/scheduled-contact-replay-integration.yml"
+      - "docs/causal4d_multi_contact_paths.md"
+      - "src/causal4d/multi_contact.py"
+      - "src/causal4d/scheduled_contact_replay.py"
+      - "tests/test_multi_contact.py"
+      - "tests/test_multi_contact_hardening.py"
+      - "tests/test_scheduled_contact_replay_adapter.py"
+      - "tests/test_scheduled_contact_replay_workflow_policy.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scheduled-contact-replay-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  installed-wheel-contract:
+    name: BPT schedule contract -> Causal4D rollout bank
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out Causal4D
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: causal4d
+          persist-credentials: false
+
+      - name: Check out exact Bayesian-PhysTwin contract revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/BayesianPhysTwin
+          ref: eb00da3d1628a913e1c0f09bf5e4cc63367cca98
+          path: bayesian-phystwin
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            causal4d/pyproject.toml
+            bayesian-phystwin/pyproject.toml
+
+      - name: Check changed source quality
+        run: |
+          python -m pip install "ruff>=0.15.22,<0.17"
+          python -m ruff check \
+            bayesian-phystwin/src/bayesian_phystwin/contracts/scheduled_replay.py \
+            bayesian-phystwin/tests/test_scheduled_contact_replay_contract.py \
+            causal4d/src/causal4d/multi_contact.py \
+            causal4d/src/causal4d/scheduled_contact_replay.py \
+            causal4d/tests/test_scheduled_contact_replay_adapter.py \
+            causal4d/tests/test_scheduled_contact_replay_workflow_policy.py
+          python -m ruff format --check --diff \
+            bayesian-phystwin/src/bayesian_phystwin/contracts/scheduled_replay.py \
+            bayesian-phystwin/tests/test_scheduled_contact_replay_contract.py \
+            causal4d/src/causal4d/multi_contact.py \
+            causal4d/src/causal4d/scheduled_contact_replay.py \
+            causal4d/tests/test_scheduled_contact_replay_adapter.py \
+            causal4d/tests/test_scheduled_contact_replay_workflow_policy.py
+
+      - name: Build both wheels
+        run: |
+          python -m pip install --upgrade build pip
+          wheelhouse="$RUNNER_TEMP/scheduled-contact-wheelhouse"
+          mkdir -p "$wheelhouse"
+          python -m build --wheel --outdir "$wheelhouse" bayesian-phystwin
+          python -m build --wheel --outdir "$wheelhouse" causal4d
+          test "$(find "$wheelhouse" -maxdepth 1 -name '*.whl' | wc -l)" -eq 2
+
+      - name: Install wheels in an isolated environment
+        run: |
+          venv="$RUNNER_TEMP/scheduled-contact-venv"
+          wheelhouse="$RUNNER_TEMP/scheduled-contact-wheelhouse"
+          python -m venv "$venv"
+          "$venv/bin/python" -m pip install --upgrade pip
+          mapfile -t wheels < <(find "$wheelhouse" -maxdepth 1 -name '*.whl' -print | sort)
+          "$venv/bin/python" -m pip install "${wheels[@]}" pytest
+          "$venv/bin/python" -m pip check
+
+      - name: Exercise the installed cross-repository contract
+        run: |
+          cd "$RUNNER_TEMP"
+          env -u PYTHONPATH \
+            "$RUNNER_TEMP/scheduled-contact-venv/bin/python" -m pytest -q \
+              --import-mode=importlib \
+              "$GITHUB_WORKSPACE/bayesian-phystwin/tests/test_scheduled_contact_replay_contract.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_scheduled_contact_replay_adapter.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_scheduled_contact_replay_workflow_policy.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_multi_contact.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_multi_contact_hardening.py"

--- a/.github/workflows/scheduled-contact-replay-integration.yml
+++ b/.github/workflows/scheduled-contact-replay-integration.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: IPS-Stuttgart/BayesianPhysTwin
-          ref: 974c4e28a41ff0b22be7fe06e34c8fe1d00c6100
+          ref: 58bf6a6f06ad27fce525060190cff787cde58fa4
           path: bayesian-phystwin
           persist-credentials: false
 

--- a/.github/workflows/scheduled-contact-replay-integration.yml
+++ b/.github/workflows/scheduled-contact-replay-integration.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: IPS-Stuttgart/BayesianPhysTwin
-          ref: 511d32fd55daeaf1df6290cb4f0e84bd3fe57604
+          ref: f4b2bdbe5372e0a1fd9bf88060ce40130fde6247
           path: bayesian-phystwin
           persist-credentials: false
 

--- a/.github/workflows/scheduled-contact-replay-integration.yml
+++ b/.github/workflows/scheduled-contact-replay-integration.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: IPS-Stuttgart/BayesianPhysTwin
-          ref: eb00da3d1628a913e1c0f09bf5e4cc63367cca98
+          ref: 511d32fd55daeaf1df6290cb4f0e84bd3fe57604
           path: bayesian-phystwin
           persist-credentials: false
 

--- a/docs/causal4d_multi_contact_paths.md
+++ b/docs/causal4d_multi_contact_paths.md
@@ -55,22 +55,11 @@ continuous simulator execution for that schedule. It must not be assembled by
 splicing independently simulated contact segments, because that would generally
 break state, velocity, and internal-stress continuity.
 
-Use `MultiContactPathBank.from_prior` after a simulator has executed every
-retained schedule:
+The low-level constructor remains available for controlled or synthetic
+providers:
 
 ```python
-from causal4d.multi_contact import (
-    MultiContactEnumerationConfig,
-    MultiContactPathBank,
-    enumerate_multi_contact_paths,
-)
-
-prior = enumerate_multi_contact_paths(
-    command_activation,             # shape (G, T)
-    contact_ids=("left", "right"),
-    transition_configs=(left_config, right_config),
-    config=MultiContactEnumerationConfig(maximum_joint_paths=128),
-)
+from causal4d.multi_contact import MultiContactPathBank
 
 bank = MultiContactPathBank.from_prior(
     prior,
@@ -81,20 +70,71 @@ bank = MultiContactPathBank.from_prior(
 )
 ```
 
+For Bayesian-PhysTwin integration, use the verified adapter instead of supplying
+an arbitrary replay identity:
+
+```python
+from causal4d.multi_contact import (
+    MultiContactEnumerationConfig,
+    enumerate_multi_contact_paths,
+    replay_multi_contact_prior,
+)
+
+prior = enumerate_multi_contact_paths(
+    command_activation,             # shape (G, T)
+    contact_ids=("left", "right"),
+    transition_configs=(left_config, right_config),
+    config=MultiContactEnumerationConfig(maximum_joint_paths=128),
+)
+
+evidence = replay_multi_contact_prior(
+    prior,
+    scheduled_provider,
+    request_id="case-17-contact-bank",
+    simulator_configuration_id=simulator_configuration_id,
+    initial_state_id=twin_endpoint_id,
+    group_log_scales=particle_log_scales,
+    controller_points_m=controller_points,
+    position_m=endpoint_position,
+    velocity_mps=endpoint_velocity,
+    frame_times_s=frame_times,
+    contact_node_indices=contact_patch_indices,
+    contact_node_weights=contact_patch_weights,
+    normal_stiffness_npm=normal_stiffness,
+    tangential_stiffness_npm=tangential_stiffness,
+    friction_coefficient=friction,
+)
+bank = evidence.bank
+```
+
+The adapter loads the additive contracts from
+`bayesian_phystwin.causal4d_provider_v2`, verifies that the runtime provider
+implements `ScheduledContactReplayProviderV1`, checks the provider configuration
+before execution, constructs a content-addressed physical request, revalidates
+the complete result, and then creates the rollout bank. Provider, request, replay,
+configuration, state, schedule, path, regime, and timebase drift fail closed.
+
 The schedule and rollout identities are deliberately separate:
 
 - `schedule_identity` binds contact names, path identifiers, complete regime
   schedules, normalized prior weights, and retained prior mass;
-- `rollout_identity` additionally binds the replay-result identity, explicit
-  timebase, trajectory bytes, and conditional-variance bytes.
+- the Bayesian-PhysTwin request identity additionally binds endpoint state,
+  controller motion, finite-area contact geometry, contact mechanics, physical
+  parameters, and explicit timebase;
+- the provider replay-result identity binds the request plus every returned
+  trajectory, conditional-variance, and provider-revision byte; and
+- Causal4D's `rollout_identity` additionally binds that verified replay identity
+  to the consumed trajectory and variance arrays.
 
 Changing a trajectory, variance tensor, replay identity, or timebase changes the
 rollout identity even when the schedule remains unchanged. Equal arrays with
-different NumPy memory layouts retain the same identity. This supplies a narrow
-content boundary for a future BayesianPhysTwin scheduled-replay provider without
-pretending that an arbitrary caller-supplied replay identifier is independently
-verified. Claim-bearing use can require both a replay-result identity and a
-strictly increasing explicit timebase.
+different NumPy memory layouts retain the same identity. Claim-bearing use can
+require both a replay-result identity and a strictly increasing explicit
+timebase.
+
+The public contract is now implemented, but the ordinary official PhysTwin/Warp
+provider does not yet advertise or implement dynamic scheduled contact. Contract
+validity must not be confused with physical replay competence.
 
 ## Prefix-only normalized likelihood
 
@@ -192,15 +232,17 @@ This implementation deliberately does not claim calibrated real-data contact
 prediction. The contact chains are independent in the prior and currently use
 the single-contact Markov transition parameterization. It does not yet provide
 source-fitted duration distributions, cross-gripper transition coupling, tactile
-label construction, contact-point migration, continuous force-transmission
-parameters, or a BayesianPhysTwin dynamic-schedule replay capability.
+label construction, contact-point migration, calibrated force-transmission
+parameters, or an official PhysTwin/Warp implementation of the scheduled replay
+protocol.
 
 The next evidence-bearing steps are therefore:
 
 1. fit transition, duration, and force-transmission parameters on source
    interactions only;
-2. add an additive BayesianPhysTwin provider capability that executes one
-   continuous rollout per schedule and returns a verified replay-result identity;
+2. implement finite-area moving contact in a Bayesian-PhysTwin provider that
+   executes one continuous rollout per schedule and returns the verified result
+   contract without silently omitting failed paths;
 3. freeze support thresholds and the exact static fallback before target access;
 4. evaluate contact onset, offset, calibration, retained support mass, and
    held-out trajectory prediction on a prospectively reserved cohort; and

--- a/src/causal4d/multi_contact.py
+++ b/src/causal4d/multi_contact.py
@@ -23,6 +23,12 @@ from causal4d._multi_contact_prior import (
     MultiContactPathPrior,
     enumerate_multi_contact_paths,
 )
+from causal4d.scheduled_contact_replay import (
+    ScheduledContactReplayEvidence,
+    ScheduledContactReplayRejectedError,
+    ScheduledContactReplayUnavailableError,
+    replay_multi_contact_prior,
+)
 
 
 __all__ = [
@@ -34,7 +40,11 @@ __all__ = [
     "MultiContactPathBank",
     "MultiContactPathPrior",
     "MultiContactPosterior",
+    "ScheduledContactReplayEvidence",
+    "ScheduledContactReplayRejectedError",
+    "ScheduledContactReplayUnavailableError",
     "enumerate_multi_contact_paths",
     "infer_multi_contact_posterior",
     "multi_contact_conditioned_variance",
+    "replay_multi_contact_prior",
 ]

--- a/src/causal4d/scheduled_contact_replay.py
+++ b/src/causal4d/scheduled_contact_replay.py
@@ -1,0 +1,207 @@
+"""Consume verified Bayesian-PhysTwin joint contact schedule replays."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from types import ModuleType
+
+import numpy as np
+
+from causal4d.multi_contact import MultiContactPathBank, MultiContactPathPrior
+
+
+class ScheduledContactReplayUnavailableError(ImportError):
+    """Raised when the installed Bayesian-PhysTwin lacks the additive contract."""
+
+
+class ScheduledContactReplayRejectedError(ValueError):
+    """Raised when a provider or result drifts from the requested replay boundary."""
+
+
+def _identifier(value: object, *, name: str) -> str:
+    if type(value) is not str or not value or value != value.strip():
+        raise ScheduledContactReplayRejectedError(
+            f"{name} must be a nonempty canonical string"
+        )
+    return value
+
+
+def _provider_contracts() -> ModuleType:
+    try:
+        module = import_module("bayesian_phystwin.causal4d_provider_v2")
+    except ImportError as error:
+        raise ScheduledContactReplayUnavailableError(
+            "Bayesian-PhysTwin provider v2 is not installed"
+        ) from error
+    required = (
+        "ScheduledContactReplayProviderV1",
+        "ScheduledContactReplayRequestV1",
+        "ScheduledContactReplayResultV1",
+        "validate_scheduled_contact_replay_result",
+    )
+    missing = tuple(name for name in required if not hasattr(module, name))
+    if missing:
+        raise ScheduledContactReplayUnavailableError(
+            "installed Bayesian-PhysTwin lacks scheduled-contact replay contracts: "
+            + ", ".join(missing)
+        )
+    return module
+
+
+@dataclass(frozen=True)
+class ScheduledContactReplayEvidence:
+    """Verified replay bank plus portable identities for run-manifest binding."""
+
+    bank: MultiContactPathBank
+    request_identity: str
+    replay_result_identity: str
+    provider_name: str
+    provider_version: str
+    provider_revision: str
+    simulator_configuration_id: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.bank, MultiContactPathBank):
+            raise TypeError("bank must be a MultiContactPathBank")
+        for name in (
+            "request_identity",
+            "replay_result_identity",
+            "provider_name",
+            "provider_version",
+            "provider_revision",
+            "simulator_configuration_id",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _identifier(getattr(self, name), name=name),
+            )
+        if self.bank.replay_result_identity != self.replay_result_identity:
+            raise ScheduledContactReplayRejectedError(
+                "bank replay identity does not match the verified provider result"
+            )
+        if not self.bank.replay_bound:
+            raise ScheduledContactReplayRejectedError(
+                "scheduled replay bank must bind a result identity and timebase"
+            )
+
+
+def replay_multi_contact_prior(
+    prior: MultiContactPathPrior,
+    provider: object,
+    *,
+    request_id: str,
+    simulator_configuration_id: str,
+    initial_state_id: str,
+    group_log_scales: np.ndarray,
+    controller_points_m: np.ndarray,
+    position_m: np.ndarray,
+    velocity_mps: np.ndarray,
+    frame_times_s: np.ndarray,
+    contact_node_indices: np.ndarray,
+    contact_node_weights: np.ndarray,
+    normal_stiffness_npm: np.ndarray | float,
+    tangential_stiffness_npm: np.ndarray | float,
+    friction_coefficient: np.ndarray | float,
+) -> ScheduledContactReplayEvidence:
+    """Replay every retained schedule and construct a provider-bound path bank.
+
+    The installed Bayesian-PhysTwin contract validates finite-area contact
+    geometry, physical parameters, endpoint state, schedule support, and timebase
+    before the provider runs. The result is revalidated before its trajectories
+    can enter ``MultiContactPathBank``.
+    """
+
+    if not isinstance(prior, MultiContactPathPrior):
+        raise TypeError("prior must be a MultiContactPathPrior")
+    contracts = _provider_contracts()
+    provider_protocol = contracts.ScheduledContactReplayProviderV1
+    if not isinstance(provider, provider_protocol):
+        raise TypeError("provider must implement ScheduledContactReplayProviderV1")
+
+    requested_configuration = _identifier(
+        simulator_configuration_id,
+        name="simulator_configuration_id",
+    )
+    provider_configuration = _identifier(
+        provider.simulator_configuration_id,
+        name="provider.simulator_configuration_id",
+    )
+    if provider_configuration != requested_configuration:
+        raise ScheduledContactReplayRejectedError(
+            "provider simulator configuration does not match the request"
+        )
+    provider_revision = _identifier(
+        provider.provider_revision,
+        name="provider.provider_revision",
+    )
+
+    request = contracts.ScheduledContactReplayRequestV1(
+        request_id=request_id,
+        schedule_identity=prior.schedule_identity,
+        simulator_configuration_id=requested_configuration,
+        initial_state_id=initial_state_id,
+        contact_ids=prior.contact_ids,
+        path_ids=prior.path_ids,
+        regime_paths=prior.regime_paths,
+        prior_weights=prior.weights,
+        retained_prior_mass=prior.retained_prior_mass,
+        group_log_scales=group_log_scales,
+        controller_points_m=controller_points_m,
+        position_m=position_m,
+        velocity_mps=velocity_mps,
+        frame_times_s=frame_times_s,
+        contact_node_indices=contact_node_indices,
+        contact_node_weights=contact_node_weights,
+        normal_stiffness_npm=normal_stiffness_npm,
+        tangential_stiffness_npm=tangential_stiffness_npm,
+        friction_coefficient=friction_coefficient,
+    )
+    result = provider.replay_scheduled_contacts(request)
+    if not isinstance(result, contracts.ScheduledContactReplayResultV1):
+        raise ScheduledContactReplayRejectedError(
+            "provider returned the wrong scheduled replay result type"
+        )
+    try:
+        validated = contracts.validate_scheduled_contact_replay_result(
+            request,
+            result,
+        )
+    except (TypeError, ValueError) as error:
+        raise ScheduledContactReplayRejectedError(
+            "provider result failed scheduled replay validation"
+        ) from error
+    if validated.provider_revision != provider_revision:
+        raise ScheduledContactReplayRejectedError(
+            "provider result revision does not match the runtime provider"
+        )
+
+    bank = MultiContactPathBank.from_prior(
+        prior,
+        validated.positions_m,
+        base_variance_m2=validated.conditional_variance_m2,
+        replay_result_identity=validated.replay_result_identity,
+        frame_times_s=validated.frame_times_s,
+    )
+    if bank.schedule_identity != prior.schedule_identity:
+        raise ScheduledContactReplayRejectedError(
+            "constructed bank changed the requested schedule identity"
+        )
+    return ScheduledContactReplayEvidence(
+        bank=bank,
+        request_identity=validated.request_identity,
+        replay_result_identity=validated.replay_result_identity,
+        provider_name=validated.provider_name,
+        provider_version=validated.provider_version,
+        provider_revision=validated.provider_revision,
+        simulator_configuration_id=validated.simulator_configuration_id,
+    )
+
+
+__all__ = [
+    "ScheduledContactReplayEvidence",
+    "ScheduledContactReplayRejectedError",
+    "ScheduledContactReplayUnavailableError",
+    "replay_multi_contact_prior",
+]

--- a/src/causal4d/scheduled_contact_replay.py
+++ b/src/causal4d/scheduled_contact_replay.py
@@ -8,7 +8,8 @@ from types import ModuleType
 
 import numpy as np
 
-from causal4d.multi_contact import MultiContactPathBank, MultiContactPathPrior
+from causal4d._multi_contact_inference import MultiContactPathBank
+from causal4d._multi_contact_prior import MultiContactPathPrior
 
 
 class ScheduledContactReplayUnavailableError(ImportError):

--- a/tests/test_scheduled_contact_replay_adapter.py
+++ b/tests/test_scheduled_contact_replay_adapter.py
@@ -5,13 +5,6 @@ from dataclasses import replace
 import numpy as np
 import pytest
 
-provider_api = pytest.importorskip("bayesian_phystwin.causal4d_provider_v2")
-if not hasattr(provider_api, "ScheduledContactReplayProviderV1"):
-    pytest.skip(
-        "installed Bayesian-PhysTwin lacks scheduled replay contracts",
-        allow_module_level=True,
-    )
-
 from causal4d.multi_contact import MultiContactPathPrior
 from causal4d.scheduled_contact_replay import (
     ScheduledContactReplayRejectedError,
@@ -19,6 +12,13 @@ from causal4d.scheduled_contact_replay import (
     replay_multi_contact_prior,
 )
 import causal4d.scheduled_contact_replay as scheduled_replay
+
+provider_api = pytest.importorskip("bayesian_phystwin.causal4d_provider_v2")
+if not hasattr(provider_api, "ScheduledContactReplayProviderV1"):
+    pytest.skip(
+        "installed Bayesian-PhysTwin lacks scheduled replay contracts",
+        allow_module_level=True,
+    )
 
 
 def _prior() -> MultiContactPathPrior:

--- a/tests/test_scheduled_contact_replay_adapter.py
+++ b/tests/test_scheduled_contact_replay_adapter.py
@@ -5,13 +5,13 @@ from dataclasses import replace
 import numpy as np
 import pytest
 
+import causal4d.scheduled_contact_replay as scheduled_replay
 from causal4d.multi_contact import MultiContactPathPrior
 from causal4d.scheduled_contact_replay import (
     ScheduledContactReplayRejectedError,
     ScheduledContactReplayUnavailableError,
     replay_multi_contact_prior,
 )
-import causal4d.scheduled_contact_replay as scheduled_replay
 
 provider_api = pytest.importorskip("bayesian_phystwin.causal4d_provider_v2")
 if not hasattr(provider_api, "ScheduledContactReplayProviderV1"):

--- a/tests/test_scheduled_contact_replay_adapter.py
+++ b/tests/test_scheduled_contact_replay_adapter.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+provider_api = pytest.importorskip("bayesian_phystwin.causal4d_provider_v2")
+if not hasattr(provider_api, "ScheduledContactReplayProviderV1"):
+    pytest.skip(
+        "installed Bayesian-PhysTwin lacks scheduled replay contracts",
+        allow_module_level=True,
+    )
+
+from causal4d.multi_contact import MultiContactPathPrior
+from causal4d.scheduled_contact_replay import (
+    ScheduledContactReplayRejectedError,
+    ScheduledContactReplayUnavailableError,
+    replay_multi_contact_prior,
+)
+import causal4d.scheduled_contact_replay as scheduled_replay
+
+
+def _prior() -> MultiContactPathPrior:
+    return MultiContactPathPrior(
+        contact_ids=("left", "right"),
+        path_ids=("path-a", "path-b"),
+        regime_paths=np.asarray(
+            [
+                [[0, 1, 1, 3], [0, 0, 2, 3]],
+                [[0, 0, 1, 3], [0, 1, 1, 3]],
+            ],
+            dtype=np.int8,
+        ),
+        weights=np.asarray((0.6, 0.4)),
+        retained_prior_mass=0.9,
+        marginal_retained_prior_mass=np.asarray((1.0, 1.0)),
+        marginal_path_indices=np.asarray(((0, 0), (1, 1))),
+        marginal_path_counts=np.asarray((2, 2)),
+    )
+
+
+def _contact_geometry(
+    prior: MultiContactPathPrior,
+) -> tuple[np.ndarray, np.ndarray]:
+    indices = np.full((*prior.regime_paths.shape, 2), -1, dtype=np.int64)
+    weights = np.zeros(indices.shape, dtype=float)
+    active = (prior.regime_paths == 1) | (prior.regime_paths == 2)
+    for path_index, contact_index, frame_index in np.argwhere(active):
+        indices[path_index, contact_index, frame_index] = (0, 1)
+        weights[path_index, contact_index, frame_index] = (0.25, 0.75)
+    return indices, weights
+
+
+def _call(provider):
+    prior = _prior()
+    indices, weights = _contact_geometry(prior)
+    return replay_multi_contact_prior(
+        prior,
+        provider,
+        request_id="scheduled-001",
+        simulator_configuration_id="sim-config-001",
+        initial_state_id="endpoint-001",
+        group_log_scales=np.asarray((0.1, -0.2)),
+        controller_points_m=np.zeros((4, 2, 3)),
+        position_m=np.zeros((3, 3)),
+        velocity_mps=np.zeros((3, 3)),
+        frame_times_s=np.asarray((0.0, 0.04, 0.08, 0.12)),
+        contact_node_indices=indices,
+        contact_node_weights=weights,
+        normal_stiffness_npm=10.0,
+        tangential_stiffness_npm=np.asarray((2.0, 3.0)),
+        friction_coefficient=0.5,
+    )
+
+
+class _FakeProvider:
+    simulator_configuration_id = "sim-config-001"
+    provider_revision = "provider-revision-001"
+
+    def __init__(self, *, mode: str = "valid") -> None:
+        self.mode = mode
+        self.calls = 0
+        self.request = None
+
+    def replay_scheduled_contacts(self, request):
+        self.calls += 1
+        self.request = request
+        if self.mode == "wrong-type":
+            return object()
+        result = provider_api.ScheduledContactReplayResultV1.from_request(
+            request,
+            positions_m=np.zeros((2, 4, 3, 3)),
+            velocities_mps=np.zeros((2, 4, 3, 3)),
+            conditional_variance_m2=1e-6,
+            provider_name="fake-phystwin",
+            provider_version="0.4.0",
+            provider_revision=(
+                "other-revision"
+                if self.mode == "revision-drift"
+                else self.provider_revision
+            ),
+        )
+        if self.mode == "request-drift":
+            result = replace(result, request_identity="other-request")
+        return result
+
+    def close(self) -> None:
+        return None
+
+
+def test_adapter_constructs_a_verified_replay_bound_bank() -> None:
+    provider = _FakeProvider()
+
+    evidence = _call(provider)
+
+    assert provider.calls == 1
+    assert provider.request.schedule_identity == _prior().schedule_identity
+    assert provider.request.contact_ids == ("left", "right")
+    assert evidence.bank.replay_bound
+    assert evidence.bank.schedule_identity == _prior().schedule_identity
+    assert evidence.bank.replay_result_identity == evidence.replay_result_identity
+    assert evidence.request_identity == provider.request.request_identity
+    assert evidence.provider_revision == provider.provider_revision
+    assert evidence.bank.trajectories_m.shape == (2, 4, 3, 3)
+    assert evidence.bank.base_variance_m2.shape == ()
+
+
+def test_configuration_mismatch_fails_before_provider_execution() -> None:
+    provider = _FakeProvider()
+    provider.simulator_configuration_id = "other-config"
+
+    with pytest.raises(ScheduledContactReplayRejectedError, match="configuration"):
+        _call(provider)
+
+    assert provider.calls == 0
+
+
+@pytest.mark.parametrize(
+    ("mode", "message"),
+    (
+        ("wrong-type", "wrong scheduled replay result type"),
+        ("revision-drift", "revision does not match"),
+        ("request-drift", "failed scheduled replay validation"),
+    ),
+)
+def test_provider_result_drift_is_rejected(mode: str, message: str) -> None:
+    provider = _FakeProvider(mode=mode)
+
+    with pytest.raises(ScheduledContactReplayRejectedError, match=message):
+        _call(provider)
+
+
+def test_missing_provider_contract_has_a_clear_additive_compatibility_error(
+    monkeypatch,
+) -> None:
+    class _LegacyProviderModule:
+        pass
+
+    monkeypatch.setattr(
+        scheduled_replay,
+        "import_module",
+        lambda name: _LegacyProviderModule(),
+    )
+
+    with pytest.raises(ScheduledContactReplayUnavailableError, match="lacks"):
+        scheduled_replay._provider_contracts()

--- a/tests/test_scheduled_contact_replay_workflow_policy.py
+++ b/tests/test_scheduled_contact_replay_workflow_policy.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 
 WORKFLOW = Path(".github/workflows/scheduled-contact-replay-integration.yml")
-BPT_CONTRACT_REVISION = "f4b2bdbe5372e0a1fd9bf88060ce40130fde6247"
+BPT_CONTRACT_REVISION = "974c4e28a41ff0b22be7fe06e34c8fe1d00c6100"
 
 
 def test_scheduled_replay_workflow_uses_exact_public_provider_revision() -> None:

--- a/tests/test_scheduled_contact_replay_workflow_policy.py
+++ b/tests/test_scheduled_contact_replay_workflow_policy.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 
 WORKFLOW = Path(".github/workflows/scheduled-contact-replay-integration.yml")
-BPT_CONTRACT_REVISION = "974c4e28a41ff0b22be7fe06e34c8fe1d00c6100"
+BPT_CONTRACT_REVISION = "58bf6a6f06ad27fce525060190cff787cde58fa4"
 
 
 def test_scheduled_replay_workflow_uses_exact_public_provider_revision() -> None:

--- a/tests/test_scheduled_contact_replay_workflow_policy.py
+++ b/tests/test_scheduled_contact_replay_workflow_policy.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WORKFLOW = Path(".github/workflows/scheduled-contact-replay-integration.yml")
+BPT_CONTRACT_REVISION = "eb00da3d1628a913e1c0f09bf5e4cc63367cca98"
+
+
+def test_scheduled_replay_workflow_uses_exact_public_provider_revision() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "repository: IPS-Stuttgart/BayesianPhysTwin" in text
+    assert f"ref: {BPT_CONTRACT_REVISION}" in text
+    assert "persist-credentials: false" in text
+    assert "BPT_READ_SSH_KEY" not in text
+
+
+def test_scheduled_replay_workflow_exercises_installed_wheels() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "python -m build --wheel" in text
+    assert "scheduled-contact-wheelhouse" in text
+    assert "scheduled-contact-venv" in text
+    assert "--import-mode=importlib" in text
+    assert "env -u PYTHONPATH" in text
+    assert "test_scheduled_contact_replay_contract.py" in text
+    assert "test_scheduled_contact_replay_adapter.py" in text
+    assert "test_multi_contact_hardening.py" in text
+
+
+def test_scheduled_replay_workflow_pins_external_actions() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert text.count(
+        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+    ) == 2
+    assert (
+        "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97"
+        in text
+    )
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("uses:"):
+            assert "@" in stripped
+            reference = stripped.rsplit("@", 1)[1].split()[0]
+            assert len(reference) == 40
+            assert all(character in "0123456789abcdef" for character in reference)

--- a/tests/test_scheduled_contact_replay_workflow_policy.py
+++ b/tests/test_scheduled_contact_replay_workflow_policy.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 
 WORKFLOW = Path(".github/workflows/scheduled-contact-replay-integration.yml")
-BPT_CONTRACT_REVISION = "511d32fd55daeaf1df6290cb4f0e84bd3fe57604"
+BPT_CONTRACT_REVISION = "f4b2bdbe5372e0a1fd9bf88060ce40130fde6247"
 
 
 def test_scheduled_replay_workflow_uses_exact_public_provider_revision() -> None:

--- a/tests/test_scheduled_contact_replay_workflow_policy.py
+++ b/tests/test_scheduled_contact_replay_workflow_policy.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 
 WORKFLOW = Path(".github/workflows/scheduled-contact-replay-integration.yml")
-BPT_CONTRACT_REVISION = "eb00da3d1628a913e1c0f09bf5e4cc63367cca98"
+BPT_CONTRACT_REVISION = "511d32fd55daeaf1df6290cb4f0e84bd3fe57604"
 
 
 def test_scheduled_replay_workflow_uses_exact_public_provider_revision() -> None:


### PR DESCRIPTION
## Summary

Connect the merged factorized multi-contact posterior to the additive Bayesian-PhysTwin scheduled-replay contract from IPS-Stuttgart/BayesianPhysTwin#157.

- add `replay_multi_contact_prior()` as the public verified path from `MultiContactPathPrior` to `MultiContactPathBank`;
- construct the complete Bayesian-PhysTwin request from the Causal4D schedule, endpoint state, controller motion, finite-area contact patches, stiffness, friction, physical parameters, and explicit timebase;
- verify the runtime provider protocol and simulator configuration before execution;
- revalidate the complete result, exact request identity, schedule, paths, regimes, state, timebase, and provider revision before any trajectory enters Causal4D;
- bind the verified provider result identity into the existing rollout-bank identity and return portable provider/request evidence for run manifests;
- fail clearly when the additive provider contract is absent, preserving compatibility with released Bayesian-PhysTwin versions;
- re-export the adapter from `causal4d.multi_contact` and update the multi-contact design document;
- add adversarial provider-drift and configuration tests;
- add an exact-revision installed-wheel workflow that builds both repositories and exercises the complete contract outside both source checkouts.

## Dependency

Validated against the reviewed BayesianPhysTwin #157 squash merge revision `58bf6a6f06ad27fce525060190cff787cde58fa4`.

## Why

The multi-contact inference layer previously accepted an arbitrary external replay-result string. That was sufficient for controlled fake providers but not for claim-bearing physical replay. This change makes the provider request and result independently content-addressed and fail-closed at the repository boundary.

## Scientific boundary

This PR does not implement finite-area contact mechanics in official PhysTwin/Warp, establish source mechanics competence, fit contact durations or force transmission, open target data, modify the frozen 36-execution protocol, or promote any paper claim. It only makes a future backend auditable and consumable.

## Validation status

Current exact head: `268e9900197d0966123d997a43a044434f716276`.

- the installed-wheel workflow is pinned to the merged BayesianPhysTwin provider-contract revision;
- the adapter import-order defect found during focused validation has been corrected;
- the exact-head installed-wheel, core CI, and extended-compatibility jobs are queued;
- the workflow reads no dataset or target outcomes.