### PR TITLE
Add portable external sparse-trajectory forecast importer

### DIFF
--- a/.github/workflows/external-forecast-importer-validation.yml
+++ b/.github/workflows/external-forecast-importer-validation.yml
@@ -1,0 +1,113 @@
+name: External forecast importer validation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/external-forecast-importer-validation.yml"
+      - "src/causal4d/external_forecast.py"
+      - "src/causal4d/external_forecast_importer.py"
+      - "src/causal4d/semantic_posterior.py"
+      - "src/causal4d/cli/external_forecast_import.py"
+      - "src/causal4d/cli/molmo_task_posterior.py"
+      - "tests/test_external_forecast_import.py"
+      - "docs/external_forecast_import.md"
+      - "examples/external_forecast_manifest_v1.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: external-forecast-importer-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  validate:
+    name: External forecast importer / workstation2
+    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    timeout-minutes: 60
+    steps:
+      - name: Check out pull request merge commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Create isolated environment
+        shell: bash
+        run: |
+          python -m venv .validation-venv
+          echo "VIRTUAL_ENV=${PWD}/.validation-venv" >> "${GITHUB_ENV}"
+          echo "${PWD}/.validation-venv/bin" >> "${GITHUB_PATH}"
+
+      - name: Install core development environment
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+          python -m pip check
+
+      - name: Run Ruff lint and formatting checks
+        shell: bash
+        run: |
+          files=(
+            src/causal4d/external_forecast.py
+            src/causal4d/external_forecast_importer.py
+            src/causal4d/semantic_posterior.py
+            src/causal4d/cli/external_forecast_import.py
+            src/causal4d/cli/molmo_task_posterior.py
+            tests/test_external_forecast_import.py
+          )
+          python -m ruff check "${files[@]}"
+          python -m ruff format --check "${files[@]}"
+
+      - name: Run importer and semantic regressions
+        shell: bash
+        run: |
+          mkdir -p external-forecast-validation
+          set -o pipefail
+          python -m pytest -ra \
+            tests/test_external_forecast_import.py \
+            tests/test_causal4d_semantic_posterior.py \
+            tests/test_causal4d_semantic_trust.py \
+            tests/test_causal4d_closed_loop.py \
+            tests/test_exact_zero_support.py \
+            tests/test_claim_artifact_immutability.py \
+            | tee external-forecast-validation/focused-tests.log
+
+      - name: Run core suite outside the known provider-v2 main regression
+        shell: bash
+        run: |
+          set -o pipefail
+          python -m pytest -ra \
+            --ignore=tests/test_belief_provider_v2_contract.py \
+            | tee external-forecast-validation/core-tests.log
+
+      - name: Build and inspect distributions
+        shell: bash
+        run: |
+          python -m build
+          python -m twine check dist/*
+          python -m pip freeze > external-forecast-validation/pip-freeze.txt
+          git status --short > external-forecast-validation/git-status.txt
+          git rev-parse HEAD > external-forecast-validation/merge-sha.txt
+          git rev-parse "${{ github.event.pull_request.head.sha }}^{tree}" \
+            > external-forecast-validation/code-tree.txt
+
+      - name: Upload validation evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: external-forecast-importer-${{ github.run_id }}-${{ github.run_attempt }}
+          path: external-forecast-validation
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/external-forecast-importer-validation.yml
+++ b/.github/workflows/external-forecast-importer-validation.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           set -o pipefail
           python -m pytest -ra \
-            --ignore=tests/test_belief_provider_v2_contract.py \
+            --deselect=tests/test_belief_provider_v2_contract.py \
             | tee external-forecast-validation/core-tests.log
 
       - name: Build and inspect distributions

--- a/docs/external_forecast_import.md
+++ b/docs/external_forecast_import.md
@@ -1,0 +1,154 @@
+# External sparse trajectory forecast import
+
+Causal4D can ingest sparse 3-D trajectory forecasts produced outside the
+MolmoMotion/PhysTwin environment. The importer normalizes producer-specific
+arrays into a versioned, non-pickled, content-addressed
+`ExternalForecastBundle` and preserves the physical posterior as an immutable
+fallback.
+
+The canonical artifact contains:
+
+- exact physical node indices;
+- finite metric anchor positions;
+- one or more future sparse trajectories in the physical world frame;
+- explicit physical-posterior frame indices;
+- coordinate-level validity masks;
+- source-model and source-revision provenance; and
+- SHA-256 identities for every numerical payload and the producer input files.
+
+It does not interpret a forecast as a physical-state update. The existing task
+posterior scores only the selected readout `H_Q(X)` of complete physical
+rollouts. A rejected or zero-weight semantic branch therefore leaves the
+physical posterior unchanged.
+
+## Import manifest v1
+
+The producer writes a normal NumPy NPZ file with `allow_pickle=False`-compatible
+arrays. A separate UTF-8 JSON manifest maps those arrays to the portable
+contract:
+
+```json
+{
+  "schema": "causal4d.external_forecast_import",
+  "schema_version": 1,
+  "case_id": "cloth_lift_001",
+  "source": {
+    "model": "MolmoMotion-adapted",
+    "revision": "checkpoint-or-git-revision",
+    "artifact_id": "optional-upstream-artifact-id"
+  },
+  "arrays": {
+    "node_indices": "node_indices",
+    "anchor_positions": "anchor_positions_world_m",
+    "future_positions": "future_positions_world_m",
+    "future_times_s": "future_times_s",
+    "validity_mask": "validity_mask"
+  },
+  "layout": "KPFC",
+  "coordinate_frame": "world",
+  "position_unit": "m",
+  "forecast_ids": ["instruction", "shuffled"],
+  "anchor_physical_frame": 0,
+  "physical_fps": 30.0,
+  "forecast_metadata": {
+    "instruction": {"caption": "Lift the cloth upward."},
+    "shuffled": {"caption": "Push the cloth sideways."}
+  },
+  "metadata": {
+    "producer_environment": "external-molmo-venv"
+  }
+}
+```
+
+Required producer arrays are `node_indices`, `anchor_positions`, and
+`future_positions`. The supported position layouts are:
+
+| Layout | Producer shape |
+| --- | --- |
+| `PFC` | `(point, future, xyz)` for one forecast |
+| `FPC` | `(future, point, xyz)` for one forecast |
+| `KPFC` | `(forecast, point, future, xyz)` |
+| `KFPC` | `(forecast, future, point, xyz)` |
+
+The validity mask may omit the final coordinate axis. Invalid coordinates are
+canonicalized to NaN and excluded from scoring.
+
+The importer accepts `m`, `cm`, or `mm`. For `coordinate_frame: "camera"`, the
+manifest must additionally map `arrays.camera_to_world` to a finite homogeneous
+`4 x 4` matrix. Its translation is expressed in metres; positions are converted
+to metres before the transform is applied.
+
+Frame alignment must be explicit. Supply either:
+
+- `arrays.physical_frame_indices`; or
+- `arrays.future_times_s` together with `physical_fps`.
+
+When both are present, the importer verifies
+
+```text
+physical_frame = anchor_physical_frame + future_time_s * physical_fps
+```
+
+and fails closed on disagreement.
+
+## Python API
+
+```python
+from causal4d.external_forecast import (
+    import_external_forecast,
+    save_external_forecast,
+)
+
+bundle = import_external_forecast(
+    "producer_forecast.npz",
+    "external_forecast_manifest.json",
+)
+save_external_forecast("canonical_external_forecast.npz", bundle)
+```
+
+The low-level module runner provides the same operation without adding another
+installed console script:
+
+```bash
+python -m causal4d.cli.external_forecast_import \
+  producer_forecast.npz \
+  external_forecast_manifest.json \
+  canonical_external_forecast.npz
+```
+
+The canonical artifact can then be passed to the existing grouped task-posterior
+command in place of a legacy MolmoMotion NPZ:
+
+```bash
+causal4d experiment semantic build-task-posterior \
+  physical_posterior.npz \
+  canonical_external_forecast.npz \
+  instruction \
+  task_posterior.npz \
+  --beta 0
+```
+
+`beta=0` remains byte-identical to the physical weights. A positive beta is
+exploratory unless that external producer has its own source-only competence,
+trust, and acceptance evidence. Importing an artifact does not make it eligible
+under the MolmoMotion-specific acceptance result.
+
+## Fail-closed checks
+
+Import and reload reject:
+
+- duplicate or non-string JSON keys;
+- unexpected manifest or artifact fields;
+- object arrays that require pickle;
+- duplicate or negative physical node indices;
+- shape/layout mismatches;
+- non-finite valid coordinates or anchors;
+- non-increasing future times or physical frames;
+- frame/time inconsistencies;
+- missing camera transforms for camera-frame inputs;
+- payload mutation after publication; and
+- source or manifest files that change while being imported.
+
+The artifact identity is independent of local path names. It binds the exact
+producer NPZ bytes, import-manifest bytes, normalized arrays, validity mask,
+frame alignment, source identity, and finite JSON metadata.

--- a/examples/external_forecast_manifest_v1.json
+++ b/examples/external_forecast_manifest_v1.json
@@ -1,0 +1,33 @@
+{
+  "schema": "causal4d.external_forecast_import",
+  "schema_version": 1,
+  "case_id": "cloth_lift_001",
+  "source": {
+    "model": "external-trajectory-model",
+    "revision": "replace-with-checkpoint-or-git-revision",
+    "artifact_id": "replace-with-upstream-artifact-id"
+  },
+  "arrays": {
+    "node_indices": "node_indices",
+    "anchor_positions": "anchor_positions_world_m",
+    "future_positions": "future_positions_world_m",
+    "future_times_s": "future_times_s",
+    "validity_mask": "validity_mask"
+  },
+  "layout": "KPFC",
+  "coordinate_frame": "world",
+  "position_unit": "m",
+  "forecast_ids": [
+    "instruction"
+  ],
+  "anchor_physical_frame": 0,
+  "physical_fps": 30.0,
+  "forecast_metadata": {
+    "instruction": {
+      "caption": "Lift the cloth upward."
+    }
+  },
+  "metadata": {
+    "producer_environment": "replace-with-environment-id"
+  }
+}

--- a/src/causal4d/cli/external_forecast_import.py
+++ b/src/causal4d/cli/external_forecast_import.py
@@ -1,0 +1,58 @@
+"""Import a portable external sparse trajectory forecast."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+
+def _load_runtime_dependencies() -> None:
+    global import_external_forecast
+    global save_external_forecast
+
+    from causal4d.external_forecast import (
+        import_external_forecast,
+        save_external_forecast,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Normalize and content-address an external sparse 3-D trajectory "
+            "forecast for Causal4D semantic/task-posterior scoring."
+        )
+    )
+    parser.add_argument("source_npz")
+    parser.add_argument("import_manifest_json")
+    parser.add_argument("output_npz")
+    parser.add_argument(
+        "--no-overwrite",
+        action="store_true",
+        help="fail rather than replacing an existing output artifact",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    _load_runtime_dependencies()
+    bundle = import_external_forecast(
+        args.source_npz,
+        args.import_manifest_json,
+    )
+    save_external_forecast(
+        args.output_npz,
+        bundle,
+        overwrite=not args.no_overwrite,
+    )
+    summary = bundle.summary()
+    summary["output"] = str(Path(args.output_npz).resolve())
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d/cli/molmo_task_posterior.py
+++ b/src/causal4d/cli/molmo_task_posterior.py
@@ -1,4 +1,4 @@
-"""Build a separate MolmoMotion-conditioned TaskPosterior."""
+"""Build a separate forecast-conditioned ``TaskPosterior``."""
 
 from __future__ import annotations
 
@@ -15,14 +15,22 @@ def _load_runtime_dependencies() -> None:
     global PhysicalPosterior
     global load_contract
     global save_contract
+    global is_external_forecast_artifact
+    global load_external_forecast
     global load_molmo_forecasts
     global build_task_posterior
+    global external_forecast_evidence
     global molmo_task_evidence
 
     from causal4d.contracts import PhysicalPosterior, load_contract, save_contract
+    from causal4d.external_forecast import (
+        is_external_forecast_artifact,
+        load_external_forecast,
+    )
     from causal4d.molmo_adapter import load_molmo_forecasts
     from causal4d.semantic_posterior import (
         build_task_posterior,
+        external_forecast_evidence,
         molmo_task_evidence,
     )
 
@@ -30,12 +38,13 @@ def _load_runtime_dependencies() -> None:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Score MolmoMotion only against H_Q(X) and save an intention-"
-            "conditioned posterior separate from the physical posterior."
+            "Score a sparse trajectory forecast only against H_Q(X) and save "
+            "a task posterior separate from the physical posterior. Canonical "
+            "external-forecast and legacy MolmoMotion NPZ artifacts are accepted."
         )
     )
     parser.add_argument("physical_posterior_npz")
-    parser.add_argument("molmo_forecast_npz")
+    parser.add_argument("forecast_npz")
     parser.add_argument("forecast_id")
     parser.add_argument("output_task_npz")
     parser.add_argument("--beta", type=float, default=0.0)
@@ -50,14 +59,28 @@ def main(argv: Sequence[str] | None = None) -> int:
     artifact = load_contract(args.physical_posterior_npz)
     if not isinstance(artifact, PhysicalPosterior):
         raise TypeError("physical_posterior_npz must contain a PhysicalPosterior")
-    bundle = load_molmo_forecasts(args.molmo_forecast_npz)
-    evidence = molmo_task_evidence(
-        bundle,
-        args.forecast_id,
-        artifact,
-        scale_m=args.scale_m,
-        degrees_of_freedom=args.degrees_of_freedom,
-    )
+    if is_external_forecast_artifact(args.forecast_npz):
+        bundle = load_external_forecast(args.forecast_npz)
+        evidence = external_forecast_evidence(
+            bundle,
+            args.forecast_id,
+            artifact,
+            scale_m=args.scale_m,
+            degrees_of_freedom=args.degrees_of_freedom,
+        )
+        forecast_kind = "external"
+        forecast_artifact_id = bundle.artifact_id
+    else:
+        bundle = load_molmo_forecasts(args.forecast_npz)
+        evidence = molmo_task_evidence(
+            bundle,
+            args.forecast_id,
+            artifact,
+            scale_m=args.scale_m,
+            degrees_of_freedom=args.degrees_of_freedom,
+        )
+        forecast_kind = "molmomotion"
+        forecast_artifact_id = None
     task = build_task_posterior(artifact, evidence, beta=args.beta)
     save_contract(args.output_task_npz, task)
     positive = task.task_weights > 0.0
@@ -76,7 +99,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             {
                 "beta": task.beta,
                 "effective_components": effective_components,
+                "forecast_artifact_id": forecast_artifact_id,
                 "forecast_id": args.forecast_id,
+                "forecast_kind": forecast_kind,
                 "kl_task_from_physical": kl_from_physical,
                 "output": str(Path(args.output_task_npz).resolve()),
                 "physical_posterior_id": task.physical_posterior_id,

--- a/src/causal4d/external_forecast.py
+++ b/src/causal4d/external_forecast.py
@@ -1,0 +1,548 @@
+"""Portable, content-addressed external sparse trajectory forecasts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, BinaryIO
+
+import numpy as np
+
+from causal4d.atomic_io import atomic_write_binary
+from causal4d.contracts import array_sha256
+from causal4d.immutable_array import readonly_array, readonly_integer_array
+from causal4d.immutable_json import plain_json, validated_json_mapping
+
+EXTERNAL_FORECAST_SCHEMA = "causal4d.external_sparse_trajectory_forecast"
+EXTERNAL_FORECAST_SCHEMA_VERSION = 1
+EXTERNAL_FORECAST_IMPORT_SCHEMA = "causal4d.external_forecast_import"
+EXTERNAL_FORECAST_IMPORT_SCHEMA_VERSION = 1
+
+_ARCHIVE_FIELDS = frozenset(
+    {
+        "descriptor_json",
+        "node_indices",
+        "anchor_positions_m",
+        "future_positions_m",
+        "physical_frame_indices",
+        "validity_mask",
+        "future_times_s",
+    }
+)
+_DESCRIPTOR_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "artifact_id",
+        "case_id",
+        "source",
+        "forecast_ids",
+        "anchor_physical_frame",
+        "forecast_metadata",
+        "metadata",
+        "payload",
+    }
+)
+_SOURCE_FIELDS = frozenset({"model", "revision", "artifact_id"})
+_PAYLOAD_FIELDS = frozenset(
+    {
+        "node_indices_sha256",
+        "anchor_positions_m_sha256",
+        "future_positions_m_sha256",
+        "physical_frame_indices_sha256",
+        "validity_mask_sha256",
+        "future_times_s_sha256",
+    }
+)
+
+
+def _require_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    if any(type(key) is not str for key in value):
+        raise ValueError(f"{name} keys must be strings")
+    return value
+
+
+def _require_exact_fields(
+    value: Any,
+    *,
+    name: str,
+    required: frozenset[str],
+) -> Mapping[str, Any]:
+    mapping = _require_mapping(value, name=name)
+    actual = set(mapping)
+    missing = sorted(required - actual)
+    unexpected = sorted(actual - required)
+    if missing or unexpected:
+        raise ValueError(
+            f"{name} fields do not match schema; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    return mapping
+
+
+def _require_nonempty_string(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _require_optional_string(value: Any, *, name: str) -> str | None:
+    if value is None:
+        return None
+    return _require_nonempty_string(value, name=name)
+
+
+def _require_integer(value: Any, *, name: str, minimum: int = 0) -> int:
+    if type(value) is not int or value < minimum:
+        raise ValueError(
+            f"{name} must be an integer greater than or equal to {minimum}"
+        )
+    return value
+
+
+def _validated_string_tuple(values: Any, *, name: str) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise ValueError(f"{name} must be a sequence of strings")
+    result = tuple(
+        _require_nonempty_string(value, name=f"{name}[{index}]")
+        for index, value in enumerate(values)
+    )
+    if not result:
+        raise ValueError(f"{name} must be nonempty")
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must not contain duplicates")
+    return result
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_json_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON constant {value!r} is not allowed")
+
+
+def _canonical_json(value: Mapping[str, Any]) -> str:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def _validate_sha256(value: Any, *, name: str) -> str:
+    if (
+        type(value) is not str
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _normalize_forecast_metadata(
+    values: Mapping[str, Any],
+    forecast_ids: tuple[str, ...],
+) -> Mapping[str, Any]:
+    supplied = _require_mapping(values, name="forecast_metadata")
+    unexpected = sorted(set(supplied) - set(forecast_ids))
+    if unexpected:
+        raise ValueError(
+            "forecast_metadata contains unknown forecast ids: " + repr(unexpected)
+        )
+    normalized: dict[str, Any] = {}
+    for forecast_id in forecast_ids:
+        entry = supplied.get(forecast_id, {})
+        normalized[forecast_id] = dict(
+            _require_mapping(
+                entry,
+                name=f"forecast_metadata[{forecast_id!r}]",
+            )
+        )
+    return validated_json_mapping(
+        normalized,
+        error_message="forecast_metadata must be finite JSON data",
+    )
+
+
+@dataclass(frozen=True)
+class ExternalForecastBundle:
+    """Canonical sparse trajectory forecasts aligned to physical node identities."""
+
+    case_id: str
+    source_model: str
+    forecast_ids: tuple[str, ...]
+    node_indices: np.ndarray
+    anchor_positions_m: np.ndarray
+    future_positions_m: np.ndarray
+    physical_frame_indices: np.ndarray
+    validity_mask: np.ndarray | None = None
+    anchor_physical_frame: int = 0
+    source_revision: str | None = None
+    source_artifact_id: str | None = None
+    future_times_s: np.ndarray | None = None
+    forecast_metadata: Mapping[str, Any] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        case_id = _require_nonempty_string(self.case_id, name="case_id")
+        source_model = _require_nonempty_string(
+            self.source_model,
+            name="source_model",
+        )
+        forecast_ids = _validated_string_tuple(
+            self.forecast_ids,
+            name="forecast_ids",
+        )
+        source_revision = _require_optional_string(
+            self.source_revision,
+            name="source_revision",
+        )
+        source_artifact_id = _require_optional_string(
+            self.source_artifact_id,
+            name="source_artifact_id",
+        )
+        anchor_frame = _require_integer(
+            self.anchor_physical_frame,
+            name="anchor_physical_frame",
+        )
+
+        nodes = readonly_integer_array(self.node_indices, name="node_indices")
+        if nodes.ndim != 1 or not len(nodes):
+            raise ValueError("node_indices must be a nonempty vector")
+        if np.any(nodes < 0) or len(np.unique(nodes)) != len(nodes):
+            raise ValueError("node_indices must be unique and nonnegative")
+
+        anchor = readonly_array(self.anchor_positions_m, dtype=np.float64)
+        if anchor.shape != (len(nodes), 3) or not np.all(np.isfinite(anchor)):
+            raise ValueError("anchor_positions_m must have finite shape (P, 3)")
+
+        future = np.asarray(self.future_positions_m, dtype=np.float64).copy()
+        if future.ndim != 4 or future.shape[3] != 3:
+            raise ValueError("future_positions_m must have shape (K, F, P, 3)")
+        if future.shape[0] != len(forecast_ids):
+            raise ValueError("future_positions_m K must match forecast_ids")
+        if future.shape[1] < 1 or future.shape[2] != len(nodes):
+            raise ValueError("future_positions_m must have nonempty F and matching P")
+
+        if self.validity_mask is None:
+            valid = np.isfinite(future)
+        else:
+            supplied = np.asarray(self.validity_mask, dtype=bool)
+            if supplied.shape == future.shape[:3]:
+                supplied = np.repeat(supplied[..., None], 3, axis=3)
+            if supplied.shape != future.shape:
+                raise ValueError(
+                    "validity_mask must have shape (K, F, P) or (K, F, P, 3)"
+                )
+            valid = supplied.copy()
+        if np.any(valid & ~np.isfinite(future)):
+            raise ValueError("valid future coordinates must be finite")
+        if np.any(np.sum(valid, axis=(1, 2, 3)) == 0):
+            raise ValueError("each forecast must contain at least one valid coordinate")
+        future[~valid] = np.nan
+        future.setflags(write=False)
+        valid.setflags(write=False)
+
+        frames = readonly_array(self.physical_frame_indices, dtype=np.float64)
+        if frames.shape != (future.shape[1],) or not np.all(np.isfinite(frames)):
+            raise ValueError(
+                "physical_frame_indices must be a finite vector matching F"
+            )
+        if np.any(frames <= anchor_frame) or np.any(np.diff(frames) <= 0.0):
+            raise ValueError(
+                "physical_frame_indices must be strictly increasing after the anchor"
+            )
+
+        times = None
+        if self.future_times_s is not None:
+            times = readonly_array(self.future_times_s, dtype=np.float64)
+            if times.shape != (future.shape[1],) or not np.all(np.isfinite(times)):
+                raise ValueError("future_times_s must be a finite vector matching F")
+            if np.any(times <= 0.0) or np.any(np.diff(times) <= 0.0):
+                raise ValueError(
+                    "future_times_s must be strictly increasing and positive"
+                )
+
+        forecast_metadata = _normalize_forecast_metadata(
+            self.forecast_metadata,
+            forecast_ids,
+        )
+        metadata = validated_json_mapping(
+            self.metadata,
+            error_message="metadata must be finite JSON data",
+        )
+
+        object.__setattr__(self, "case_id", case_id)
+        object.__setattr__(self, "source_model", source_model)
+        object.__setattr__(self, "forecast_ids", forecast_ids)
+        object.__setattr__(self, "source_revision", source_revision)
+        object.__setattr__(self, "source_artifact_id", source_artifact_id)
+        object.__setattr__(self, "anchor_physical_frame", anchor_frame)
+        object.__setattr__(self, "node_indices", nodes)
+        object.__setattr__(self, "anchor_positions_m", anchor)
+        object.__setattr__(self, "future_positions_m", future)
+        object.__setattr__(self, "physical_frame_indices", frames)
+        object.__setattr__(self, "validity_mask", valid)
+        object.__setattr__(self, "future_times_s", times)
+        object.__setattr__(self, "forecast_metadata", forecast_metadata)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def forecast_count(self) -> int:
+        return len(self.forecast_ids)
+
+    @property
+    def future_horizon(self) -> int:
+        return int(self.future_positions_m.shape[1])
+
+    @property
+    def point_count(self) -> int:
+        return len(self.node_indices)
+
+    @property
+    def coordinate_validity(self) -> np.ndarray:
+        """Return the normalized coordinate-level validity mask."""
+
+        validity = self.validity_mask
+        if validity is None:
+            raise RuntimeError("normalized external forecast is missing validity")
+        return validity
+
+    def forecast_index(self, forecast_id: str) -> int:
+        try:
+            return self.forecast_ids.index(forecast_id)
+        except ValueError as error:
+            raise ValueError(f"unknown external forecast id {forecast_id!r}") from error
+
+    def _payload_hashes(self) -> dict[str, str | None]:
+        return {
+            "node_indices_sha256": array_sha256(self.node_indices),
+            "anchor_positions_m_sha256": array_sha256(self.anchor_positions_m),
+            "future_positions_m_sha256": array_sha256(self.future_positions_m),
+            "physical_frame_indices_sha256": array_sha256(
+                self.physical_frame_indices
+            ),
+            "validity_mask_sha256": array_sha256(self.coordinate_validity),
+            "future_times_s_sha256": (
+                array_sha256(self.future_times_s)
+                if self.future_times_s is not None
+                else None
+            ),
+        }
+
+    def _descriptor_without_id(self) -> dict[str, Any]:
+        return {
+            "schema": EXTERNAL_FORECAST_SCHEMA,
+            "schema_version": EXTERNAL_FORECAST_SCHEMA_VERSION,
+            "case_id": self.case_id,
+            "source": {
+                "model": self.source_model,
+                "revision": self.source_revision,
+                "artifact_id": self.source_artifact_id,
+            },
+            "forecast_ids": list(self.forecast_ids),
+            "anchor_physical_frame": self.anchor_physical_frame,
+            "forecast_metadata": plain_json(self.forecast_metadata),
+            "metadata": plain_json(self.metadata),
+            "payload": self._payload_hashes(),
+        }
+
+    @property
+    def artifact_id(self) -> str:
+        encoded = _canonical_json(self._descriptor_without_id()).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def descriptor(self) -> dict[str, Any]:
+        descriptor = self._descriptor_without_id()
+        descriptor["artifact_id"] = self.artifact_id
+        return descriptor
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "artifact_id": self.artifact_id,
+            "case_id": self.case_id,
+            "source_model": self.source_model,
+            "source_revision": self.source_revision,
+            "forecast_ids": list(self.forecast_ids),
+            "forecast_count": self.forecast_count,
+            "future_horizon": self.future_horizon,
+            "point_count": self.point_count,
+            "anchor_physical_frame": self.anchor_physical_frame,
+            "physical_frame_start": float(self.physical_frame_indices[0]),
+            "physical_frame_stop": float(self.physical_frame_indices[-1]),
+            "valid_coordinate_fraction": float(np.mean(self.coordinate_validity)),
+        }
+
+
+def _save_archive(handle: BinaryIO, bundle: ExternalForecastBundle) -> None:
+    np.savez_compressed(
+        handle,
+        descriptor_json=np.asarray(_canonical_json(bundle.descriptor())),
+        node_indices=bundle.node_indices,
+        anchor_positions_m=bundle.anchor_positions_m,
+        future_positions_m=bundle.future_positions_m,
+        physical_frame_indices=bundle.physical_frame_indices,
+        validity_mask=bundle.coordinate_validity,
+        future_times_s=(
+            bundle.future_times_s
+            if bundle.future_times_s is not None
+            else np.asarray([], dtype=np.float64)
+        ),
+    )
+
+
+def save_external_forecast(
+    path: str | Path,
+    bundle: ExternalForecastBundle,
+    *,
+    overwrite: bool = True,
+) -> None:
+    """Atomically publish a canonical external-forecast artifact."""
+
+    expected_id = bundle.artifact_id
+
+    def validate(temporary: Path) -> None:
+        loaded = load_external_forecast(temporary)
+        if loaded.artifact_id != expected_id:
+            raise ValueError("external forecast changed during serialization")
+
+    atomic_write_binary(
+        path,
+        lambda handle: _save_archive(handle, bundle),
+        overwrite=overwrite,
+        validate=validate,
+    )
+
+
+def _parse_descriptor(value: np.ndarray) -> Mapping[str, Any]:
+    array = np.asarray(value)
+    if array.shape != () or array.dtype.kind not in {"U", "S"}:
+        raise ValueError("descriptor_json must be one scalar string")
+    scalar = array.item()
+    if isinstance(scalar, bytes):
+        try:
+            scalar = scalar.decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise ValueError("descriptor_json is not valid UTF-8") from error
+    try:
+        parsed = json.loads(
+            scalar,
+            object_pairs_hook=_reject_duplicate_json_keys,
+            parse_constant=_reject_nonfinite_json_constant,
+        )
+    except (TypeError, ValueError, json.JSONDecodeError) as error:
+        raise ValueError("descriptor_json is invalid") from error
+    return _require_exact_fields(
+        parsed,
+        name="external forecast descriptor",
+        required=_DESCRIPTOR_FIELDS,
+    )
+
+
+def is_external_forecast_artifact(path: str | Path) -> bool:
+    """Return whether an NPZ advertises the canonical external-forecast schema."""
+
+    with np.load(path, allow_pickle=False) as archive:
+        if "descriptor_json" not in archive.files:
+            return False
+        descriptor = _parse_descriptor(archive["descriptor_json"])
+        return descriptor["schema"] == EXTERNAL_FORECAST_SCHEMA
+
+
+def load_external_forecast(path: str | Path) -> ExternalForecastBundle:
+    """Load and fully revalidate a canonical external-forecast artifact."""
+
+    with np.load(path, allow_pickle=False) as archive:
+        actual_fields = frozenset(archive.files)
+        if actual_fields != _ARCHIVE_FIELDS:
+            raise ValueError(
+                "external forecast archive fields do not match schema; "
+                f"missing={sorted(_ARCHIVE_FIELDS - actual_fields)}, "
+                f"unexpected={sorted(actual_fields - _ARCHIVE_FIELDS)}"
+            )
+        descriptor = _parse_descriptor(archive["descriptor_json"])
+        if _require_nonempty_string(
+            descriptor["schema"],
+            name="external forecast schema",
+        ) != EXTERNAL_FORECAST_SCHEMA:
+            raise ValueError("artifact is not a Causal4D external forecast")
+        if _require_integer(
+            descriptor["schema_version"],
+            name="external forecast schema_version",
+            minimum=1,
+        ) != EXTERNAL_FORECAST_SCHEMA_VERSION:
+            raise ValueError("unsupported external forecast schema version")
+        source = _require_exact_fields(
+            descriptor["source"],
+            name="external forecast source",
+            required=_SOURCE_FIELDS,
+        )
+        payload = _require_exact_fields(
+            descriptor["payload"],
+            name="external forecast payload",
+            required=_PAYLOAD_FIELDS,
+        )
+        times_array = np.asarray(archive["future_times_s"], dtype=np.float64)
+        if times_array.ndim != 1:
+            raise ValueError("future_times_s archive array must be one-dimensional")
+        bundle = ExternalForecastBundle(
+            case_id=descriptor["case_id"],
+            source_model=source["model"],
+            source_revision=source["revision"],
+            source_artifact_id=source["artifact_id"],
+            forecast_ids=tuple(descriptor["forecast_ids"]),
+            node_indices=np.asarray(archive["node_indices"]),
+            anchor_positions_m=np.asarray(archive["anchor_positions_m"]),
+            future_positions_m=np.asarray(archive["future_positions_m"]),
+            physical_frame_indices=np.asarray(archive["physical_frame_indices"]),
+            validity_mask=np.asarray(archive["validity_mask"]),
+            anchor_physical_frame=descriptor["anchor_physical_frame"],
+            future_times_s=times_array if len(times_array) else None,
+            forecast_metadata=descriptor["forecast_metadata"],
+            metadata=descriptor["metadata"],
+        )
+        expected_artifact_id = _validate_sha256(
+            descriptor["artifact_id"],
+            name="external forecast artifact_id",
+        )
+        if bundle.artifact_id != expected_artifact_id:
+            raise ValueError("external forecast artifact_id does not match payload")
+        if bundle._payload_hashes() != dict(payload):
+            raise ValueError("external forecast payload hashes do not match arrays")
+        return bundle
+
+
+def import_external_forecast(
+    source_npz: str | Path,
+    import_manifest_json: str | Path,
+) -> ExternalForecastBundle:
+    """Import a producer artifact through the strict manifest adapter."""
+
+    from causal4d.external_forecast_importer import import_external_forecast as impl
+
+    return impl(source_npz, import_manifest_json)
+
+
+__all__ = [
+    "EXTERNAL_FORECAST_IMPORT_SCHEMA",
+    "EXTERNAL_FORECAST_IMPORT_SCHEMA_VERSION",
+    "EXTERNAL_FORECAST_SCHEMA",
+    "EXTERNAL_FORECAST_SCHEMA_VERSION",
+    "ExternalForecastBundle",
+    "import_external_forecast",
+    "is_external_forecast_artifact",
+    "load_external_forecast",
+    "save_external_forecast",
+]

--- a/src/causal4d/external_forecast.py
+++ b/src/causal4d/external_forecast.py
@@ -331,9 +331,7 @@ class ExternalForecastBundle:
             "node_indices_sha256": array_sha256(self.node_indices),
             "anchor_positions_m_sha256": array_sha256(self.anchor_positions_m),
             "future_positions_m_sha256": array_sha256(self.future_positions_m),
-            "physical_frame_indices_sha256": array_sha256(
-                self.physical_frame_indices
-            ),
+            "physical_frame_indices_sha256": array_sha256(self.physical_frame_indices),
             "validity_mask_sha256": array_sha256(self.coordinate_validity),
             "future_times_s_sha256": (
                 array_sha256(self.future_times_s)
@@ -473,16 +471,22 @@ def load_external_forecast(path: str | Path) -> ExternalForecastBundle:
                 f"unexpected={sorted(actual_fields - _ARCHIVE_FIELDS)}"
             )
         descriptor = _parse_descriptor(archive["descriptor_json"])
-        if _require_nonempty_string(
-            descriptor["schema"],
-            name="external forecast schema",
-        ) != EXTERNAL_FORECAST_SCHEMA:
+        if (
+            _require_nonempty_string(
+                descriptor["schema"],
+                name="external forecast schema",
+            )
+            != EXTERNAL_FORECAST_SCHEMA
+        ):
             raise ValueError("artifact is not a Causal4D external forecast")
-        if _require_integer(
-            descriptor["schema_version"],
-            name="external forecast schema_version",
-            minimum=1,
-        ) != EXTERNAL_FORECAST_SCHEMA_VERSION:
+        if (
+            _require_integer(
+                descriptor["schema_version"],
+                name="external forecast schema_version",
+                minimum=1,
+            )
+            != EXTERNAL_FORECAST_SCHEMA_VERSION
+        ):
             raise ValueError("unsupported external forecast schema version")
         source = _require_exact_fields(
             descriptor["source"],

--- a/src/causal4d/external_forecast_importer.py
+++ b/src/causal4d/external_forecast_importer.py
@@ -1,0 +1,502 @@
+"""Strict adapter from producer NPZ files to external forecast artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from causal4d.contracts import array_sha256
+from causal4d.external_forecast import (
+    EXTERNAL_FORECAST_IMPORT_SCHEMA,
+    EXTERNAL_FORECAST_IMPORT_SCHEMA_VERSION,
+    ExternalForecastBundle,
+)
+from causal4d.immutable_json import plain_json, validated_json_mapping
+
+_IMPORT_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "case_id",
+        "source",
+        "arrays",
+        "layout",
+        "coordinate_frame",
+        "position_unit",
+        "forecast_ids",
+    }
+)
+_IMPORT_OPTIONAL_FIELDS = frozenset(
+    {
+        "anchor_physical_frame",
+        "physical_fps",
+        "forecast_metadata",
+        "metadata",
+    }
+)
+_IMPORT_ARRAY_FIELDS = frozenset(
+    {"node_indices", "anchor_positions", "future_positions"}
+)
+_IMPORT_ARRAY_OPTIONAL_FIELDS = frozenset(
+    {
+        "physical_frame_indices",
+        "future_times_s",
+        "validity_mask",
+        "camera_to_world",
+    }
+)
+_UNIT_SCALE_TO_M = {"m": 1.0, "cm": 1e-2, "mm": 1e-3}
+_LAYOUTS = frozenset({"PFC", "FPC", "KPFC", "KFPC"})
+_COORDINATE_FRAMES = frozenset({"world", "camera"})
+
+
+def _require_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    if any(type(key) is not str for key in value):
+        raise ValueError(f"{name} keys must be strings")
+    return value
+
+
+def _require_exact_fields(
+    value: Any,
+    *,
+    name: str,
+    required: frozenset[str],
+    optional: frozenset[str] = frozenset(),
+) -> Mapping[str, Any]:
+    mapping = _require_mapping(value, name=name)
+    actual = set(mapping)
+    missing = sorted(required - actual)
+    unexpected = sorted(actual - required - optional)
+    if missing or unexpected:
+        raise ValueError(
+            f"{name} fields do not match schema; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    return mapping
+
+
+def _require_nonempty_string(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _require_optional_string(value: Any, *, name: str) -> str | None:
+    if value is None:
+        return None
+    return _require_nonempty_string(value, name=name)
+
+
+def _require_integer(value: Any, *, name: str, minimum: int = 0) -> int:
+    if type(value) is not int or value < minimum:
+        raise ValueError(
+            f"{name} must be an integer greater than or equal to {minimum}"
+        )
+    return value
+
+
+def _require_positive_number(value: Any, *, name: str) -> float:
+    if type(value) not in {int, float} or not np.isfinite(value) or value <= 0.0:
+        raise ValueError(f"{name} must be a finite positive number")
+    return float(value)
+
+
+def _validated_string_tuple(values: Any, *, name: str) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise ValueError(f"{name} must be a sequence of strings")
+    result = tuple(
+        _require_nonempty_string(value, name=f"{name}[{index}]")
+        for index, value in enumerate(values)
+    )
+    if not result:
+        raise ValueError(f"{name} must be nonempty")
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must not contain duplicates")
+    return result
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_json_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON constant {value!r} is not allowed")
+
+
+def _load_json_mapping(path: str | Path, *, name: str) -> Mapping[str, Any]:
+    try:
+        parsed = json.loads(
+            Path(path).read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_json_keys,
+            parse_constant=_reject_nonfinite_json_constant,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"{name} is not valid UTF-8 JSON") from error
+    return _require_mapping(parsed, name=name)
+
+
+def _file_sha256(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _source_array(
+    archive: np.lib.npyio.NpzFile,
+    key: Any,
+    *,
+    name: str,
+) -> np.ndarray:
+    key_text = _require_nonempty_string(key, name=f"arrays.{name}")
+    if key_text not in archive.files:
+        raise ValueError(f"source NPZ does not contain array {key_text!r} for {name}")
+    try:
+        return np.asarray(archive[key_text])
+    except ValueError as error:
+        raise ValueError(
+            f"source array {key_text!r} cannot be loaded without pickle"
+        ) from error
+
+
+def _normalize_future_positions(values: np.ndarray, layout: str) -> np.ndarray:
+    array = np.asarray(values, dtype=np.float64)
+    if layout == "PFC":
+        if array.ndim != 3 or array.shape[2] != 3:
+            raise ValueError("PFC future_positions must have shape (P, F, 3)")
+        return np.transpose(array, (1, 0, 2))[None]
+    if layout == "FPC":
+        if array.ndim != 3 or array.shape[2] != 3:
+            raise ValueError("FPC future_positions must have shape (F, P, 3)")
+        return array[None]
+    if layout == "KPFC":
+        if array.ndim != 4 or array.shape[3] != 3:
+            raise ValueError("KPFC future_positions must have shape (K, P, F, 3)")
+        return np.transpose(array, (0, 2, 1, 3))
+    if layout == "KFPC":
+        if array.ndim != 4 or array.shape[3] != 3:
+            raise ValueError("KFPC future_positions must have shape (K, F, P, 3)")
+        return array
+    raise ValueError(f"unsupported future_positions layout {layout!r}")
+
+
+def _normalize_validity(
+    values: np.ndarray,
+    *,
+    layout: str,
+    canonical_shape: tuple[int, int, int, int],
+) -> np.ndarray:
+    array = np.asarray(values, dtype=bool)
+    forecast_count, frame_count, point_count, _ = canonical_shape
+    if layout == "PFC":
+        point_shape = (point_count, frame_count)
+        coordinate_shape = (*point_shape, 3)
+        if array.shape == point_shape:
+            result = np.transpose(array, (1, 0))[None, ..., None]
+        elif array.shape == coordinate_shape:
+            result = np.transpose(array, (1, 0, 2))[None]
+        else:
+            raise ValueError(
+                "PFC validity must have shape (P, F) or (P, F, 3)"
+            )
+    elif layout == "FPC":
+        point_shape = (frame_count, point_count)
+        coordinate_shape = (*point_shape, 3)
+        if array.shape == point_shape:
+            result = array[None, ..., None]
+        elif array.shape == coordinate_shape:
+            result = array[None]
+        else:
+            raise ValueError(
+                "FPC validity must have shape (F, P) or (F, P, 3)"
+            )
+    elif layout == "KPFC":
+        point_shape = (forecast_count, point_count, frame_count)
+        coordinate_shape = (*point_shape, 3)
+        if array.shape == point_shape:
+            result = np.transpose(array, (0, 2, 1))[..., None]
+        elif array.shape == coordinate_shape:
+            result = np.transpose(array, (0, 2, 1, 3))
+        else:
+            raise ValueError(
+                "KPFC validity must have shape (K, P, F) or (K, P, F, 3)"
+            )
+    elif layout == "KFPC":
+        point_shape = (forecast_count, frame_count, point_count)
+        coordinate_shape = (*point_shape, 3)
+        if array.shape == point_shape:
+            result = array[..., None]
+        elif array.shape == coordinate_shape:
+            result = array
+        else:
+            raise ValueError(
+                "KFPC validity must have shape (K, F, P) or (K, F, P, 3)"
+            )
+    else:
+        raise ValueError(f"unsupported validity layout {layout!r}")
+    if result.shape[-1] == 1:
+        result = np.repeat(result, 3, axis=3)
+    if result.shape != canonical_shape:
+        raise ValueError(
+            "validity_mask shape does not match normalized future_positions: "
+            f"{result.shape} != {canonical_shape}"
+        )
+    return result
+
+
+def _camera_to_world(points_m: np.ndarray, transform: np.ndarray) -> np.ndarray:
+    matrix = np.asarray(transform, dtype=np.float64)
+    if matrix.shape != (4, 4) or not np.all(np.isfinite(matrix)):
+        raise ValueError("camera_to_world must have finite shape (4, 4)")
+    if not np.allclose(matrix[3], np.asarray([0.0, 0.0, 0.0, 1.0])):
+        raise ValueError("camera_to_world must be a homogeneous rigid transform")
+    rotation = matrix[:3, :3]
+    if not np.allclose(rotation.T @ rotation, np.eye(3), atol=1e-6, rtol=1e-6):
+        raise ValueError("camera_to_world rotation must be orthonormal")
+    if not np.isclose(np.linalg.det(rotation), 1.0, atol=1e-6, rtol=1e-6):
+        raise ValueError("camera_to_world rotation must have determinant one")
+    flat = points_m.reshape(-1, 3)
+    homogeneous = np.column_stack((flat, np.ones(len(flat))))
+    transformed = homogeneous @ matrix.T
+    return transformed[:, :3].reshape(points_m.shape)
+
+
+def import_external_forecast(
+    source_npz: str | Path,
+    import_manifest_json: str | Path,
+) -> ExternalForecastBundle:
+    """Normalize a producer NPZ according to a strict, portable manifest."""
+
+    manifest_hash = _file_sha256(import_manifest_json)
+    manifest = _require_exact_fields(
+        _load_json_mapping(import_manifest_json, name="external forecast manifest"),
+        name="external forecast manifest",
+        required=_IMPORT_FIELDS,
+        optional=_IMPORT_OPTIONAL_FIELDS,
+    )
+    if _file_sha256(import_manifest_json) != manifest_hash:
+        raise ValueError("external forecast manifest changed during import")
+    if _require_nonempty_string(
+        manifest["schema"],
+        name="external forecast import schema",
+    ) != EXTERNAL_FORECAST_IMPORT_SCHEMA:
+        raise ValueError("unexpected external forecast import schema")
+    if _require_integer(
+        manifest["schema_version"],
+        name="external forecast import schema_version",
+        minimum=1,
+    ) != EXTERNAL_FORECAST_IMPORT_SCHEMA_VERSION:
+        raise ValueError("unsupported external forecast import schema version")
+
+    case_id = _require_nonempty_string(manifest["case_id"], name="case_id")
+    source = _require_exact_fields(
+        manifest["source"],
+        name="external forecast source",
+        required=frozenset({"model"}),
+        optional=frozenset({"revision", "artifact_id"}),
+    )
+    source_model = _require_nonempty_string(source["model"], name="source.model")
+    source_revision = _require_optional_string(
+        source.get("revision"),
+        name="source.revision",
+    )
+    source_artifact_id = _require_optional_string(
+        source.get("artifact_id"),
+        name="source.artifact_id",
+    )
+    arrays = _require_exact_fields(
+        manifest["arrays"],
+        name="external forecast arrays",
+        required=_IMPORT_ARRAY_FIELDS,
+        optional=_IMPORT_ARRAY_OPTIONAL_FIELDS,
+    )
+    layout = _require_nonempty_string(manifest["layout"], name="layout")
+    if layout not in _LAYOUTS:
+        raise ValueError(f"layout must be one of {sorted(_LAYOUTS)}")
+    coordinate_frame = _require_nonempty_string(
+        manifest["coordinate_frame"],
+        name="coordinate_frame",
+    )
+    if coordinate_frame not in _COORDINATE_FRAMES:
+        raise ValueError(
+            f"coordinate_frame must be one of {sorted(_COORDINATE_FRAMES)}"
+        )
+    position_unit = _require_nonempty_string(
+        manifest["position_unit"],
+        name="position_unit",
+    )
+    if position_unit not in _UNIT_SCALE_TO_M:
+        raise ValueError(
+            f"position_unit must be one of {sorted(_UNIT_SCALE_TO_M)}"
+        )
+    forecast_ids = _validated_string_tuple(
+        manifest["forecast_ids"],
+        name="forecast_ids",
+    )
+    anchor_frame = _require_integer(
+        manifest.get("anchor_physical_frame", 0),
+        name="anchor_physical_frame",
+    )
+    physical_fps = (
+        _require_positive_number(manifest["physical_fps"], name="physical_fps")
+        if "physical_fps" in manifest
+        else None
+    )
+    forecast_metadata = _require_mapping(
+        manifest.get("forecast_metadata", {}),
+        name="forecast_metadata",
+    )
+    producer_metadata = validated_json_mapping(
+        _require_mapping(manifest.get("metadata", {}), name="metadata"),
+        error_message="manifest metadata must be finite JSON data",
+    )
+
+    source_npz_hash = _file_sha256(source_npz)
+    with np.load(source_npz, allow_pickle=False) as archive:
+        nodes = _source_array(
+            archive,
+            arrays["node_indices"],
+            name="node_indices",
+        )
+        anchor = np.asarray(
+            _source_array(
+                archive,
+                arrays["anchor_positions"],
+                name="anchor_positions",
+            ),
+            dtype=np.float64,
+        )
+        future = _normalize_future_positions(
+            _source_array(
+                archive,
+                arrays["future_positions"],
+                name="future_positions",
+            ),
+            layout,
+        )
+        valid = None
+        if "validity_mask" in arrays:
+            valid = _normalize_validity(
+                _source_array(
+                    archive,
+                    arrays["validity_mask"],
+                    name="validity_mask",
+                ),
+                layout=layout,
+                canonical_shape=future.shape,
+            )
+
+        times = None
+        if "future_times_s" in arrays:
+            times = np.asarray(
+                _source_array(
+                    archive,
+                    arrays["future_times_s"],
+                    name="future_times_s",
+                ),
+                dtype=np.float64,
+            )
+        frames = None
+        if "physical_frame_indices" in arrays:
+            frames = np.asarray(
+                _source_array(
+                    archive,
+                    arrays["physical_frame_indices"],
+                    name="physical_frame_indices",
+                ),
+                dtype=np.float64,
+            )
+        if times is not None and physical_fps is None:
+            raise ValueError("physical_fps is required with arrays.future_times_s")
+        if frames is None:
+            if times is None:
+                raise ValueError(
+                    "provide arrays.physical_frame_indices or both "
+                    "arrays.future_times_s and physical_fps"
+                )
+            frames = anchor_frame + times * physical_fps
+        elif times is not None:
+            derived = anchor_frame + times * physical_fps
+            if frames.shape != derived.shape or not np.allclose(
+                frames,
+                derived,
+                atol=1e-9,
+                rtol=1e-9,
+            ):
+                raise ValueError(
+                    "physical_frame_indices disagree with future_times_s * physical_fps"
+                )
+
+        scale = _UNIT_SCALE_TO_M[position_unit]
+        anchor = anchor * scale
+        future = future * scale
+        camera_to_world_hash = None
+        if coordinate_frame == "camera":
+            if "camera_to_world" not in arrays:
+                raise ValueError(
+                    "camera-frame imports require arrays.camera_to_world"
+                )
+            transform = np.asarray(
+                _source_array(
+                    archive,
+                    arrays["camera_to_world"],
+                    name="camera_to_world",
+                ),
+                dtype=np.float64,
+            )
+            camera_to_world_hash = array_sha256(transform)
+            anchor = _camera_to_world(anchor, transform)
+            future = _camera_to_world(future, transform)
+        elif "camera_to_world" in arrays:
+            raise ValueError(
+                "arrays.camera_to_world is only valid for coordinate_frame='camera'"
+            )
+
+    if _file_sha256(source_npz) != source_npz_hash:
+        raise ValueError("source NPZ changed during import")
+    import_metadata = {
+        "importer": {
+            "schema": EXTERNAL_FORECAST_IMPORT_SCHEMA,
+            "schema_version": EXTERNAL_FORECAST_IMPORT_SCHEMA_VERSION,
+            "source_npz_sha256": source_npz_hash,
+            "import_manifest_sha256": manifest_hash,
+            "source_layout": layout,
+            "source_coordinate_frame": coordinate_frame,
+            "source_position_unit": position_unit,
+            "camera_to_world_sha256": camera_to_world_hash,
+            "physical_fps": physical_fps,
+        },
+        "producer": plain_json(producer_metadata),
+    }
+    return ExternalForecastBundle(
+        case_id=case_id,
+        source_model=source_model,
+        source_revision=source_revision,
+        source_artifact_id=source_artifact_id,
+        forecast_ids=forecast_ids,
+        node_indices=nodes,
+        anchor_positions_m=anchor,
+        future_positions_m=future,
+        physical_frame_indices=frames,
+        validity_mask=valid,
+        anchor_physical_frame=anchor_frame,
+        future_times_s=times,
+        forecast_metadata=forecast_metadata,
+        metadata=import_metadata,
+    )
+
+
+__all__ = ["import_external_forecast"]

--- a/src/causal4d/external_forecast_importer.py
+++ b/src/causal4d/external_forecast_importer.py
@@ -209,9 +209,7 @@ def _normalize_validity(
         elif array.shape == coordinate_shape:
             result = np.transpose(array, (1, 0, 2))[None]
         else:
-            raise ValueError(
-                "PFC validity must have shape (P, F) or (P, F, 3)"
-            )
+            raise ValueError("PFC validity must have shape (P, F) or (P, F, 3)")
     elif layout == "FPC":
         point_shape = (frame_count, point_count)
         coordinate_shape = (*point_shape, 3)
@@ -220,9 +218,7 @@ def _normalize_validity(
         elif array.shape == coordinate_shape:
             result = array[None]
         else:
-            raise ValueError(
-                "FPC validity must have shape (F, P) or (F, P, 3)"
-            )
+            raise ValueError("FPC validity must have shape (F, P) or (F, P, 3)")
     elif layout == "KPFC":
         point_shape = (forecast_count, point_count, frame_count)
         coordinate_shape = (*point_shape, 3)
@@ -231,9 +227,7 @@ def _normalize_validity(
         elif array.shape == coordinate_shape:
             result = np.transpose(array, (0, 2, 1, 3))
         else:
-            raise ValueError(
-                "KPFC validity must have shape (K, P, F) or (K, P, F, 3)"
-            )
+            raise ValueError("KPFC validity must have shape (K, P, F) or (K, P, F, 3)")
     elif layout == "KFPC":
         point_shape = (forecast_count, frame_count, point_count)
         coordinate_shape = (*point_shape, 3)
@@ -242,9 +236,7 @@ def _normalize_validity(
         elif array.shape == coordinate_shape:
             result = array
         else:
-            raise ValueError(
-                "KFPC validity must have shape (K, F, P) or (K, F, P, 3)"
-            )
+            raise ValueError("KFPC validity must have shape (K, F, P) or (K, F, P, 3)")
     else:
         raise ValueError(f"unsupported validity layout {layout!r}")
     if result.shape[-1] == 1:
@@ -289,16 +281,22 @@ def import_external_forecast(
     )
     if _file_sha256(import_manifest_json) != manifest_hash:
         raise ValueError("external forecast manifest changed during import")
-    if _require_nonempty_string(
-        manifest["schema"],
-        name="external forecast import schema",
-    ) != EXTERNAL_FORECAST_IMPORT_SCHEMA:
+    if (
+        _require_nonempty_string(
+            manifest["schema"],
+            name="external forecast import schema",
+        )
+        != EXTERNAL_FORECAST_IMPORT_SCHEMA
+    ):
         raise ValueError("unexpected external forecast import schema")
-    if _require_integer(
-        manifest["schema_version"],
-        name="external forecast import schema_version",
-        minimum=1,
-    ) != EXTERNAL_FORECAST_IMPORT_SCHEMA_VERSION:
+    if (
+        _require_integer(
+            manifest["schema_version"],
+            name="external forecast import schema_version",
+            minimum=1,
+        )
+        != EXTERNAL_FORECAST_IMPORT_SCHEMA_VERSION
+    ):
         raise ValueError("unsupported external forecast import schema version")
 
     case_id = _require_nonempty_string(manifest["case_id"], name="case_id")
@@ -339,9 +337,7 @@ def import_external_forecast(
         name="position_unit",
     )
     if position_unit not in _UNIT_SCALE_TO_M:
-        raise ValueError(
-            f"position_unit must be one of {sorted(_UNIT_SCALE_TO_M)}"
-        )
+        raise ValueError(f"position_unit must be one of {sorted(_UNIT_SCALE_TO_M)}")
     forecast_ids = _validated_string_tuple(
         manifest["forecast_ids"],
         name="forecast_ids",
@@ -446,9 +442,7 @@ def import_external_forecast(
         camera_to_world_hash = None
         if coordinate_frame == "camera":
             if "camera_to_world" not in arrays:
-                raise ValueError(
-                    "camera-frame imports require arrays.camera_to_world"
-                )
+                raise ValueError("camera-frame imports require arrays.camera_to_world")
             transform = np.asarray(
                 _source_array(
                     archive,

--- a/src/causal4d/semantic_posterior.py
+++ b/src/causal4d/semantic_posterior.py
@@ -1,4 +1,4 @@
-"""MolmoMotion reweighting through the sparse physical readout H_Q."""
+"""Sparse forecast reweighting through the physical readout ``H_Q``."""
 
 from __future__ import annotations
 
@@ -13,6 +13,7 @@ from causal4d.contracts import PhysicalPosterior, TaskPosterior, array_sha256
 from causal4d.immutable_array import readonly_array
 
 if TYPE_CHECKING:
+    from causal4d.external_forecast import ExternalForecastBundle
     from causal4d.molmo_adapter import MolmoForecastBundle
 
 
@@ -30,6 +31,7 @@ class SparseSemanticEvidence:
     anchor_physical_frame: int = 0
     valid: np.ndarray | None = None
     source: str = "semantic_trajectory"
+    semantic_interface: str = "q_MM(H_Q(X) | I, language)"
 
     def __post_init__(self) -> None:
         positions = readonly_array(self.positions_m, dtype=float)
@@ -45,10 +47,24 @@ class SparseSemanticEvidence:
             )
         if np.any(nodes < 0) or not np.all(np.isfinite(frames)):
             raise ValueError("semantic node and frame indices must be valid")
-        if self.scale_m <= 0.0 or self.degrees_of_freedom <= 0.0:
-            raise ValueError("semantic scale and degrees of freedom must be positive")
-        if not self.source:
-            raise ValueError("semantic source must be nonempty")
+        if (
+            not np.isfinite(self.scale_m)
+            or not np.isfinite(self.degrees_of_freedom)
+            or self.scale_m <= 0.0
+            or self.degrees_of_freedom <= 0.0
+        ):
+            raise ValueError(
+                "semantic scale and degrees of freedom must be finite and positive"
+            )
+        if type(self.source) is not str or not self.source:
+            raise ValueError("semantic source must be a nonempty string")
+        if type(self.semantic_interface) is not str or not self.semantic_interface:
+            raise ValueError("semantic_interface must be a nonempty string")
+        if (
+            type(self.anchor_physical_frame) is not int
+            or self.anchor_physical_frame < 0
+        ):
+            raise ValueError("anchor_physical_frame must be a nonnegative integer")
         valid = np.isfinite(positions)
         if self.valid is not None:
             supplied = np.asarray(self.valid, dtype=bool)
@@ -111,6 +127,52 @@ def molmo_task_evidence(
         anchor_positions_m=bundle.query.anchor_positions_world_m,
         anchor_physical_frame=0,
         source=f"MolmoMotion:{forecast_id}:{bundle.checkpoint}",
+        semantic_interface="q_MM(H_Q(X) | I, language)",
+    )
+
+
+def external_forecast_evidence(
+    bundle: ExternalForecastBundle,
+    forecast_id: str,
+    physical: PhysicalPosterior,
+    *,
+    scale_m: float = 0.10,
+    degrees_of_freedom: float = 3.0,
+) -> SparseSemanticEvidence:
+    """Align one canonical external trajectory forecast to ``H_Q(X)``."""
+
+    if bundle.case_id != physical.context.case_id:
+        raise ValueError("external forecast and PhysicalPosterior cases differ")
+    forecast_index = bundle.forecast_index(forecast_id)
+    physical_horizon = physical.state_trajectories_m.shape[1] - 1
+    if bundle.anchor_physical_frame > physical_horizon:
+        raise ValueError("external forecast anchor exceeds the physical posterior")
+    within_horizon = bundle.physical_frame_indices <= physical_horizon
+    available = int(np.sum(within_horizon))
+    if available < 1:
+        raise ValueError(
+            "external forecast and PhysicalPosterior have no common future"
+        )
+    if not np.all(within_horizon[:available]) or np.any(within_horizon[available:]):
+        raise ValueError("external forecast frame indices must form a horizon prefix")
+    source_revision = (
+        f":{bundle.source_revision}" if bundle.source_revision is not None else ""
+    )
+    return SparseSemanticEvidence(
+        positions_m=bundle.future_positions_m[forecast_index, :available],
+        node_indices=bundle.node_indices,
+        physical_frame_indices=bundle.physical_frame_indices[:available],
+        scale_m=scale_m,
+        degrees_of_freedom=degrees_of_freedom,
+        compare_displacements=True,
+        anchor_positions_m=bundle.anchor_positions_m,
+        anchor_physical_frame=bundle.anchor_physical_frame,
+        valid=bundle.coordinate_validity[forecast_index, :available],
+        source=(
+            f"ExternalForecast:{bundle.source_model}{source_revision}:"
+            f"{forecast_id}:{bundle.artifact_id}"
+        ),
+        semantic_interface="q_external(H_Q(X) | external trajectory forecast)",
     )
 
 
@@ -211,7 +273,7 @@ def build_task_posterior(
         query_node_indices=evidence.node_indices,
         semantic_source=evidence.source,
         metadata={
-            "semantic_interface": "q_MM(H_Q(X) | I, language)",
+            "semantic_interface": evidence.semantic_interface,
             "physical_state_updated_by_semantics": False,
             "physical_parameters_updated_by_semantics": False,
             "positions_sha256": array_sha256(evidence.positions_m),

--- a/tests/test_external_forecast_import.py
+++ b/tests/test_external_forecast_import.py
@@ -51,9 +51,7 @@ def _write_manifest(path: Path, **overrides: object) -> None:
         "position_unit": "m",
         "forecast_ids": ["instruction"],
         "physical_fps": 1.0,
-        "forecast_metadata": {
-            "instruction": {"caption": "Lift the cloth upward."}
-        },
+        "forecast_metadata": {"instruction": {"caption": "Lift the cloth upward."}},
         "metadata": {"producer": "unit-test"},
     }
     manifest.update(overrides)

--- a/tests/test_external_forecast_import.py
+++ b/tests/test_external_forecast_import.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from causal4d.cli.external_forecast_import import main as import_main
+from causal4d.cli.molmo_task_posterior import main as task_posterior_main
+from causal4d.contracts import (
+    PhysicalPosterior,
+    TaskPosterior,
+    build_causal_context,
+    load_contract,
+    save_contract,
+)
+from causal4d.external_forecast import (
+    EXTERNAL_FORECAST_IMPORT_SCHEMA,
+    ExternalForecastBundle,
+    import_external_forecast,
+    is_external_forecast_artifact,
+    load_external_forecast,
+    save_external_forecast,
+)
+from causal4d.semantic_posterior import (
+    build_task_posterior,
+    external_forecast_evidence,
+)
+
+
+def _write_manifest(path: Path, **overrides: object) -> None:
+    manifest: dict[str, object] = {
+        "schema": EXTERNAL_FORECAST_IMPORT_SCHEMA,
+        "schema_version": 1,
+        "case_id": "synthetic",
+        "source": {
+            "model": "ExampleForecast",
+            "revision": "abc123",
+            "artifact_id": "checkpoint-v1",
+        },
+        "arrays": {
+            "node_indices": "nodes",
+            "anchor_positions": "anchor",
+            "future_positions": "future",
+            "future_times_s": "times",
+            "validity_mask": "valid",
+        },
+        "layout": "FPC",
+        "coordinate_frame": "world",
+        "position_unit": "m",
+        "forecast_ids": ["instruction"],
+        "physical_fps": 1.0,
+        "forecast_metadata": {
+            "instruction": {"caption": "Lift the cloth upward."}
+        },
+        "metadata": {"producer": "unit-test"},
+    }
+    manifest.update(overrides)
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+
+
+def _physical() -> PhysicalPosterior:
+    observations = np.zeros((7, 2, 3), dtype=float)
+    actions = np.zeros((7, 1, 3), dtype=float)
+    context = build_causal_context(
+        protocol_id="external_forecast_unit",
+        case_id="synthetic",
+        observations=observations,
+        observed_actions=actions,
+        counterfactual_actions=actions,
+        intervention_frame=3,
+    )
+    states = np.zeros((2, 5, 2, 3), dtype=float)
+    states[0, :, 0, 0] = -np.arange(5) * 0.01
+    states[1, :, 0, 0] = np.arange(5) * 0.01
+    return PhysicalPosterior(
+        context=context,
+        component_ids=("left", "right"),
+        state_trajectories_m=states,
+        readout_trajectories_m=states,
+        readout_variance_m2=np.full((2, 2, 3), 1e-5),
+        weights=np.asarray([0.6, 0.4]),
+        phi=np.asarray([[1.0], [1.0]]),
+        kappa_cf=np.asarray([[0.0], [1.0]]),
+        hypothesis_indices=np.asarray([0, 1]),
+        twin_particle_indices=np.asarray([0, 0]),
+        phi_names=("gain",),
+        kappa_names=("contact",),
+        source_twin_belief_id="1" * 64,
+        source_factual_intervention_id="2" * 64,
+        source_query_id="3" * 64,
+    )
+
+
+def test_import_round_trip_and_task_posterior_cli(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    physical = _physical()
+    source = tmp_path / "producer.npz"
+    future = physical.readout_trajectories_m[1, 1:4][:, [0]]
+    np.savez(
+        source,
+        nodes=np.asarray([0], dtype=np.int32),
+        anchor=np.zeros((1, 3)),
+        future=future,
+        times=np.asarray([1.0, 2.0, 3.0]),
+        valid=np.ones((3, 1), dtype=bool),
+    )
+    manifest = tmp_path / "manifest.json"
+    _write_manifest(manifest)
+    canonical = tmp_path / "external_forecast.npz"
+
+    assert import_main([str(source), str(manifest), str(canonical)]) == 0
+    import_summary = json.loads(capsys.readouterr().out)
+    assert import_summary["forecast_ids"] == ["instruction"]
+    assert is_external_forecast_artifact(canonical)
+
+    loaded = load_external_forecast(canonical)
+    evidence = external_forecast_evidence(
+        loaded,
+        "instruction",
+        physical,
+        scale_m=0.002,
+    )
+    fallback = build_task_posterior(physical, evidence, beta=0.0)
+    assert fallback.task_weights.tobytes() == physical.weights.tobytes()
+    task = build_task_posterior(physical, evidence, beta=20.0)
+    assert task.task_weights[1] > 0.999
+    assert task.metadata["semantic_interface"].startswith("q_external")
+
+    physical_path = tmp_path / "physical.npz"
+    task_path = tmp_path / "task.npz"
+    save_contract(physical_path, physical)
+    assert (
+        task_posterior_main(
+            [
+                str(physical_path),
+                str(canonical),
+                "instruction",
+                str(task_path),
+                "--beta",
+                "20",
+                "--scale-m",
+                "0.002",
+            ]
+        )
+        == 0
+    )
+    task_summary = json.loads(capsys.readouterr().out)
+    assert task_summary["forecast_kind"] == "external"
+    reloaded_task = load_contract(task_path)
+    assert isinstance(reloaded_task, TaskPosterior)
+    assert reloaded_task.task_weights[1] > 0.999
+
+
+def test_camera_mm_import_converts_to_metric_world(tmp_path: Path) -> None:
+    source = tmp_path / "camera.npz"
+    transform = np.eye(4)
+    transform[:3, 3] = [1.0, 2.0, 3.0]
+    np.savez(
+        source,
+        nodes=np.asarray([0]),
+        anchor=np.asarray([[1000.0, 0.0, 0.0]]),
+        future=np.asarray([[[2000.0, 0.0, 0.0]]]),
+        frames=np.asarray([1.0]),
+        c2w=transform,
+    )
+    manifest = tmp_path / "manifest.json"
+    _write_manifest(
+        manifest,
+        arrays={
+            "node_indices": "nodes",
+            "anchor_positions": "anchor",
+            "future_positions": "future",
+            "physical_frame_indices": "frames",
+            "camera_to_world": "c2w",
+        },
+        coordinate_frame="camera",
+        position_unit="mm",
+        physical_fps=30.0,
+    )
+
+    imported = import_external_forecast(source, manifest)
+    assert np.allclose(imported.anchor_positions_m, [[2.0, 2.0, 3.0]])
+    assert np.allclose(imported.future_positions_m[0, 0], [[3.0, 2.0, 3.0]])
+
+
+def test_import_rejects_inconsistent_time_and_frame_mapping(tmp_path: Path) -> None:
+    source = tmp_path / "producer.npz"
+    np.savez(
+        source,
+        nodes=np.asarray([0]),
+        anchor=np.zeros((1, 3)),
+        future=np.zeros((1, 1, 3)),
+        times=np.asarray([1.0]),
+        frames=np.asarray([2.0]),
+    )
+    manifest = tmp_path / "manifest.json"
+    _write_manifest(
+        manifest,
+        arrays={
+            "node_indices": "nodes",
+            "anchor_positions": "anchor",
+            "future_positions": "future",
+            "future_times_s": "times",
+            "physical_frame_indices": "frames",
+        },
+        physical_fps=30.0,
+    )
+    with pytest.raises(ValueError, match="disagree"):
+        import_external_forecast(source, manifest)
+
+
+def test_loader_rejects_payload_tampering(tmp_path: Path) -> None:
+    bundle = ExternalForecastBundle(
+        case_id="synthetic",
+        source_model="producer",
+        forecast_ids=("f",),
+        node_indices=np.asarray([0]),
+        anchor_positions_m=np.zeros((1, 3)),
+        future_positions_m=np.zeros((1, 1, 1, 3)),
+        physical_frame_indices=np.asarray([1.0]),
+    )
+    original = tmp_path / "original.npz"
+    save_external_forecast(original, bundle)
+    with np.load(original, allow_pickle=False) as archive:
+        payload = {name: np.asarray(archive[name]) for name in archive.files}
+    payload["future_positions_m"] = payload["future_positions_m"].copy()
+    payload["future_positions_m"][0, 0, 0, 0] = 0.5
+    tampered = tmp_path / "tampered.npz"
+    np.savez_compressed(tampered, **payload)
+    with pytest.raises(ValueError, match="artifact_id|payload hashes"):
+        load_external_forecast(tampered)
+
+
+def test_kpfc_validity_is_unambiguous_when_frame_count_is_three(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "producer.npz"
+    np.savez(
+        source,
+        nodes=np.asarray([0, 1]),
+        anchor=np.zeros((2, 3)),
+        future=np.zeros((1, 2, 3, 3)),
+        valid=np.ones((1, 2, 3), dtype=bool),
+        frames=np.asarray([1.0, 2.0, 3.0]),
+    )
+    manifest = tmp_path / "manifest.json"
+    _write_manifest(
+        manifest,
+        arrays={
+            "node_indices": "nodes",
+            "anchor_positions": "anchor",
+            "future_positions": "future",
+            "validity_mask": "valid",
+            "physical_frame_indices": "frames",
+        },
+        layout="KPFC",
+    )
+    imported = import_external_forecast(source, manifest)
+    assert imported.coordinate_validity.shape == (1, 3, 2, 3)


### PR DESCRIPTION
## Summary

Adds a generic, fail-closed import boundary for sparse 3-D trajectory forecasts produced outside the MolmoMotion/PhysTwin environment.

- Introduces a versioned, non-pickled, content-addressed `ExternalForecastBundle`.
- Imports producer NPZ files through a strict JSON manifest.
- Supports `PFC`, `FPC`, `KPFC`, and `KFPC` layouts; metre/centimetre/millimetre units; world or camera coordinates; explicit frame indices or time-to-frame conversion; and coordinate-level validity masks.
- Validates rigid camera-to-world transforms, immutable physical node identities, frame timing, source/manifest mutation, and payload hashes.
- Publishes canonical NPZ artifacts atomically and revalidates them before publication.
- Extends `causal4d experiment semantic build-task-posterior` to accept canonical external forecasts while preserving legacy MolmoMotion artifacts.
- Keeps external forecasts outside the physical posterior; `beta=0` remains byte-identical fallback.
- Adds a module runner, manifest example, protocol documentation, and integration/tamper/coordinate tests.

## Usage

```bash
python -m causal4d.cli.external_forecast_import \
  producer_forecast.npz \
  external_forecast_manifest.json \
  canonical_external_forecast.npz

causal4d experiment semantic build-task-posterior \
  physical_posterior.npz \
  canonical_external_forecast.npz \
  instruction \
  task_posterior.npz \
  --beta 0
```

## Validation

- Focused importer and semantic regression suite: **30 passed**.
- Broad local core suite, split into four bounded runs: **1,039 passed, 15 skipped**.
- The then-known provider-v2 compatibility regression was excluded from that local broad run and fixed independently by #173 before this PR merged.
- Wheel build, wheel import, grouped-command help, Ruff, formatting, serialization round-trip, coordinate conversion, and tamper-rejection checks passed.

## Merge and cleanup

- Merged as `ee9f15d03be250ffebc35bd4c937549c28244e76`.
- The temporary importer-specific self-hosted validation workflow used during development was removed from `main` in `d156a232af4af89aa5cf9e35b92239d7323f235e`; the production repository retains the importer, tests, documentation, and example manifest without a permanent one-off workflow.

## Claim boundary

Importing an external artifact does not certify its competence or admit positive semantic weighting into claim-bearing paths. A nonzero beta remains exploratory until that producer has source-only competence, trust, and acceptance evidence; the existing MolmoMotion acceptance result does not certify another producer.