### PR TITLE
Allow BayesianPhysTwin belief provider v2 at the import boundary

### DIFF
--- a/tests/test_bpt_provider_import_boundary.py
+++ b/tests/test_bpt_provider_import_boundary.py
@@ -14,6 +14,7 @@ ALLOWED_BAYESIAN_PHYSTWIN_MODULES = frozenset(
         "bayesian_phystwin.causal4d_artifacts_v1",
         "bayesian_phystwin.causal4d_artifacts_v2",
         "bayesian_phystwin.causal4d_belief_provider_v1",
+        "bayesian_phystwin.causal4d_belief_provider_v2",
         "bayesian_phystwin.causal4d_graph_provider_v1",
         "bayesian_phystwin.causal4d_provider_v1",
         "bayesian_phystwin.causal4d_provider_v2",


### PR DESCRIPTION
## Summary

Add the already-used versioned `bayesian_phystwin.causal4d_belief_provider_v2` module to Causal4D's explicit BayesianPhysTwin import allowlist.

This fixes the cross-repository provider compatibility gate without relaxing private-name or unversioned-import checks.