### PR TITLE
Add acquisition campaign status and reports

### DIFF
--- a/docs/causal4d_acquisition_campaign.md
+++ b/docs/causal4d_acquisition_campaign.md
@@ -1,0 +1,142 @@
+# Acquisition campaign status and reports
+
+The acquisition campaign surface turns one hash-verified pre-session doctor
+artifact into concise operator decisions and deterministic human-readable
+reports. It does not rerun validation, inspect target outcomes, or change the
+locked protocol. The source doctor report remains authoritative.
+
+## Generate the source doctor report
+
+Run the doctor from the exact deployed checkout immediately before a session:
+
+```bash
+causal4d protocol acquisition doctor \
+  configs/causal4d/sloth_multi_action_v1.json \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  --minimum-free-gib 100 \
+  --write-probe-mib 64 \
+  --minimum-write-mib-s 100 \
+  --output-json \
+  /data/causal4d-sloth-multi-action-v1/operator/doctor-latest.json \
+  --overwrite \
+  --require-ready
+```
+
+The campaign commands first verify the doctor artifact kind, schema, canonical
+SHA-256, execution counts, check counts, next-execution identity, completion
+state, and `target_outcomes_used=false` boundary. A modified or contradictory
+doctor artifact is rejected.
+
+## Compact machine-readable status
+
+```bash
+causal4d protocol acquisition campaign status \
+  /data/causal4d-sloth-multi-action-v1/operator/doctor-latest.json \
+  --output-json \
+  /data/causal4d-sloth-multi-action-v1/operator/campaign-latest.json \
+  --overwrite \
+  --require-ready
+```
+
+The summary reports:
+
+- `state`: `invalid`, `blocked`, `ready`, or `complete`;
+- completed, remaining, and total registered executions;
+- progress as a fraction of the frozen protocol;
+- the complete next registered execution descriptor;
+- blocking checks and warnings;
+- the exact source doctor report SHA-256; and
+- `target_outcomes_used=false`.
+
+`--require-ready` returns exit code 3 for a structurally valid but blocked
+campaign.
+
+## Show only the next decision
+
+```bash
+causal4d protocol acquisition campaign next \
+  /data/causal4d-sloth-multi-action-v1/operator/doctor-latest.json
+```
+
+This emits the campaign state, the next registered execution, blocking checks,
+and the source doctor identity. It returns:
+
+| Code | Meaning |
+| ---: | --- |
+| `0` | The next execution is ready, or collection is complete. |
+| `2` | The doctor artifact is invalid, tampered, or contradictory. |
+| `3` | The campaign is valid but blocked or requires operator review. |
+
+A blocked `next` result must not be used as permission to record.
+
+## Render an operator report
+
+Markdown is selected by default unless the output name ends in `.html`:
+
+```bash
+causal4d protocol acquisition campaign report \
+  /data/causal4d-sloth-multi-action-v1/operator/doctor-latest.json \
+  /data/causal4d-sloth-multi-action-v1/operator/campaign-latest.md \
+  --overwrite
+
+causal4d protocol acquisition campaign report \
+  /data/causal4d-sloth-multi-action-v1/operator/doctor-latest.json \
+  /data/causal4d-sloth-multi-action-v1/operator/campaign-latest.html \
+  --format html \
+  --overwrite
+```
+
+Both formats contain the progress, next execution, blockers, warnings, complete
+doctor-check table, source doctor digest, and explicit scientific boundary.
+Publication is atomic; without `--overwrite`, an existing destination is
+preserved and the command fails.
+
+## Workflow usage
+
+A collection supervisor can use this sequence:
+
+```bash
+set -euo pipefail
+
+doctor=operator/doctor-latest.json
+summary=operator/campaign-latest.json
+report=operator/campaign-latest.html
+
+causal4d protocol acquisition doctor \
+  configs/causal4d/sloth_multi_action_v1.json \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  --output-json "$doctor" \
+  --overwrite
+
+causal4d protocol acquisition campaign status \
+  "$doctor" \
+  --output-json "$summary" \
+  --overwrite \
+  --require-ready
+
+causal4d protocol acquisition campaign next "$doctor"
+
+causal4d protocol acquisition campaign report \
+  "$doctor" \
+  "$report" \
+  --overwrite
+```
+
+Retain the doctor JSON beside any rendered report. The rendered files are
+operator views derived from the doctor identity; they do not replace readiness,
+method-freeze, execution-manifest, journal, or evidence-status artifacts.
+
+## Scientific boundary
+
+Campaign status and reports are operational provenance only. They do not:
+
+- increment the acquired or validated execution count;
+- alter the registered order, split, thresholds, exclusions, or estimator;
+- inspect or summarize held-out target outcomes;
+- authorize target-informed method selection; or
+- establish physical-prediction accuracy or calibration.
+
+Only the registered execution and session manifests, together with the
+hash-verified evidence-status validator, establish confirmatory evidence.

--- a/docs/causal4d_acquisition_campaign.md
+++ b/docs/causal4d_acquisition_campaign.md
@@ -23,10 +23,12 @@ causal4d protocol acquisition doctor \
   --require-ready
 ```
 
-The campaign commands first verify the doctor artifact kind, schema, canonical
-SHA-256, execution counts, check counts, next-execution identity, completion
-state, and `target_outcomes_used=false` boundary. A modified or contradictory
-doctor artifact is rejected.
+The campaign commands first verify the exact schema-1 doctor contract: artifact
+kind, canonical SHA-256, timestamp and protocol identity, threshold types, the
+complete check inventory, derived validity/readiness/completion flags, execution
+counts, next-execution identity and index, resume semantics, and the recursive
+`target_outcomes_used=false` boundary. A modified, self-rehashed but
+contradictory, or outcome-contaminated doctor artifact is rejected.
 
 ## Compact machine-readable status
 
@@ -89,8 +91,14 @@ causal4d protocol acquisition campaign report \
 
 Both formats contain the progress, next execution, blockers, warnings, complete
 doctor-check table, source doctor digest, and explicit scientific boundary.
-Publication is atomic; without `--overwrite`, an existing destination is
-preserved and the command fails.
+Operator-controlled strings are escaped before rendering. Publication is
+atomic; without `--overwrite`, an existing destination is preserved and the
+command fails.
+
+A campaign output must be distinct from its source doctor report. The command
+rejects the same pathname as well as an existing symbolic-link or hard-link
+alias, even when `--overwrite` is supplied. This prevents a derived summary or
+rendered report from replacing the authoritative doctor artifact.
 
 ## Workflow usage
 

--- a/src/causal4d/acquisition_campaign.py
+++ b/src/causal4d/acquisition_campaign.py
@@ -1,0 +1,392 @@
+"""Operator-facing summaries for hash-verified acquisition-doctor reports."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from html import escape
+from typing import Any, Literal
+
+from causal4d.acquisition_flight_common import (
+    DOCTOR_REPORT_KIND,
+    _canonical_sha256,
+    _is_sha256,
+    _require,
+)
+
+CAMPAIGN_SCHEMA_VERSION = 1
+CAMPAIGN_SUMMARY_KIND = "Causal4DAcquisitionCampaignSummary"
+CampaignState = Literal["invalid", "blocked", "ready", "complete"]
+_CHECK_STATUSES = frozenset({"pass", "warn", "fail", "skipped"})
+
+
+def _nonnegative_integer(value: Any, *, name: str) -> int:
+    _require(type(value) is int and value >= 0, f"{name} must be a nonnegative integer")
+    return value
+
+
+def _boolean(value: Any, *, name: str) -> bool:
+    _require(type(value) is bool, f"{name} must be Boolean")
+    return value
+
+
+def _validated_checks(value: Any) -> list[dict[str, Any]]:
+    _require(isinstance(value, list), "doctor report checks must be a list")
+    checks: list[dict[str, Any]] = []
+    identifiers: set[str] = set()
+    for index, raw in enumerate(value):
+        _require(isinstance(raw, Mapping), f"doctor check {index} must be an object")
+        check = dict(raw)
+        identifier = check.get("check_id")
+        status = check.get("status")
+        message = check.get("message")
+        _require(
+            type(identifier) is str and bool(identifier),
+            f"doctor check {index} lacks check_id",
+        )
+        _require(identifier not in identifiers, f"duplicate doctor check: {identifier}")
+        _require(
+            type(status) is str and status in _CHECK_STATUSES,
+            f"doctor check {identifier} has invalid status",
+        )
+        _require(
+            type(message) is str and bool(message),
+            f"doctor check {identifier} lacks message",
+        )
+        identifiers.add(identifier)
+        checks.append(check)
+    _require(bool(checks), "doctor report must contain checks")
+    return checks
+
+
+def validate_acquisition_doctor_report(
+    report: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate one complete doctor artifact before deriving operator summaries."""
+
+    values = dict(report)
+    _require(
+        values.get("schema_version") == 1,
+        "unsupported acquisition-doctor schema version",
+    )
+    _require(
+        values.get("artifact_kind") == DOCTOR_REPORT_KIND,
+        "wrong acquisition-doctor artifact kind",
+    )
+    protocol_id = values.get("protocol_id")
+    _require(
+        type(protocol_id) is str and bool(protocol_id),
+        "doctor report protocol_id is missing",
+    )
+    source_sha = values.get("report_sha256")
+    _require(_is_sha256(source_sha), "doctor report SHA-256 is invalid")
+    _require(
+        source_sha == _canonical_sha256(values, omitted="report_sha256"),
+        "doctor report checksum mismatch",
+    )
+    _require(
+        values.get("target_outcomes_used") is False,
+        "doctor report must preserve the target-outcome boundary",
+    )
+    completed = _nonnegative_integer(
+        values.get("completed_executions"),
+        name="completed_executions",
+    )
+    total = _nonnegative_integer(
+        values.get("total_executions"),
+        name="total_executions",
+    )
+    _require(total > 0, "total_executions must be positive")
+    _require(completed <= total, "completed executions exceed the protocol total")
+    failure_count = _nonnegative_integer(
+        values.get("failure_count"),
+        name="failure_count",
+    )
+    warning_count = _nonnegative_integer(
+        values.get("warning_count"),
+        name="warning_count",
+    )
+    checks = _validated_checks(values.get("checks"))
+    _require(
+        failure_count == sum(check["status"] == "fail" for check in checks),
+        "doctor failure_count differs from its checks",
+    )
+    _require(
+        warning_count == sum(check["status"] == "warn" for check in checks),
+        "doctor warning_count differs from its checks",
+    )
+    valid = _boolean(values.get("valid"), name="valid")
+    ready = _boolean(values.get("ready_to_record"), name="ready_to_record")
+    complete = _boolean(values.get("collection_complete"), name="collection_complete")
+    passed = _boolean(values.get("passed"), name="passed")
+    _require(not (ready and complete), "campaign cannot be ready and complete")
+    _require(passed == (ready or complete), "doctor passed flag is contradictory")
+    next_execution = values.get("next_execution")
+    _require(
+        next_execution is None or isinstance(next_execution, Mapping),
+        "doctor next_execution must be an object or null",
+    )
+    if next_execution is not None:
+        identifier = next_execution.get("execution_id")
+        _require(
+            type(identifier) is str and bool(identifier),
+            "doctor next_execution lacks execution_id",
+        )
+    _require(
+        complete
+        == (
+            completed == total
+            and next_execution is None
+            and failure_count == 0
+        ),
+        "doctor completion fields are contradictory",
+    )
+    values["checks"] = checks
+    values["next_execution"] = (
+        None if next_execution is None else dict(next_execution)
+    )
+    values["valid"] = valid
+    values["ready_to_record"] = ready
+    values["collection_complete"] = complete
+    values["passed"] = passed
+    return values
+
+
+def _campaign_state(report: Mapping[str, Any]) -> CampaignState:
+    if report["valid"] is not True:
+        return "invalid"
+    if report["collection_complete"] is True:
+        return "complete"
+    if report["ready_to_record"] is True:
+        return "ready"
+    return "blocked"
+
+
+def build_acquisition_campaign_summary(
+    report: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Derive a compact status artifact from a verified doctor report."""
+
+    values = validate_acquisition_doctor_report(report)
+    state = _campaign_state(values)
+    checks = values["checks"]
+    failures = [
+        {
+            "check_id": check["check_id"],
+            "status": check["status"],
+            "message": check["message"],
+        }
+        for check in checks
+        if check["status"] == "fail"
+    ]
+    warnings = [
+        {
+            "check_id": check["check_id"],
+            "status": check["status"],
+            "message": check["message"],
+        }
+        for check in checks
+        if check["status"] == "warn"
+    ]
+    blocking = failures if failures else (warnings if state == "blocked" else [])
+    completed = values["completed_executions"]
+    total = values["total_executions"]
+    summary: dict[str, Any] = {
+        "schema_version": CAMPAIGN_SCHEMA_VERSION,
+        "artifact_kind": CAMPAIGN_SUMMARY_KIND,
+        "source_doctor_report_sha256": values["report_sha256"],
+        "protocol_id": values["protocol_id"],
+        "state": state,
+        "completed_executions": completed,
+        "total_executions": total,
+        "remaining_executions": total - completed,
+        "progress_fraction": completed / total,
+        "next_execution": values["next_execution"],
+        "blocking_checks": blocking,
+        "warnings": warnings,
+        "target_outcomes_used": False,
+    }
+    summary["summary_sha256"] = _canonical_sha256(summary, omitted="summary_sha256")
+    return summary
+
+
+def _next_execution_markdown(next_execution: Mapping[str, Any] | None) -> list[str]:
+    if next_execution is None:
+        return ["No registered execution remains."]
+    rows = ["| Field | Value |", "| --- | --- |"]
+    for key, value in next_execution.items():
+        rows.append(f"| `{key}` | `{value}` |")
+    return rows
+
+
+def render_acquisition_campaign_markdown(
+    report: Mapping[str, Any],
+) -> str:
+    """Render a deterministic human-readable campaign report."""
+
+    values = validate_acquisition_doctor_report(report)
+    summary = build_acquisition_campaign_summary(values)
+    progress = 100.0 * summary["progress_fraction"]
+    lines = [
+        "# Causal4D acquisition campaign",
+        "",
+        f"- **Protocol:** `{summary['protocol_id']}`",
+        f"- **State:** `{summary['state']}`",
+        (
+            "- **Progress:** "
+            f"{summary['completed_executions']}/{summary['total_executions']} "
+            f"executions ({progress:.1f}%)"
+        ),
+        (
+            "- **Source doctor report:** "
+            f"`{summary['source_doctor_report_sha256']}`"
+        ),
+        "- **Target outcomes used:** `false`",
+        "",
+        "## Next registered execution",
+        "",
+        *_next_execution_markdown(summary["next_execution"]),
+        "",
+        "## Blocking checks",
+        "",
+    ]
+    if summary["blocking_checks"]:
+        lines.extend(
+            f"- `{check['check_id']}`: {check['message']}"
+            for check in summary["blocking_checks"]
+        )
+    else:
+        lines.append("None.")
+    lines.extend(["", "## Warnings", ""])
+    if summary["warnings"]:
+        lines.extend(
+            f"- `{check['check_id']}`: {check['message']}"
+            for check in summary["warnings"]
+        )
+    else:
+        lines.append("None.")
+    lines.extend(
+        [
+            "",
+            "## Complete doctor checks",
+            "",
+            "| Status | Check | Message |",
+            "| --- | --- | --- |",
+        ]
+    )
+    for check in values["checks"]:
+        message = check["message"].replace("|", "\\|")
+        lines.append(f"| `{check['status']}` | `{check['check_id']}` | {message} |")
+    lines.extend(
+        [
+            "",
+            "This is operational provenance only. It does not increment the "
+            "confirmatory evidence count or authorize target-informed changes.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_acquisition_campaign_html(
+    report: Mapping[str, Any],
+) -> str:
+    """Render a standalone deterministic HTML campaign report."""
+
+    values = validate_acquisition_doctor_report(report)
+    summary = build_acquisition_campaign_summary(values)
+    progress = 100.0 * summary["progress_fraction"]
+    next_execution = summary["next_execution"]
+    if next_execution is None:
+        next_html = "<p>No registered execution remains.</p>"
+    else:
+        rows = "".join(
+            "<tr><th><code>"
+            + escape(str(key))
+            + "</code></th><td><code>"
+            + escape(str(value))
+            + "</code></td></tr>"
+            for key, value in next_execution.items()
+        )
+        next_html = f"<table><tbody>{rows}</tbody></table>"
+
+    def list_html(items: list[dict[str, Any]]) -> str:
+        if not items:
+            return "<p>None.</p>"
+        rows = "".join(
+            "<li><code>"
+            + escape(str(item["check_id"]))
+            + "</code>: "
+            + escape(str(item["message"]))
+            + "</li>"
+            for item in items
+        )
+        return f"<ul>{rows}</ul>"
+
+    check_rows = "".join(
+        "<tr><td><code>"
+        + escape(str(check["status"]))
+        + "</code></td><td><code>"
+        + escape(str(check["check_id"]))
+        + "</code></td><td>"
+        + escape(str(check["message"]))
+        + "</td></tr>"
+        for check in values["checks"]
+    )
+    return "\n".join(
+        [
+            "<!doctype html>",
+            '<html lang="en">',
+            "<head>",
+            '<meta charset="utf-8">',
+            "<title>Causal4D acquisition campaign</title>",
+            "</head>",
+            "<body>",
+            "<main>",
+            "<h1>Causal4D acquisition campaign</h1>",
+            "<dl>",
+            f"<dt>Protocol</dt><dd><code>{escape(summary['protocol_id'])}</code></dd>",
+            f"<dt>State</dt><dd><code>{escape(summary['state'])}</code></dd>",
+            (
+                "<dt>Progress</dt><dd>"
+                f"{summary['completed_executions']}/{summary['total_executions']} "
+                f"executions ({progress:.1f}%)</dd>"
+            ),
+            (
+                "<dt>Source doctor report</dt><dd><code>"
+                f"{escape(summary['source_doctor_report_sha256'])}"
+                "</code></dd>"
+            ),
+            "<dt>Target outcomes used</dt><dd><code>false</code></dd>",
+            "</dl>",
+            "<h2>Next registered execution</h2>",
+            next_html,
+            "<h2>Blocking checks</h2>",
+            list_html(summary["blocking_checks"]),
+            "<h2>Warnings</h2>",
+            list_html(summary["warnings"]),
+            "<h2>Complete doctor checks</h2>",
+            "<table>",
+            "<thead><tr><th>Status</th><th>Check</th><th>Message</th></tr></thead>",
+            f"<tbody>{check_rows}</tbody>",
+            "</table>",
+            (
+                "<p>This is operational provenance only. It does not increment "
+                "the confirmatory evidence count or authorize target-informed "
+                "changes.</p>"
+            ),
+            "</main>",
+            "</body>",
+            "</html>",
+            "",
+        ]
+    )
+
+
+__all__ = [
+    "CAMPAIGN_SCHEMA_VERSION",
+    "CAMPAIGN_SUMMARY_KIND",
+    "build_acquisition_campaign_summary",
+    "render_acquisition_campaign_html",
+    "render_acquisition_campaign_markdown",
+    "validate_acquisition_doctor_report",
+]

--- a/src/causal4d/acquisition_campaign.py
+++ b/src/causal4d/acquisition_campaign.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from html import escape
 from typing import Any, Literal
@@ -10,6 +11,8 @@ from causal4d.acquisition_flight_common import (
     DOCTOR_REPORT_KIND,
     _canonical_sha256,
     _is_sha256,
+    _parse_utc,
+    _reject_target_outcomes,
     _require,
 )
 
@@ -17,6 +20,45 @@ CAMPAIGN_SCHEMA_VERSION = 1
 CAMPAIGN_SUMMARY_KIND = "Causal4DAcquisitionCampaignSummary"
 CampaignState = Literal["invalid", "blocked", "ready", "complete"]
 _CHECK_STATUSES = frozenset({"pass", "warn", "fail", "skipped"})
+_DOCTOR_CHECK_IDS = frozenset(
+    {
+        "protocol_schedule",
+        "frozen_checkout",
+        "sealed_readiness",
+        "storage_capacity",
+        "storage_write_probe",
+        "real_evidence_status",
+        "execution_manifests",
+        "next_execution",
+        "session_journal",
+    }
+)
+_INVALID_CHECK_IDS = frozenset(
+    {
+        "frozen_checkout",
+        "sealed_readiness",
+        "real_evidence_status",
+        "execution_manifests",
+        "session_journal",
+    }
+)
+_NEXT_EXECUTION_FIELDS = (
+    "acquisition_execution_index",
+    "execution_id",
+    "session_id",
+    "pair_order",
+    "contact_region_id",
+    "command_profile_id",
+    "realization_condition_id",
+    "replicate_block",
+)
+_NEXT_EXECUTION_INTEGER_FIELDS = frozenset(
+    {
+        "acquisition_execution_index",
+        "pair_order",
+        "replicate_block",
+    }
+)
 
 
 def _nonnegative_integer(value: Any, *, name: str) -> int:
@@ -24,15 +66,32 @@ def _nonnegative_integer(value: Any, *, name: str) -> int:
     return value
 
 
+def _nonnegative_number(value: Any, *, name: str) -> float:
+    _require(
+        type(value) in {int, float}
+        and math.isfinite(float(value))
+        and float(value) >= 0.0,
+        f"{name} must be a finite nonnegative number",
+    )
+    return float(value)
+
+
 def _boolean(value: Any, *, name: str) -> bool:
     _require(type(value) is bool, f"{name} must be Boolean")
     return value
 
 
-def _validated_checks(value: Any) -> list[dict[str, Any]]:
+def _nonempty_string(value: Any, *, name: str) -> str:
+    _require(type(value) is str and bool(value), f"{name} must be a nonempty string")
+    return value
+
+
+def _validated_checks(
+    value: Any,
+) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]]]:
     _require(isinstance(value, list), "doctor report checks must be a list")
     checks: list[dict[str, Any]] = []
-    identifiers: set[str] = set()
+    by_identifier: dict[str, dict[str, Any]] = {}
     for index, raw in enumerate(value):
         _require(isinstance(raw, Mapping), f"doctor check {index} must be an object")
         check = dict(raw)
@@ -43,7 +102,10 @@ def _validated_checks(value: Any) -> list[dict[str, Any]]:
             type(identifier) is str and bool(identifier),
             f"doctor check {index} lacks check_id",
         )
-        _require(identifier not in identifiers, f"duplicate doctor check: {identifier}")
+        _require(
+            identifier not in by_identifier,
+            f"duplicate doctor check: {identifier}",
+        )
         _require(
             type(status) is str and status in _CHECK_STATUSES,
             f"doctor check {identifier} has invalid status",
@@ -52,10 +114,66 @@ def _validated_checks(value: Any) -> list[dict[str, Any]]:
             type(message) is str and bool(message),
             f"doctor check {identifier} lacks message",
         )
-        identifiers.add(identifier)
+        by_identifier[identifier] = check
         checks.append(check)
-    _require(bool(checks), "doctor report must contain checks")
-    return checks
+    _require(
+        set(by_identifier) == _DOCTOR_CHECK_IDS,
+        "doctor check inventory differs from schema version 1",
+    )
+    return checks, by_identifier
+
+
+def _validated_next_execution(value: Any) -> dict[str, Any] | None:
+    _require(
+        value is None or isinstance(value, Mapping),
+        "doctor next_execution must be an object or null",
+    )
+    if value is None:
+        return None
+    result = dict(value)
+    _require(
+        set(result) == set(_NEXT_EXECUTION_FIELDS),
+        "doctor next_execution inventory differs from the registered summary contract",
+    )
+    for field in _NEXT_EXECUTION_FIELDS:
+        if field in _NEXT_EXECUTION_INTEGER_FIELDS:
+            result[field] = _nonnegative_integer(
+                result[field],
+                name=f"doctor next_execution {field}",
+            )
+        else:
+            result[field] = _nonempty_string(
+                result[field],
+                name=f"doctor next_execution {field}",
+            )
+    return result
+
+
+def _validate_thresholds(value: Any) -> dict[str, Any]:
+    _require(isinstance(value, Mapping), "doctor thresholds must be an object")
+    thresholds = dict(value)
+    _require(
+        set(thresholds)
+        == {
+            "minimum_free_bytes",
+            "write_probe_bytes",
+            "minimum_write_mib_s",
+        },
+        "doctor threshold inventory differs from schema version 1",
+    )
+    thresholds["minimum_free_bytes"] = _nonnegative_integer(
+        thresholds["minimum_free_bytes"],
+        name="doctor minimum_free_bytes",
+    )
+    thresholds["write_probe_bytes"] = _nonnegative_integer(
+        thresholds["write_probe_bytes"],
+        name="doctor write_probe_bytes",
+    )
+    thresholds["minimum_write_mib_s"] = _nonnegative_number(
+        thresholds["minimum_write_mib_s"],
+        name="doctor minimum_write_mib_s",
+    )
+    return thresholds
 
 
 def validate_acquisition_doctor_report(
@@ -64,18 +182,34 @@ def validate_acquisition_doctor_report(
     """Validate one complete doctor artifact before deriving operator summaries."""
 
     values = dict(report)
+    schema_version = values.get("schema_version")
     _require(
-        values.get("schema_version") == 1,
+        type(schema_version) is int and schema_version == 1,
         "unsupported acquisition-doctor schema version",
     )
     _require(
-        values.get("artifact_kind") == DOCTOR_REPORT_KIND,
+        type(values.get("artifact_kind")) is str
+        and values["artifact_kind"] == DOCTOR_REPORT_KIND,
         "wrong acquisition-doctor artifact kind",
     )
-    protocol_id = values.get("protocol_id")
+    _parse_utc(
+        values.get("generated_at_utc"),
+        name="acquisition-doctor generated_at_utc",
+    )
+    protocol_id = _nonempty_string(
+        values.get("protocol_id"),
+        name="doctor report protocol_id",
+    )
     _require(
-        type(protocol_id) is str and bool(protocol_id),
-        "doctor report protocol_id is missing",
+        _is_sha256(values.get("protocol_design_sha256")),
+        "doctor protocol_design_sha256 is invalid",
+    )
+    _nonempty_string(values.get("repository_root"), name="doctor repository_root")
+    _nonempty_string(values.get("dataset_root"), name="doctor dataset_root")
+    thresholds = _validate_thresholds(values.get("thresholds"))
+    resume_acknowledged = _boolean(
+        values.get("resume_acknowledged"),
+        name="resume_acknowledged",
     )
     source_sha = values.get("report_sha256")
     _require(_is_sha256(source_sha), "doctor report SHA-256 is invalid")
@@ -83,10 +217,12 @@ def validate_acquisition_doctor_report(
         source_sha == _canonical_sha256(values, omitted="report_sha256"),
         "doctor report checksum mismatch",
     )
+    _reject_target_outcomes(values)
     _require(
         values.get("target_outcomes_used") is False,
         "doctor report must preserve the target-outcome boundary",
     )
+
     completed = _nonnegative_integer(
         values.get("completed_executions"),
         name="completed_executions",
@@ -105,45 +241,81 @@ def validate_acquisition_doctor_report(
         values.get("warning_count"),
         name="warning_count",
     )
-    checks = _validated_checks(values.get("checks"))
+    checks, check_by_identifier = _validated_checks(values.get("checks"))
+    actual_failure_count = sum(check["status"] == "fail" for check in checks)
+    actual_warning_count = sum(check["status"] == "warn" for check in checks)
     _require(
-        failure_count == sum(check["status"] == "fail" for check in checks),
+        failure_count == actual_failure_count,
         "doctor failure_count differs from its checks",
     )
     _require(
-        warning_count == sum(check["status"] == "warn" for check in checks),
+        warning_count == actual_warning_count,
         "doctor warning_count differs from its checks",
     )
+
     valid = _boolean(values.get("valid"), name="valid")
     ready = _boolean(values.get("ready_to_record"), name="ready_to_record")
     complete = _boolean(values.get("collection_complete"), name="collection_complete")
     passed = _boolean(values.get("passed"), name="passed")
+    expected_valid = not any(
+        check["status"] == "fail" and identifier in _INVALID_CHECK_IDS
+        for identifier, check in check_by_identifier.items()
+    )
+    _require(valid == expected_valid, "doctor valid flag is contradictory")
+
+    session_journal = check_by_identifier["session_journal"]
+    if session_journal["status"] == "warn":
+        journal_resume = _boolean(
+            session_journal.get("resume_acknowledged"),
+            name="session_journal resume_acknowledged",
+        )
+        _require(
+            journal_resume == resume_acknowledged,
+            "session-journal resume acknowledgement differs from the doctor report",
+        )
+        journal_requires_review = not resume_acknowledged
+    else:
+        _require(
+            "resume_acknowledged" not in session_journal,
+            "non-warning session_journal check must not contain resume acknowledgement",
+        )
+        journal_requires_review = False
+
+    next_execution = _validated_next_execution(values.get("next_execution"))
+    if next_execution is None:
+        _require(
+            completed == total,
+            "doctor without a next execution must report all executions completed",
+        )
+    else:
+        _require(
+            completed < total,
+            "doctor with a next execution must have remaining executions",
+        )
+        _require(
+            next_execution["acquisition_execution_index"] == completed,
+            "doctor next-execution index differs from completed execution count",
+        )
+
+    expected_complete = next_execution is None and failure_count == 0
+    expected_ready = (
+        next_execution is not None
+        and failure_count == 0
+        and not journal_requires_review
+    )
+    _require(
+        complete == expected_complete,
+        "doctor collection_complete flag is contradictory",
+    )
+    _require(ready == expected_ready, "doctor ready_to_record flag is contradictory")
     _require(not (ready and complete), "campaign cannot be ready and complete")
     _require(passed == (ready or complete), "doctor passed flag is contradictory")
-    next_execution = values.get("next_execution")
-    _require(
-        next_execution is None or isinstance(next_execution, Mapping),
-        "doctor next_execution must be an object or null",
-    )
-    if next_execution is not None:
-        identifier = next_execution.get("execution_id")
-        _require(
-            type(identifier) is str and bool(identifier),
-            "doctor next_execution lacks execution_id",
-        )
-    _require(
-        complete
-        == (
-            completed == total
-            and next_execution is None
-            and failure_count == 0
-        ),
-        "doctor completion fields are contradictory",
-    )
+
+    values["protocol_id"] = protocol_id
+    values["thresholds"] = thresholds
     values["checks"] = checks
-    values["next_execution"] = (
-        None if next_execution is None else dict(next_execution)
-    )
+    values["next_execution"] = next_execution
+    values["resume_acknowledged"] = resume_acknowledged
     values["valid"] = valid
     values["ready_to_record"] = ready
     values["collection_complete"] = complete
@@ -209,12 +381,26 @@ def build_acquisition_campaign_summary(
     return summary
 
 
+def _markdown_text(value: Any) -> str:
+    return (
+        escape(str(value))
+        .replace("|", "&#124;")
+        .replace("\r\n", "\n")
+        .replace("\r", "\n")
+        .replace("\n", "<br>")
+    )
+
+
+def _markdown_code(value: Any) -> str:
+    return f"<code>{_markdown_text(value)}</code>"
+
+
 def _next_execution_markdown(next_execution: Mapping[str, Any] | None) -> list[str]:
     if next_execution is None:
         return ["No registered execution remains."]
     rows = ["| Field | Value |", "| --- | --- |"]
     for key, value in next_execution.items():
-        rows.append(f"| `{key}` | `{value}` |")
+        rows.append(f"| {_markdown_code(key)} | {_markdown_code(value)} |")
     return rows
 
 
@@ -229,8 +415,8 @@ def render_acquisition_campaign_markdown(
     lines = [
         "# Causal4D acquisition campaign",
         "",
-        f"- **Protocol:** `{summary['protocol_id']}`",
-        f"- **State:** `{summary['state']}`",
+        f"- **Protocol:** {_markdown_code(summary['protocol_id'])}",
+        f"- **State:** {_markdown_code(summary['state'])}",
         (
             "- **Progress:** "
             f"{summary['completed_executions']}/{summary['total_executions']} "
@@ -238,9 +424,9 @@ def render_acquisition_campaign_markdown(
         ),
         (
             "- **Source doctor report:** "
-            f"`{summary['source_doctor_report_sha256']}`"
+            f"{_markdown_code(summary['source_doctor_report_sha256'])}"
         ),
-        "- **Target outcomes used:** `false`",
+        "- **Target outcomes used:** <code>false</code>",
         "",
         "## Next registered execution",
         "",
@@ -251,7 +437,8 @@ def render_acquisition_campaign_markdown(
     ]
     if summary["blocking_checks"]:
         lines.extend(
-            f"- `{check['check_id']}`: {check['message']}"
+            f"- {_markdown_code(check['check_id'])}: "
+            f"{_markdown_text(check['message'])}"
             for check in summary["blocking_checks"]
         )
     else:
@@ -259,7 +446,8 @@ def render_acquisition_campaign_markdown(
     lines.extend(["", "## Warnings", ""])
     if summary["warnings"]:
         lines.extend(
-            f"- `{check['check_id']}`: {check['message']}"
+            f"- {_markdown_code(check['check_id'])}: "
+            f"{_markdown_text(check['message'])}"
             for check in summary["warnings"]
         )
     else:
@@ -274,8 +462,11 @@ def render_acquisition_campaign_markdown(
         ]
     )
     for check in values["checks"]:
-        message = check["message"].replace("|", "\\|")
-        lines.append(f"| `{check['status']}` | `{check['check_id']}` | {message} |")
+        lines.append(
+            f"| {_markdown_code(check['status'])} | "
+            f"{_markdown_code(check['check_id'])} | "
+            f"{_markdown_text(check['message'])} |"
+        )
     lines.extend(
         [
             "",

--- a/src/causal4d/cli/acquisition_operations.py
+++ b/src/causal4d/cli/acquisition_operations.py
@@ -32,6 +32,17 @@ def _json_object(path: Path, *, name: str) -> dict[str, Any]:
     return load_strict_json_object(snapshot.payload, name=name)
 
 
+def _require_distinct_campaign_output(source: Path, output: Path) -> None:
+    try:
+        same_file = source.samefile(output)
+    except (FileNotFoundError, OSError):
+        same_file = source.resolve() == output.resolve()
+    if same_file:
+        raise ValueError(
+            "campaign output must differ from the source doctor report"
+        )
+
+
 def _gib(value: str | float) -> int:
     amount = float(value)
     if amount < 0.0:
@@ -190,6 +201,10 @@ def _campaign(arguments: argparse.Namespace) -> int:
     summary = build_acquisition_campaign_summary(report)
     if arguments.campaign_command == "status":
         if arguments.output_json is not None:
+            _require_distinct_campaign_output(
+                arguments.doctor_report_json,
+                arguments.output_json,
+            )
             atomic_write_json(
                 arguments.output_json,
                 summary,
@@ -219,6 +234,10 @@ def _campaign(arguments: argparse.Namespace) -> int:
             return 3
         return 0
     if arguments.campaign_command == "report":
+        _require_distinct_campaign_output(
+            arguments.doctor_report_json,
+            arguments.output,
+        )
         selected_format = arguments.format
         if selected_format is None:
             selected_format = (

--- a/src/causal4d/cli/acquisition_operations.py
+++ b/src/causal4d/cli/acquisition_operations.py
@@ -7,6 +7,11 @@ import json
 from pathlib import Path
 from typing import Any, Sequence
 
+from causal4d.acquisition_campaign import (
+    build_acquisition_campaign_summary,
+    render_acquisition_campaign_html,
+    render_acquisition_campaign_markdown,
+)
 from causal4d.acquisition_flight_recorder import (
     DoctorThresholds,
     HealthThresholds,
@@ -17,15 +22,14 @@ from causal4d.acquisition_flight_recorder import (
     validate_acquisition_journal,
     validate_acquisition_journal_seal,
 )
-from causal4d.atomic_io import atomic_write_json
+from causal4d.artifact_io import load_strict_json_object, read_regular_file
+from causal4d.atomic_io import atomic_write_json, atomic_write_text
 from causal4d.real_protocol import validate_protocol
 
 
 def _json_object(path: Path, *, name: str) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError(f"{name} must contain a JSON object")
-    return payload
+    snapshot = read_regular_file(path, name=name)
+    return load_strict_json_object(snapshot.payload, name=name)
 
 
 def _gib(value: str | float) -> int:
@@ -60,6 +64,38 @@ def _add_doctor(subparsers: Any) -> None:
     parser.add_argument("--overwrite", action="store_true")
     parser.add_argument("--allow-resume", action="store_true")
     parser.add_argument("--require-ready", action="store_true")
+
+
+def _add_campaign(subparsers: Any) -> None:
+    campaign = subparsers.add_parser(
+        "campaign",
+        help="summarize or render a hash-verified acquisition-doctor report",
+    )
+    operations = campaign.add_subparsers(dest="campaign_command", required=True)
+
+    status = operations.add_parser(
+        "status",
+        help="emit a compact machine-readable campaign status",
+    )
+    status.add_argument("doctor_report_json", type=Path)
+    status.add_argument("--output-json", type=Path)
+    status.add_argument("--overwrite", action="store_true")
+    status.add_argument("--require-ready", action="store_true")
+
+    next_execution = operations.add_parser(
+        "next",
+        help="show the next registered execution and whether recording may start",
+    )
+    next_execution.add_argument("doctor_report_json", type=Path)
+
+    report = operations.add_parser(
+        "report",
+        help="render a deterministic Markdown or HTML operator report",
+    )
+    report.add_argument("doctor_report_json", type=Path)
+    report.add_argument("output", type=Path)
+    report.add_argument("--format", choices=("markdown", "html"))
+    report.add_argument("--overwrite", action="store_true")
 
 
 def _add_journal(subparsers: Any) -> None:
@@ -108,6 +144,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
     _add_doctor(subparsers)
+    _add_campaign(subparsers)
     _add_journal(subparsers)
     _add_snapshot(subparsers)
     return parser
@@ -143,6 +180,75 @@ def _doctor(arguments: argparse.Namespace) -> int:
     if arguments.require_ready and not report["passed"]:
         return 3
     return 0
+
+
+def _campaign(arguments: argparse.Namespace) -> int:
+    report = _json_object(
+        arguments.doctor_report_json,
+        name="acquisition-doctor report",
+    )
+    summary = build_acquisition_campaign_summary(report)
+    if arguments.campaign_command == "status":
+        if arguments.output_json is not None:
+            atomic_write_json(
+                arguments.output_json,
+                summary,
+                overwrite=arguments.overwrite,
+            )
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        if summary["state"] == "invalid":
+            return 2
+        if arguments.require_ready and summary["state"] not in {"ready", "complete"}:
+            return 3
+        return 0
+    if arguments.campaign_command == "next":
+        result = {
+            "protocol_id": summary["protocol_id"],
+            "state": summary["state"],
+            "next_execution": summary["next_execution"],
+            "blocking_checks": summary["blocking_checks"],
+            "source_doctor_report_sha256": summary[
+                "source_doctor_report_sha256"
+            ],
+            "target_outcomes_used": False,
+        }
+        print(json.dumps(result, indent=2, sort_keys=True))
+        if summary["state"] == "invalid":
+            return 2
+        if summary["state"] not in {"ready", "complete"}:
+            return 3
+        return 0
+    if arguments.campaign_command == "report":
+        selected_format = arguments.format
+        if selected_format is None:
+            selected_format = (
+                "html" if arguments.output.suffix.lower() == ".html" else "markdown"
+            )
+        text = (
+            render_acquisition_campaign_html(report)
+            if selected_format == "html"
+            else render_acquisition_campaign_markdown(report)
+        )
+        atomic_write_text(
+            arguments.output,
+            text,
+            overwrite=arguments.overwrite,
+        )
+        result = {
+            "protocol_id": summary["protocol_id"],
+            "state": summary["state"],
+            "format": selected_format,
+            "output": str(arguments.output.resolve()),
+            "source_doctor_report_sha256": summary[
+                "source_doctor_report_sha256"
+            ],
+            "target_outcomes_used": False,
+        }
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    raise RuntimeError(
+        f"unsupported acquisition campaign command: {arguments.campaign_command}"
+    )
 
 
 def _journal(arguments: argparse.Namespace) -> int:
@@ -204,6 +310,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         if arguments.command == "doctor":
             return _doctor(arguments)
+        if arguments.command == "campaign":
+            return _campaign(arguments)
         if arguments.command == "journal":
             return _journal(arguments)
         if arguments.command == "snapshot":

--- a/tests/test_acquisition_campaign.py
+++ b/tests/test_acquisition_campaign.py
@@ -19,42 +19,90 @@ from causal4d.acquisition_flight_common import (
 from causal4d.cli.acquisition_operations import main
 
 
+_CHECK_ORDER = (
+    "protocol_schedule",
+    "frozen_checkout",
+    "sealed_readiness",
+    "storage_capacity",
+    "storage_write_probe",
+    "real_evidence_status",
+    "execution_manifests",
+    "next_execution",
+    "session_journal",
+)
+_INVALID_CHECK_IDS = frozenset(
+    {
+        "frozen_checkout",
+        "sealed_readiness",
+        "real_evidence_status",
+        "execution_manifests",
+        "session_journal",
+    }
+)
+_UNSET = object()
+
+
+def _checks_with(*overrides: dict[str, object]) -> list[dict[str, object]]:
+    checks = {
+        check_id: {
+            "check_id": check_id,
+            "status": "pass",
+            "message": f"{check_id} validates.",
+        }
+        for check_id in _CHECK_ORDER
+    }
+    for override in overrides:
+        checks[str(override["check_id"])] = dict(override)
+    return [checks[check_id] for check_id in _CHECK_ORDER]
+
+
 def _doctor_report(
     *,
-    state: str = "ready",
     completed: int = 1,
     total: int = 2,
+    complete: bool = False,
     checks: list[dict[str, object]] | None = None,
-    next_execution: dict[str, object] | None = None,
+    next_execution: dict[str, object] | None | object = _UNSET,
+    resume_acknowledged: bool = False,
+    protocol_id: str = "protocol-v1",
 ) -> dict[str, object]:
     if checks is None:
-        checks = [
-            {
-                "check_id": "frozen_checkout",
-                "status": "pass",
-                "message": "Frozen checkout validates.",
-            },
-            {
-                "check_id": "session_journal",
-                "status": "pass",
-                "message": "No prior journal bytes exist.",
-            },
-        ]
-    if next_execution is None and state != "complete":
-        next_execution = {
-            "acquisition_execution_index": completed,
-            "execution_id": "execution-2",
-            "session_id": "session-1",
-            "command_profile_id": "command-2",
-        }
-    ready = state == "ready"
-    complete = state == "complete"
-    valid = state != "invalid"
+        checks = _checks_with()
+    if complete:
+        completed = total
+    if next_execution is _UNSET:
+        next_execution = (
+            None
+            if complete
+            else {
+                "acquisition_execution_index": completed,
+                "execution_id": "execution-2",
+                "session_id": "session-1",
+                "pair_order": 1,
+                "contact_region_id": "upper_torso",
+                "command_profile_id": "command-2",
+                "realization_condition_id": "nominal",
+                "replicate_block": 0,
+            }
+        )
+    failures = [check for check in checks if check["status"] == "fail"]
+    warnings = [check for check in checks if check["status"] == "warn"]
+    by_id = {str(check["check_id"]): check for check in checks}
+    valid = not any(
+        check["status"] == "fail" and check_id in _INVALID_CHECK_IDS
+        for check_id, check in by_id.items()
+    )
+    session_journal = by_id["session_journal"]
+    journal_requires_review = (
+        session_journal["status"] == "warn" and not resume_acknowledged
+    )
+    ready = next_execution is not None and not failures and not journal_requires_review
+    collection_complete = next_execution is None and not failures
     report: dict[str, object] = {
         "schema_version": 1,
         "artifact_kind": DOCTOR_REPORT_KIND,
         "generated_at_utc": "2026-08-06T04:00:00+00:00",
-        "protocol_id": "protocol-v1",
+        "protocol_id": protocol_id,
         "protocol_design_sha256": "a" * 64,
         "repository_root": "/opt/causal4d-frozen",
         "dataset_root": "/data/causal4d",
@@ -63,19 +111,23 @@ def _doctor_report(
             "write_probe_bytes": 0,
             "minimum_write_mib_s": 0.0,
         },
-        "resume_acknowledged": False,
+        "resume_acknowledged": resume_acknowledged,
         "checks": checks,
-        "failure_count": sum(check["status"] == "fail" for check in checks),
-        "warning_count": sum(check["status"] == "warn" for check in checks),
-        "completed_executions": total if complete else completed,
+        "failure_count": len(failures),
+        "warning_count": len(warnings),
+        "completed_executions": completed,
         "total_executions": total,
-        "next_execution": None if complete else next_execution,
+        "next_execution": next_execution,
         "ready_to_record": ready,
-        "collection_complete": complete,
+        "collection_complete": collection_complete,
         "valid": valid,
-        "passed": ready or complete,
+        "passed": ready or collection_complete,
         "target_outcomes_used": False,
     }
+    return _rehash(report)
+
+
+def _rehash(report: dict[str, object]) -> dict[str, object]:
     report["report_sha256"] = _canonical_sha256(
         report,
         omitted="report_sha256",
@@ -98,19 +150,14 @@ def test_campaign_summary_reports_ready_progress_and_next_execution() -> None:
 
 def test_campaign_summary_surfaces_blocking_warning_without_failure() -> None:
     report = _doctor_report(
-        state="blocked",
-        checks=[
-            {
-                "check_id": "frozen_checkout",
-                "status": "pass",
-                "message": "Frozen checkout validates.",
-            },
+        checks=_checks_with(
             {
                 "check_id": "session_journal",
                 "status": "warn",
                 "message": "Review the unsealed journal before resuming.",
-            },
-        ],
+                "resume_acknowledged": False,
+            }
+        )
     )
 
     summary = build_acquisition_campaign_summary(report)
@@ -120,22 +167,42 @@ def test_campaign_summary_surfaces_blocking_warning_without_failure() -> None:
     assert summary["blocking_checks"][0]["check_id"] == "session_journal"
 
 
-def test_campaign_renderers_preserve_boundary_and_escape_html() -> None:
+def test_campaign_renderers_escape_operator_controlled_markdown_and_html() -> None:
+    next_execution = {
+        "acquisition_execution_index": 1,
+        "execution_id": "execution-|<2>\n## injected",
+        "session_id": "session-&1`",
+        "pair_order": 1,
+        "contact_region_id": "upper_torso",
+        "command_profile_id": "command-2",
+        "realization_condition_id": "nominal",
+        "replicate_block": 0,
+    }
     report = _doctor_report(
-        next_execution={
-            "execution_id": "execution-<2>",
-            "session_id": "session-&1",
-        }
+        protocol_id="protocol|<v1>\n## protocol-injected",
+        next_execution=next_execution,
+        checks=_checks_with(
+            {
+                "check_id": "sealed_readiness",
+                "status": "warn",
+                "message": "Relocated | archive\n## message-injected",
+            }
+        ),
     )
 
     markdown = render_acquisition_campaign_markdown(report)
     html = render_acquisition_campaign_html(report)
 
     assert "1/2 executions (50.0%)" in markdown
-    assert "Target outcomes used:** `false`" in markdown
-    assert "execution-<2>" in markdown
-    assert "execution-&lt;2&gt;" in html
-    assert "session-&amp;1" in html
+    assert "Target outcomes used:** <code>false</code>" in markdown
+    assert "&#124;" in markdown
+    assert "&lt;2&gt;<br>## injected" in markdown
+    assert "\n## injected" not in markdown
+    assert "\n## protocol-injected" not in markdown
+    assert "\n## message-injected" not in markdown
+    assert "execution-&#124;&lt;2&gt;" in markdown
+    assert "execution-|&lt;2&gt;\n## injected" in html
+    assert "session-&amp;1`" in html
     assert "<code>false</code>" in html
 
 
@@ -144,6 +211,37 @@ def test_campaign_rejects_doctor_report_tampering() -> None:
     report["completed_executions"] = 0
 
     with pytest.raises(ValueError, match="checksum mismatch"):
+        validate_acquisition_doctor_report(report)
+
+
+def test_campaign_rejects_boolean_schema_version_after_rehash() -> None:
+    report = _doctor_report()
+    report["schema_version"] = True
+    _rehash(report)
+
+    with pytest.raises(ValueError, match="schema version"):
+        validate_acquisition_doctor_report(report)
+
+
+def test_campaign_rejects_nested_target_outcomes_after_rehash() -> None:
+    report = _doctor_report()
+    next_execution = dict(report["next_execution"])
+    next_execution["target_metrics"] = {"track_error_m": 0.0}
+    report["next_execution"] = next_execution
+    _rehash(report)
+
+    with pytest.raises(ValueError, match="target-outcome"):
+        validate_acquisition_doctor_report(report)
+
+
+def test_campaign_rejects_contradictory_next_execution_index() -> None:
+    report = _doctor_report()
+    next_execution = dict(report["next_execution"])
+    next_execution["acquisition_execution_index"] = 0
+    report["next_execution"] = next_execution
+    _rehash(report)
+
+    with pytest.raises(ValueError, match="index differs"):
         validate_acquisition_doctor_report(report)
 
 
@@ -190,6 +288,48 @@ def test_campaign_status_and_report_cli(
     assert "# Causal4D acquisition campaign" in report_path.read_text(encoding="utf-8")
 
 
+def test_campaign_outputs_cannot_replace_the_source_doctor(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "doctor.json"
+    original = json.dumps(_doctor_report()).encode("utf-8")
+    source.write_bytes(original)
+
+    assert (
+        main(
+            [
+                "campaign",
+                "status",
+                str(source),
+                "--output-json",
+                str(source),
+                "--overwrite",
+            ]
+        )
+        == 2
+    )
+    status_error = json.loads(capsys.readouterr().out)
+    assert "must differ" in status_error["error"]
+    assert source.read_bytes() == original
+
+    assert (
+        main(
+            [
+                "campaign",
+                "report",
+                str(source),
+                str(source),
+                "--overwrite",
+            ]
+        )
+        == 2
+    )
+    report_error = json.loads(capsys.readouterr().out)
+    assert "must differ" in report_error["error"]
+    assert source.read_bytes() == original
+
+
 def test_campaign_next_cli_blocks_when_not_ready(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -198,14 +338,14 @@ def test_campaign_next_cli_blocks_when_not_ready(
     source.write_text(
         json.dumps(
             _doctor_report(
-                state="blocked",
-                checks=[
+                checks=_checks_with(
                     {
                         "check_id": "session_journal",
                         "status": "warn",
                         "message": "Resume acknowledgement is required.",
+                        "resume_acknowledged": False,
                     }
-                ],
+                )
             )
         ),
         encoding="utf-8",

--- a/tests/test_acquisition_campaign.py
+++ b/tests/test_acquisition_campaign.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from causal4d.acquisition_campaign import (
+    CAMPAIGN_SUMMARY_KIND,
+    build_acquisition_campaign_summary,
+    render_acquisition_campaign_html,
+    render_acquisition_campaign_markdown,
+    validate_acquisition_doctor_report,
+)
+from causal4d.acquisition_flight_common import (
+    DOCTOR_REPORT_KIND,
+    _canonical_sha256,
+)
+from causal4d.cli.acquisition_operations import main
+
+
+def _doctor_report(
+    *,
+    state: str = "ready",
+    completed: int = 1,
+    total: int = 2,
+    checks: list[dict[str, object]] | None = None,
+    next_execution: dict[str, object] | None = None,
+) -> dict[str, object]:
+    if checks is None:
+        checks = [
+            {
+                "check_id": "frozen_checkout",
+                "status": "pass",
+                "message": "Frozen checkout validates.",
+            },
+            {
+                "check_id": "session_journal",
+                "status": "pass",
+                "message": "No prior journal bytes exist.",
+            },
+        ]
+    if next_execution is None and state != "complete":
+        next_execution = {
+            "acquisition_execution_index": completed,
+            "execution_id": "execution-2",
+            "session_id": "session-1",
+            "command_profile_id": "command-2",
+        }
+    ready = state == "ready"
+    complete = state == "complete"
+    valid = state != "invalid"
+    report: dict[str, object] = {
+        "schema_version": 1,
+        "artifact_kind": DOCTOR_REPORT_KIND,
+        "generated_at_utc": "2026-08-06T04:00:00+00:00",
+        "protocol_id": "protocol-v1",
+        "protocol_design_sha256": "a" * 64,
+        "repository_root": "/opt/causal4d-frozen",
+        "dataset_root": "/data/causal4d",
+        "thresholds": {
+            "minimum_free_bytes": 0,
+            "write_probe_bytes": 0,
+            "minimum_write_mib_s": 0.0,
+        },
+        "resume_acknowledged": False,
+        "checks": checks,
+        "failure_count": sum(check["status"] == "fail" for check in checks),
+        "warning_count": sum(check["status"] == "warn" for check in checks),
+        "completed_executions": total if complete else completed,
+        "total_executions": total,
+        "next_execution": None if complete else next_execution,
+        "ready_to_record": ready,
+        "collection_complete": complete,
+        "valid": valid,
+        "passed": ready or complete,
+        "target_outcomes_used": False,
+    }
+    report["report_sha256"] = _canonical_sha256(
+        report,
+        omitted="report_sha256",
+    )
+    return report
+
+
+def test_campaign_summary_reports_ready_progress_and_next_execution() -> None:
+    summary = build_acquisition_campaign_summary(_doctor_report())
+
+    assert summary["artifact_kind"] == CAMPAIGN_SUMMARY_KIND
+    assert summary["state"] == "ready"
+    assert summary["completed_executions"] == 1
+    assert summary["remaining_executions"] == 1
+    assert summary["progress_fraction"] == 0.5
+    assert summary["next_execution"]["execution_id"] == "execution-2"
+    assert summary["blocking_checks"] == []
+    assert summary["target_outcomes_used"] is False
+
+
+def test_campaign_summary_surfaces_blocking_warning_without_failure() -> None:
+    report = _doctor_report(
+        state="blocked",
+        checks=[
+            {
+                "check_id": "frozen_checkout",
+                "status": "pass",
+                "message": "Frozen checkout validates.",
+            },
+            {
+                "check_id": "session_journal",
+                "status": "warn",
+                "message": "Review the unsealed journal before resuming.",
+            },
+        ],
+    )
+
+    summary = build_acquisition_campaign_summary(report)
+
+    assert summary["state"] == "blocked"
+    assert summary["blocking_checks"] == summary["warnings"]
+    assert summary["blocking_checks"][0]["check_id"] == "session_journal"
+
+
+def test_campaign_renderers_preserve_boundary_and_escape_html() -> None:
+    report = _doctor_report(
+        next_execution={
+            "execution_id": "execution-<2>",
+            "session_id": "session-&1",
+        }
+    )
+
+    markdown = render_acquisition_campaign_markdown(report)
+    html = render_acquisition_campaign_html(report)
+
+    assert "1/2 executions (50.0%)" in markdown
+    assert "Target outcomes used:** `false`" in markdown
+    assert "execution-<2>" in markdown
+    assert "execution-&lt;2&gt;" in html
+    assert "session-&amp;1" in html
+    assert "<code>false</code>" in html
+
+
+def test_campaign_rejects_doctor_report_tampering() -> None:
+    report = _doctor_report()
+    report["completed_executions"] = 0
+
+    with pytest.raises(ValueError, match="checksum mismatch"):
+        validate_acquisition_doctor_report(report)
+
+
+def test_campaign_status_and_report_cli(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "doctor.json"
+    summary_path = tmp_path / "campaign.json"
+    report_path = tmp_path / "campaign.md"
+    source.write_text(json.dumps(_doctor_report()), encoding="utf-8")
+
+    assert (
+        main(
+            [
+                "campaign",
+                "status",
+                str(source),
+                "--output-json",
+                str(summary_path),
+                "--require-ready",
+            ]
+        )
+        == 0
+    )
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["state"] == "ready"
+    assert json.loads(summary_path.read_text(encoding="utf-8"))["state"] == "ready"
+
+    assert (
+        main(
+            [
+                "campaign",
+                "report",
+                str(source),
+                str(report_path),
+            ]
+        )
+        == 0
+    )
+    result = json.loads(capsys.readouterr().out)
+    assert result["format"] == "markdown"
+    assert result["state"] == "ready"
+    assert "# Causal4D acquisition campaign" in report_path.read_text(encoding="utf-8")
+
+
+def test_campaign_next_cli_blocks_when_not_ready(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "doctor.json"
+    source.write_text(
+        json.dumps(
+            _doctor_report(
+                state="blocked",
+                checks=[
+                    {
+                        "check_id": "session_journal",
+                        "status": "warn",
+                        "message": "Resume acknowledgement is required.",
+                    }
+                ],
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    assert main(["campaign", "next", str(source)]) == 3
+    result = json.loads(capsys.readouterr().out)
+    assert result["state"] == "blocked"
+    assert result["next_execution"]["execution_id"] == "execution-2"


### PR DESCRIPTION
## Summary

- derive a compact, content-addressed campaign summary from the existing hash-verified acquisition-doctor report;
- add `campaign status`, `campaign next`, and `campaign report` operations beneath `causal4d protocol acquisition`;
- render deterministic Markdown and standalone HTML operator reports with progress, the next registered execution, blockers, warnings, and the complete doctor check table;
- reuse the shared exact-byte strict JSON reader added on current `main`;
- atomically publish JSON, Markdown, and HTML outputs; and
- add focused tests and an operator runbook.

## Why

Causal4D already has a rigorous pre-session doctor, but the 36-execution campaign still needs a concise operator-facing decision surface. This change makes the current status, next registered execution, and blocking gates directly consumable by humans and collection supervisors without duplicating or weakening the underlying validation.

## Safety and scientific boundary

Every campaign artifact binds the exact source doctor SHA-256 and requires `target_outcomes_used=false`. Validation reconstructs the exact schema-1 doctor semantics: complete check inventory, derived validity/readiness/completion flags, progress and next-execution consistency, resume handling, thresholds, timestamp, protocol identity, and recursive target-outcome exclusion. A self-rehashed but contradictory or outcome-contaminated report therefore fails closed.

Derived output paths must differ from the authoritative doctor source. Same-path, existing symbolic-link, and hard-link aliases are rejected even with `--overwrite`. Markdown and HTML renderers escape operator-controlled fields before publication.

This is operational provenance only. It does not change the estimator, protocol, acquisition order, split, thresholds, exclusions, analysis, or evidence count, and it does not inspect target outcomes.

## Validation

An isolated source-layout harness completed:

```text
10 passed in 0.05s
```

The focused tests cover ready and blocked states, progress and next-execution reporting, source checksum tampering, Boolean schema confusion, recursively nested target outcomes, contradictory execution indices, source-file replacement, Markdown/HTML escaping, status/report output, and blocking exit codes. Python byte compilation and an 88-column source audit also passed.

Repository-wide Ruff, mypy, complete pytest, installed-artifact help, distribution, and merge-result checks remain authoritative in GitHub Actions.