### PR TITLE
Split independent CI quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,29 @@ env:
   PYTHONUNBUFFERED: "1"
 
 jobs:
-  quality:
-    name: Ruff, formatting, and types
+  lint:
+    name: Ruff lint
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python 3.10
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+          cache: pip
+      - name: Install development tools
+        run: python -m pip install -e ".[dev]"
+      - name: Run Ruff
+        run: python -m ruff check .
+
+  format:
+    name: Ruff formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository with comparison history
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
@@ -36,8 +54,6 @@ jobs:
           cache: pip
       - name: Install development tools
         run: python -m pip install -e ".[dev]"
-      - name: Run Ruff
-        run: python -m ruff check .
       - name: Select changed Python files
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
@@ -53,11 +69,29 @@ jobs:
           else
             echo "No changed Python files require a formatting check."
           fi
+
+  types:
+    name: Mypy stable contracts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install development tools
+        run: python -m pip install -e ".[dev]"
       - name: Type-check stable contracts and CI utilities
         run: |
           python -m mypy --python-version 3.12 \
             scripts/ci \
+            src/causal4d/artifact_io.py \
             src/causal4d/atomic_io.py \
+            src/causal4d/discrepancy_belief.py \
             src/causal4d/result_bundle_publication.py \
             src/causal4d/trusted_pickle.py \
             src/causal4d/immutable_array.py \
@@ -297,7 +331,16 @@ jobs:
   release:
     name: Publish GitHub release
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [quality, core, pinned-bpt, build, installed-artifact, bundles, frozen-manifest]
+    needs:
+      - lint
+      - format
+      - types
+      - core
+      - pinned-bpt
+      - build
+      - installed-artifact
+      - bundles
+      - frozen-manifest
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/tests/test_release_workflow_policy.py
+++ b/tests/test_release_workflow_policy.py
@@ -13,8 +13,35 @@ def test_tag_release_requires_public_provider_integration() -> None:
     assert "python -m build --wheel" in text
     assert "artifact-venv/bin/python scripts/ci/run_bpt_integration_tests.py" in text
     assert (
-        "needs: [quality, core, pinned-bpt, build, installed-artifact, bundles, frozen-manifest]"
+        "    needs:\n"
+        "      - lint\n"
+        "      - format\n"
+        "      - types\n"
+        "      - core\n"
+        "      - pinned-bpt\n"
+        "      - build\n"
+        "      - installed-artifact\n"
+        "      - bundles\n"
+        "      - frozen-manifest\n"
         in text
     )
     assert "BPT_READ_SSH_KEY" not in text
     assert "ssh-key:" not in text
+
+
+def test_quality_failures_are_reported_by_independent_jobs() -> None:
+    workflow = Path(__file__).resolve().parents[1] / ".github/workflows/ci.yml"
+    if not workflow.is_file():
+        pytest.skip("GitHub workflow is not included in the source distribution")
+    text = workflow.read_text(encoding="utf-8")
+    quality_section, _ = text.split("\n  core:\n", maxsplit=1)
+
+    assert "\n  quality:\n" not in quality_section
+    assert "\n  lint:\n    name: Ruff lint\n" in quality_section
+    assert "\n  format:\n    name: Ruff formatting\n" in quality_section
+    assert "\n  types:\n    name: Mypy stable contracts\n" in quality_section
+    assert quality_section.count("python -m ruff check .") == 1
+    assert quality_section.count("python -m ruff format --check") == 1
+    assert quality_section.count("python -m mypy --python-version 3.12") == 1
+    assert "src/causal4d/artifact_io.py" in quality_section
+    assert "src/causal4d/discrepancy_belief.py" in quality_section

--- a/tests/test_release_workflow_policy.py
+++ b/tests/test_release_workflow_policy.py
@@ -22,8 +22,7 @@ def test_tag_release_requires_public_provider_integration() -> None:
         "      - build\n"
         "      - installed-artifact\n"
         "      - bundles\n"
-        "      - frozen-manifest\n"
-        in text
+        "      - frozen-manifest\n" in text
     )
     assert "BPT_READ_SSH_KEY" not in text
     assert "ssh-key:" not in text


### PR DESCRIPTION
## Summary

- replace the serial `quality` job with independent `lint`, `format`, and `types` jobs;
- keep full comparison history only in the changed-file formatting job while lint and mypy use shallow checkouts;
- run mypy on Python 3.12 and extend its stable surface to the exact-byte artifact reader and graph-discrepancy artifact boundary;
- require all three quality jobs before tag publication;
- update release workflow policy coverage and add a regression proving the checks remain independent.

## Why

The previous job ran Ruff lint, incremental formatting, and mypy sequentially. A formatting failure stopped the job before mypy, so contributors needed another CI cycle to discover type failures. Independent jobs expose all quality failures in one run and let them execute concurrently.

## Compatibility

This changes CI scheduling and release gating only. Test matrices, package builds, result bundles, frozen milestone validation, pinned BayesianPhysTwin integration, estimator behavior, artifact identities, and scientific protocols are unchanged.

## Validation

The pull-request workflows exercise the new job graph directly. The dedicated Causal4D merge gate additionally validates the synthetic merge result with repository quality checks, the complete default suite, distributions, and installed-wheel provider integration.