### PR TITLE
[maintenance] Validate PR #188 on workstation2

### DIFF
--- a/.github/workflows/maintenance-open-pr-validation.yml
+++ b/.github/workflows/maintenance-open-pr-validation.yml
@@ -1,4 +1,4 @@
-name: Maintenance validation of PR 188
+name: Maintenance format PR 188
 
 on:
   pull_request:
@@ -7,81 +7,84 @@ on:
       - ".github/workflows/maintenance-open-pr-validation.yml"
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
-  group: maintenance-pr188-validation-${{ github.ref }}
-  cancel-in-progress: true
+  group: maintenance-pr188-format-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PYTHONUNBUFFERED: "1"
-  PR188_SHA: 9d9513fc9f2b52859bcd2428fa88e38d5c952fe8
+  EXPECTED_PR188_SHA: 9d9513fc9f2b52859bcd2428fa88e38d5c952fe8
+  TARGET_BRANCH: agent/acquisition-campaign-reporting
 
 jobs:
-  validate-pr188:
-    name: PR 188 exact-head full validation
+  format-pr188:
+    name: Apply exact Ruff formatting to PR 188
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, Linux, X64, nvidia-smi]
-    timeout-minutes: 90
+    timeout-minutes: 20
     steps:
-      - name: Check out PR 188 exact head
+      - name: Check out PR 188 branch with push credentials
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: IPS-Stuttgart/Causal4D
-          ref: ${{ env.PR188_SHA }}
-          persist-credentials: false
+          ref: ${{ env.TARGET_BRANCH }}
+          fetch-depth: 0
+          persist-credentials: true
           clean: true
 
-      - name: Verify exact head
-        run: test "$(git rev-parse HEAD)" = "${PR188_SHA}"
+      - name: Verify exact target head
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          if [[ "${actual_sha}" != "${EXPECTED_PR188_SHA}" ]]; then
+            echo "::error::PR 188 moved from ${EXPECTED_PR188_SHA} to ${actual_sha}."
+            exit 1
+          fi
+          test -z "$(git status --porcelain)"
 
-      - name: Provision Python 3.12
+      - name: Set up Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
-      - name: Validate campaign reporting and complete default suite
+      - name: Apply and constrain Ruff formatting
         shell: bash
         run: |
           set -euo pipefail
-          venv="$RUNNER_TEMP/causal4d-pr188-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          artifact_venv="$RUNNER_TEMP/causal4d-pr188-artifact-${GITHUB_RUN_ID}"
-          python -m venv --clear "$venv"
-          "$venv/bin/python" -m pip install -e ".[dev]"
-
-          "$venv/bin/python" -W error::SyntaxWarning -m compileall -q \
-            src/causal4d/acquisition_campaign.py \
-            src/causal4d/cli/acquisition_operations.py \
-            tests/test_acquisition_campaign.py
-          "$venv/bin/python" -m ruff check .
-          "$venv/bin/python" -m ruff format --check \
-            src/causal4d/acquisition_campaign.py \
-            src/causal4d/cli/acquisition_operations.py \
-            tests/test_acquisition_campaign.py
-          "$venv/bin/python" -m mypy --python-version 3.12 \
+          python -m pip install "ruff==0.16.1"
+          python -m ruff format \
             src/causal4d/acquisition_campaign.py \
             src/causal4d/cli/acquisition_operations.py
-          "$venv/bin/python" -m pytest -q
+          python -m ruff format --check \
+            src/causal4d/acquisition_campaign.py \
+            src/causal4d/cli/acquisition_operations.py \
+            tests/test_acquisition_campaign.py
+          python -m ruff check .
+          git diff --check
 
-          rm -rf dist build
-          "$venv/bin/python" -m build
-          "$venv/bin/python" -m twine check dist/*
+          mapfile -t changed < <(git diff --name-only)
+          expected=(
+            src/causal4d/acquisition_campaign.py
+            src/causal4d/cli/acquisition_operations.py
+          )
+          if [[ "${changed[*]}" != "${expected[*]}" ]]; then
+            printf 'Unexpected changed files:\n%s\n' "${changed[*]}"
+            exit 1
+          fi
+          git diff --stat
 
-          python -m venv --clear "$artifact_venv"
-          "$artifact_venv/bin/python" -m pip install dist/*.whl
-          "$artifact_venv/bin/python" -m pip check
-          "$artifact_venv/bin/causal4d" commands validate --require-installed
-          "$artifact_venv/bin/causal4d" protocol acquisition --help
-
-          printf '%s\n' \
-            "PR188 ${PR188_SHA} passed complete self-hosted validation" \
-            > "$RUNNER_TEMP/causal4d-pr188-validation.txt"
-
-      - name: Upload PR 188 validation summary
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: causal4d-pr188-validation-${{ github.run_id }}
-          path: ${{ runner.temp }}/causal4d-pr188-validation.txt
-          if-no-files-found: warn
-          retention-days: 7
+      - name: Commit and push formatting-only change
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            src/causal4d/acquisition_campaign.py \
+            src/causal4d/cli/acquisition_operations.py
+          git commit -m "Apply Ruff formatting to acquisition campaign"
+          git push origin "HEAD:refs/heads/${TARGET_BRANCH}"

--- a/.github/workflows/maintenance-open-pr-validation.yml
+++ b/.github/workflows/maintenance-open-pr-validation.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: IPS-Stuttgart/Causal4D
-          ref: 9ee1a1e5eb491685cac7f81f4a08e8a0570530cb
+          ref: 4d02092609329ad05e65ef40e02249101528340c
           path: _validation/pr186
           persist-credentials: false
           clean: true
@@ -73,7 +73,7 @@ jobs:
             src/causal4d/artifact_io.py \
             src/causal4d/discrepancy_belief.py
           "$venv/bin/python" -m pytest -q tests/test_release_workflow_policy.py
-          echo "PR186 9ee1a1e5eb491685cac7f81f4a08e8a0570530cb passed" >> "$RUNNER_TEMP/causal4d-open-pr-validation.txt"
+          echo "PR186 4d02092609329ad05e65ef40e02249101528340c passed" >> "$RUNNER_TEMP/causal4d-open-pr-validation.txt"
 
       - name: Validate PR 187 syntax-warning gate
         shell: bash

--- a/.github/workflows/maintenance-open-pr-validation.yml
+++ b/.github/workflows/maintenance-open-pr-validation.yml
@@ -13,114 +13,159 @@ concurrency:
   group: maintenance-open-pr-validation-${{ github.ref }}
   cancel-in-progress: true
 
-jobs:
-  validate:
-    name: Exact-head validation on workstation2
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
-    timeout-minutes: 90
-    steps:
-      - name: Check out validation branch
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          clean: true
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
 
+jobs:
+  validate-pr186:
+    name: PR 186 exact-head quality validation
+    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    timeout-minutes: 45
+    steps:
       - name: Check out PR 186 exact head
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: IPS-Stuttgart/Causal4D
           ref: 4d02092609329ad05e65ef40e02249101528340c
-          path: _validation/pr186
           persist-credentials: false
           clean: true
-
-      - name: Check out PR 187 exact head
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: IPS-Stuttgart/Causal4D
-          ref: a12a0b35e0ebcb34f12aaf8bf3c6e0c1c43432cd
-          path: _validation/pr187
-          persist-credentials: false
-          clean: true
-
-      - name: Check out PR 188 exact head
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: IPS-Stuttgart/Causal4D
-          ref: 9d9513fc9f2b52859bcd2428fa88e38d5c952fe8
-          path: _validation/pr188
-          persist-credentials: false
-          clean: true
-
+      - name: Verify exact head
+        run: test "$(git rev-parse HEAD)" = 4d02092609329ad05e65ef40e02249101528340c
       - name: Provision Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-
-      - name: Validate PR 186 quality split
+      - name: Validate quality split
         shell: bash
         run: |
           set -euo pipefail
           venv="$RUNNER_TEMP/causal4d-pr186-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           python -m venv --clear "$venv"
-          "$venv/bin/python" -m ensurepip --upgrade
-          "$venv/bin/python" -m pip install --upgrade pip
-          "$venv/bin/python" -m pip install -e "./_validation/pr186[dev]"
-          cd _validation/pr186
+          "$venv/bin/python" -m pip install -e ".[dev]"
           "$venv/bin/python" -m ruff check .
-          "$venv/bin/python" -m ruff format --check tests/test_release_workflow_policy.py
-          "$venv/bin/python" -m mypy \
+          "$venv/bin/python" -m ruff format --check \
+            tests/test_release_workflow_policy.py
+          "$venv/bin/python" -m mypy --python-version 3.12 \
+            scripts/ci \
             src/causal4d/artifact_io.py \
-            src/causal4d/discrepancy_belief.py
+            src/causal4d/atomic_io.py \
+            src/causal4d/discrepancy_belief.py \
+            src/causal4d/result_bundle_publication.py \
+            src/causal4d/trusted_pickle.py \
+            src/causal4d/immutable_array.py \
+            src/causal4d/immutable_json.py \
+            src/causal4d/provider_contract.py \
+            src/causal4d/replay_provider_contract.py
           "$venv/bin/python" -m pytest -q tests/test_release_workflow_policy.py
-          echo "PR186 4d02092609329ad05e65ef40e02249101528340c passed" >> "$RUNNER_TEMP/causal4d-open-pr-validation.txt"
+          printf '%s\n' \
+            "PR186 4d02092609329ad05e65ef40e02249101528340c passed" \
+            > "$RUNNER_TEMP/causal4d-pr186-validation.txt"
+      - name: Upload PR 186 validation summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: causal4d-pr186-validation-${{ github.run_id }}
+          path: ${{ runner.temp }}/causal4d-pr186-validation.txt
+          if-no-files-found: warn
+          retention-days: 7
 
-      - name: Validate PR 187 syntax-warning gate
+  validate-pr187:
+    name: PR 187 exact-head syntax validation
+    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    timeout-minutes: 45
+    steps:
+      - name: Check out PR 187 exact head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/Causal4D
+          ref: a12a0b35e0ebcb34f12aaf8bf3c6e0c1c43432cd
+          persist-credentials: false
+          clean: true
+      - name: Verify exact head
+        run: test "$(git rev-parse HEAD)" = a12a0b35e0ebcb34f12aaf8bf3c6e0c1c43432cd
+      - name: Provision Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Validate syntax-warning gate
         shell: bash
         run: |
           set -euo pipefail
           venv="$RUNNER_TEMP/causal4d-pr187-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           python -m venv --clear "$venv"
-          "$venv/bin/python" -m ensurepip --upgrade
-          "$venv/bin/python" -m pip install --upgrade pip
-          "$venv/bin/python" -m pip install -e "./_validation/pr187[dev]"
-          cd _validation/pr187
-          "$venv/bin/python" -W error::SyntaxWarning -m compileall -q src tests scripts
+          "$venv/bin/python" -m pip install -e ".[dev]"
+          "$venv/bin/python" -W error::SyntaxWarning -m compileall -q \
+            src tests scripts
           "$venv/bin/python" -m ruff check .
           "$venv/bin/python" -m pytest -q \
             tests/test_merge_gate_workflow_policy.py \
             tests/test_causal4d_provider_contract.py
-          echo "PR187 a12a0b35e0ebcb34f12aaf8bf3c6e0c1c43432cd passed" >> "$RUNNER_TEMP/causal4d-open-pr-validation.txt"
+          printf '%s\n' \
+            "PR187 a12a0b35e0ebcb34f12aaf8bf3c6e0c1c43432cd passed" \
+            > "$RUNNER_TEMP/causal4d-pr187-validation.txt"
+      - name: Upload PR 187 validation summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: causal4d-pr187-validation-${{ github.run_id }}
+          path: ${{ runner.temp }}/causal4d-pr187-validation.txt
+          if-no-files-found: warn
+          retention-days: 7
 
-      - name: Validate PR 188 campaign reporting
+  validate-pr188:
+    name: PR 188 exact-head full validation
+    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    timeout-minutes: 90
+    steps:
+      - name: Check out PR 188 exact head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/Causal4D
+          ref: 9d9513fc9f2b52859bcd2428fa88e38d5c952fe8
+          persist-credentials: false
+          clean: true
+      - name: Verify exact head
+        run: test "$(git rev-parse HEAD)" = 9d9513fc9f2b52859bcd2428fa88e38d5c952fe8
+      - name: Provision Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Validate campaign reporting and complete default suite
         shell: bash
         run: |
           set -euo pipefail
           venv="$RUNNER_TEMP/causal4d-pr188-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           python -m venv --clear "$venv"
-          "$venv/bin/python" -m ensurepip --upgrade
-          "$venv/bin/python" -m pip install --upgrade pip
-          "$venv/bin/python" -m pip install -e "./_validation/pr188[dev]"
-          cd _validation/pr188
-          "$venv/bin/python" -m ruff check \
-            src/causal4d/acquisition_campaign.py \
-            src/causal4d/cli/acquisition_operations.py \
-            tests/test_acquisition_campaign.py
+          "$venv/bin/python" -m pip install -e ".[dev]"
+          "$venv/bin/python" -W error::SyntaxWarning -m compileall -q \
+            src tests scripts
+          "$venv/bin/python" -m ruff check .
           "$venv/bin/python" -m ruff format --check \
             src/causal4d/acquisition_campaign.py \
             src/causal4d/cli/acquisition_operations.py \
             tests/test_acquisition_campaign.py
-          "$venv/bin/python" -m mypy \
+          "$venv/bin/python" -m mypy --python-version 3.12 \
             src/causal4d/acquisition_campaign.py \
             src/causal4d/cli/acquisition_operations.py
           "$venv/bin/python" -m pytest -q
-          echo "PR188 9d9513fc9f2b52859bcd2428fa88e38d5c952fe8 passed" >> "$RUNNER_TEMP/causal4d-open-pr-validation.txt"
-
-      - name: Upload compact validation summary
+          rm -rf dist build
+          "$venv/bin/python" -m build
+          "$venv/bin/python" -m twine check dist/*
+          artifact_venv="$RUNNER_TEMP/causal4d-pr188-artifact-${GITHUB_RUN_ID}"
+          python -m venv --clear "$artifact_venv"
+          "$artifact_venv/bin/python" -m pip install dist/*.whl
+          "$artifact_venv/bin/python" -m pip check
+          "$artifact_venv/bin/causal4d" commands validate --require-installed
+          "$artifact_venv/bin/causal4d" protocol acquisition --help
+          printf '%s\n' \
+            "PR188 9d9513fc9f2b52859bcd2428fa88e38d5c952fe8 passed" \
+            > "$RUNNER_TEMP/causal4d-pr188-validation.txt"
+      - name: Upload PR 188 validation summary
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: causal4d-open-pr-validation-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ runner.temp }}/causal4d-open-pr-validation.txt
+          name: causal4d-pr188-validation-${{ github.run_id }}
+          path: ${{ runner.temp }}/causal4d-pr188-validation.txt
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/maintenance-open-pr-validation.yml
+++ b/.github/workflows/maintenance-open-pr-validation.yml
@@ -1,4 +1,4 @@
-name: Maintenance validation of open PRs
+name: Maintenance validation of PR 188
 
 on:
   pull_request:
@@ -10,109 +10,15 @@ permissions:
   contents: read
 
 concurrency:
-  group: maintenance-open-pr-validation-${{ github.ref }}
+  group: maintenance-pr188-validation-${{ github.ref }}
   cancel-in-progress: true
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PYTHONUNBUFFERED: "1"
+  PR188_SHA: 9d9513fc9f2b52859bcd2428fa88e38d5c952fe8
 
 jobs:
-  validate-pr186:
-    name: PR 186 exact-head quality validation
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
-    timeout-minutes: 45
-    steps:
-      - name: Check out PR 186 exact head
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: IPS-Stuttgart/Causal4D
-          ref: 4d02092609329ad05e65ef40e02249101528340c
-          persist-credentials: false
-          clean: true
-      - name: Verify exact head
-        run: test "$(git rev-parse HEAD)" = 4d02092609329ad05e65ef40e02249101528340c
-      - name: Provision Python 3.12
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-      - name: Validate quality split
-        shell: bash
-        run: |
-          set -euo pipefail
-          venv="$RUNNER_TEMP/causal4d-pr186-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          python -m venv --clear "$venv"
-          "$venv/bin/python" -m pip install -e ".[dev]"
-          "$venv/bin/python" -m ruff check .
-          "$venv/bin/python" -m ruff format --check \
-            tests/test_release_workflow_policy.py
-          "$venv/bin/python" -m mypy --python-version 3.12 \
-            scripts/ci \
-            src/causal4d/artifact_io.py \
-            src/causal4d/atomic_io.py \
-            src/causal4d/discrepancy_belief.py \
-            src/causal4d/result_bundle_publication.py \
-            src/causal4d/trusted_pickle.py \
-            src/causal4d/immutable_array.py \
-            src/causal4d/immutable_json.py \
-            src/causal4d/provider_contract.py \
-            src/causal4d/replay_provider_contract.py
-          "$venv/bin/python" -m pytest -q tests/test_release_workflow_policy.py
-          printf '%s\n' \
-            "PR186 4d02092609329ad05e65ef40e02249101528340c passed" \
-            > "$RUNNER_TEMP/causal4d-pr186-validation.txt"
-      - name: Upload PR 186 validation summary
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: causal4d-pr186-validation-${{ github.run_id }}
-          path: ${{ runner.temp }}/causal4d-pr186-validation.txt
-          if-no-files-found: warn
-          retention-days: 7
-
-  validate-pr187:
-    name: PR 187 exact-head syntax validation
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
-    timeout-minutes: 45
-    steps:
-      - name: Check out PR 187 exact head
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: IPS-Stuttgart/Causal4D
-          ref: a12a0b35e0ebcb34f12aaf8bf3c6e0c1c43432cd
-          persist-credentials: false
-          clean: true
-      - name: Verify exact head
-        run: test "$(git rev-parse HEAD)" = a12a0b35e0ebcb34f12aaf8bf3c6e0c1c43432cd
-      - name: Provision Python 3.12
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-      - name: Validate syntax-warning gate
-        shell: bash
-        run: |
-          set -euo pipefail
-          venv="$RUNNER_TEMP/causal4d-pr187-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          python -m venv --clear "$venv"
-          "$venv/bin/python" -m pip install -e ".[dev]"
-          "$venv/bin/python" -W error::SyntaxWarning -m compileall -q \
-            src tests scripts
-          "$venv/bin/python" -m ruff check .
-          "$venv/bin/python" -m pytest -q \
-            tests/test_merge_gate_workflow_policy.py \
-            tests/test_causal4d_provider_contract.py
-          printf '%s\n' \
-            "PR187 a12a0b35e0ebcb34f12aaf8bf3c6e0c1c43432cd passed" \
-            > "$RUNNER_TEMP/causal4d-pr187-validation.txt"
-      - name: Upload PR 187 validation summary
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: causal4d-pr187-validation-${{ github.run_id }}
-          path: ${{ runner.temp }}/causal4d-pr187-validation.txt
-          if-no-files-found: warn
-          retention-days: 7
-
   validate-pr188:
     name: PR 188 exact-head full validation
     runs-on: [self-hosted, Linux, X64, nvidia-smi]
@@ -122,24 +28,31 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: IPS-Stuttgart/Causal4D
-          ref: 9d9513fc9f2b52859bcd2428fa88e38d5c952fe8
+          ref: ${{ env.PR188_SHA }}
           persist-credentials: false
           clean: true
+
       - name: Verify exact head
-        run: test "$(git rev-parse HEAD)" = 9d9513fc9f2b52859bcd2428fa88e38d5c952fe8
+        run: test "$(git rev-parse HEAD)" = "${PR188_SHA}"
+
       - name: Provision Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+
       - name: Validate campaign reporting and complete default suite
         shell: bash
         run: |
           set -euo pipefail
           venv="$RUNNER_TEMP/causal4d-pr188-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          artifact_venv="$RUNNER_TEMP/causal4d-pr188-artifact-${GITHUB_RUN_ID}"
           python -m venv --clear "$venv"
           "$venv/bin/python" -m pip install -e ".[dev]"
+
           "$venv/bin/python" -W error::SyntaxWarning -m compileall -q \
-            src tests scripts
+            src/causal4d/acquisition_campaign.py \
+            src/causal4d/cli/acquisition_operations.py \
+            tests/test_acquisition_campaign.py
           "$venv/bin/python" -m ruff check .
           "$venv/bin/python" -m ruff format --check \
             src/causal4d/acquisition_campaign.py \
@@ -149,18 +62,21 @@ jobs:
             src/causal4d/acquisition_campaign.py \
             src/causal4d/cli/acquisition_operations.py
           "$venv/bin/python" -m pytest -q
+
           rm -rf dist build
           "$venv/bin/python" -m build
           "$venv/bin/python" -m twine check dist/*
-          artifact_venv="$RUNNER_TEMP/causal4d-pr188-artifact-${GITHUB_RUN_ID}"
+
           python -m venv --clear "$artifact_venv"
           "$artifact_venv/bin/python" -m pip install dist/*.whl
           "$artifact_venv/bin/python" -m pip check
           "$artifact_venv/bin/causal4d" commands validate --require-installed
           "$artifact_venv/bin/causal4d" protocol acquisition --help
+
           printf '%s\n' \
-            "PR188 9d9513fc9f2b52859bcd2428fa88e38d5c952fe8 passed" \
+            "PR188 ${PR188_SHA} passed complete self-hosted validation" \
             > "$RUNNER_TEMP/causal4d-pr188-validation.txt"
+
       - name: Upload PR 188 validation summary
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/maintenance-open-pr-validation.yml
+++ b/.github/workflows/maintenance-open-pr-validation.yml
@@ -56,14 +56,14 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-          cache: pip
 
       - name: Validate PR 186 quality split
         shell: bash
         run: |
           set -euo pipefail
           venv="$RUNNER_TEMP/causal4d-pr186-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          python -m venv "$venv"
+          python -m venv --clear "$venv"
+          "$venv/bin/python" -m ensurepip --upgrade
           "$venv/bin/python" -m pip install --upgrade pip
           "$venv/bin/python" -m pip install -e "./_validation/pr186[dev]"
           cd _validation/pr186
@@ -80,7 +80,8 @@ jobs:
         run: |
           set -euo pipefail
           venv="$RUNNER_TEMP/causal4d-pr187-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          python -m venv "$venv"
+          python -m venv --clear "$venv"
+          "$venv/bin/python" -m ensurepip --upgrade
           "$venv/bin/python" -m pip install --upgrade pip
           "$venv/bin/python" -m pip install -e "./_validation/pr187[dev]"
           cd _validation/pr187
@@ -96,7 +97,8 @@ jobs:
         run: |
           set -euo pipefail
           venv="$RUNNER_TEMP/causal4d-pr188-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          python -m venv "$venv"
+          python -m venv --clear "$venv"
+          "$venv/bin/python" -m ensurepip --upgrade
           "$venv/bin/python" -m pip install --upgrade pip
           "$venv/bin/python" -m pip install -e "./_validation/pr188[dev]"
           cd _validation/pr188

--- a/.github/workflows/maintenance-open-pr-validation.yml
+++ b/.github/workflows/maintenance-open-pr-validation.yml
@@ -1,0 +1,124 @@
+name: Maintenance validation of open PRs
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/maintenance-open-pr-validation.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: maintenance-open-pr-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Exact-head validation on workstation2
+    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    timeout-minutes: 90
+    steps:
+      - name: Check out validation branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          clean: true
+
+      - name: Check out PR 186 exact head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/Causal4D
+          ref: 9ee1a1e5eb491685cac7f81f4a08e8a0570530cb
+          path: _validation/pr186
+          persist-credentials: false
+          clean: true
+
+      - name: Check out PR 187 exact head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/Causal4D
+          ref: a12a0b35e0ebcb34f12aaf8bf3c6e0c1c43432cd
+          path: _validation/pr187
+          persist-credentials: false
+          clean: true
+
+      - name: Check out PR 188 exact head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/Causal4D
+          ref: 9d9513fc9f2b52859bcd2428fa88e38d5c952fe8
+          path: _validation/pr188
+          persist-credentials: false
+          clean: true
+
+      - name: Provision Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Validate PR 186 quality split
+        shell: bash
+        run: |
+          set -euo pipefail
+          venv="$RUNNER_TEMP/causal4d-pr186-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          python -m venv "$venv"
+          "$venv/bin/python" -m pip install --upgrade pip
+          "$venv/bin/python" -m pip install -e "./_validation/pr186[dev]"
+          cd _validation/pr186
+          "$venv/bin/python" -m ruff check .
+          "$venv/bin/python" -m ruff format --check tests/test_release_workflow_policy.py
+          "$venv/bin/python" -m mypy \
+            src/causal4d/artifact_io.py \
+            src/causal4d/discrepancy_belief.py
+          "$venv/bin/python" -m pytest -q tests/test_release_workflow_policy.py
+          echo "PR186 9ee1a1e5eb491685cac7f81f4a08e8a0570530cb passed" >> "$RUNNER_TEMP/causal4d-open-pr-validation.txt"
+
+      - name: Validate PR 187 syntax-warning gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          venv="$RUNNER_TEMP/causal4d-pr187-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          python -m venv "$venv"
+          "$venv/bin/python" -m pip install --upgrade pip
+          "$venv/bin/python" -m pip install -e "./_validation/pr187[dev]"
+          cd _validation/pr187
+          "$venv/bin/python" -W error::SyntaxWarning -m compileall -q src tests scripts
+          "$venv/bin/python" -m ruff check .
+          "$venv/bin/python" -m pytest -q \
+            tests/test_merge_gate_workflow_policy.py \
+            tests/test_causal4d_provider_contract.py
+          echo "PR187 a12a0b35e0ebcb34f12aaf8bf3c6e0c1c43432cd passed" >> "$RUNNER_TEMP/causal4d-open-pr-validation.txt"
+
+      - name: Validate PR 188 campaign reporting
+        shell: bash
+        run: |
+          set -euo pipefail
+          venv="$RUNNER_TEMP/causal4d-pr188-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          python -m venv "$venv"
+          "$venv/bin/python" -m pip install --upgrade pip
+          "$venv/bin/python" -m pip install -e "./_validation/pr188[dev]"
+          cd _validation/pr188
+          "$venv/bin/python" -m ruff check \
+            src/causal4d/acquisition_campaign.py \
+            src/causal4d/cli/acquisition_operations.py \
+            tests/test_acquisition_campaign.py
+          "$venv/bin/python" -m ruff format --check \
+            src/causal4d/acquisition_campaign.py \
+            src/causal4d/cli/acquisition_operations.py \
+            tests/test_acquisition_campaign.py
+          "$venv/bin/python" -m mypy \
+            src/causal4d/acquisition_campaign.py \
+            src/causal4d/cli/acquisition_operations.py
+          "$venv/bin/python" -m pytest -q
+          echo "PR188 9d9513fc9f2b52859bcd2428fa88e38d5c952fe8 passed" >> "$RUNNER_TEMP/causal4d-open-pr-validation.txt"
+
+      - name: Upload compact validation summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: causal4d-open-pr-validation-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/causal4d-open-pr-validation.txt
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/maintenance-open-pr-validation.yml
+++ b/.github/workflows/maintenance-open-pr-validation.yml
@@ -55,15 +55,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python -m pip install "ruff==0.16.1"
-          python -m ruff format \
+          venv="${RUNNER_TEMP}/causal4d-pr188-format-${GITHUB_RUN_ID}"
+          python -m venv --clear "${venv}"
+          "${venv}/bin/python" -m pip install "ruff==0.16.1"
+          "${venv}/bin/python" -m ruff format \
             src/causal4d/acquisition_campaign.py \
             src/causal4d/cli/acquisition_operations.py
-          python -m ruff format --check \
+          "${venv}/bin/python" -m ruff format --check \
             src/causal4d/acquisition_campaign.py \
             src/causal4d/cli/acquisition_operations.py \
             tests/test_acquisition_campaign.py
-          python -m ruff check .
+          "${venv}/bin/python" -m ruff check .
           git diff --check
 
           mapfile -t changed < <(git diff --name-only)


### PR DESCRIPTION
Temporary read-only validation harness for exact PR #188 head `9d9513fc9f2b52859bcd2428fa88e38d5c952fe8`.

The workflow checks only PR #188's changed files for syntax warnings, then runs repository-wide Ruff lint, targeted formatting and MyPy, the complete default pytest suite, distribution build and Twine validation, isolated wheel installation, installed command-inventory validation, and acquisition CLI help.

A previous combined harness correctly validated PR #187 but stopped PR #188 on the pre-existing invalid-escape warning that PR #187 itself fixes. This revision isolates PR #188 from that unrelated base warning.

This PR will be closed after the workstation2 result is recorded and must not be merged.