### PR TITLE
Harden immutable artifacts and centralize the BayesianPhysTwin provider registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ evidence. Source-panel executions remain source-only and cannot increment the
   write access through `setflags(write=True)` or `flags.writeable = True`.
   Serialization boundaries now export explicit plain JSON, preserving existing
   content identities and artifact schemas for valid inputs.
+- Add adversarial regression and source-policy coverage for built-in container
+  mutation bypasses and attempts to re-enable NumPy write access.
 - Reject coercible or schema-drifted Causal4D contract descriptors, archive
   inventories, support indices, and grouped-observation indices before they can
   change content identity or evidence selection. Preserve exact JSON numeric

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- Add a strict non-pickled physical evaluation target with canonical float32
+  observation identities, target/context validation, and atomic exactly-once
+  publication.
+- Add an explicit legacy importer that requires unsafe-pickle consent and an
+  independently obtained SHA-256 before opening PhysTwin `final_data.pkl`.
 - Add a declarative Bayesian-PhysTwin provider registry that owns the complete
   versioned import inventory, API suffixes, roles, lifecycle labels, and local
   contract modules. The AST import boundary and documentation validation now
@@ -61,6 +66,9 @@ evidence. Source-panel executions remain source-only and cannot increment the
 
 ### Fixed
 
+- Remove direct pickle loading from the stable claim-bearing physical evaluator,
+  bind results to posterior, query, physical-target, and held-out-suffix IDs, and
+  publish result JSON atomically with no-overwrite behavior by default.
 - Replace mutable `dict`/`list` subclasses used for frozen JSON with read-only
   mapping and sequence value objects, closing `dict.__setitem__`, `dict.update`,
   `list.append`, and `list.__setitem__` base-class mutation bypasses while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- Add a declarative Bayesian-PhysTwin provider registry that owns the complete
+  versioned import inventory, API suffixes, roles, lifecycle labels, and local
+  contract modules. The AST import boundary and documentation validation now
+  consume that registry instead of maintaining a separate hard-coded allowlist.
+- Document the additive belief-provider-v2 horizon-discrepancy boundary, released
+  artifact-v2 surface, verified scheduled-contact replay integration, and portable
+  external sparse-trajectory forecast import without changing frozen v1 results.
 - Add a locked, source-only Deform360 filament-support boundary that preserves
   exact registered graphs on connected resets and applies a deterministic
   component-level minimum-spanning bridge only to the frozen disconnected
@@ -54,6 +61,16 @@ evidence. Source-panel executions remain source-only and cannot increment the
 
 ### Fixed
 
+- Replace mutable `dict`/`list` subclasses used for frozen JSON with read-only
+  mapping and sequence value objects, closing `dict.__setitem__`, `dict.update`,
+  `list.append`, and `list.__setitem__` base-class mutation bypasses while
+  preserving valid JSON values and content identities. Frozen containers now
+  expose the explicit read-only `Mapping`/`Sequence` protocols; use
+  `plain_json()` at mutable built-in or serialization boundaries.
+- Back frozen NumPy arrays with immutable byte storage so callers cannot restore
+  write access through `setflags(write=True)` or `flags.writeable = True`.
+  Serialization boundaries now export explicit plain JSON, preserving existing
+  content identities and artifact schemas for valid inputs.
 - Reject coercible or schema-drifted Causal4D contract descriptors, archive
   inventories, support indices, and grouped-observation indices before they can
   change content identity or evidence selection. Preserve exact JSON numeric

--- a/ci/bayesian_phystwin_provider_registry.json
+++ b/ci/bayesian_phystwin_provider_registry.json
@@ -1,0 +1,64 @@
+{
+  "schema": "causal4d.bayesian_phystwin_provider_registry",
+  "schema_version": 1,
+  "supported_distribution": "bayesian-phystwin>=0.4,<0.5",
+  "import_policy": "versioned_public_modules_only",
+  "modules": [
+    {
+      "module": "bayesian_phystwin.causal4d_artifacts_v1",
+      "api_version": 1,
+      "role": "released_artifact_io",
+      "lifecycle": "frozen_compatibility",
+      "local_contract_module": null
+    },
+    {
+      "module": "bayesian_phystwin.causal4d_artifacts_v2",
+      "api_version": 2,
+      "role": "released_visual_artifact_io",
+      "lifecycle": "production_additive",
+      "local_contract_module": null
+    },
+    {
+      "module": "bayesian_phystwin.causal4d_belief_provider_v1",
+      "api_version": 1,
+      "role": "fixed_anchor_endpoint_inference",
+      "lifecycle": "frozen_compatibility",
+      "local_contract_module": "causal4d.belief_provider_contract"
+    },
+    {
+      "module": "bayesian_phystwin.causal4d_belief_provider_v2",
+      "api_version": 2,
+      "role": "model_averaged_horizon_discrepancy",
+      "lifecycle": "additive_development",
+      "local_contract_module": "causal4d.belief_provider_v2_contract"
+    },
+    {
+      "module": "bayesian_phystwin.causal4d_graph_provider_v1",
+      "api_version": 1,
+      "role": "spring_graph_and_controller_grouping",
+      "lifecycle": "production",
+      "local_contract_module": "causal4d.graph_provider_contract"
+    },
+    {
+      "module": "bayesian_phystwin.causal4d_provider_v1",
+      "api_version": 1,
+      "role": "scientific_compatibility_facade",
+      "lifecycle": "frozen_compatibility",
+      "local_contract_module": "causal4d.provider_contract"
+    },
+    {
+      "module": "bayesian_phystwin.causal4d_provider_v2",
+      "api_version": 2,
+      "role": "request_complete_replay",
+      "lifecycle": "production",
+      "local_contract_module": "causal4d.replay_provider_contract"
+    },
+    {
+      "module": "bayesian_phystwin.causal4d_public_provider_v1",
+      "api_version": 1,
+      "role": "source_locked_public_diagnostics",
+      "lifecycle": "diagnostic",
+      "local_contract_module": null
+    }
+  ]
+}

--- a/docs/bayesian_phystwin_provider.md
+++ b/docs/bayesian_phystwin_provider.md
@@ -9,10 +9,14 @@ modules:
   replay execution through immutable request-complete contracts;
 - `bayesian_phystwin.causal4d_belief_provider_v1` for NumPy-only fixed-anchor
   endpoint inference and immutable endpoint posteriors;
+- `bayesian_phystwin.causal4d_belief_provider_v2` for additive model-averaged
+  endpoints and source-calibrated horizon discrepancy moments;
 - `bayesian_phystwin.causal4d_graph_provider_v1` for the NumPy-only spring-graph
   value type, graph construction, and released controller grouping semantics;
 - `bayesian_phystwin.causal4d_artifacts_v1` for hash-locked released pickle
   inputs and immutable raw-track correspondence;
+- `bayesian_phystwin.causal4d_artifacts_v2` for versioned released visual and
+  correspondence artifacts without importing experiment internals;
 - `bayesian_phystwin.causal4d_public_provider_v1` for source-locked public-data
   diagnostics that still reuse BPT experiment semantics.
 
@@ -24,14 +28,18 @@ provider v2. Provider v1 remains only for frozen scientific and diagnostic
 compatibility operations.
 
 Production source and scripts no longer import any unversioned
-Bayesian-PhysTwin implementation module. An AST allowlist makes new direct
-experiment imports a blocking test failure.
+Bayesian-PhysTwin implementation module. The canonical module inventory is
+[`ci/bayesian_phystwin_provider_registry.json`](../ci/bayesian_phystwin_provider_registry.json).
+The AST boundary test derives its allowlist from that registry, while a separate
+schema test checks unique roles, exact API-version suffixes, local contract
+modules, and documentation coverage. Adding a provider therefore requires one
+reviewable registry entry rather than synchronized hand-written inventories.
 
 ## Compatibility contract
 
 Normal development accepts Bayesian-PhysTwin versions in the range
 `>=0.4,<0.5`. Compatibility is not inferred from the package version alone.
-Causal4D validates four deliberately separate provider manifests:
+Causal4D validates five deliberately separate provider manifests:
 
 - scientific provider API/schema version 1 for frozen compatibility names and
   migrated diagnostics;
@@ -40,6 +48,8 @@ Causal4D validates four deliberately separate provider manifests:
   replay execution;
 - belief provider API/schema version 1 for the fixed robust discrepancy endpoint,
   immutable configuration, causal-prefix validation, and immutable posterior;
+- additive belief provider API/schema version 2 for evidence-weighted endpoint
+  model averaging and source-frozen horizon discrepancy prediction; and
 - graph provider API/schema version 1 for graph and controller grouping values.
 
 The scientific manifest requires its existing `TwinBelief` and `GraphBelief`
@@ -54,6 +64,17 @@ The belief provider is checked separately for:
 - `FixedBayesianAnchorConfig` and `RobustEndpointPosterior` schema version 1;
 - the fixed readout/model-discrepancy inference role; and
 - the supported Bayesian-PhysTwin package range.
+
+The additive belief provider is checked separately for:
+
+- the exact `bayesian_phystwin.causal4d_belief_provider_v2` API identity and
+  manifest schema version 2;
+- evidence-weighted endpoint model averaging, per-track component evidence, and
+  causal-prefix finite-residual preflight;
+- source-calibrated mean retention and horizon-dependent predictive covariance;
+- immutable endpoint, prediction, and calibration artifact schemas; and
+- an explicit boundary that keeps raw model covariance distinct from interval
+  calibration and target-side coverage claims.
 
 The graph provider is checked separately for:
 
@@ -70,8 +91,10 @@ The scientific manifest is loaded with
 `load_bayesian_phystwin_replay_provider_manifest()` and checked with
 `validate_bayesian_phystwin_replay_provider()`. The belief manifest is loaded
 with `load_bayesian_phystwin_belief_provider_manifest()` and checked with
-`validate_bayesian_phystwin_belief_provider()`. The graph manifest is loaded
-with `load_bayesian_phystwin_graph_provider_manifest()` and checked with
+`validate_bayesian_phystwin_belief_provider()`. The additive belief manifest
+is loaded with `load_bayesian_phystwin_belief_provider_v2_manifest()` and checked
+with `validate_bayesian_phystwin_belief_provider_v2()`. The graph manifest is
+loaded with `load_bayesian_phystwin_graph_provider_manifest()` and checked with
 `validate_bayesian_phystwin_graph_provider()`. A version, capability, artifact,
 provider-identity, inference-role, graph-provider, or parent-provider mismatch
 fails closed and is reported explicitly.
@@ -135,7 +158,8 @@ the extra encodes the supported `>=0.4,<0.5` range rather than one Git commit.
 The cross-repository workflows test the current development branches against
 each other's public contracts. An AST boundary test rejects every BPT import in
 production source and scripts unless its exact module is present in the
-versioned allowlist above.
+machine-readable registry. `tests/test_bpt_provider_registry.py` prevents the
+registry, local contract modules, and this document from drifting independently.
 
 ## Frozen experiments
 

--- a/src/causal4d/action_conditioned_counterfactual.py
+++ b/src/causal4d/action_conditioned_counterfactual.py
@@ -7,6 +7,7 @@ from typing import Any, Literal, Mapping
 
 import numpy as np
 
+from causal4d.immutable_array import readonly_array
 from causal4d.immutable_json import validated_json_mapping
 
 from causal4d.action_conditioned_discrepancy import (
@@ -31,9 +32,7 @@ from causal4d.stable_discrepancy_dynamics import (
 
 
 def _readonly(values: np.ndarray, *, dtype: type | None = float) -> np.ndarray:
-    array = np.asarray(values, dtype=dtype).copy()
-    array.setflags(write=False)
-    return array
+    return readonly_array(values, dtype=dtype)
 
 
 @dataclass(frozen=True)

--- a/src/causal4d/action_conditioned_discrepancy.py
+++ b/src/causal4d/action_conditioned_discrepancy.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from causal4d.contracts import array_sha256
 from causal4d.discrepancy_belief import GraphDiscrepancyBelief
+from causal4d.immutable_array import readonly_array
 
 
 CONTACT_POLICIES = ("same_grasp", "new_contact")
@@ -17,9 +18,7 @@ TIME_PARAMETERIZATIONS = ("per_step", "per_second")
 
 
 def _readonly(values: np.ndarray) -> np.ndarray:
-    array = np.asarray(values, dtype=float).copy()
-    array.setflags(write=False)
-    return array
+    return readonly_array(values, dtype=float)
 
 
 def _parameter_vector(
@@ -72,9 +71,7 @@ def _step_duration_array(
     elif durations.shape == (component_count, horizon):
         result = durations
     else:
-        raise ValueError(
-            "step_duration_s must be scalar or have shape (H,) or (K, H)"
-        )
+        raise ValueError("step_duration_s must be scalar or have shape (H,) or (K, H)")
     if not np.all(np.isfinite(result)) or np.any(result <= 0.0):
         raise ValueError("step durations must be finite and strictly positive")
     return np.asarray(result, dtype=float)
@@ -407,9 +404,7 @@ class ActionConditionedDiscrepancyModel:
             trace = float(np.trace(increment))
             if trace > self.maximum_increment_trace_m2:
                 increment *= self.maximum_increment_trace_m2 / trace
-        return _positive_semidefinite(
-            self.base_innovation_covariance_m2 + increment
-        )
+        return _positive_semidefinite(self.base_innovation_covariance_m2 + increment)
 
     def innovation_covariance_m2(
         self,
@@ -486,10 +481,8 @@ def forecast_action_conditioned_persistence(
                 step_duration_s=float(durations[component, step]),
             )
             for coordinate in range(3):
-                covariance[component, step + 1, coordinate] = (
-                    _positive_semidefinite(
-                        covariance[component, step, coordinate] + increment
-                    )
+                covariance[component, step + 1, coordinate] = _positive_semidefinite(
+                    covariance[component, step, coordinate] + increment
                 )
 
     readout_mean = np.einsum("nr,khrc->khnc", graph_basis, mean)

--- a/src/causal4d/camera_geometry.py
+++ b/src/causal4d/camera_geometry.py
@@ -106,8 +106,7 @@ def invert_se3_transform(
     inverse = np.eye(4, dtype=np.float64)
     inverse[:3, :3] = rotation.T
     inverse[:3, 3] = -(rotation.T @ translation)
-    inverse.setflags(write=False)
-    return inverse
+    return readonly_array(inverse)
 
 
 __all__ = [

--- a/src/causal4d/causal_sufficiency.py
+++ b/src/causal4d/causal_sufficiency.py
@@ -7,7 +7,7 @@ from typing import Any, Mapping, Sequence
 
 import numpy as np
 
-from causal4d.immutable_json import validated_json_mapping
+from causal4d.immutable_json import plain_json, validated_json_mapping
 
 
 @dataclass(frozen=True)
@@ -58,7 +58,7 @@ class CausalSufficiencyResult:
             "execution_count": self.execution_count,
             "group_count": self.group_count,
             "command_count": self.command_count,
-            "metadata": dict(self.metadata),
+            "metadata": plain_json(self.metadata),
         }
 
 

--- a/src/causal4d/closed_loop.py
+++ b/src/causal4d/closed_loop.py
@@ -52,9 +52,7 @@ def _validated_graph_discrepancy_state(
         raise ValueError(
             f"{owner} graph discrepancy covariance must be positive semidefinite"
         )
-    mean.setflags(write=False)
-    covariance.setflags(write=False)
-    return mean, covariance
+    return readonly_array(mean), readonly_array(covariance)
 
 
 @dataclass(frozen=True)
@@ -209,7 +207,7 @@ class RecursivePhysicalBelief:
             component_count=len(component),
             owner="recursive",
         )
-        for values in (
+        (
             component,
             particle_indices,
             phi_support,
@@ -219,8 +217,20 @@ class RecursivePhysicalBelief:
             particles,
             phi,
             kappa,
-        ):
-            values.setflags(write=False)
+        ) = tuple(
+            readonly_array(values)
+            for values in (
+                component,
+                particle_indices,
+                phi_support,
+                kappa_support,
+                state_position,
+                state_velocity,
+                particles,
+                phi,
+                kappa,
+            )
+        )
         object.__setattr__(self, "component_weights", component)
         object.__setattr__(self, "twin_particle_indices", particle_indices)
         object.__setattr__(self, "phi_support", phi_support)

--- a/src/causal4d/contact_topology_covariance_diagnostic.py
+++ b/src/causal4d/contact_topology_covariance_diagnostic.py
@@ -25,6 +25,8 @@ from typing import Any
 
 import numpy as np
 
+from causal4d.immutable_array import readonly_array
+
 from causal4d.benchmark import CounterfactualBenchmarkConfig
 from causal4d.contact_concentration_diagnostic import (
     _CalibrationCase,
@@ -233,7 +235,7 @@ def _build_seed_folds(
                 prefix,
             )
             feature_matrix = _canonical_residual_features(feature_matrix)
-            feature_matrix.setflags(write=False)
+            feature_matrix = readonly_array(feature_matrix)
         output.append(
             _TopologyFold(
                 seed=seed,

--- a/src/causal4d/contracts.py
+++ b/src/causal4d/contracts.py
@@ -13,7 +13,7 @@ import numpy as np
 from causal4d.atomic_io import atomic_write_binary
 from causal4d.immutable_array import readonly_array as _readonly_array
 from causal4d.immutable_array import readonly_integer_array as _readonly_integer_array
-from causal4d.immutable_json import validated_json_mapping
+from causal4d.immutable_json import plain_json, validated_json_mapping
 
 
 CONTRACT_VERSION = 1
@@ -519,7 +519,7 @@ class TwinBelief(_Contract):
             "endpoint_frame": self.endpoint_frame,
             "particle_ids": list(self.particle_ids),
             "theta_names": list(self.theta_names),
-            "metadata": self.metadata,
+            "metadata": plain_json(self.metadata),
         }
 
     def _array_payload(self) -> dict[str, np.ndarray]:
@@ -620,7 +620,7 @@ class FactualIntervention(_Contract):
             "kappa_names": list(self.kappa_names),
             "evidence_frame_stop": self.evidence_frame_stop,
             "source_twin_belief_id": self.source_twin_belief_id,
-            "metadata": self.metadata,
+            "metadata": plain_json(self.metadata),
         }
 
     def _array_payload(self) -> dict[str, np.ndarray]:
@@ -706,7 +706,7 @@ class CounterfactualQuery(_Contract):
             "contact_policy": self.contact_policy,
             "language": self.language,
             "source_factual_intervention_id": self.source_factual_intervention_id,
-            "metadata": self.metadata,
+            "metadata": plain_json(self.metadata),
         }
 
     def _array_payload(self) -> dict[str, np.ndarray]:
@@ -823,7 +823,7 @@ class PhysicalPosterior(_Contract):
             "source_twin_belief_id": self.source_twin_belief_id,
             "source_factual_intervention_id": self.source_factual_intervention_id,
             "source_query_id": self.source_query_id,
-            "metadata": self.metadata,
+            "metadata": plain_json(self.metadata),
         }
 
     def _array_payload(self) -> dict[str, np.ndarray]:
@@ -906,7 +906,7 @@ class TaskPosterior(_Contract):
             "component_ids": list(self.component_ids),
             "beta": self.beta,
             "semantic_source": self.semantic_source,
-            "metadata": self.metadata,
+            "metadata": plain_json(self.metadata),
         }
 
     def _array_payload(self) -> dict[str, np.ndarray]:

--- a/src/causal4d/discrepancy_belief.py
+++ b/src/causal4d/discrepancy_belief.py
@@ -10,7 +10,8 @@ from typing import Any, Mapping, Sequence
 
 import numpy as np
 
-from causal4d.immutable_json import validated_json_mapping
+from causal4d.immutable_array import readonly_array
+from causal4d.immutable_json import plain_json, validated_json_mapping
 
 from causal4d.contracts import array_sha256
 from causal4d.observation_evidence import GroupedObservationEvidence
@@ -20,9 +21,7 @@ GRAPH_DISCREPANCY_BELIEF_VERSION = 1
 
 
 def _readonly(values: np.ndarray, *, dtype: type | None = float) -> np.ndarray:
-    array = np.asarray(values, dtype=dtype).copy()
-    array.setflags(write=False)
-    return array
+    return readonly_array(values, dtype=dtype)
 
 
 def _validate_sha256(value: str, *, name: str) -> None:
@@ -131,7 +130,7 @@ class GraphDiscrepancyBelief:
             "transition_model_id": self.transition_model_id,
             "innovation_model_id": self.innovation_model_id,
             "source_physical_posterior_id": self.source_physical_posterior_id,
-            "metadata": self.metadata,
+            "metadata": plain_json(self.metadata),
         }
         digest = hashlib.sha256(
             json.dumps(
@@ -254,7 +253,7 @@ def write_graph_discrepancy_belief(
         "transition_model_id": belief.transition_model_id,
         "innovation_model_id": belief.innovation_model_id,
         "source_physical_posterior_id": belief.source_physical_posterior_id,
-        "metadata": belief.metadata,
+        "metadata": plain_json(belief.metadata),
         "payload": {
             "path": payload.name,
             "sha256": _file_sha256(payload),

--- a/src/causal4d/dynamic_contact.py
+++ b/src/causal4d/dynamic_contact.py
@@ -16,6 +16,7 @@ from typing import Any
 
 import numpy as np
 
+from causal4d.immutable_array import readonly_array
 from causal4d.weighting import log_weights_from_probabilities
 
 
@@ -32,9 +33,7 @@ CONTACT_REGIME_NAMES = tuple(regime.name.lower() for regime in ContactRegime)
 
 
 def _readonly(values: np.ndarray, *, dtype: Any = None) -> np.ndarray:
-    array = np.asarray(values, dtype=dtype).copy()
-    array.setflags(write=False)
-    return array
+    return readonly_array(values, dtype=dtype)
 
 
 def _normalized_weights(values: np.ndarray, *, name: str) -> np.ndarray:

--- a/src/causal4d/evidence_ownership.py
+++ b/src/causal4d/evidence_ownership.py
@@ -582,7 +582,7 @@ def strict_reweight_factual_intervention_with_independent_sensors(
     if not isinstance(diagnostics, Mapping):
         raise RuntimeError("sensor update omitted its evidence diagnostics")
     summaries = diagnostics.get("factors")
-    if not isinstance(summaries, list):
+    if isinstance(summaries, (str, bytes)) or not isinstance(summaries, Sequence):
         raise RuntimeError("sensor update omitted its factor diagnostics")
     informative_ids = {
         summary.get("evidence_id")

--- a/src/causal4d/execution_block_calibration.py
+++ b/src/causal4d/execution_block_calibration.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from causal4d.atomic_io import atomic_write_json
 from causal4d.immutable_array import readonly_array as _readonly_array
-from causal4d.immutable_json import validated_json_mapping
+from causal4d.immutable_json import plain_json, validated_json_mapping
 
 
 EXECUTION_BLOCK_CALIBRATION_SCHEMA_VERSION = 1
@@ -91,7 +91,7 @@ class ExecutionBlockCalibrationCase:
         valid[: self.start_frame] = False
         if not np.any(valid):
             raise ValueError("execution has no valid held-out point-frames")
-        valid.setflags(write=False)
+        valid = _readonly_array(valid, dtype=bool)
 
         labels = self.node_group_labels
         if labels is not None:
@@ -510,7 +510,7 @@ class ExecutionBlockConformalCalibration:
             "expected_calibration_units": self.expected_calibration_units,
             "order_statistic_rank_one_based": (self.order_statistic_rank_one_based),
             "threshold": float(self.threshold),
-            "fragility_diagnostics": self.fragility_diagnostics,
+            "fragility_diagnostics": plain_json(self.fragility_diagnostics),
             "claim_ready": self.claim_ready,
             "coverage_claim": (
                 "finite marginal execution-block split-conformal coverage under "
@@ -518,7 +518,7 @@ class ExecutionBlockConformalCalibration:
             ),
             "worst_group_coverage_guarantee_claimed": False,
             "pooled_coordinate_conformal_claimed": False,
-            "metadata": self.metadata,
+            "metadata": plain_json(self.metadata),
         }
 
     @property

--- a/src/causal4d/external_forecast.py
+++ b/src/causal4d/external_forecast.py
@@ -252,8 +252,8 @@ class ExternalForecastBundle:
         if np.any(np.sum(valid, axis=(1, 2, 3)) == 0):
             raise ValueError("each forecast must contain at least one valid coordinate")
         future[~valid] = np.nan
-        future.setflags(write=False)
-        valid.setflags(write=False)
+        future = readonly_array(future)
+        valid = readonly_array(valid, dtype=bool)
 
         frames = readonly_array(self.physical_frame_indices, dtype=np.float64)
         if frames.shape != (future.shape[1],) or not np.all(np.isfinite(frames)):

--- a/src/causal4d/finite_query_ambiguity.py
+++ b/src/causal4d/finite_query_ambiguity.py
@@ -6,11 +6,11 @@ from dataclasses import dataclass
 
 import numpy as np
 
+from causal4d.immutable_array import readonly_array
+
 
 def _readonly(values: np.ndarray, *, dtype: type = float) -> np.ndarray:
-    result = np.asarray(values, dtype=dtype).copy()
-    result.setflags(write=False)
-    return result
+    return readonly_array(values, dtype=dtype)
 
 
 def _normalized_weights(values: np.ndarray) -> np.ndarray:

--- a/src/causal4d/graph_mode_abduction.py
+++ b/src/causal4d/graph_mode_abduction.py
@@ -9,15 +9,14 @@ from typing import Any
 import numpy as np
 
 from causal4d.contracts import FactualIntervention, TwinBelief, array_sha256
+from causal4d.immutable_array import readonly_array
 from causal4d.intervention_abduction import physical_readout_components
 from causal4d.rollout_bank import JointRolloutBank
 from causal4d.weighting import log_weights_from_probabilities
 
 
 def _readonly(values: np.ndarray) -> np.ndarray:
-    array = np.asarray(values, dtype=float).copy()
-    array.setflags(write=False)
-    return array
+    return readonly_array(values, dtype=float)
 
 
 def _coordinate_mask(observations: np.ndarray, mask: np.ndarray | None) -> np.ndarray:

--- a/src/causal4d/hierarchical_abduction.py
+++ b/src/causal4d/hierarchical_abduction.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import Counter
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Sequence
 
@@ -43,7 +44,7 @@ def _default_phi_values(bank: JointRolloutBank) -> np.ndarray:
     rows = []
     for metadata in bank.hypothesis_metadata:
         contact = metadata.get("contact")
-        if not isinstance(contact, dict):
+        if not isinstance(contact, Mapping):
             raise ValueError("hypothesis metadata is missing contact variables")
         rows.append(
             (

--- a/src/causal4d/horizon_discrepancy.py
+++ b/src/causal4d/horizon_discrepancy.py
@@ -16,7 +16,7 @@ from causal4d.belief_provider_v2_contract import (
 )
 from causal4d.contracts import TwinBelief, array_sha256
 from causal4d.immutable_array import readonly_array
-from causal4d.immutable_json import validated_json_mapping
+from causal4d.immutable_json import plain_json, validated_json_mapping
 
 
 HORIZON_DISCREPANCY_BANK_SCHEMA_VERSION = "causal4d.horizon_discrepancy_bank.v1"
@@ -65,18 +65,17 @@ def _horizons(values: Sequence[int]) -> np.ndarray:
         raise ValueError("horizon_steps must not contain duplicates")
     result = np.asarray(sorted(raw), dtype=np.int64)
     if result[0] != 0:
-        raise ValueError("horizon_steps must include zero as an endpoint parity control")
-    result.setflags(write=False)
-    return result
+        raise ValueError(
+            "horizon_steps must include zero as an endpoint parity control"
+        )
+    return readonly_array(result)
 
 
 def _probability_vector(values: np.ndarray, *, name: str) -> np.ndarray:
     result = readonly_array(values, dtype=float)
     if result.ndim != 1 or not len(result):
         raise ValueError(f"{name} must be a nonempty vector")
-    if not np.all(np.isfinite(result)) or np.any(
-        (result < 0.0) | (result > 1.0)
-    ):
+    if not np.all(np.isfinite(result)) or np.any((result < 0.0) | (result > 1.0)):
         raise ValueError(f"{name} must contain finite probabilities")
     return result
 
@@ -139,9 +138,7 @@ def _lift_map(
     if extra_count:
         if neighbor_indices.shape[1] < 1:
             raise ValueError("untracked state nodes require at least one neighbor")
-        if np.any(neighbor_indices < 0) or np.any(
-            neighbor_indices >= tracked_count
-        ):
+        if np.any(neighbor_indices < 0) or np.any(neighbor_indices >= tracked_count):
             raise ValueError("lift_indices reference an unavailable tracked node")
         if not np.allclose(
             np.sum(neighbor_weights, axis=1),
@@ -153,9 +150,7 @@ def _lift_map(
         for row in neighbor_indices:
             if len(np.unique(row)) != len(row):
                 raise ValueError("one lift row must not repeat a tracked node")
-    neighbor_indices.setflags(write=False)
-    neighbor_weights.setflags(write=False)
-    return neighbor_indices, neighbor_weights
+    return readonly_array(neighbor_indices), readonly_array(neighbor_weights)
 
 
 def _lift_prediction(
@@ -199,9 +194,7 @@ def _lift_prediction(
             maximum_discrepancy_m / np.maximum(norms, np.finfo(float).tiny),
         )
         result_mean *= scale[:, None]
-    result_covariance = 0.5 * (
-        result_covariance + result_covariance.swapaxes(-1, -2)
-    )
+    result_covariance = 0.5 * (result_covariance + result_covariance.swapaxes(-1, -2))
     _validate_covariance(result_covariance, name="lifted covariance_m2")
     return result_mean, result_covariance
 
@@ -256,9 +249,7 @@ class HorizonDiscrepancyBankV1:
             raise ValueError("mean_retention must identify every horizon")
         additional = readonly_array(self.additional_axis_variance_m2, dtype=float)
         if additional.shape != (horizon_count, 3):
-            raise ValueError(
-                "additional_axis_variance_m2 must have shape (H, 3)"
-            )
+            raise ValueError("additional_axis_variance_m2 must have shape (H, 3)")
         if not np.all(np.isfinite(additional)) or np.any(additional < 0.0):
             raise ValueError(
                 "additional_axis_variance_m2 must be finite and nonnegative"
@@ -296,7 +287,7 @@ class HorizonDiscrepancyBankV1:
             "particle_ids": list(self.particle_ids),
             "calibration_id": self.calibration_id,
             "provider_revision": self.provider_revision,
-            "metadata": dict(self.metadata),
+            "metadata": plain_json(self.metadata),
             "arrays": {
                 "particle_weights": array_sha256(self.particle_weights),
                 "horizon_steps": array_sha256(self.horizon_steps),
@@ -369,9 +360,7 @@ def build_horizon_discrepancy_bank(
     if len(posteriors) != particle_count or not all(
         isinstance(value, ModelAveragedEndpointPosteriorV1) for value in posteriors
     ):
-        raise ValueError(
-            "endpoint_posteriors must identify every TwinBelief particle"
-        )
+        raise ValueError("endpoint_posteriors must identify every TwinBelief particle")
     horizons = _horizons(horizon_steps)
     state_count = twin_belief.endpoint_position_m.shape[1]
     tracked_counts = {len(value.mean_m) for value in posteriors}
@@ -421,7 +410,9 @@ def build_horizon_discrepancy_bank(
                 retention[horizon_index] = prediction.mean_retention
                 additional[horizon_index] = prediction.additional_axis_variance_m2
             else:
-                if prediction.mean_retention != retention[horizon_index] or not np.array_equal(
+                if prediction.mean_retention != retention[
+                    horizon_index
+                ] or not np.array_equal(
                     prediction.additional_axis_variance_m2,
                     additional[horizon_index],
                 ):

--- a/src/causal4d/identifiability.py
+++ b/src/causal4d/identifiability.py
@@ -7,6 +7,8 @@ from typing import Sequence
 
 import numpy as np
 
+from causal4d.immutable_array import readonly_array
+
 
 @dataclass(frozen=True)
 class IdentifiabilityConfig:
@@ -27,7 +29,9 @@ class IdentifiabilityConfig:
         if self.maximum_condition_number <= 1.0:
             raise ValueError("maximum_condition_number must exceed one")
         if not 0.0 <= self.minimum_residualized_response_fraction <= 1.0:
-            raise ValueError("minimum_residualized_response_fraction must lie in [0, 1]")
+            raise ValueError(
+                "minimum_residualized_response_fraction must lie in [0, 1]"
+            )
         if not 0.0 <= self.maximum_subspace_cosine <= 1.0:
             raise ValueError("maximum_subspace_cosine must lie in [0, 1]")
         if not 0.0 <= self.maximum_query_null_response_fraction <= 1.0:
@@ -95,11 +99,15 @@ class InterventionIdentifiabilityResult:
                 rtol=1e-10,
             ):
                 raise ValueError(f"{name} must have orthonormal columns")
-        if identified.shape[1] and null.shape[1] and not np.allclose(
-            identified.T @ null,
-            0.0,
-            atol=1e-10,
-            rtol=1e-10,
+        if (
+            identified.shape[1]
+            and null.shape[1]
+            and not np.allclose(
+                identified.T @ null,
+                0.0,
+                atol=1e-10,
+                rtol=1e-10,
+            )
         ):
             raise ValueError("identified and null bases must be orthogonal")
         if self.query_null_response_fraction is not None and not (
@@ -107,11 +115,11 @@ class InterventionIdentifiabilityResult:
             and 0.0 <= self.query_null_response_fraction <= 1.0 + 1e-12
         ):
             raise ValueError("query_null_response_fraction must lie in [0, 1]")
-        information.setflags(write=False)
-        eigenvalues.setflags(write=False)
-        scales.setflags(write=False)
-        identified.setflags(write=False)
-        null.setflags(write=False)
+        information = readonly_array(information)
+        eigenvalues = readonly_array(eigenvalues)
+        scales = readonly_array(scales)
+        identified = readonly_array(identified)
+        null = readonly_array(null)
         object.__setattr__(self, "conditional_information", information)
         object.__setattr__(self, "eigenvalues", eigenvalues)
         object.__setattr__(self, "parameter_scales", scales)
@@ -176,10 +184,20 @@ def finite_response_sensitivity(
     perturbed = np.asarray(perturbed_responses, dtype=float)
     steps = np.asarray(tuple(perturbation_steps), dtype=float)
     if perturbed.ndim != reference.ndim + 1 or perturbed.shape[1:] != reference.shape:
-        raise ValueError("perturbed_responses must have shape (parameter, *reference.shape)")
-    if steps.shape != (len(perturbed),) or np.any(~np.isfinite(steps)) or np.any(steps == 0.0):
-        raise ValueError("perturbation_steps must be finite, nonzero, and match parameters")
-    responses = (perturbed - reference[None]) / steps.reshape((-1,) + (1,) * reference.ndim)
+        raise ValueError(
+            "perturbed_responses must have shape (parameter, *reference.shape)"
+        )
+    if (
+        steps.shape != (len(perturbed),)
+        or np.any(~np.isfinite(steps))
+        or np.any(steps == 0.0)
+    ):
+        raise ValueError(
+            "perturbation_steps must be finite, nonzero, and match parameters"
+        )
+    responses = (perturbed - reference[None]) / steps.reshape(
+        (-1,) + (1,) * reference.ndim
+    )
     if valid is None:
         selected = np.ones(reference.shape, dtype=bool)
     else:
@@ -310,10 +328,14 @@ def assess_intervention_identifiability(
     )
     original_energy = float(np.sum(np.square(intervention)))
     residual_energy = float(np.sum(np.square(residualized)))
-    residual_fraction = residual_energy / original_energy if original_energy > 0.0 else 0.0
+    residual_fraction = (
+        residual_energy / original_energy if original_energy > 0.0 else 0.0
+    )
     if nuisance_basis.shape[1] and intervention_basis.shape[1]:
         maximum_cosine = float(
-            np.max(np.linalg.svd(nuisance_basis.T @ intervention_basis, compute_uv=False))
+            np.max(
+                np.linalg.svd(nuisance_basis.T @ intervention_basis, compute_uv=False)
+            )
         )
     else:
         maximum_cosine = 0.0
@@ -351,7 +373,9 @@ def assess_intervention_identifiability(
             query_fraction <= settings.maximum_query_null_response_fraction
         )
         if not query_identifiable:
-            query_reasons.append("query_depends_on_unidentified_intervention_directions")
+            query_reasons.append(
+                "query_depends_on_unidentified_intervention_directions"
+            )
 
     return InterventionIdentifiabilityResult(
         conditional_information=information,

--- a/src/causal4d/immutable_array.py
+++ b/src/causal4d/immutable_array.py
@@ -1,4 +1,4 @@
-"""Owned read-only NumPy array helpers for frozen artifacts."""
+"""Owned, irreversibly read-only NumPy array helpers for frozen artifacts."""
 
 from __future__ import annotations
 
@@ -7,26 +7,46 @@ from typing import Any
 import numpy as np
 
 
+def _immutable_buffer_array(values: np.ndarray) -> np.ndarray:
+    """Copy an array into immutable bytes and rebuild its exact dtype and shape."""
+
+    if values.dtype.hasobject:
+        raise ValueError("frozen arrays must not contain Python objects")
+    original_shape = values.shape
+    contiguous = np.ascontiguousarray(values)
+    result = np.frombuffer(
+        contiguous.tobytes(order="C"),
+        dtype=contiguous.dtype,
+    ).reshape(original_shape)
+    if result.flags.writeable:
+        raise RuntimeError("immutable array construction produced writable storage")
+    return result
+
+
 def readonly_array(
     values: Any,
     *,
     dtype: np.dtype[Any] | type | None = None,
 ) -> np.ndarray:
-    """Return a defensive NumPy copy that rejects writes."""
+    """Return a defensive array whose write flag cannot be re-enabled.
 
-    array = np.asarray(values, dtype=dtype).copy()
-    array.setflags(write=False)
-    return array
+    A normal owned NumPy array can be made writable again with
+    ``array.setflags(write=True)`` after a caller merely clears its write flag.
+    Frozen Causal4D artifacts instead retain arrays backed by immutable ``bytes``
+    storage, so both direct writes and attempts to re-enable writes fail.
+    """
+
+    array = np.asarray(values, dtype=dtype)
+    return _immutable_buffer_array(array)
 
 
 def readonly_integer_array(values: Any, *, name: str) -> np.ndarray:
-    """Return owned ``int64`` data without coercing non-integer inputs.
+    """Return immutable ``int64`` data without coercing non-integer inputs.
 
     NumPy's normal ``dtype=np.int64`` conversion silently truncates floats and
-    converts booleans or numeric strings.  Indices are part of Causal4D's
-    evidence and content-identity boundaries, so accepting those conversions
-    could select a different frame, node, or support component than the caller
-    supplied.
+    converts booleans or numeric strings. Indices are part of Causal4D's evidence
+    and content-identity boundaries, so accepting those conversions could select
+    a different frame, node, or support component than the caller supplied.
     """
 
     array = np.asarray(values)
@@ -36,9 +56,7 @@ def readonly_integer_array(values: Any, *, name: str) -> np.ndarray:
         maximum = int(np.max(array))
         if maximum > np.iinfo(np.int64).max:
             raise ValueError(f"{name} contains an integer outside int64 range")
-    result = array.astype(np.int64, copy=True)
-    result.setflags(write=False)
-    return result
+    return _immutable_buffer_array(array.astype(np.int64, copy=False))
 
 
 __all__ = ["readonly_array", "readonly_integer_array"]

--- a/src/causal4d/immutable_json.py
+++ b/src/causal4d/immutable_json.py
@@ -3,8 +3,173 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
-from typing import Any
+from collections.abc import Iterator, Mapping, Sequence
+from types import MappingProxyType
+from typing import Any, NoReturn, overload
+
+
+class _FrozenJSONMapping(Mapping[str, Any]):
+    """An immutable JSON object without a mutable ``dict`` base class."""
+
+    __slots__ = ("__values",)
+    __values: Mapping[str, Any]
+
+    def __init__(self, values: Mapping[str, Any]) -> None:
+        object.__setattr__(
+            self,
+            "_FrozenJSONMapping__values",
+            MappingProxyType(dict(values)),
+        )
+
+    def __getitem__(self, key: str) -> Any:
+        return self.__values[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.__values)
+
+    def __len__(self) -> int:
+        return len(self.__values)
+
+    def __repr__(self) -> str:
+        return repr(dict(self.__values))
+
+    def __setattr__(self, name: str, value: object) -> NoReturn:
+        del name, value
+        raise TypeError("JSON data is immutable")
+
+    def __delattr__(self, name: str) -> NoReturn:
+        del name
+        raise TypeError("JSON data is immutable")
+
+    @staticmethod
+    def _immutable(*args: object, **kwargs: object) -> NoReturn:
+        del args, kwargs
+        raise TypeError("JSON data is immutable")
+
+    def __setitem__(self, key: object, value: object) -> NoReturn:
+        self._immutable(key, value)
+
+    def __delitem__(self, key: object) -> NoReturn:
+        self._immutable(key)
+
+    def clear(self) -> NoReturn:
+        self._immutable()
+
+    def pop(self, *args: object) -> NoReturn:
+        self._immutable(*args)
+
+    def popitem(self) -> NoReturn:
+        self._immutable()
+
+    def setdefault(self, *args: object) -> NoReturn:
+        self._immutable(*args)
+
+    def update(self, *args: object, **kwargs: object) -> NoReturn:
+        self._immutable(*args, **kwargs)
+
+    def __ior__(self, other: object) -> NoReturn:
+        self._immutable(other)
+
+    def __copy__(self) -> dict[str, Any]:
+        return plain_json(self)
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> dict[str, Any]:
+        del memo
+        return plain_json(self)
+
+
+class _FrozenJSONSequence(Sequence[Any]):
+    """An immutable JSON array without a mutable ``list`` base class."""
+
+    __slots__ = ("__values",)
+    __values: tuple[Any, ...]
+
+    def __init__(self, values: Sequence[Any]) -> None:
+        object.__setattr__(self, "_FrozenJSONSequence__values", tuple(values))
+
+    @overload
+    def __getitem__(self, index: int) -> Any: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> tuple[Any, ...]: ...
+
+    def __getitem__(self, index: int | slice) -> Any | tuple[Any, ...]:
+        return self.__values[index]
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self.__values)
+
+    def __len__(self) -> int:
+        return len(self.__values)
+
+    def __repr__(self) -> str:
+        return repr(list(self.__values))
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, _FrozenJSONSequence):
+            return self.__values == other.__values
+        if isinstance(other, (list, tuple)):
+            return self.__values == tuple(other)
+        return False
+
+    def __setattr__(self, name: str, value: object) -> NoReturn:
+        del name, value
+        raise TypeError("JSON data is immutable")
+
+    def __delattr__(self, name: str) -> NoReturn:
+        del name
+        raise TypeError("JSON data is immutable")
+
+    @staticmethod
+    def _immutable(*args: object, **kwargs: object) -> NoReturn:
+        del args, kwargs
+        raise TypeError("JSON data is immutable")
+
+    def __setitem__(self, key: object, value: object) -> NoReturn:
+        self._immutable(key, value)
+
+    def __delitem__(self, key: object) -> NoReturn:
+        self._immutable(key)
+
+    def append(self, value: object) -> NoReturn:
+        self._immutable(value)
+
+    def clear(self) -> NoReturn:
+        self._immutable()
+
+    def extend(self, values: object) -> NoReturn:
+        self._immutable(values)
+
+    def insert(self, index: object, value: object) -> NoReturn:
+        self._immutable(index, value)
+
+    def pop(self, *args: object) -> NoReturn:
+        self._immutable(*args)
+
+    def remove(self, value: object) -> NoReturn:
+        self._immutable(value)
+
+    def reverse(self) -> NoReturn:
+        self._immutable()
+
+    def sort(self, *args: object, **kwargs: object) -> NoReturn:
+        self._immutable(*args, **kwargs)
+
+    def __iadd__(self, other: object) -> NoReturn:
+        self._immutable(other)
+
+    def __imul__(self, other: object) -> NoReturn:
+        self._immutable(other)
+
+    def __copy__(self) -> list[Any]:
+        return plain_json(self)
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> list[Any]:
+        del memo
+        return plain_json(self)
+
+
+_JSON_ARRAY_TYPES = (list, tuple, _FrozenJSONSequence)
 
 
 def plain_json(value: Any) -> Any:
@@ -12,7 +177,7 @@ def plain_json(value: Any) -> Any:
 
     if isinstance(value, Mapping):
         return {key: plain_json(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
+    if isinstance(value, _JSON_ARRAY_TYPES):
         return [plain_json(item) for item in value]
     return value
 
@@ -25,90 +190,18 @@ def _require_string_mapping_keys(value: Any) -> None:
             if not isinstance(key, str):
                 raise TypeError("JSON object keys must be strings")
             _require_string_mapping_keys(item)
-    elif isinstance(value, (list, tuple)):
+    elif isinstance(value, _JSON_ARRAY_TYPES):
         for item in value:
             _require_string_mapping_keys(item)
 
 
-class _FrozenDict(dict):
-    """A JSON object that preserves ``dict`` compatibility but rejects mutation."""
-
-    __slots__ = ()
-    _MUTATORS = frozenset({"clear", "pop", "popitem", "setdefault", "update"})
-
-    def __getattribute__(self, name: str) -> Any:
-        if name in type(self)._MUTATORS:
-            return self._immutable
-        return super().__getattribute__(name)
-
-    @staticmethod
-    def _immutable(*args: object, **kwargs: object) -> None:
-        del args, kwargs
-        raise TypeError("JSON data is immutable")
-
-    def __setitem__(self, key: object, value: object) -> None:
-        self._immutable(key, value)
-
-    def __delitem__(self, key: object) -> None:
-        self._immutable(key)
-
-    def __ior__(self, other: object) -> _FrozenDict:  # type: ignore[misc]
-        self._immutable(other)
-        return self
-
-    def __copy__(self) -> dict[str, Any]:
-        return plain_json(self)
-
-    def __deepcopy__(self, memo: dict[int, Any]) -> dict[str, Any]:
-        del memo
-        return plain_json(self)
-
-
-class _FrozenList(list):
-    """A JSON array that preserves ``list`` compatibility but rejects mutation."""
-
-    __slots__ = ()
-    _MUTATORS = frozenset(
-        {"append", "clear", "extend", "insert", "pop", "remove", "reverse", "sort"}
-    )
-
-    def __getattribute__(self, name: str) -> Any:
-        if name in type(self)._MUTATORS:
-            return self._immutable
-        return super().__getattribute__(name)
-
-    @staticmethod
-    def _immutable(*args: object, **kwargs: object) -> None:
-        del args, kwargs
-        raise TypeError("JSON data is immutable")
-
-    def __setitem__(self, key: object, value: object) -> None:
-        self._immutable(key, value)
-
-    def __delitem__(self, key: object) -> None:
-        self._immutable(key)
-
-    def __iadd__(self, other: object) -> _FrozenList:  # type: ignore[misc]
-        self._immutable(other)
-        return self
-
-    def __imul__(self, other: object) -> _FrozenList:
-        self._immutable(other)
-        return self
-
-    def __copy__(self) -> list[Any]:
-        return plain_json(self)
-
-    def __deepcopy__(self, memo: dict[int, Any]) -> list[Any]:
-        del memo
-        return plain_json(self)
-
-
 def _freeze_json(value: Any) -> Any:
     if isinstance(value, dict):
-        return _FrozenDict({key: _freeze_json(item) for key, item in value.items()})
+        return _FrozenJSONMapping(
+            {key: _freeze_json(item) for key, item in value.items()}
+        )
     if isinstance(value, list):
-        return _FrozenList(_freeze_json(item) for item in value)
+        return _FrozenJSONSequence(tuple(_freeze_json(item) for item in value))
     return value
 
 
@@ -121,9 +214,10 @@ def validated_json_mapping(
 
     Tuples become JSON arrays. Object keys must already be strings so the JSON
     encoder cannot silently coerce a key or collapse distinct Python identities.
-    Non-finite and unsupported values fail closed. The returned containers still
-    satisfy ordinary ``isinstance(value, dict/list)`` checks, while ``copy.copy``
-    and ``copy.deepcopy`` yield independent mutable JSON data.
+    Non-finite and unsupported values fail closed. The returned values implement
+    the read-only ``Mapping`` and ``Sequence`` protocols without inheriting from
+    mutable ``dict`` or ``list``. Call :func:`plain_json` at serialization or
+    explicit mutable-export boundaries.
     """
 
     try:

--- a/src/causal4d/observation_contract_bundle.py
+++ b/src/causal4d/observation_contract_bundle.py
@@ -19,6 +19,8 @@ from typing import Any, Mapping
 
 import numpy as np
 
+from causal4d.immutable_array import readonly_array
+
 OBSERVATION_BELIEF_CONTRACT_BUNDLE = "phys4d.observation_belief.v1"
 OBSERVATION_BELIEF_CONTRACT_BUNDLE_VERSION = 1
 OBSERVATION_BELIEF_CONTRACT_BUNDLE_SHA256 = (
@@ -256,8 +258,7 @@ def observation_contract_vector(name: str) -> ObservationContractVector:
                 f"array record {array_name!r} has shape {array.shape}, "
                 f"expected {expected_shape}"
             )
-        array.setflags(write=False)
-        arrays[str(array_name)] = array
+        arrays[str(array_name)] = readonly_array(array)
 
     expected_artifact_id = _validate_sha256(
         str(payload["expected_artifact_id"]),
@@ -378,8 +379,7 @@ def invalid_observation_contract_vector(
         else:
             raise ValueError("unsupported observation-contract mutation target")
 
-    for array in arrays.values():
-        array.setflags(write=False)
+    arrays = {name: readonly_array(array) for name, array in arrays.items()}
     return InvalidObservationContractVector(
         case_id=identifier,
         mode=str(case["mode"]),

--- a/src/causal4d/observation_evidence.py
+++ b/src/causal4d/observation_evidence.py
@@ -7,14 +7,12 @@ from typing import Any, Mapping, Sequence
 
 import numpy as np
 
-from causal4d.immutable_array import readonly_integer_array
+from causal4d.immutable_array import readonly_array, readonly_integer_array
 from causal4d.immutable_json import validated_json_mapping
 
 
 def _readonly(values: np.ndarray, *, dtype: Any = float) -> np.ndarray:
-    result = np.asarray(values, dtype=dtype).copy()
-    result.setflags(write=False)
-    return result
+    return readonly_array(values, dtype=dtype)
 
 
 def _require_nonempty_string(value: Any, *, name: str) -> str:

--- a/src/causal4d/provider_contract.py
+++ b/src/causal4d/provider_contract.py
@@ -11,7 +11,7 @@ from typing import Any
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
-from causal4d.immutable_json import validated_json_mapping
+from causal4d.immutable_json import plain_json, validated_json_mapping
 
 
 PHYSICAL_BELIEF_PROVIDER_SCHEMA_VERSION = 1
@@ -215,8 +215,8 @@ class PhysicalBeliefProviderManifest:
             "provider_revision": self.provider_revision,
             "schema_version": self.schema_version,
             "capabilities": list(self.capabilities),
-            "artifact_schema_versions": self.artifact_schema_versions,
-            "metadata": self.metadata,
+            "artifact_schema_versions": plain_json(self.artifact_schema_versions),
+            "metadata": plain_json(self.metadata),
         }
         return hashlib.sha256(
             json.dumps(
@@ -235,8 +235,8 @@ class PhysicalBeliefProviderManifest:
             "provider_revision": self.provider_revision,
             "schema_version": self.schema_version,
             "capabilities": list(self.capabilities),
-            "artifact_schema_versions": dict(self.artifact_schema_versions),
-            "metadata": dict(self.metadata),
+            "artifact_schema_versions": plain_json(self.artifact_schema_versions),
+            "metadata": plain_json(self.metadata),
         }
 
 

--- a/src/causal4d/replay_provider_contract.py
+++ b/src/causal4d/replay_provider_contract.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import numpy as np
 
-from causal4d.immutable_json import validated_json_mapping
+from causal4d.immutable_json import plain_json, validated_json_mapping
 from causal4d.provider_contract import (
     BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE,
     PhysicalBeliefProviderManifest,
@@ -56,7 +56,7 @@ def stable_replay_identifier(namespace: str, payload: Mapping[str, Any]) -> str:
         ),
     )
     encoded = json.dumps(
-        normalized,
+        plain_json(normalized),
         sort_keys=True,
         separators=(",", ":"),
         allow_nan=False,

--- a/src/causal4d/rollout_bank.py
+++ b/src/causal4d/rollout_bank.py
@@ -48,8 +48,7 @@ def _normalized_weights(values: np.ndarray, *, name: str) -> np.ndarray:
     if total <= 0.0:
         raise ValueError(f"{name} must have positive mass")
     normalized = weights / total
-    normalized.setflags(write=False)
-    return normalized
+    return _readonly_array(normalized)
 
 
 def _validated_joint_weights(
@@ -236,8 +235,7 @@ class SparseTrajectoryEvidence:
                 raise ValueError(
                     "evidence validity must have shape (F, Q) or (F, Q, C)"
                 )
-            valid.setflags(write=False)
-            object.__setattr__(self, "valid", valid)
+            object.__setattr__(self, "valid", _readonly_array(valid, dtype=bool))
         if self.compare_displacements:
             if self.anchor_positions_m is None:
                 raise ValueError("displacement evidence requires anchor_positions_m")

--- a/src/causal4d/rollout_cache.py
+++ b/src/causal4d/rollout_cache.py
@@ -16,6 +16,7 @@ import zipfile
 import numpy as np
 
 from causal4d.contracts import array_sha256
+from causal4d.immutable_array import readonly_array, readonly_integer_array
 
 ROLLOUT_CACHE_SCHEMA_NAME = "causal4d.phystwin-rollout-cache"
 ROLLOUT_CACHE_SCHEMA_VERSION = 1
@@ -212,8 +213,7 @@ def _validated_trajectory(
         raise ValueError("cached rollout contains fewer nodes than requested")
     if not np.all(np.isfinite(trajectory)):
         raise ValueError("cached rollout must contain only finite values")
-    trajectory.setflags(write=False)
-    return trajectory
+    return readonly_array(trajectory)
 
 
 @dataclass(frozen=True)
@@ -516,7 +516,7 @@ class CachedReplayTrajectory:
             raise ValueError(
                 "cached replay frame_ids must be increasing and nonnegative"
             )
-        frame_ids.setflags(write=False)
+        frame_ids = readonly_integer_array(frame_ids, name="frame_ids")
         dt_s = float(self.dt_s)
         if not np.isfinite(dt_s) or dt_s <= 0.0:
             raise ValueError("cached replay dt_s must be positive and finite")

--- a/src/causal4d/sensor_evidence.py
+++ b/src/causal4d/sensor_evidence.py
@@ -10,7 +10,8 @@ from typing import Any, Mapping
 
 import numpy as np
 
-from causal4d.immutable_json import validated_json_mapping
+from causal4d.immutable_array import readonly_array
+from causal4d.immutable_json import plain_json, validated_json_mapping
 
 from causal4d.contracts import array_sha256
 
@@ -19,9 +20,7 @@ INDEPENDENT_SENSOR_SCHEMA_VERSION = 1
 
 
 def _readonly(values: np.ndarray, *, dtype: type | None = float) -> np.ndarray:
-    array = np.asarray(values, dtype=dtype).copy()
-    array.setflags(write=False)
-    return array
+    return readonly_array(values, dtype=dtype)
 
 
 def _validate_identity(
@@ -71,8 +70,7 @@ def _broadcast_variance(
         raise ValueError(f"{name} must broadcast to {shape}") from error
     if not np.all(np.isfinite(result)) or np.any(result <= 0.0):
         raise ValueError(f"{name} must be finite and strictly positive")
-    result.setflags(write=False)
-    return result
+    return readonly_array(result)
 
 
 def _broadcast_mask(
@@ -88,8 +86,7 @@ def _broadcast_mask(
             result = np.broadcast_to(supplied, shape).copy()
         except ValueError as error:
             raise ValueError(f"{name} must broadcast to {shape}") from error
-    result.setflags(write=False)
-    return result
+    return readonly_array(result)
 
 
 def _validate_times(values: np.ndarray, sample_count: int) -> np.ndarray:
@@ -111,7 +108,7 @@ def _artifact_id(
     digest.update(artifact_kind.encode("utf-8"))
     digest.update(
         json.dumps(
-            dict(scalar_payload),
+            plain_json(scalar_payload),
             sort_keys=True,
             separators=(",", ":"),
             allow_nan=False,
@@ -183,7 +180,7 @@ class ActuatorEvidence:
             scalar_payload={
                 **_identity_payload(self),
                 "evidence_frame_stop": self.evidence_frame_stop,
-                "metadata": self.metadata,
+                "metadata": plain_json(self.metadata),
                 "independent_of_object_observations": True,
             },
             arrays={
@@ -259,7 +256,7 @@ class ContactWrenchEvidence:
                 **_identity_payload(self),
                 "quantity_names": list(self.quantity_names),
                 "evidence_frame_stop": self.evidence_frame_stop,
-                "metadata": self.metadata,
+                "metadata": plain_json(self.metadata),
                 "independent_of_object_observations": True,
             },
             arrays={
@@ -283,7 +280,7 @@ def save_independent_sensor_evidence(
             "artifact_kind": "ActuatorEvidence",
             **_identity_payload(evidence),
             "evidence_frame_stop": evidence.evidence_frame_stop,
-            "metadata": evidence.metadata,
+            "metadata": plain_json(evidence.metadata),
             "artifact_id": evidence.artifact_id,
         }
         arrays = {
@@ -299,7 +296,7 @@ def save_independent_sensor_evidence(
             **_identity_payload(evidence),
             "quantity_names": list(evidence.quantity_names),
             "evidence_frame_stop": evidence.evidence_frame_stop,
-            "metadata": evidence.metadata,
+            "metadata": plain_json(evidence.metadata),
             "artifact_id": evidence.artifact_id,
         }
         arrays = {

--- a/src/causal4d/simulator.py
+++ b/src/causal4d/simulator.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import numpy as np
 
+from causal4d.immutable_array import readonly_array
+
 
 PARAMETER_NAMES = ("stiffness", "damping", "contact_gain")
 
@@ -69,9 +71,9 @@ class GraphObject:
             node < 0 or node >= node_count for node in self.sensor_nodes
         ):
             raise ValueError("sensor_nodes must contain valid node indices")
-        positions = positions.copy()
-        positions.setflags(write=False)
-        object.__setattr__(self, "rest_positions", positions)
+        object.__setattr__(
+            self, "rest_positions", readonly_array(positions, dtype=float)
+        )
 
     @property
     def node_count(self) -> int:
@@ -116,9 +118,9 @@ class Action:
             )
         if forces.shape[0] == 0 or not np.all(np.isfinite(forces)):
             raise ValueError("commanded_forces must be non-empty and finite")
-        forces = forces.copy()
-        forces.setflags(write=False)
-        object.__setattr__(self, "commanded_forces", forces)
+        object.__setattr__(
+            self, "commanded_forces", readonly_array(forces, dtype=float)
+        )
 
     @property
     def frame_count(self) -> int:

--- a/src/causal4d/stable_discrepancy_dynamics.py
+++ b/src/causal4d/stable_discrepancy_dynamics.py
@@ -15,15 +15,14 @@ from causal4d.action_conditioned_discrepancy import (
 )
 from causal4d.contracts import array_sha256
 from causal4d.discrepancy_belief import GraphDiscrepancyBelief
+from causal4d.immutable_array import readonly_array
 
 
 TIME_PARAMETERIZATIONS = ("per_step", "per_second")
 
 
 def _readonly(values: np.ndarray) -> np.ndarray:
-    result = np.asarray(values, dtype=float).copy()
-    result.setflags(write=False)
-    return result
+    return readonly_array(values, dtype=float)
 
 
 def _positive_semidefinite(values: np.ndarray) -> np.ndarray:
@@ -115,9 +114,7 @@ class StableDiscrepancyTransitionModel:
             skew = skew / norms[:, None, None]
         skew_weights = np.asarray(self.skew_feature_weights, dtype=float)
         if skew_weights.shape != (len(skew), feature_count):
-            raise ValueError(
-                "skew_feature_weights must have shape (J, feature_count)"
-            )
+            raise ValueError("skew_feature_weights must have shape (J, feature_count)")
 
         contraction = _normalized_rows(
             self.contraction_directions,
@@ -145,9 +142,7 @@ class StableDiscrepancyTransitionModel:
             drift = drift / norms[:, None, None]
         drift_weights = np.asarray(self.drift_feature_weights, dtype=float)
         if drift_weights.shape != (len(drift), feature_count):
-            raise ValueError(
-                "drift_feature_weights must have shape (J, feature_count)"
-            )
+            raise ValueError("drift_feature_weights must have shape (J, feature_count)")
         if not all(
             np.all(np.isfinite(value))
             for value in (skew_weights, contraction_weights, drift_weights)
@@ -352,9 +347,7 @@ def forecast_action_conditioned_dynamics(
                 feature_vector,
                 step_duration_s=duration,
             )
-            mean[component, step + 1] = (
-                transition @ mean[component, step] + drift
-            )
+            mean[component, step + 1] = transition @ mean[component, step] + drift
             if (
                 transition_model.time_parameterization == "per_second"
                 and innovation_model.time_parameterization == "per_second"
@@ -371,10 +364,8 @@ def forecast_action_conditioned_dynamics(
                 )
             for coordinate in range(3):
                 previous = covariance[component, step, coordinate]
-                covariance[component, step + 1, coordinate] = (
-                    _positive_semidefinite(
-                        transition @ previous @ transition.T + innovation
-                    )
+                covariance[component, step + 1, coordinate] = _positive_semidefinite(
+                    transition @ previous @ transition.T + innovation
                 )
 
     readout_mean = np.einsum("nr,khrc->khnc", graph_basis, mean)

--- a/src/causal4d_public/deform360_prefix_kinematics.py
+++ b/src/causal4d_public/deform360_prefix_kinematics.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import numpy as np
 
+from causal4d.immutable_array import readonly_array
+
 from .deform360_replication_graph import Deform360SparseGraph
 
 
@@ -42,9 +44,7 @@ def _positive_integer(value: Any, *, name: str) -> int:
 
 
 def _readonly(values: np.ndarray, *, dtype: np.dtype[Any] | type[Any]) -> np.ndarray:
-    result = np.asarray(values, dtype=dtype).copy()
-    result.setflags(write=False)
-    return result
+    return readonly_array(values, dtype=dtype)
 
 
 def _edge_graph_is_connected(node_count: int, edges: np.ndarray) -> bool:

--- a/src/causal4d_public/deform360_replication_case.py
+++ b/src/causal4d_public/deform360_replication_case.py
@@ -8,6 +8,8 @@ from typing import Any, Sequence
 
 import numpy as np
 
+from causal4d.immutable_array import readonly_array
+
 from .deform360_replication_graph import build_sparse_graph_for_stratum
 from .deform360_replication_warp import (
     Deform360WarpForecastCase,
@@ -45,9 +47,7 @@ class ReplicationWarpObservation:
             > int(frames[-1]) - self.prefix_endpoint_frame,
             "case does not reach the final hull",
         )
-        copied = frames.copy()
-        copied.setflags(write=False)
-        object.__setattr__(self, "raw_hull_frame_indices", copied)
+        object.__setattr__(self, "raw_hull_frame_indices", readonly_array(frames))
 
 
 def _robot_arrays(state: Any) -> tuple[np.ndarray, np.ndarray]:
@@ -138,9 +138,9 @@ def build_replication_warp_observation(
             taxels = gripper_taxel_points(
                 float(openings[raw_frame, axis]), transforms[raw_frame, axis]
             )
-            controllers[output_index, axis] = np.mean(
-                taxels[selected_taxels[axis]], axis=0
-            ) + offsets[axis]
+            controllers[output_index, axis] = (
+                np.mean(taxels[selected_taxels[axis]], axis=0) + offsets[axis]
+            )
     case = Deform360WarpForecastCase(
         episode_id=episode_id,
         graph=graph,
@@ -192,12 +192,8 @@ def score_constant_persistence(
         "future hull references are required for scoring",
     )
     count = len(observation.reference_hulls_m) - 1
-    prediction = np.repeat(
-        observation.case.graph.positions_m[None], count, axis=0
-    )
-    return sparse_trajectory_chamfer_m(
-        observation.reference_hulls_m[1:], prediction
-    )
+    prediction = np.repeat(observation.case.graph.positions_m[None], count, axis=0)
+    return sparse_trajectory_chamfer_m(observation.reference_hulls_m[1:], prediction)
 
 
 __all__ = [

--- a/src/causal4d_public/deform360_replication_contact.py
+++ b/src/causal4d_public/deform360_replication_contact.py
@@ -9,6 +9,8 @@ from typing import Mapping, Sequence
 
 import numpy as np
 
+from causal4d.immutable_array import readonly_array
+
 
 TACTILE_ROWS_USED = 12
 CONTACT_PATIENCE_FRAMES = 5
@@ -114,9 +116,7 @@ class ReplicationContactEpisode:
             all(values.shape == (len(openings),) for values in groups.values()),
             "tactile contact length differs from robot trajectory",
         )
-        copied = openings.copy()
-        copied.setflags(write=False)
-        object.__setattr__(self, "openings_m", copied)
+        object.__setattr__(self, "openings_m", readonly_array(openings))
         object.__setattr__(self, "tactile_by_group", groups)
 
 
@@ -153,7 +153,9 @@ def load_replication_contact_episode(
     _require(tactile_paths, f"tactile streams are missing: {directory}")
     for path in tactile_paths:
         values = np.load(path, mmap_mode="r", allow_pickle=False)
-        _require(values.ndim == 3 and len(values) == len(openings), "invalid tactile stream")
+        _require(
+            values.ndim == 3 and len(values) == len(openings), "invalid tactile stream"
+        )
         counts = np.count_nonzero(
             values[:, :TACTILE_ROWS_USED, :] > tactile_threshold,
             axis=(1, 2),
@@ -161,8 +163,7 @@ def load_replication_contact_episode(
         group = _gripper_group(path.parent.name)
         groups[group] = groups.get(group, np.zeros_like(counts)) + counts
     windows = {
-        group: official_contact_window(counts > 1)
-        for group, counts in groups.items()
+        group: official_contact_window(counts > 1) for group, counts in groups.items()
     }
     if not bimanual:
         selected = _mono_event_group(groups)
@@ -188,7 +189,9 @@ def _mapping_candidates(
         }
     )
     _require(len(groups) == 2, "expected two bimanual tactile groups")
-    return [dict(zip(groups, permutation)) for permutation in itertools.permutations((0, 1))]
+    return [
+        dict(zip(groups, permutation)) for permutation in itertools.permutations((0, 1))
+    ]
 
 
 def contact_state_by_robot_axis(
@@ -199,7 +202,9 @@ def contact_state_by_robot_axis(
 
     output = np.zeros_like(episode.openings_m, dtype=bool)
     if episode.bimanual:
-        _require(set(episode.tactile_by_group) == set(mapping), "tactile groups changed")
+        _require(
+            set(episode.tactile_by_group) == set(mapping), "tactile groups changed"
+        )
         for group, values in episode.tactile_by_group.items():
             output[:, int(mapping[group])] = values
     else:

--- a/src/causal4d_public/deform360_replication_controls.py
+++ b/src/causal4d_public/deform360_replication_controls.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 import numpy as np
+
+from causal4d.immutable_array import readonly_array
 from scipy.optimize import minimize
 
 
@@ -283,9 +285,7 @@ class ContactTransitionEpisode:
             ("predicted_object_positions_m", objects),
             ("contact_active", active),
         ):
-            copied = values.copy()
-            copied.setflags(write=False)
-            object.__setattr__(self, name, copied)
+            object.__setattr__(self, name, readonly_array(values))
 
 
 @dataclass(frozen=True)

--- a/src/causal4d_public/deform360_replication_graph.py
+++ b/src/causal4d_public/deform360_replication_graph.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import numpy as np
 
+from causal4d.immutable_array import readonly_array
+
 from .deform360_rope_graph import (
     RopeCenterlineConfig,
     extract_rope_centerline,
@@ -77,9 +79,7 @@ class Deform360SparseGraph:
             ("spring_families", families),
             ("masses", masses),
         ):
-            copied = values.copy()
-            copied.setflags(write=False)
-            object.__setattr__(self, name, copied)
+            object.__setattr__(self, name, readonly_array(values))
 
 
 def _edge_arrays(

--- a/src/causal4d_public/deform360_replication_warp.py
+++ b/src/causal4d_public/deform360_replication_warp.py
@@ -9,6 +9,8 @@ from typing import Sequence
 
 import numpy as np
 
+from causal4d.immutable_array import readonly_array
+
 from .deform360_phystwin_feasibility import (
     WarpRopeCandidate,
     WarpRopeFeasibilityConfig,
@@ -78,9 +80,7 @@ class Deform360WarpForecastCase:
             ("contact_rest_lengths_m", rest),
             ("initial_velocities_m_s", velocities),
         ):
-            copied = values.copy()
-            copied.setflags(write=False)
-            object.__setattr__(self, name, copied)
+            object.__setattr__(self, name, readonly_array(values))
 
 
 def symmetric_chamfer_distance_m(

--- a/src/causal4d_public/deform360_rope_dynamics.py
+++ b/src/causal4d_public/deform360_rope_dynamics.py
@@ -7,6 +7,8 @@ from typing import Any, Sequence
 
 import numpy as np
 
+from causal4d.immutable_array import readonly_array
+
 
 PARAMETER_NAMES = (
     "spring_acceleration_per_m_s2",
@@ -116,18 +118,10 @@ class RopeDynamicsObservation:
             "observation trajectories contain non-finite values",
         )
         _require(self.dt_seconds > 0.0, "frame interval must be positive")
-        positions = positions.copy()
-        controllers = controllers.copy()
-        active = active.copy()
-        offsets = offsets.copy()
-        positions.setflags(write=False)
-        controllers.setflags(write=False)
-        active.setflags(write=False)
-        offsets.setflags(write=False)
-        object.__setattr__(self, "positions_m", positions)
-        object.__setattr__(self, "controller_positions_m", controllers)
-        object.__setattr__(self, "contact_active", active)
-        object.__setattr__(self, "contact_offsets_m", offsets)
+        object.__setattr__(self, "positions_m", readonly_array(positions))
+        object.__setattr__(self, "controller_positions_m", readonly_array(controllers))
+        object.__setattr__(self, "contact_active", readonly_array(active))
+        object.__setattr__(self, "contact_offsets_m", readonly_array(offsets))
 
 
 @dataclass(frozen=True)
@@ -146,9 +140,7 @@ class RopeDynamicsFit:
             "invalid rope parameter covariance shape",
         )
         _require(np.all(np.isfinite(covariance)), "parameter covariance is non-finite")
-        covariance = covariance.copy()
-        covariance.setflags(write=False)
-        object.__setattr__(self, "parameter_covariance", covariance)
+        object.__setattr__(self, "parameter_covariance", readonly_array(covariance))
 
 
 def _chain_force_bases(

--- a/tests/test_bpt_provider_import_boundary.py
+++ b/tests/test_bpt_provider_import_boundary.py
@@ -5,22 +5,34 @@ from __future__ import annotations
 import ast
 import importlib
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
 
-ALLOWED_BAYESIAN_PHYSTWIN_MODULES = frozenset(
-    {
-        "bayesian_phystwin.causal4d_artifacts_v1",
-        "bayesian_phystwin.causal4d_artifacts_v2",
-        "bayesian_phystwin.causal4d_belief_provider_v1",
-        "bayesian_phystwin.causal4d_belief_provider_v2",
-        "bayesian_phystwin.causal4d_graph_provider_v1",
-        "bayesian_phystwin.causal4d_provider_v1",
-        "bayesian_phystwin.causal4d_provider_v2",
-        "bayesian_phystwin.causal4d_public_provider_v1",
-    }
-)
+
+def _provider_registry() -> dict[str, object]:
+    repository_root = Path(__file__).resolve().parents[1]
+    path = repository_root / "ci" / "bayesian_phystwin_provider_registry.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise AssertionError("Bayesian-PhysTwin provider registry must be an object")
+    return payload
+
+
+def _allowed_bayesian_phystwin_modules() -> frozenset[str]:
+    modules = _provider_registry().get("modules")
+    if not isinstance(modules, list):
+        raise AssertionError("provider registry modules must be a list")
+    result: set[str] = set()
+    for entry in modules:
+        if not isinstance(entry, dict) or type(entry.get("module")) is not str:
+            raise AssertionError("provider registry entries require string modules")
+        result.add(entry["module"])
+    return frozenset(result)
+
+
+ALLOWED_BAYESIAN_PHYSTWIN_MODULES = _allowed_bayesian_phystwin_modules()
 
 
 def _python_sources() -> list[Path]:

--- a/tests/test_bpt_provider_registry.py
+++ b/tests/test_bpt_provider_registry.py
@@ -1,0 +1,129 @@
+"""Validate the declarative Bayesian-PhysTwin provider inventory."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+_REGISTRY_PATH = _REPOSITORY_ROOT / "ci" / "bayesian_phystwin_provider_registry.json"
+_DOC_PATH = _REPOSITORY_ROOT / "docs" / "bayesian_phystwin_provider.md"
+_EXPECTED_ENTRY_FIELDS = frozenset(
+    {
+        "module",
+        "api_version",
+        "role",
+        "lifecycle",
+        "local_contract_module",
+    }
+)
+_ALLOWED_LIFECYCLES = frozenset(
+    {
+        "frozen_compatibility",
+        "production",
+        "production_additive",
+        "additive_development",
+        "diagnostic",
+    }
+)
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _registry() -> dict[str, Any]:
+    payload = json.loads(
+        _REGISTRY_PATH.read_text(encoding="utf-8"),
+        object_pairs_hook=_reject_duplicate_keys,
+        parse_constant=lambda value: (_ for _ in ()).throw(
+            ValueError(f"non-finite JSON constant: {value}")
+        ),
+    )
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_provider_registry_schema_and_entries_are_exact() -> None:
+    registry = _registry()
+    assert set(registry) == {
+        "schema",
+        "schema_version",
+        "supported_distribution",
+        "import_policy",
+        "modules",
+    }
+    assert registry["schema"] == "causal4d.bayesian_phystwin_provider_registry"
+    assert type(registry["schema_version"]) is int
+    assert registry["schema_version"] == 1
+    assert registry["supported_distribution"] == "bayesian-phystwin>=0.4,<0.5"
+    assert registry["import_policy"] == "versioned_public_modules_only"
+
+    entries = registry["modules"]
+    assert isinstance(entries, list) and entries
+    modules: list[str] = []
+    roles: list[str] = []
+    for entry in entries:
+        assert isinstance(entry, dict)
+        assert set(entry) == _EXPECTED_ENTRY_FIELDS
+        module = entry["module"]
+        version = entry["api_version"]
+        role = entry["role"]
+        lifecycle = entry["lifecycle"]
+        contract_module = entry["local_contract_module"]
+        assert type(module) is str and module.startswith("bayesian_phystwin.")
+        match = re.fullmatch(r"bayesian_phystwin\.[a-z0-9_]+_v([1-9][0-9]*)", module)
+        assert match is not None
+        assert type(version) is int and version == int(match.group(1))
+        assert type(role) is str and role
+        assert lifecycle in _ALLOWED_LIFECYCLES
+        assert contract_module is None or (
+            type(contract_module) is str and contract_module.startswith("causal4d.")
+        )
+        modules.append(module)
+        roles.append(role)
+
+    assert len(modules) == len(set(modules))
+    assert len(roles) == len(set(roles))
+
+
+def test_registry_contract_modules_and_documentation_exist() -> None:
+    registry = _registry()
+    documentation = _DOC_PATH.read_text(encoding="utf-8")
+    for entry in registry["modules"]:
+        module = entry["module"]
+        assert f"`{module}`" in documentation
+        contract_module = entry["local_contract_module"]
+        if contract_module is None:
+            continue
+        path = _REPOSITORY_ROOT / "src" / Path(*contract_module.split("."))
+        assert path.with_suffix(".py").is_file(), contract_module
+
+
+def test_registry_contains_current_additive_provider_boundaries() -> None:
+    modules = {entry["module"] for entry in _registry()["modules"]}
+    assert "bayesian_phystwin.causal4d_artifacts_v2" in modules
+    assert "bayesian_phystwin.causal4d_belief_provider_v2" in modules
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        "bayesian_phystwin.internal_experiment",
+        "bayesian_phystwin.causal4d_provider",
+        "bayesian_phystwin.causal4d_provider_v0",
+    ],
+)
+def test_registry_excludes_unversioned_or_private_modules(module: str) -> None:
+    modules = {entry["module"] for entry in _registry()["modules"]}
+    assert module not in modules

--- a/tests/test_causal4d_contracts.py
+++ b/tests/test_causal4d_contracts.py
@@ -1,5 +1,6 @@
 import copy
 import json
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, Callable
 
@@ -249,8 +250,10 @@ def test_contract_metadata_is_deeply_immutable_and_artifact_id_stable(
     metadata["nested"]["items"][1]["accepted"] = False
     assert belief.metadata["nested"]["items"][1]["accepted"] is True
     assert belief.artifact_id == artifact_id
-    assert isinstance(belief.metadata, dict)
-    assert isinstance(belief.metadata["nested"]["items"], list)
+    assert isinstance(belief.metadata, Mapping)
+    assert isinstance(belief.metadata["nested"]["items"], Sequence)
+    assert not isinstance(belief.metadata, dict)
+    assert not isinstance(belief.metadata["nested"]["items"], list)
 
     with pytest.raises(TypeError, match="immutable"):
         belief.metadata["nested"]["items"][1]["accepted"] = False

--- a/tests/test_claim_artifact_immutability.py
+++ b/tests/test_claim_artifact_immutability.py
@@ -52,6 +52,10 @@ def _assert_read_only(values: np.ndarray) -> None:
     assert not values.flags.writeable
     with pytest.raises(ValueError, match="read-only"):
         values[...] = 0
+    with pytest.raises(ValueError, match="WRITEABLE"):
+        values.setflags(write=True)
+    with pytest.raises(ValueError, match="WRITEABLE"):
+        values.flags.writeable = True
 
 
 def test_sparse_semantic_evidence_owns_every_retained_array() -> None:

--- a/tests/test_immutable_array.py
+++ b/tests/test_immutable_array.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from causal4d.contracts import array_sha256
+from causal4d.immutable_array import readonly_array, readonly_integer_array
+
+
+def _assert_irreversibly_read_only(values: np.ndarray) -> None:
+    assert not values.flags.writeable
+    with pytest.raises(ValueError, match="read-only"):
+        values[...] = 0
+    with pytest.raises(ValueError, match="WRITEABLE"):
+        values.setflags(write=True)
+    with pytest.raises(ValueError, match="WRITEABLE"):
+        values.flags.writeable = True
+
+
+def test_readonly_array_owns_values_and_preserves_identity() -> None:
+    source = np.arange(24, dtype=np.float32).reshape(2, 3, 4).transpose(1, 0, 2)
+    expected = np.asarray(source, dtype=np.float64).copy()
+    expected_identity = array_sha256(expected)
+
+    frozen = readonly_array(source, dtype=np.float64)
+    source[...] = -1
+
+    assert frozen.dtype == expected.dtype
+    assert frozen.shape == expected.shape
+    np.testing.assert_array_equal(frozen, expected)
+    assert array_sha256(frozen) == expected_identity
+    _assert_irreversibly_read_only(frozen)
+
+
+def test_readonly_array_handles_scalar_and_empty_shapes() -> None:
+    scalar = readonly_array(4.5)
+    empty = readonly_array(np.empty((0, 3), dtype=np.float32))
+
+    assert scalar.shape == ()
+    assert empty.shape == (0, 3)
+    _assert_irreversibly_read_only(scalar)
+    _assert_irreversibly_read_only(empty)
+
+
+def test_readonly_array_rejects_python_object_storage() -> None:
+    values = np.asarray([object()], dtype=object)
+    with pytest.raises(ValueError, match="Python objects"):
+        readonly_array(values)
+
+
+def test_readonly_integer_array_rejects_coercion_and_is_irreversible() -> None:
+    source = np.asarray([0, 2, 4], dtype=np.uint32)
+    frozen = readonly_integer_array(source, name="indices")
+    source[...] = 9
+
+    assert frozen.dtype == np.dtype(np.int64)
+    np.testing.assert_array_equal(frozen, [0, 2, 4])
+    _assert_irreversibly_read_only(frozen)
+
+    for invalid in ([1.0], [True], ["1"]):
+        with pytest.raises(ValueError, match="must contain integers"):
+            readonly_integer_array(invalid, name="indices")
+
+
+def test_source_does_not_freeze_arrays_by_clearing_only_the_write_flag() -> None:
+    import ast
+    from pathlib import Path
+
+    repository_root = Path(__file__).resolve().parents[1]
+    violations: list[str] = []
+    for source_root in (
+        repository_root / "src" / "causal4d",
+        repository_root / "src" / "causal4d_public",
+    ):
+        for path in sorted(source_root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                    if node.func.attr != "setflags":
+                        continue
+                    clears_write = any(
+                        keyword.arg == "write"
+                        and isinstance(keyword.value, ast.Constant)
+                        and keyword.value.value is False
+                        for keyword in node.keywords
+                    )
+                    if clears_write:
+                        violations.append(
+                            f"{path}:{node.lineno}: setflags(write=False)"
+                        )
+                if not isinstance(node, ast.Assign):
+                    continue
+                target = node.targets[0] if len(node.targets) == 1 else None
+                if not (
+                    isinstance(target, ast.Attribute)
+                    and target.attr == "writeable"
+                    and isinstance(target.value, ast.Attribute)
+                    and target.value.attr == "flags"
+                    and isinstance(node.value, ast.Constant)
+                    and node.value.value is False
+                ):
+                    continue
+                violations.append(f"{path}:{node.lineno}: flags.writeable = False")
+    assert not violations, (
+        "write flags can be re-enabled; use causal4d.immutable_array.readonly_array:\n"
+        + "\n".join(violations)
+    )

--- a/tests/test_immutable_json.py
+++ b/tests/test_immutable_json.py
@@ -1,4 +1,6 @@
 import copy
+import json
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 import pytest
@@ -18,8 +20,10 @@ def test_validated_json_mapping_is_deeply_immutable_and_copyable() -> None:
     source["nested"]["items"][1]["accepted"] = False
     assert frozen["nested"]["items"][1]["accepted"] is True
     assert frozen["nested"]["tuple_items"] == [2, 3]
-    assert isinstance(frozen, dict)
-    assert isinstance(frozen["nested"]["items"], list)
+    assert isinstance(frozen, Mapping)
+    assert isinstance(frozen["nested"]["items"], Sequence)
+    assert not isinstance(frozen, dict)
+    assert not isinstance(frozen["nested"]["items"], list)
 
     with pytest.raises(TypeError, match="immutable"):
         frozen["new"] = "value"
@@ -45,6 +49,34 @@ def test_validated_json_mapping_is_deeply_immutable_and_copyable() -> None:
             "items": [1, {"accepted": True}, "copy-only"],
             "tuple_items": [2, 3],
         }
+    }
+
+
+def test_validated_json_mapping_blocks_mutable_builtin_base_class_bypasses() -> None:
+    frozen = validated_json_mapping({"nested": {"items": [1, 2]}})
+    nested = frozen["nested"]
+    items = nested["items"]
+    expected = plain_json(frozen)
+
+    with pytest.raises(TypeError):
+        dict.__setitem__(frozen, "changed", True)
+    with pytest.raises(TypeError):
+        dict.update(nested, {"changed": True})
+    with pytest.raises(TypeError):
+        list.append(items, 3)
+    with pytest.raises(TypeError):
+        list.__setitem__(items, 0, 99)
+
+    assert plain_json(frozen) == expected
+
+
+def test_frozen_json_requires_explicit_plain_export_for_serialization() -> None:
+    frozen = validated_json_mapping({"nested": {"items": [1, 2]}})
+
+    with pytest.raises(TypeError, match="not JSON serializable"):
+        json.dumps(frozen)
+    assert json.loads(json.dumps(plain_json(frozen), sort_keys=True)) == {
+        "nested": {"items": [1, 2]}
     }
 
 

--- a/tests/test_rollout_bank_io.py
+++ b/tests/test_rollout_bank_io.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import causal4d.rollout_bank_io as rollout_bank_io
+from causal4d.immutable_json import plain_json
 from causal4d.rollout_bank import JointRolloutBank
 from causal4d.rollout_bank_io import load_rollout_bank, save_rollout_bank
 
@@ -41,7 +42,10 @@ def _legacy_archive(path: Path, bank: JointRolloutBank, manifest: dict) -> None:
         path,
         hypothesis_ids=np.asarray(bank.hypothesis_ids),
         hypothesis_metadata_json=np.asarray(
-            [json.dumps(value, sort_keys=True) for value in bank.hypothesis_metadata]
+            [
+                json.dumps(plain_json(value), sort_keys=True)
+                for value in bank.hypothesis_metadata
+            ]
         ),
         hypothesis_prior_weights=bank.hypothesis_prior_weights,
         parameter_particles=bank.parameter_particles,


### PR DESCRIPTION
## Summary

- replace mutable `dict`/`list` subclasses with genuine read-only `Mapping`/`Sequence` JSON values and require explicit `plain_json()` exports;
- back frozen NumPy arrays with immutable byte storage so writeability cannot be restored;
- migrate every core/public write-flag-only freeze, including external forecast and horizon-discrepancy paths, and add a policy test preventing regression;
- centralize the complete versioned BayesianPhysTwin module inventory in one strict machine-readable registry used by the AST import boundary; and
- synchronize provider-v2/artifact-v2 documentation and the changelog.

## Why

The previous frozen JSON values inherited from mutable built-ins, allowing base-class descriptors to bypass their overridden mutators. Ordinary owned NumPy arrays also allowed callers to re-enable writes after `setflags(False)`. Both behaviors could mutate claim-bearing values after validation or content-ID calculation.

The provider-v2 compatibility fix also showed that the module inventory was manually duplicated. The registry removes that drift source without admitting unversioned or private imports.

## Scientific boundary

Maintenance-only. No estimator, protocol, likelihood, target-access rule, registered analysis, or evidence count changes. Valid-input artifact identities and fallback behavior remain covered by the suite.

## Publication and validation

The SHA-256-bound publication gate reconstructed and applied the exact reviewed patch, removed all temporary transport files, and published product commit `bad9fdf9bbeb3bd16641859a1daa4d49b4881e5a`. A connector-authored changelog-only follow-up records the adversarial coverage on the current head.

On the applied product tree:

- Ruff lint: passed;
- Ruff formatting: passed after deterministic formatting of nine changed files;
- mypy on the stable integrity/provider boundary: passed;
- complete suite: **1074 passed, 16 expected optional/build skips**;
- wheel and source distribution build: passed;
- `twine check` for both distributions: passed;
- isolated installed-wheel and external-forecast/horizon-discrepancy immutability smokes: passed;
- zero source uses of write-flag-only freezing remain.

The PR contains exactly the 45 intended product files and no publication workflow or transport artifact.