### PR TITLE
Reject Python syntax warnings in the merge gate

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -51,7 +51,8 @@ jobs:
 
       - name: Run repository quality checks
         run: |
-          python -W error::SyntaxWarning -m compileall -q -f src tests scripts
+          PYTHONPYCACHEPREFIX="$RUNNER_TEMP/python-syntax-cache" \
+            python -W error::SyntaxWarning -m compileall -q -f src tests scripts
           python -m ruff check .
           python -m mypy --python-version 3.12 \
             scripts/ci \

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Run repository quality checks
         run: |
+          python -W error::SyntaxWarning -m compileall -q -f src tests scripts
           python -m ruff check .
           python -m mypy --python-version 3.12 \
             scripts/ci \

--- a/tests/test_causal4d_provider_contract.py
+++ b/tests/test_causal4d_provider_contract.py
@@ -196,7 +196,7 @@ def test_exact_provider_descriptor_constructs_the_same_manifest() -> None:
     (
         ({"provider_name": None}, "provider_name must be a nonempty string"),
         ({"schema_version": True}, "schema_version must be a positive integer"),
-        ({"capabilities": ("valid", 3)}, "capabilities\[1\]"),
+        ({"capabilities": ("valid", 3)}, r"capabilities\[1\]"),
         (
             {"artifact_schema_versions": {1: 1}},
             "artifact_schema_versions key must be a nonempty string",
@@ -227,7 +227,7 @@ def test_provider_descriptor_rejects_schema_and_type_drift() -> None:
     malformed.append((missing, "fields do not match schema"))
 
     unknown = _descriptor(unregistered="value")
-    malformed.append((unknown, "unexpected=\['unregistered'\]"))
+    malformed.append((unknown, r"unexpected=\['unregistered'\]"))
 
     non_string_key = _descriptor()
     non_string_key[1] = "value"
@@ -253,9 +253,9 @@ def test_provider_descriptor_rejects_schema_and_type_drift() -> None:
 def test_compatibility_requirements_reject_coercible_values() -> None:
     manifest = _manifest()
 
-    with pytest.raises(ValueError, match="required_capabilities\[0\]"):
+    with pytest.raises(ValueError, match=r"required_capabilities\[0\]"):
         validate_provider_compatibility(manifest, required_capabilities=(1,))
-    with pytest.raises(ValueError, match="supported_schema_versions\[0\]"):
+    with pytest.raises(ValueError, match=r"supported_schema_versions\[0\]"):
         validate_provider_compatibility(manifest, supported_schema_versions=(True,))
     with pytest.raises(
         ValueError, match="supported_provider_versions must be a string"

--- a/tests/test_merge_gate_workflow_policy.py
+++ b/tests/test_merge_gate_workflow_policy.py
@@ -32,6 +32,10 @@ def test_merge_gate_validates_the_pull_request_merge_result() -> None:
 def test_merge_gate_covers_quality_tests_build_and_provider_integration() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
 
+    assert (
+        "python -W error::SyntaxWarning -m compileall -q -f src tests scripts"
+        in text
+    )
     assert "python -m ruff check ." in text
     assert "python -m mypy --python-version 3.12" in text
     assert "src/causal4d/belief_provider_v2_contract.py" in text

--- a/tests/test_merge_gate_workflow_policy.py
+++ b/tests/test_merge_gate_workflow_policy.py
@@ -32,6 +32,7 @@ def test_merge_gate_validates_the_pull_request_merge_result() -> None:
 def test_merge_gate_covers_quality_tests_build_and_provider_integration() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
 
+    assert 'PYTHONPYCACHEPREFIX="$RUNNER_TEMP/python-syntax-cache"' in text
     assert (
         "python -W error::SyntaxWarning -m compileall -q -f src tests scripts"
         in text


### PR DESCRIPTION
## Summary

- convert the four regular-expression expectations that emitted invalid-escape `SyntaxWarning`s into raw strings;
- compile all repository Python under `src`, `tests`, and `scripts` with `SyntaxWarning` promoted to an error before Ruff and MyPy run; and
- bind that command into the merge-gate workflow policy so it cannot disappear silently.

## Why

The complete test suite was passing but emitted four Python syntax warnings from regex strings in `tests/test_causal4d_provider_contract.py`. Such warnings are easy to overlook and can become errors under newer Python releases. The merge gate now rejects this class of source-level compatibility defect before tests execute.

## Scientific boundary

This is quality-only maintenance. It changes no production behavior, estimator, provider contract, frozen method, protocol, artifact identity, target access, evidence accounting, or result.

## Validation

The branch is based on current `main`, including graph-discrepancy IO hardening from #184. The exact pull-request merge result will run the new forced `compileall` command with `SyntaxWarning` treated as an error, followed by Ruff, MyPy, the complete default suite, distribution validation, and pinned BayesianPhysTwin installed-wheel integration.