### PR TITLE
Add runnable MolmoMotion-to-physics bridge quickstart

### DIFF
--- a/docs/external_forecast_import.md
+++ b/docs/external_forecast_import.md
@@ -91,6 +91,48 @@ physical_frame = anchor_physical_frame + future_time_s * physical_fps
 
 and fails closed on disagreement.
 
+## Runnable MolmoMotion/PhysTwin bridge
+
+[`examples/molmomotion_physics_bridge`](../examples/molmomotion_physics_bridge)
+contains a standalone producer-side exporter, a synthetic input generator, and
+an end-to-end quickstart covering:
+
+- exact PhysTwin node identities and metric world coordinates;
+- several prompts in one `KPFC` forecast bundle;
+- 30 Hz physical data aligned to a 15 Hz MolmoMotion forecast;
+- canonical import and content addressing;
+- BayesianPhysTwin/Causal4D physical posterior generation;
+- byte-identical `beta=0` fallback and exploratory positive-beta sweeps; and
+- the later Prob4D observation-belief extension.
+
+The helper only depends on NumPy and can be copied into an existing MolmoMotion
+environment. A complete local export smoke test is:
+
+```bash
+workdir=/tmp/molmomotion-physics-bridge
+mkdir -p "${workdir}"
+
+python examples/molmomotion_physics_bridge/make_demo_input.py \
+  "${workdir}/molmo_raw.npz"
+
+python examples/molmomotion_physics_bridge/export_molmo_forecast.py \
+  "${workdir}/molmo_raw.npz" \
+  "${workdir}/producer_forecast.npz" \
+  "${workdir}/external_forecast_manifest.json" \
+  --case-id single_lift_cloth \
+  --source-revision demo-checkpoint \
+  --anchor-physical-frame 70 \
+  --physical-fps 30 \
+  --forecast-fps 15 \
+  --forecast 'instruction=Lift the cloth upward.' \
+  --forecast 'paraphrase=Raise the cloth vertically with one hand.' \
+  --forecast 'shuffled=Push the cloth sideways across the table.'
+```
+
+The example supports arbitrary point count; eight points are recommended for the
+first locked comparison, while 16/32-point calls should remain a separate
+scalability ablation.
+
 ## Python API
 
 ```python

--- a/examples/molmomotion_physics_bridge/README.md
+++ b/examples/molmomotion_physics_bridge/README.md
@@ -1,0 +1,214 @@
+# MolmoMotion → Bayesian physics bridge
+
+This example is the lowest-effort integration path for a motion model such as
+MolmoMotion:
+
+1. keep the motion model frozen in its existing environment;
+2. export sparse 3-D query trajectories and exact physical node identities;
+3. normalize them through Causal4D's portable external-forecast contract;
+4. score only the matching readout `H_Q(X)` of complete physical rollouts; and
+5. retain the physical posterior exactly when semantic weight `beta` is zero.
+
+The learned trajectory never overwrites simulator state, physical parameters,
+contact variables, or model discrepancy.
+
+## Install the lightweight consumer
+
+From the Causal4D checkout:
+
+```bash
+python -m pip install -e .
+```
+
+The producer-side helper in this directory only needs NumPy, so it can also be
+copied into an existing MolmoMotion environment.
+
+## Run the self-contained export demo
+
+From the repository root:
+
+```bash
+workdir=/tmp/molmomotion-physics-bridge
+mkdir -p "${workdir}"
+
+python examples/molmomotion_physics_bridge/make_demo_input.py \
+  "${workdir}/molmo_raw.npz"
+
+python examples/molmomotion_physics_bridge/export_molmo_forecast.py \
+  "${workdir}/molmo_raw.npz" \
+  "${workdir}/producer_forecast.npz" \
+  "${workdir}/external_forecast_manifest.json" \
+  --case-id single_lift_cloth \
+  --source-revision demo-checkpoint \
+  --anchor-physical-frame 70 \
+  --physical-fps 30 \
+  --forecast-fps 15 \
+  --forecast 'instruction=Lift the cloth upward.' \
+  --forecast 'paraphrase=Raise the cloth vertically with one hand.' \
+  --forecast 'shuffled=Push the cloth sideways across the table.'
+
+python -m causal4d.cli.external_forecast_import \
+  "${workdir}/producer_forecast.npz" \
+  "${workdir}/external_forecast_manifest.json" \
+  "${workdir}/canonical_forecast.npz"
+```
+
+At 30 physical frames per second and 15 forecast frames per second, an anchor at
+frame 70 maps the six forecast steps to physical frames 72, 74, ..., 82. The
+importer verifies this mapping rather than inferring it from filenames.
+
+## Export a real MolmoMotion result
+
+After the existing MolmoMotion inference call, save one small NPZ:
+
+```python
+import numpy as np
+
+# P exact PhysTwin object-node identities.
+node_indices = np.asarray(node_indices, dtype=np.int64)              # (P,)
+
+# Query positions at t0, in metres in the physical world frame.
+anchor_positions_world_m = np.asarray(anchor_world, dtype=np.float64)  # (P, 3)
+
+# Forecast order must match the repeated --forecast arguments below.
+# K forecasts, P material points, F future timestamps, xyz coordinates.
+future_positions_world_m = np.asarray(future_world, dtype=np.float64)  # (K,P,F,3)
+
+validity_mask = np.all(np.isfinite(future_positions_world_m), axis=-1) # (K,P,F)
+
+np.savez_compressed(
+    "molmo_raw.npz",
+    node_indices=node_indices,
+    anchor_positions_world_m=anchor_positions_world_m,
+    future_positions_world_m=future_positions_world_m,
+    validity_mask=validity_mask,
+)
+```
+
+Then run the export helper with the real case, checkpoint revision, anchor
+frame, source rate, forecast rate, and captions. Eight, 16, and 32 points use the
+same format; point count is not hard-coded. For the first result, use one fixed
+eight-point query set and keep denser queries as a secondary ablation.
+
+The helper deliberately accepts only metric world-frame trajectories. The
+underlying generic importer also supports camera coordinates, `m`/`cm`/`mm`,
+`PFC`/`FPC`/`KPFC`/`KFPC` layouts, explicit frame indices, and coordinate-level
+validity; see [`docs/external_forecast_import.md`](../../docs/external_forecast_import.md).
+
+## Generate the physical posterior
+
+BayesianPhysTwin supplies uncertain state/parameter particles and PhysTwin/Warp
+replay. Causal4D adds realized-intervention uncertainty such as contact,
+actuation gain, delay, slip, and frame error. A typical sequence is:
+
+```bash
+causal4d evidence bpt-belief export \
+  PHYSTWIN_REPO \
+  CASE_DIRECTORY \
+  parameter_profile.npz \
+  refit_checkpoint.pt \
+  belief.npz
+
+causal4d experiment phystwin rollout-bank \
+  PHYSTWIN_REPO \
+  CASE_DIRECTORY \
+  parameter_profile.npz \
+  refit_checkpoint.pt \
+  known_action_bank.npz \
+  --action-setting known \
+  --twin-belief belief.npz
+
+causal4d experiment phystwin abduct-intervention \
+  known_action_bank.npz \
+  belief.npz \
+  CASE_DIRECTORY/final_data.pkl \
+  factual_intervention.npz \
+  factual_evaluation.json
+
+causal4d experiment phystwin counterfactual \
+  PHYSTWIN_REPO \
+  CASE_DIRECTORY \
+  parameter_profile.npz \
+  refit_checkpoint.pt \
+  belief.npz \
+  factual_intervention.npz \
+  physical_posterior.npz \
+  --counterfactual-action-id ACTION_ID \
+  --contact-policy CONTACT_POLICY
+```
+
+`ACTION_ID` and `CONTACT_POLICY` must come from the selected registered case
+configuration. For an initial cloth study, compare:
+
+- `known`: true future controller trajectory is available to physics;
+- `ambiguous`: the true action is one member of a feasible candidate set; and
+- `hidden`: future controls are withheld and proposed from observed history.
+
+The known-action setting tests whether MolmoMotion contributes deformation
+information beyond recognizing the word “upward.”
+
+## Apply the sparse forecast without changing physics
+
+First prove the exact fallback:
+
+```bash
+causal4d experiment semantic build-task-posterior \
+  physical_posterior.npz \
+  "${workdir}/canonical_forecast.npz" \
+  instruction \
+  task_beta0.npz \
+  --beta 0
+```
+
+The command reports `weights_bit_identical: true`. For an exploratory source-only
+sweep:
+
+```bash
+for beta in 1 3 6 12; do
+  causal4d experiment semantic build-task-posterior \
+    physical_posterior.npz \
+    "${workdir}/canonical_forecast.npz" \
+    instruction \
+    "task_beta${beta}.npz" \
+    --beta "${beta}"
+done
+```
+
+A positive beta is not admitted merely because the import succeeds. It requires
+independent source-only competence and trust evidence. Rejection must return the
+byte-identical physical weights.
+
+## Add Prob4D only after the first bridge works
+
+The released PhysTwin case already provides metric tracks and calibration, so
+Prob4D is optional for the first experiment. In an RGB/video-only extension,
+Prob4D can produce a causally sealed observation belief with covariance,
+reliability, dependence, gauge uncertainty, and source lineage:
+
+```bash
+prob4d observation export-calibrated \
+  outputs/single_lift_cloth/predictions.json \
+  outputs/single_lift_cloth/observation_belief.npz \
+  --case-id single_lift_cloth \
+  --causal-frame-stop 71 \
+  --metric-gauge-anchor calibration/metric_gauge_anchor.json \
+  --gauge-covariance-calibration calibration/gauge.json \
+  --point-uncertainty-calibration calibration/point.json \
+  --source-revision "$(git rev-parse HEAD)" \
+  --summary-json outputs/single_lift_cloth/observation_belief_summary.json
+
+bpt observation validate \
+  outputs/single_lift_cloth/observation_belief.npz
+```
+
+Prob4D evidence belongs on the observed prefix. A predicted MolmoMotion future
+must remain a separate task/readout factor, not be relabeled as an independent
+physical observation.
+
+## Minimum comparison
+
+Report zero motion, constant velocity, rigid hand transform, MolmoMotion,
+nominal PhysTwin, BayesianPhysTwin, BayesianPhysTwin+Causal4D, and the gated
+hybrid. Use 3-D ADE/FDE, full-object track or surface error, grasp slip,
+strain/contact violations, predictive coverage, and runtime. The component
+oracle is diagnostic only.

--- a/examples/molmomotion_physics_bridge/export_molmo_forecast.py
+++ b/examples/molmomotion_physics_bridge/export_molmo_forecast.py
@@ -1,0 +1,376 @@
+"""Package MolmoMotion trajectories for Causal4D's external-forecast importer.
+
+The helper is intentionally standalone: it depends only on NumPy and can run in
+an existing MolmoMotion environment without installing Causal4D. It accepts a
+small NPZ with metric world-frame query trajectories and emits the producer NPZ
+plus strict JSON manifest consumed by ``causal4d.external_forecast``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def _forecast(value: str) -> tuple[str, str]:
+    if "=" not in value:
+        raise argparse.ArgumentTypeError("forecasts must use ID=CAPTION")
+    identifier, caption = value.split("=", 1)
+    identifier = identifier.strip()
+    caption = caption.strip()
+    if not identifier or not caption:
+        raise argparse.ArgumentTypeError("forecast id and caption must be nonempty")
+    return identifier, caption
+
+
+def _positive_float(value: str) -> float:
+    parsed = float(value)
+    if not np.isfinite(parsed) or parsed <= 0.0:
+        raise argparse.ArgumentTypeError("value must be finite and positive")
+    return parsed
+
+
+def _nonnegative_integer(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("value must be nonnegative")
+    return parsed
+
+
+def _load_array(
+    archive: np.lib.npyio.NpzFile,
+    key: str,
+    *,
+    name: str,
+) -> np.ndarray:
+    if key not in archive.files:
+        raise ValueError(f"input NPZ is missing {name} array {key!r}")
+    try:
+        return np.asarray(archive[key])
+    except ValueError as error:
+        raise ValueError(f"{name} cannot be loaded without pickle") from error
+
+
+def _normalize_validity(
+    supplied: np.ndarray | None,
+    future: np.ndarray,
+) -> np.ndarray:
+    if supplied is None:
+        valid = np.isfinite(future)
+    else:
+        valid = np.asarray(supplied, dtype=bool)
+        if valid.shape == future.shape[:3]:
+            valid = np.repeat(valid[..., None], 3, axis=3)
+        if valid.shape != future.shape:
+            raise ValueError(
+                "validity_mask must have shape (K, P, F) or (K, P, F, 3)"
+            )
+        valid = valid.copy()
+    if np.any(valid & ~np.isfinite(future)):
+        raise ValueError("coordinates marked valid must be finite")
+    if np.any(np.sum(valid, axis=(1, 2, 3)) == 0):
+        raise ValueError("every forecast must contain at least one valid coordinate")
+    return valid
+
+
+def _atomic_write_npz(
+    path: Path,
+    arrays: Mapping[str, np.ndarray],
+    *,
+    overwrite: bool,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists() and not overwrite:
+        raise FileExistsError(path)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    try:
+        with temporary.open("wb") as handle:
+            np.savez_compressed(handle, **arrays)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if path.exists() and not overwrite:
+            raise FileExistsError(path)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _atomic_write_json(path: Path, value: Mapping[str, Any], *, overwrite: bool) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists() and not overwrite:
+        raise FileExistsError(path)
+    payload = json.dumps(
+        value,
+        indent=2,
+        sort_keys=True,
+        allow_nan=False,
+    ) + "\n"
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+        text=True,
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if path.exists() and not overwrite:
+            raise FileExistsError(path)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def export_bridge_package(
+    input_npz: str | Path,
+    output_npz: str | Path,
+    output_manifest_json: str | Path,
+    *,
+    case_id: str,
+    source_model: str,
+    source_revision: str,
+    source_artifact_id: str | None,
+    forecasts: Sequence[tuple[str, str]],
+    anchor_physical_frame: int,
+    physical_fps: float,
+    forecast_fps: float,
+    producer_environment: str,
+    node_key: str = "node_indices",
+    anchor_key: str = "anchor_positions_world_m",
+    future_key: str = "future_positions_world_m",
+    validity_key: str = "validity_mask",
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Write a portable producer NPZ and its strict import manifest.
+
+    The input future array must use ``(forecast, point, future, xyz)`` order.
+    Output coordinates remain in metres in the physical world frame.
+    """
+
+    for name, value in (
+        ("case_id", case_id),
+        ("source_model", source_model),
+        ("source_revision", source_revision),
+        ("producer_environment", producer_environment),
+    ):
+        if type(value) is not str or not value.strip():
+            raise ValueError(f"{name} must be a nonempty string")
+    if source_artifact_id is not None and (
+        type(source_artifact_id) is not str or not source_artifact_id.strip()
+    ):
+        raise ValueError("source_artifact_id must be None or a nonempty string")
+    if type(anchor_physical_frame) is not int or anchor_physical_frame < 0:
+        raise ValueError("anchor_physical_frame must be a nonnegative integer")
+    if not np.isfinite(physical_fps) or physical_fps <= 0.0:
+        raise ValueError("physical_fps must be finite and positive")
+    if not np.isfinite(forecast_fps) or forecast_fps <= 0.0:
+        raise ValueError("forecast_fps must be finite and positive")
+
+    forecast_entries = tuple(forecasts)
+    if not forecast_entries:
+        raise ValueError("at least one forecast is required")
+    forecast_ids = tuple(identifier for identifier, _ in forecast_entries)
+    if any(not identifier or not caption for identifier, caption in forecast_entries):
+        raise ValueError("forecast identifiers and captions must be nonempty")
+    if len(set(forecast_ids)) != len(forecast_ids):
+        raise ValueError("forecast identifiers must be unique")
+
+    input_path = Path(input_npz).resolve()
+    output_path = Path(output_npz).resolve()
+    manifest_path = Path(output_manifest_json).resolve()
+    if input_path == output_path:
+        raise ValueError("input_npz and output_npz must be different files")
+    if manifest_path in {input_path, output_path}:
+        raise ValueError("output manifest must be a separate file")
+
+    with np.load(input_path, allow_pickle=False) as archive:
+        node_values = _load_array(archive, node_key, name="node_indices")
+        if not np.issubdtype(node_values.dtype, np.integer):
+            raise ValueError("node_indices must use an integer dtype")
+        nodes = np.asarray(node_values, dtype=np.int64)
+        anchor = np.asarray(
+            _load_array(archive, anchor_key, name="anchor_positions"),
+            dtype=np.float64,
+        )
+        future = np.asarray(
+            _load_array(archive, future_key, name="future_positions"),
+            dtype=np.float64,
+        )
+        supplied_validity = (
+            _load_array(archive, validity_key, name="validity_mask")
+            if validity_key in archive.files
+            else None
+        )
+
+    if nodes.ndim != 1 or not len(nodes):
+        raise ValueError("node_indices must be a nonempty vector")
+    if np.any(nodes < 0) or len(np.unique(nodes)) != len(nodes):
+        raise ValueError("node_indices must be unique and nonnegative")
+    if anchor.shape != (len(nodes), 3) or not np.all(np.isfinite(anchor)):
+        raise ValueError("anchor_positions_world_m must have finite shape (P, 3)")
+    if future.ndim != 4 or future.shape[3] != 3:
+        raise ValueError(
+            "future_positions_world_m must have shape (K, P, F, 3)"
+        )
+    if future.shape[0] != len(forecast_entries):
+        raise ValueError("future forecast count must match repeated --forecast values")
+    if future.shape[1] != len(nodes) or future.shape[2] < 1:
+        raise ValueError("future positions must have matching P and nonempty F")
+
+    validity = _normalize_validity(supplied_validity, future)
+    future = future.copy()
+    future[~validity] = np.nan
+    future_count = int(future.shape[2])
+    future_times_s = (
+        np.arange(1, future_count + 1, dtype=np.float64) / float(forecast_fps)
+    )
+    physical_frames = (
+        float(anchor_physical_frame) + future_times_s * float(physical_fps)
+    )
+
+    producer_arrays = {
+        "node_indices": nodes,
+        "anchor_positions_world_m": anchor,
+        "future_positions_world_m": future,
+        "future_times_s": future_times_s,
+        "validity_mask": validity,
+    }
+    _atomic_write_npz(output_path, producer_arrays, overwrite=overwrite)
+
+    source: dict[str, Any] = {
+        "model": source_model.strip(),
+        "revision": source_revision.strip(),
+    }
+    if source_artifact_id is not None:
+        source["artifact_id"] = source_artifact_id.strip()
+    manifest: dict[str, Any] = {
+        "schema": "causal4d.external_forecast_import",
+        "schema_version": 1,
+        "case_id": case_id.strip(),
+        "source": source,
+        "arrays": {
+            "node_indices": "node_indices",
+            "anchor_positions": "anchor_positions_world_m",
+            "future_positions": "future_positions_world_m",
+            "future_times_s": "future_times_s",
+            "validity_mask": "validity_mask",
+        },
+        "layout": "KPFC",
+        "coordinate_frame": "world",
+        "position_unit": "m",
+        "forecast_ids": list(forecast_ids),
+        "anchor_physical_frame": anchor_physical_frame,
+        "physical_fps": float(physical_fps),
+        "forecast_metadata": {
+            identifier: {"caption": caption}
+            for identifier, caption in forecast_entries
+        },
+        "metadata": {
+            "bridge_helper": "molmomotion_physics_bridge_v1",
+            "forecast_fps": float(forecast_fps),
+            "producer_environment": producer_environment.strip(),
+        },
+    }
+    try:
+        _atomic_write_json(manifest_path, manifest, overwrite=overwrite)
+    except Exception:
+        if not overwrite:
+            output_path.unlink(missing_ok=True)
+        raise
+
+    return {
+        "anchor_physical_frame": anchor_physical_frame,
+        "forecast_ids": list(forecast_ids),
+        "forecast_shape_kpfc": list(future.shape),
+        "future_times_s": future_times_s.tolist(),
+        "manifest": str(manifest_path),
+        "node_count": int(len(nodes)),
+        "physical_frame_indices": physical_frames.tolist(),
+        "producer_npz": str(output_path),
+        "valid_coordinate_fraction": float(np.mean(validity)),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Export MolmoMotion query trajectories as a producer NPZ and strict "
+            "Causal4D external-forecast manifest."
+        )
+    )
+    parser.add_argument("input_npz")
+    parser.add_argument("output_npz")
+    parser.add_argument("output_manifest_json")
+    parser.add_argument("--case-id", required=True)
+    parser.add_argument("--source-model", default="MolmoMotion")
+    parser.add_argument("--source-revision", required=True)
+    parser.add_argument("--source-artifact-id")
+    parser.add_argument(
+        "--forecast",
+        type=_forecast,
+        action="append",
+        required=True,
+        help="repeat ID=CAPTION in the same order as future_positions K",
+    )
+    parser.add_argument(
+        "--anchor-physical-frame",
+        type=_nonnegative_integer,
+        required=True,
+    )
+    parser.add_argument("--physical-fps", type=_positive_float, required=True)
+    parser.add_argument("--forecast-fps", type=_positive_float, default=15.0)
+    parser.add_argument(
+        "--producer-environment",
+        default="existing-molmomotion-environment",
+    )
+    parser.add_argument("--node-key", default="node_indices")
+    parser.add_argument("--anchor-key", default="anchor_positions_world_m")
+    parser.add_argument("--future-key", default="future_positions_world_m")
+    parser.add_argument("--validity-key", default="validity_mask")
+    parser.add_argument("--overwrite", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    summary = export_bridge_package(
+        args.input_npz,
+        args.output_npz,
+        args.output_manifest_json,
+        case_id=args.case_id,
+        source_model=args.source_model,
+        source_revision=args.source_revision,
+        source_artifact_id=args.source_artifact_id,
+        forecasts=args.forecast,
+        anchor_physical_frame=args.anchor_physical_frame,
+        physical_fps=args.physical_fps,
+        forecast_fps=args.forecast_fps,
+        producer_environment=args.producer_environment,
+        node_key=args.node_key,
+        anchor_key=args.anchor_key,
+        future_key=args.future_key,
+        validity_key=args.validity_key,
+        overwrite=args.overwrite,
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/molmomotion_physics_bridge/export_molmo_forecast.py
+++ b/examples/molmomotion_physics_bridge/export_molmo_forecast.py
@@ -69,9 +69,7 @@ def _normalize_validity(
         if valid.shape == future.shape[:3]:
             valid = np.repeat(valid[..., None], 3, axis=3)
         if valid.shape != future.shape:
-            raise ValueError(
-                "validity_mask must have shape (K, P, F) or (K, P, F, 3)"
-            )
+            raise ValueError("validity_mask must have shape (K, P, F) or (K, P, F, 3)")
         valid = valid.copy()
     if np.any(valid & ~np.isfinite(future)):
         raise ValueError("coordinates marked valid must be finite")
@@ -108,16 +106,21 @@ def _atomic_write_npz(
         temporary.unlink(missing_ok=True)
 
 
-def _atomic_write_json(path: Path, value: Mapping[str, Any], *, overwrite: bool) -> None:
+def _atomic_write_json(
+    path: Path, value: Mapping[str, Any], *, overwrite: bool
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     if path.exists() and not overwrite:
         raise FileExistsError(path)
-    payload = json.dumps(
-        value,
-        indent=2,
-        sort_keys=True,
-        allow_nan=False,
-    ) + "\n"
+    payload = (
+        json.dumps(
+            value,
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        )
+        + "\n"
+    )
     descriptor, temporary_name = tempfile.mkstemp(
         prefix=f".{path.name}.",
         suffix=".tmp",
@@ -225,9 +228,7 @@ def export_bridge_package(
     if anchor.shape != (len(nodes), 3) or not np.all(np.isfinite(anchor)):
         raise ValueError("anchor_positions_world_m must have finite shape (P, 3)")
     if future.ndim != 4 or future.shape[3] != 3:
-        raise ValueError(
-            "future_positions_world_m must have shape (K, P, F, 3)"
-        )
+        raise ValueError("future_positions_world_m must have shape (K, P, F, 3)")
     if future.shape[0] != len(forecast_entries):
         raise ValueError("future forecast count must match repeated --forecast values")
     if future.shape[1] != len(nodes) or future.shape[2] < 1:
@@ -237,11 +238,11 @@ def export_bridge_package(
     future = future.copy()
     future[~validity] = np.nan
     future_count = int(future.shape[2])
-    future_times_s = (
-        np.arange(1, future_count + 1, dtype=np.float64) / float(forecast_fps)
+    future_times_s = np.arange(1, future_count + 1, dtype=np.float64) / float(
+        forecast_fps
     )
-    physical_frames = (
-        float(anchor_physical_frame) + future_times_s * float(physical_fps)
+    physical_frames = float(anchor_physical_frame) + future_times_s * float(
+        physical_fps
     )
 
     producer_arrays = {
@@ -278,8 +279,7 @@ def export_bridge_package(
         "anchor_physical_frame": anchor_physical_frame,
         "physical_fps": float(physical_fps),
         "forecast_metadata": {
-            identifier: {"caption": caption}
-            for identifier, caption in forecast_entries
+            identifier: {"caption": caption} for identifier, caption in forecast_entries
         },
         "metadata": {
             "bridge_helper": "molmomotion_physics_bridge_v1",

--- a/examples/molmomotion_physics_bridge/make_demo_input.py
+++ b/examples/molmomotion_physics_bridge/make_demo_input.py
@@ -1,0 +1,101 @@
+"""Create a small synthetic MolmoMotion-style NPZ for the bridge quickstart."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+import numpy as np
+
+
+def build_demo_arrays(
+    *,
+    point_count: int = 8,
+    future_count: int = 6,
+) -> dict[str, np.ndarray]:
+    if point_count < 2:
+        raise ValueError("point_count must be at least two")
+    if future_count < 1:
+        raise ValueError("future_count must be positive")
+
+    columns = int(np.ceil(np.sqrt(point_count)))
+    rows = int(np.ceil(point_count / columns))
+    grid_x, grid_y = np.meshgrid(
+        np.linspace(-0.12, 0.12, columns),
+        np.linspace(-0.08, 0.08, rows),
+    )
+    anchor = np.column_stack(
+        (
+            grid_x.reshape(-1)[:point_count],
+            grid_y.reshape(-1)[:point_count],
+            np.zeros(point_count),
+        )
+    )
+    time = np.arange(1, future_count + 1, dtype=np.float64) / 15.0
+    phase = np.linspace(0.0, np.pi, point_count, dtype=np.float64)
+
+    instruction = np.repeat(anchor[:, None, :], future_count, axis=1)
+    instruction[:, :, 2] += 0.10 * time[None]
+    instruction[:, :, 2] += 0.008 * np.sin(phase)[:, None] * (
+        1.0 - np.exp(-4.0 * time[None])
+    )
+
+    paraphrase = instruction.copy()
+    paraphrase[:, :, 0] += 0.002 * np.sin(phase)[:, None] * time[None]
+
+    shuffled = np.repeat(anchor[:, None, :], future_count, axis=1)
+    shuffled[:, :, 0] += 0.10 * time[None]
+
+    future = np.stack((instruction, paraphrase, shuffled), axis=0)
+    return {
+        "node_indices": np.arange(point_count, dtype=np.int64),
+        "anchor_positions_world_m": anchor.astype(np.float64),
+        "future_positions_world_m": future.astype(np.float64),
+        "validity_mask": np.ones(future.shape[:-1], dtype=bool),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Create a synthetic MolmoMotion-style bridge input NPZ."
+    )
+    parser.add_argument("output_npz")
+    parser.add_argument("--point-count", type=int, default=8)
+    parser.add_argument("--future-count", type=int, default=6)
+    parser.add_argument("--overwrite", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    output = Path(args.output_npz)
+    if output.exists() and not args.overwrite:
+        raise FileExistsError(output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    arrays = build_demo_arrays(
+        point_count=args.point_count,
+        future_count=args.future_count,
+    )
+    with output.open("wb") as handle:
+        np.savez_compressed(handle, **arrays)
+    print(
+        json.dumps(
+            {
+                "forecast_shape_kpfc": list(
+                    arrays["future_positions_world_m"].shape
+                ),
+                "forecast_ids": ["instruction", "paraphrase", "shuffled"],
+                "output": str(output.resolve()),
+                "point_count": int(len(arrays["node_indices"])),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/molmomotion_physics_bridge/make_demo_input.py
+++ b/examples/molmomotion_physics_bridge/make_demo_input.py
@@ -38,8 +38,8 @@ def build_demo_arrays(
 
     instruction = np.repeat(anchor[:, None, :], future_count, axis=1)
     instruction[:, :, 2] += 0.10 * time[None]
-    instruction[:, :, 2] += 0.008 * np.sin(phase)[:, None] * (
-        1.0 - np.exp(-4.0 * time[None])
+    instruction[:, :, 2] += (
+        0.008 * np.sin(phase)[:, None] * (1.0 - np.exp(-4.0 * time[None]))
     )
 
     paraphrase = instruction.copy()
@@ -83,9 +83,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(
         json.dumps(
             {
-                "forecast_shape_kpfc": list(
-                    arrays["future_positions_world_m"].shape
-                ),
+                "forecast_shape_kpfc": list(arrays["future_positions_world_m"].shape),
                 "forecast_ids": ["instruction", "paraphrase", "shuffled"],
                 "output": str(output.resolve()),
                 "point_count": int(len(arrays["node_indices"])),

--- a/src/causal4d/physical_target.py
+++ b/src/causal4d/physical_target.py
@@ -20,6 +20,7 @@ from causal4d.contracts import (
     PhysicalPosterior,
     array_sha256,
 )
+from causal4d.immutable_array import readonly_array
 from causal4d.immutable_json import plain_json, validated_json_mapping
 from causal4d.stage_provenance import EvaluationTarget
 
@@ -225,8 +226,8 @@ class PhysicalTargetBundle:
         if not np.any(valid[o_plus_offset:]):
             raise ValueError("physical target has no valid O+ point frames")
 
-        points.setflags(write=False)
-        valid.setflags(write=False)
+        points = readonly_array(points)
+        valid = readonly_array(valid)
         metadata = validated_json_mapping(
             self.metadata,
             error_message="physical target metadata must be finite JSON data",

--- a/tests/test_molmomotion_physics_bridge_example.py
+++ b/tests/test_molmomotion_physics_bridge_example.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import numpy as np
+import pytest
+
+from causal4d.cli.external_forecast_import import main as import_main
+from causal4d.cli.molmo_task_posterior import main as task_posterior_main
+from causal4d.contracts import (
+    PhysicalPosterior,
+    TaskPosterior,
+    build_causal_context,
+    load_contract,
+    save_contract,
+)
+from causal4d.external_forecast import import_external_forecast
+
+
+EXAMPLE_DIR = (
+    Path(__file__).resolve().parents[1] / "examples" / "molmomotion_physics_bridge"
+)
+
+
+def _load_example_module(filename: str) -> ModuleType:
+    path = EXAMPLE_DIR / filename
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load example module {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _matching_physical_posterior(bundle) -> PhysicalPosterior:
+    horizon = int(np.ceil(bundle.physical_frame_indices[-1]))
+    node_count = int(np.max(bundle.node_indices)) + 1
+    observations = np.zeros((horizon + 1, node_count, 3), dtype=float)
+    actions = np.zeros((horizon + 1, 1, 3), dtype=float)
+    context = build_causal_context(
+        protocol_id="molmomotion_bridge_example",
+        case_id=bundle.case_id,
+        observations=observations,
+        observed_actions=actions,
+        counterfactual_actions=actions,
+        intervention_frame=bundle.anchor_physical_frame,
+    )
+
+    states = np.zeros((2, horizon + 1, node_count, 3), dtype=float)
+    states[:, :, bundle.node_indices] = bundle.anchor_positions_m[None, None]
+    forecast = bundle.future_positions_m[bundle.forecast_index("instruction")]
+    for frame, positions in zip(
+        bundle.physical_frame_indices.astype(int),
+        forecast,
+        strict=True,
+    ):
+        states[1, frame, bundle.node_indices] = positions
+
+    return PhysicalPosterior(
+        context=context,
+        component_ids=("stationary", "matching"),
+        state_trajectories_m=states,
+        readout_trajectories_m=states,
+        readout_variance_m2=np.full((2, node_count, 3), 1e-5),
+        weights=np.asarray([0.6, 0.4]),
+        phi=np.asarray([[1.0], [1.0]]),
+        kappa_cf=np.asarray([[0.0], [1.0]]),
+        hypothesis_indices=np.asarray([0, 1]),
+        twin_particle_indices=np.asarray([0, 0]),
+        phi_names=("gain",),
+        kappa_names=("contact",),
+        source_twin_belief_id="1" * 64,
+        source_factual_intervention_id="2" * 64,
+        source_query_id="3" * 64,
+    )
+
+
+def test_runnable_bridge_export_import_and_exact_fallback(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    demo = _load_example_module("make_demo_input.py")
+    exporter = _load_example_module("export_molmo_forecast.py")
+
+    raw = tmp_path / "molmo_raw.npz"
+    producer = tmp_path / "producer_forecast.npz"
+    manifest = tmp_path / "external_forecast_manifest.json"
+    canonical = tmp_path / "canonical_forecast.npz"
+
+    assert demo.main([str(raw), "--future-count", "4"]) == 0
+    demo_summary = json.loads(capsys.readouterr().out)
+    assert demo_summary["forecast_shape_kpfc"] == [3, 8, 4, 3]
+
+    assert (
+        exporter.main(
+            [
+                str(raw),
+                str(producer),
+                str(manifest),
+                "--case-id",
+                "single_lift_cloth",
+                "--source-revision",
+                "demo-checkpoint",
+                "--anchor-physical-frame",
+                "70",
+                "--physical-fps",
+                "30",
+                "--forecast-fps",
+                "15",
+                "--forecast",
+                "instruction=Lift the cloth upward.",
+                "--forecast",
+                "paraphrase=Raise the cloth vertically with one hand.",
+                "--forecast",
+                "shuffled=Push the cloth sideways.",
+            ]
+        )
+        == 0
+    )
+    export_summary = json.loads(capsys.readouterr().out)
+    assert export_summary["physical_frame_indices"] == [72.0, 74.0, 76.0, 78.0]
+
+    manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
+    assert manifest_payload["layout"] == "KPFC"
+    assert manifest_payload["forecast_ids"] == [
+        "instruction",
+        "paraphrase",
+        "shuffled",
+    ]
+
+    imported = import_external_forecast(producer, manifest)
+    assert imported.future_positions_m.shape == (3, 4, 8, 3)
+    assert imported.source_model == "MolmoMotion"
+    assert imported.source_revision == "demo-checkpoint"
+
+    assert import_main([str(producer), str(manifest), str(canonical)]) == 0
+    import_summary = json.loads(capsys.readouterr().out)
+    assert import_summary["forecast_ids"] == [
+        "instruction",
+        "paraphrase",
+        "shuffled",
+    ]
+
+    physical = _matching_physical_posterior(imported)
+    physical_path = tmp_path / "physical.npz"
+    task_zero_path = tmp_path / "task_beta0.npz"
+    task_positive_path = tmp_path / "task_beta20.npz"
+    save_contract(physical_path, physical)
+
+    assert (
+        task_posterior_main(
+            [
+                str(physical_path),
+                str(canonical),
+                "instruction",
+                str(task_zero_path),
+                "--beta",
+                "0",
+                "--scale-m",
+                "0.005",
+            ]
+        )
+        == 0
+    )
+    zero_summary = json.loads(capsys.readouterr().out)
+    assert zero_summary["forecast_kind"] == "external"
+    assert zero_summary["weights_bit_identical"] is True
+    zero_task = load_contract(task_zero_path)
+    assert isinstance(zero_task, TaskPosterior)
+    assert zero_task.task_weights.tobytes() == physical.weights.tobytes()
+
+    assert (
+        task_posterior_main(
+            [
+                str(physical_path),
+                str(canonical),
+                "instruction",
+                str(task_positive_path),
+                "--beta",
+                "20",
+                "--scale-m",
+                "0.005",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    positive_task = load_contract(task_positive_path)
+    assert isinstance(positive_task, TaskPosterior)
+    assert positive_task.task_weights[1] > 0.999
+
+
+def test_export_helper_rejects_forecast_count_mismatch(tmp_path: Path) -> None:
+    demo = _load_example_module("make_demo_input.py")
+    exporter = _load_example_module("export_molmo_forecast.py")
+    raw = tmp_path / "molmo_raw.npz"
+    demo.main([str(raw)])
+
+    with pytest.raises(ValueError, match="forecast count"):
+        exporter.export_bridge_package(
+            raw,
+            tmp_path / "producer.npz",
+            tmp_path / "manifest.json",
+            case_id="single_lift_cloth",
+            source_model="MolmoMotion",
+            source_revision="demo",
+            source_artifact_id=None,
+            forecasts=(("instruction", "Lift the cloth upward."),),
+            anchor_physical_frame=70,
+            physical_fps=30.0,
+            forecast_fps=15.0,
+            producer_environment="test",
+        )


### PR DESCRIPTION
## Summary

Adds a zero-training, producer/consumer bridge that lets an existing MolmoMotion environment export sparse metric trajectories for BayesianPhysTwin/Causal4D physical-posterior scoring.

- Adds a standalone NumPy-only exporter for `(K, P, F, 3)` MolmoMotion trajectories, exact PhysTwin node identities, captions, cadence, and provenance.
- Writes a strict producer NPZ plus external-forecast import manifest with atomic file publication and validation.
- Adds a synthetic input generator so the export/import path is runnable without model weights or datasets.
- Documents the full path from MolmoMotion output through canonical Causal4D import, BayesianPhysTwin/Causal4D rollout generation, exact `beta=0` fallback, exploratory beta sweeps, and the later Prob4D observation-belief extension.
- Adds an end-to-end regression that runs the examples, imports the canonical bundle, builds a matching physical posterior, proves byte-identical fallback, and verifies positive semantic reweighting only on physical support.
- Repairs a pre-existing merge-result immutability regression in `PhysicalTargetBundle`: the full suite exposed two arrays still frozen only via `setflags(write=False)` after the new repository-wide policy test had landed. They now use irreversible byte-backed `readonly_array` storage.

## Usage

```bash
workdir=/tmp/molmomotion-physics-bridge
mkdir -p "${workdir}"

python examples/molmomotion_physics_bridge/make_demo_input.py \
  "${workdir}/molmo_raw.npz"

python examples/molmomotion_physics_bridge/export_molmo_forecast.py \
  "${workdir}/molmo_raw.npz" \
  "${workdir}/producer_forecast.npz" \
  "${workdir}/external_forecast_manifest.json" \
  --case-id single_lift_cloth \
  --source-revision demo-checkpoint \
  --anchor-physical-frame 70 \
  --physical-fps 30 \
  --forecast-fps 15 \
  --forecast 'instruction=Lift the cloth upward.' \
  --forecast 'paraphrase=Raise the cloth vertically with one hand.' \
  --forecast 'shuffled=Push the cloth sideways across the table.'

python -m causal4d.cli.external_forecast_import \
  "${workdir}/producer_forecast.npz" \
  "${workdir}/external_forecast_manifest.json" \
  "${workdir}/canonical_forecast.npz"
```

## Scientific boundary

The external forecast remains a task/readout factor. It cannot update simulator state, physical parameters, realized contact, or model discrepancy. `beta=0` must preserve physical weights byte for byte; positive beta remains exploratory until independently admitted by source-only competence and trust evidence.

The physical-target immutability repair changes storage ownership only; valid numerical payloads, hashes, artifact identities, and estimator semantics remain unchanged.