### PR TITLE
Fix provider v2 compatibility and harden PR validation

### DIFF
--- a/.github/workflows/horizon-discrepancy-integration.yml
+++ b/.github/workflows/horizon-discrepancy-integration.yml
@@ -36,11 +36,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Check out Causal4D
+      - name: Check out exact Causal4D revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           path: causal4d
           persist-credentials: false
+
+      - name: Verify tested Causal4D revision
+        working-directory: causal4d
+        env:
+          EXPECTED_CAUSAL4D_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          actual_sha="$(git rev-parse HEAD)"
+          test "$actual_sha" = "$EXPECTED_CAUSAL4D_SHA"
+          echo "Tested Causal4D revision: $actual_sha"
 
       - name: Check out exact Bayesian-PhysTwin horizon-provider revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -58,22 +68,6 @@ jobs:
           cache-dependency-path: |
             causal4d/pyproject.toml
             bayesian-phystwin/pyproject.toml
-
-      - name: Check changed source quality
-        run: |
-          python -m pip install "ruff>=0.15.22,<0.17"
-          python -m ruff check \
-            causal4d/src/causal4d/belief_provider_v2_contract.py \
-            causal4d/src/causal4d/horizon_discrepancy.py \
-            causal4d/tests/test_belief_provider_v2_contract.py \
-            causal4d/tests/test_horizon_discrepancy.py \
-            causal4d/tests/test_horizon_discrepancy_workflow_policy.py
-          python -m ruff format --check --diff \
-            causal4d/src/causal4d/belief_provider_v2_contract.py \
-            causal4d/src/causal4d/horizon_discrepancy.py \
-            causal4d/tests/test_belief_provider_v2_contract.py \
-            causal4d/tests/test_horizon_discrepancy.py \
-            causal4d/tests/test_horizon_discrepancy_workflow_policy.py
 
       - name: Build both wheels
         run: |
@@ -104,3 +98,20 @@ jobs:
               "$GITHUB_WORKSPACE/causal4d/tests/test_belief_provider_v2_contract.py" \
               "$GITHUB_WORKSPACE/causal4d/tests/test_horizon_discrepancy.py" \
               "$GITHUB_WORKSPACE/causal4d/tests/test_horizon_discrepancy_workflow_policy.py"
+
+      - name: Check Causal4D source quality
+        if: always()
+        run: |
+          python -m pip install "ruff>=0.15.22,<0.17"
+          python -m ruff check \
+            causal4d/src/causal4d/belief_provider_v2_contract.py \
+            causal4d/src/causal4d/horizon_discrepancy.py \
+            causal4d/tests/test_belief_provider_v2_contract.py \
+            causal4d/tests/test_horizon_discrepancy.py \
+            causal4d/tests/test_horizon_discrepancy_workflow_policy.py
+          python -m ruff format --check --diff \
+            causal4d/src/causal4d/belief_provider_v2_contract.py \
+            causal4d/src/causal4d/horizon_discrepancy.py \
+            causal4d/tests/test_belief_provider_v2_contract.py \
+            causal4d/tests/test_horizon_discrepancy.py \
+            causal4d/tests/test_horizon_discrepancy_workflow_policy.py

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -1,0 +1,108 @@
+name: Causal4D merge gate
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: merge-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  merge-gate:
+    name: Causal4D merge gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Check out pull-request merge result
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Record tested merge and head revisions
+        env:
+          EXPECTED_MERGE_SHA: ${{ github.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          actual_merge_sha="$(git rev-parse HEAD)"
+          test "$actual_merge_sha" = "$EXPECTED_MERGE_SHA"
+          echo "Tested merge revision: $actual_merge_sha"
+          if [[ -n "$PR_HEAD_SHA" ]]; then
+            echo "Pull-request head revision: $PR_HEAD_SHA"
+          fi
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install development dependencies
+        run: python -m pip install -e ".[dev]"
+
+      - name: Run repository quality checks
+        run: |
+          python -m ruff check .
+          python -m mypy --python-version 3.12 \
+            scripts/ci \
+            src/causal4d/atomic_io.py \
+            src/causal4d/result_bundle_publication.py \
+            src/causal4d/trusted_pickle.py \
+            src/causal4d/immutable_array.py \
+            src/causal4d/immutable_json.py \
+            src/causal4d/provider_contract.py \
+            src/causal4d/belief_provider_v2_contract.py \
+            src/causal4d/replay_provider_contract.py
+
+      - name: Run the complete default test suite
+        run: python -m pytest --junitxml=pytest-merge-gate.xml
+
+      - name: Build and validate distributions
+        run: |
+          python -m build
+          python -m twine check dist/*
+
+      - name: Read exact Bayesian-PhysTwin pin
+        id: pin
+        run: echo "sha=$(python scripts/ci/read_bpt_pin.py)" >> "$GITHUB_OUTPUT"
+
+      - name: Check out pinned Bayesian-PhysTwin
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/BayesianPhysTwin
+          ref: ${{ steps.pin.outputs.sha }}
+          path: _bpt
+          persist-credentials: false
+
+      - name: Build installed-wheel integration pair
+        run: |
+          wheelhouse="$RUNNER_TEMP/merge-gate-wheelhouse"
+          mkdir -p "$wheelhouse"
+          python -m build --wheel --outdir "$wheelhouse" .
+          python -m build --wheel --outdir "$wheelhouse" ./_bpt
+          test "$(find "$wheelhouse" -maxdepth 1 -name '*.whl' | wc -l)" -eq 2
+
+      - name: Install integration pair in an isolated environment
+        run: |
+          wheelhouse="$RUNNER_TEMP/merge-gate-wheelhouse"
+          venv="$RUNNER_TEMP/merge-gate-venv"
+          python -m venv "$venv"
+          "$venv/bin/python" -m pip install --upgrade pip
+          "$venv/bin/python" -m pip install "$wheelhouse"/*.whl pytest
+          "$venv/bin/python" -m pip check
+
+      - name: Run pinned-provider integration tests
+        env:
+          CAUSAL4D_REQUIRE_BPT_PROVIDER: "1"
+        run: |
+          "$RUNNER_TEMP/merge-gate-venv/bin/python" \
+            scripts/ci/run_bpt_integration_tests.py

--- a/.github/workflows/scheduled-contact-replay-integration.yml
+++ b/.github/workflows/scheduled-contact-replay-integration.yml
@@ -38,11 +38,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Check out Causal4D
+      - name: Check out exact Causal4D revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           path: causal4d
           persist-credentials: false
+
+      - name: Verify tested Causal4D revision
+        working-directory: causal4d
+        env:
+          EXPECTED_CAUSAL4D_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          actual_sha="$(git rev-parse HEAD)"
+          test "$actual_sha" = "$EXPECTED_CAUSAL4D_SHA"
+          echo "Tested Causal4D revision: $actual_sha"
 
       - name: Check out exact Bayesian-PhysTwin contract revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -60,24 +70,6 @@ jobs:
           cache-dependency-path: |
             causal4d/pyproject.toml
             bayesian-phystwin/pyproject.toml
-
-      - name: Check changed source quality
-        run: |
-          python -m pip install "ruff>=0.15.22,<0.17"
-          python -m ruff check \
-            bayesian-phystwin/src/bayesian_phystwin/contracts/scheduled_replay.py \
-            bayesian-phystwin/tests/test_scheduled_contact_replay_contract.py \
-            causal4d/src/causal4d/multi_contact.py \
-            causal4d/src/causal4d/scheduled_contact_replay.py \
-            causal4d/tests/test_scheduled_contact_replay_adapter.py \
-            causal4d/tests/test_scheduled_contact_replay_workflow_policy.py
-          python -m ruff format --check --diff \
-            bayesian-phystwin/src/bayesian_phystwin/contracts/scheduled_replay.py \
-            bayesian-phystwin/tests/test_scheduled_contact_replay_contract.py \
-            causal4d/src/causal4d/multi_contact.py \
-            causal4d/src/causal4d/scheduled_contact_replay.py \
-            causal4d/tests/test_scheduled_contact_replay_adapter.py \
-            causal4d/tests/test_scheduled_contact_replay_workflow_policy.py
 
       - name: Build both wheels
         run: |
@@ -109,3 +101,18 @@ jobs:
               "$GITHUB_WORKSPACE/causal4d/tests/test_scheduled_contact_replay_workflow_policy.py" \
               "$GITHUB_WORKSPACE/causal4d/tests/test_multi_contact.py" \
               "$GITHUB_WORKSPACE/causal4d/tests/test_multi_contact_hardening.py"
+
+      - name: Check Causal4D source quality
+        if: always()
+        run: |
+          python -m pip install "ruff>=0.15.22,<0.17"
+          python -m ruff check \
+            causal4d/src/causal4d/multi_contact.py \
+            causal4d/src/causal4d/scheduled_contact_replay.py \
+            causal4d/tests/test_scheduled_contact_replay_adapter.py \
+            causal4d/tests/test_scheduled_contact_replay_workflow_policy.py
+          python -m ruff format --check --diff \
+            causal4d/src/causal4d/multi_contact.py \
+            causal4d/src/causal4d/scheduled_contact_replay.py \
+            causal4d/tests/test_scheduled_contact_replay_adapter.py \
+            causal4d/tests/test_scheduled_contact_replay_workflow_policy.py

--- a/src/causal4d/belief_provider_v2_contract.py
+++ b/src/causal4d/belief_provider_v2_contract.py
@@ -15,6 +15,7 @@ BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API = (
     "bayesian_phystwin.causal4d_belief_provider_v2"
 )
 BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API_VERSION = 2
+BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_SCHEMA_VERSIONS = (2,)
 BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_CAPABILITIES = (
     "causal_prefix_endpoint_inference",
     "evidence_weighted_endpoint_model_average",
@@ -111,6 +112,9 @@ def validate_bayesian_phystwin_belief_provider_v2(
     return validate_provider_compatibility(
         candidate,
         required_capabilities=BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_CAPABILITIES,
+        supported_schema_versions=(
+            BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_SCHEMA_VERSIONS
+        ),
         supported_provider_versions=BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE,
         required_artifact_versions=(
             BAYESIAN_PHYSTWIN_BELIEF_V2_ARTIFACT_SCHEMA_VERSIONS
@@ -140,6 +144,7 @@ __all__ = [
     "BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API",
     "BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API_VERSION",
     "BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_CAPABILITIES",
+    "BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_SCHEMA_VERSIONS",
     "BAYESIAN_PHYSTWIN_BELIEF_V2_ARTIFACT_SCHEMA_VERSIONS",
     "BAYESIAN_PHYSTWIN_BELIEF_V2_COMPATIBILITY",
     "BAYESIAN_PHYSTWIN_BELIEF_V2_INFERENCE_ROLE",

--- a/tests/test_belief_provider_v2_contract.py
+++ b/tests/test_belief_provider_v2_contract.py
@@ -6,6 +6,7 @@ from causal4d.belief_provider_v2_contract import (
     BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API,
     BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API_VERSION,
     BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_CAPABILITIES,
+    BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_SCHEMA_VERSIONS,
     BAYESIAN_PHYSTWIN_BELIEF_V2_ARTIFACT_SCHEMA_VERSIONS,
     BAYESIAN_PHYSTWIN_BELIEF_V2_COMPATIBILITY,
     BAYESIAN_PHYSTWIN_BELIEF_V2_INFERENCE_ROLE,
@@ -17,6 +18,7 @@ from causal4d.provider_contract import PhysicalBeliefProviderManifest
 
 def _manifest(
     *,
+    schema_version: int = 2,
     capabilities: tuple[str, ...] = (
         BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_CAPABILITIES
     ),
@@ -27,7 +29,7 @@ def _manifest(
         provider_name="bayesian-phystwin",
         provider_version="0.4.0",
         provider_revision="a" * 40,
-        schema_version=2,
+        schema_version=schema_version,
         capabilities=capabilities,
         artifact_schema_versions=(
             BAYESIAN_PHYSTWIN_BELIEF_V2_ARTIFACT_SCHEMA_VERSIONS
@@ -55,9 +57,23 @@ def _manifest(
 def test_belief_provider_v2_accepts_complete_additive_manifest() -> None:
     result = validate_bayesian_phystwin_belief_provider_v2(_manifest())
 
+    assert BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_SCHEMA_VERSIONS == (2,)
     assert result.compatible
+    assert result.unsupported_schema_version is None
     assert result.missing_capabilities == ()
     assert result.artifact_version_mismatches == ()
+
+
+@pytest.mark.parametrize("schema_version", [1, 3])
+def test_belief_provider_v2_rejects_other_manifest_schemas(
+    schema_version: int,
+) -> None:
+    result = validate_bayesian_phystwin_belief_provider_v2(
+        _manifest(schema_version=schema_version)
+    )
+
+    assert not result.compatible
+    assert result.unsupported_schema_version == schema_version
 
 
 def test_belief_provider_v2_rejects_missing_horizon_capability() -> None:

--- a/tests/test_horizon_discrepancy_workflow_policy.py
+++ b/tests/test_horizon_discrepancy_workflow_policy.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 WORKFLOW = Path(".github/workflows/horizon-discrepancy-integration.yml")
 BPT_HORIZON_PROVIDER_REVISION = "bfa844798f0ab3ddbc67a0744ae14a221324e504"
+CAUSAL4D_HEAD_REF = "${{ github.event.pull_request.head.sha || github.sha }}"
 
 
 def test_horizon_workflow_uses_exact_public_provider_revision() -> None:
@@ -14,6 +15,15 @@ def test_horizon_workflow_uses_exact_public_provider_revision() -> None:
     assert f"ref: {BPT_HORIZON_PROVIDER_REVISION}" in text
     assert "persist-credentials: false" in text
     assert "BPT_READ_SSH_KEY" not in text
+
+
+def test_horizon_workflow_records_exact_causal4d_revision() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert f"ref: {CAUSAL4D_HEAD_REF}" in text
+    assert f"EXPECTED_CAUSAL4D_SHA: {CAUSAL4D_HEAD_REF}" in text
+    assert 'actual_sha="$(git rev-parse HEAD)"' in text
+    assert 'test "$actual_sha" = "$EXPECTED_CAUSAL4D_SHA"' in text
 
 
 def test_horizon_workflow_exercises_installed_wheels() -> None:
@@ -27,6 +37,18 @@ def test_horizon_workflow_exercises_installed_wheels() -> None:
     assert "test_belief_provider_v2_contract.py" in text
     assert "test_horizon_discrepancy.py" in text
     assert "test_belief_provider_contract.py" in text
+
+
+def test_horizon_workflow_runs_contract_before_local_quality() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    contract_index = text.index(
+        "- name: Exercise the installed cross-repository contract"
+    )
+    quality_index = text.index("- name: Check Causal4D source quality")
+
+    assert contract_index < quality_index
+    assert "if: always()" in text[quality_index:]
 
 
 def test_horizon_workflow_pins_external_actions() -> None:

--- a/tests/test_merge_gate_workflow_policy.py
+++ b/tests/test_merge_gate_workflow_policy.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WORKFLOW = Path(".github/workflows/merge-gate.yml")
+
+
+def test_merge_gate_has_one_stable_pull_request_status() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert text.count("name: Causal4D merge gate") == 2
+    assert "pull_request:" in text
+    assert "branches: [main]" in text
+    assert "  merge-gate:" in text
+
+
+def test_merge_gate_validates_the_pull_request_merge_result() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    checkout_index = text.index("- name: Check out pull-request merge result")
+    record_index = text.index("- name: Record tested merge and head revisions")
+    checkout_block = text[checkout_index:record_index]
+
+    assert "ref:" not in checkout_block
+    assert "EXPECTED_MERGE_SHA: ${{ github.sha }}" in text
+    assert "PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}" in text
+    assert 'actual_merge_sha="$(git rev-parse HEAD)"' in text
+    assert 'test "$actual_merge_sha" = "$EXPECTED_MERGE_SHA"' in text
+
+
+def test_merge_gate_covers_quality_tests_build_and_provider_integration() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "python -m ruff check ." in text
+    assert "python -m mypy --python-version 3.12" in text
+    assert "src/causal4d/belief_provider_v2_contract.py" in text
+    assert "python -m pytest --junitxml=pytest-merge-gate.xml" in text
+    assert "python -m build" in text
+    assert "python -m twine check dist/*" in text
+    assert "python scripts/ci/read_bpt_pin.py" in text
+    assert "scripts/ci/run_bpt_integration_tests.py" in text
+    assert "CAUSAL4D_REQUIRE_BPT_PROVIDER: \"1\"" in text
+
+
+def test_merge_gate_pins_external_actions() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert text.count(
+        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+    ) == 2
+    assert (
+        "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97"
+        in text
+    )
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("uses:"):
+            assert "@" in stripped
+            reference = stripped.rsplit("@", 1)[1].split()[0]
+            assert len(reference) == 40
+            assert all(character in "0123456789abcdef" for character in reference)

--- a/tests/test_scheduled_contact_replay_workflow_policy.py
+++ b/tests/test_scheduled_contact_replay_workflow_policy.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 WORKFLOW = Path(".github/workflows/scheduled-contact-replay-integration.yml")
 BPT_CONTRACT_REVISION = "58bf6a6f06ad27fce525060190cff787cde58fa4"
+CAUSAL4D_HEAD_REF = "${{ github.event.pull_request.head.sha || github.sha }}"
 
 
 def test_scheduled_replay_workflow_uses_exact_public_provider_revision() -> None:
@@ -14,6 +15,15 @@ def test_scheduled_replay_workflow_uses_exact_public_provider_revision() -> None
     assert f"ref: {BPT_CONTRACT_REVISION}" in text
     assert "persist-credentials: false" in text
     assert "BPT_READ_SSH_KEY" not in text
+
+
+def test_scheduled_replay_workflow_records_exact_causal4d_revision() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert f"ref: {CAUSAL4D_HEAD_REF}" in text
+    assert f"EXPECTED_CAUSAL4D_SHA: {CAUSAL4D_HEAD_REF}" in text
+    assert 'actual_sha="$(git rev-parse HEAD)"' in text
+    assert 'test "$actual_sha" = "$EXPECTED_CAUSAL4D_SHA"' in text
 
 
 def test_scheduled_replay_workflow_exercises_installed_wheels() -> None:
@@ -27,6 +37,22 @@ def test_scheduled_replay_workflow_exercises_installed_wheels() -> None:
     assert "test_scheduled_contact_replay_contract.py" in text
     assert "test_scheduled_contact_replay_adapter.py" in text
     assert "test_multi_contact_hardening.py" in text
+
+
+def test_scheduled_replay_workflow_runs_contract_before_local_quality() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    contract_index = text.index(
+        "- name: Exercise the installed cross-repository contract"
+    )
+    quality_index = text.index("- name: Check Causal4D source quality")
+
+    assert contract_index < quality_index
+    assert "if: always()" in text[quality_index:]
+    assert (
+        "bayesian-phystwin/src/bayesian_phystwin/contracts/scheduled_replay.py"
+        not in text
+    )
 
 
 def test_scheduled_replay_workflow_pins_external_actions() -> None:


### PR DESCRIPTION
## What changed

- define the supported BayesianPhysTwin belief-provider-v2 manifest schema explicitly as `(2,)` and pass it to the generic compatibility validator;
- add regression coverage accepting schema 2 while rejecting schema 1 and unknown future schemas;
- make the horizon-discrepancy and scheduled-contact installed-wheel workflows check out and record the exact Causal4D PR head revision;
- run cross-repository contract tests before local formatting checks, while keeping local quality checks fail-closed with `if: always()`;
- stop the scheduled-contact workflow from linting files owned by the pinned BayesianPhysTwin checkout;
- add a stable `Causal4D merge gate` workflow that validates the synthetic PR merge result with Ruff, mypy, the complete default test suite, distribution builds, and pinned BayesianPhysTwin installed-wheel integration;
- add workflow-policy tests for the new provenance and ordering guarantees.

## Root cause

`validate_bayesian_phystwin_belief_provider_v2()` relied on the generic validator's default manifest schema support, which is schema 1. A complete provider-v2 manifest declares schema 2, so it was incorrectly rejected despite matching the v2 API, capabilities, metadata, artifact schemas, and supported provider-version range.

## Impact

The additive horizon-discrepancy provider can now be admitted as intended, unsupported manifest schemas still fail closed, integration evidence is no longer masked by foreign-repository lint, and PRs expose one stable merge-result status suitable for branch protection.

## Validation

- local minimal provider-contract harness: 11 tests passed;
- local workflow-policy harness: 14 tests passed;
- full repository and installed-wheel validation: delegated to the PR workflows introduced and updated here.