### PR TITLE
Harden claim-bearing physical target evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- Add a strict non-pickled physical evaluation target with canonical float32
+  observation identities, target/context validation, and atomic exactly-once
+  publication.
+- Add an explicit legacy importer that requires unsafe-pickle consent and an
+  independently obtained SHA-256 before opening PhysTwin `final_data.pkl`.
+
 - Add a locked, source-only Deform360 filament-support boundary that preserves
   exact registered graphs on connected resets and applies a deterministic
   component-level minimum-spanning bridge only to the frozen disconnected
@@ -53,6 +59,10 @@ evidence. Source-panel executions remain source-only and cannot increment the
 `0/36` confirmatory evidence count.
 
 ### Fixed
+
+- Remove direct pickle loading from the stable claim-bearing physical evaluator,
+  bind results to posterior, query, physical-target, and held-out-suffix IDs, and
+  publish result JSON atomically with no-overwrite behavior by default.
 
 - Reject coercible or schema-drifted Causal4D contract descriptors, archive
   inventories, support indices, and grouped-observation indices before they can

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,11 @@ Bayesian-PhysTwin provider boundary. Unpickling can execute code. A SHA-256 chec
 proves that the bytes match an expected digest; it does not make arbitrary pickle
 content safe or sandbox its execution.
 
+For registered physical-counterfactual evaluation, prefer the one-time
+`causal4d evidence physical-target import-legacy` conversion. It requires
+explicit unsafe-pickle consent and an expected digest, then emits a strict
+non-pickled artifact used by the stable evaluator.
+
 Only load a legacy pickle when all of the following hold:
 
 1. the expected digest was obtained through a trusted, independently identified

--- a/docs/physical_target_artifact.md
+++ b/docs/physical_target_artifact.md
@@ -1,0 +1,73 @@
+# Physical evaluation target artifact
+
+The stable physical-counterfactual evaluator consumes a non-pickled,
+content-addressed `PhysicalTargetBundle`. It no longer opens `final_data.pkl`
+directly.
+
+## Why this boundary exists
+
+Python pickle is executable code. A digest proves byte identity but does not make
+untrusted pickle content safe. Legacy PhysTwin data is therefore opened only by
+an explicit conversion command that requires both operator consent and an
+independently obtained SHA-256. All subsequent evaluation uses a strict NPZ
+artifact loaded with `allow_pickle=False`.
+
+The target artifact binds:
+
+- the complete `CausalContext`, including protocol, case, observation windows,
+  and counterfactual action;
+- the canonical float32 `object_points` bytes used by the PhysTwin backend, from
+  the pre-intervention endpoint through the end of `O+`;
+- the point-frame validity mask and its canonical provider semantics;
+- the trusted legacy source SHA-256;
+- payload hashes and one content-derived artifact ID.
+
+The importer reproduces the backend's declared float32 observation normalization
+before checking `O-` and `O+`. The stored hashes therefore match the bytes used to
+build the Causal4D context, while the trusted pickle SHA-256 separately binds the
+original source file.
+
+## Convert one trusted legacy target
+
+Obtain the expected digest through the trusted experiment manifest or release
+channel, not from an untrusted sidecar supplied with the same file.
+
+```bash
+sha256sum /data/case/final_data.pkl
+
+causal4d evidence physical-target import-legacy \
+  physical-posterior.npz \
+  /data/case/final_data.pkl \
+  physical-target.npz \
+  --allow-unsafe-pickle \
+  --expected-sha256 <lowercase-sha256>
+```
+
+The command verifies the digest before unpickling, rejects symlinked pickle
+paths through `load_trusted_pickle`, validates the observation and validity
+arrays, checks the complete `O+` digest against the posterior context, and
+publishes the NPZ atomically. Publication is exactly once by default. Use
+`--overwrite` only for an explicitly non-frozen replacement.
+
+## Evaluate without pickle
+
+```bash
+causal4d evidence physical-counterfactual evaluate \
+  physical-posterior.npz \
+  physical-target.npz \
+  physical-evaluation.json \
+  --start-frame 7
+```
+
+The evaluator independently checks context equality, frame alignment, and node
+support. It creates an additive `EvaluationTarget` identity for the exact suffix
+selected by `--start-frame`, binds that ID together with the physical posterior,
+query, and target IDs, and publishes a content-addressed JSON result atomically.
+The output is also exactly once by default.
+
+## Scientific boundary
+
+A valid target artifact establishes data identity, alignment, and safe transport.
+It is not accuracy, calibration, transfer, or physical-experiment evidence. The
+registered analysis manifest and evidence registry still decide whether an
+execution may contribute to a claim.

--- a/scripts/remote/run_causal4d_abduction_pipeline.sh
+++ b/scripts/remote/run_causal4d_abduction_pipeline.sh
@@ -14,9 +14,11 @@ contact_count="${CAUSAL4D_CONTACT_STATES:-9}"
 prefix_frames="${CAUSAL4D_O_PLUS_PREFIX_FRAMES:-6}"
 
 case_dir="${data_root}/${case_name}"
+final_data="${case_dir}/final_data.pkl"
 profile="${profile_dir}/parameter_profile.npz"
 checkpoint="${profile_dir}/refit_checkpoint.pt"
 mkdir -p "${output}"
+final_data_sha256="$(sha256sum "${final_data}" | awk '{print $1}')"
 
 run() {
   PYTHONPATH="${repo_root}/src" CUDA_VISIBLE_DEVICES="${PHYSTWIN_GPU:-0}" \
@@ -39,7 +41,7 @@ run -m causal4d.cli.phystwin_rollout_bank \
 run -m causal4d.cli.abduct_phystwin_intervention \
   "${output}/known.bank.npz" \
   "${output}/known.twin_belief.npz" \
-  "${case_dir}/final_data.pkl" \
+  "${final_data}" \
   "${output}/factual.npz" \
   "${output}/factual_evaluation.json" \
   --o-plus-prefix-frames "${prefix_frames}"
@@ -56,9 +58,16 @@ for specification in "known_action:same_grasp" "history_reverse:new_contact"; do
     --maximum-contact-states "${contact_count}"
 done
 
+run -m causal4d.cli.import_physical_target \
+  "${output}/known_action.physical.npz" \
+  "${final_data}" \
+  "${output}/known_action.target.npz" \
+  --allow-unsafe-pickle \
+  --expected-sha256 "${final_data_sha256}"
+
 run -m causal4d.cli.evaluate_physical_counterfactual \
   "${output}/known_action.physical.npz" \
-  "${case_dir}/final_data.pkl" \
+  "${output}/known_action.target.npz" \
   "${output}/known_action.beta0_evaluation.json" \
   --start-frame "$((prefix_frames + 1))"
 

--- a/src/causal4d/cli/command_registry.py
+++ b/src/causal4d/cli/command_registry.py
@@ -148,14 +148,21 @@ COMMANDS = (
         removed_in=REMOVED_EXECUTABLE_VERSION,
     ),
     CommandSpec(
+        route=("evidence", "physical-target", "import-legacy"),
+        target="causal4d.cli.import_physical_target:main",
+        summary="Convert a trusted legacy target into the safe target contract.",
+        lifecycle="stable",
+        extras=("phystwin",),
+        claim_bearing=True,
+        requires=("BayesianPhysTwin provider", "trusted legacy pickle"),
+    ),
+    CommandSpec(
         route=("evidence", "physical-counterfactual", "evaluate"),
         target="causal4d.cli.evaluate_physical_counterfactual:main",
         summary="Evaluate registered physical counterfactual predictions.",
         lifecycle="stable",
         historical_name="causal4d-evaluate-physical-counterfactual",
-        extras=("phystwin",),
         claim_bearing=True,
-        requires=("BayesianPhysTwin provider",),
         removed_in=REMOVED_EXECUTABLE_VERSION,
     ),
     CommandSpec(

--- a/src/causal4d/cli/evaluate_physical_counterfactual.py
+++ b/src/causal4d/cli/evaluate_physical_counterfactual.py
@@ -1,73 +1,169 @@
-"""Evaluate a PhysicalPosterior without semantic evidence."""
+"""Evaluate a PhysicalPosterior against an identity-bound physical target."""
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
-import pickle
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import Any, BinaryIO
 
 import numpy as np
 
+EVALUATION_SCHEMA = "causal4d.physical_counterfactual_evaluation"
+EVALUATION_SCHEMA_VERSION = 1
+
 
 def _load_runtime_dependencies() -> None:
-    """Load optional integrations only after argparse handles ``--help``."""
-    global target_validity
+    """Load command dependencies only after argparse handles ``--help``."""
+
+    global atomic_write_binary
     global PhysicalPosterior
     global load_contract
+    global load_physical_target
     global evaluate_beta_zero_physical_posterior
 
-    from bayesian_phystwin.causal4d_provider_v1 import target_validity
+    from causal4d.atomic_io import atomic_write_binary
     from causal4d.contracts import PhysicalPosterior, load_contract
+    from causal4d.physical_target import load_physical_target
     from causal4d.physical_validation import evaluate_beta_zero_physical_posterior
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Evaluate a discrepancy-aware physical posterior at beta=0."
+        description=(
+            "Evaluate a discrepancy-aware physical posterior at beta=0 against "
+            "a strict, non-pickled physical target artifact."
+        )
     )
     parser.add_argument("physical_posterior_npz")
-    parser.add_argument("final_data_pickle")
+    parser.add_argument("physical_target_npz")
     parser.add_argument("output_json")
     parser.add_argument("--start-frame", type=int, default=1)
     parser.add_argument("--confidence-level", type=float, default=0.90)
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="replace an existing result instead of enforcing exactly-once output",
+    )
     return parser
+
+
+def _evaluation_id(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_json_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON constant {value!r} is not allowed")
+
+
+def _reject_symlink_components(path: Path) -> None:
+    absolute = path.absolute()
+    current = Path(absolute.anchor)
+    for component in absolute.parts[1:]:
+        current /= component
+        if current.is_symlink():
+            raise ValueError(
+                f"physical evaluation output path contains a symlink: {current}"
+            )
+
+
+def _publish_result(
+    path: str | Path,
+    result: Mapping[str, Any],
+    *,
+    overwrite: bool,
+) -> None:
+    target = Path(path)
+    _reject_symlink_components(target)
+    serialized = (
+        json.dumps(result, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    ).encode("utf-8")
+
+    def writer(handle: BinaryIO) -> None:
+        handle.write(serialized)
+
+    def validate(temporary: Path) -> None:
+        try:
+            restored = json.loads(
+                temporary.read_text(encoding="utf-8"),
+                object_pairs_hook=_reject_duplicate_json_keys,
+                parse_constant=_reject_nonfinite_json_constant,
+            )
+        except (OSError, UnicodeError, json.JSONDecodeError) as error:
+            raise ValueError("physical evaluation result is not valid JSON") from error
+        if not isinstance(restored, dict) or restored != dict(result):
+            raise ValueError("physical evaluation result changed during serialization")
+        candidate = dict(restored)
+        artifact_id = candidate.pop("evaluation_id", None)
+        if artifact_id != _evaluation_id(candidate):
+            raise ValueError("physical evaluation result has an invalid content ID")
+
+    atomic_write_binary(
+        target,
+        writer,
+        overwrite=overwrite,
+        validate=validate,
+    )
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     _load_runtime_dependencies()
-    artifact = load_contract(args.physical_posterior_npz)
-    if not isinstance(artifact, PhysicalPosterior):
+    if not np.isfinite(args.confidence_level) or not 0.0 < args.confidence_level < 1.0:
+        raise ValueError("--confidence-level must lie strictly between zero and one")
+
+    posterior = load_contract(args.physical_posterior_npz)
+    if not isinstance(posterior, PhysicalPosterior):
         raise TypeError("physical_posterior_npz must contain a PhysicalPosterior")
-    with Path(args.final_data_pickle).open("rb") as handle:
-        data = pickle.load(handle)
-    observed = np.asarray(data["object_points"], dtype=float)
-    valid = target_validity(
-        np.asarray(data["object_visibilities"], dtype=bool),
-        np.asarray(data["object_motions_valid"], dtype=bool),
-    )
-    endpoint = artifact.context.o_minus.frame_stop - 1
-    state_count = artifact.readout_trajectories_m.shape[2]
-    truth = observed[endpoint:, :state_count]
-    mask = valid[endpoint:, :state_count]
-    result = evaluate_beta_zero_physical_posterior(
-        artifact,
+    target = load_physical_target(args.physical_target_npz)
+    truth, mask = target.aligned_for_posterior(posterior)
+    evaluation_target = target.evaluation_target(start_frame=args.start_frame)
+
+    metrics = evaluate_beta_zero_physical_posterior(
+        posterior,
         truth,
         mask=mask,
         start_frame=args.start_frame,
         confidence_level=args.confidence_level,
     )
-    result["case"] = artifact.context.case_id
-    result["causal_context"] = artifact.context.as_dict()
-    output = Path(args.output_json)
-    output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(
-        json.dumps(result, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
+    result: dict[str, Any] = {
+        **metrics,
+        "schema": EVALUATION_SCHEMA,
+        "schema_version": EVALUATION_SCHEMA_VERSION,
+        "case": posterior.context.case_id,
+        "causal_context": posterior.context.as_dict(),
+        "physical_posterior_id": posterior.artifact_id,
+        "source_query_id": posterior.source_query_id,
+        "physical_target_id": target.artifact_id,
+        "evaluation_target_id": evaluation_target.artifact_id,
+        "evaluation_target": evaluation_target.as_dict(),
+        "source_final_data_sha256": target.source_final_data_sha256,
+        "confidence_level": float(args.confidence_level),
+    }
+    result["evaluation_id"] = _evaluation_id(result)
+    _publish_result(
+        args.output_json,
+        result,
+        overwrite=args.overwrite,
     )
-    print(json.dumps(result, indent=2, sort_keys=True))
+    print(json.dumps(result, indent=2, sort_keys=True, allow_nan=False))
     return 0
 
 

--- a/src/causal4d/cli/import_physical_target.py
+++ b/src/causal4d/cli/import_physical_target.py
@@ -1,0 +1,141 @@
+"""Convert a trusted legacy PhysTwin target into a safe Causal4D artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def _load_runtime_dependencies() -> None:
+    """Load optional integrations only after argparse handles ``--help``."""
+
+    global target_validity
+    global PhysicalPosterior
+    global load_contract
+    global build_physical_target
+    global save_physical_target
+    global load_trusted_pickle
+
+    from bayesian_phystwin.causal4d_provider_v1 import target_validity
+    from causal4d.contracts import PhysicalPosterior, load_contract
+    from causal4d.physical_target import (
+        build_physical_target,
+        save_physical_target,
+    )
+    from causal4d.trusted_pickle import load_trusted_pickle
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert one explicitly trusted, digest-verified legacy final_data "
+            "pickle into a strict non-pickled physical evaluation target."
+        )
+    )
+    parser.add_argument("physical_posterior_npz")
+    parser.add_argument("legacy_final_data_pickle")
+    parser.add_argument("output_target_npz")
+    parser.add_argument(
+        "--allow-unsafe-pickle",
+        action="store_true",
+        required=True,
+        help=(
+            "required explicit consent: Python pickle loading can execute code; "
+            "use only with a trusted producer and independently obtained digest"
+        ),
+    )
+    parser.add_argument(
+        "--expected-sha256",
+        required=True,
+        help="independently obtained lowercase SHA-256 of the legacy pickle",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="replace an existing target instead of enforcing exactly-once output",
+    )
+    return parser
+
+
+def _require_mapping(value: Any) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError("legacy final_data payload must be a mapping")
+    if any(type(key) is not str for key in value):
+        raise ValueError("legacy final_data mapping keys must be strings")
+    return value
+
+
+def _required_array(data: Mapping[str, Any], name: str) -> np.ndarray:
+    if name not in data:
+        raise ValueError(f"legacy final_data payload is missing {name!r}")
+    return np.asarray(data[name])
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    _load_runtime_dependencies()
+
+    posterior = load_contract(args.physical_posterior_npz)
+    if not isinstance(posterior, PhysicalPosterior):
+        raise TypeError("physical_posterior_npz must contain a PhysicalPosterior")
+    data = _require_mapping(
+        load_trusted_pickle(
+            args.legacy_final_data_pickle,
+            allow_unsafe_pickle=args.allow_unsafe_pickle,
+            expected_sha256=args.expected_sha256,
+        )
+    )
+
+    object_points = _required_array(data, "object_points")
+    visible = _required_array(data, "object_visibilities")
+    motion_valid = _required_array(data, "object_motions_valid")
+    if object_points.dtype not in {np.dtype(np.float32), np.dtype(np.float64)}:
+        raise ValueError("legacy object_points must use float32 or float64")
+    if object_points.ndim != 3 or object_points.shape[2] != 3:
+        raise ValueError("legacy object_points must have shape (T, N, 3)")
+    if visible.dtype != np.dtype(bool) or visible.shape != object_points.shape[:2]:
+        raise ValueError("legacy object_visibilities must have boolean shape (T, N)")
+    if motion_valid.dtype != np.dtype(bool):
+        raise ValueError("legacy object_motions_valid must use the boolean dtype")
+
+    canonical_points = np.asarray(object_points, dtype=np.float32)
+    valid = target_validity(visible, motion_valid)
+    if np.asarray(valid).dtype != np.dtype(bool):
+        raise ValueError("target_validity must return a boolean array")
+    bundle = build_physical_target(
+        posterior.context,
+        canonical_points,
+        valid,
+        source_final_data_sha256=args.expected_sha256,
+        metadata={
+            "importer": "causal4d evidence physical-target import-legacy",
+            "source_keys": [
+                "object_points",
+                "object_visibilities",
+                "object_motions_valid",
+            ],
+        },
+    )
+    bundle.aligned_for_posterior(posterior)
+    save_physical_target(
+        args.output_target_npz,
+        bundle,
+        overwrite=args.overwrite,
+    )
+    result = {
+        **bundle.summary(),
+        "output": str(Path(args.output_target_npz).resolve()),
+        "unsafe_pickle_consent": True,
+        "source_digest_verified_before_unpickling": True,
+    }
+    print(json.dumps(result, indent=2, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d/physical_target.py
+++ b/src/causal4d/physical_target.py
@@ -1,0 +1,547 @@
+"""Portable, content-addressed physical evaluation targets."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import stat
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, BinaryIO
+
+import numpy as np
+
+from causal4d.atomic_io import atomic_write_binary
+from causal4d.contracts import (
+    CausalContext,
+    ObservationWindow,
+    PhysicalPosterior,
+    array_sha256,
+)
+from causal4d.immutable_json import plain_json, validated_json_mapping
+from causal4d.stage_provenance import EvaluationTarget
+
+PHYSICAL_TARGET_SCHEMA = "causal4d.physical_evaluation_target"
+PHYSICAL_TARGET_SCHEMA_VERSION = 1
+PHYSICAL_TARGET_OBSERVATION_SEMANTICS = (
+    "causal4d.phystwin_backend.object_points_float32"
+)
+PHYSICAL_TARGET_VALIDITY_SEMANTICS = (
+    "bayesian_phystwin.causal4d_provider_v1.target_validity"
+)
+
+_ARCHIVE_FIELDS = frozenset(
+    {
+        "descriptor_json",
+        "object_points",
+        "validity_mask",
+    }
+)
+_DESCRIPTOR_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "artifact_id",
+        "context",
+        "source",
+        "alignment",
+        "metadata",
+        "payload",
+    }
+)
+_SOURCE_FIELDS = frozenset(
+    {
+        "format",
+        "observation_semantics",
+        "sha256",
+        "validity_semantics",
+    }
+)
+_ALIGNMENT_FIELDS = frozenset(
+    {
+        "anchor_frame",
+        "frame_stop",
+        "stream_id",
+    }
+)
+_PAYLOAD_FIELDS = frozenset(
+    {
+        "object_points_sha256",
+        "validity_mask_sha256",
+    }
+)
+_LOWER_HEX = frozenset("0123456789abcdef")
+
+
+def _require_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    if any(type(key) is not str for key in value):
+        raise ValueError(f"{name} keys must be strings")
+    return value
+
+
+def _require_exact_fields(
+    value: Any,
+    *,
+    name: str,
+    required: frozenset[str],
+) -> Mapping[str, Any]:
+    mapping = _require_mapping(value, name=name)
+    actual = set(mapping)
+    missing = sorted(required - actual)
+    unexpected = sorted(actual - required)
+    if missing or unexpected:
+        raise ValueError(
+            f"{name} fields do not match schema; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    return mapping
+
+
+def _require_nonempty_string(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _require_integer(value: Any, *, name: str, minimum: int = 0) -> int:
+    if type(value) is not int or value < minimum:
+        raise ValueError(
+            f"{name} must be an integer greater than or equal to {minimum}"
+        )
+    return value
+
+
+def _validate_sha256(value: Any, *, name: str) -> str:
+    if (
+        type(value) is not str
+        or len(value) != 64
+        or any(character not in _LOWER_HEX for character in value)
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_json_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON constant {value!r} is not allowed")
+
+
+def _canonical_json(value: Mapping[str, Any]) -> str:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def _parse_descriptor(value: np.ndarray) -> Mapping[str, Any]:
+    array = np.asarray(value)
+    if array.shape != () or array.dtype.kind not in {"U", "S"}:
+        raise ValueError("descriptor_json must be one scalar string")
+    scalar = array.item()
+    if isinstance(scalar, bytes):
+        try:
+            scalar = scalar.decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise ValueError("descriptor_json is not valid UTF-8") from error
+    try:
+        parsed = json.loads(
+            scalar,
+            object_pairs_hook=_reject_duplicate_json_keys,
+            parse_constant=_reject_nonfinite_json_constant,
+        )
+    except (TypeError, ValueError, json.JSONDecodeError) as error:
+        raise ValueError("descriptor_json is not valid canonical JSON") from error
+    return _require_mapping(parsed, name="physical target descriptor")
+
+
+def _reject_symlink_components(path: Path) -> None:
+    absolute = path.absolute()
+    current = Path(absolute.anchor)
+    for component in absolute.parts[1:]:
+        current /= component
+        if current.is_symlink():
+            raise ValueError(f"physical target path contains a symlink: {current}")
+
+
+@dataclass(frozen=True)
+class PhysicalTargetBundle:
+    """Held-out physical observations aligned to one Causal4D trajectory."""
+
+    context: CausalContext
+    object_points: np.ndarray
+    validity_mask: np.ndarray
+    source_final_data_sha256: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if type(self.context) is not CausalContext:
+            raise ValueError("context must be a CausalContext")
+        source_sha256 = _validate_sha256(
+            self.source_final_data_sha256,
+            name="source_final_data_sha256",
+        )
+
+        raw_points = np.asarray(self.object_points)
+        if raw_points.dtype != np.dtype(np.float32):
+            raise ValueError("object_points must use the canonical float32 dtype")
+        points = np.ascontiguousarray(raw_points).copy()
+        if points.ndim != 3 or points.shape[1] < 1 or points.shape[2] != 3:
+            raise ValueError("object_points must have shape (T, N>=1, 3)")
+
+        raw_valid = np.asarray(self.validity_mask)
+        if raw_valid.dtype != np.dtype(bool):
+            raise ValueError("validity_mask must use the boolean dtype")
+        valid = np.ascontiguousarray(raw_valid).copy()
+        if valid.shape != points.shape[:2]:
+            raise ValueError("validity_mask must have shape (T, N)")
+
+        anchor_frame = self.anchor_frame
+        expected_frames = self.context.o_plus.frame_stop - anchor_frame
+        if expected_frames < 2 or len(points) != expected_frames:
+            raise ValueError(
+                "object_points must cover the pre-intervention endpoint through O+"
+            )
+        o_plus_offset = self.context.o_plus.frame_start - anchor_frame
+        if not 0 <= o_plus_offset < len(points):
+            raise ValueError("O+ does not lie inside the aligned physical target")
+        if array_sha256(points[o_plus_offset:]) != (
+            self.context.o_plus.content_sha256
+        ):
+            raise ValueError("physical target does not match the declared O+ digest")
+        if np.any(valid & ~np.all(np.isfinite(points), axis=2)):
+            raise ValueError("valid physical target points must be finite")
+        if not np.any(valid[o_plus_offset:]):
+            raise ValueError("physical target has no valid O+ point frames")
+
+        points.setflags(write=False)
+        valid.setflags(write=False)
+        metadata = validated_json_mapping(
+            self.metadata,
+            error_message="physical target metadata must be finite JSON data",
+        )
+        object.__setattr__(self, "object_points", points)
+        object.__setattr__(self, "validity_mask", valid)
+        object.__setattr__(self, "source_final_data_sha256", source_sha256)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def anchor_frame(self) -> int:
+        """Global frame represented by local trajectory frame zero."""
+
+        return self.context.o_minus.frame_stop - 1
+
+    @property
+    def frame_stop(self) -> int:
+        return self.context.o_plus.frame_stop
+
+    @property
+    def frame_count(self) -> int:
+        return len(self.object_points)
+
+    @property
+    def point_count(self) -> int:
+        return int(self.object_points.shape[1])
+
+    def _descriptor_without_id(self) -> dict[str, Any]:
+        return {
+            "schema": PHYSICAL_TARGET_SCHEMA,
+            "schema_version": PHYSICAL_TARGET_SCHEMA_VERSION,
+            "context": self.context.as_dict(),
+            "source": {
+                "format": "trusted_python_pickle",
+                "observation_semantics": PHYSICAL_TARGET_OBSERVATION_SEMANTICS,
+                "sha256": self.source_final_data_sha256,
+                "validity_semantics": PHYSICAL_TARGET_VALIDITY_SEMANTICS,
+            },
+            "alignment": {
+                "anchor_frame": self.anchor_frame,
+                "frame_stop": self.frame_stop,
+                "stream_id": self.context.o_plus.stream_id,
+            },
+            "metadata": plain_json(self.metadata),
+            "payload": {
+                "object_points_sha256": array_sha256(self.object_points),
+                "validity_mask_sha256": array_sha256(self.validity_mask),
+            },
+        }
+
+    @property
+    def artifact_id(self) -> str:
+        encoded = _canonical_json(self._descriptor_without_id()).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def descriptor(self) -> dict[str, Any]:
+        descriptor = self._descriptor_without_id()
+        descriptor["artifact_id"] = self.artifact_id
+        return descriptor
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "artifact_id": self.artifact_id,
+            "protocol_id": self.context.protocol_id,
+            "case_id": self.context.case_id,
+            "stream_id": self.context.o_plus.stream_id,
+            "anchor_frame": self.anchor_frame,
+            "frame_stop": self.frame_stop,
+            "frame_count": self.frame_count,
+            "point_count": self.point_count,
+            "valid_point_frames": int(np.sum(self.validity_mask)),
+            "source_final_data_sha256": self.source_final_data_sha256,
+        }
+
+    def evaluation_target(self, *, start_frame: int) -> EvaluationTarget:
+        """Build a content identity for the selected held-out suffix."""
+
+        local_start = _require_integer(
+            start_frame,
+            name="start_frame",
+        )
+        if not 0 <= local_start < self.frame_count:
+            raise ValueError("start_frame must lie inside the physical target")
+        global_start = self.anchor_frame + local_start
+        if not (
+            self.context.o_plus.frame_start
+            <= global_start
+            < self.context.o_plus.frame_stop
+        ):
+            raise ValueError("evaluation suffix must be a nonempty part of O+")
+        target = ObservationWindow(
+            case_id=self.context.case_id,
+            stream_id=self.context.o_plus.stream_id,
+            frame_start=global_start,
+            frame_stop=self.context.o_plus.frame_stop,
+            content_sha256=array_sha256(self.object_points[local_start:]),
+        )
+        return EvaluationTarget(
+            protocol_id=self.context.protocol_id,
+            target=target,
+        )
+
+    def aligned_for_posterior(
+        self,
+        posterior: PhysicalPosterior,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Validate context and return the target restricted to posterior nodes."""
+
+        if type(posterior) is not PhysicalPosterior:
+            raise ValueError("posterior must be a PhysicalPosterior")
+        if posterior.context != self.context:
+            raise ValueError("physical target context does not match the posterior")
+        trajectory = posterior.readout_trajectories_m
+        if trajectory.shape[1] != self.frame_count:
+            raise ValueError("physical target frame count does not match the posterior")
+        node_count = int(trajectory.shape[2])
+        if self.point_count < node_count:
+            raise ValueError("physical target does not cover all posterior nodes")
+        return (
+            self.object_points[:, :node_count],
+            self.validity_mask[:, :node_count],
+        )
+
+
+def build_physical_target(
+    context: CausalContext,
+    object_points: np.ndarray,
+    validity_mask: np.ndarray,
+    *,
+    source_final_data_sha256: str,
+    metadata: Mapping[str, Any] | None = None,
+) -> PhysicalTargetBundle:
+    """Build an aligned target from an exact legacy acquisition payload."""
+
+    raw_points = np.asarray(object_points)
+    if raw_points.dtype not in {np.dtype(np.float32), np.dtype(np.float64)}:
+        raise ValueError("source object_points must use float32 or float64")
+    points = np.asarray(raw_points, dtype=np.float32)
+    valid = np.asarray(validity_mask)
+    if points.ndim != 3 or points.shape[2] != 3:
+        raise ValueError("source object_points must have shape (T, N, 3)")
+    if valid.shape != points.shape[:2]:
+        raise ValueError("source validity_mask must have shape (T, N)")
+    anchor = context.o_minus.frame_stop - 1
+    if anchor < 0 or context.o_plus.frame_stop > len(points):
+        raise ValueError("source object_points do not cover the Causal4D context")
+    if array_sha256(
+        points[context.o_minus.frame_start : context.o_minus.frame_stop]
+    ) != context.o_minus.content_sha256:
+        raise ValueError("source object_points do not match the declared O- digest")
+    if array_sha256(
+        points[context.o_plus.frame_start : context.o_plus.frame_stop]
+    ) != context.o_plus.content_sha256:
+        raise ValueError("source object_points do not match the declared O+ digest")
+    return PhysicalTargetBundle(
+        context=context,
+        object_points=points[anchor : context.o_plus.frame_stop],
+        validity_mask=valid[anchor : context.o_plus.frame_stop],
+        source_final_data_sha256=source_final_data_sha256,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def _save_archive(handle: BinaryIO, bundle: PhysicalTargetBundle) -> None:
+    np.savez_compressed(
+        handle,
+        descriptor_json=np.asarray(_canonical_json(bundle.descriptor())),
+        object_points=bundle.object_points,
+        validity_mask=bundle.validity_mask,
+    )
+
+
+def save_physical_target(
+    path: str | Path,
+    bundle: PhysicalTargetBundle,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Atomically publish and independently reload one target artifact."""
+
+    target = Path(path)
+    _reject_symlink_components(target)
+    expected_id = bundle.artifact_id
+
+    def validate(temporary: Path) -> None:
+        loaded = load_physical_target(temporary)
+        if loaded.artifact_id != expected_id:
+            raise ValueError("physical target changed during serialization")
+
+    atomic_write_binary(
+        target,
+        lambda handle: _save_archive(handle, bundle),
+        overwrite=overwrite,
+        validate=validate,
+    )
+
+
+def load_physical_target(path: str | Path) -> PhysicalTargetBundle:
+    """Load a strict non-pickled physical target from one immutable byte snapshot."""
+
+    supplied = Path(path)
+    _reject_symlink_components(supplied)
+    try:
+        metadata = supplied.stat()
+    except FileNotFoundError:
+        raise FileNotFoundError(f"physical target does not exist: {supplied}") from None
+    if not stat.S_ISREG(metadata.st_mode):
+        raise ValueError(f"physical target must be an ordinary file: {supplied}")
+    payload = supplied.read_bytes()
+
+    try:
+        with np.load(io.BytesIO(payload), allow_pickle=False) as archive:
+            actual_fields = set(archive.files)
+            if actual_fields != _ARCHIVE_FIELDS:
+                raise ValueError(
+                    "physical target archive fields do not match schema; "
+                    f"missing={sorted(_ARCHIVE_FIELDS - actual_fields)}, "
+                    f"unexpected={sorted(actual_fields - _ARCHIVE_FIELDS)}"
+                )
+            descriptor = _require_exact_fields(
+                _parse_descriptor(archive["descriptor_json"]),
+                name="physical target descriptor",
+                required=_DESCRIPTOR_FIELDS,
+            )
+            points = np.asarray(archive["object_points"])
+            valid = np.asarray(archive["validity_mask"])
+    except (OSError, ValueError) as error:
+        if isinstance(error, ValueError) and str(error).startswith("physical target"):
+            raise
+        raise ValueError("physical target is not a valid non-pickled NPZ") from error
+
+    if type(descriptor["schema"]) is not str or (
+        descriptor["schema"] != PHYSICAL_TARGET_SCHEMA
+    ):
+        raise ValueError("unexpected physical target schema")
+    if type(descriptor["schema_version"]) is not int or (
+        descriptor["schema_version"] != PHYSICAL_TARGET_SCHEMA_VERSION
+    ):
+        raise ValueError("unsupported physical target schema version")
+    _validate_sha256(
+        descriptor["artifact_id"],
+        name="physical target artifact_id",
+    )
+    source = _require_exact_fields(
+        descriptor["source"],
+        name="physical target source",
+        required=_SOURCE_FIELDS,
+    )
+    if type(source["format"]) is not str or (
+        source["format"] != "trusted_python_pickle"
+    ):
+        raise ValueError("unsupported physical target source format")
+    if type(source["observation_semantics"]) is not str or (
+        source["observation_semantics"] != PHYSICAL_TARGET_OBSERVATION_SEMANTICS
+    ):
+        raise ValueError("unsupported physical target observation semantics")
+    if type(source["validity_semantics"]) is not str or (
+        source["validity_semantics"] != PHYSICAL_TARGET_VALIDITY_SEMANTICS
+    ):
+        raise ValueError("unsupported physical target validity semantics")
+    alignment = _require_exact_fields(
+        descriptor["alignment"],
+        name="physical target alignment",
+        required=_ALIGNMENT_FIELDS,
+    )
+    if type(alignment["anchor_frame"]) is not int or (
+        alignment["anchor_frame"] < 0
+    ):
+        raise ValueError("physical target anchor_frame must be a nonnegative integer")
+    if type(alignment["frame_stop"]) is not int or alignment["frame_stop"] < 1:
+        raise ValueError("physical target frame_stop must be a positive integer")
+    _require_nonempty_string(alignment["stream_id"], name="alignment.stream_id")
+    payload_descriptor = _require_exact_fields(
+        descriptor["payload"],
+        name="physical target payload",
+        required=_PAYLOAD_FIELDS,
+    )
+    for name, value in payload_descriptor.items():
+        _validate_sha256(value, name=f"physical target payload.{name}")
+    context = CausalContext.from_dict(
+        _require_mapping(descriptor["context"], name="physical target context")
+    )
+    bundle = PhysicalTargetBundle(
+        context=context,
+        object_points=points,
+        validity_mask=valid,
+        source_final_data_sha256=_validate_sha256(
+            source["sha256"],
+            name="physical target source.sha256",
+        ),
+        metadata=_require_mapping(
+            descriptor["metadata"],
+            name="physical target metadata",
+        ),
+    )
+    if alignment != bundle.descriptor()["alignment"]:
+        raise ValueError("physical target alignment does not match its arrays")
+    if payload_descriptor != bundle.descriptor()["payload"]:
+        raise ValueError("physical target payload hashes do not match its arrays")
+    if descriptor["artifact_id"] != bundle.artifact_id:
+        raise ValueError("physical target artifact_id does not match its content")
+    if dict(descriptor) != bundle.descriptor():
+        raise ValueError("physical target descriptor is not canonical")
+    return bundle
+
+
+__all__ = [
+    "PHYSICAL_TARGET_SCHEMA",
+    "PHYSICAL_TARGET_SCHEMA_VERSION",
+    "PHYSICAL_TARGET_OBSERVATION_SEMANTICS",
+    "PHYSICAL_TARGET_VALIDITY_SEMANTICS",
+    "PhysicalTargetBundle",
+    "build_physical_target",
+    "load_physical_target",
+    "save_physical_target",
+]

--- a/src/causal4d/physical_target.py
+++ b/src/causal4d/physical_target.py
@@ -218,9 +218,7 @@ class PhysicalTargetBundle:
         o_plus_offset = self.context.o_plus.frame_start - anchor_frame
         if not 0 <= o_plus_offset < len(points):
             raise ValueError("O+ does not lie inside the aligned physical target")
-        if array_sha256(points[o_plus_offset:]) != (
-            self.context.o_plus.content_sha256
-        ):
+        if array_sha256(points[o_plus_offset:]) != (self.context.o_plus.content_sha256):
             raise ValueError("physical target does not match the declared O+ digest")
         if np.any(valid & ~np.all(np.isfinite(points), axis=2)):
             raise ValueError("valid physical target points must be finite")
@@ -375,13 +373,15 @@ def build_physical_target(
     anchor = context.o_minus.frame_stop - 1
     if anchor < 0 or context.o_plus.frame_stop > len(points):
         raise ValueError("source object_points do not cover the Causal4D context")
-    if array_sha256(
-        points[context.o_minus.frame_start : context.o_minus.frame_stop]
-    ) != context.o_minus.content_sha256:
+    if (
+        array_sha256(points[context.o_minus.frame_start : context.o_minus.frame_stop])
+        != context.o_minus.content_sha256
+    ):
         raise ValueError("source object_points do not match the declared O- digest")
-    if array_sha256(
-        points[context.o_plus.frame_start : context.o_plus.frame_stop]
-    ) != context.o_plus.content_sha256:
+    if (
+        array_sha256(points[context.o_plus.frame_start : context.o_plus.frame_stop])
+        != context.o_plus.content_sha256
+    ):
         raise ValueError("source object_points do not match the declared O+ digest")
     return PhysicalTargetBundle(
         context=context,
@@ -494,9 +494,7 @@ def load_physical_target(path: str | Path) -> PhysicalTargetBundle:
         name="physical target alignment",
         required=_ALIGNMENT_FIELDS,
     )
-    if type(alignment["anchor_frame"]) is not int or (
-        alignment["anchor_frame"] < 0
-    ):
+    if type(alignment["anchor_frame"]) is not int or (alignment["anchor_frame"] < 0):
         raise ValueError("physical target anchor_frame must be a nonnegative integer")
     if type(alignment["frame_stop"]) is not int or alignment["frame_stop"] < 1:
         raise ValueError("physical target frame_stop must be a positive integer")

--- a/tests/test_claim_bearing_pickle_boundary.py
+++ b/tests/test_claim_bearing_pickle_boundary.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from causal4d.cli.command_registry import find_command, grouped_commands
+
+
+def _module_path(module_name: str) -> Path:
+    repository_root = Path(__file__).resolve().parents[1]
+    relative = Path(*module_name.split(".")).with_suffix(".py")
+    for source_root in (repository_root / "src", repository_root):
+        candidate = source_root / relative
+        if candidate.is_file():
+            return candidate
+    raise AssertionError(f"cannot resolve command module {module_name!r}")
+
+
+def test_claim_bearing_commands_do_not_import_pickle_directly() -> None:
+    violations: list[str] = []
+    for command in grouped_commands():
+        if not command.claim_bearing:
+            continue
+        module_name = command.target.split(":", 1)[0]
+        path = _module_path(module_name)
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "pickle":
+                        violations.append(f"{path}:{node.lineno}: import pickle")
+            elif isinstance(node, ast.ImportFrom) and node.module == "pickle":
+                violations.append(f"{path}:{node.lineno}: from pickle import ...")
+    message = "claim-bearing commands import pickle directly:\n" + "\n".join(
+        violations
+    )
+    assert not violations, message
+
+
+def test_physical_target_routes_have_the_intended_claim_boundary() -> None:
+    importer = find_command("evidence/physical-target/import-legacy")
+    evaluator = find_command("evidence/physical-counterfactual/evaluate")
+    assert importer.claim_bearing
+    assert importer.extras == ("phystwin",)
+    assert evaluator.claim_bearing
+    assert evaluator.extras == ()
+    assert evaluator.requires == ()
+
+
+def test_physical_evaluator_has_no_bayesian_phystwin_imports() -> None:
+    evaluator = find_command("evidence/physical-counterfactual/evaluate")
+    module_name = evaluator.target.split(":", 1)[0]
+    path = _module_path(module_name)
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    provider_imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            provider_imports.extend(
+                alias.name
+                for alias in node.names
+                if alias.name.startswith("bayesian_phystwin")
+            )
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module.startswith("bayesian_phystwin"):
+                provider_imports.append(module)
+    assert not provider_imports, (
+        "physical evaluator imports an optional BayesianPhysTwin provider: "
+        f"{provider_imports}"
+    )

--- a/tests/test_claim_bearing_pickle_boundary.py
+++ b/tests/test_claim_bearing_pickle_boundary.py
@@ -31,9 +31,7 @@ def test_claim_bearing_commands_do_not_import_pickle_directly() -> None:
                         violations.append(f"{path}:{node.lineno}: import pickle")
             elif isinstance(node, ast.ImportFrom) and node.module == "pickle":
                 violations.append(f"{path}:{node.lineno}: from pickle import ...")
-    message = "claim-bearing commands import pickle directly:\n" + "\n".join(
-        violations
-    )
+    message = "claim-bearing commands import pickle directly:\n" + "\n".join(violations)
     assert not violations, message
 
 

--- a/tests/test_physical_target.py
+++ b/tests/test_physical_target.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from causal4d.contracts import PhysicalPosterior, array_sha256, build_causal_context
+from causal4d.physical_target import (
+    PhysicalTargetBundle,
+    build_physical_target,
+    load_physical_target,
+    save_physical_target,
+)
+
+
+def _fixture() -> tuple[PhysicalPosterior, np.ndarray, np.ndarray]:
+    observations = np.arange(7 * 2 * 3, dtype=np.float32).reshape(7, 2, 3)
+    actions = np.zeros((7, 1, 3), dtype=np.float64)
+    context = build_causal_context(
+        protocol_id="physical-target-unit",
+        case_id="synthetic",
+        observations=observations,
+        observed_actions=actions,
+        counterfactual_actions=actions,
+        intervention_frame=3,
+    )
+    states = np.zeros((2, 5, 2, 3), dtype=np.float32)
+    posterior = PhysicalPosterior(
+        context=context,
+        component_ids=("a", "b"),
+        state_trajectories_m=states,
+        readout_trajectories_m=states,
+        readout_variance_m2=np.full((2, 2, 3), 1e-5, dtype=np.float32),
+        weights=np.asarray([0.75, 0.25]),
+        phi=np.asarray([[1.0], [1.0]]),
+        kappa_cf=np.asarray([[0.0], [1.0]]),
+        hypothesis_indices=np.asarray([0, 1]),
+        twin_particle_indices=np.asarray([0, 0]),
+        phi_names=("gain",),
+        kappa_names=("contact",),
+        source_twin_belief_id="1" * 64,
+        source_factual_intervention_id="2" * 64,
+        source_query_id="3" * 64,
+    )
+    valid = np.ones(observations.shape[:2], dtype=bool)
+    valid[5, 1] = False
+    return posterior, observations, valid
+
+
+def _bundle() -> tuple[PhysicalTargetBundle, PhysicalPosterior, np.ndarray]:
+    posterior, observations, valid = _fixture()
+    bundle = build_physical_target(
+        posterior.context,
+        observations,
+        valid,
+        source_final_data_sha256="a" * 64,
+        metadata={"producer": "unit-test"},
+    )
+    return bundle, posterior, observations
+
+
+def test_physical_target_round_trip_preserves_canonical_backend_bytes(
+    tmp_path: Path,
+) -> None:
+    bundle, posterior, observations = _bundle()
+    path = tmp_path / "target.npz"
+    save_physical_target(path, bundle)
+    restored = load_physical_target(path)
+
+    assert restored.artifact_id == bundle.artifact_id
+    assert restored.object_points.dtype == observations.dtype
+    assert np.array_equal(restored.object_points, observations[2:])
+    assert not restored.object_points.flags.writeable
+    truth, valid = restored.aligned_for_posterior(posterior)
+    assert truth.shape == posterior.readout_trajectories_m.shape[1:]
+    assert valid.shape == truth.shape[:2]
+
+
+def test_evaluation_target_hashes_the_exact_selected_suffix() -> None:
+    bundle, _, observations = _bundle()
+    target = bundle.evaluation_target(start_frame=2)
+    assert target.target.frame_start == bundle.anchor_frame + 2
+    assert target.target.frame_stop == bundle.context.o_plus.frame_stop
+    assert target.target.content_sha256 == array_sha256(observations[4:])
+
+
+def test_builder_reproduces_backend_float32_observation_semantics() -> None:
+    bundle, posterior, observations = _bundle()
+    valid = np.ones(observations.shape[:2], dtype=bool)
+    valid[5, 1] = False
+    rebuilt = build_physical_target(
+        posterior.context,
+        observations.astype(np.float64),
+        valid,
+        source_final_data_sha256="b" * 64,
+    )
+    assert rebuilt.object_points.dtype == np.dtype(np.float32)
+    assert np.array_equal(rebuilt.object_points, observations[2:])
+    assert rebuilt.context.o_plus.content_sha256 == bundle.context.o_plus.content_sha256
+
+
+def test_physical_target_rejects_tampered_payload(tmp_path: Path) -> None:
+    bundle, _, _ = _bundle()
+    path = tmp_path / "target.npz"
+    save_physical_target(path, bundle)
+    with np.load(path, allow_pickle=False) as archive:
+        descriptor = np.asarray(archive["descriptor_json"])
+        points = np.asarray(archive["object_points"]).copy()
+        valid = np.asarray(archive["validity_mask"])
+    points[1, 0, 0] += np.float32(1.0)
+    np.savez_compressed(
+        path,
+        descriptor_json=descriptor,
+        object_points=points,
+        validity_mask=valid,
+    )
+    with pytest.raises(ValueError, match=r"O\+ digest|payload hashes"):
+        load_physical_target(path)
+
+
+def test_physical_target_rejects_context_or_support_mismatch() -> None:
+    bundle, posterior, observations = _bundle()
+    actions = np.zeros((7, 1, 3), dtype=np.float64)
+    changed_context = build_causal_context(
+        protocol_id="other-protocol",
+        case_id="synthetic",
+        observations=observations,
+        observed_actions=actions,
+        counterfactual_actions=actions,
+        intervention_frame=3,
+    )
+    changed_posterior = replace(posterior, context=changed_context)
+    with pytest.raises(ValueError, match="context does not match"):
+        bundle.aligned_for_posterior(changed_posterior)
+
+    too_short = replace(
+        posterior,
+        state_trajectories_m=posterior.state_trajectories_m[:, :-1],
+        readout_trajectories_m=posterior.readout_trajectories_m[:, :-1],
+    )
+    with pytest.raises(ValueError, match="frame count"):
+        bundle.aligned_for_posterior(too_short)
+
+
+def test_physical_target_publication_is_exactly_once_by_default(tmp_path: Path) -> None:
+    bundle, _, _ = _bundle()
+    path = tmp_path / "target.npz"
+    save_physical_target(path, bundle)
+    with pytest.raises(FileExistsError):
+        save_physical_target(path, bundle)
+    save_physical_target(path, bundle, overwrite=True)
+
+
+def test_physical_target_rejects_coercion_dependent_arrays() -> None:
+    bundle, _, _ = _bundle()
+    with pytest.raises(ValueError, match="canonical float32"):
+        PhysicalTargetBundle(
+            context=bundle.context,
+            object_points=bundle.object_points.astype(np.int64),
+            validity_mask=bundle.validity_mask,
+            source_final_data_sha256="a" * 64,
+        )
+    with pytest.raises(ValueError, match="boolean dtype"):
+        PhysicalTargetBundle(
+            context=bundle.context,
+            object_points=bundle.object_points,
+            validity_mask=bundle.validity_mask.astype(np.uint8),
+            source_final_data_sha256="a" * 64,
+        )

--- a/tests/test_physical_target_cli.py
+++ b/tests/test_physical_target_cli.py
@@ -60,8 +60,8 @@ def _posterior() -> tuple[PhysicalPosterior, np.ndarray]:
 
 def _install_import_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
     def load_dependencies() -> None:
-        import_cli.target_validity = (
-            lambda visible, motion: np.asarray(visible, dtype=bool)
+        import_cli.target_validity = lambda visible, motion: np.asarray(
+            visible, dtype=bool
         )
         import_cli.PhysicalPosterior = PhysicalPosterior
         import_cli.load_contract = load_contract
@@ -106,16 +106,19 @@ def test_legacy_import_requires_digest_and_produces_safe_target(
     digest = hashlib.sha256(pickle_path.read_bytes()).hexdigest()
     _install_import_dependencies(monkeypatch)
 
-    assert import_cli.main(
-        [
-            str(posterior_path),
-            str(pickle_path),
-            str(target_path),
-            "--allow-unsafe-pickle",
-            "--expected-sha256",
-            digest,
-        ]
-    ) == 0
+    assert (
+        import_cli.main(
+            [
+                str(posterior_path),
+                str(pickle_path),
+                str(target_path),
+                "--allow-unsafe-pickle",
+                "--expected-sha256",
+                digest,
+            ]
+        )
+        == 0
+    )
     target = load_physical_target(target_path)
     assert target.source_final_data_sha256 == digest
     assert target.object_points.dtype == np.dtype(np.float32)
@@ -140,21 +143,25 @@ def test_safe_evaluation_binds_target_and_publishes_exactly_once(
     save_physical_target(target_path, target)
     _install_evaluate_dependencies(monkeypatch)
 
-    assert evaluate_cli.main(
-        [
-            str(posterior_path),
-            str(target_path),
-            str(output_path),
-            "--start-frame",
-            "2",
-        ]
-    ) == 0
+    assert (
+        evaluate_cli.main(
+            [
+                str(posterior_path),
+                str(target_path),
+                str(output_path),
+                "--start-frame",
+                "2",
+            ]
+        )
+        == 0
+    )
     result = json.loads(output_path.read_text(encoding="utf-8"))
     assert result["physical_target_id"] == target.artifact_id
     assert result["physical_posterior_id"] == posterior.artifact_id
-    assert result["evaluation_target_id"] == target.evaluation_target(
-        start_frame=2
-    ).artifact_id
+    assert (
+        result["evaluation_target_id"]
+        == target.evaluation_target(start_frame=2).artifact_id
+    )
     assert len(result["evaluation_id"]) == 64
 
     with pytest.raises(FileExistsError):

--- a/tests/test_physical_target_cli.py
+++ b/tests/test_physical_target_cli.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import pickle
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from causal4d.atomic_io import atomic_write_binary
+from causal4d.cli import evaluate_physical_counterfactual as evaluate_cli
+from causal4d.cli import import_physical_target as import_cli
+from causal4d.contracts import (
+    PhysicalPosterior,
+    build_causal_context,
+    load_contract,
+    save_contract,
+)
+from causal4d.physical_target import (
+    build_physical_target,
+    load_physical_target,
+    save_physical_target,
+)
+from causal4d.physical_validation import evaluate_beta_zero_physical_posterior
+from causal4d.trusted_pickle import load_trusted_pickle
+
+
+def _posterior() -> tuple[PhysicalPosterior, np.ndarray]:
+    observations = np.zeros((7, 1, 3), dtype=np.float32)
+    actions = np.zeros((7, 1, 3), dtype=np.float64)
+    context = build_causal_context(
+        protocol_id="physical-target-cli",
+        case_id="synthetic",
+        observations=observations,
+        observed_actions=actions,
+        counterfactual_actions=actions,
+        intervention_frame=3,
+    )
+    states = np.zeros((1, 5, 1, 3), dtype=np.float32)
+    posterior = PhysicalPosterior(
+        context=context,
+        component_ids=("component",),
+        state_trajectories_m=states,
+        readout_trajectories_m=states,
+        readout_variance_m2=np.full((1, 1, 3), 1e-5, dtype=np.float32),
+        weights=np.asarray([1.0]),
+        phi=np.asarray([[1.0]]),
+        kappa_cf=np.asarray([[0.0]]),
+        hypothesis_indices=np.asarray([0]),
+        twin_particle_indices=np.asarray([0]),
+        phi_names=("gain",),
+        kappa_names=("contact",),
+        source_twin_belief_id="1" * 64,
+        source_factual_intervention_id="2" * 64,
+        source_query_id="3" * 64,
+    )
+    return posterior, observations
+
+
+def _install_import_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    def load_dependencies() -> None:
+        import_cli.target_validity = (
+            lambda visible, motion: np.asarray(visible, dtype=bool)
+        )
+        import_cli.PhysicalPosterior = PhysicalPosterior
+        import_cli.load_contract = load_contract
+        import_cli.build_physical_target = build_physical_target
+        import_cli.save_physical_target = save_physical_target
+        import_cli.load_trusted_pickle = load_trusted_pickle
+
+    monkeypatch.setattr(import_cli, "_load_runtime_dependencies", load_dependencies)
+
+
+def _install_evaluate_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    def load_dependencies() -> None:
+        evaluate_cli.atomic_write_binary = atomic_write_binary
+        evaluate_cli.PhysicalPosterior = PhysicalPosterior
+        evaluate_cli.load_contract = load_contract
+        evaluate_cli.load_physical_target = load_physical_target
+        evaluate_cli.evaluate_beta_zero_physical_posterior = (
+            evaluate_beta_zero_physical_posterior
+        )
+
+    monkeypatch.setattr(evaluate_cli, "_load_runtime_dependencies", load_dependencies)
+
+
+def test_legacy_import_requires_digest_and_produces_safe_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    posterior, observations = _posterior()
+    posterior_path = tmp_path / "posterior.npz"
+    pickle_path = tmp_path / "final_data.pkl"
+    target_path = tmp_path / "target.npz"
+    save_contract(posterior_path, posterior)
+    pickle_path.write_bytes(
+        pickle.dumps(
+            {
+                "object_points": observations.astype(np.float64),
+                "object_visibilities": np.ones(observations.shape[:2], dtype=bool),
+                "object_motions_valid": np.ones(observations.shape[:2], dtype=bool),
+            }
+        )
+    )
+    digest = hashlib.sha256(pickle_path.read_bytes()).hexdigest()
+    _install_import_dependencies(monkeypatch)
+
+    assert import_cli.main(
+        [
+            str(posterior_path),
+            str(pickle_path),
+            str(target_path),
+            "--allow-unsafe-pickle",
+            "--expected-sha256",
+            digest,
+        ]
+    ) == 0
+    target = load_physical_target(target_path)
+    assert target.source_final_data_sha256 == digest
+    assert target.object_points.dtype == np.dtype(np.float32)
+    assert target.context == posterior.context
+
+
+def test_safe_evaluation_binds_target_and_publishes_exactly_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    posterior, observations = _posterior()
+    posterior_path = tmp_path / "posterior.npz"
+    target_path = tmp_path / "target.npz"
+    output_path = tmp_path / "evaluation.json"
+    save_contract(posterior_path, posterior)
+    target = build_physical_target(
+        posterior.context,
+        observations,
+        np.ones(observations.shape[:2], dtype=bool),
+        source_final_data_sha256="a" * 64,
+    )
+    save_physical_target(target_path, target)
+    _install_evaluate_dependencies(monkeypatch)
+
+    assert evaluate_cli.main(
+        [
+            str(posterior_path),
+            str(target_path),
+            str(output_path),
+            "--start-frame",
+            "2",
+        ]
+    ) == 0
+    result = json.loads(output_path.read_text(encoding="utf-8"))
+    assert result["physical_target_id"] == target.artifact_id
+    assert result["physical_posterior_id"] == posterior.artifact_id
+    assert result["evaluation_target_id"] == target.evaluation_target(
+        start_frame=2
+    ).artifact_id
+    assert len(result["evaluation_id"]) == 64
+
+    with pytest.raises(FileExistsError):
+        evaluate_cli.main(
+            [
+                str(posterior_path),
+                str(target_path),
+                str(output_path),
+                "--start-frame",
+                "2",
+            ]
+        )
+
+
+def test_safe_evaluation_rejects_symlinked_output_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    posterior, observations = _posterior()
+    posterior_path = tmp_path / "posterior.npz"
+    target_path = tmp_path / "target.npz"
+    real_output = tmp_path / "real-output"
+    linked_output = tmp_path / "linked-output"
+    save_contract(posterior_path, posterior)
+    target = build_physical_target(
+        posterior.context,
+        observations,
+        np.ones(observations.shape[:2], dtype=bool),
+        source_final_data_sha256="a" * 64,
+    )
+    save_physical_target(target_path, target)
+    real_output.mkdir()
+    try:
+        linked_output.symlink_to(real_output, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks are unavailable on this platform")
+    _install_evaluate_dependencies(monkeypatch)
+
+    with pytest.raises(ValueError, match="output path contains a symlink"):
+        evaluate_cli.main(
+            [
+                str(posterior_path),
+                str(target_path),
+                str(linked_output / "evaluation.json"),
+                "--start-frame",
+                "2",
+            ]
+        )


### PR DESCRIPTION
## Summary

Replace direct pickle loading in the stable physical-counterfactual evaluator with a strict, content-addressed physical target artifact.

- add `PhysicalTargetBundle`, a non-pickled NPZ contract that reproduces the canonical float32 `object_points` bytes used by the PhysTwin backend, validates both O- and O+ identities during conversion, binds validity semantics and the trusted source digest, and publishes atomically;
- add `causal4d evidence physical-target import-legacy`, which requires explicit unsafe-pickle consent and an independently obtained SHA-256 before unpickling;
- make `causal4d evidence physical-counterfactual evaluate` core-only and pickle-free, with exact posterior/context/support checks;
- bind each result to the physical posterior, source query, target artifact, and exact held-out `EvaluationTarget` suffix identity;
- add a content-derived evaluation ID and validated, atomic, exactly-once result publication, including symlink-path rejection;
- add a claim-bearing command policy test that rejects direct `pickle` imports and keeps the stable evaluator independent of BayesianPhysTwin imports; and
- update the remote pipeline, route metadata, security guidance, changelog, and artifact documentation.

## Security and provenance boundary

The legacy importer is the only new path that opens a pickle. It uses `load_trusted_pickle`, rejects missing consent, verifies the expected digest before unpickling, and retains the digest in the target identity. A matching digest proves byte identity, not that arbitrary pickle content is safe; the source must still be trusted.

The stable evaluator opens only the safe NPZ artifact with `allow_pickle=False`. It no longer imports BayesianPhysTwin or `pickle`.

## Compatibility

The second positional input of `causal4d evidence physical-counterfactual evaluate` changes from `final_data.pkl` to `physical-target.npz`. Existing scripts must perform the one-time explicit conversion first. The included remote pipeline demonstrates the migration.

Frozen tags, recorded environments, and prior scientific artifacts are unchanged. This is an additive artifact/provenance and security boundary; it does not change the posterior, metrics, method freeze, 0/36 physical evidence count, or any paper claim.

## Validation

Focused pre-publication validation:

- target/import/evaluation/policy suite: `13 passed`;
- focused branch coverage over the three new or changed runtime modules: `74%`;
- Python byte compilation passed;
- `bash -n`, `git apply --check`, and `git diff --check` passed.

GitHub validation on exact head `0e3d99eee28274821662552ae63346387ab878a4` and its synthetic merge result:

- Ruff lint, incremental formatting, and mypy passed;
- complete core suite passed on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- exact declared dependency-floor suite passed;
- wheel and source distribution builds and metadata checks passed;
- installed wheel and source-distribution CLI-help checks passed without optional-provider leakage;
- deterministic result-bundle production, archive, and consumption passed;
- frozen milestone manifest validation passed;
- pinned BayesianPhysTwin installed-wheel integration passed; and
- the complete `Causal4D merge gate` passed on the synthetic PR merge commit.
