### PR TITLE
Consume source-calibrated horizon discrepancy forecasts

### DIFF
--- a/.github/workflows/horizon-discrepancy-integration.yml
+++ b/.github/workflows/horizon-discrepancy-integration.yml
@@ -1,0 +1,106 @@
+name: Horizon-discrepancy installed-wheel integration
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/horizon-discrepancy-integration.yml"
+      - "docs/causal4d_horizon_discrepancy.md"
+      - "src/causal4d/belief_provider_v2_contract.py"
+      - "src/causal4d/horizon_discrepancy.py"
+      - "tests/test_belief_provider_v2_contract.py"
+      - "tests/test_horizon_discrepancy.py"
+      - "tests/test_horizon_discrepancy_workflow_policy.py"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/horizon-discrepancy-integration.yml"
+      - "docs/causal4d_horizon_discrepancy.md"
+      - "src/causal4d/belief_provider_v2_contract.py"
+      - "src/causal4d/horizon_discrepancy.py"
+      - "tests/test_belief_provider_v2_contract.py"
+      - "tests/test_horizon_discrepancy.py"
+      - "tests/test_horizon_discrepancy_workflow_policy.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: horizon-discrepancy-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  installed-wheel-contract:
+    name: BPT horizon provider -> Causal4D discrepancy bank
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out Causal4D
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: causal4d
+          persist-credentials: false
+
+      - name: Check out exact Bayesian-PhysTwin horizon-provider revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/BayesianPhysTwin
+          ref: bfa844798f0ab3ddbc67a0744ae14a221324e504
+          path: bayesian-phystwin
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            causal4d/pyproject.toml
+            bayesian-phystwin/pyproject.toml
+
+      - name: Check changed source quality
+        run: |
+          python -m pip install "ruff>=0.15.22,<0.17"
+          python -m ruff check \
+            causal4d/src/causal4d/belief_provider_v2_contract.py \
+            causal4d/src/causal4d/horizon_discrepancy.py \
+            causal4d/tests/test_belief_provider_v2_contract.py \
+            causal4d/tests/test_horizon_discrepancy.py \
+            causal4d/tests/test_horizon_discrepancy_workflow_policy.py
+          python -m ruff format --check --diff \
+            causal4d/src/causal4d/belief_provider_v2_contract.py \
+            causal4d/src/causal4d/horizon_discrepancy.py \
+            causal4d/tests/test_belief_provider_v2_contract.py \
+            causal4d/tests/test_horizon_discrepancy.py \
+            causal4d/tests/test_horizon_discrepancy_workflow_policy.py
+
+      - name: Build both wheels
+        run: |
+          python -m pip install --upgrade build pip
+          wheelhouse="$RUNNER_TEMP/horizon-discrepancy-wheelhouse"
+          mkdir -p "$wheelhouse"
+          python -m build --wheel --outdir "$wheelhouse" bayesian-phystwin
+          python -m build --wheel --outdir "$wheelhouse" causal4d
+          test "$(find "$wheelhouse" -maxdepth 1 -name '*.whl' | wc -l)" -eq 2
+
+      - name: Install wheels in an isolated environment
+        run: |
+          venv="$RUNNER_TEMP/horizon-discrepancy-venv"
+          wheelhouse="$RUNNER_TEMP/horizon-discrepancy-wheelhouse"
+          python -m venv "$venv"
+          "$venv/bin/python" -m pip install --upgrade pip
+          mapfile -t wheels < <(find "$wheelhouse" -maxdepth 1 -name '*.whl' -print | sort)
+          "$venv/bin/python" -m pip install "${wheels[@]}" pytest
+          "$venv/bin/python" -m pip check
+
+      - name: Exercise the installed cross-repository contract
+        run: |
+          cd "$RUNNER_TEMP"
+          env -u PYTHONPATH \
+            "$RUNNER_TEMP/horizon-discrepancy-venv/bin/python" -m pytest -q \
+              --import-mode=importlib \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_belief_provider_contract.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_belief_provider_v2_contract.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_horizon_discrepancy.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_horizon_discrepancy_workflow_policy.py"

--- a/.github/workflows/horizon-discrepancy-self-hosted.yml
+++ b/.github/workflows/horizon-discrepancy-self-hosted.yml
@@ -1,0 +1,92 @@
+name: Horizon-discrepancy self-hosted validation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/horizon-discrepancy-self-hosted.yml"
+      - "docs/causal4d_horizon_discrepancy.md"
+      - "src/causal4d/belief_provider_v2_contract.py"
+      - "src/causal4d/horizon_discrepancy.py"
+      - "tests/test_belief_provider_v2_contract.py"
+      - "tests/test_horizon_discrepancy.py"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: horizon-discrepancy-self-hosted-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: Provider-v2 horizon discrepancy contracts
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    timeout-minutes: 25
+    steps:
+      - name: Check out exact Causal4D pull-request head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: causal4d
+          persist-credentials: false
+          clean: true
+
+      - name: Check out exact Bayesian-PhysTwin horizon-provider revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/BayesianPhysTwin
+          ref: bfa844798f0ab3ddbc67a0744ae14a221324e504
+          path: bayesian-phystwin
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Build isolated installed-wheel environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m venv "$RUNNER_TEMP/horizon-discrepancy-self-hosted-venv"
+          py="$RUNNER_TEMP/horizon-discrepancy-self-hosted-venv/bin/python"
+          "$py" -m pip install --upgrade pip build
+          wheelhouse="$RUNNER_TEMP/horizon-discrepancy-self-hosted-wheelhouse"
+          mkdir -p "$wheelhouse"
+          "$py" -m build --wheel --outdir "$wheelhouse" bayesian-phystwin
+          "$py" -m build --wheel --outdir "$wheelhouse" causal4d
+          mapfile -t wheels < <(find "$wheelhouse" -maxdepth 1 -name '*.whl' -print | sort)
+          test "${#wheels[@]}" -eq 2
+          "$py" -m pip install "${wheels[@]}" pytest "ruff>=0.15.22,<0.17"
+          "$py" -m pip check
+
+      - name: Check focused source quality
+        shell: bash
+        run: |
+          set -euo pipefail
+          py="$RUNNER_TEMP/horizon-discrepancy-self-hosted-venv/bin/python"
+          "$py" -m ruff check \
+            causal4d/src/causal4d/belief_provider_v2_contract.py \
+            causal4d/src/causal4d/horizon_discrepancy.py \
+            causal4d/tests/test_belief_provider_v2_contract.py \
+            causal4d/tests/test_horizon_discrepancy.py
+          "$py" -m ruff format --check --diff \
+            causal4d/src/causal4d/belief_provider_v2_contract.py \
+            causal4d/src/causal4d/horizon_discrepancy.py \
+            causal4d/tests/test_belief_provider_v2_contract.py \
+            causal4d/tests/test_horizon_discrepancy.py
+
+      - name: Run installed provider and bank contracts
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP"
+          env -u PYTHONPATH \
+            "$RUNNER_TEMP/horizon-discrepancy-self-hosted-venv/bin/python" \
+            -m pytest -q --import-mode=importlib \
+            "$GITHUB_WORKSPACE/causal4d/tests/test_belief_provider_contract.py" \
+            "$GITHUB_WORKSPACE/causal4d/tests/test_belief_provider_v2_contract.py" \
+            "$GITHUB_WORKSPACE/causal4d/tests/test_horizon_discrepancy.py"

--- a/docs/causal4d_horizon_discrepancy.md
+++ b/docs/causal4d_horizon_discrepancy.md
@@ -1,0 +1,116 @@
+# Horizon-conditioned Bayesian-PhysTwin discrepancy
+
+## Status and claim boundary
+
+This is an additive development path for consuming Bayesian-PhysTwin's
+source-calibrated horizon discrepancy provider. It does not change the frozen
+Causal4D estimator, the registered 36-execution protocol, or any completed
+result. In particular, it does not describe raw covariance as calibrated and it
+does not use target outcomes to choose horizon dynamics.
+
+The motivation is the completed real undercoverage audit: discrepancy uncertainty
+changes materially with prediction horizon, while one global affine covariance
+multiplier transferred harmfully across actions. The new adapter preserves the
+source-frozen mean-retention and process-growth semantics instead of applying one
+post-hoc target inflation.
+
+## Provider boundary
+
+`causal4d.belief_provider_v2_contract` validates the additive
+`bayesian_phystwin.causal4d_belief_provider_v2` manifest before any residual or
+prediction payload is consumed. The required capabilities include:
+
+- evidence-weighted endpoint model averaging;
+- horizon-dependent predictive covariance;
+- source-calibrated horizon discrepancy;
+- mean-reverting discrepancy prediction;
+- per-track component evidence; and
+- immutable endpoint artifacts.
+
+The original fixed-anchor provider-v1 contract remains unchanged and continues to
+own frozen reproductions.
+
+## Bank construction
+
+`build_horizon_discrepancy_bank()` takes:
+
+- one immutable Causal4D `TwinBelief`;
+- one Bayesian-PhysTwin `ModelAveragedEndpointPosteriorV1` per physical particle;
+- one source-only `HorizonDiscrepancyCalibrationV1`;
+- a registered horizon set containing zero;
+- the fixed tracked-to-state readout map; and
+- an optional discrepancy-norm cap fixed before target access.
+
+For every physical particle and horizon, Bayesian-PhysTwin predicts tracked-node
+mean and covariance. Causal4D then lifts those moments to the complete physical
+state. If an untracked state node is represented by fixed readout weights
+`w_j`, the current covariance lift is
+
+```text
+mu_extra = sum_j w_j mu_j
+Sigma_extra = sum_j w_j^2 Sigma_j
+```
+
+The covariance expression assumes conditionally independent tracked-node
+errors. This assumption is retained explicitly in the artifact metadata; the
+adapter does not manufacture unobserved cross-node covariance.
+
+The returned `HorizonDiscrepancyBankV1` stores:
+
+```text
+mean_m                         (P, H, N, 3)
+covariance_m2                  (P, H, N, 3, 3)
+horizon_steps                  (H,)
+mean_retention                 (H,)
+additional_axis_variance_m2    (H, 3)
+particle_weights               (P,)
+```
+
+It binds the exact `TwinBelief` artifact, particle identities and weights,
+calibration artifact, provider revision, source-group declaration, readout
+semantics, optional cap, and every numerical array into one SHA-256 identity.
+
+## Horizon-zero parity
+
+Every bank must contain horizon zero. At horizon zero, Bayesian-PhysTwin must
+return the endpoint posterior moments without process growth:
+
+```text
+mean_retention = 1
+additional_axis_variance = 0
+```
+
+This supplies an executable parity check between the endpoint posterior and the
+horizon-conditioned path before any positive-horizon result is interpreted.
+
+## Information boundary
+
+The adapter receives already inferred causal-prefix posteriors. It reads no
+future observations and records `future_observations_read = 0`. The calibration
+contract itself requires at least two independent source groups and rejects
+interval-calibration, confirmation, or target outcomes as selectors of horizon
+dynamics.
+
+A future claim-bearing protocol must still keep source fitting, interval
+calibration, and target evaluation as separate stages. Passing the provider and
+artifact contracts establishes lineage and numerical semantics, not empirical
+coverage.
+
+## Current limitations
+
+This first consumer conditions discrepancy on horizon only. It does not yet fit
+or select graph-region, action-family, or contact-regime calibration. It also
+propagates tracked-node covariance through a fixed independent-readout
+approximation. These limitations must be reported rather than hidden by a global
+inflation factor.
+
+The next evidence step is a source/calibration-separated comparison of:
+
+1. raw model-averaged endpoint covariance;
+2. horizon-conditioned discrepancy covariance;
+3. horizon plus predeclared graph-region conditioning; and
+4. exact uncalibrated fallback.
+
+The evaluation unit must be the independent execution or session, not frames,
+vertices, or coordinates. Report coverage, interval width, NLL or energy score,
+and worst-group coverage together.

--- a/src/causal4d/belief_provider_v2_contract.py
+++ b/src/causal4d/belief_provider_v2_contract.py
@@ -1,0 +1,150 @@
+"""Compatibility contract for Bayesian-PhysTwin horizon discrepancy provider v2."""
+
+from __future__ import annotations
+
+import json
+
+from causal4d.provider_contract import (
+    BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE,
+    PhysicalBeliefProviderManifest,
+    ProviderCompatibilityResult,
+    validate_provider_compatibility,
+)
+
+BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API = (
+    "bayesian_phystwin.causal4d_belief_provider_v2"
+)
+BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API_VERSION = 2
+BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_CAPABILITIES = (
+    "causal_prefix_endpoint_inference",
+    "evidence_weighted_endpoint_model_average",
+    "horizon_dependent_predictive_covariance",
+    "source_calibrated_horizon_discrepancy",
+    "mean_reverting_discrepancy_prediction",
+    "immutable_endpoint_posterior",
+    "numpy_only_endpoint_inference",
+    "per_track_component_evidence",
+    "residual_finite_preflight",
+)
+BAYESIAN_PHYSTWIN_BELIEF_V2_ARTIFACT_SCHEMA_VERSIONS = {
+    "ModelAveragedEndpointConfig": 1,
+    "ModelAveragedEndpointPosterior": 1,
+    "ModelAveragedEndpointPrediction": 1,
+    "HorizonDiscrepancyCalibration": 1,
+    "HorizonConditionedEndpointPrediction": 1,
+}
+BAYESIAN_PHYSTWIN_BELIEF_V2_INFERENCE_ROLE = (
+    "model-averaged robust readout-discrepancy endpoint"
+)
+BAYESIAN_PHYSTWIN_BELIEF_V2_COMPATIBILITY = (
+    "additive provider; causal4d_belief_provider_v1 is unchanged"
+)
+BAYESIAN_PHYSTWIN_BELIEF_V2_RAW_COVARIANCE_CLAIM = (
+    "model-based predictive covariance; source-calibrated horizon dynamics and "
+    "interval calibration remain separate gates"
+)
+
+
+def load_bayesian_phystwin_belief_provider_v2_manifest(
+    *,
+    provider_revision: str | None = None,
+) -> PhysicalBeliefProviderManifest:
+    """Load BPT's additive model-averaged horizon provider descriptor."""
+
+    if provider_revision is not None and (
+        type(provider_revision) is not str or not provider_revision
+    ):
+        raise ValueError("provider_revision must be a nonempty string")
+    from bayesian_phystwin.causal4d_belief_provider_v2 import (
+        causal4d_belief_provider_v2_manifest,
+    )
+
+    values = causal4d_belief_provider_v2_manifest(
+        provider_revision=provider_revision
+    )
+    manifest = PhysicalBeliefProviderManifest.from_provider_descriptor(values)
+    if (
+        provider_revision is not None
+        and manifest.provider_revision != provider_revision
+    ):
+        raise ValueError(
+            "belief provider v2 descriptor revision does not match requested revision"
+        )
+    return manifest
+
+
+def _validate_belief_provider_v2_metadata(
+    manifest: PhysicalBeliefProviderManifest,
+) -> None:
+    expected = {
+        "provider_api": BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API,
+        "provider_api_version": BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API_VERSION,
+        "inference_role": BAYESIAN_PHYSTWIN_BELIEF_V2_INFERENCE_ROLE,
+        "compatibility": BAYESIAN_PHYSTWIN_BELIEF_V2_COMPATIBILITY,
+        "raw_covariance_claim": BAYESIAN_PHYSTWIN_BELIEF_V2_RAW_COVARIANCE_CLAIM,
+    }
+    mismatches = {}
+    for name, value in expected.items():
+        actual = manifest.metadata.get(name)
+        if type(actual) is not type(value) or actual != value:
+            mismatches[name] = (value, actual)
+    if mismatches:
+        raise ValueError(
+            "unexpected Bayesian-PhysTwin belief provider v2 metadata: "
+            + json.dumps(mismatches, sort_keys=True)
+        )
+
+
+def validate_bayesian_phystwin_belief_provider_v2(
+    manifest: PhysicalBeliefProviderManifest | None = None,
+    *,
+    provider_revision: str | None = None,
+) -> ProviderCompatibilityResult:
+    """Validate the additive horizon-discrepancy provider contract."""
+
+    candidate = manifest or load_bayesian_phystwin_belief_provider_v2_manifest(
+        provider_revision=provider_revision
+    )
+    if candidate.provider_name != "bayesian-phystwin":
+        raise ValueError("expected the bayesian-phystwin belief provider v2")
+    _validate_belief_provider_v2_metadata(candidate)
+    return validate_provider_compatibility(
+        candidate,
+        required_capabilities=BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_CAPABILITIES,
+        supported_provider_versions=BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE,
+        required_artifact_versions=(
+            BAYESIAN_PHYSTWIN_BELIEF_V2_ARTIFACT_SCHEMA_VERSIONS
+        ),
+    )
+
+
+def require_bayesian_phystwin_belief_provider_v2(
+    *,
+    provider_revision: str | None = None,
+) -> PhysicalBeliefProviderManifest:
+    """Return the installed v2 manifest or fail before opening residual inputs."""
+
+    manifest = load_bayesian_phystwin_belief_provider_v2_manifest(
+        provider_revision=provider_revision
+    )
+    result = validate_bayesian_phystwin_belief_provider_v2(manifest)
+    if not result.compatible:
+        raise RuntimeError(
+            "incompatible Bayesian-PhysTwin belief provider v2: "
+            + json.dumps(result.as_dict(), sort_keys=True)
+        )
+    return manifest
+
+
+__all__ = [
+    "BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API",
+    "BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API_VERSION",
+    "BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_CAPABILITIES",
+    "BAYESIAN_PHYSTWIN_BELIEF_V2_ARTIFACT_SCHEMA_VERSIONS",
+    "BAYESIAN_PHYSTWIN_BELIEF_V2_COMPATIBILITY",
+    "BAYESIAN_PHYSTWIN_BELIEF_V2_INFERENCE_ROLE",
+    "BAYESIAN_PHYSTWIN_BELIEF_V2_RAW_COVARIANCE_CLAIM",
+    "load_bayesian_phystwin_belief_provider_v2_manifest",
+    "require_bayesian_phystwin_belief_provider_v2",
+    "validate_bayesian_phystwin_belief_provider_v2",
+]

--- a/src/causal4d/horizon_discrepancy.py
+++ b/src/causal4d/horizon_discrepancy.py
@@ -1,0 +1,473 @@
+"""Source-calibrated horizon discrepancy forecasts for Causal4D twin beliefs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import hashlib
+import json
+from numbers import Real
+from typing import Any
+
+import numpy as np
+
+from causal4d.belief_provider_v2_contract import (
+    require_bayesian_phystwin_belief_provider_v2,
+)
+from causal4d.contracts import TwinBelief, array_sha256
+from causal4d.immutable_array import readonly_array
+from causal4d.immutable_json import validated_json_mapping
+
+
+HORIZON_DISCREPANCY_BANK_SCHEMA_VERSION = "causal4d.horizon_discrepancy_bank.v1"
+
+
+def _identifier(value: object, *, name: str) -> str:
+    if type(value) is not str or not value or value != value.strip():
+        raise ValueError(f"{name} must be a nonempty canonical string")
+    return value
+
+
+def _sha256(value: object, *, name: str) -> str:
+    result = _identifier(value, name=name)
+    if len(result) != 64 or any(
+        character not in "0123456789abcdef" for character in result
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return result
+
+
+def _identifiers(
+    values: Sequence[str],
+    *,
+    name: str,
+    expected_count: int,
+) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)):
+        raise ValueError(f"{name} must be a sequence of strings")
+    result = tuple(_identifier(value, name=name) for value in values)
+    if len(result) != expected_count:
+        raise ValueError(f"{name} must identify every particle")
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must not contain duplicates")
+    return result
+
+
+def _horizons(values: Sequence[int]) -> np.ndarray:
+    if isinstance(values, (str, bytes)):
+        raise ValueError("horizon_steps must be a sequence of integers")
+    raw = tuple(values)
+    if not raw:
+        raise ValueError("horizon_steps must be nonempty")
+    if any(type(value) is not int or value < 0 for value in raw):
+        raise ValueError("horizon_steps must contain nonnegative integers")
+    if len(set(raw)) != len(raw):
+        raise ValueError("horizon_steps must not contain duplicates")
+    result = np.asarray(sorted(raw), dtype=np.int64)
+    if result[0] != 0:
+        raise ValueError("horizon_steps must include zero as an endpoint parity control")
+    result.setflags(write=False)
+    return result
+
+
+def _probability_vector(values: np.ndarray, *, name: str) -> np.ndarray:
+    result = readonly_array(values, dtype=float)
+    if result.ndim != 1 or not len(result):
+        raise ValueError(f"{name} must be a nonempty vector")
+    if not np.all(np.isfinite(result)) or np.any(
+        (result < 0.0) | (result > 1.0)
+    ):
+        raise ValueError(f"{name} must contain finite probabilities")
+    return result
+
+
+def _particle_weights(values: np.ndarray, particle_count: int) -> np.ndarray:
+    weights = _probability_vector(values, name="particle_weights")
+    if weights.shape != (particle_count,) or not np.isclose(
+        np.sum(weights),
+        1.0,
+        rtol=1e-10,
+        atol=1e-10,
+    ):
+        raise ValueError("particle_weights must identify every particle and sum to one")
+    return weights
+
+
+def _maximum_norm(value: float | None) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise ValueError("maximum_discrepancy_m must be a positive real or null")
+    result = float(value)
+    if not np.isfinite(result) or result <= 0.0:
+        raise ValueError("maximum_discrepancy_m must be positive and finite")
+    return result
+
+
+def _validate_covariance(values: np.ndarray, *, name: str) -> None:
+    if not np.all(np.isfinite(values)):
+        raise ValueError(f"{name} must contain only finite values")
+    if not np.allclose(values, values.swapaxes(-1, -2), rtol=0.0, atol=1e-12):
+        raise ValueError(f"{name} must be symmetric")
+    if np.min(np.linalg.eigvalsh(values), initial=0.0) < -1e-12:
+        raise ValueError(f"{name} must be positive semidefinite")
+
+
+def _lift_map(
+    indices: np.ndarray,
+    weights: np.ndarray,
+    *,
+    tracked_count: int,
+    state_count: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    raw_indices = np.asarray(indices)
+    if not np.issubdtype(raw_indices.dtype, np.integer):
+        raise ValueError("lift_indices must contain integers")
+    neighbor_indices = np.array(raw_indices, dtype=np.int64, copy=True, order="C")
+    neighbor_weights = np.array(weights, dtype=np.float64, copy=True, order="C")
+    extra_count = state_count - tracked_count
+    if extra_count < 0:
+        raise ValueError("tracked endpoint count exceeds the physical state")
+    if (
+        neighbor_indices.ndim != 2
+        or neighbor_indices.shape != neighbor_weights.shape
+        or neighbor_indices.shape[0] != extra_count
+    ):
+        raise ValueError("lift map must identify every untracked state node")
+    if not np.all(np.isfinite(neighbor_weights)) or np.any(neighbor_weights < 0.0):
+        raise ValueError("lift_weights must be finite and nonnegative")
+    if extra_count:
+        if neighbor_indices.shape[1] < 1:
+            raise ValueError("untracked state nodes require at least one neighbor")
+        if np.any(neighbor_indices < 0) or np.any(
+            neighbor_indices >= tracked_count
+        ):
+            raise ValueError("lift_indices reference an unavailable tracked node")
+        if not np.allclose(
+            np.sum(neighbor_weights, axis=1),
+            1.0,
+            rtol=0.0,
+            atol=1e-12,
+        ):
+            raise ValueError("lift_weights must sum to one per untracked node")
+        for row in neighbor_indices:
+            if len(np.unique(row)) != len(row):
+                raise ValueError("one lift row must not repeat a tracked node")
+    neighbor_indices.setflags(write=False)
+    neighbor_weights.setflags(write=False)
+    return neighbor_indices, neighbor_weights
+
+
+def _lift_prediction(
+    mean_m: np.ndarray,
+    covariance_m2: np.ndarray,
+    *,
+    state_count: int,
+    lift_indices: np.ndarray,
+    lift_weights: np.ndarray,
+    maximum_discrepancy_m: float | None,
+) -> tuple[np.ndarray, np.ndarray]:
+    mean = np.asarray(mean_m, dtype=float)
+    covariance = np.asarray(covariance_m2, dtype=float)
+    if mean.ndim != 2 or mean.shape[1] != 3 or len(mean) < 1:
+        raise ValueError("provider mean_m must have shape (N>=1, 3)")
+    if covariance.shape != (len(mean), 3, 3):
+        raise ValueError("provider covariance_m2 must have shape (N, 3, 3)")
+    if not np.all(np.isfinite(mean)):
+        raise ValueError("provider discrepancy mean must be finite")
+    _validate_covariance(covariance, name="provider covariance_m2")
+    tracked_count = len(mean)
+    result_mean = np.empty((state_count, 3), dtype=float)
+    result_covariance = np.empty((state_count, 3, 3), dtype=float)
+    result_mean[:tracked_count] = mean
+    result_covariance[:tracked_count] = covariance
+    if state_count > tracked_count:
+        result_mean[tracked_count:] = np.einsum(
+            "ek,ekc->ec",
+            lift_weights,
+            mean[lift_indices],
+        )
+        result_covariance[tracked_count:] = np.einsum(
+            "ek,ekij->eij",
+            np.square(lift_weights),
+            covariance[lift_indices],
+        )
+    if maximum_discrepancy_m is not None:
+        norms = np.linalg.norm(result_mean, axis=1)
+        scale = np.minimum(
+            1.0,
+            maximum_discrepancy_m / np.maximum(norms, np.finfo(float).tiny),
+        )
+        result_mean *= scale[:, None]
+    result_covariance = 0.5 * (
+        result_covariance + result_covariance.swapaxes(-1, -2)
+    )
+    _validate_covariance(result_covariance, name="lifted covariance_m2")
+    return result_mean, result_covariance
+
+
+@dataclass(frozen=True)
+class HorizonDiscrepancyBankV1:
+    """Per-particle, per-horizon discrepancy moments bound to one TwinBelief."""
+
+    twin_belief_id: str
+    particle_ids: tuple[str, ...]
+    particle_weights: np.ndarray
+    horizon_steps: np.ndarray
+    mean_m: np.ndarray
+    covariance_m2: np.ndarray
+    mean_retention: np.ndarray
+    additional_axis_variance_m2: np.ndarray
+    calibration_id: str
+    provider_revision: str
+    metadata: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        belief_id = _sha256(self.twin_belief_id, name="twin_belief_id")
+        mean = readonly_array(self.mean_m, dtype=float)
+        covariance = readonly_array(self.covariance_m2, dtype=float)
+        if mean.ndim != 4 or mean.shape[-1] != 3:
+            raise ValueError("mean_m must have shape (P, H, N, 3)")
+        particle_count, horizon_count, state_count, _ = mean.shape
+        if particle_count < 1 or horizon_count < 1 or state_count < 1:
+            raise ValueError("discrepancy bank dimensions must be nonempty")
+        particle_ids = _identifiers(
+            self.particle_ids,
+            name="particle_ids",
+            expected_count=particle_count,
+        )
+        weights = _particle_weights(self.particle_weights, particle_count)
+        horizons = np.asarray(self.horizon_steps)
+        if not np.issubdtype(horizons.dtype, np.integer):
+            raise ValueError("horizon_steps must contain integers")
+        horizons = _horizons(tuple(int(value) for value in horizons.tolist()))
+        if len(horizons) != horizon_count:
+            raise ValueError("horizon_steps must identify every bank horizon")
+        if covariance.shape != (particle_count, horizon_count, state_count, 3, 3):
+            raise ValueError("covariance_m2 must have shape (P, H, N, 3, 3)")
+        if not np.all(np.isfinite(mean)):
+            raise ValueError("mean_m must contain only finite values")
+        _validate_covariance(covariance, name="covariance_m2")
+        retention = _probability_vector(
+            self.mean_retention,
+            name="mean_retention",
+        )
+        if retention.shape != (horizon_count,):
+            raise ValueError("mean_retention must identify every horizon")
+        additional = readonly_array(self.additional_axis_variance_m2, dtype=float)
+        if additional.shape != (horizon_count, 3):
+            raise ValueError(
+                "additional_axis_variance_m2 must have shape (H, 3)"
+            )
+        if not np.all(np.isfinite(additional)) or np.any(additional < 0.0):
+            raise ValueError(
+                "additional_axis_variance_m2 must be finite and nonnegative"
+            )
+        if retention[0] != 1.0 or np.any(additional[0] != 0.0):
+            raise ValueError("horizon zero must preserve the endpoint moments exactly")
+        calibration_id = _sha256(self.calibration_id, name="calibration_id")
+        provider_revision = _identifier(
+            self.provider_revision,
+            name="provider_revision",
+        )
+        metadata = validated_json_mapping(
+            self.metadata,
+            error_message="horizon discrepancy bank metadata must be finite JSON data",
+        )
+        object.__setattr__(self, "twin_belief_id", belief_id)
+        object.__setattr__(self, "particle_ids", particle_ids)
+        object.__setattr__(self, "particle_weights", weights)
+        object.__setattr__(self, "horizon_steps", horizons)
+        object.__setattr__(self, "mean_m", mean)
+        object.__setattr__(self, "covariance_m2", covariance)
+        object.__setattr__(self, "mean_retention", retention)
+        object.__setattr__(self, "additional_axis_variance_m2", additional)
+        object.__setattr__(self, "calibration_id", calibration_id)
+        object.__setattr__(self, "provider_revision", provider_revision)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def artifact_id(self) -> str:
+        """Content identity for all provenance and numerical bank values."""
+
+        descriptor = {
+            "schema_version": HORIZON_DISCREPANCY_BANK_SCHEMA_VERSION,
+            "twin_belief_id": self.twin_belief_id,
+            "particle_ids": list(self.particle_ids),
+            "calibration_id": self.calibration_id,
+            "provider_revision": self.provider_revision,
+            "metadata": dict(self.metadata),
+            "arrays": {
+                "particle_weights": array_sha256(self.particle_weights),
+                "horizon_steps": array_sha256(self.horizon_steps),
+                "mean_m": array_sha256(self.mean_m),
+                "covariance_m2": array_sha256(self.covariance_m2),
+                "mean_retention": array_sha256(self.mean_retention),
+                "additional_axis_variance_m2": array_sha256(
+                    self.additional_axis_variance_m2
+                ),
+            },
+        }
+        encoded = json.dumps(
+            descriptor,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def index_for_horizon(self, horizon_steps: int) -> int:
+        """Return the canonical bank index for an exact registered horizon."""
+
+        if type(horizon_steps) is not int or horizon_steps < 0:
+            raise ValueError("horizon_steps must be a nonnegative integer")
+        indices = np.flatnonzero(self.horizon_steps == horizon_steps)
+        if len(indices) != 1:
+            raise KeyError(f"horizon {horizon_steps} is not registered")
+        return int(indices[0])
+
+    def moments_at_horizon(
+        self,
+        horizon_steps: int,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Return immutable per-particle mean and covariance for one horizon."""
+
+        index = self.index_for_horizon(horizon_steps)
+        return self.mean_m[:, index], self.covariance_m2[:, index]
+
+
+def build_horizon_discrepancy_bank(
+    twin_belief: TwinBelief,
+    endpoint_posteriors: Sequence[object],
+    calibration: object,
+    *,
+    horizon_steps: Sequence[int],
+    lift_indices: np.ndarray,
+    lift_weights: np.ndarray,
+    maximum_discrepancy_m: float | None = None,
+    provider_revision: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> HorizonDiscrepancyBankV1:
+    """Propagate source-frozen BPT discrepancy dynamics without target outcomes."""
+
+    if not isinstance(twin_belief, TwinBelief):
+        raise TypeError("twin_belief must be a TwinBelief")
+    manifest = require_bayesian_phystwin_belief_provider_v2(
+        provider_revision=provider_revision
+    )
+    from bayesian_phystwin.causal4d_belief_provider_v2 import (
+        HorizonConditionedEndpointPredictionV1,
+        HorizonDiscrepancyCalibrationV1,
+        ModelAveragedEndpointPosteriorV1,
+        predict_horizon_conditioned_endpoint,
+    )
+
+    if not isinstance(calibration, HorizonDiscrepancyCalibrationV1):
+        raise TypeError("calibration must be a HorizonDiscrepancyCalibrationV1")
+    posteriors = tuple(endpoint_posteriors)
+    particle_count = len(twin_belief.particle_ids)
+    if len(posteriors) != particle_count or not all(
+        isinstance(value, ModelAveragedEndpointPosteriorV1) for value in posteriors
+    ):
+        raise ValueError(
+            "endpoint_posteriors must identify every TwinBelief particle"
+        )
+    horizons = _horizons(horizon_steps)
+    state_count = twin_belief.endpoint_position_m.shape[1]
+    tracked_counts = {len(value.mean_m) for value in posteriors}
+    if len(tracked_counts) != 1:
+        raise ValueError("endpoint posteriors must use one common tracked state")
+    tracked_count = tracked_counts.pop()
+    neighbor_indices, neighbor_weights = _lift_map(
+        lift_indices,
+        lift_weights,
+        tracked_count=tracked_count,
+        state_count=state_count,
+    )
+    maximum_norm = _maximum_norm(maximum_discrepancy_m)
+
+    mean = np.empty((particle_count, len(horizons), state_count, 3), dtype=float)
+    covariance = np.empty(
+        (particle_count, len(horizons), state_count, 3, 3),
+        dtype=float,
+    )
+    retention = np.empty(len(horizons), dtype=float)
+    additional = np.empty((len(horizons), 3), dtype=float)
+    calibration_id: str | None = None
+    for particle_index, posterior in enumerate(posteriors):
+        for horizon_index, horizon in enumerate(horizons):
+            prediction = predict_horizon_conditioned_endpoint(
+                posterior,
+                calibration,
+                horizon_steps=int(horizon),
+            )
+            if not isinstance(prediction, HorizonConditionedEndpointPredictionV1):
+                raise TypeError(
+                    "Bayesian-PhysTwin returned the wrong horizon prediction type"
+                )
+            if prediction.calibration_id != calibration.artifact_id:
+                raise ValueError("horizon prediction calibration identity changed")
+            lifted_mean, lifted_covariance = _lift_prediction(
+                prediction.mean_m,
+                prediction.covariance_m2,
+                state_count=state_count,
+                lift_indices=neighbor_indices,
+                lift_weights=neighbor_weights,
+                maximum_discrepancy_m=maximum_norm,
+            )
+            mean[particle_index, horizon_index] = lifted_mean
+            covariance[particle_index, horizon_index] = lifted_covariance
+            if particle_index == 0:
+                retention[horizon_index] = prediction.mean_retention
+                additional[horizon_index] = prediction.additional_axis_variance_m2
+            else:
+                if prediction.mean_retention != retention[horizon_index] or not np.array_equal(
+                    prediction.additional_axis_variance_m2,
+                    additional[horizon_index],
+                ):
+                    raise ValueError(
+                        "horizon calibration semantics changed across particles"
+                    )
+            if calibration_id is None:
+                calibration_id = prediction.calibration_id
+            elif prediction.calibration_id != calibration_id:
+                raise ValueError("calibration identity changed across predictions")
+
+    assert calibration_id is not None
+    bank_metadata: dict[str, Any] = {
+        "provider_manifest": manifest.as_dict(),
+        "calibration_source_group_count": len(calibration.source_group_ids),
+        "calibration_source_group_ids": list(calibration.source_group_ids),
+        "calibration_target_outcomes_used": calibration.target_outcomes_used,
+        "calibration_confirmation_outcomes_used": (
+            calibration.confirmation_outcomes_used
+        ),
+        "maximum_discrepancy_m": maximum_norm,
+        "covariance_lift_semantics": (
+            "independent tracked-node covariance propagated by squared fixed "
+            "readout weights"
+        ),
+        "future_observations_read": 0,
+    }
+    if metadata is not None:
+        bank_metadata["consumer_metadata"] = dict(metadata)
+    return HorizonDiscrepancyBankV1(
+        twin_belief_id=twin_belief.artifact_id,
+        particle_ids=twin_belief.particle_ids,
+        particle_weights=twin_belief.weights,
+        horizon_steps=horizons,
+        mean_m=mean,
+        covariance_m2=covariance,
+        mean_retention=retention,
+        additional_axis_variance_m2=additional,
+        calibration_id=calibration_id,
+        provider_revision=manifest.provider_revision,
+        metadata=bank_metadata,
+    )
+
+
+__all__ = [
+    "HORIZON_DISCREPANCY_BANK_SCHEMA_VERSION",
+    "HorizonDiscrepancyBankV1",
+    "build_horizon_discrepancy_bank",
+]

--- a/src/causal4d/horizon_discrepancy.py
+++ b/src/causal4d/horizon_discrepancy.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
 import hashlib
 import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from numbers import Real
 from typing import Any
 

--- a/tests/test_belief_provider_v2_contract.py
+++ b/tests/test_belief_provider_v2_contract.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import pytest
+
+from causal4d.belief_provider_v2_contract import (
+    BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API,
+    BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API_VERSION,
+    BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_CAPABILITIES,
+    BAYESIAN_PHYSTWIN_BELIEF_V2_ARTIFACT_SCHEMA_VERSIONS,
+    BAYESIAN_PHYSTWIN_BELIEF_V2_COMPATIBILITY,
+    BAYESIAN_PHYSTWIN_BELIEF_V2_INFERENCE_ROLE,
+    BAYESIAN_PHYSTWIN_BELIEF_V2_RAW_COVARIANCE_CLAIM,
+    validate_bayesian_phystwin_belief_provider_v2,
+)
+from causal4d.provider_contract import PhysicalBeliefProviderManifest
+
+
+def _manifest(
+    *,
+    capabilities: tuple[str, ...] = (
+        BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_CAPABILITIES
+    ),
+    schemas: dict[str, int] | None = None,
+    metadata: dict[str, object] | None = None,
+) -> PhysicalBeliefProviderManifest:
+    return PhysicalBeliefProviderManifest(
+        provider_name="bayesian-phystwin",
+        provider_version="0.4.0",
+        provider_revision="a" * 40,
+        schema_version=2,
+        capabilities=capabilities,
+        artifact_schema_versions=(
+            BAYESIAN_PHYSTWIN_BELIEF_V2_ARTIFACT_SCHEMA_VERSIONS
+            if schemas is None
+            else schemas
+        ),
+        metadata=(
+            {
+                "provider_api": BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API,
+                "provider_api_version": (
+                    BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API_VERSION
+                ),
+                "inference_role": BAYESIAN_PHYSTWIN_BELIEF_V2_INFERENCE_ROLE,
+                "compatibility": BAYESIAN_PHYSTWIN_BELIEF_V2_COMPATIBILITY,
+                "raw_covariance_claim": (
+                    BAYESIAN_PHYSTWIN_BELIEF_V2_RAW_COVARIANCE_CLAIM
+                ),
+            }
+            if metadata is None
+            else metadata
+        ),
+    )
+
+
+def test_belief_provider_v2_accepts_complete_additive_manifest() -> None:
+    result = validate_bayesian_phystwin_belief_provider_v2(_manifest())
+
+    assert result.compatible
+    assert result.missing_capabilities == ()
+    assert result.artifact_version_mismatches == ()
+
+
+def test_belief_provider_v2_rejects_missing_horizon_capability() -> None:
+    capabilities = tuple(
+        value
+        for value in BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_CAPABILITIES
+        if value != "source_calibrated_horizon_discrepancy"
+    )
+
+    result = validate_bayesian_phystwin_belief_provider_v2(
+        _manifest(capabilities=capabilities)
+    )
+
+    assert not result.compatible
+    assert result.missing_capabilities == (
+        "source_calibrated_horizon_discrepancy",
+    )
+
+
+def test_belief_provider_v2_rejects_horizon_schema_drift() -> None:
+    schemas = dict(BAYESIAN_PHYSTWIN_BELIEF_V2_ARTIFACT_SCHEMA_VERSIONS)
+    schemas["HorizonConditionedEndpointPrediction"] = 2
+
+    result = validate_bayesian_phystwin_belief_provider_v2(
+        _manifest(schemas=schemas)
+    )
+
+    assert not result.compatible
+    assert result.artifact_version_mismatches == (
+        "HorizonConditionedEndpointPrediction:expected=1:actual=2",
+    )
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("provider_api", "bayesian_phystwin.causal4d_belief_provider_v1"),
+        ("provider_api_version", 1),
+        ("inference_role", "physical state correction"),
+        ("compatibility", "replaces provider v1"),
+        ("raw_covariance_claim", "calibrated deployment intervals"),
+    ],
+)
+def test_belief_provider_v2_rejects_metadata_drift(
+    name: str,
+    value: object,
+) -> None:
+    metadata = dict(_manifest().metadata)
+    metadata[name] = value
+
+    with pytest.raises(ValueError, match="unexpected"):
+        validate_bayesian_phystwin_belief_provider_v2(
+            _manifest(metadata=metadata)
+        )
+
+
+def test_belief_provider_v2_rejects_wrong_provider_name() -> None:
+    manifest = _manifest()
+    wrong = PhysicalBeliefProviderManifest(
+        provider_name="other-provider",
+        provider_version=manifest.provider_version,
+        provider_revision=manifest.provider_revision,
+        schema_version=manifest.schema_version,
+        capabilities=manifest.capabilities,
+        artifact_schema_versions=manifest.artifact_schema_versions,
+        metadata=manifest.metadata,
+    )
+
+    with pytest.raises(ValueError, match="bayesian-phystwin"):
+        validate_bayesian_phystwin_belief_provider_v2(wrong)

--- a/tests/test_horizon_discrepancy.py
+++ b/tests/test_horizon_discrepancy.py
@@ -4,7 +4,6 @@ from dataclasses import replace
 
 import numpy as np
 import pytest
-
 from causal4d.contracts import TwinBelief, build_causal_context
 from causal4d.horizon_discrepancy import (
     HorizonDiscrepancyBankV1,

--- a/tests/test_horizon_discrepancy.py
+++ b/tests/test_horizon_discrepancy.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+provider_api = pytest.importorskip(
+    "bayesian_phystwin.causal4d_belief_provider_v2"
+)
+if not hasattr(provider_api, "HorizonDiscrepancyCalibrationV1"):
+    pytest.skip(
+        "installed Bayesian-PhysTwin lacks horizon discrepancy provider v2",
+        allow_module_level=True,
+    )
+
+from causal4d.contracts import TwinBelief, build_causal_context
+from causal4d.horizon_discrepancy import (
+    HorizonDiscrepancyBankV1,
+    build_horizon_discrepancy_bank,
+)
+
+
+def _belief() -> TwinBelief:
+    observations = np.zeros((5, 2, 3), dtype=float)
+    observed_actions = np.zeros((5, 1, 3), dtype=float)
+    counterfactual_actions = np.ones((5, 1, 3), dtype=float)
+    context = build_causal_context(
+        protocol_id="horizon-discrepancy-test-v1",
+        case_id="case-001",
+        observations=observations,
+        observed_actions=observed_actions,
+        counterfactual_actions=counterfactual_actions,
+        intervention_frame=3,
+    )
+    return TwinBelief(
+        context=context,
+        endpoint_frame=2,
+        particle_ids=("particle-a", "particle-b"),
+        theta_names=("spring_log_scale",),
+        endpoint_position_m=np.zeros((2, 3, 3), dtype=float),
+        endpoint_velocity_mps=np.zeros((2, 3, 3), dtype=float),
+        theta=np.asarray(((0.0,), (0.2,)), dtype=float),
+        discrepancy_mean_m=np.zeros((2, 3, 3), dtype=float),
+        discrepancy_variance_m2=np.full((2, 3, 3), 1e-6, dtype=float),
+        weights=np.asarray((0.6, 0.4), dtype=float),
+        metadata={"test_fixture": True},
+    )
+
+
+def _posteriors():
+    residual_a = np.zeros((4, 2, 3), dtype=float)
+    residual_a[:, 0, 0] = (0.001, 0.002, 0.003, 0.004)
+    residual_a[:, 1, 1] = (0.0, -0.001, -0.002, -0.003)
+    residual_b = 1.5 * residual_a
+    valid = np.ones((4, 2), dtype=bool)
+    return (
+        provider_api.infer_model_averaged_bayesian_anchor_endpoint(
+            residual_a,
+            valid,
+            end_frame=4,
+        ),
+        provider_api.infer_model_averaged_bayesian_anchor_endpoint(
+            residual_b,
+            valid,
+            end_frame=4,
+        ),
+    )
+
+
+def _calibration():
+    return provider_api.HorizonDiscrepancyCalibrationV1(
+        source_group_ids=("source-a", "source-b", "source-c"),
+        source_summary_sha256="a" * 64,
+        horizon_steps=(1, 2, 4),
+        mean_reversion_half_life_steps=2.0,
+        minimum_mean_retention=0.1,
+        stationary_std_m=np.asarray((0.01, 0.02, 0.03)),
+        additional_process_std_m_per_sqrt_step=np.asarray(
+            (0.001, 0.002, 0.003)
+        ),
+        component_process_variance_scale=1.0,
+        metadata={"split": "source-only"},
+    )
+
+
+def _build(
+    *,
+    horizons=(3, 0, 1),
+    maximum_discrepancy_m=None,
+) -> HorizonDiscrepancyBankV1:
+    return build_horizon_discrepancy_bank(
+        _belief(),
+        _posteriors(),
+        _calibration(),
+        horizon_steps=horizons,
+        lift_indices=np.asarray(((0, 1),), dtype=np.int64),
+        lift_weights=np.asarray(((0.25, 0.75),), dtype=float),
+        maximum_discrepancy_m=maximum_discrepancy_m,
+        provider_revision="b" * 40,
+        metadata={"registered_role": "development-only"},
+    )
+
+
+def test_builds_source_bound_horizon_bank_with_endpoint_parity() -> None:
+    belief = _belief()
+    posteriors = _posteriors()
+    bank = build_horizon_discrepancy_bank(
+        belief,
+        posteriors,
+        _calibration(),
+        horizon_steps=(3, 0, 1),
+        lift_indices=np.asarray(((0, 1),), dtype=np.int64),
+        lift_weights=np.asarray(((0.25, 0.75),), dtype=float),
+        provider_revision="b" * 40,
+    )
+
+    np.testing.assert_array_equal(bank.horizon_steps, (0, 1, 3))
+    assert bank.mean_m.shape == (2, 3, 3, 3)
+    assert bank.covariance_m2.shape == (2, 3, 3, 3, 3)
+    assert bank.twin_belief_id == belief.artifact_id
+    assert bank.particle_ids == belief.particle_ids
+    np.testing.assert_allclose(bank.particle_weights, belief.weights)
+    assert bank.calibration_id == _calibration().artifact_id
+    assert bank.provider_revision == "b" * 40
+    assert len(bank.artifact_id) == 64
+    assert bank.metadata["future_observations_read"] == 0
+    assert bank.metadata["calibration_source_group_count"] == 3
+    assert bank.metadata["calibration_target_outcomes_used"] is False
+    assert not bank.mean_m.flags.writeable
+    assert not bank.covariance_m2.flags.writeable
+
+    for particle_index, posterior in enumerate(posteriors):
+        np.testing.assert_allclose(
+            bank.mean_m[particle_index, 0, :2],
+            posterior.mean_m,
+        )
+        np.testing.assert_allclose(
+            bank.covariance_m2[particle_index, 0, :2],
+            posterior.covariance_m2,
+        )
+        expected_extra_mean = (
+            0.25 * posterior.mean_m[0] + 0.75 * posterior.mean_m[1]
+        )
+        expected_extra_covariance = (
+            0.25**2 * posterior.covariance_m2[0]
+            + 0.75**2 * posterior.covariance_m2[1]
+        )
+        np.testing.assert_allclose(
+            bank.mean_m[particle_index, 0, 2],
+            expected_extra_mean,
+        )
+        np.testing.assert_allclose(
+            bank.covariance_m2[particle_index, 0, 2],
+            expected_extra_covariance,
+        )
+
+    assert bank.mean_retention[0] == 1.0
+    np.testing.assert_array_equal(bank.additional_axis_variance_m2[0], 0.0)
+    assert bank.mean_retention[-1] < bank.mean_retention[1] < 1.0
+    assert np.all(bank.additional_axis_variance_m2[-1] > 0.0)
+
+
+def test_moments_accessor_returns_registered_immutable_view() -> None:
+    bank = _build()
+
+    mean, covariance = bank.moments_at_horizon(1)
+
+    np.testing.assert_array_equal(mean, bank.mean_m[:, 1])
+    np.testing.assert_array_equal(covariance, bank.covariance_m2[:, 1])
+    assert not mean.flags.writeable
+    assert not covariance.flags.writeable
+    with pytest.raises(KeyError, match="not registered"):
+        bank.moments_at_horizon(2)
+
+
+def test_mean_cap_changes_means_without_rewriting_covariance() -> None:
+    uncapped = _build()
+    capped = _build(maximum_discrepancy_m=5e-4)
+
+    assert np.max(np.linalg.norm(capped.mean_m, axis=-1)) <= 5e-4 + 1e-15
+    np.testing.assert_array_equal(capped.covariance_m2, uncapped.covariance_m2)
+    assert capped.artifact_id != uncapped.artifact_id
+
+
+@pytest.mark.parametrize(
+    "horizons",
+    [
+        (1, 2),
+        (0, 1, 1),
+        (0, -1),
+        (0, 1.5),
+    ],
+)
+def test_rejects_noncanonical_horizon_sets(horizons) -> None:
+    with pytest.raises(ValueError, match="horizon_steps"):
+        _build(horizons=horizons)
+
+
+def test_rejects_invalid_or_repeated_lift_nodes() -> None:
+    belief = _belief()
+    posteriors = _posteriors()
+    calibration = _calibration()
+
+    with pytest.raises(ValueError, match="unavailable tracked node"):
+        build_horizon_discrepancy_bank(
+            belief,
+            posteriors,
+            calibration,
+            horizon_steps=(0, 1),
+            lift_indices=np.asarray(((0, 2),), dtype=np.int64),
+            lift_weights=np.asarray(((0.5, 0.5),), dtype=float),
+            provider_revision="b" * 40,
+        )
+    with pytest.raises(ValueError, match="must not repeat"):
+        build_horizon_discrepancy_bank(
+            belief,
+            posteriors,
+            calibration,
+            horizon_steps=(0, 1),
+            lift_indices=np.asarray(((0, 0),), dtype=np.int64),
+            lift_weights=np.asarray(((0.5, 0.5),), dtype=float),
+            provider_revision="b" * 40,
+        )
+
+
+def test_rejects_particle_or_calibration_type_mismatch() -> None:
+    belief = _belief()
+
+    with pytest.raises(ValueError, match="every TwinBelief particle"):
+        build_horizon_discrepancy_bank(
+            belief,
+            _posteriors()[:1],
+            _calibration(),
+            horizon_steps=(0, 1),
+            lift_indices=np.asarray(((0, 1),), dtype=np.int64),
+            lift_weights=np.asarray(((0.5, 0.5),), dtype=float),
+            provider_revision="b" * 40,
+        )
+    with pytest.raises(TypeError, match="calibration"):
+        build_horizon_discrepancy_bank(
+            belief,
+            _posteriors(),
+            object(),
+            horizon_steps=(0, 1),
+            lift_indices=np.asarray(((0, 1),), dtype=np.int64),
+            lift_weights=np.asarray(((0.5, 0.5),), dtype=float),
+            provider_revision="b" * 40,
+        )
+
+
+def test_artifact_identity_binds_provider_and_numerical_values() -> None:
+    bank = _build()
+    changed_provider = replace(bank, provider_revision="c" * 40)
+    changed_mean_values = np.asarray(bank.mean_m).copy()
+    changed_mean_values[0, -1, 0, 0] += 1e-6
+    changed_mean = replace(bank, mean_m=changed_mean_values)
+
+    assert changed_provider.artifact_id != bank.artifact_id
+    assert changed_mean.artifact_id != bank.artifact_id

--- a/tests/test_horizon_discrepancy.py
+++ b/tests/test_horizon_discrepancy.py
@@ -5,6 +5,12 @@ from dataclasses import replace
 import numpy as np
 import pytest
 
+from causal4d.contracts import TwinBelief, build_causal_context
+from causal4d.horizon_discrepancy import (
+    HorizonDiscrepancyBankV1,
+    build_horizon_discrepancy_bank,
+)
+
 provider_api = pytest.importorskip(
     "bayesian_phystwin.causal4d_belief_provider_v2"
 )
@@ -13,12 +19,6 @@ if not hasattr(provider_api, "HorizonDiscrepancyCalibrationV1"):
         "installed Bayesian-PhysTwin lacks horizon discrepancy provider v2",
         allow_module_level=True,
     )
-
-from causal4d.contracts import TwinBelief, build_causal_context
-from causal4d.horizon_discrepancy import (
-    HorizonDiscrepancyBankV1,
-    build_horizon_discrepancy_bank,
-)
 
 
 def _belief() -> TwinBelief:

--- a/tests/test_horizon_discrepancy_workflow_policy.py
+++ b/tests/test_horizon_discrepancy_workflow_policy.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WORKFLOW = Path(".github/workflows/horizon-discrepancy-integration.yml")
+BPT_HORIZON_PROVIDER_REVISION = "bfa844798f0ab3ddbc67a0744ae14a221324e504"
+
+
+def test_horizon_workflow_uses_exact_public_provider_revision() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "repository: IPS-Stuttgart/BayesianPhysTwin" in text
+    assert f"ref: {BPT_HORIZON_PROVIDER_REVISION}" in text
+    assert "persist-credentials: false" in text
+    assert "BPT_READ_SSH_KEY" not in text
+
+
+def test_horizon_workflow_exercises_installed_wheels() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "python -m build --wheel" in text
+    assert "horizon-discrepancy-wheelhouse" in text
+    assert "horizon-discrepancy-venv" in text
+    assert "--import-mode=importlib" in text
+    assert "env -u PYTHONPATH" in text
+    assert "test_belief_provider_v2_contract.py" in text
+    assert "test_horizon_discrepancy.py" in text
+    assert "test_belief_provider_contract.py" in text
+
+
+def test_horizon_workflow_pins_external_actions() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert text.count(
+        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+    ) == 2
+    assert (
+        "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97"
+        in text
+    )
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("uses:"):
+            assert "@" in stripped
+            reference = stripped.rsplit("@", 1)[1].split()[0]
+            assert len(reference) == 40
+            assert all(character in "0123456789abcdef" for character in reference)


### PR DESCRIPTION
## Summary

Add an experimental Causal4D consumer for Bayesian-PhysTwin's additive belief-provider v2 horizon dynamics.

- validate the exact model-averaged and horizon-conditioned provider capabilities, artifact schemas, and scientific metadata before residual-derived predictions are consumed;
- construct a content-addressed `HorizonDiscrepancyBankV1` bound to one immutable `TwinBelief`, its particles and weights, one source-only calibration artifact, the exact provider revision, and every numerical prediction array;
- retain full per-node `3 x 3` covariance for every physical particle and registered horizon;
- require horizon zero as an executable endpoint-parity control with unit mean retention and zero added process variance;
- lift tracked discrepancy means and covariance to the complete state through a fixed readout map, with the independent-node covariance assumption recorded explicitly;
- support a pre-frozen discrepancy-norm cap without rewriting covariance;
- retain source-group identities and prove that no future observations, confirmation outcomes, or target outcomes selected the horizon dynamics;
- add adversarial compatibility, covariance, lift-map, horizon, immutability, and content-identity tests;
- build and test exact Bayesian-PhysTwin and Causal4D wheels in an isolated `PYTHONPATH`-free workflow.

## Why

The completed real audit shows strong horizon-dependent undercoverage and harmful transfer from one global affine covariance multiplier. Bayesian-PhysTwin now owns source-calibrated mean retention and process growth; this PR gives Causal4D a fail-closed, provenance-complete way to consume those moments without altering the frozen provider-v1 path.

## Scientific boundary

This is an additive development artifact, not a calibration result. It does not modify the frozen Causal4D estimator or the 36-execution protocol, fit graph-region/action/contact-regime calibration, use target outcomes, establish nominal coverage, or describe raw covariance as calibrated. Independent execution-level evaluation remains required.

## Validation status

Current exact head: `5717f12ee7a739aea912c270d8e25e072024d53e`.

- the preceding workstation2 installed-wheel run reached Ruff and identified two import-order violations;
- both violations are corrected on the current head;
- the exact-head workstation2, installed-wheel, core CI, and extended-compatibility jobs are queued;
- the workflows pin Bayesian-PhysTwin revision `bfa844798f0ab3ddbc67a0744ae14a221324e504` and read no datasets or target outcomes.