### PR TITLE
Add fail-closed security scanning

### DIFF
--- a/.github/workflows/security-scanning.yml
+++ b/.github/workflows/security-scanning.yml
@@ -1,0 +1,101 @@
+name: Security scanning
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "37 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  codeql:
+    name: CodeQL / ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, actions]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  dependency-audit:
+    name: Audit resolved runtime dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install the pinned audit tool
+        run: python -m pip install "pip-audit==2.10.1"
+
+      - name: Audit the project runtime dependency resolution
+        shell: bash
+        run: |
+          set -u
+          status=0
+          python -m pip_audit \
+            --strict \
+            --progress-spinner off \
+            --format json \
+            --output pip-audit.json \
+            . || status=$?
+          if [[ -f pip-audit.json ]]; then
+            cat pip-audit.json
+          else
+            echo "pip-audit did not produce its JSON report" >&2
+          fi
+          exit "$status"
+
+      - name: Upload the audit report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pip-audit-${{ github.sha }}
+          path: pip-audit.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/tests/test_security_scanning_workflow_policy.py
+++ b/tests/test_security_scanning_workflow_policy.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "security-scanning.yml"
+
+
+def test_security_scanning_has_read_only_triggers_and_permissions() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "push:" in text
+    assert "pull_request:" in text
+    assert "schedule:" in text
+    assert "workflow_dispatch:" in text
+    assert "permissions:\n  contents: read" in text
+    assert "contents: write" not in text
+    assert "persist-credentials: false" in text
+    assert "continue-on-error: true" not in text
+
+
+def test_codeql_scans_python_and_workflow_sources() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "language: [python, actions]" in text
+    assert "build-mode: none" in text
+    assert "queries: security-extended" in text
+    assert "security-events: write" in text
+    assert "github/codeql-action/init@" in text
+    assert "github/codeql-action/analyze@" in text
+    assert 'category: "/language:${{ matrix.language }}"' in text
+
+
+def test_dependency_audit_is_strict_pinned_and_archived() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'python -m pip install "pip-audit==2.10.1"' in text
+    assert "python -m pip_audit" in text
+    assert "--strict" in text
+    assert "--progress-spinner off" in text
+    assert "--output pip-audit.json" in text
+    assert "if: always()" in text
+    assert "actions/upload-artifact@" in text
+    assert "if-no-files-found: warn" in text


### PR DESCRIPTION
## Residual change

The original pre-commit and code-quality work has already landed on `main`. This PR now contains only the remaining security hardening:

- CodeQL scans for Python and GitHub Actions sources using pinned actions.
- A strict, pinned `pip-audit` job uploads its JSON report even on failure.
- Workflow-policy tests enforce read-only checkout permissions, fail-closed behavior, and pinned audit configuration.

## Validation

- `Causal4D merge gate`: passed on head `41b7cdeb96bd0b2538632b676e084a03c185ddc0`.
- The dedicated security workflow and broader suites were queued in the Actions backlog at review time.