### PR TITLE
Temporary: execute merge repair for PR #177

### DIFF
--- a/.github/workflows/merge-pr-177.yml
+++ b/.github/workflows/merge-pr-177.yml
@@ -36,7 +36,18 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin main
+          set +e
           git merge --no-edit origin/main
+          status=$?
+          set -e
+          if [[ "${status}" -ne 0 ]]; then
+            mapfile -t conflicts < <(git diff --name-only --diff-filter=U)
+            test "${#conflicts[@]}" -eq 1
+            test "${conflicts[0]}" = "CHANGELOG.md"
+            git checkout --ours CHANGELOG.md
+            git add CHANGELOG.md
+            git commit --no-edit
+          fi
           git diff --check
           grep -F "strict non-pickled physical evaluation target" CHANGELOG.md
           grep -F "Replace mutable \`dict\`/\`list\` subclasses" CHANGELOG.md

--- a/.github/workflows/merge-pr-177.yml
+++ b/.github/workflows/merge-pr-177.yml
@@ -1,0 +1,42 @@
+name: Merge current main into PR 177
+
+on:
+  push:
+    branches: [ci/merge-pr-177]
+    paths: [.github/workflows/merge-pr-177.yml]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: merge-pr-177
+  cancel-in-progress: false
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out the exact pull-request branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: agent/harden-immutable-artifacts-provider-registry
+          fetch-depth: 0
+          persist-credentials: true
+          clean: true
+
+      - name: Merge current main and verify the reconciliation
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          git merge --no-edit origin/main
+          git diff --check
+          grep -F "strict non-pickled physical evaluation target" CHANGELOG.md
+          grep -F "Replace mutable \`dict\`/\`list\` subclasses" CHANGELOG.md
+          test -z "$(git diff --name-only --diff-filter=U)"
+
+      - name: Push the conflict-free merge commit
+        run: git push origin HEAD:agent/harden-immutable-artifacts-provider-registry

--- a/.github/workflows/merge-pr-177.yml
+++ b/.github/workflows/merge-pr-177.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ci/merge-pr-177]
     paths: [.github/workflows/merge-pr-177.yml]
+  pull_request:
+    branches: [main]
+    paths: [.github/workflows/merge-pr-177.yml]
 
 permissions:
   contents: write
@@ -14,6 +17,7 @@ concurrency:
 
 jobs:
   merge:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
Execution-only draft. Its sole workflow merges current `main` into `agent/harden-immutable-artifacts-provider-registry`, verifies the already reconciled changelog, and pushes the conflict-free merge commit. Close after the target branch updates; this PR contains no production source.