### PR TITLE
Harden claim-bearing physical target evaluation

### DIFF
--- a/docs/causal4d_identifiability_and_grouped_likelihood.md
+++ b/docs/causal4d_identifiability_and_grouped_likelihood.md
@@ -112,12 +112,15 @@ The physical simulator trajectories remain immutable.
 ## Command-line use
 
 The factual-abduction CLI can construct frame-grouped evidence directly from
-the permitted object tracks:
+the permitted object tracks. Legacy pickle input is admitted only with explicit
+consent and a digest checked before deserialization:
 
 ```bash
 causal4d experiment phystwin abduct-intervention \
   known.bank.npz belief.npz CASE/final_data.pkl \
   factual.npz factual_eval.json \
+  --allow-unsafe-pickle \
+  --expected-final-data-sha256 <lowercase-sha256> \
   --grouped-observation-likelihood \
   --prior-nominal-probability 0.95 \
   --outlier-scale-multiplier 100
@@ -131,6 +134,8 @@ arrays. Guarded use is:
 causal4d experiment phystwin abduct-intervention \
   known.bank.npz belief.npz CASE/final_data.pkl \
   factual.npz factual_eval.json \
+  --allow-unsafe-pickle \
+  --expected-final-data-sha256 <lowercase-sha256> \
   --grouped-observation-likelihood \
   --identifiability-npz source_identifiability.npz \
   --abstain-when-unidentifiable
@@ -138,7 +143,9 @@ causal4d experiment phystwin abduct-intervention \
 
 The sensitivity artifact must be fitted or generated without the target
 continuation. Threshold flags are explicit CLI inputs so a protocol can freeze
-them before target outcomes are opened.
+them before target outcomes are opened. Consent and an expected digest do not
+make an untrusted pickle safe; new acquisition pipelines should use data-only
+prefix artifacts.
 
 ## Required protocol usage
 

--- a/docs/factual_prefix_likelihood_semantics.md
+++ b/docs/factual_prefix_likelihood_semantics.md
@@ -61,12 +61,16 @@ artifact metadata, so a normalized result cannot be mistaken for a legacy one.
 
 ## Command line
 
-The factual-abduction command defaults to the registered path:
+Legacy `final_data.pkl` inputs require explicit consent and the exact SHA-256 of
+the trusted bytes. The factual-abduction command defaults to the registered
+likelihood path:
 
 ```bash
 causal4d experiment phystwin abduct-intervention \
   rollout-bank.npz twin-belief.npz final_data.pkl \
-  factual.npz evaluation.json
+  factual.npz evaluation.json \
+  --allow-unsafe-pickle \
+  --expected-final-data-sha256 <lowercase-sha256>
 ```
 
 Run the development comparator explicitly with:
@@ -75,13 +79,18 @@ Run the development comparator explicitly with:
 causal4d experiment phystwin abduct-intervention \
   rollout-bank.npz twin-belief.npz final_data.pkl \
   factual-normalized-v2.npz evaluation-normalized-v2.json \
+  --allow-unsafe-pickle \
+  --expected-final-data-sha256 <lowercase-sha256> \
   --likelihood-semantics normalized_v2 \
   --difference-correlation 0.25
 ```
 
-`difference_correlation` is accepted only with `normalized_v2`. The normalized
-dense path cannot be combined with the separate grouped full-covariance evidence
-path; contradictory requests fail rather than silently ignoring one model.
+The digest is checked before deserialization. Consent and byte identity do not
+make an untrusted pickle safe; new acquisition pipelines should use data-only
+artifacts instead. `difference_correlation` is accepted only with
+`normalized_v2`. The normalized dense path cannot be combined with the separate
+grouped full-covariance evidence path; contradictory requests fail rather than
+silently ignoring one model.
 
 ## Promotion boundary
 

--- a/docs/held_out_physical_target.md
+++ b/docs/held_out_physical_target.md
@@ -1,0 +1,99 @@
+# Identity-bound held-out physical targets
+
+The stable beta-zero physical evaluator consumes a versioned, non-pickled
+`HeldOutPhysicalTarget` artifact. It no longer opens `final_data.pkl` directly.
+This separates the unsafe migration boundary from claim-bearing evaluation and
+binds every score to the exact causal query and target bytes.
+
+## Why this boundary exists
+
+A pickle can execute arbitrary code while it is loaded. A compatible array shape
+also does not prove that a target belongs to the same protocol, case, action, or
+counterfactual query as a physical posterior. The held-out target archive closes
+both gaps:
+
+- it is a normal NumPy NPZ readable with `allow_pickle=False`;
+- its descriptor includes the complete `CausalContext` and exact
+  `source_query_id`;
+- its target interval begins at the factual-prefix endpoint and ends at the
+  registered counterfactual-action stop;
+- schema v1 records the existing dense zero-based physical-node ordering
+  explicitly;
+- target positions, validity, node indices, and source bytes have SHA-256
+  identities; and
+- saving is atomic and followed by an independent reload/identity check.
+
+The artifact contains only the aligned target trajectory required by the
+physical posterior. It does not carry unused future observations or semantic
+inputs.
+
+## Convert a legacy PhysTwin target once
+
+The migration command is intentionally not an installed console route. Invoke it
+as a module and provide both explicit consent and the expected digest of the
+trusted pickle bytes:
+
+```bash
+python -m causal4d.cli.import_physical_target \
+  physical_posterior.npz \
+  /path/to/final_data.pkl \
+  held_out_target.npz \
+  --allow-unsafe-pickle \
+  --expected-sha256 <lowercase-sha256> \
+  --source-revision <dataset-or-acquisition-revision>
+```
+
+`--allow-unsafe-pickle` acknowledges executable-code risk. The SHA-256 check
+establishes byte identity but does not make an untrusted pickle safe. The
+converter rejects symlinks, nonordinary files, digest mismatch, malformed target
+arrays, incompatible frame coverage, and a posterior whose trajectory length
+does not agree with its causal context.
+
+For a new acquisition pipeline, construct `HeldOutPhysicalTarget` directly from
+validated data-only arrays and a source manifest instead of creating a pickle.
+
+## Claim-bearing evaluation
+
+```bash
+causal4d evidence physical-counterfactual evaluate \
+  physical_posterior.npz \
+  held_out_target.npz \
+  physical_evaluation.json \
+  --start-frame 7 \
+  --confidence-level 0.90 \
+  --no-overwrite
+```
+
+Before scoring, the evaluator requires:
+
+- exact equality of the posterior and target causal contexts;
+- equality of the target and posterior `source_query_id`;
+- exact trajectory and dense-node shape agreement; and
+- a valid target interval and payload identity.
+
+The output JSON is finite, key-sorted, atomically published, and content
+addressed. It records:
+
+- `evaluation_id`;
+- `physical_posterior_id`;
+- `held_out_target_id` and its complete validated descriptor;
+- `source_query_id`;
+- protocol, case, and counterfactual-action identities;
+- relative and absolute evaluation intervals;
+- confidence level and target source identity; and
+- the complete beta-zero accuracy and calibration metrics.
+
+The evaluator continues to state explicitly that semantic beta is zero and no
+semantic evidence was consumed.
+
+## CI policy
+
+The command registry already distinguishes claim-bearing routes. CI now scans
+all such command modules and rejects direct `pickle.load`, `pickle.loads`, and
+`numpy.load(..., allow_pickle=True)` calls. A separate regression requires the
+physical evaluator to use the safe held-out-target loader and the independently
+reloaded atomic evaluation publisher rather than direct path writes.
+
+This is an evidence-integrity and software-safety improvement. It does not change
+posterior weights, the registered estimator, the 36-execution protocol, or any
+frozen scientific result.

--- a/docs/held_out_physical_target.md
+++ b/docs/held_out_physical_target.md
@@ -31,7 +31,8 @@ inputs.
 
 The migration command is intentionally not an installed console route. Invoke it
 as a module and provide both explicit consent and the expected digest of the
-trusted pickle bytes:
+trusted pickle bytes. The experimental factual-abduction CLI requires the same
+explicit consent and digest before it can inspect the legacy prefix source:
 
 ```bash
 python -m causal4d.cli.import_physical_target \
@@ -41,6 +42,16 @@ python -m causal4d.cli.import_physical_target \
   --allow-unsafe-pickle \
   --expected-sha256 <lowercase-sha256> \
   --source-revision <dataset-or-acquisition-revision>
+```
+
+For the existing factual-abduction path, pass the same byte identity as:
+
+```bash
+python -m causal4d.cli.abduct_phystwin_intervention \
+  rollout_bank.npz twin_belief.npz /path/to/final_data.pkl \
+  factual.npz factual_evaluation.json \
+  --allow-unsafe-pickle \
+  --expected-final-data-sha256 <lowercase-sha256>
 ```
 
 `--allow-unsafe-pickle` acknowledges executable-code risk. The SHA-256 check

--- a/scripts/remote/run_causal4d_abduction_pipeline.sh
+++ b/scripts/remote/run_causal4d_abduction_pipeline.sh
@@ -12,11 +12,20 @@ output="${CAUSAL4D_OUTPUT_ROOT:-${repo_root}/runs/causal4d-abduction-v1/${case_n
 particle_count="${CAUSAL4D_PARAMETER_PARTICLES:-4}"
 contact_count="${CAUSAL4D_CONTACT_STATES:-9}"
 prefix_frames="${CAUSAL4D_O_PLUS_PREFIX_FRAMES:-6}"
+final_data_sha256="${CAUSAL4D_FINAL_DATA_SHA256:-}"
+target_source_revision="${CAUSAL4D_TARGET_SOURCE_REVISION:-legacy-final-data-v1}"
 
 case_dir="${data_root}/${case_name}"
 profile="${profile_dir}/parameter_profile.npz"
 checkpoint="${profile_dir}/refit_checkpoint.pt"
 mkdir -p "${output}"
+
+if [[ -z "${final_data_sha256}" ]]; then
+  printf '%s\n' \
+    "CAUSAL4D_FINAL_DATA_SHA256 must identify the exact trusted final_data.pkl bytes" \
+    >&2
+  exit 2
+fi
 
 run() {
   PYTHONPATH="${repo_root}/src" CUDA_VISIBLE_DEVICES="${PHYSTWIN_GPU:-0}" \
@@ -56,9 +65,17 @@ for specification in "known_action:same_grasp" "history_reverse:new_contact"; do
     --maximum-contact-states "${contact_count}"
 done
 
-run -m causal4d.cli.evaluate_physical_counterfactual \
+run -m causal4d.cli.import_physical_target \
   "${output}/known_action.physical.npz" \
   "${case_dir}/final_data.pkl" \
+  "${output}/known_action.held_out_target.npz" \
+  --allow-unsafe-pickle \
+  --expected-sha256 "${final_data_sha256}" \
+  --source-revision "${target_source_revision}"
+
+run -m causal4d.cli.evaluate_physical_counterfactual \
+  "${output}/known_action.physical.npz" \
+  "${output}/known_action.held_out_target.npz" \
   "${output}/known_action.beta0_evaluation.json" \
   --start-frame "$((prefix_frames + 1))"
 

--- a/scripts/remote/run_causal4d_abduction_pipeline.sh
+++ b/scripts/remote/run_causal4d_abduction_pipeline.sh
@@ -51,6 +51,8 @@ run -m causal4d.cli.abduct_phystwin_intervention \
   "${case_dir}/final_data.pkl" \
   "${output}/factual.npz" \
   "${output}/factual_evaluation.json" \
+  --allow-unsafe-pickle \
+  --expected-final-data-sha256 "${final_data_sha256}" \
   --o-plus-prefix-frames "${prefix_frames}"
 
 for specification in "known_action:same_grasp" "history_reverse:new_contact"; do

--- a/src/causal4d/_held_out_target_contract.py
+++ b/src/causal4d/_held_out_target_contract.py
@@ -30,9 +30,7 @@ DESCRIPTOR_FIELDS = frozenset(
         "payload",
     }
 )
-SOURCE_FIELDS = frozenset(
-    {"kind", "revision", "content_sha256", "artifact_id"}
-)
+SOURCE_FIELDS = frozenset({"kind", "revision", "content_sha256", "artifact_id"})
 PAYLOAD_FIELDS = frozenset(
     {"node_indices_sha256", "positions_m_sha256", "validity_mask_sha256"}
 )
@@ -230,9 +228,7 @@ def validate_target_descriptor(values: Mapping[str, Any]) -> dict[str, Any]:
     )
     supplied_id = normalized.pop("artifact_id")
     validate_sha256(supplied_id, name="artifact_id")
-    expected_id = hashlib.sha256(
-        canonical_json(normalized).encode("utf-8")
-    ).hexdigest()
+    expected_id = hashlib.sha256(canonical_json(normalized).encode("utf-8")).hexdigest()
     if supplied_id != expected_id:
         raise ValueError("held-out target artifact_id does not match descriptor")
     normalized["artifact_id"] = supplied_id

--- a/src/causal4d/_held_out_target_contract.py
+++ b/src/causal4d/_held_out_target_contract.py
@@ -1,0 +1,241 @@
+"""Shared strict-contract helpers for held-out physical target evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from typing import Any
+
+import numpy as np
+
+from causal4d.contracts import CausalContext
+from causal4d.immutable_json import plain_json, validated_json_mapping
+
+HELD_OUT_PHYSICAL_TARGET_SCHEMA = "causal4d.held_out_physical_target"
+HELD_OUT_PHYSICAL_TARGET_SCHEMA_VERSION = 1
+NODE_ORDER_DENSE_PREFIX_V1 = "dense_zero_based_prefix_v1"
+
+DESCRIPTOR_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "artifact_id",
+        "context",
+        "source_query_id",
+        "trajectory_frame_interval",
+        "node_order",
+        "source",
+        "metadata",
+        "payload",
+    }
+)
+SOURCE_FIELDS = frozenset(
+    {"kind", "revision", "content_sha256", "artifact_id"}
+)
+PAYLOAD_FIELDS = frozenset(
+    {"node_indices_sha256", "positions_m_sha256", "validity_mask_sha256"}
+)
+LOWER_HEX = frozenset("0123456789abcdef")
+
+
+def require_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    if any(type(key) is not str for key in value):
+        raise ValueError(f"{name} keys must be strings")
+    return value
+
+
+def require_exact_fields(
+    value: Any,
+    *,
+    name: str,
+    required: frozenset[str],
+) -> Mapping[str, Any]:
+    mapping = require_mapping(value, name=name)
+    actual = set(mapping)
+    missing = sorted(required - actual)
+    unexpected = sorted(actual - required)
+    if missing or unexpected:
+        raise ValueError(
+            f"{name} fields do not match schema; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    return mapping
+
+
+def require_nonempty_string(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def require_optional_string(value: Any, *, name: str) -> str | None:
+    if value is None:
+        return None
+    return require_nonempty_string(value, name=name)
+
+
+def require_integer(value: Any, *, name: str, minimum: int = 0) -> int:
+    if type(value) is not int or value < minimum:
+        raise ValueError(
+            f"{name} must be an integer greater than or equal to {minimum}"
+        )
+    return value
+
+
+def validate_sha256(value: Any, *, name: str) -> str:
+    if (
+        type(value) is not str
+        or len(value) != 64
+        or any(character not in LOWER_HEX for character in value)
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return value
+
+
+def reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key {key!r}")
+        result[key] = value
+    return result
+
+
+def reject_nonfinite_json_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON constant {value!r} is not allowed")
+
+
+def canonical_json(value: Mapping[str, Any]) -> str:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def require_integer_interval(value: Any, *, name: str) -> list[int]:
+    if (
+        type(value) is not list
+        or len(value) != 2
+        or any(type(item) is not int for item in value)
+        or value[0] < 0
+        or value[1] <= value[0]
+    ):
+        raise ValueError(f"{name} must contain a nonempty integer interval")
+    return value
+
+
+def require_finite_number(
+    value: Any,
+    *,
+    name: str,
+    minimum: float | None = None,
+    maximum: float | None = None,
+) -> float:
+    if type(value) not in {int, float} or not np.isfinite(value):
+        raise ValueError(f"{name} must be a finite JSON number")
+    result = float(value)
+    if minimum is not None and result < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    if maximum is not None and result > maximum:
+        raise ValueError(f"{name} must be at most {maximum}")
+    return result
+
+
+def target_validity(visible: np.ndarray, motion_valid: np.ndarray) -> np.ndarray:
+    """Reproduce the public BayesianPhysTwin target-validity convention."""
+
+    visible_array = np.asarray(visible)
+    motion_array = np.asarray(motion_valid)
+    if visible_array.dtype.kind != "b" or motion_array.dtype.kind != "b":
+        raise ValueError("legacy visibility and motion-valid arrays must be boolean")
+    if visible_array.ndim != 2 or visible_array.shape[0] < 1:
+        raise ValueError("legacy visibility must have shape (T>=1, N)")
+    frame_count, track_count = visible_array.shape
+    if motion_array.shape not in {
+        (frame_count, track_count),
+        (frame_count - 1, track_count),
+    }:
+        raise ValueError("legacy motion-valid array has an incompatible shape")
+    valid = np.zeros_like(visible_array, dtype=bool)
+    valid[0] = visible_array[0]
+    valid[1:] = motion_array[: frame_count - 1]
+    return valid
+
+
+def validate_target_descriptor(values: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate the self-contained identity of a target descriptor."""
+
+    fields = require_exact_fields(
+        values,
+        name="held-out target descriptor",
+        required=DESCRIPTOR_FIELDS,
+    )
+    if fields["schema"] != HELD_OUT_PHYSICAL_TARGET_SCHEMA:
+        raise ValueError("unsupported held-out target schema")
+    schema_version = require_integer(
+        fields["schema_version"],
+        name="held-out target schema_version",
+        minimum=1,
+    )
+    if schema_version != HELD_OUT_PHYSICAL_TARGET_SCHEMA_VERSION:
+        raise ValueError("unsupported held-out target schema version")
+    if fields["node_order"] != NODE_ORDER_DENSE_PREFIX_V1:
+        raise ValueError("unsupported held-out target node order")
+
+    context = CausalContext.from_dict(fields["context"])
+    source_query_id = validate_sha256(
+        fields["source_query_id"],
+        name="source_query_id",
+    )
+    interval = require_integer_interval(
+        fields["trajectory_frame_interval"],
+        name="trajectory_frame_interval",
+    )
+    expected_interval = [
+        context.o_minus.frame_stop - 1,
+        context.u_cf.frame_stop,
+    ]
+    if interval != expected_interval:
+        raise ValueError("held-out target interval disagrees with its causal context")
+
+    source = require_exact_fields(
+        fields["source"],
+        name="held-out target source",
+        required=SOURCE_FIELDS,
+    )
+    require_nonempty_string(source["kind"], name="source.kind")
+    require_nonempty_string(source["revision"], name="source.revision")
+    validate_sha256(source["content_sha256"], name="source.content_sha256")
+    require_optional_string(source["artifact_id"], name="source.artifact_id")
+
+    payload = require_exact_fields(
+        fields["payload"],
+        name="held-out target payload",
+        required=PAYLOAD_FIELDS,
+    )
+    for name, value in payload.items():
+        validate_sha256(value, name=f"payload.{name}")
+    require_mapping(fields["metadata"], name="held-out target metadata")
+
+    normalized = plain_json(
+        validated_json_mapping(
+            fields,
+            error_message="held-out target descriptor must be finite JSON data",
+        )
+    )
+    supplied_id = normalized.pop("artifact_id")
+    validate_sha256(supplied_id, name="artifact_id")
+    expected_id = hashlib.sha256(
+        canonical_json(normalized).encode("utf-8")
+    ).hexdigest()
+    if supplied_id != expected_id:
+        raise ValueError("held-out target artifact_id does not match descriptor")
+    normalized["artifact_id"] = supplied_id
+    if normalized["source_query_id"] != source_query_id:
+        raise ValueError("held-out target source_query_id changed during validation")
+    return normalized

--- a/src/causal4d/cli/abduct_phystwin_intervention.py
+++ b/src/causal4d/cli/abduct_phystwin_intervention.py
@@ -82,9 +82,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--difference-correlation",
         type=float,
         default=0.0,
-        help=(
-            "Adjacent-frame observation correlation used only by normalized_v2."
-        ),
+        help=("Adjacent-frame observation correlation used only by normalized_v2."),
     )
     parser.add_argument(
         "--grouped-observation-likelihood",
@@ -152,9 +150,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.abstain_when_unidentifiable and args.identifiability_npz is None:
         raise ValueError("--abstain-when-unidentifiable requires --identifiability-npz")
     if args.expected_final_data_sha256 is None:
-        raise ValueError(
-            "--expected-final-data-sha256 is required for final_data.pkl"
-        )
+        raise ValueError("--expected-final-data-sha256 is required for final_data.pkl")
     _load_runtime_dependencies()
     bank, manifest = load_rollout_bank(args.rollout_bank_npz)
     artifact = load_contract(args.twin_belief_npz)

--- a/src/causal4d/cli/abduct_phystwin_intervention.py
+++ b/src/causal4d/cli/abduct_phystwin_intervention.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
-import pickle
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 import numpy as np
@@ -25,6 +24,7 @@ def _load_runtime_dependencies() -> None:
     global evaluate_factual_abduction
     global GroupedObservationEvidence
     global load_rollout_bank
+    global load_trusted_pickle
 
     from bayesian_phystwin.causal4d_provider_v1 import target_validity
     from causal4d.contracts import TwinBelief, load_contract, save_contract
@@ -40,6 +40,7 @@ def _load_runtime_dependencies() -> None:
     )
     from causal4d.observation_evidence import GroupedObservationEvidence
     from causal4d.rollout_bank_io import load_rollout_bank
+    from causal4d.trusted_pickle import load_trusted_pickle
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -54,6 +55,15 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("final_data_pickle")
     parser.add_argument("output_factual_npz")
     parser.add_argument("output_evaluation_json")
+    parser.add_argument(
+        "--allow-unsafe-pickle",
+        action="store_true",
+        help="explicitly acknowledge that unpickling can execute arbitrary code",
+    )
+    parser.add_argument(
+        "--expected-final-data-sha256",
+        help="lowercase SHA-256 digest of the exact trusted final_data.pkl bytes",
+    )
     parser.add_argument("--o-plus-prefix-frames", type=int, default=6)
     parser.add_argument("--observation-scale-m", type=float, default=0.01)
     parser.add_argument("--likelihood-power", type=float, default=12.0)
@@ -137,17 +147,34 @@ def _load_identifiability(
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    _load_runtime_dependencies()
     if args.o_plus_prefix_frames < 1:
         raise ValueError("--o-plus-prefix-frames must be positive")
     if args.abstain_when_unidentifiable and args.identifiability_npz is None:
         raise ValueError("--abstain-when-unidentifiable requires --identifiability-npz")
+    if args.expected_final_data_sha256 is None:
+        raise ValueError(
+            "--expected-final-data-sha256 is required for final_data.pkl"
+        )
+    _load_runtime_dependencies()
     bank, manifest = load_rollout_bank(args.rollout_bank_npz)
     artifact = load_contract(args.twin_belief_npz)
     if not isinstance(artifact, TwinBelief):
         raise TypeError("twin_belief_npz must contain a TwinBelief")
-    with Path(args.final_data_pickle).open("rb") as handle:
-        data = pickle.load(handle)
+    data = load_trusted_pickle(
+        args.final_data_pickle,
+        allow_unsafe_pickle=args.allow_unsafe_pickle,
+        expected_sha256=args.expected_final_data_sha256,
+    )
+    if not isinstance(data, Mapping):
+        raise ValueError("final_data.pkl must contain a mapping")
+    required_keys = {
+        "object_points",
+        "object_visibilities",
+        "object_motions_valid",
+    }
+    missing = sorted(required_keys - set(data))
+    if missing:
+        raise ValueError("final_data.pkl is missing: " + ", ".join(missing))
     observed = np.asarray(data["object_points"], dtype=float)
     visible = np.asarray(data["object_visibilities"], dtype=bool)
     motion_valid = np.asarray(data["object_motions_valid"], dtype=bool)
@@ -216,6 +243,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             "factual_intervention_id": factual.artifact_id,
             "rollout_bank_manifest": manifest,
             "twin_belief_id": artifact.artifact_id,
+            "source_final_data_sha256": args.expected_final_data_sha256,
+            "trusted_pickle_input": {
+                "explicitly_allowed": bool(args.allow_unsafe_pickle),
+                "digest_verified_before_load": True,
+            },
             "grouped_observation_evidence_id": (
                 None if grouped_evidence is None else grouped_evidence.evidence_id
             ),

--- a/src/causal4d/cli/evaluate_physical_counterfactual.py
+++ b/src/causal4d/cli/evaluate_physical_counterfactual.py
@@ -1,37 +1,48 @@
-"""Evaluate a PhysicalPosterior without semantic evidence."""
+"""Evaluate a PhysicalPosterior against an identity-bound held-out target."""
 
 from __future__ import annotations
 
 import argparse
 import json
-import pickle
 from collections.abc import Sequence
-from pathlib import Path
-
-import numpy as np
 
 
 def _load_runtime_dependencies() -> None:
-    """Load optional integrations only after argparse handles ``--help``."""
-    global target_validity
-    global PhysicalPosterior
-    global load_contract
-    global evaluate_beta_zero_physical_posterior
+    """Load integrations only after argparse handles ``--help``."""
 
-    from bayesian_phystwin.causal4d_provider_v1 import target_validity
+    global PhysicalPosterior
+    global build_physical_counterfactual_evaluation_record
+    global evaluate_beta_zero_physical_posterior
+    global load_contract
+    global load_held_out_physical_target
+    global save_physical_counterfactual_evaluation_record
+
     from causal4d.contracts import PhysicalPosterior, load_contract
+    from causal4d.held_out_target import load_held_out_physical_target
+    from causal4d.physical_evaluation_record import (
+        build_physical_counterfactual_evaluation_record,
+        save_physical_counterfactual_evaluation_record,
+    )
     from causal4d.physical_validation import evaluate_beta_zero_physical_posterior
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Evaluate a discrepancy-aware physical posterior at beta=0."
+        description=(
+            "Evaluate a discrepancy-aware physical posterior at beta=0 against "
+            "a non-pickled, content-addressed held-out target artifact."
+        )
     )
     parser.add_argument("physical_posterior_npz")
-    parser.add_argument("final_data_pickle")
+    parser.add_argument("held_out_target_npz")
     parser.add_argument("output_json")
     parser.add_argument("--start-frame", type=int, default=1)
     parser.add_argument("--confidence-level", type=float, default=0.90)
+    parser.add_argument(
+        "--no-overwrite",
+        action="store_true",
+        help="fail rather than replacing an existing evaluation artifact",
+    )
     return parser
 
 
@@ -41,31 +52,27 @@ def main(argv: Sequence[str] | None = None) -> int:
     artifact = load_contract(args.physical_posterior_npz)
     if not isinstance(artifact, PhysicalPosterior):
         raise TypeError("physical_posterior_npz must contain a PhysicalPosterior")
-    with Path(args.final_data_pickle).open("rb") as handle:
-        data = pickle.load(handle)
-    observed = np.asarray(data["object_points"], dtype=float)
-    valid = target_validity(
-        np.asarray(data["object_visibilities"], dtype=bool),
-        np.asarray(data["object_motions_valid"], dtype=bool),
-    )
-    endpoint = artifact.context.o_minus.frame_stop - 1
-    state_count = artifact.readout_trajectories_m.shape[2]
-    truth = observed[endpoint:, :state_count]
-    mask = valid[endpoint:, :state_count]
-    result = evaluate_beta_zero_physical_posterior(
+    target = load_held_out_physical_target(args.held_out_target_npz)
+    target.require_compatible_physical_posterior(artifact)
+
+    metrics = evaluate_beta_zero_physical_posterior(
         artifact,
-        truth,
-        mask=mask,
+        target.positions_m,
+        mask=target.validity_mask,
         start_frame=args.start_frame,
         confidence_level=args.confidence_level,
     )
-    result["case"] = artifact.context.case_id
-    result["causal_context"] = artifact.context.as_dict()
-    output = Path(args.output_json)
-    output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(
-        json.dumps(result, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
+    result = build_physical_counterfactual_evaluation_record(
+        artifact,
+        target,
+        metrics,
+        start_frame=args.start_frame,
+        confidence_level=args.confidence_level,
+    )
+    save_physical_counterfactual_evaluation_record(
+        args.output_json,
+        result,
+        overwrite=not args.no_overwrite,
     )
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0

--- a/src/causal4d/cli/import_physical_target.py
+++ b/src/causal4d/cli/import_physical_target.py
@@ -1,0 +1,86 @@
+"""Convert one explicitly trusted legacy target pickle into a safe artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+
+def _load_runtime_dependencies() -> None:
+    global PhysicalPosterior
+    global import_legacy_physical_target
+    global load_contract
+    global save_held_out_physical_target
+
+    from causal4d.contracts import PhysicalPosterior, load_contract
+    from causal4d.held_out_target import save_held_out_physical_target
+    from causal4d.legacy_physical_target import import_legacy_physical_target
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert an explicitly trusted, SHA-256-verified final_data.pkl into "
+            "a non-pickled held-out physical target. This is a migration command; "
+            "the claim-bearing evaluator never opens pickle inputs."
+        )
+    )
+    parser.add_argument("physical_posterior_npz")
+    parser.add_argument("final_data_pickle")
+    parser.add_argument("output_target_npz")
+    parser.add_argument(
+        "--allow-unsafe-pickle",
+        action="store_true",
+        help="explicitly acknowledge that unpickling can execute arbitrary code",
+    )
+    parser.add_argument(
+        "--expected-sha256",
+        required=True,
+        help="lowercase SHA-256 digest of the exact trusted pickle bytes",
+    )
+    parser.add_argument(
+        "--source-revision",
+        default="legacy-final-data-v1",
+        help="dataset, acquisition, or producer revision bound into the target",
+    )
+    parser.add_argument(
+        "--source-artifact-id",
+        help="optional upstream dataset or acquisition artifact identity",
+    )
+    parser.add_argument(
+        "--no-overwrite",
+        action="store_true",
+        help="fail rather than replacing an existing target artifact",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    _load_runtime_dependencies()
+    artifact = load_contract(args.physical_posterior_npz)
+    if not isinstance(artifact, PhysicalPosterior):
+        raise TypeError("physical_posterior_npz must contain a PhysicalPosterior")
+    target = import_legacy_physical_target(
+        artifact,
+        args.final_data_pickle,
+        allow_unsafe_pickle=args.allow_unsafe_pickle,
+        expected_sha256=args.expected_sha256,
+        source_revision=args.source_revision,
+        source_artifact_id=args.source_artifact_id,
+    )
+    save_held_out_physical_target(
+        args.output_target_npz,
+        target,
+        overwrite=not args.no_overwrite,
+    )
+    summary = target.summary()
+    summary["output"] = str(Path(args.output_target_npz).resolve())
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d/held_out_target.py
+++ b/src/causal4d/held_out_target.py
@@ -1,0 +1,352 @@
+"""Portable, content-addressed held-out targets for physical evaluation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, BinaryIO
+
+import numpy as np
+
+from causal4d._held_out_target_contract import (
+    HELD_OUT_PHYSICAL_TARGET_SCHEMA,
+    HELD_OUT_PHYSICAL_TARGET_SCHEMA_VERSION,
+    NODE_ORDER_DENSE_PREFIX_V1,
+    canonical_json,
+    reject_duplicate_json_keys,
+    reject_nonfinite_json_constant,
+    require_mapping,
+    require_nonempty_string,
+    require_optional_string,
+    require_integer,
+    validate_sha256,
+    validate_target_descriptor,
+)
+from causal4d.atomic_io import atomic_write_binary
+from causal4d.contracts import CausalContext, PhysicalPosterior, array_sha256
+from causal4d.immutable_array import readonly_integer_array
+from causal4d.immutable_json import plain_json, validated_json_mapping
+
+_ARCHIVE_FIELDS = frozenset(
+    {"descriptor_json", "node_indices", "positions_m", "validity_mask"}
+)
+
+
+@dataclass(frozen=True)
+class HeldOutPhysicalTarget:
+    """Exact held-out trajectory and validity bound to one causal query."""
+
+    context: CausalContext
+    source_query_id: str
+    trajectory_frame_start: int
+    node_indices: np.ndarray
+    positions_m: np.ndarray
+    validity_mask: np.ndarray
+    source_kind: str
+    source_revision: str
+    source_content_sha256: str
+    source_artifact_id: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if type(self.context) is not CausalContext:
+            raise ValueError("context must be a CausalContext")
+        source_query_id = validate_sha256(
+            self.source_query_id,
+            name="source_query_id",
+        )
+        frame_start = require_integer(
+            self.trajectory_frame_start,
+            name="trajectory_frame_start",
+        )
+        expected_start = self.context.o_minus.frame_stop - 1
+        if frame_start != expected_start:
+            raise ValueError(
+                "trajectory_frame_start must be the factual-prefix endpoint "
+                f"{expected_start}"
+            )
+
+        source_kind = require_nonempty_string(
+            self.source_kind,
+            name="source_kind",
+        )
+        source_revision = require_nonempty_string(
+            self.source_revision,
+            name="source_revision",
+        )
+        source_content_sha256 = validate_sha256(
+            self.source_content_sha256,
+            name="source_content_sha256",
+        )
+        source_artifact_id = require_optional_string(
+            self.source_artifact_id,
+            name="source_artifact_id",
+        )
+
+        nodes = readonly_integer_array(self.node_indices, name="node_indices")
+        if nodes.ndim != 1 or not len(nodes):
+            raise ValueError("node_indices must be a nonempty vector")
+        if not np.array_equal(nodes, np.arange(len(nodes), dtype=np.int64)):
+            raise ValueError(
+                "schema v1 requires the canonical zero-based dense-prefix node order"
+            )
+
+        raw_positions = np.asarray(self.positions_m)
+        if raw_positions.dtype.kind not in {"f", "i", "u"}:
+            raise ValueError("positions_m must contain real numeric values")
+        positions = raw_positions.astype(np.float64, copy=True)
+        if (
+            positions.ndim != 3
+            or positions.shape[0] < 1
+            or positions.shape[1] != len(nodes)
+            or positions.shape[2] != 3
+        ):
+            raise ValueError("positions_m must have shape (T>=1, N, 3)")
+
+        supplied_validity = np.asarray(self.validity_mask)
+        if supplied_validity.dtype.kind != "b":
+            raise ValueError("validity_mask must contain booleans")
+        if supplied_validity.shape == positions.shape:
+            valid = np.all(supplied_validity, axis=2)
+        elif supplied_validity.shape == positions.shape[:2]:
+            valid = supplied_validity.copy()
+        else:
+            raise ValueError("validity_mask must have shape (T, N) or (T, N, 3)")
+        if np.any(valid & ~np.all(np.isfinite(positions), axis=2)):
+            raise ValueError("valid target points must contain finite coordinates")
+        if not np.any(valid):
+            raise ValueError("held-out target must contain at least one valid point")
+        positions[~valid] = np.nan
+        positions.setflags(write=False)
+        valid.setflags(write=False)
+
+        frame_stop = frame_start + len(positions)
+        if frame_stop != self.context.u_cf.frame_stop:
+            raise ValueError(
+                "target trajectory must end at the counterfactual action stop; "
+                f"expected {self.context.u_cf.frame_stop}, got {frame_stop}"
+            )
+
+        metadata = validated_json_mapping(
+            self.metadata,
+            error_message="held-out target metadata must be finite JSON data",
+        )
+        object.__setattr__(self, "source_query_id", source_query_id)
+        object.__setattr__(self, "trajectory_frame_start", frame_start)
+        object.__setattr__(self, "node_indices", nodes)
+        object.__setattr__(self, "positions_m", positions)
+        object.__setattr__(self, "validity_mask", valid)
+        object.__setattr__(self, "source_kind", source_kind)
+        object.__setattr__(self, "source_revision", source_revision)
+        object.__setattr__(self, "source_content_sha256", source_content_sha256)
+        object.__setattr__(self, "source_artifact_id", source_artifact_id)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def trajectory_frame_stop(self) -> int:
+        return self.trajectory_frame_start + len(self.positions_m)
+
+    @property
+    def point_count(self) -> int:
+        return len(self.node_indices)
+
+    @property
+    def source(self) -> dict[str, str | None]:
+        return {
+            "kind": self.source_kind,
+            "revision": self.source_revision,
+            "content_sha256": self.source_content_sha256,
+            "artifact_id": self.source_artifact_id,
+        }
+
+    def payload_hashes(self) -> dict[str, str]:
+        return {
+            "node_indices_sha256": array_sha256(self.node_indices),
+            "positions_m_sha256": array_sha256(self.positions_m),
+            "validity_mask_sha256": array_sha256(self.validity_mask),
+        }
+
+    def _descriptor_without_id(self) -> dict[str, Any]:
+        return {
+            "schema": HELD_OUT_PHYSICAL_TARGET_SCHEMA,
+            "schema_version": HELD_OUT_PHYSICAL_TARGET_SCHEMA_VERSION,
+            "context": self.context.as_dict(),
+            "source_query_id": self.source_query_id,
+            "trajectory_frame_interval": [
+                self.trajectory_frame_start,
+                self.trajectory_frame_stop,
+            ],
+            "node_order": NODE_ORDER_DENSE_PREFIX_V1,
+            "source": self.source,
+            "metadata": plain_json(self.metadata),
+            "payload": self.payload_hashes(),
+        }
+
+    @property
+    def artifact_id(self) -> str:
+        encoded = canonical_json(self._descriptor_without_id()).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def descriptor(self) -> dict[str, Any]:
+        descriptor = self._descriptor_without_id()
+        descriptor["artifact_id"] = self.artifact_id
+        return descriptor
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "artifact_id": self.artifact_id,
+            "protocol_id": self.context.protocol_id,
+            "case_id": self.context.case_id,
+            "counterfactual_action_id": self.context.u_cf.action_id,
+            "source_query_id": self.source_query_id,
+            "trajectory_frame_interval": [
+                self.trajectory_frame_start,
+                self.trajectory_frame_stop,
+            ],
+            "trajectory_length": len(self.positions_m),
+            "point_count": self.point_count,
+            "valid_point_frames": int(np.sum(self.validity_mask)),
+            "source": self.source,
+        }
+
+    def require_compatible_physical_posterior(
+        self,
+        posterior: PhysicalPosterior,
+    ) -> None:
+        """Fail before scoring unless target and posterior identify one query."""
+
+        if not isinstance(posterior, PhysicalPosterior):
+            raise TypeError("posterior must be a PhysicalPosterior")
+        if self.context.as_dict() != posterior.context.as_dict():
+            raise ValueError("held-out target causal context does not match posterior")
+        if self.source_query_id != posterior.source_query_id:
+            raise ValueError("held-out target source_query_id does not match posterior")
+        expected_shape = posterior.readout_trajectories_m.shape[1:]
+        if self.positions_m.shape != expected_shape:
+            raise ValueError(
+                "held-out target shape does not match posterior readout trajectory: "
+                f"{self.positions_m.shape} != {expected_shape}"
+            )
+        expected_nodes = np.arange(expected_shape[1], dtype=np.int64)
+        if not np.array_equal(self.node_indices, expected_nodes):
+            raise ValueError("held-out target node order does not match posterior")
+
+
+def _save_archive(handle: BinaryIO, target: HeldOutPhysicalTarget) -> None:
+    np.savez_compressed(
+        handle,
+        descriptor_json=np.asarray(canonical_json(target.descriptor())),
+        node_indices=target.node_indices,
+        positions_m=target.positions_m,
+        validity_mask=target.validity_mask,
+    )
+
+
+def save_held_out_physical_target(
+    path: str | Path,
+    target: HeldOutPhysicalTarget,
+    *,
+    overwrite: bool = True,
+) -> None:
+    """Atomically publish a safe held-out target archive."""
+
+    expected_id = target.artifact_id
+
+    def validate(temporary: Path) -> None:
+        restored = load_held_out_physical_target(temporary)
+        if restored.artifact_id != expected_id:
+            raise ValueError("held-out target changed during serialization")
+
+    atomic_write_binary(
+        path,
+        lambda handle: _save_archive(handle, target),
+        overwrite=overwrite,
+        validate=validate,
+    )
+
+
+def _parse_descriptor(value: np.ndarray) -> Mapping[str, Any]:
+    array = np.asarray(value)
+    if array.shape != () or array.dtype.kind not in {"U", "S"}:
+        raise ValueError("descriptor_json must be one scalar string")
+    scalar = array.item()
+    if isinstance(scalar, bytes):
+        try:
+            scalar = scalar.decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise ValueError("descriptor_json is not valid UTF-8") from error
+    if type(scalar) is not str:
+        raise ValueError("descriptor_json must be one scalar string")
+    try:
+        parsed = json.loads(
+            scalar,
+            object_pairs_hook=reject_duplicate_json_keys,
+            parse_constant=reject_nonfinite_json_constant,
+        )
+    except (TypeError, ValueError, json.JSONDecodeError) as error:
+        raise ValueError("descriptor_json is invalid") from error
+    return require_mapping(parsed, name="held-out target descriptor")
+
+
+def load_held_out_physical_target(path: str | Path) -> HeldOutPhysicalTarget:
+    """Load and independently revalidate a held-out target archive."""
+
+    with np.load(path, allow_pickle=False) as archive:
+        if len(archive.files) != len(set(archive.files)):
+            raise ValueError("held-out target archive contains duplicate entries")
+        actual_fields = set(archive.files)
+        if actual_fields != _ARCHIVE_FIELDS:
+            raise ValueError(
+                "held-out target archive fields do not match schema; "
+                f"missing={sorted(_ARCHIVE_FIELDS - actual_fields)}, "
+                f"unexpected={sorted(actual_fields - _ARCHIVE_FIELDS)}"
+            )
+        descriptor = validate_target_descriptor(
+            _parse_descriptor(np.asarray(archive["descriptor_json"]))
+        )
+        node_indices = np.asarray(archive["node_indices"])
+        positions_m = np.asarray(archive["positions_m"])
+        validity_mask = np.asarray(archive["validity_mask"])
+        if node_indices.dtype != np.dtype(np.int64):
+            raise ValueError("node_indices must use int64 storage")
+        if positions_m.dtype != np.dtype(np.float64):
+            raise ValueError("positions_m must use float64 storage")
+        if validity_mask.dtype != np.dtype(np.bool_):
+            raise ValueError("validity_mask must use boolean storage")
+
+    source = descriptor["source"]
+    payload = descriptor["payload"]
+    interval = descriptor["trajectory_frame_interval"]
+    target = HeldOutPhysicalTarget(
+        context=CausalContext.from_dict(descriptor["context"]),
+        source_query_id=descriptor["source_query_id"],
+        trajectory_frame_start=interval[0],
+        node_indices=node_indices,
+        positions_m=positions_m,
+        validity_mask=validity_mask,
+        source_kind=source["kind"],
+        source_revision=source["revision"],
+        source_content_sha256=source["content_sha256"],
+        source_artifact_id=source["artifact_id"],
+        metadata=require_mapping(descriptor["metadata"], name="metadata"),
+    )
+    if descriptor["artifact_id"] != target.artifact_id:
+        raise ValueError("held-out target artifact_id does not match payload")
+    if dict(payload) != target.payload_hashes():
+        raise ValueError("held-out target payload hashes do not match arrays")
+    if interval[1] != target.trajectory_frame_stop:
+        raise ValueError("held-out target frame interval does not match payload")
+    return target
+
+
+__all__ = [
+    "HELD_OUT_PHYSICAL_TARGET_SCHEMA",
+    "HELD_OUT_PHYSICAL_TARGET_SCHEMA_VERSION",
+    "NODE_ORDER_DENSE_PREFIX_V1",
+    "HeldOutPhysicalTarget",
+    "load_held_out_physical_target",
+    "save_held_out_physical_target",
+]

--- a/src/causal4d/held_out_target.py
+++ b/src/causal4d/held_out_target.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import zipfile
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -33,6 +34,7 @@ from causal4d.immutable_json import plain_json, validated_json_mapping
 _ARCHIVE_FIELDS = frozenset(
     {"descriptor_json", "node_indices", "positions_m", "validity_mask"}
 )
+_ARCHIVE_MEMBERS = frozenset(f"{name}.npy" for name in _ARCHIVE_FIELDS)
 
 
 @dataclass(frozen=True)
@@ -293,6 +295,21 @@ def _parse_descriptor(value: np.ndarray) -> Mapping[str, Any]:
 
 def load_held_out_physical_target(path: str | Path) -> HeldOutPhysicalTarget:
     """Load and independently revalidate a held-out target archive."""
+
+    try:
+        with zipfile.ZipFile(path) as archive_zip:
+            member_names = archive_zip.namelist()
+    except (OSError, zipfile.BadZipFile) as error:
+        raise ValueError("held-out target archive is not a valid ZIP file") from error
+    if len(member_names) != len(set(member_names)):
+        raise ValueError("held-out target archive contains duplicate ZIP members")
+    actual_members = set(member_names)
+    if actual_members != _ARCHIVE_MEMBERS:
+        raise ValueError(
+            "held-out target ZIP members do not match schema; "
+            f"missing={sorted(_ARCHIVE_MEMBERS - actual_members)}, "
+            f"unexpected={sorted(actual_members - _ARCHIVE_MEMBERS)}"
+        )
 
     with np.load(path, allow_pickle=False) as archive:
         if len(archive.files) != len(set(archive.files)):

--- a/src/causal4d/legacy_physical_target.py
+++ b/src/causal4d/legacy_physical_target.py
@@ -1,0 +1,104 @@
+"""Explicitly trusted migration from legacy PhysTwin target pickles."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from causal4d._held_out_target_contract import (
+    require_mapping,
+    target_validity,
+    validate_sha256,
+)
+from causal4d.contracts import PhysicalPosterior
+from causal4d.held_out_target import HeldOutPhysicalTarget
+from causal4d.trusted_pickle import load_trusted_pickle
+
+
+def import_legacy_physical_target(
+    posterior: PhysicalPosterior,
+    final_data_pickle: str | Path,
+    *,
+    allow_unsafe_pickle: bool = False,
+    expected_sha256: str | None = None,
+    source_revision: str = "legacy-final-data-v1",
+    source_artifact_id: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> HeldOutPhysicalTarget:
+    """Convert one trusted legacy ``final_data.pkl`` into a safe target artifact."""
+
+    if not isinstance(posterior, PhysicalPosterior):
+        raise TypeError("posterior must be a PhysicalPosterior")
+    if expected_sha256 is None:
+        raise ValueError("expected_sha256 is required for legacy target import")
+    expected = validate_sha256(expected_sha256, name="expected_sha256")
+    values = load_trusted_pickle(
+        final_data_pickle,
+        allow_unsafe_pickle=allow_unsafe_pickle,
+        expected_sha256=expected,
+    )
+    mapping = require_mapping(values, name="legacy final_data pickle")
+    required = {
+        "object_points",
+        "object_visibilities",
+        "object_motions_valid",
+    }
+    missing = sorted(required - set(mapping))
+    if missing:
+        raise ValueError("legacy final_data pickle is missing: " + ", ".join(missing))
+
+    raw_positions = np.asarray(mapping["object_points"])
+    if raw_positions.dtype.kind not in {"f", "i", "u"}:
+        raise ValueError("legacy object_points must contain real numeric values")
+    observed = raw_positions.astype(np.float64, copy=False)
+    if observed.ndim != 3 or observed.shape[2] != 3:
+        raise ValueError("legacy object_points must have shape (T, N, 3)")
+    valid = target_validity(
+        np.asarray(mapping["object_visibilities"]),
+        np.asarray(mapping["object_motions_valid"]),
+    )
+    if valid.shape != observed.shape[:2]:
+        raise ValueError("legacy target validity does not match object_points")
+
+    frame_start = posterior.context.o_minus.frame_stop - 1
+    trajectory_length = posterior.readout_trajectories_m.shape[1]
+    point_count = posterior.readout_trajectories_m.shape[2]
+    frame_stop = frame_start + trajectory_length
+    if frame_stop != posterior.context.u_cf.frame_stop:
+        raise ValueError(
+            "posterior readout length does not match its counterfactual context"
+        )
+    if frame_stop > len(observed) or point_count > observed.shape[1]:
+        raise ValueError("legacy final_data does not cover the posterior target")
+
+    supplied_metadata = {} if metadata is None else dict(metadata)
+    if "legacy_import" in supplied_metadata:
+        raise ValueError("metadata key 'legacy_import' is reserved")
+    supplied_metadata["legacy_import"] = {
+        "format": "python-pickle",
+        "object_points_key": "object_points",
+        "visibility_key": "object_visibilities",
+        "motion_valid_key": "object_motions_valid",
+        "target_validity_semantics": "bayesian_phystwin.target_validity_v1",
+    }
+    target = HeldOutPhysicalTarget(
+        context=posterior.context,
+        source_query_id=posterior.source_query_id,
+        trajectory_frame_start=frame_start,
+        node_indices=np.arange(point_count, dtype=np.int64),
+        positions_m=observed[frame_start:frame_stop, :point_count],
+        validity_mask=valid[frame_start:frame_stop, :point_count],
+        source_kind="trusted_legacy_final_data_pickle",
+        source_revision=source_revision,
+        source_content_sha256=expected,
+        source_artifact_id=source_artifact_id,
+        metadata=supplied_metadata,
+    )
+    target.require_compatible_physical_posterior(posterior)
+    return target
+
+
+__all__ = ["import_legacy_physical_target"]

--- a/src/causal4d/physical_evaluation_record.py
+++ b/src/causal4d/physical_evaluation_record.py
@@ -1,0 +1,357 @@
+"""Content-addressed beta-zero physical evaluation records."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, BinaryIO
+
+import numpy as np
+
+from causal4d._held_out_target_contract import (
+    PAYLOAD_FIELDS,
+    SOURCE_FIELDS,
+    canonical_json,
+    reject_duplicate_json_keys,
+    reject_nonfinite_json_constant,
+    require_exact_fields,
+    require_finite_number,
+    require_integer,
+    require_integer_interval,
+    require_mapping,
+    require_nonempty_string,
+    require_optional_string,
+    validate_sha256,
+    validate_target_descriptor,
+)
+from causal4d.atomic_io import atomic_write_binary
+from causal4d.contracts import CausalContext, PhysicalPosterior
+from causal4d.held_out_target import HeldOutPhysicalTarget
+from causal4d.immutable_json import plain_json, validated_json_mapping
+
+PHYSICAL_COUNTERFACTUAL_EVALUATION_SCHEMA = (
+    "causal4d.physical_counterfactual_evaluation"
+)
+PHYSICAL_COUNTERFACTUAL_EVALUATION_SCHEMA_VERSION = 1
+
+_EVALUATION_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "evaluation_id",
+        "physical_posterior_id",
+        "held_out_target_id",
+        "held_out_target_descriptor",
+        "source_query_id",
+        "protocol_id",
+        "case",
+        "counterfactual_action_id",
+        "causal_context",
+        "target_frame_interval",
+        "evaluation_frame_interval",
+        "evaluation_frame_interval_absolute",
+        "confidence_level",
+        "target_source",
+        "target_payload",
+        "claim_boundary",
+        "semantic_beta",
+        "semantic_evidence_consumed",
+        "molmo_motion_consumed",
+        "valid_point_frames",
+        "coordinate_rmse_m",
+        "track_error_m",
+        "fde_m",
+        "coverage",
+        "coverage_error",
+        "mean_interval_width_m",
+        "nees",
+        "gaussian_nll",
+    }
+)
+
+
+def build_physical_counterfactual_evaluation_record(
+    posterior: PhysicalPosterior,
+    target: HeldOutPhysicalTarget,
+    metrics: Mapping[str, Any],
+    *,
+    start_frame: int,
+    confidence_level: float,
+) -> dict[str, Any]:
+    """Bind finite beta-zero metrics to exact posterior and target identities."""
+
+    target.require_compatible_physical_posterior(posterior)
+    start = require_integer(start_frame, name="start_frame")
+    if start >= len(target.positions_m):
+        raise ValueError("start_frame must lie inside the held-out target")
+    confidence = require_finite_number(
+        confidence_level,
+        name="confidence_level",
+        minimum=0.0,
+        maximum=1.0,
+    )
+    if confidence in {0.0, 1.0}:
+        raise ValueError("confidence_level must lie strictly inside (0, 1)")
+
+    normalized_metrics = validated_json_mapping(
+        metrics,
+        error_message="physical evaluation metrics must be finite JSON data",
+    )
+    if normalized_metrics.get("physical_posterior_id") != posterior.artifact_id:
+        raise ValueError("metrics identify a different physical posterior")
+    semantic_beta = require_finite_number(
+        normalized_metrics.get("semantic_beta"),
+        name="semantic_beta",
+    )
+    if semantic_beta != 0.0:
+        raise ValueError("physical evaluation must retain semantic_beta=0")
+    if normalized_metrics.get("semantic_evidence_consumed") is not False:
+        raise ValueError("physical evaluation must not consume semantic evidence")
+
+    record: dict[str, Any] = plain_json(normalized_metrics)
+    record.update(
+        {
+            "schema": PHYSICAL_COUNTERFACTUAL_EVALUATION_SCHEMA,
+            "schema_version": PHYSICAL_COUNTERFACTUAL_EVALUATION_SCHEMA_VERSION,
+            "held_out_target_id": target.artifact_id,
+            "held_out_target_descriptor": target.descriptor(),
+            "source_query_id": target.source_query_id,
+            "protocol_id": target.context.protocol_id,
+            "case": target.context.case_id,
+            "counterfactual_action_id": target.context.u_cf.action_id,
+            "causal_context": target.context.as_dict(),
+            "target_frame_interval": [
+                target.trajectory_frame_start,
+                target.trajectory_frame_stop,
+            ],
+            "evaluation_frame_interval_absolute": [
+                target.trajectory_frame_start + start,
+                target.trajectory_frame_stop,
+            ],
+            "confidence_level": confidence,
+            "target_source": target.source,
+            "target_payload": target.payload_hashes(),
+            "claim_boundary": (
+                "beta-zero physical evaluation; no semantic evidence consumed"
+            ),
+        }
+    )
+    encoded = canonical_json(record).encode("utf-8")
+    record["evaluation_id"] = hashlib.sha256(encoded).hexdigest()
+    return validate_physical_counterfactual_evaluation_record(record)
+
+
+def validate_physical_counterfactual_evaluation_record(
+    values: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate an evaluation record and its content identity."""
+
+    fields = require_exact_fields(
+        values,
+        name="physical counterfactual evaluation",
+        required=_EVALUATION_FIELDS,
+    )
+    if fields["schema"] != PHYSICAL_COUNTERFACTUAL_EVALUATION_SCHEMA:
+        raise ValueError("unsupported physical evaluation schema")
+    schema_version = require_integer(
+        fields["schema_version"],
+        name="physical evaluation schema_version",
+        minimum=1,
+    )
+    if schema_version != PHYSICAL_COUNTERFACTUAL_EVALUATION_SCHEMA_VERSION:
+        raise ValueError("unsupported physical evaluation schema version")
+    for name in (
+        "evaluation_id",
+        "physical_posterior_id",
+        "held_out_target_id",
+        "source_query_id",
+    ):
+        validate_sha256(fields[name], name=name)
+
+    context = CausalContext.from_dict(fields["causal_context"])
+    target_descriptor = validate_target_descriptor(
+        fields["held_out_target_descriptor"]
+    )
+    if target_descriptor["artifact_id"] != fields["held_out_target_id"]:
+        raise ValueError("held-out target descriptor identity is inconsistent")
+    if target_descriptor["context"] != context.as_dict():
+        raise ValueError("held-out target descriptor context is inconsistent")
+    if target_descriptor["source_query_id"] != fields["source_query_id"]:
+        raise ValueError("held-out target descriptor query identity is inconsistent")
+    if fields["protocol_id"] != context.protocol_id:
+        raise ValueError("evaluation protocol_id disagrees with causal_context")
+    if fields["case"] != context.case_id:
+        raise ValueError("evaluation case disagrees with causal_context")
+    if fields["counterfactual_action_id"] != context.u_cf.action_id:
+        raise ValueError(
+            "evaluation counterfactual_action_id disagrees with causal_context"
+        )
+
+    target_interval = require_integer_interval(
+        fields["target_frame_interval"],
+        name="target_frame_interval",
+    )
+    if target_descriptor["trajectory_frame_interval"] != target_interval:
+        raise ValueError("held-out target descriptor interval is inconsistent")
+    relative_interval = require_integer_interval(
+        fields["evaluation_frame_interval"],
+        name="evaluation_frame_interval",
+    )
+    absolute_interval = require_integer_interval(
+        fields["evaluation_frame_interval_absolute"],
+        name="evaluation_frame_interval_absolute",
+    )
+    if relative_interval[1] != target_interval[1] - target_interval[0]:
+        raise ValueError("relative evaluation stop does not match target length")
+    if absolute_interval != [
+        target_interval[0] + relative_interval[0],
+        target_interval[1],
+    ]:
+        raise ValueError("absolute evaluation interval is inconsistent")
+
+    confidence = require_finite_number(
+        fields["confidence_level"],
+        name="confidence_level",
+        minimum=0.0,
+        maximum=1.0,
+    )
+    if confidence in {0.0, 1.0}:
+        raise ValueError("confidence_level must lie strictly inside (0, 1)")
+    semantic_beta = require_finite_number(
+        fields["semantic_beta"],
+        name="semantic_beta",
+    )
+    if semantic_beta != 0.0:
+        raise ValueError("physical evaluation must retain semantic_beta=0")
+    if fields["semantic_evidence_consumed"] is not False:
+        raise ValueError("physical evaluation must not consume semantic evidence")
+    if fields["molmo_motion_consumed"] is not False:
+        raise ValueError("physical evaluation must not consume MolmoMotion")
+    if (
+        type(fields["valid_point_frames"]) is not int
+        or fields["valid_point_frames"] < 1
+    ):
+        raise ValueError("valid_point_frames must be a positive integer")
+    for name in (
+        "coordinate_rmse_m",
+        "track_error_m",
+        "coverage_error",
+        "mean_interval_width_m",
+        "nees",
+    ):
+        require_finite_number(fields[name], name=name, minimum=0.0)
+    require_finite_number(fields["gaussian_nll"], name="gaussian_nll")
+    require_finite_number(
+        fields["coverage"],
+        name="coverage",
+        minimum=0.0,
+        maximum=1.0,
+    )
+    if fields["fde_m"] is not None:
+        require_finite_number(fields["fde_m"], name="fde_m", minimum=0.0)
+
+    source = require_exact_fields(
+        fields["target_source"],
+        name="target_source",
+        required=SOURCE_FIELDS,
+    )
+    require_nonempty_string(source["kind"], name="target_source.kind")
+    require_nonempty_string(source["revision"], name="target_source.revision")
+    validate_sha256(
+        source["content_sha256"],
+        name="target_source.content_sha256",
+    )
+    require_optional_string(
+        source["artifact_id"],
+        name="target_source.artifact_id",
+    )
+    target_payload = require_exact_fields(
+        fields["target_payload"],
+        name="target_payload",
+        required=PAYLOAD_FIELDS,
+    )
+    for name, value in target_payload.items():
+        validate_sha256(value, name=f"target_payload.{name}")
+    if target_descriptor["source"] != dict(source):
+        raise ValueError("held-out target descriptor source is inconsistent")
+    if target_descriptor["payload"] != dict(target_payload):
+        raise ValueError("held-out target descriptor payload is inconsistent")
+    if fields["claim_boundary"] != (
+        "beta-zero physical evaluation; no semantic evidence consumed"
+    ):
+        raise ValueError("unexpected physical evaluation claim boundary")
+
+    normalized = plain_json(
+        validated_json_mapping(
+            fields,
+            error_message="physical evaluation must be finite JSON data",
+        )
+    )
+    supplied_id = normalized.pop("evaluation_id")
+    expected_id = hashlib.sha256(
+        canonical_json(normalized).encode("utf-8")
+    ).hexdigest()
+    if supplied_id != expected_id:
+        raise ValueError("physical evaluation_id does not match its contents")
+    normalized["evaluation_id"] = supplied_id
+    return normalized
+
+
+def load_physical_counterfactual_evaluation_record(
+    path: str | Path,
+) -> dict[str, Any]:
+    """Load and validate one claim-bearing physical evaluation JSON."""
+
+    try:
+        parsed = json.loads(
+            Path(path).read_text(encoding="utf-8"),
+            object_pairs_hook=reject_duplicate_json_keys,
+            parse_constant=reject_nonfinite_json_constant,
+        )
+    except (UnicodeDecodeError, TypeError, ValueError, json.JSONDecodeError) as error:
+        raise ValueError("physical evaluation JSON is invalid") from error
+    return validate_physical_counterfactual_evaluation_record(
+        require_mapping(parsed, name="physical evaluation JSON")
+    )
+
+
+def save_physical_counterfactual_evaluation_record(
+    path: str | Path,
+    record: Mapping[str, Any],
+    *,
+    overwrite: bool = True,
+) -> None:
+    """Atomically publish and independently reload a physical evaluation."""
+
+    validated = validate_physical_counterfactual_evaluation_record(record)
+    serialized = (
+        json.dumps(validated, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    ).encode("utf-8")
+    expected_id = validated["evaluation_id"]
+
+    def write(handle: BinaryIO) -> None:
+        handle.write(serialized)
+
+    def validate(temporary: Path) -> None:
+        restored = load_physical_counterfactual_evaluation_record(temporary)
+        if restored["evaluation_id"] != expected_id:
+            raise ValueError("physical evaluation changed during serialization")
+
+    atomic_write_binary(
+        path,
+        write,
+        overwrite=overwrite,
+        validate=validate,
+    )
+
+
+__all__ = [
+    "PHYSICAL_COUNTERFACTUAL_EVALUATION_SCHEMA",
+    "PHYSICAL_COUNTERFACTUAL_EVALUATION_SCHEMA_VERSION",
+    "build_physical_counterfactual_evaluation_record",
+    "load_physical_counterfactual_evaluation_record",
+    "save_physical_counterfactual_evaluation_record",
+    "validate_physical_counterfactual_evaluation_record",
+]

--- a/src/causal4d/physical_evaluation_record.py
+++ b/src/causal4d/physical_evaluation_record.py
@@ -8,8 +8,6 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, BinaryIO
 
-import numpy as np
-
 from causal4d._held_out_target_contract import (
     PAYLOAD_FIELDS,
     SOURCE_FIELDS,

--- a/src/causal4d/physical_validation.py
+++ b/src/causal4d/physical_validation.py
@@ -42,6 +42,14 @@ def evaluate_beta_zero_physical_posterior(
 ) -> dict[str, Any]:
     """Evaluate physical prediction with the semantic factor explicitly absent."""
 
+    if type(start_frame) is not int:
+        raise ValueError("start_frame must be an integer")
+    if type(confidence_level) not in {int, float}:
+        raise ValueError("confidence_level must be a finite number in (0, 1)")
+    confidence = float(confidence_level)
+    if not np.isfinite(confidence) or not 0.0 < confidence < 1.0:
+        raise ValueError("confidence_level must be a finite number in (0, 1)")
+
     truth = np.asarray(truth_m, dtype=float)
     mean, variance = physical_posterior_moments(posterior)
     if truth.shape != mean.shape:
@@ -63,7 +71,7 @@ def evaluate_beta_zero_physical_posterior(
     residual = mean - truth
     selected_residual = residual[coordinate_valid]
     selected_variance = variance[coordinate_valid]
-    z_score = NormalDist().inv_cdf(0.5 * (1.0 + confidence_level))
+    z_score = NormalDist().inv_cdf(0.5 * (1.0 + confidence))
     standard_deviation = np.sqrt(variance)
     lower = mean - z_score * standard_deviation
     upper = mean + z_score * standard_deviation
@@ -77,6 +85,9 @@ def evaluate_beta_zero_physical_posterior(
         if np.any(final_valid)
         else None
     )
+    coverage = float(
+        np.mean((selected_truth >= selected_lower) & (selected_truth <= selected_upper))
+    )
     return {
         "physical_posterior_id": posterior.artifact_id,
         "semantic_beta": 0.0,
@@ -87,24 +98,9 @@ def evaluate_beta_zero_physical_posterior(
         "coordinate_rmse_m": float(np.sqrt(np.mean(np.square(selected_residual)))),
         "track_error_m": float(np.mean(np.linalg.norm(vectors, axis=1))),
         "fde_m": fde,
-        "coverage": float(
-            np.mean(
-                (selected_truth >= selected_lower)
-                & (selected_truth <= selected_upper)
-            )
-        ),
-        "coverage_error": float(
-            abs(
-                np.mean(
-                    (selected_truth >= selected_lower)
-                    & (selected_truth <= selected_upper)
-                )
-                - confidence_level
-            )
-        ),
-        "mean_interval_width_m": float(
-            np.mean(selected_upper - selected_lower)
-        ),
+        "coverage": coverage,
+        "coverage_error": float(abs(coverage - confidence)),
+        "mean_interval_width_m": float(np.mean(selected_upper - selected_lower)),
         "nees": float(np.mean(np.square(selected_residual) / selected_variance)),
         "gaussian_nll": float(
             np.mean(

--- a/src/causal4d/physical_validation.py
+++ b/src/causal4d/physical_validation.py
@@ -42,14 +42,6 @@ def evaluate_beta_zero_physical_posterior(
 ) -> dict[str, Any]:
     """Evaluate physical prediction with the semantic factor explicitly absent."""
 
-    if type(start_frame) is not int:
-        raise ValueError("start_frame must be an integer")
-    if type(confidence_level) not in {int, float}:
-        raise ValueError("confidence_level must be a finite number in (0, 1)")
-    confidence = float(confidence_level)
-    if not np.isfinite(confidence) or not 0.0 < confidence < 1.0:
-        raise ValueError("confidence_level must be a finite number in (0, 1)")
-
     truth = np.asarray(truth_m, dtype=float)
     mean, variance = physical_posterior_moments(posterior)
     if truth.shape != mean.shape:
@@ -71,7 +63,7 @@ def evaluate_beta_zero_physical_posterior(
     residual = mean - truth
     selected_residual = residual[coordinate_valid]
     selected_variance = variance[coordinate_valid]
-    z_score = NormalDist().inv_cdf(0.5 * (1.0 + confidence))
+    z_score = NormalDist().inv_cdf(0.5 * (1.0 + confidence_level))
     standard_deviation = np.sqrt(variance)
     lower = mean - z_score * standard_deviation
     upper = mean + z_score * standard_deviation
@@ -85,9 +77,6 @@ def evaluate_beta_zero_physical_posterior(
         if np.any(final_valid)
         else None
     )
-    coverage = float(
-        np.mean((selected_truth >= selected_lower) & (selected_truth <= selected_upper))
-    )
     return {
         "physical_posterior_id": posterior.artifact_id,
         "semantic_beta": 0.0,
@@ -98,9 +87,24 @@ def evaluate_beta_zero_physical_posterior(
         "coordinate_rmse_m": float(np.sqrt(np.mean(np.square(selected_residual)))),
         "track_error_m": float(np.mean(np.linalg.norm(vectors, axis=1))),
         "fde_m": fde,
-        "coverage": coverage,
-        "coverage_error": float(abs(coverage - confidence)),
-        "mean_interval_width_m": float(np.mean(selected_upper - selected_lower)),
+        "coverage": float(
+            np.mean(
+                (selected_truth >= selected_lower)
+                & (selected_truth <= selected_upper)
+            )
+        ),
+        "coverage_error": float(
+            abs(
+                np.mean(
+                    (selected_truth >= selected_lower)
+                    & (selected_truth <= selected_upper)
+                )
+                - confidence_level
+            )
+        ),
+        "mean_interval_width_m": float(
+            np.mean(selected_upper - selected_lower)
+        ),
         "nees": float(np.mean(np.square(selected_residual) / selected_variance)),
         "gaussian_nll": float(
             np.mean(

--- a/tests/test_claim_bearing_cli_io_policy.py
+++ b/tests/test_claim_bearing_cli_io_policy.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from causal4d.cli.command_registry import find_command, grouped_commands
+
+
+def _command_source(target: str) -> Path:
+    module_name, separator, function_name = target.partition(":")
+    assert separator == ":" and function_name
+    repository_root = Path(__file__).resolve().parents[1]
+    source = repository_root / "src" / Path(*module_name.split("."))
+    return source.with_suffix(".py")
+
+
+def _unsafe_deserialization_calls(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    pickle_modules: set[str] = set()
+    pickle_loads: set[str] = set()
+    numpy_modules: set[str] = set()
+    numpy_loads: set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                local_name = alias.asname or alias.name
+                if alias.name == "pickle":
+                    pickle_modules.add(local_name)
+                elif alias.name == "numpy":
+                    numpy_modules.add(local_name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module == "pickle":
+                for alias in node.names:
+                    if alias.name in {"load", "loads"}:
+                        pickle_loads.add(alias.asname or alias.name)
+            elif node.module == "numpy":
+                for alias in node.names:
+                    if alias.name == "load":
+                        numpy_loads.add(alias.asname or alias.name)
+
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Name) and node.func.id in pickle_loads:
+            violations.append(f"{path}:{node.lineno}: direct pickle deserialization")
+        elif (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id in pickle_modules
+            and node.func.attr in {"load", "loads"}
+        ):
+            violations.append(f"{path}:{node.lineno}: direct pickle deserialization")
+
+        numpy_load = (
+            isinstance(node.func, ast.Name) and node.func.id in numpy_loads
+        ) or (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id in numpy_modules
+            and node.func.attr == "load"
+        )
+        if numpy_load:
+            for keyword in node.keywords:
+                if (
+                    keyword.arg == "allow_pickle"
+                    and isinstance(keyword.value, ast.Constant)
+                    and keyword.value.value is True
+                ):
+                    violations.append(
+                        f"{path}:{node.lineno}: numpy.load(allow_pickle=True)"
+                    )
+    return violations
+
+
+def test_claim_bearing_command_modules_do_not_deserialize_pickle_directly() -> None:
+    violations: list[str] = []
+    for command in grouped_commands():
+        if not command.claim_bearing:
+            continue
+        source = _command_source(command.target)
+        assert source.is_file(), command.target
+        violations.extend(_unsafe_deserialization_calls(source))
+    assert not violations, "unsafe claim-bearing input paths:\n" + "\n".join(
+        violations
+    )
+
+
+def test_physical_evaluator_uses_safe_target_and_atomic_publication() -> None:
+    command = find_command("evidence/physical-counterfactual/evaluate")
+    assert command.claim_bearing
+    source = _command_source(command.target)
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+
+    imported: set[tuple[str | None, str]] = set()
+    direct_writes: list[int] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            imported.update((node.module, alias.name) for alias in node.names)
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in {"write_text", "write_bytes"}
+        ):
+            direct_writes.append(node.lineno)
+
+    assert (
+        "causal4d.held_out_target",
+        "load_held_out_physical_target",
+    ) in imported
+    assert (
+        "causal4d.physical_evaluation_record",
+        "save_physical_counterfactual_evaluation_record",
+    ) in imported
+    assert not direct_writes, f"direct evidence writes at lines {direct_writes}"

--- a/tests/test_claim_bearing_cli_io_policy.py
+++ b/tests/test_claim_bearing_cli_io_policy.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
 from causal4d.cli.command_registry import find_command, grouped_commands
 
 
@@ -114,3 +116,33 @@ def test_physical_evaluator_uses_safe_target_and_atomic_publication() -> None:
         "save_physical_counterfactual_evaluation_record",
     ) in imported
     assert not direct_writes, f"direct evidence writes at lines {direct_writes}"
+
+
+def test_phystwin_abduction_uses_the_trusted_pickle_boundary() -> None:
+    repository_root = Path(__file__).resolve().parents[1]
+    source = (
+        repository_root
+        / "src"
+        / "causal4d"
+        / "cli"
+        / "abduct_phystwin_intervention.py"
+    )
+    assert not _unsafe_deserialization_calls(source)
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+    imported = {
+        (node.module, alias.name)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        for alias in node.names
+    }
+    assert ("causal4d.trusted_pickle", "load_trusted_pickle") in imported
+    text = source.read_text(encoding="utf-8")
+    assert '"--allow-unsafe-pickle"' in text
+    assert '"--expected-final-data-sha256"' in text
+
+
+def test_phystwin_abduction_rejects_an_unidentified_pickle_before_imports() -> None:
+    from causal4d.cli.abduct_phystwin_intervention import main
+
+    with pytest.raises(ValueError, match="expected-final-data-sha256"):
+        main(["bank", "belief", "data", "factual", "evaluation"])

--- a/tests/test_held_out_physical_target.py
+++ b/tests/test_held_out_physical_target.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import pickle
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from causal4d.cli import evaluate_physical_counterfactual
+from causal4d.contracts import PhysicalPosterior, build_causal_context, save_contract
+from causal4d.held_out_target import (
+    HeldOutPhysicalTarget,
+    load_held_out_physical_target,
+    save_held_out_physical_target,
+)
+from causal4d.legacy_physical_target import import_legacy_physical_target
+from causal4d.physical_evaluation_record import (
+    build_physical_counterfactual_evaluation_record,
+    load_physical_counterfactual_evaluation_record,
+    validate_physical_counterfactual_evaluation_record,
+)
+from causal4d.physical_validation import (
+    evaluate_beta_zero_physical_posterior,
+    physical_posterior_moments,
+)
+
+
+def _posterior(*, source_query_id: str = "3" * 64) -> PhysicalPosterior:
+    observations = np.zeros((7, 1, 3), dtype=float)
+    actions = np.zeros((7, 1, 3), dtype=float)
+    context = build_causal_context(
+        protocol_id="held_out_target",
+        case_id="synthetic",
+        observations=observations,
+        observed_actions=actions,
+        counterfactual_actions=actions,
+        intervention_frame=3,
+    )
+    states = np.zeros((2, 5, 1, 3), dtype=float)
+    states[0, :, 0, 0] = np.arange(5) * 0.01
+    states[1, :, 0, 0] = np.arange(5) * 0.02
+    return PhysicalPosterior(
+        context=context,
+        component_ids=("a", "b"),
+        state_trajectories_m=states,
+        readout_trajectories_m=states + np.asarray([0.001, 0.0, 0.0]),
+        readout_variance_m2=np.full((2, 1, 3), 1e-5),
+        weights=np.asarray([0.75, 0.25]),
+        phi=np.asarray([[1.0], [1.0]]),
+        kappa_cf=np.asarray([[0.0], [1.0]]),
+        hypothesis_indices=np.asarray([0, 1]),
+        twin_particle_indices=np.asarray([0, 0]),
+        phi_names=("gain",),
+        kappa_names=("contact",),
+        source_twin_belief_id="1" * 64,
+        source_factual_intervention_id="2" * 64,
+        source_query_id=source_query_id,
+    )
+
+
+def _target(posterior: PhysicalPosterior) -> HeldOutPhysicalTarget:
+    mean, _ = physical_posterior_moments(posterior)
+    return HeldOutPhysicalTarget(
+        context=posterior.context,
+        source_query_id=posterior.source_query_id,
+        trajectory_frame_start=posterior.context.o_minus.frame_stop - 1,
+        node_indices=np.arange(mean.shape[1], dtype=np.int64),
+        positions_m=mean,
+        validity_mask=np.ones(mean.shape[:2], dtype=bool),
+        source_kind="synthetic_test_target",
+        source_revision="test-v1",
+        source_content_sha256="4" * 64,
+        metadata={"split": "held-out"},
+    )
+
+
+def test_held_out_target_round_trip_is_content_addressed_and_immutable(
+    tmp_path: Path,
+) -> None:
+    posterior = _posterior()
+    target = _target(posterior)
+    path = tmp_path / "target.npz"
+    save_held_out_physical_target(path, target)
+    restored = load_held_out_physical_target(path)
+
+    assert restored.artifact_id == target.artifact_id
+    assert restored.summary()["source_query_id"] == posterior.source_query_id
+    assert restored.positions_m.flags.writeable is False
+    assert restored.validity_mask.flags.writeable is False
+    assert restored.node_indices.flags.writeable is False
+    with pytest.raises(ValueError):
+        restored.positions_m[0, 0, 0] = 1.0
+    restored.require_compatible_physical_posterior(posterior)
+
+
+def test_held_out_target_rejects_payload_tampering(tmp_path: Path) -> None:
+    target = _target(_posterior())
+    path = tmp_path / "target.npz"
+    save_held_out_physical_target(path, target)
+    with np.load(path, allow_pickle=False) as archive:
+        descriptor = np.asarray(archive["descriptor_json"]).copy()
+        nodes = np.asarray(archive["node_indices"]).copy()
+        positions = np.asarray(archive["positions_m"]).copy()
+        validity = np.asarray(archive["validity_mask"]).copy()
+    positions[1, 0, 0] += 0.5
+    with path.open("wb") as handle:
+        np.savez_compressed(
+            handle,
+            descriptor_json=descriptor,
+            node_indices=nodes,
+            positions_m=positions,
+            validity_mask=validity,
+        )
+    with pytest.raises(ValueError, match="artifact_id|payload hashes"):
+        load_held_out_physical_target(path)
+
+
+def test_held_out_target_binds_exact_query_and_shape() -> None:
+    posterior = _posterior()
+    target = _target(posterior)
+    with pytest.raises(ValueError, match="source_query_id"):
+        target.require_compatible_physical_posterior(
+            _posterior(source_query_id="5" * 64)
+        )
+
+    mean, _ = physical_posterior_moments(posterior)
+    with pytest.raises(ValueError, match="counterfactual action stop"):
+        HeldOutPhysicalTarget(
+            context=posterior.context,
+            source_query_id=posterior.source_query_id,
+            trajectory_frame_start=posterior.context.o_minus.frame_stop - 1,
+            node_indices=np.arange(mean.shape[1], dtype=np.int64),
+            positions_m=mean[:-1],
+            validity_mask=np.ones(mean.shape[:2], dtype=bool)[:-1],
+            source_kind="synthetic_test_target",
+            source_revision="test-v1",
+            source_content_sha256="4" * 64,
+        )
+
+
+def test_legacy_import_requires_explicit_consent_and_exact_digest(
+    tmp_path: Path,
+) -> None:
+    posterior = _posterior()
+    mean, _ = physical_posterior_moments(posterior)
+    points = np.zeros((7, 1, 3), dtype=float)
+    points[2:] = mean
+    payload = {
+        "object_points": points,
+        "object_visibilities": np.ones((7, 1), dtype=bool),
+        "object_motions_valid": np.ones((6, 1), dtype=bool),
+    }
+    source = tmp_path / "final_data.pkl"
+    source.write_bytes(pickle.dumps(payload, protocol=pickle.HIGHEST_PROTOCOL))
+    digest = hashlib.sha256(source.read_bytes()).hexdigest()
+
+    with pytest.raises(PermissionError, match="pickle loading is disabled"):
+        import_legacy_physical_target(
+            posterior,
+            source,
+            expected_sha256=digest,
+        )
+    with pytest.raises(ValueError, match="SHA-256 mismatch"):
+        import_legacy_physical_target(
+            posterior,
+            source,
+            allow_unsafe_pickle=True,
+            expected_sha256="0" * 64,
+        )
+
+    target = import_legacy_physical_target(
+        posterior,
+        source,
+        allow_unsafe_pickle=True,
+        expected_sha256=digest,
+        source_revision="fixture-v1",
+    )
+    assert target.source_content_sha256 == digest
+    assert target.positions_m.shape == posterior.readout_trajectories_m.shape[1:]
+    assert target.metadata["legacy_import"]["format"] == "python-pickle"
+    target.require_compatible_physical_posterior(posterior)
+
+
+def test_evaluation_record_and_cli_bind_both_input_artifacts(tmp_path: Path) -> None:
+    posterior = _posterior()
+    target = _target(posterior)
+    metrics = evaluate_beta_zero_physical_posterior(
+        posterior,
+        target.positions_m,
+        mask=target.validity_mask,
+        start_frame=1,
+    )
+    record = build_physical_counterfactual_evaluation_record(
+        posterior,
+        target,
+        metrics,
+        start_frame=1,
+        confidence_level=0.90,
+    )
+    assert len(record["evaluation_id"]) == 64
+    assert record["physical_posterior_id"] == posterior.artifact_id
+    assert record["held_out_target_id"] == target.artifact_id
+    assert record["source_query_id"] == posterior.source_query_id
+    assert record["evaluation_frame_interval_absolute"] == [3, 7]
+
+    posterior_path = tmp_path / "physical.npz"
+    target_path = tmp_path / "target.npz"
+    output_path = tmp_path / "evaluation.json"
+    save_contract(posterior_path, posterior)
+    save_held_out_physical_target(target_path, target)
+    assert (
+        evaluate_physical_counterfactual.main(
+            [str(posterior_path), str(target_path), str(output_path)]
+        )
+        == 0
+    )
+    written = load_physical_counterfactual_evaluation_record(output_path)
+    assert written["held_out_target_id"] == target.artifact_id
+    assert written["physical_posterior_id"] == posterior.artifact_id
+    assert (
+        written["held_out_target_descriptor"]["artifact_id"]
+        == target.artifact_id
+    )
+    malformed_target = json.loads(json.dumps(written))
+    malformed_target["held_out_target_descriptor"]["metadata"] = {
+        "split": "changed"
+    }
+    with pytest.raises(ValueError, match="held-out target artifact_id"):
+        validate_physical_counterfactual_evaluation_record(malformed_target)
+    malformed = dict(written)
+    malformed["schema_version"] = True
+    with pytest.raises(ValueError, match="schema_version"):
+        validate_physical_counterfactual_evaluation_record(malformed)
+
+    tampered = dict(written)
+    tampered["coverage"] = 0.5
+    tampered_path = tmp_path / "tampered-evaluation.json"
+    tampered_path.write_text(json.dumps(tampered), encoding="utf-8")
+    with pytest.raises(ValueError, match="evaluation_id"):
+        load_physical_counterfactual_evaluation_record(tampered_path)
+    with pytest.raises(FileExistsError):
+        evaluate_physical_counterfactual.main(
+            [
+                str(posterior_path),
+                str(target_path),
+                str(output_path),
+                "--no-overwrite",
+            ]
+        )

--- a/tests/test_held_out_target_archive_members.py
+++ b/tests/test_held_out_target_archive_members.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from causal4d.contracts import PhysicalPosterior, build_causal_context
+from causal4d.held_out_target import (
+    HeldOutPhysicalTarget,
+    load_held_out_physical_target,
+    save_held_out_physical_target,
+)
+
+
+def _target() -> HeldOutPhysicalTarget:
+    observations = np.zeros((7, 1, 3), dtype=float)
+    actions = np.zeros((7, 1, 3), dtype=float)
+    context = build_causal_context(
+        protocol_id="held-out-target-archive-members",
+        case_id="synthetic",
+        observations=observations,
+        observed_actions=actions,
+        counterfactual_actions=actions,
+        intervention_frame=3,
+    )
+    states = np.zeros((1, 5, 1, 3), dtype=float)
+    posterior = PhysicalPosterior(
+        context=context,
+        component_ids=("component",),
+        state_trajectories_m=states,
+        readout_trajectories_m=states,
+        readout_variance_m2=np.full((1, 1, 3), 1e-5),
+        weights=np.asarray([1.0]),
+        phi=np.asarray([[1.0]]),
+        kappa_cf=np.asarray([[0.0]]),
+        hypothesis_indices=np.asarray([0]),
+        twin_particle_indices=np.asarray([0]),
+        phi_names=("gain",),
+        kappa_names=("contact",),
+        source_twin_belief_id="1" * 64,
+        source_factual_intervention_id="2" * 64,
+        source_query_id="3" * 64,
+    )
+    return HeldOutPhysicalTarget(
+        context=context,
+        source_query_id=posterior.source_query_id,
+        trajectory_frame_start=context.o_minus.frame_stop - 1,
+        node_indices=np.asarray([0], dtype=np.int64),
+        positions_m=states[0],
+        validity_mask=np.ones(states.shape[1:3], dtype=bool),
+        source_kind="synthetic_test_target",
+        source_revision="test-v1",
+        source_content_sha256="4" * 64,
+    )
+
+
+def test_held_out_target_rejects_undeclared_zip_members(tmp_path: Path) -> None:
+    path = tmp_path / "target.npz"
+    save_held_out_physical_target(path, _target())
+    with zipfile.ZipFile(path, "a") as archive:
+        archive.writestr("unexpected.txt", "not part of the target schema")
+    with pytest.raises(ValueError, match="ZIP members"):
+        load_held_out_physical_target(path)


### PR DESCRIPTION
## Summary

- replace direct `final_data.pkl` loading in the stable claim-bearing physical evaluator with a versioned, non-pickled, content-addressed `HeldOutPhysicalTarget` NPZ;
- bind the target to the complete causal context, exact `source_query_id`, frame interval, node order, source bytes, payload hashes, and exact ZIP member inventory before any score is computed;
- add a migration-only legacy importer that requires explicit unsafe-pickle consent and the exact expected SHA-256 digest;
- route the existing factual-prefix abduction command through the same trusted-pickle boundary, removing its direct `pickle.load` path and recording the verified source digest;
- publish physical evaluation JSON atomically, reload it through an independent validator, and bind its metrics to the exact posterior, target, query, action, source, and payload identities;
- add adversarial target/evaluation tests and a static policy that rejects direct pickle deserialization in every `claim_bearing=True` command module and in the factual-abduction path;
- update the remote abduction pipeline and document the new evidence boundary.

## Security and scientific boundary

The stable evaluator no longer imports `pickle` or opens legacy PhysTwin target files. Legacy conversion is a separate module command, is not an installed stable route, and fails without both explicit consent and a verified lowercase SHA-256 digest. Factual-prefix abduction still consumes the legacy format for compatibility, but only after the same explicit consent, ordinary-file/symlink checks, and exact pre-load digest verification.

The physical scoring implementation is byte-identical to `main`; this PR changes evidence transport, validation, and publication only. It does **not** change posterior weights, likelihood semantics, intervention support, the registered 36-execution protocol, or any frozen scientific result.

## Validation

Authoritative merge gate run `31034378649` succeeded on the pull-request merge result:

- repository Ruff, formatting, and configured type checks;
- complete default pytest suite;
- wheel and source-distribution build and validation;
- pinned BayesianPhysTwin wheel build and isolated installation; and
- pinned-provider integration tests.

Additional local checks:

- focused isolated harness: `11 passed`;
- Python byte compilation passed for all changed source and test modules;
- shell syntax validation passed for the updated remote runner; and
- changed Python files passed local import-use and 88-column checks.

The full `CI and release` and `Extended compatibility` matrices are still queued on the exact head and remain visible as merge checks.