### PR TITLE
Harden graph-discrepancy artifact IO

### DIFF
--- a/src/causal4d/artifact_io.py
+++ b/src/causal4d/artifact_io.py
@@ -1,0 +1,344 @@
+"""Exact-byte, fail-closed readers for portable research artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import math
+import os
+import stat
+import zipfile
+from collections.abc import Collection
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, BinaryIO
+
+import numpy as np
+
+
+class ArtifactValidationError(ValueError):
+    """Raised when an artifact cannot satisfy its immutable wire contract."""
+
+
+class _StrictJSONValueError(ArtifactValidationError):
+    """Internal marker for contextual strict-JSON failures."""
+
+
+@dataclass(frozen=True)
+class ArtifactFileSnapshot:
+    """The exact bytes read from one ordinary file and their identity."""
+
+    path: Path
+    payload: bytes
+    sha256: str
+    byte_count: int
+
+
+def _snapshot(path: Path, handle: BinaryIO, *, name: str) -> ArtifactFileSnapshot:
+    mode = os.fstat(handle.fileno()).st_mode
+    if not stat.S_ISREG(mode):
+        raise ArtifactValidationError(f"{name} must be an ordinary file")
+    try:
+        payload = handle.read()
+    except OSError as error:
+        raise ArtifactValidationError(f"{name} is not readable") from error
+    return ArtifactFileSnapshot(
+        path=path,
+        payload=payload,
+        sha256=hashlib.sha256(payload).hexdigest(),
+        byte_count=len(payload),
+    )
+
+
+def _read_open_descriptor(
+    descriptor: int,
+    path: Path,
+    *,
+    name: str,
+) -> ArtifactFileSnapshot:
+    try:
+        with os.fdopen(descriptor, "rb") as handle:
+            descriptor = -1
+            return _snapshot(path, handle, name=name)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _ordinary_file_flags() -> int:
+    flags = os.O_RDONLY
+    flags |= getattr(os, "O_BINARY", 0)
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    return flags
+
+
+def _ordinary_directory_flags() -> int:
+    flags = os.O_RDONLY
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_DIRECTORY", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    return flags
+
+
+def read_regular_file(
+    path: str | Path,
+    *,
+    name: str = "artifact file",
+) -> ArtifactFileSnapshot:
+    """Read and hash one ordinary file through the same open descriptor."""
+
+    target = Path(path)
+    if not hasattr(os, "O_NOFOLLOW"):
+        try:
+            status = target.lstat()
+        except OSError as error:
+            raise ArtifactValidationError(f"{name} is not readable") from error
+        if stat.S_ISLNK(status.st_mode):
+            raise ArtifactValidationError(f"{name} must not be a symbolic link")
+    try:
+        descriptor = os.open(target, _ordinary_file_flags())
+    except OSError as error:
+        raise ArtifactValidationError(
+            f"{name} must be an ordinary readable file"
+        ) from error
+    return _read_open_descriptor(descriptor, target, name=name)
+
+
+def _validated_relative_parts(value: Any, *, name: str) -> tuple[str, ...]:
+    if type(value) is not str or not value:
+        raise ArtifactValidationError(f"{name} must be a nonempty string")
+    if (
+        "\x00" in value
+        or "\\" in value
+        or value.startswith("/")
+        or value.endswith("/")
+        or "//" in value
+    ):
+        raise ArtifactValidationError(
+            f"{name} must be a safe POSIX relative path"
+        )
+    parts = tuple(value.split("/"))
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ArtifactValidationError(
+            f"{name} must be a safe POSIX relative path"
+        )
+    return parts
+
+
+def _read_regular_file_beneath_posix(
+    root: Path,
+    parts: tuple[str, ...],
+    *,
+    name: str,
+) -> ArtifactFileSnapshot:
+    directory_descriptors: list[int] = []
+    file_descriptor = -1
+    target = root.joinpath(*parts)
+    try:
+        directory_descriptors.append(os.open(root, _ordinary_directory_flags()))
+        for part in parts[:-1]:
+            descriptor = os.open(
+                part,
+                _ordinary_directory_flags(),
+                dir_fd=directory_descriptors[-1],
+            )
+            if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+                os.close(descriptor)
+                raise ArtifactValidationError(
+                    f"{name} parent components must be ordinary directories"
+                )
+            directory_descriptors.append(descriptor)
+        file_descriptor = os.open(
+            parts[-1],
+            _ordinary_file_flags(),
+            dir_fd=directory_descriptors[-1],
+        )
+        owned_descriptor = file_descriptor
+        file_descriptor = -1
+        return _read_open_descriptor(owned_descriptor, target, name=name)
+    except ArtifactValidationError:
+        raise
+    except OSError as error:
+        raise ArtifactValidationError(
+            f"{name} must be an ordinary readable file below its artifact root"
+        ) from error
+    finally:
+        if file_descriptor >= 0:
+            os.close(file_descriptor)
+        for descriptor in reversed(directory_descriptors):
+            os.close(descriptor)
+
+
+def _read_regular_file_beneath_fallback(
+    root: Path,
+    parts: tuple[str, ...],
+    *,
+    name: str,
+) -> ArtifactFileSnapshot:
+    try:
+        root_status = root.lstat()
+    except OSError as error:
+        raise ArtifactValidationError(f"{name} artifact root is unavailable") from error
+    if stat.S_ISLNK(root_status.st_mode) or not stat.S_ISDIR(root_status.st_mode):
+        raise ArtifactValidationError(
+            f"{name} artifact root must be an ordinary directory"
+        )
+
+    target = root
+    for index, part in enumerate(parts):
+        target = target / part
+        try:
+            status = target.lstat()
+        except OSError as error:
+            raise ArtifactValidationError(f"{name} is not readable") from error
+        if stat.S_ISLNK(status.st_mode):
+            raise ArtifactValidationError(
+                f"{name} path must not contain symbolic links"
+            )
+        final = index == len(parts) - 1
+        if final and not stat.S_ISREG(status.st_mode):
+            raise ArtifactValidationError(f"{name} must be an ordinary file")
+        if not final and not stat.S_ISDIR(status.st_mode):
+            raise ArtifactValidationError(
+                f"{name} parent components must be ordinary directories"
+            )
+    return read_regular_file(target, name=name)
+
+
+def read_regular_file_beneath(
+    root: str | Path,
+    relative_path: Any,
+    *,
+    name: str = "artifact payload",
+) -> ArtifactFileSnapshot:
+    """Read a regular file below ``root`` without following relative symlinks."""
+
+    root_path = Path(root)
+    parts = _validated_relative_parts(relative_path, name=f"{name} path")
+    supports_openat = (
+        os.name == "posix"
+        and hasattr(os, "O_NOFOLLOW")
+        and os.open in os.supports_dir_fd
+    )
+    if supports_openat:
+        return _read_regular_file_beneath_posix(
+            root_path,
+            parts,
+            name=name,
+        )
+    return _read_regular_file_beneath_fallback(
+        root_path,
+        parts,
+        name=name,
+    )
+
+
+def load_strict_json_object(payload: bytes, *, name: str) -> dict[str, Any]:
+    """Decode one finite UTF-8 JSON object while rejecting duplicate keys."""
+
+    def object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise _StrictJSONValueError(
+                    f"{name} contains duplicate JSON object key {key!r}"
+                )
+            result[key] = value
+        return result
+
+    def reject_constant(token: str) -> Any:
+        raise _StrictJSONValueError(
+            f"{name} contains non-finite JSON number {token!r}"
+        )
+
+    def parse_float(token: str) -> float:
+        value = float(token)
+        if not math.isfinite(value):
+            raise _StrictJSONValueError(
+                f"{name} contains non-finite JSON number {token!r}"
+            )
+        return value
+
+    try:
+        decoded = payload.decode("utf-8")
+        value = json.loads(
+            decoded,
+            object_pairs_hook=object_pairs,
+            parse_constant=reject_constant,
+            parse_float=parse_float,
+        )
+    except _StrictJSONValueError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ArtifactValidationError(f"{name} is not valid UTF-8 JSON") from error
+    if not isinstance(value, dict):
+        raise ArtifactValidationError(f"{name} must contain one JSON object")
+    return value
+
+
+def load_npz_bytes(
+    payload: bytes,
+    *,
+    name: str,
+    expected_arrays: Collection[str],
+) -> dict[str, np.ndarray]:
+    """Load exact non-pickled NPZ bytes with a closed array inventory."""
+
+    expected = frozenset(expected_arrays)
+    if not expected or any(type(key) is not str or not key for key in expected):
+        raise ValueError("expected_arrays must contain nonempty strings")
+    expected_members = {f"{key}.npy" for key in expected}
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(payload), mode="r") as zip_archive:
+            members = [entry.filename for entry in zip_archive.infolist()]
+            if len(members) != len(set(members)):
+                raise ArtifactValidationError(
+                    f"{name} contains duplicate ZIP members"
+                )
+            if set(members) != expected_members:
+                missing = sorted(expected_members - set(members))
+                extra = sorted(set(members) - expected_members)
+                raise ArtifactValidationError(
+                    f"{name} array inventory changed; "
+                    f"missing={missing}, extra={extra}"
+                )
+
+        with np.load(io.BytesIO(payload), allow_pickle=False) as archive:
+            actual = set(archive.files)
+            if actual != expected:
+                missing = sorted(expected - actual)
+                extra = sorted(actual - expected)
+                raise ArtifactValidationError(
+                    f"{name} array inventory changed; "
+                    f"missing={missing}, extra={extra}"
+                )
+            arrays = {
+                key: np.array(archive[key], copy=True)
+                for key in sorted(expected)
+            }
+    except ArtifactValidationError:
+        raise
+    except (
+        EOFError,
+        KeyError,
+        OSError,
+        ValueError,
+        zipfile.BadZipFile,
+    ) as error:
+        raise ArtifactValidationError(
+            f"{name} is not a valid non-pickled NPZ"
+        ) from error
+    return arrays
+
+
+__all__ = [
+    "ArtifactFileSnapshot",
+    "ArtifactValidationError",
+    "load_npz_bytes",
+    "load_strict_json_object",
+    "read_regular_file",
+    "read_regular_file_beneath",
+]

--- a/src/causal4d/discrepancy_belief.py
+++ b/src/causal4d/discrepancy_belief.py
@@ -4,37 +4,109 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any, BinaryIO
 
 import numpy as np
 
+from causal4d.artifact_io import (
+    load_npz_bytes,
+    load_strict_json_object,
+    read_regular_file,
+    read_regular_file_beneath,
+)
+from causal4d.atomic_io import atomic_write_binary, atomic_write_json
+from causal4d.contracts import array_sha256
 from causal4d.immutable_array import readonly_array
 from causal4d.immutable_json import plain_json, validated_json_mapping
-
-from causal4d.contracts import array_sha256
 from causal4d.observation_evidence import GroupedObservationEvidence
 
 
 GRAPH_DISCREPANCY_BELIEF_VERSION = 1
+
+_MANIFEST_FIELDS = frozenset(
+    {
+        "artifact_kind",
+        "version",
+        "artifact_id",
+        "basis_sha256",
+        "component_ids",
+        "transition_model_id",
+        "innovation_model_id",
+        "source_physical_posterior_id",
+        "metadata",
+        "payload",
+    }
+)
+_PAYLOAD_FIELDS = frozenset({"path", "sha256"})
+_PAYLOAD_ARRAYS = frozenset(
+    {
+        "coefficient_mean_m",
+        "coefficient_covariance_m2",
+        "projection_variance_m2",
+    }
+)
 
 
 def _readonly(values: np.ndarray, *, dtype: type | None = float) -> np.ndarray:
     return readonly_array(values, dtype=dtype)
 
 
-def _validate_sha256(value: str, *, name: str) -> None:
-    if len(value) != 64 or any(char not in "0123456789abcdef" for char in value):
+def _validated_sha256(value: Any, *, name: str) -> str:
+    if (
+        type(value) is not str
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
         raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return value
 
 
-def _file_sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as stream:
-        for block in iter(lambda: stream.read(1024 * 1024), b""):
-            digest.update(block)
-    return digest.hexdigest()
+def _nonempty_string(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _require_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a JSON object")
+    if any(type(key) is not str for key in value):
+        raise ValueError(f"{name} keys must be strings")
+    return value
+
+
+def _require_exact_fields(
+    value: Mapping[str, Any],
+    expected: frozenset[str],
+    *,
+    name: str,
+) -> None:
+    missing = sorted(expected - value.keys())
+    extra = sorted(value.keys() - expected)
+    if missing or extra:
+        raise ValueError(f"{name} fields changed; missing={missing}, extra={extra}")
+
+
+def _validated_component_ids(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise ValueError("component_ids must be a nonempty JSON array")
+    result = tuple(
+        _nonempty_string(identifier, name=f"component_ids[{index}]")
+        for index, identifier in enumerate(value)
+    )
+    if len(set(result)) != len(result):
+        raise ValueError("component_ids must be unique")
+    return result
+
+
+def _require_float64_array(values: np.ndarray, *, name: str) -> np.ndarray:
+    result = np.asarray(values)
+    if result.dtype != np.dtype(np.float64):
+        raise ValueError(f"{name} must use float64")
+    return result
 
 
 def _positive_semidefinite(covariance: np.ndarray, *, name: str) -> None:
@@ -70,23 +142,29 @@ class GraphDiscrepancyBelief:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        _validate_sha256(self.basis_sha256, name="basis_sha256")
+        _validated_sha256(self.basis_sha256, name="basis_sha256")
         if self.source_physical_posterior_id is not None:
-            _validate_sha256(
+            _validated_sha256(
                 self.source_physical_posterior_id,
                 name="source_physical_posterior_id",
             )
-        if not self.transition_model_id or not self.innovation_model_id:
-            raise ValueError("discrepancy model identifiers must be nonempty")
-        if not self.component_ids or len(set(self.component_ids)) != len(
-            self.component_ids
+        _nonempty_string(self.transition_model_id, name="transition_model_id")
+        _nonempty_string(self.innovation_model_id, name="innovation_model_id")
+        if isinstance(self.component_ids, (str, bytes)):
+            raise ValueError("component_ids must be a nonempty sequence")
+        component_ids = tuple(self.component_ids)
+        if not component_ids or any(
+            type(identifier) is not str or not identifier
+            for identifier in component_ids
         ):
-            raise ValueError("component_ids must be nonempty and unique")
+            raise ValueError("component_ids must contain nonempty strings")
+        if len(set(component_ids)) != len(component_ids):
+            raise ValueError("component_ids must be unique")
 
         mean = _readonly(self.coefficient_mean_m)
         covariance = _readonly(self.coefficient_covariance_m2)
         projection = _readonly(self.projection_variance_m2)
-        component_count = len(self.component_ids)
+        component_count = len(component_ids)
         if mean.ndim != 3 or mean.shape[0] != component_count or mean.shape[2] != 3:
             raise ValueError("coefficient_mean_m must have shape (K, rank, 3)")
         rank = mean.shape[1]
@@ -104,6 +182,7 @@ class GraphDiscrepancyBelief:
             raise ValueError("projection variance must be nonnegative")
         _positive_semidefinite(covariance, name="coefficient covariance")
 
+        object.__setattr__(self, "component_ids", component_ids)
         object.__setattr__(self, "coefficient_mean_m", mean)
         object.__setattr__(self, "coefficient_covariance_m2", covariance)
         object.__setattr__(self, "projection_variance_m2", projection)
@@ -233,16 +312,25 @@ def write_graph_discrepancy_belief(
     manifest_path: str | Path,
     belief: GraphDiscrepancyBelief,
 ) -> dict[str, Any]:
-    """Write a JSON manifest and non-pickled NPZ payload."""
+    """Atomically write a strict JSON manifest and non-pickled NPZ payload."""
 
     manifest = Path(manifest_path)
     payload = manifest.with_suffix(".npz")
-    manifest.parent.mkdir(parents=True, exist_ok=True)
-    np.savez_compressed(
+    if payload == manifest:
+        raise ValueError("graph-discrepancy manifest must not use the .npz suffix")
+
+    def write_payload(handle: BinaryIO) -> None:
+        np.savez_compressed(
+            handle,
+            coefficient_mean_m=belief.coefficient_mean_m,
+            coefficient_covariance_m2=belief.coefficient_covariance_m2,
+            projection_variance_m2=belief.projection_variance_m2,
+        )
+
+    atomic_write_binary(payload, write_payload)
+    payload_snapshot = read_regular_file(
         payload,
-        coefficient_mean_m=belief.coefficient_mean_m,
-        coefficient_covariance_m2=belief.coefficient_covariance_m2,
-        projection_variance_m2=belief.projection_variance_m2,
+        name="graph-discrepancy payload",
     )
     record = {
         "artifact_kind": "GraphDiscrepancyBelief",
@@ -256,42 +344,101 @@ def write_graph_discrepancy_belief(
         "metadata": plain_json(belief.metadata),
         "payload": {
             "path": payload.name,
-            "sha256": _file_sha256(payload),
+            "sha256": payload_snapshot.sha256,
         },
     }
-    manifest.write_text(
-        json.dumps(record, indent=2, sort_keys=True, allow_nan=False) + "\n",
-        encoding="utf-8",
-    )
+    atomic_write_json(manifest, record)
     return record
 
 
 def load_graph_discrepancy_belief(
     manifest_path: str | Path,
 ) -> GraphDiscrepancyBelief:
-    """Load and verify a graph-discrepancy belief artifact."""
+    """Load and verify one graph-discrepancy belief from exact file bytes."""
 
     manifest = Path(manifest_path)
-    record = json.loads(manifest.read_text(encoding="utf-8"))
-    if record.get("artifact_kind") != "GraphDiscrepancyBelief":
+    manifest_snapshot = read_regular_file(
+        manifest,
+        name="graph-discrepancy manifest",
+    )
+    record = load_strict_json_object(
+        manifest_snapshot.payload,
+        name="graph-discrepancy manifest",
+    )
+    _require_exact_fields(record, _MANIFEST_FIELDS, name="graph-discrepancy manifest")
+
+    if record["artifact_kind"] != "GraphDiscrepancyBelief":
         raise ValueError("manifest is not a graph-discrepancy belief")
-    if int(record.get("version", -1)) != GRAPH_DISCREPANCY_BELIEF_VERSION:
+    if type(record["version"]) is not int:
+        raise ValueError("graph-discrepancy version must be an integer")
+    if record["version"] != GRAPH_DISCREPANCY_BELIEF_VERSION:
         raise ValueError("unsupported graph-discrepancy belief version")
-    payload = manifest.parent / str(record["payload"]["path"])
-    if _file_sha256(payload) != record["payload"]["sha256"]:
-        raise ValueError("graph-discrepancy payload checksum changed")
-    with np.load(payload, allow_pickle=False) as arrays:
-        belief = GraphDiscrepancyBelief(
-            basis_sha256=str(record["basis_sha256"]),
-            component_ids=tuple(map(str, record["component_ids"])),
-            coefficient_mean_m=arrays["coefficient_mean_m"],
-            coefficient_covariance_m2=arrays["coefficient_covariance_m2"],
-            projection_variance_m2=arrays["projection_variance_m2"],
-            transition_model_id=str(record["transition_model_id"]),
-            innovation_model_id=str(record["innovation_model_id"]),
-            source_physical_posterior_id=record.get("source_physical_posterior_id"),
-            metadata=record.get("metadata", {}),
+
+    artifact_id = _validated_sha256(record["artifact_id"], name="artifact_id")
+    basis_sha256 = _validated_sha256(
+        record["basis_sha256"],
+        name="basis_sha256",
+    )
+    component_ids = _validated_component_ids(record["component_ids"])
+    transition_model_id = _nonempty_string(
+        record["transition_model_id"],
+        name="transition_model_id",
+    )
+    innovation_model_id = _nonempty_string(
+        record["innovation_model_id"],
+        name="innovation_model_id",
+    )
+    source_physical_posterior_id = record["source_physical_posterior_id"]
+    if source_physical_posterior_id is not None:
+        source_physical_posterior_id = _validated_sha256(
+            source_physical_posterior_id,
+            name="source_physical_posterior_id",
         )
-    if belief.artifact_id != record["artifact_id"]:
+    metadata = _require_mapping(record["metadata"], name="metadata")
+
+    payload_record = _require_mapping(record["payload"], name="payload")
+    _require_exact_fields(payload_record, _PAYLOAD_FIELDS, name="payload")
+    declared_payload_sha256 = _validated_sha256(
+        payload_record["sha256"],
+        name="payload.sha256",
+    )
+    payload_snapshot = read_regular_file_beneath(
+        manifest.parent,
+        payload_record["path"],
+        name="graph-discrepancy payload",
+    )
+    if payload_snapshot.sha256 != declared_payload_sha256:
+        raise ValueError("graph-discrepancy payload checksum changed")
+
+    arrays = load_npz_bytes(
+        payload_snapshot.payload,
+        name="graph-discrepancy payload",
+        expected_arrays=_PAYLOAD_ARRAYS,
+    )
+    coefficient_mean_m = _require_float64_array(
+        arrays["coefficient_mean_m"],
+        name="coefficient_mean_m",
+    )
+    coefficient_covariance_m2 = _require_float64_array(
+        arrays["coefficient_covariance_m2"],
+        name="coefficient_covariance_m2",
+    )
+    projection_variance_m2 = _require_float64_array(
+        arrays["projection_variance_m2"],
+        name="projection_variance_m2",
+    )
+
+    belief = GraphDiscrepancyBelief(
+        basis_sha256=basis_sha256,
+        component_ids=component_ids,
+        coefficient_mean_m=coefficient_mean_m,
+        coefficient_covariance_m2=coefficient_covariance_m2,
+        projection_variance_m2=projection_variance_m2,
+        transition_model_id=transition_model_id,
+        innovation_model_id=innovation_model_id,
+        source_physical_posterior_id=source_physical_posterior_id,
+        metadata=metadata,
+    )
+    if belief.artifact_id != artifact_id:
         raise ValueError("graph-discrepancy artifact identifier changed")
     return belief

--- a/tests/test_graph_discrepancy_artifact_io.py
+++ b/tests/test_graph_discrepancy_artifact_io.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+import causal4d.discrepancy_belief as discrepancy_module
+from causal4d.artifact_io import (
+    load_strict_json_object,
+    read_regular_file_beneath,
+)
+from causal4d.contracts import array_sha256
+from causal4d.discrepancy_belief import (
+    GraphDiscrepancyBelief,
+    load_graph_discrepancy_belief,
+    write_graph_discrepancy_belief,
+)
+
+
+def _basis() -> np.ndarray:
+    return np.asarray([[1.0, 0.0], [0.0, 1.0], [0.5, -0.5]])
+
+
+def _belief() -> GraphDiscrepancyBelief:
+    return GraphDiscrepancyBelief(
+        basis_sha256=array_sha256(_basis()),
+        component_ids=("component-0",),
+        coefficient_mean_m=np.asarray(
+            [[[0.01, 0.0, 0.0], [0.0, -0.02, 0.0]]],
+            dtype=np.float64,
+        ),
+        coefficient_covariance_m2=np.zeros((1, 3, 2, 2), dtype=np.float64),
+        projection_variance_m2=np.asarray(
+            [1e-6, 2e-6, 3e-6],
+            dtype=np.float64,
+        ),
+        transition_model_id="persistence",
+        innovation_model_id="unit-test",
+        metadata={"future_frames_read": 0},
+    )
+
+
+def _write_bundle(tmp_path: Path) -> tuple[Path, Path, dict[str, Any]]:
+    manifest = tmp_path / "belief.json"
+    record = write_graph_discrepancy_belief(manifest, _belief())
+    payload = tmp_path / record["payload"]["path"]
+    return manifest, payload, record
+
+
+def _write_manifest(manifest: Path, record: dict[str, Any]) -> None:
+    manifest.write_text(
+        json.dumps(record, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _read_payload_arrays(payload: Path) -> dict[str, np.ndarray]:
+    with np.load(payload, allow_pickle=False) as archive:
+        return {key: np.array(archive[key], copy=True) for key in archive.files}
+
+
+def _replace_payload(
+    payload: Path,
+    record: dict[str, Any],
+    arrays: dict[str, np.ndarray],
+) -> None:
+    np.savez_compressed(payload, **arrays)
+    record["payload"]["sha256"] = hashlib.sha256(payload.read_bytes()).hexdigest()
+
+
+def test_round_trip_preserves_identity_and_arrays(tmp_path: Path) -> None:
+    manifest, _, record = _write_bundle(tmp_path)
+    loaded = load_graph_discrepancy_belief(manifest)
+
+    assert loaded.artifact_id == record["artifact_id"] == _belief().artifact_id
+    np.testing.assert_array_equal(
+        loaded.coefficient_mean_m,
+        _belief().coefficient_mean_m,
+    )
+    np.testing.assert_array_equal(
+        loaded.coefficient_covariance_m2,
+        _belief().coefficient_covariance_m2,
+    )
+    np.testing.assert_array_equal(
+        loaded.projection_variance_m2,
+        _belief().projection_variance_m2,
+    )
+
+
+def test_manifest_validation_uses_the_exact_opened_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest, _, record = _write_bundle(tmp_path)
+    real_loader = discrepancy_module.load_strict_json_object
+
+    def replacing_loader(payload: bytes, *, name: str) -> dict[str, Any]:
+        manifest.write_text("{}\n", encoding="utf-8")
+        return real_loader(payload, name=name)
+
+    monkeypatch.setattr(
+        discrepancy_module,
+        "load_strict_json_object",
+        replacing_loader,
+    )
+    loaded = load_graph_discrepancy_belief(manifest)
+
+    assert loaded.artifact_id == record["artifact_id"]
+
+
+def test_payload_validation_uses_the_exact_opened_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest, payload, record = _write_bundle(tmp_path)
+    real_loader = discrepancy_module.load_npz_bytes
+
+    def replacing_loader(
+        payload_bytes: bytes,
+        *,
+        name: str,
+        expected_arrays: frozenset[str],
+    ) -> dict[str, np.ndarray]:
+        payload.write_bytes(b"concurrent replacement")
+        return real_loader(
+            payload_bytes,
+            name=name,
+            expected_arrays=expected_arrays,
+        )
+
+    monkeypatch.setattr(discrepancy_module, "load_npz_bytes", replacing_loader)
+    loaded = load_graph_discrepancy_belief(manifest)
+
+    assert loaded.artifact_id == record["artifact_id"]
+
+
+def test_payload_path_rejects_parent_traversal(tmp_path: Path) -> None:
+    manifest, _, record = _write_bundle(tmp_path)
+    record["payload"]["path"] = "../belief.npz"
+    _write_manifest(manifest, record)
+
+    with pytest.raises(ValueError, match="safe POSIX relative path"):
+        load_graph_discrepancy_belief(manifest)
+
+
+def test_payload_path_rejects_symbolic_link(tmp_path: Path) -> None:
+    manifest, payload, record = _write_bundle(tmp_path)
+    link = tmp_path / "linked-payload.npz"
+    try:
+        link.symlink_to(payload.name)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+    record["payload"]["path"] = link.name
+    _write_manifest(manifest, record)
+
+    with pytest.raises(ValueError, match="ordinary readable file"):
+        load_graph_discrepancy_belief(manifest)
+
+
+def test_payload_path_rejects_intermediate_symbolic_link(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    real = root / "real"
+    real.mkdir(parents=True)
+    (real / "payload.bin").write_bytes(b"payload")
+    link = root / "linked"
+    try:
+        link.symlink_to(real.name, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(ValueError, match="ordinary readable file"):
+        read_regular_file_beneath(root, "linked/payload.bin")
+
+
+def test_manifest_rejects_duplicate_json_keys(tmp_path: Path) -> None:
+    manifest, _, _ = _write_bundle(tmp_path)
+    text = manifest.read_text(encoding="utf-8")
+    text = text.replace(
+        '  "artifact_kind": "GraphDiscrepancyBelief",',
+        (
+            '  "artifact_kind": "GraphDiscrepancyBelief",\n'
+            '  "artifact_kind": "GraphDiscrepancyBelief",'
+        ),
+        1,
+    )
+    manifest.write_text(text, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        load_graph_discrepancy_belief(manifest)
+
+
+def test_manifest_rejects_nonfinite_json_numbers(tmp_path: Path) -> None:
+    manifest, _, record = _write_bundle(tmp_path)
+    record["metadata"] = {"invalid": float("nan")}
+    manifest.write_text(
+        json.dumps(record, sort_keys=True, allow_nan=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="non-finite JSON number"):
+        load_graph_discrepancy_belief(manifest)
+
+
+def test_manifest_rejects_overflowing_json_numbers() -> None:
+    with pytest.raises(ValueError, match="non-finite JSON number"):
+        load_strict_json_object(
+            b'{"overflow": 1e400}',
+            name="test manifest",
+        )
+
+
+def test_manifest_rejects_coercion_dependent_version(tmp_path: Path) -> None:
+    manifest, _, record = _write_bundle(tmp_path)
+    record["version"] = "1"
+    _write_manifest(manifest, record)
+
+    with pytest.raises(ValueError, match="version must be an integer"):
+        load_graph_discrepancy_belief(manifest)
+
+
+def test_manifest_rejects_unexpected_fields(tmp_path: Path) -> None:
+    manifest, _, record = _write_bundle(tmp_path)
+    record["unexpected"] = True
+    _write_manifest(manifest, record)
+
+    with pytest.raises(ValueError, match="fields changed"):
+        load_graph_discrepancy_belief(manifest)
+
+
+def test_payload_rejects_unexpected_arrays(tmp_path: Path) -> None:
+    manifest, payload, record = _write_bundle(tmp_path)
+    arrays = _read_payload_arrays(payload)
+    arrays["unexpected"] = np.asarray([1.0], dtype=np.float64)
+    _replace_payload(payload, record, arrays)
+    _write_manifest(manifest, record)
+
+    with pytest.raises(ValueError, match="array inventory changed"):
+        load_graph_discrepancy_belief(manifest)
+
+
+def test_payload_rejects_noncanonical_dtypes(tmp_path: Path) -> None:
+    manifest, payload, record = _write_bundle(tmp_path)
+    arrays = _read_payload_arrays(payload)
+    arrays["coefficient_mean_m"] = arrays["coefficient_mean_m"].astype(
+        np.float32
+    )
+    _replace_payload(payload, record, arrays)
+    _write_manifest(manifest, record)
+
+    with pytest.raises(ValueError, match="coefficient_mean_m must use float64"):
+        load_graph_discrepancy_belief(manifest)
+
+
+def test_manifest_itself_must_not_be_a_symbolic_link(tmp_path: Path) -> None:
+    manifest, _, _ = _write_bundle(tmp_path)
+    link = tmp_path / "belief-link.json"
+    try:
+        link.symlink_to(manifest.name)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(ValueError, match="ordinary readable file"):
+        load_graph_discrepancy_belief(link)
+
+
+def test_writer_rejects_npz_manifest_path(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="must not use the .npz suffix"):
+        write_graph_discrepancy_belief(tmp_path / "belief.npz", _belief())


### PR DESCRIPTION
## Summary

- add a shared exact-byte artifact reader that hashes and consumes the same open file bytes;
- reject absolute, traversal, backslash, empty-component, final-symlink, and intermediate-symlink payload paths;
- decode strict finite UTF-8 JSON with duplicate-key and overflowing-number rejection;
- load NPZ payloads from the retained bytes with `allow_pickle=False`, duplicate ZIP-member rejection, and a closed array inventory;
- make `GraphDiscrepancyBelief` manifests use closed field sets and exact scalar types instead of coercive `str(...)` / `int(...)` parsing;
- require canonical `float64` payload arrays while preserving valid version-1 artifact identities;
- atomically publish the NPZ payload and JSON manifest, with fail-closed mismatch behavior during replacement;
- add adversarial regressions for concurrent manifest/payload replacement, traversal, symlinks, duplicate/non-finite JSON, schema drift, extra arrays, and wrong dtypes.

## Root cause

The graph-discrepancy loader hashed the NPZ path and later reopened that path with `np.load`, so a concurrent replacement could make the retained digest identify bytes different from those actually consumed. It also joined an untrusted manifest path directly below the manifest directory, accepted coercion-dependent JSON values, allowed open manifest field sets, and did not reject extra NPZ arrays or noncanonical dtypes.

## Compatibility and scientific boundary

- `GRAPH_DISCREPANCY_BELIEF_VERSION` remains 1.
- The valid writer schema, numerical arrays, artifact-ID calculation, graph basis identity, transition/innovation semantics, and discrepancy inference are unchanged.
- Existing in-memory callers may still supply sequence-like component IDs; the frozen artifact normalizes them to an immutable tuple.
- This is artifact-integrity and publication hardening only. It does not change the frozen estimator, evidence count, registered protocol, or scientific claim.

## Validation

A local isolated harness on Python 3.13 ran the new focused regressions:

```text
15 passed
```

The repository pull-request workflows should additionally run Ruff, formatting, the complete Python 3.10/3.12/3.14 suite, distribution and installed-artifact checks, frozen-manifest validation, and pinned BayesianPhysTwin integration.