### PR TITLE
Lock session-clustered real-analysis reporting

### DIFF
--- a/docs/causal4d_real_analysis_interval_diagnostics.md
+++ b/docs/causal4d_real_analysis_interval_diagnostics.md
@@ -1,0 +1,88 @@
+# Real-analysis interval diagnostics
+
+The registered real-analysis report remains session-clustered and keeps its
+frozen percentile-bootstrap interval unchanged.  A source-only operating-
+characteristic audit completed before physical target acquisition showed that
+an unstudentized percentile interval for the session mean can materially
+undercover at the registered sample sizes of 12 and 18 sessions.
+
+This companion artifact makes that limitation explicit and adds two
+non-decision-making sensitivity intervals:
+
+- a Student-t interval for a transparent symmetric small-sample check; and
+- a deterministic bootstrap-t interval for better calibration under skew and
+  other non-Gaussian session-effect distributions.
+
+Neither sensitivity interval may rescue a failed primary endpoint, alter a
+registered gate, or select a method after target access.  Promotion to primary
+status requires a separate, content-addressed preacquisition amendment.
+
+## Workflow evidence
+
+All studies evaluated the immutable implementation at
+`fa6a64b2442474321e453e9e8fdccd591e0a282d` and used no physical target
+outcomes.
+
+### Exact percentile-bootstrap operating characteristics
+
+- workflow run: `31091137654`;
+- audit ID:
+  `7dbea2a9b99cbc98acd03fa28af9583f0e95d4d0772e58853af4f05d0584267a`;
+- ten distribution/sample-size scenarios;
+- 2,000 synthetic session panels per scenario;
+- the frozen 20,000 bootstrap resamples and seed `20260726` for every panel;
+- matrix implementation verified against the production `_bootstrap` function
+  in every scenario.
+
+For Gaussian session effects, nominal 95% percentile coverage was about 90.9%
+at 12 sessions and 93.1% at 18 sessions.  Coverage was lower under strong
+right skew.
+
+### Interval-method comparison
+
+- workflow run: `31091652355`;
+- audit ID:
+  `5a13c416d7efd522f5123f98afacaacd218838583d78256d463eeb5e1d478576`;
+- 15,000 common synthetic panels;
+- percentile, basic, Student-t, BCa, and bootstrap-t intervals compared on the
+  same panels and bootstrap resamples.
+
+Across the ten scenarios, bootstrap-t had the smallest mean absolute coverage
+error, 0.019, and the best worst-case absolute coverage error, 0.042.  The
+Student-t interval had the smallest maximum favorable one-sided type-I error,
+about 0.0267.  Basic and BCa intervals did not improve the aggregate result.
+
+These findings justify publishing bootstrap-t and Student-t as sensitivity
+intervals; they do not change the frozen primary analysis.
+
+## Build the companion artifact
+
+```bash
+python -m causal4d.cli.real_analysis_interval_diagnostics \
+  effects.json \
+  configs/causal4d/sloth_multi_action_v1.json \
+  interval-diagnostics.json \
+  --method-freeze method-freeze.json \
+  --analysis-manifest registered-analysis.json
+```
+
+Use `--overwrite` only for an intentional regeneration of the same output
+path.  The command first builds the complete primary report, including protocol
+and source verification, and then derives the companion intervals from the
+same equal-session-weighted effects.
+
+## Output contract
+
+The companion JSON records:
+
+- the exact primary report and effect-table identities;
+- the unchanged primary percentile interval;
+- `finite_sample_coverage_guaranteed=false` for that interval;
+- Student-t and bootstrap-t sensitivity bounds;
+- the fixed bootstrap seed and replicate count;
+- the completed workflow evidence and audit identifiers;
+- `may_change_primary_decision=false` for every sensitivity interval; and
+- the same one-object, non-safety claim boundary as the primary report.
+
+The companion artifact is additive.  Existing report consumers and the frozen
+primary percentile output are unaffected.

--- a/docs/causal4d_real_analysis_reporting.md
+++ b/docs/causal4d_real_analysis_reporting.md
@@ -1,0 +1,196 @@
+# Registered real-analysis reporting
+
+This layer reports paired Causal4D effects without treating the 36 command
+executions as 36 independent experiments. It is additive reporting code for the
+frozen real protocol. It does not change the estimator, target split,
+calibration threshold, exclusion policy, or gate decisions.
+
+## Why sessions are the resampling unit
+
+The protocol contains 18 grasp sessions and two executions per grasp. Executions
+within one session share the grasp, reset, registration, object state, and other
+nuisance variables. The primary effect report therefore:
+
+1. computes the paired candidate-versus-baseline effect for every included
+   registered evaluation unit;
+2. averages those effects within each target grasp session;
+3. weights the resulting session effects equally; and
+4. obtains a deterministic 95% percentile interval by resampling sessions.
+
+The fixed reporting configuration is:
+
+```text
+resampling unit: target grasp session
+bootstrap replicates: 20,000
+bootstrap seed: 20,260,726
+confidence level: 95%
+```
+
+An unweighted execution mean is retained only as a diagnostic. It cannot replace
+or override the equal-session estimate.
+
+## Complete accounting
+
+A report consumes a content-addressed
+`Causal4DRealAnalysisEffectTable`. The table must account for every target unit
+in exactly one registered endpoint:
+
+| Endpoint | Registered units | Target sessions |
+| --- | ---: | ---: |
+| factual continuation | 36 | 18 |
+| same-grasp transfer | 18 | 18 |
+| new-contact transfer | 12 | 12 |
+
+Every record is matched against the locked protocol by source execution, target
+execution, target session, acquisition index, action, contact, and realization
+condition. Missing, additional, reordered, or relabelled target identities fail
+closed.
+
+A preregistered exclusion remains in the table with:
+
+```json
+{
+  "included": false,
+  "exclusion_reason": "<registered reason>",
+  "baseline_value": null,
+  "candidate_value": null
+}
+```
+
+Excluded units cannot carry target metric values. Included units cannot carry an
+exclusion reason.
+
+## Effect-table contract
+
+The top-level fields are closed:
+
+```json
+{
+  "schema_version": 1,
+  "artifact_kind": "Causal4DRealAnalysisEffectTable",
+  "effect_table_id": "<canonical SHA-256>",
+  "protocol_id": "causal4d-sloth-multi-action-v1",
+  "protocol_design_sha256":
+    "6d61f2bea96af0ba04faaf3476990b58cd87e0a9c826420c254a012dec647968",
+  "preacquisition_amendment_sha256":
+    "0e167538a7824e5ec053031d8359d4e9b4ff89ad61a85666400a86c2a88ac42f",
+  "method_freeze_sha256": "<64 lowercase hex>",
+  "analysis_manifest_sha256": "<64 lowercase hex>",
+  "endpoint": "factual_continuation",
+  "metric_id": "track_error_m",
+  "metric_unit": "m",
+  "lower_is_better": true,
+  "target_outcomes_used": true,
+  "target_informed_selection": false,
+  "object_id": "sloth_plush_instance_1",
+  "records": []
+}
+```
+
+For factual continuation, `unit_id` equals `target_execution_id` and
+`source_execution_id` is null. For transfer endpoints, `unit_id` is exactly:
+
+```text
+<source_execution_id>-><target_execution_id>
+```
+
+The table identity is the canonical SHA-256 of every field except
+`effect_table_id` itself. Use
+`causal4d.real_analysis_reporting.effect_table_id_for_payload` to derive it.
+
+## Source verification
+
+The report reopens and verifies the concrete sealed method freeze and registered
+analysis manifest. Their SHA-256 values must match the effect table, and their
+internal protocol, amendment, target-access, and optional-branch restrictions
+must pass the same source-verification boundary used by the final interpretation
+artifact.
+
+The verifier reads, hashes, and parses the same exact bytes. Duplicate JSON keys,
+non-finite JSON values, symbolic links, and concurrent file replacement cannot
+silently separate the retained digest from the validated payload.
+
+## Reported diagnostics
+
+The output contains:
+
+- the equal-session primary effect and deterministic clustered interval;
+- candidate-better, tied, and worse session counts;
+- complete inclusion and exclusion accounting;
+- an unweighted execution diagnostic;
+- a non-decision-making acquisition-order slope and early/late contrast;
+- secondary action, contact, and realization-condition summaries;
+- the complete registered action-condition support matrix; and
+- explicit same-object and non-safety claim boundaries.
+
+The acquisition-order diagnostic cannot select exclusions or revise the primary
+result. Realization-condition summaries are descriptive because condition and
+action are not fully crossed and conditions occupy different acquisition-time
+ranges.
+
+## Calibration utility
+
+`summarize_execution_block_utility` combines an existing frozen
+`ExecutionBlockConformalCalibration` with its target-fold evaluation. It reports:
+
+- execution-block coverage;
+- target coordinate count;
+- mean, median, and maximum interval width;
+- the frozen threshold;
+- largest, second-largest, and median calibration scores;
+- maximum-to-median score ratio; and
+- leave-one-calibration-session-out diagnostics.
+
+Coverage without interval width is explicitly marked insufficient. Fragility
+outputs cannot select or modify the threshold. Pointwise, pooled-coordinate, and
+worst-group conformal guarantees remain prohibited.
+
+## Python and module CLI
+
+```python
+from causal4d.real_analysis_reporting import (
+    build_real_analysis_effect_report,
+    write_real_analysis_effect_report,
+)
+
+report = build_real_analysis_effect_report(
+    "factual-track-effects.json",
+    "configs/causal4d/sloth_multi_action_v1.json",
+    method_freeze_path="method_freeze.json",
+    analysis_manifest_path="registered-analysis.json",
+)
+write_real_analysis_effect_report(
+    "factual-track-session-report.json",
+    report,
+)
+```
+
+The packaged module CLI exposes the same operation:
+
+```bash
+python -m causal4d.cli.real_analysis_reporting \
+  factual-track-effects.json \
+  configs/causal4d/sloth_multi_action_v1.json \
+  factual-track-session-report.json \
+  --method-freeze method_freeze.json \
+  --analysis-manifest registered-analysis.json \
+  --require-estimable
+```
+
+Run it separately for each registered endpoint and primary metric. A return code
+of 3 with `--require-estimable` means complete accounting was retained but fewer
+than two target sessions remained estimable.
+
+## Claim boundary
+
+Even a positive report remains bounded to:
+
+- the single registered physical sloth instance;
+- the three registered contact regions;
+- the four registered action profiles;
+- the registered realization conditions; and
+- the deployed perception, actuator, and physical-twin configuration.
+
+It does not establish object-class generalization, individual-level real
+counterfactual ground truth, raw-covariance calibration, or general robot safety.
+Subgroup and drift diagnostics cannot rescue a failed registered endpoint.

--- a/docs/causal4d_real_analysis_reporting.md
+++ b/docs/causal4d_real_analysis_reporting.md
@@ -109,6 +109,10 @@ artifact.
 The verifier reads, hashes, and parses the same exact bytes. Duplicate JSON keys,
 non-finite JSON values, symbolic links, and concurrent file replacement cannot
 silently separate the retained digest from the validated payload.
+The registered protocol is also passed through the repository's complete
+`validate_protocol` contract. Its design SHA-256 is recomputed from the full
+content, so a modified split, execution label, acquisition order, or balance
+cannot be admitted by retaining the old embedded digest.
 
 ## Reported diagnostics
 
@@ -124,9 +128,9 @@ The output contains:
 - explicit same-object and non-safety claim boundaries.
 
 The acquisition-order diagnostic cannot select exclusions or revise the primary
-result. Realization-condition summaries are descriptive because condition and
-action are not fully crossed and conditions occupy different acquisition-time
-ranges.
+result. Realization-condition summaries are descriptive because all condition/action
+cells exist but are unequally replicated, and conditions occupy different
+acquisition-time ranges.
 
 ## Calibration utility
 

--- a/src/causal4d/cli/real_analysis_interval_diagnostics.py
+++ b/src/causal4d/cli/real_analysis_interval_diagnostics.py
@@ -1,0 +1,65 @@
+"""CLI for non-decision-making real-analysis interval diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from causal4d.real_analysis_interval_diagnostics import (
+    build_real_analysis_interval_diagnostics,
+    write_real_analysis_interval_diagnostics,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build source-verified Student-t and bootstrap-t companion intervals "
+            "without changing the frozen primary percentile report."
+        )
+    )
+    parser.add_argument("effect_table", type=Path)
+    parser.add_argument("protocol", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--method-freeze", type=Path, required=True)
+    parser.add_argument("--analysis-manifest", type=Path, required=True)
+    parser.add_argument("--overwrite", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Build and publish the companion interval artifact."""
+
+    arguments = _parser().parse_args(argv)
+    payload = build_real_analysis_interval_diagnostics(
+        arguments.effect_table,
+        arguments.protocol,
+        method_freeze_path=arguments.method_freeze,
+        analysis_manifest_path=arguments.analysis_manifest,
+    )
+    write_real_analysis_interval_diagnostics(
+        arguments.output,
+        payload,
+        overwrite=arguments.overwrite,
+    )
+    print(
+        json.dumps(
+            {
+                "artifact_kind": payload["artifact_kind"],
+                "diagnostic_id": payload["diagnostic_id"],
+                "output": str(arguments.output),
+                "primary_interval_unchanged": True,
+                "sensitivity_intervals_may_change_primary_decision": False,
+            },
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d/cli/real_analysis_reporting.py
+++ b/src/causal4d/cli/real_analysis_reporting.py
@@ -1,0 +1,48 @@
+"""Build registered session-clustered real-experiment effect reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from causal4d.real_analysis_reporting import (
+    build_real_analysis_effect_report,
+    write_real_analysis_effect_report,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("effect_table", type=Path)
+    parser.add_argument("protocol", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--method-freeze", type=Path, required=True)
+    parser.add_argument("--analysis-manifest", type=Path, required=True)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--require-estimable", action="store_true")
+    arguments = parser.parse_args(argv)
+
+    report = build_real_analysis_effect_report(
+        arguments.effect_table,
+        arguments.protocol,
+        method_freeze_path=arguments.method_freeze,
+        analysis_manifest_path=arguments.analysis_manifest,
+    )
+    write_real_analysis_effect_report(
+        arguments.output,
+        report,
+        overwrite=arguments.overwrite,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if (
+        arguments.require_estimable
+        and not report["primary_session_clustered_effect"]["estimable"]
+    ):
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d/real_analysis_interval_diagnostics.py
+++ b/src/causal4d/real_analysis_interval_diagnostics.py
@@ -1,0 +1,378 @@
+"""Preacquisition interval diagnostics for session-clustered real effects.
+
+The registered percentile interval remains unchanged.  This module publishes
+source-verified Student-t and bootstrap-t sensitivity intervals that are
+explicitly ineligible to alter the primary decision unless a separate,
+content-addressed preacquisition amendment promotes one of them.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy.stats import t as student_t_distribution
+
+from causal4d.atomic_io import atomic_write_json
+from causal4d.real_analysis_reporting import (
+    BOOTSTRAP_CONFIDENCE_LEVEL,
+    BOOTSTRAP_REPLICATES,
+    BOOTSTRAP_SEED,
+    build_real_analysis_effect_report,
+    load_real_analysis_effect_table,
+)
+
+
+REAL_ANALYSIS_INTERVAL_DIAGNOSTICS_SCHEMA_VERSION = 1
+OPERATING_CHARACTERISTIC_TARGET_SHA = (
+    "fa6a64b2442474321e453e9e8fdccd591e0a282d"
+)
+BOOTSTRAP_OPERATING_CHARACTERISTIC_RUN_ID = 31091137654
+BOOTSTRAP_OPERATING_CHARACTERISTIC_AUDIT_ID = (
+    "7dbea2a9b99cbc98acd03fa28af9583f0e95d4d0772e58853af4f05d0584267a"
+)
+INTERVAL_COMPARISON_RUN_ID = 31091652355
+INTERVAL_COMPARISON_AUDIT_ID = (
+    "5a13c416d7efd522f5123f98afacaacd218838583d78256d463eeb5e1d478576"
+)
+
+FloatArray = NDArray[np.float64]
+
+
+def _canonical_sha256(payload: Mapping[str, Any]) -> str:
+    serialized = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def _validated_values(values: Sequence[float]) -> FloatArray:
+    array = np.asarray(values, dtype=np.float64)
+    if array.ndim != 1:
+        raise ValueError("session effects must be one-dimensional")
+    if not np.all(np.isfinite(array)):
+        raise ValueError("session effects must be finite")
+    return array
+
+
+def _not_estimable_interval(
+    *,
+    method: str,
+    sample_count: int,
+    confidence_level: float,
+    reason: str,
+) -> dict[str, Any]:
+    return {
+        "estimable": False,
+        "method": method,
+        "confidence_level": confidence_level,
+        "sample_count": sample_count,
+        "point_estimate": None,
+        "lower": None,
+        "upper": None,
+        "reason": reason,
+        "finite_sample_coverage_guaranteed": False,
+        "may_change_primary_decision": False,
+    }
+
+
+def student_t_sensitivity_interval(
+    values: Sequence[float],
+    *,
+    confidence_level: float = BOOTSTRAP_CONFIDENCE_LEVEL,
+) -> dict[str, Any]:
+    """Return a transparent small-sample mean interval under t assumptions."""
+
+    array = _validated_values(values)
+    if not 0.0 < confidence_level < 1.0:
+        raise ValueError("confidence_level must be in (0, 1)")
+    if len(array) < 2:
+        return _not_estimable_interval(
+            method="student_t_mean_sensitivity",
+            sample_count=len(array),
+            confidence_level=confidence_level,
+            reason="at least two included sessions are required",
+        )
+
+    point = float(np.mean(array))
+    sample_sd = float(np.std(array, ddof=1))
+    standard_error = sample_sd / math.sqrt(len(array))
+    tail = 0.5 * (1.0 - confidence_level)
+    critical_value = float(
+        student_t_distribution.ppf(1.0 - tail, df=len(array) - 1)
+    )
+    half_width = critical_value * standard_error
+    return {
+        "estimable": True,
+        "method": "student_t_mean_sensitivity",
+        "confidence_level": confidence_level,
+        "sample_count": len(array),
+        "degrees_of_freedom": len(array) - 1,
+        "point_estimate": point,
+        "sample_standard_deviation": sample_sd,
+        "standard_error": standard_error,
+        "critical_value": critical_value,
+        "lower": point - half_width,
+        "upper": point + half_width,
+        "degenerate_sample": sample_sd == 0.0,
+        "coverage_assumptions": [
+            "independent session effects",
+            "approximately normal sampling distribution of the session mean",
+        ],
+        "finite_sample_coverage_guaranteed": False,
+        "may_change_primary_decision": False,
+    }
+
+
+def bootstrap_t_sensitivity_interval(
+    values: Sequence[float],
+    *,
+    confidence_level: float = BOOTSTRAP_CONFIDENCE_LEVEL,
+    replicates: int = BOOTSTRAP_REPLICATES,
+    seed: int = BOOTSTRAP_SEED,
+) -> dict[str, Any]:
+    """Return a deterministic studentized bootstrap interval for the mean."""
+
+    array = _validated_values(values)
+    if not 0.0 < confidence_level < 1.0:
+        raise ValueError("confidence_level must be in (0, 1)")
+    if replicates < 1:
+        raise ValueError("replicates must be positive")
+    if len(array) < 2:
+        return _not_estimable_interval(
+            method="bootstrap_t_mean_sensitivity",
+            sample_count=len(array),
+            confidence_level=confidence_level,
+            reason="at least two included sessions are required",
+        )
+
+    sample_count = len(array)
+    point = float(np.mean(array))
+    sample_sd = float(np.std(array, ddof=1))
+    sample_standard_error = sample_sd / math.sqrt(sample_count)
+    if sample_standard_error == 0.0:
+        return {
+            "estimable": True,
+            "method": "bootstrap_t_mean_sensitivity",
+            "confidence_level": confidence_level,
+            "sample_count": sample_count,
+            "point_estimate": point,
+            "lower": point,
+            "upper": point,
+            "replicates": replicates,
+            "seed": seed,
+            "finite_studentized_replicate_count": replicates,
+            "finite_studentized_replicate_fraction": 1.0,
+            "degenerate_sample": True,
+            "finite_sample_coverage_guaranteed": False,
+            "may_change_primary_decision": False,
+        }
+
+    generator = np.random.default_rng(seed)
+    indices = generator.integers(
+        0,
+        sample_count,
+        size=(replicates, sample_count),
+    )
+    resamples = array[indices]
+    resample_means = np.mean(resamples, axis=1)
+    resample_sd = np.std(resamples, axis=1, ddof=1)
+    resample_standard_error = resample_sd / math.sqrt(sample_count)
+    differences = resample_means - point
+    studentized = np.empty(replicates, dtype=np.float64)
+    finite = resample_standard_error > 0.0
+    studentized[finite] = differences[finite] / resample_standard_error[finite]
+    zero_error = ~finite
+    studentized[zero_error] = np.where(
+        differences[zero_error] > 0.0,
+        np.inf,
+        np.where(differences[zero_error] < 0.0, -np.inf, 0.0),
+    )
+
+    tail = 0.5 * (1.0 - confidence_level)
+    lower_pivot, upper_pivot = np.quantile(
+        studentized,
+        [tail, 1.0 - tail],
+    )
+    lower = point - float(upper_pivot) * sample_standard_error
+    upper = point - float(lower_pivot) * sample_standard_error
+    if not np.isfinite(lower) or not np.isfinite(upper):
+        result = _not_estimable_interval(
+            method="bootstrap_t_mean_sensitivity",
+            sample_count=sample_count,
+            confidence_level=confidence_level,
+            reason="too many degenerate bootstrap resamples for finite pivots",
+        )
+        result.update(
+            replicates=replicates,
+            seed=seed,
+            finite_studentized_replicate_count=int(np.sum(finite)),
+            finite_studentized_replicate_fraction=float(np.mean(finite)),
+        )
+        return result
+
+    return {
+        "estimable": True,
+        "method": "bootstrap_t_mean_sensitivity",
+        "confidence_level": confidence_level,
+        "sample_count": sample_count,
+        "point_estimate": point,
+        "sample_standard_deviation": sample_sd,
+        "standard_error": sample_standard_error,
+        "lower_pivot_quantile": float(lower_pivot),
+        "upper_pivot_quantile": float(upper_pivot),
+        "lower": lower,
+        "upper": upper,
+        "replicates": replicates,
+        "seed": seed,
+        "finite_studentized_replicate_count": int(np.sum(finite)),
+        "finite_studentized_replicate_fraction": float(np.mean(finite)),
+        "degenerate_sample": False,
+        "finite_sample_coverage_guaranteed": False,
+        "may_change_primary_decision": False,
+    }
+
+
+def _included_session_effects(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    lower_is_better: bool,
+) -> tuple[float, ...]:
+    grouped: dict[str, list[float]] = defaultdict(list)
+    for record in records:
+        if not bool(record["included"]):
+            continue
+        baseline = float(record["baseline_value"])
+        candidate = float(record["candidate_value"])
+        improvement = (
+            baseline - candidate if lower_is_better else candidate - baseline
+        )
+        grouped[str(record["session_id"])].append(improvement)
+    return tuple(float(np.mean(values)) for values in grouped.values())
+
+
+def build_real_analysis_interval_diagnostics(
+    effect_table_path: str | Path,
+    protocol_path: str | Path,
+    *,
+    method_freeze_path: str | Path,
+    analysis_manifest_path: str | Path,
+) -> dict[str, Any]:
+    """Build source-verified companion intervals without changing the report."""
+
+    primary_report = build_real_analysis_effect_report(
+        effect_table_path,
+        protocol_path,
+        method_freeze_path=method_freeze_path,
+        analysis_manifest_path=analysis_manifest_path,
+    )
+    table, _ = load_real_analysis_effect_table(effect_table_path)
+    values = _included_session_effects(
+        table.records,
+        lower_is_better=table.lower_is_better,
+    )
+    primary = primary_report["primary_session_clustered_effect"]
+    primary_summary = primary["equal_session_weighted_improvement"]
+    expected_point = None if primary_summary is None else float(primary_summary["mean"])
+    actual_point = None if not values else float(np.mean(values))
+    if expected_point is None:
+        if actual_point is not None:
+            raise ValueError("companion interval point estimate differs from primary report")
+    elif actual_point is None or not np.isclose(expected_point, actual_point):
+        raise ValueError("companion interval point estimate differs from primary report")
+
+    payload: dict[str, Any] = {
+        "schema_version": REAL_ANALYSIS_INTERVAL_DIAGNOSTICS_SCHEMA_VERSION,
+        "artifact_kind": "Causal4DRealAnalysisIntervalDiagnostics",
+        "protocol_id": primary_report["protocol_id"],
+        "protocol_design_sha256": primary_report["protocol_design_sha256"],
+        "preacquisition_amendment_sha256": primary_report[
+            "preacquisition_amendment_sha256"
+        ],
+        "method_freeze_sha256": primary_report["method_freeze_sha256"],
+        "analysis_manifest_sha256": primary_report["analysis_manifest_sha256"],
+        "endpoint": primary_report["endpoint"],
+        "metric_id": primary_report["metric_id"],
+        "metric_unit": primary_report["metric_unit"],
+        "source_primary_report_id": primary_report["report_id"],
+        "source_effect_table": primary_report["source_effect_table"],
+        "source_protocol": primary_report["source_protocol"],
+        "source_verification": primary_report["source_verification"],
+        "included_session_count": len(values),
+        "point_estimate": actual_point,
+        "primary_percentile_interval": {
+            "interval": primary["confidence_interval"],
+            "frozen_primary_output_unchanged": True,
+            "finite_sample_coverage_guaranteed": False,
+            "coverage_evidence": {
+                "workflow_run_id": BOOTSTRAP_OPERATING_CHARACTERISTIC_RUN_ID,
+                "audit_id": BOOTSTRAP_OPERATING_CHARACTERISTIC_AUDIT_ID,
+                "implementation_target_sha": OPERATING_CHARACTERISTIC_TARGET_SHA,
+                "tested_session_counts": [12, 18],
+                "uses_target_outcomes": False,
+            },
+        },
+        "sensitivity_intervals": {
+            "student_t": student_t_sensitivity_interval(values),
+            "bootstrap_t": bootstrap_t_sensitivity_interval(values),
+            "may_change_primary_decision": False,
+            "promotion_requires_explicit_preacquisition_amendment": True,
+        },
+        "interval_method_comparison_evidence": {
+            "workflow_run_id": INTERVAL_COMPARISON_RUN_ID,
+            "audit_id": INTERVAL_COMPARISON_AUDIT_ID,
+            "implementation_target_sha": OPERATING_CHARACTERISTIC_TARGET_SHA,
+            "bootstrap_t_best_mean_absolute_coverage_error": 0.019,
+            "student_t_best_maximum_favorable_type_i_error": 0.02666666666666667,
+            "uses_target_outcomes": False,
+            "automatically_selected_method": False,
+        },
+        "interpretation": {
+            "percentile_interval_is_reproduced_not_recalibrated": True,
+            "bootstrap_t_is_general_calibration_sensitivity": True,
+            "student_t_is_transparent_symmetric_sensitivity": True,
+            "sensitivity_intervals_cannot_rescue_failed_primary_endpoint": True,
+            "target_informed_selection": False,
+        },
+        "claim_boundary": {
+            **primary_report["claim_boundary"],
+            "companion_intervals_are_non_decision_making": True,
+            "physical_target_outcomes_used_to_choose_interval": False,
+        },
+    }
+    payload["diagnostic_id"] = _canonical_sha256(payload)
+    return payload
+
+
+def write_real_analysis_interval_diagnostics(
+    path: str | Path,
+    payload: Mapping[str, Any],
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Atomically publish a finite companion interval artifact."""
+
+    atomic_write_json(path, payload, overwrite=overwrite)
+
+
+__all__ = [
+    "BOOTSTRAP_OPERATING_CHARACTERISTIC_AUDIT_ID",
+    "BOOTSTRAP_OPERATING_CHARACTERISTIC_RUN_ID",
+    "INTERVAL_COMPARISON_AUDIT_ID",
+    "INTERVAL_COMPARISON_RUN_ID",
+    "REAL_ANALYSIS_INTERVAL_DIAGNOSTICS_SCHEMA_VERSION",
+    "bootstrap_t_sensitivity_interval",
+    "build_real_analysis_interval_diagnostics",
+    "student_t_sensitivity_interval",
+    "write_real_analysis_interval_diagnostics",
+]

--- a/src/causal4d/real_analysis_interval_diagnostics.py
+++ b/src/causal4d/real_analysis_interval_diagnostics.py
@@ -14,7 +14,7 @@ import hashlib
 import json
 import math
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeAlias
 
 import numpy as np
 from numpy.typing import NDArray
@@ -41,7 +41,7 @@ INTERVAL_COMPARISON_AUDIT_ID = (
     "5a13c416d7efd522f5123f98afacaacd218838583d78256d463eeb5e1d478576"
 )
 
-FloatArray = NDArray[np.float64]
+FloatArray: TypeAlias = NDArray[np.float64]
 
 
 def _canonical_sha256(payload: Mapping[str, Any]) -> str:

--- a/src/causal4d/real_analysis_interval_diagnostics.py
+++ b/src/causal4d/real_analysis_interval_diagnostics.py
@@ -31,9 +31,7 @@ from causal4d.real_analysis_reporting import (
 
 
 REAL_ANALYSIS_INTERVAL_DIAGNOSTICS_SCHEMA_VERSION = 1
-OPERATING_CHARACTERISTIC_TARGET_SHA = (
-    "fa6a64b2442474321e453e9e8fdccd591e0a282d"
-)
+OPERATING_CHARACTERISTIC_TARGET_SHA = "fa6a64b2442474321e453e9e8fdccd591e0a282d"
 BOOTSTRAP_OPERATING_CHARACTERISTIC_RUN_ID = 31091137654
 BOOTSTRAP_OPERATING_CHARACTERISTIC_AUDIT_ID = (
     "7dbea2a9b99cbc98acd03fa28af9583f0e95d4d0772e58853af4f05d0584267a"
@@ -108,9 +106,7 @@ def student_t_sensitivity_interval(
     sample_sd = float(np.std(array, ddof=1))
     standard_error = sample_sd / math.sqrt(len(array))
     tail = 0.5 * (1.0 - confidence_level)
-    critical_value = float(
-        student_t_distribution.ppf(1.0 - tail, df=len(array) - 1)
-    )
+    critical_value = float(student_t_distribution.ppf(1.0 - tail, df=len(array) - 1))
     half_width = critical_value * standard_error
     return {
         "estimable": True,
@@ -254,9 +250,7 @@ def _included_session_effects(
             continue
         baseline = float(record["baseline_value"])
         candidate = float(record["candidate_value"])
-        improvement = (
-            baseline - candidate if lower_is_better else candidate - baseline
-        )
+        improvement = baseline - candidate if lower_is_better else candidate - baseline
         grouped[str(record["session_id"])].append(improvement)
     return tuple(float(np.mean(values)) for values in grouped.values())
 
@@ -287,9 +281,13 @@ def build_real_analysis_interval_diagnostics(
     actual_point = None if not values else float(np.mean(values))
     if expected_point is None:
         if actual_point is not None:
-            raise ValueError("companion interval point estimate differs from primary report")
+            raise ValueError(
+                "companion interval point estimate differs from primary report"
+            )
     elif actual_point is None or not np.isclose(expected_point, actual_point):
-        raise ValueError("companion interval point estimate differs from primary report")
+        raise ValueError(
+            "companion interval point estimate differs from primary report"
+        )
 
     payload: dict[str, Any] = {
         "schema_version": REAL_ANALYSIS_INTERVAL_DIAGNOSTICS_SCHEMA_VERSION,

--- a/src/causal4d/real_analysis_reporting.py
+++ b/src/causal4d/real_analysis_reporting.py
@@ -9,9 +9,10 @@ from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import numpy as np
+from numpy.typing import NDArray
 
 from causal4d.artifact_io import (
     ArtifactFileSnapshot,
@@ -23,6 +24,7 @@ from causal4d.execution_block_calibration import (
     ExecutionBlockConformalCalibration,
 )
 from causal4d.immutable_json import plain_json
+from causal4d.real_protocol import validate_protocol
 from causal4d.real_result_source_verification import verify_real_result_sources
 
 REAL_ANALYSIS_EFFECT_TABLE_SCHEMA_VERSION = 1
@@ -101,7 +103,12 @@ def _require(condition: bool, message: str) -> None:
 def _mapping(value: Any, *, name: str) -> Mapping[str, Any]:
     _require(isinstance(value, Mapping), f"{name} must be a JSON object")
     _require(all(type(key) is str for key in value), f"{name} keys must be strings")
-    return value
+    return cast(Mapping[str, Any], value)
+
+
+def _json_array(value: Any, *, name: str) -> list[Any]:
+    _require(isinstance(value, list), f"{name} must be a JSON array")
+    return cast(list[Any], value)
 
 
 def _exact_fields(
@@ -347,6 +354,7 @@ def _registered_units(
     protocol: Mapping[str, Any],
     endpoint: Endpoint,
 ) -> tuple[dict[str, Any], ...]:
+    validate_protocol(protocol)
     _require(protocol.get("protocol_id") == EXPECTED_PROTOCOL_ID, "wrong protocol")
     _require(
         protocol.get("design_sha256") == EXPECTED_PROTOCOL_DESIGN_SHA256,
@@ -354,8 +362,10 @@ def _registered_units(
     )
     object_record = _mapping(protocol.get("object"), name="protocol object")
     _require(object_record.get("object_id") == EXPECTED_OBJECT_ID, "wrong object")
-    raw_executions = protocol.get("executions")
-    _require(isinstance(raw_executions, list), "protocol executions must be an array")
+    raw_executions = _json_array(
+        protocol.get("executions"),
+        name="protocol executions",
+    )
     executions: dict[str, Mapping[str, Any]] = {}
     for raw in raw_executions:
         execution = _mapping(raw, name="protocol execution")
@@ -366,8 +376,10 @@ def _registered_units(
         )
         executions[execution_id] = execution
     splits = _mapping(protocol.get("splits"), name="protocol splits")
-    entries = splits.get(_ENDPOINT_SPLIT_KEYS[endpoint])
-    _require(isinstance(entries, list), "endpoint split must be an array")
+    entries = _json_array(
+        splits.get(_ENDPOINT_SPLIT_KEYS[endpoint]),
+        name="endpoint split",
+    )
     units: list[dict[str, Any]] = []
     for raw in entries:
         entry = _mapping(raw, name="endpoint unit")
@@ -447,7 +459,7 @@ def _improvement(record: Mapping[str, Any], *, lower_is_better: bool) -> float:
 def _summary(values: Sequence[float]) -> dict[str, Any] | None:
     if not values:
         return None
-    array = np.asarray(values, dtype=float)
+    array: NDArray[np.float64] = np.asarray(values, dtype=np.float64)
     return {
         "count": int(len(array)),
         "mean": float(np.mean(array)),
@@ -477,7 +489,7 @@ def _session_effects(
 
 
 def _bootstrap(values: Sequence[float]) -> dict[str, Any]:
-    array = np.asarray(values, dtype=float)
+    array: NDArray[np.float64] = np.asarray(values, dtype=np.float64)
     result: dict[str, Any] = {
         "estimable": len(array) >= 2,
         "method": "session_cluster_percentile_bootstrap",
@@ -519,8 +531,14 @@ def _drift(
     }
     if len(sessions) < 3:
         return result
-    x = np.asarray([indices[session] for session in sessions], dtype=float)
-    y = np.asarray([effects[session] for session in sessions], dtype=float)
+    x: NDArray[np.float64] = np.asarray(
+        [indices[session] for session in sessions],
+        dtype=np.float64,
+    )
+    y: NDArray[np.float64] = np.asarray(
+        [effects[session] for session in sessions],
+        dtype=np.float64,
+    )
     centered = x - np.mean(x)
     slope = float(np.dot(centered, y - np.mean(y)) / np.dot(centered, centered))
     correlation = 0.0
@@ -597,6 +615,9 @@ def _design_diagnostics(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
             count > 0
             for action_counts in counts.values()
             for count in action_counts.values()
+        ),
+        "balanced_across_actions": all(
+            len(set(action_counts.values())) == 1 for action_counts in counts.values()
         ),
         "condition_acquisition_timing": timing,
         "condition_comparisons_are_descriptive_only": True,
@@ -752,11 +773,8 @@ def summarize_execution_block_utility(
         evaluation.get("outer_fold_id") == calibration.outer_fold_id,
         "execution-block evaluation identifies another outer fold",
     )
-    raw_cases = evaluation.get("cases")
-    _require(
-        isinstance(raw_cases, list) and bool(raw_cases),
-        "evaluation cases missing",
-    )
+    raw_cases = _json_array(evaluation.get("cases"), name="evaluation cases")
+    _require(bool(raw_cases), "evaluation cases missing")
     cases = [_mapping(value, name="evaluation case") for value in raw_cases]
     mean_widths = [
         _number(case.get("mean_interval_width_m"), name="mean_interval_width_m")

--- a/src/causal4d/real_analysis_reporting.py
+++ b/src/causal4d/real_analysis_reporting.py
@@ -565,9 +565,7 @@ def _subgroups(
 
 def _design_diagnostics(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     actions = sorted({str(record["action_id"]) for record in records})
-    conditions = sorted(
-        {str(record["realization_condition_id"]) for record in records}
-    )
+    conditions = sorted({str(record["realization_condition_id"]) for record in records})
     counts = {
         condition: {
             action: sum(

--- a/src/causal4d/real_analysis_reporting.py
+++ b/src/causal4d/real_analysis_reporting.py
@@ -1,0 +1,833 @@
+"""Registered session-clustered reporting for the Causal4D real experiment."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+
+from causal4d.artifact_io import (
+    ArtifactFileSnapshot,
+    load_strict_json_object,
+    read_regular_file,
+)
+from causal4d.atomic_io import atomic_write_json
+from causal4d.execution_block_calibration import (
+    ExecutionBlockConformalCalibration,
+)
+from causal4d.immutable_json import plain_json
+from causal4d.real_result_source_verification import verify_real_result_sources
+
+REAL_ANALYSIS_EFFECT_TABLE_SCHEMA_VERSION = 1
+REAL_ANALYSIS_REPORT_SCHEMA_VERSION = 1
+EXPECTED_PROTOCOL_ID = "causal4d-sloth-multi-action-v1"
+EXPECTED_PROTOCOL_DESIGN_SHA256 = (
+    "6d61f2bea96af0ba04faaf3476990b58cd87e0a9c826420c254a012dec647968"
+)
+EXPECTED_PREACQUISITION_SHA256 = (
+    "0e167538a7824e5ec053031d8359d4e9b4ff89ad61a85666400a86c2a88ac42f"
+)
+EXPECTED_OBJECT_ID = "sloth_plush_instance_1"
+BOOTSTRAP_REPLICATES = 20_000
+BOOTSTRAP_SEED = 20_260_726
+BOOTSTRAP_CONFIDENCE_LEVEL = 0.95
+
+Endpoint = Literal[
+    "factual_continuation",
+    "same_grasp_transfer",
+    "new_contact_transfer",
+]
+
+_ENDPOINT_SPLIT_KEYS: dict[Endpoint, str] = {
+    "factual_continuation": "factual_continuation",
+    "same_grasp_transfer": "same_grasp_intervention_prediction",
+    "new_contact_transfer": "new_contact_intervention_prediction",
+}
+_ENDPOINT_COUNTS: dict[Endpoint, tuple[int, int]] = {
+    "factual_continuation": (36, 18),
+    "same_grasp_transfer": (18, 18),
+    "new_contact_transfer": (12, 12),
+}
+_TABLE_FIELDS = frozenset(
+    {
+        "schema_version",
+        "artifact_kind",
+        "effect_table_id",
+        "protocol_id",
+        "protocol_design_sha256",
+        "preacquisition_amendment_sha256",
+        "method_freeze_sha256",
+        "analysis_manifest_sha256",
+        "endpoint",
+        "metric_id",
+        "metric_unit",
+        "lower_is_better",
+        "target_outcomes_used",
+        "target_informed_selection",
+        "object_id",
+        "records",
+    }
+)
+_RECORD_FIELDS = frozenset(
+    {
+        "unit_id",
+        "source_execution_id",
+        "target_execution_id",
+        "session_id",
+        "acquisition_execution_index",
+        "action_id",
+        "contact_region_id",
+        "realization_condition_id",
+        "included",
+        "exclusion_reason",
+        "baseline_value",
+        "candidate_value",
+    }
+)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    _require(isinstance(value, Mapping), f"{name} must be a JSON object")
+    _require(all(type(key) is str for key in value), f"{name} keys must be strings")
+    return value
+
+
+def _exact_fields(
+    value: Mapping[str, Any],
+    expected: frozenset[str],
+    *,
+    name: str,
+) -> None:
+    missing = sorted(expected - set(value))
+    extra = sorted(set(value) - expected)
+    _require(
+        not missing and not extra,
+        f"{name} fields changed; missing={missing}, extra={extra}",
+    )
+
+
+def _string(value: Any, *, name: str, optional: bool = False) -> str | None:
+    if optional and value is None:
+        return None
+    _require(type(value) is str and bool(value), f"{name} must be a nonempty string")
+    return value
+
+
+def _sha256(value: Any, *, name: str) -> str:
+    _require(
+        type(value) is str
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value),
+        f"{name} must be a lowercase SHA-256 digest",
+    )
+    return value
+
+
+def _integer(value: Any, *, name: str) -> int:
+    _require(type(value) is int and value >= 0, f"{name} must be nonnegative")
+    return value
+
+
+def _number(value: Any, *, name: str) -> float:
+    _require(
+        type(value) in {int, float} and math.isfinite(float(value)),
+        f"{name} must be a finite JSON number",
+    )
+    return float(value)
+
+
+def _canonical_sha256(value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def effect_table_id_for_payload(payload: Mapping[str, Any]) -> str:
+    """Content-address one effect table without hashing its self identity."""
+
+    canonical = dict(payload)
+    canonical.pop("effect_table_id", None)
+    return _canonical_sha256(canonical)
+
+
+@dataclass(frozen=True)
+class RealAnalysisEffectTable:
+    """Validated complete effect inventory for one endpoint and metric."""
+
+    protocol_id: str
+    protocol_design_sha256: str
+    preacquisition_amendment_sha256: str
+    method_freeze_sha256: str
+    analysis_manifest_sha256: str
+    endpoint: Endpoint
+    metric_id: str
+    metric_unit: str
+    lower_is_better: bool
+    object_id: str
+    records: tuple[Mapping[str, Any], ...]
+    effect_table_id: str
+
+
+def _validate_record(value: Mapping[str, Any], *, position: int) -> dict[str, Any]:
+    record = _mapping(value, name=f"effect record {position}")
+    _exact_fields(record, _RECORD_FIELDS, name=f"effect record {position}")
+    included = record["included"]
+    _require(type(included) is bool, "included must be Boolean")
+    normalized: dict[str, Any] = {
+        "unit_id": _string(record["unit_id"], name="unit_id"),
+        "source_execution_id": _string(
+            record["source_execution_id"],
+            name="source_execution_id",
+            optional=True,
+        ),
+        "target_execution_id": _string(
+            record["target_execution_id"],
+            name="target_execution_id",
+        ),
+        "session_id": _string(record["session_id"], name="session_id"),
+        "acquisition_execution_index": _integer(
+            record["acquisition_execution_index"],
+            name="acquisition_execution_index",
+        ),
+        "action_id": _string(record["action_id"], name="action_id"),
+        "contact_region_id": _string(
+            record["contact_region_id"],
+            name="contact_region_id",
+        ),
+        "realization_condition_id": _string(
+            record["realization_condition_id"],
+            name="realization_condition_id",
+        ),
+        "included": included,
+        "exclusion_reason": _string(
+            record["exclusion_reason"],
+            name="exclusion_reason",
+            optional=True,
+        ),
+    }
+    baseline = record["baseline_value"]
+    candidate = record["candidate_value"]
+    if included:
+        _require(
+            normalized["exclusion_reason"] is None,
+            "included records cannot have an exclusion reason",
+        )
+        normalized["baseline_value"] = _number(baseline, name="baseline_value")
+        normalized["candidate_value"] = _number(candidate, name="candidate_value")
+    else:
+        _require(
+            normalized["exclusion_reason"] is not None,
+            "excluded records require an exclusion reason",
+        )
+        _require(
+            baseline is None and candidate is None,
+            "excluded records must not contain target metric values",
+        )
+        normalized["baseline_value"] = None
+        normalized["candidate_value"] = None
+    return normalized
+
+
+def _load_json_snapshot(
+    path: str | Path,
+    *,
+    name: str,
+) -> tuple[ArtifactFileSnapshot, dict[str, Any]]:
+    snapshot = read_regular_file(path, name=name)
+    return snapshot, load_strict_json_object(snapshot.payload, name=name)
+
+
+def load_real_analysis_effect_table(
+    path: str | Path,
+) -> tuple[RealAnalysisEffectTable, ArtifactFileSnapshot]:
+    """Load one exact-byte, content-addressed effect table."""
+
+    snapshot, payload = _load_json_snapshot(path, name="real-analysis effect table")
+    _exact_fields(payload, _TABLE_FIELDS, name="real-analysis effect table")
+    _require(
+        payload["schema_version"] == REAL_ANALYSIS_EFFECT_TABLE_SCHEMA_VERSION,
+        "unsupported real-analysis effect-table schema",
+    )
+    _require(
+        payload["artifact_kind"] == "Causal4DRealAnalysisEffectTable",
+        "unexpected real-analysis effect-table artifact kind",
+    )
+    endpoint = _string(payload["endpoint"], name="endpoint")
+    _require(endpoint in _ENDPOINT_SPLIT_KEYS, "unknown real endpoint")
+    for name in (
+        "lower_is_better",
+        "target_outcomes_used",
+        "target_informed_selection",
+    ):
+        _require(type(payload[name]) is bool, f"{name} must be Boolean")
+    _require(payload["target_outcomes_used"] is True, "target outcomes are required")
+    _require(
+        payload["target_informed_selection"] is False,
+        "target-informed selection invalidates registered reporting",
+    )
+    records_value = payload["records"]
+    _require(isinstance(records_value, list), "records must be a JSON array")
+    records = tuple(
+        sorted(
+            (
+                _validate_record(_mapping(item, name="effect record"), position=index)
+                for index, item in enumerate(records_value)
+            ),
+            key=lambda record: (
+                record["acquisition_execution_index"],
+                record["unit_id"],
+            ),
+        )
+    )
+    _require(bool(records), "effect table records must be nonempty")
+    unit_ids = [record["unit_id"] for record in records]
+    targets = [record["target_execution_id"] for record in records]
+    _require(len(unit_ids) == len(set(unit_ids)), "effect unit IDs must be unique")
+    _require(len(targets) == len(set(targets)), "target executions must be unique")
+    table = RealAnalysisEffectTable(
+        protocol_id=str(_string(payload["protocol_id"], name="protocol_id")),
+        protocol_design_sha256=_sha256(
+            payload["protocol_design_sha256"],
+            name="protocol_design_sha256",
+        ),
+        preacquisition_amendment_sha256=_sha256(
+            payload["preacquisition_amendment_sha256"],
+            name="preacquisition_amendment_sha256",
+        ),
+        method_freeze_sha256=_sha256(
+            payload["method_freeze_sha256"],
+            name="method_freeze_sha256",
+        ),
+        analysis_manifest_sha256=_sha256(
+            payload["analysis_manifest_sha256"],
+            name="analysis_manifest_sha256",
+        ),
+        endpoint=endpoint,  # type: ignore[arg-type]
+        metric_id=str(_string(payload["metric_id"], name="metric_id")),
+        metric_unit=str(_string(payload["metric_unit"], name="metric_unit")),
+        lower_is_better=payload["lower_is_better"],
+        object_id=str(_string(payload["object_id"], name="object_id")),
+        records=records,
+        effect_table_id=_sha256(payload["effect_table_id"], name="effect_table_id"),
+    )
+    _require(table.protocol_id == EXPECTED_PROTOCOL_ID, "unexpected protocol")
+    _require(
+        table.protocol_design_sha256 == EXPECTED_PROTOCOL_DESIGN_SHA256,
+        "effect table protocol digest differs from the locked design",
+    )
+    _require(
+        table.preacquisition_amendment_sha256 == EXPECTED_PREACQUISITION_SHA256,
+        "effect table amendment digest differs from locked v4",
+    )
+    _require(table.object_id == EXPECTED_OBJECT_ID, "unexpected physical object")
+    _require(
+        table.effect_table_id == effect_table_id_for_payload(payload),
+        "real-analysis effect-table checksum mismatch",
+    )
+    return table, snapshot
+
+
+def _registered_units(
+    protocol: Mapping[str, Any],
+    endpoint: Endpoint,
+) -> tuple[dict[str, Any], ...]:
+    _require(protocol.get("protocol_id") == EXPECTED_PROTOCOL_ID, "wrong protocol")
+    _require(
+        protocol.get("design_sha256") == EXPECTED_PROTOCOL_DESIGN_SHA256,
+        "protocol design digest differs from the locked design",
+    )
+    object_record = _mapping(protocol.get("object"), name="protocol object")
+    _require(object_record.get("object_id") == EXPECTED_OBJECT_ID, "wrong object")
+    raw_executions = protocol.get("executions")
+    _require(isinstance(raw_executions, list), "protocol executions must be an array")
+    executions: dict[str, Mapping[str, Any]] = {}
+    for raw in raw_executions:
+        execution = _mapping(raw, name="protocol execution")
+        execution_id = str(_string(execution.get("execution_id"), name="execution_id"))
+        _require(
+            execution_id not in executions,
+            "protocol execution IDs are duplicated",
+        )
+        executions[execution_id] = execution
+    splits = _mapping(protocol.get("splits"), name="protocol splits")
+    entries = splits.get(_ENDPOINT_SPLIT_KEYS[endpoint])
+    _require(isinstance(entries, list), "endpoint split must be an array")
+    units: list[dict[str, Any]] = []
+    for raw in entries:
+        entry = _mapping(raw, name="endpoint unit")
+        if endpoint == "factual_continuation":
+            source_id = None
+            target_id = str(_string(entry.get("execution_id"), name="execution_id"))
+            unit_id = target_id
+        else:
+            source_id = str(
+                _string(entry.get("source_execution_id"), name="source_execution_id")
+            )
+            target_id = str(
+                _string(entry.get("target_execution_id"), name="target_execution_id")
+            )
+            unit_id = f"{source_id}->{target_id}"
+            _require(source_id in executions, f"unknown source execution {source_id}")
+        _require(target_id in executions, f"unknown target execution {target_id}")
+        target = executions[target_id]
+        units.append(
+            {
+                "unit_id": unit_id,
+                "source_execution_id": source_id,
+                "target_execution_id": target_id,
+                "session_id": target["session_id"],
+                "acquisition_execution_index": target["acquisition_execution_index"],
+                "action_id": target["command_profile_id"],
+                "contact_region_id": target["contact_region_id"],
+                "realization_condition_id": target["realization_condition_id"],
+            }
+        )
+    expected_units, expected_sessions = _ENDPOINT_COUNTS[endpoint]
+    _require(len(units) == expected_units, "registered endpoint unit count changed")
+    _require(
+        len({unit["session_id"] for unit in units}) == expected_sessions,
+        "registered endpoint session count changed",
+    )
+    return tuple(units)
+
+
+def _validate_accounting(
+    table: RealAnalysisEffectTable,
+    registered: Sequence[Mapping[str, Any]],
+) -> None:
+    expected = {str(unit["unit_id"]): unit for unit in registered}
+    actual = {str(record["unit_id"]): record for record in table.records}
+    missing = sorted(set(expected) - set(actual))
+    extra = sorted(set(actual) - set(expected))
+    _require(
+        not missing and not extra,
+        f"effect-table accounting differs from the registered endpoint; "
+        f"missing={missing}, extra={extra}",
+    )
+    fields = (
+        "source_execution_id",
+        "target_execution_id",
+        "session_id",
+        "acquisition_execution_index",
+        "action_id",
+        "contact_region_id",
+        "realization_condition_id",
+    )
+    for unit_id, unit in expected.items():
+        record = actual[unit_id]
+        for field in fields:
+            _require(
+                record[field] == unit[field],
+                f"effect record {unit_id} {field} differs from the locked protocol",
+            )
+
+
+def _improvement(record: Mapping[str, Any], *, lower_is_better: bool) -> float:
+    baseline = float(record["baseline_value"])
+    candidate = float(record["candidate_value"])
+    return baseline - candidate if lower_is_better else candidate - baseline
+
+
+def _summary(values: Sequence[float]) -> dict[str, Any] | None:
+    if not values:
+        return None
+    array = np.asarray(values, dtype=float)
+    return {
+        "count": int(len(array)),
+        "mean": float(np.mean(array)),
+        "median": float(np.median(array)),
+        "minimum": float(np.min(array)),
+        "maximum": float(np.max(array)),
+    }
+
+
+def _session_effects(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    lower_is_better: bool,
+) -> tuple[dict[str, float], dict[str, float]]:
+    effects: dict[str, list[float]] = defaultdict(list)
+    indices: dict[str, list[float]] = defaultdict(list)
+    for record in records:
+        if not record["included"]:
+            continue
+        session = str(record["session_id"])
+        effects[session].append(_improvement(record, lower_is_better=lower_is_better))
+        indices[session].append(float(record["acquisition_execution_index"]))
+    return (
+        {session: float(np.mean(values)) for session, values in effects.items()},
+        {session: float(np.mean(indices[session])) for session in effects},
+    )
+
+
+def _bootstrap(values: Sequence[float]) -> dict[str, Any]:
+    array = np.asarray(values, dtype=float)
+    result: dict[str, Any] = {
+        "estimable": len(array) >= 2,
+        "method": "session_cluster_percentile_bootstrap",
+        "confidence_level": BOOTSTRAP_CONFIDENCE_LEVEL,
+        "replicates": BOOTSTRAP_REPLICATES,
+        "seed": BOOTSTRAP_SEED,
+        "lower": None,
+        "upper": None,
+    }
+    if len(array) < 2:
+        return result
+    generator = np.random.default_rng(BOOTSTRAP_SEED)
+    indices = generator.integers(
+        0,
+        len(array),
+        size=(BOOTSTRAP_REPLICATES, len(array)),
+    )
+    means = np.mean(array[indices], axis=1)
+    tail = 0.5 * (1.0 - BOOTSTRAP_CONFIDENCE_LEVEL)
+    lower, upper = np.quantile(means, [tail, 1.0 - tail])
+    result.update(lower=float(lower), upper=float(upper))
+    return result
+
+
+def _drift(
+    effects: Mapping[str, float],
+    indices: Mapping[str, float],
+) -> dict[str, Any]:
+    sessions = sorted(effects, key=lambda session: indices[session])
+    result: dict[str, Any] = {
+        "estimable": len(sessions) >= 3,
+        "session_count": len(sessions),
+        "slope_per_execution_index": None,
+        "fitted_early_to_late_change": None,
+        "pearson_correlation": None,
+        "late_minus_early_mean": None,
+        "may_select_exclusions": False,
+        "may_change_primary_decision": False,
+    }
+    if len(sessions) < 3:
+        return result
+    x = np.asarray([indices[session] for session in sessions], dtype=float)
+    y = np.asarray([effects[session] for session in sessions], dtype=float)
+    centered = x - np.mean(x)
+    slope = float(np.dot(centered, y - np.mean(y)) / np.dot(centered, centered))
+    correlation = 0.0
+    if np.std(y) > 0.0:
+        correlation = float(np.corrcoef(x, y)[0, 1])
+    split = len(sessions) // 2
+    result.update(
+        slope_per_execution_index=slope,
+        fitted_early_to_late_change=float(slope * (np.max(x) - np.min(x))),
+        pearson_correlation=correlation,
+        late_minus_early_mean=float(np.mean(y[-split:]) - np.mean(y[:split])),
+    )
+    return result
+
+
+def _subgroups(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    field: str,
+    lower_is_better: bool,
+) -> dict[str, Any]:
+    groups: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for record in records:
+        groups[str(record[field])].append(record)
+    result = {}
+    for group_id, group_records in sorted(groups.items()):
+        effects, _ = _session_effects(
+            group_records,
+            lower_is_better=lower_is_better,
+        )
+        result[group_id] = {
+            "registered_unit_count": len(group_records),
+            "included_unit_count": sum(
+                bool(record["included"]) for record in group_records
+            ),
+            "included_session_count": len(effects),
+            "equal_session_weighted_improvement": _summary(list(effects.values())),
+            "primary_decision_eligible": False,
+        }
+    return result
+
+
+def _design_diagnostics(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    actions = sorted({str(record["action_id"]) for record in records})
+    conditions = sorted(
+        {str(record["realization_condition_id"]) for record in records}
+    )
+    counts = {
+        condition: {
+            action: sum(
+                record["action_id"] == action
+                and record["realization_condition_id"] == condition
+                for record in records
+            )
+            for action in actions
+        }
+        for condition in conditions
+    }
+    timing = {}
+    for condition in conditions:
+        values = [
+            int(record["acquisition_execution_index"])
+            for record in records
+            if record["realization_condition_id"] == condition
+        ]
+        timing[condition] = {
+            "minimum_acquisition_index": min(values),
+            "median_acquisition_index": float(np.median(values)),
+            "maximum_acquisition_index": max(values),
+        }
+    return {
+        "action_ids": actions,
+        "realization_condition_ids": conditions,
+        "registered_action_condition_counts": counts,
+        "fully_crossed": all(
+            count > 0
+            for action_counts in counts.values()
+            for count in action_counts.values()
+        ),
+        "condition_acquisition_timing": timing,
+        "condition_comparisons_are_descriptive_only": True,
+        "condition_comparisons_may_change_primary_decision": False,
+    }
+
+
+def build_real_analysis_effect_report(
+    effect_table_path: str | Path,
+    protocol_path: str | Path,
+    *,
+    method_freeze_path: str | Path,
+    analysis_manifest_path: str | Path,
+) -> dict[str, Any]:
+    """Build a source-verified, session-clustered paired-effect report."""
+
+    table, table_snapshot = load_real_analysis_effect_table(effect_table_path)
+    protocol_snapshot, protocol = _load_json_snapshot(
+        protocol_path,
+        name="registered real protocol",
+    )
+    _validate_accounting(table, _registered_units(protocol, table.endpoint))
+    verification = verify_real_result_sources(
+        table,
+        method_freeze_path=method_freeze_path,
+        analysis_manifest_path=analysis_manifest_path,
+    )
+    effects, indices = _session_effects(
+        table.records,
+        lower_is_better=table.lower_is_better,
+    )
+    session_values = list(effects.values())
+    expected_units, expected_sessions = _ENDPOINT_COUNTS[table.endpoint]
+    tolerance = 1e-12
+    report: dict[str, Any] = {
+        "schema_version": REAL_ANALYSIS_REPORT_SCHEMA_VERSION,
+        "artifact_kind": "Causal4DSessionClusteredEffectReport",
+        "protocol_id": table.protocol_id,
+        "protocol_design_sha256": table.protocol_design_sha256,
+        "preacquisition_amendment_sha256": table.preacquisition_amendment_sha256,
+        "method_freeze_sha256": table.method_freeze_sha256,
+        "analysis_manifest_sha256": table.analysis_manifest_sha256,
+        "endpoint": table.endpoint,
+        "metric_id": table.metric_id,
+        "metric_unit": table.metric_unit,
+        "improvement_sign": (
+            "baseline_minus_candidate"
+            if table.lower_is_better
+            else "candidate_minus_baseline"
+        ),
+        "positive_values_favor_candidate": True,
+        "source_effect_table": {
+            "effect_table_id": table.effect_table_id,
+            "sha256": table_snapshot.sha256,
+            "bytes": table_snapshot.byte_count,
+        },
+        "source_protocol": {
+            "sha256": protocol_snapshot.sha256,
+            "bytes": protocol_snapshot.byte_count,
+            "semantic_design_sha256": EXPECTED_PROTOCOL_DESIGN_SHA256,
+        },
+        "source_verification": verification,
+        "accounting": {
+            "complete": True,
+            "expected_unit_count": expected_units,
+            "registered_unit_count": len(table.records),
+            "included_unit_count": sum(
+                bool(record["included"]) for record in table.records
+            ),
+            "excluded_unit_count": sum(
+                not record["included"] for record in table.records
+            ),
+            "expected_session_count": expected_sessions,
+            "included_session_count": len(effects),
+            "exclusions": [
+                {
+                    "unit_id": record["unit_id"],
+                    "target_execution_id": record["target_execution_id"],
+                    "reason": record["exclusion_reason"],
+                }
+                for record in table.records
+                if not record["included"]
+            ],
+        },
+        "primary_session_clustered_effect": {
+            "estimable": len(session_values) >= 2,
+            "equal_session_weighted_improvement": _summary(session_values),
+            "confidence_interval": _bootstrap(session_values),
+            "candidate_better_session_count": sum(
+                value > tolerance for value in session_values
+            ),
+            "candidate_tied_session_count": sum(
+                abs(value) <= tolerance for value in session_values
+            ),
+            "candidate_worse_session_count": sum(
+                value < -tolerance for value in session_values
+            ),
+            "session_is_resampling_unit": True,
+            "executions_are_not_treated_as_independent": True,
+        },
+        "unweighted_execution_diagnostic": _summary(
+            [
+                _improvement(record, lower_is_better=table.lower_is_better)
+                for record in table.records
+                if record["included"]
+            ]
+        ),
+        "acquisition_order_diagnostic": _drift(effects, indices),
+        "secondary_subgroups": {
+            "action": _subgroups(
+                table.records,
+                field="action_id",
+                lower_is_better=table.lower_is_better,
+            ),
+            "contact_region": _subgroups(
+                table.records,
+                field="contact_region_id",
+                lower_is_better=table.lower_is_better,
+            ),
+            "realization_condition": _subgroups(
+                table.records,
+                field="realization_condition_id",
+                lower_is_better=table.lower_is_better,
+            ),
+        },
+        "design_diagnostics": _design_diagnostics(table.records),
+        "claim_boundary": {
+            "object_id": table.object_id,
+            "same_object_protocol_only": True,
+            "object_class_generalization_claimed": False,
+            "individual_real_counterfactual_ground_truth_claimed": False,
+            "hardware_safety_claimed": False,
+            "subgroup_summaries_may_change_primary_decision": False,
+            "drift_diagnostics_may_select_exclusions": False,
+            "target_informed_selection": False,
+        },
+    }
+    report["report_id"] = _canonical_sha256(report)
+    return report
+
+
+def summarize_execution_block_utility(
+    calibration: ExecutionBlockConformalCalibration,
+    evaluation: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Report interval utility and fragility without changing calibration."""
+
+    _require(
+        evaluation.get("calibration_id") == calibration.calibration_id,
+        "execution-block evaluation identifies another calibration",
+    )
+    _require(
+        evaluation.get("outer_fold_id") == calibration.outer_fold_id,
+        "execution-block evaluation identifies another outer fold",
+    )
+    raw_cases = evaluation.get("cases")
+    _require(
+        isinstance(raw_cases, list) and bool(raw_cases),
+        "evaluation cases missing",
+    )
+    cases = [_mapping(value, name="evaluation case") for value in raw_cases]
+    mean_widths = [
+        _number(case.get("mean_interval_width_m"), name="mean_interval_width_m")
+        for case in cases
+    ]
+    maximum_widths = [
+        _number(
+            case.get("maximum_interval_width_m"),
+            name="maximum_interval_width_m",
+        )
+        for case in cases
+    ]
+    coordinate_counts = [
+        _integer(case.get("coordinate_count"), name="coordinate_count")
+        for case in cases
+    ]
+    _require(all(value > 0 for value in coordinate_counts), "coordinate count is zero")
+    coverage = _number(
+        evaluation.get("execution_block_coverage"),
+        name="execution_block_coverage",
+    )
+    _require(0.0 <= coverage <= 1.0, "execution-block coverage must lie in [0, 1]")
+    return {
+        "schema_version": 1,
+        "artifact_kind": "Causal4DExecutionBlockUtilitySummary",
+        "calibration_id": calibration.calibration_id,
+        "outer_fold_id": calibration.outer_fold_id,
+        "confidence_level": float(calibration.confidence_level),
+        "target_execution_count": len(cases),
+        "execution_block_coverage": coverage,
+        "target_coordinate_count": int(sum(coordinate_counts)),
+        "interval_width_m": {
+            "mean_of_execution_means": float(np.mean(mean_widths)),
+            "median_of_execution_means": float(np.median(mean_widths)),
+            "maximum_execution_mean": float(np.max(mean_widths)),
+            "maximum_coordinate_width": float(np.max(maximum_widths)),
+        },
+        "calibration_threshold": float(calibration.threshold),
+        "calibration_fragility": plain_json(calibration.fragility_diagnostics),
+        "coverage_without_interval_width_is_sufficient": False,
+        "fragility_may_select_threshold": False,
+        "worst_group_coverage_guarantee_claimed": False,
+        "pooled_coordinate_conformal_claimed": False,
+    }
+
+
+def write_real_analysis_effect_report(
+    path: str | Path,
+    report: Mapping[str, Any],
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Publish one finite report atomically."""
+
+    atomic_write_json(path, dict(report), overwrite=overwrite)
+
+
+__all__ = [
+    "BOOTSTRAP_CONFIDENCE_LEVEL",
+    "BOOTSTRAP_REPLICATES",
+    "BOOTSTRAP_SEED",
+    "EXPECTED_OBJECT_ID",
+    "EXPECTED_PREACQUISITION_SHA256",
+    "EXPECTED_PROTOCOL_DESIGN_SHA256",
+    "EXPECTED_PROTOCOL_ID",
+    "RealAnalysisEffectTable",
+    "build_real_analysis_effect_report",
+    "effect_table_id_for_payload",
+    "load_real_analysis_effect_table",
+    "summarize_execution_block_utility",
+    "write_real_analysis_effect_report",
+]

--- a/src/causal4d/real_result_source_verification.py
+++ b/src/causal4d/real_result_source_verification.py
@@ -193,9 +193,7 @@ def verify_real_result_sources(
         "artifact_kind": SOURCE_VERIFICATION_ARTIFACT_KIND,
         "protocol_id": binding.protocol_id,
         "protocol_design_sha256": binding.protocol_design_sha256,
-        "preacquisition_amendment_sha256": (
-            binding.preacquisition_amendment_sha256
-        ),
+        "preacquisition_amendment_sha256": (binding.preacquisition_amendment_sha256),
         "method_freeze": method_descriptor,
         "registered_analysis_manifest": analysis_descriptor,
     }

--- a/src/causal4d/real_result_source_verification.py
+++ b/src/causal4d/real_result_source_verification.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Final, Protocol
+from typing import Any, Final, Protocol, cast
 
 from causal4d.artifact_io import load_strict_json_object, read_regular_file
 from causal4d.real_experiment_freeze import MILESTONE_ID, SCHEMA_VERSION
@@ -20,11 +20,20 @@ SOURCE_VERIFICATION_ARTIFACT_KIND: Final = "Causal4DRealResultSourceVerification
 class RealResultSourceBinding(Protocol):
     """Minimum provenance identity needed to verify registered analysis sources."""
 
-    protocol_id: str
-    protocol_design_sha256: str
-    preacquisition_amendment_sha256: str
-    method_freeze_sha256: str
-    analysis_manifest_sha256: str
+    @property
+    def protocol_id(self) -> str: ...
+
+    @property
+    def protocol_design_sha256(self) -> str: ...
+
+    @property
+    def preacquisition_amendment_sha256(self) -> str: ...
+
+    @property
+    def method_freeze_sha256(self) -> str: ...
+
+    @property
+    def analysis_manifest_sha256(self) -> str: ...
 
 
 def _require(condition: bool, message: str) -> None:
@@ -88,24 +97,33 @@ def _validate_method_freeze(
         payload.get("target_outcomes_observed_at_freeze") is False,
         "method freeze records target access before locking",
     )
-    protocol = payload.get("protocol")
-    _require(isinstance(protocol, Mapping), "method freeze lacks protocol provenance")
+    protocol_value = payload.get("protocol")
+    _require(
+        isinstance(protocol_value, Mapping),
+        "method freeze lacks protocol provenance",
+    )
+    protocol = cast(Mapping[str, Any], protocol_value)
     _require(
         protocol.get("design_sha256") == binding.protocol_design_sha256,
         "method freeze protocol digest differs from the gate summary",
     )
-    preacquisition = payload.get("preacquisition")
+    preacquisition_value = payload.get("preacquisition")
     _require(
-        isinstance(preacquisition, Mapping),
+        isinstance(preacquisition_value, Mapping),
         "method freeze lacks pre-acquisition provenance",
     )
+    preacquisition = cast(Mapping[str, Any], preacquisition_value)
     _require(
         preacquisition.get("amendment_sha256")
         == binding.preacquisition_amendment_sha256,
         "method freeze amendment digest differs from the gate summary",
     )
-    analysis = payload.get("analysis_contract")
-    _require(isinstance(analysis, Mapping), "method freeze lacks an analysis contract")
+    analysis_value = payload.get("analysis_contract")
+    _require(
+        isinstance(analysis_value, Mapping),
+        "method freeze lacks an analysis contract",
+    )
+    analysis = cast(Mapping[str, Any], analysis_value)
     _require(
         analysis.get("target_outcomes_may_select_method_or_hyperparameters") is False,
         "method freeze permits target-informed analysis selection",
@@ -225,8 +243,12 @@ def validate_real_result_source_verification(
         value = payload.get(field)
         _require(isinstance(value, str) and bool(value), f"{field} is missing")
     for field in ("method_freeze", "registered_analysis_manifest"):
-        descriptor = payload.get(field)
-        _require(isinstance(descriptor, Mapping), f"{field} descriptor is missing")
+        descriptor_value = payload.get(field)
+        _require(
+            isinstance(descriptor_value, Mapping),
+            f"{field} descriptor is missing",
+        )
+        descriptor = cast(Mapping[str, Any], descriptor_value)
         digest = descriptor.get("sha256")
         byte_count = descriptor.get("bytes")
         _require(

--- a/src/causal4d/real_result_source_verification.py
+++ b/src/causal4d/real_result_source_verification.py
@@ -1,4 +1,4 @@
-"""Verify the concrete source artifacts bound by a real-result gate summary."""
+"""Verify the concrete source artifacts bound by registered real analysis."""
 
 from __future__ import annotations
 
@@ -6,15 +6,25 @@ import hashlib
 import json
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Final
+from typing import Any, Final, Protocol
 
+from causal4d.artifact_io import load_strict_json_object, read_regular_file
 from causal4d.real_experiment_freeze import MILESTONE_ID, SCHEMA_VERSION
-from causal4d.real_result_interpretation import RealResultGateSummary
 
 REGISTERED_ANALYSIS_SCHEMA_VERSION: Final = 1
 REGISTERED_ANALYSIS_ARTIFACT_KIND: Final = "Causal4DRegisteredRealAnalysisManifest"
 SOURCE_VERIFICATION_SCHEMA_VERSION: Final = 1
 SOURCE_VERIFICATION_ARTIFACT_KIND: Final = "Causal4DRealResultSourceVerification"
+
+
+class RealResultSourceBinding(Protocol):
+    """Minimum provenance identity needed to verify registered analysis sources."""
+
+    protocol_id: str
+    protocol_design_sha256: str
+    preacquisition_amendment_sha256: str
+    method_freeze_sha256: str
+    analysis_manifest_sha256: str
 
 
 def _require(condition: bool, message: str) -> None:
@@ -34,37 +44,32 @@ def _canonical_sha256(values: Mapping[str, Any], *, omitted_field: str) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _artifact_descriptor(path: str | Path, *, name: str) -> dict[str, object]:
+def _read_source_json(
+    path: str | Path,
+    *,
+    name: str,
+) -> tuple[dict[str, object], dict[str, Any]]:
     source = Path(path)
     _require(not source.is_symlink(), f"{name} must not be a symlink")
-    _require(source.is_file(), f"{name} is not a regular file")
-    digest = hashlib.sha256()
-    byte_count = 0
     try:
-        with source.open("rb") as handle:
-            for block in iter(lambda: handle.read(1024 * 1024), b""):
-                digest.update(block)
-                byte_count += len(block)
+        snapshot = read_regular_file(source, name=name)
+        payload = load_strict_json_object(snapshot.payload, name=name)
+    except ValueError:
+        raise
     except OSError as error:
         raise ValueError(f"cannot read {name}") from error
-    return {
-        "sha256": digest.hexdigest(),
-        "bytes": byte_count,
-    }
-
-
-def _read_json_object(path: str | Path, *, name: str) -> dict[str, Any]:
-    try:
-        payload = json.loads(Path(path).read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as error:
-        raise ValueError(f"{name} must be readable JSON") from error
-    _require(isinstance(payload, Mapping), f"{name} must contain a JSON object")
-    return dict(payload)
+    return (
+        {
+            "sha256": snapshot.sha256,
+            "bytes": snapshot.byte_count,
+        },
+        payload,
+    )
 
 
 def _validate_method_freeze(
     payload: Mapping[str, Any],
-    gates: RealResultGateSummary,
+    binding: RealResultSourceBinding,
 ) -> None:
     _require(
         payload.get("schema_version") == SCHEMA_VERSION,
@@ -86,7 +91,7 @@ def _validate_method_freeze(
     protocol = payload.get("protocol")
     _require(isinstance(protocol, Mapping), "method freeze lacks protocol provenance")
     _require(
-        protocol.get("design_sha256") == gates.protocol_design_sha256,
+        protocol.get("design_sha256") == binding.protocol_design_sha256,
         "method freeze protocol digest differs from the gate summary",
     )
     preacquisition = payload.get("preacquisition")
@@ -95,7 +100,8 @@ def _validate_method_freeze(
         "method freeze lacks pre-acquisition provenance",
     )
     _require(
-        preacquisition.get("amendment_sha256") == gates.preacquisition_amendment_sha256,
+        preacquisition.get("amendment_sha256")
+        == binding.preacquisition_amendment_sha256,
         "method freeze amendment digest differs from the gate summary",
     )
     analysis = payload.get("analysis_contract")
@@ -112,7 +118,7 @@ def _validate_method_freeze(
 
 def _validate_registered_analysis(
     payload: Mapping[str, Any],
-    gates: RealResultGateSummary,
+    binding: RealResultSourceBinding,
 ) -> None:
     _require(
         payload.get("schema_version") == REGISTERED_ANALYSIS_SCHEMA_VERSION,
@@ -128,13 +134,13 @@ def _validate_registered_analysis(
         "registered analysis manifest lacks analysis_id",
     )
     for field, expected in (
-        ("protocol_id", gates.protocol_id),
-        ("protocol_design_sha256", gates.protocol_design_sha256),
+        ("protocol_id", binding.protocol_id),
+        ("protocol_design_sha256", binding.protocol_design_sha256),
         (
             "preacquisition_amendment_sha256",
-            gates.preacquisition_amendment_sha256,
+            binding.preacquisition_amendment_sha256,
         ),
-        ("method_freeze_sha256", gates.method_freeze_sha256),
+        ("method_freeze_sha256", binding.method_freeze_sha256),
     ):
         _require(
             payload.get(field) == expected,
@@ -155,47 +161,41 @@ def _validate_registered_analysis(
 
 
 def verify_real_result_sources(
-    gates: RealResultGateSummary,
+    binding: RealResultSourceBinding,
     *,
     method_freeze_path: str | Path,
     analysis_manifest_path: str | Path,
 ) -> dict[str, Any]:
-    """Verify exact files and their protocol bindings before interpretation."""
+    """Verify exact files and their protocol bindings before reporting."""
 
-    method_descriptor = _artifact_descriptor(
+    method_descriptor, method_payload = _read_source_json(
         method_freeze_path,
         name="method freeze",
     )
     _require(
-        method_descriptor["sha256"] == gates.method_freeze_sha256,
+        method_descriptor["sha256"] == binding.method_freeze_sha256,
         "method-freeze file SHA-256 differs from the gate summary",
     )
-    method_payload = _read_json_object(
-        method_freeze_path,
-        name="method freeze",
-    )
-    _validate_method_freeze(method_payload, gates)
+    _validate_method_freeze(method_payload, binding)
 
-    analysis_descriptor = _artifact_descriptor(
+    analysis_descriptor, analysis_payload = _read_source_json(
         analysis_manifest_path,
         name="registered analysis manifest",
     )
     _require(
-        analysis_descriptor["sha256"] == gates.analysis_manifest_sha256,
+        analysis_descriptor["sha256"] == binding.analysis_manifest_sha256,
         "analysis-manifest file SHA-256 differs from the gate summary",
     )
-    analysis_payload = _read_json_object(
-        analysis_manifest_path,
-        name="registered analysis manifest",
-    )
-    _validate_registered_analysis(analysis_payload, gates)
+    _validate_registered_analysis(analysis_payload, binding)
 
     result: dict[str, Any] = {
         "schema_version": SOURCE_VERIFICATION_SCHEMA_VERSION,
         "artifact_kind": SOURCE_VERIFICATION_ARTIFACT_KIND,
-        "protocol_id": gates.protocol_id,
-        "protocol_design_sha256": gates.protocol_design_sha256,
-        "preacquisition_amendment_sha256": (gates.preacquisition_amendment_sha256),
+        "protocol_id": binding.protocol_id,
+        "protocol_design_sha256": binding.protocol_design_sha256,
+        "preacquisition_amendment_sha256": (
+            binding.preacquisition_amendment_sha256
+        ),
         "method_freeze": method_descriptor,
         "registered_analysis_manifest": analysis_descriptor,
     }
@@ -254,6 +254,7 @@ def validate_real_result_source_verification(
 __all__ = [
     "REGISTERED_ANALYSIS_ARTIFACT_KIND",
     "REGISTERED_ANALYSIS_SCHEMA_VERSION",
+    "RealResultSourceBinding",
     "SOURCE_VERIFICATION_ARTIFACT_KIND",
     "SOURCE_VERIFICATION_SCHEMA_VERSION",
     "validate_real_result_source_verification",

--- a/tests/test_real_analysis_interval_diagnostics.py
+++ b/tests/test_real_analysis_interval_diagnostics.py
@@ -213,13 +213,12 @@ def test_companion_artifact_preserves_primary_interval_and_sources(
     assert first["source_primary_report_id"] == primary["report_id"]
     assert first["source_verification"] == primary["source_verification"]
     assert first["included_session_count"] == 18
-    assert first["primary_percentile_interval"]["interval"] == primary[
-        "primary_session_clustered_effect"
-    ]["confidence_interval"]
     assert (
-        first["primary_percentile_interval"][
-            "finite_sample_coverage_guaranteed"
-        ]
+        first["primary_percentile_interval"]["interval"]
+        == primary["primary_session_clustered_effect"]["confidence_interval"]
+    )
+    assert (
+        first["primary_percentile_interval"]["finite_sample_coverage_guaranteed"]
         is False
     )
     assert first["sensitivity_intervals"]["may_change_primary_decision"] is False
@@ -230,7 +229,10 @@ def test_companion_artifact_preserves_primary_interval_and_sources(
         is True
     )
     assert first["interpretation"]["target_informed_selection"] is False
-    assert first["claim_boundary"]["physical_target_outcomes_used_to_choose_interval"] is False
+    assert (
+        first["claim_boundary"]["physical_target_outcomes_used_to_choose_interval"]
+        is False
+    )
 
 
 def test_cli_publishes_atomically_and_requires_explicit_overwrite(

--- a/tests/test_real_analysis_interval_diagnostics.py
+++ b/tests/test_real_analysis_interval_diagnostics.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from causal4d.cli.real_analysis_interval_diagnostics import main as diagnostics_main
+from causal4d.real_analysis_interval_diagnostics import (
+    bootstrap_t_sensitivity_interval,
+    build_real_analysis_interval_diagnostics,
+    student_t_sensitivity_interval,
+)
+from causal4d.real_analysis_reporting import (
+    EXPECTED_OBJECT_ID,
+    EXPECTED_PREACQUISITION_SHA256,
+    EXPECTED_PROTOCOL_DESIGN_SHA256,
+    EXPECTED_PROTOCOL_ID,
+    build_real_analysis_effect_report,
+    effect_table_id_for_payload,
+)
+from causal4d.real_experiment_freeze import MILESTONE_ID, SCHEMA_VERSION
+from causal4d.real_result_source_verification import (
+    REGISTERED_ANALYSIS_ARTIFACT_KIND,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL = ROOT / "configs/causal4d/sloth_multi_action_v1.json"
+
+
+def _write_json(path: Path, payload: object) -> str:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _source_pair(tmp_path: Path) -> tuple[Path, Path, str, str]:
+    freeze = tmp_path / "method-freeze.json"
+    freeze_sha = _write_json(
+        freeze,
+        {
+            "schema_version": SCHEMA_VERSION,
+            "milestone_id": MILESTONE_ID,
+            "status": "sealed",
+            "locked_before_confirmatory_collection": True,
+            "target_outcomes_observed_at_freeze": False,
+            "protocol": {"design_sha256": EXPECTED_PROTOCOL_DESIGN_SHA256},
+            "preacquisition": {"amendment_sha256": EXPECTED_PREACQUISITION_SHA256},
+            "analysis_contract": {
+                "target_outcomes_may_select_method_or_hyperparameters": False,
+                "optional_branches_may_change_primary_analysis": False,
+            },
+        },
+    )
+    analysis = tmp_path / "registered-analysis.json"
+    analysis_sha = _write_json(
+        analysis,
+        {
+            "schema_version": 1,
+            "artifact_kind": REGISTERED_ANALYSIS_ARTIFACT_KIND,
+            "analysis_id": "registered-real-analysis-v1",
+            "protocol_id": EXPECTED_PROTOCOL_ID,
+            "protocol_design_sha256": EXPECTED_PROTOCOL_DESIGN_SHA256,
+            "preacquisition_amendment_sha256": EXPECTED_PREACQUISITION_SHA256,
+            "method_freeze_sha256": freeze_sha,
+            "primary_analysis_locked": True,
+            "target_outcomes_may_select_method_or_hyperparameters": False,
+            "optional_branches_may_change_primary_analysis": False,
+        },
+    )
+    return freeze, analysis, freeze_sha, analysis_sha
+
+
+def _factual_payload(
+    *,
+    freeze_sha: str,
+    analysis_sha: str,
+) -> dict[str, object]:
+    protocol = json.loads(PROTOCOL.read_text(encoding="utf-8"))
+    executions = {value["execution_id"]: value for value in protocol["executions"]}
+    session_order: dict[str, int] = {}
+    records = []
+    for split in protocol["splits"]["factual_continuation"]:
+        execution = executions[split["execution_id"]]
+        session_id = execution["session_id"]
+        if session_id not in session_order:
+            session_order[session_id] = len(session_order)
+        index = execution["acquisition_execution_index"]
+        baseline = 2.0 + 0.01 * index
+        improvement = 0.25 + 0.03 * session_order[session_id]
+        records.append(
+            {
+                "unit_id": execution["execution_id"],
+                "source_execution_id": None,
+                "target_execution_id": execution["execution_id"],
+                "session_id": session_id,
+                "acquisition_execution_index": index,
+                "action_id": execution["command_profile_id"],
+                "contact_region_id": execution["contact_region_id"],
+                "realization_condition_id": execution["realization_condition_id"],
+                "included": True,
+                "exclusion_reason": None,
+                "baseline_value": baseline,
+                "candidate_value": baseline - improvement,
+            }
+        )
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "artifact_kind": "Causal4DRealAnalysisEffectTable",
+        "protocol_id": EXPECTED_PROTOCOL_ID,
+        "protocol_design_sha256": EXPECTED_PROTOCOL_DESIGN_SHA256,
+        "preacquisition_amendment_sha256": EXPECTED_PREACQUISITION_SHA256,
+        "method_freeze_sha256": freeze_sha,
+        "analysis_manifest_sha256": analysis_sha,
+        "endpoint": "factual_continuation",
+        "metric_id": "track_error_m",
+        "metric_unit": "m",
+        "lower_is_better": True,
+        "target_outcomes_used": True,
+        "target_informed_selection": False,
+        "object_id": EXPECTED_OBJECT_ID,
+        "records": records,
+    }
+    payload["effect_table_id"] = effect_table_id_for_payload(payload)
+    return payload
+
+
+def test_sensitivity_intervals_are_translation_equivariant() -> None:
+    values = [-0.2, -0.05, 0.1, 0.25, 0.6]
+    offset = 3.25
+    shifted = [value + offset for value in values]
+
+    for builder in (
+        student_t_sensitivity_interval,
+        bootstrap_t_sensitivity_interval,
+    ):
+        original = builder(values)
+        translated = builder(shifted)
+        assert translated["point_estimate"] == pytest.approx(
+            original["point_estimate"] + offset
+        )
+        assert translated["lower"] == pytest.approx(original["lower"] + offset)
+        assert translated["upper"] == pytest.approx(original["upper"] + offset)
+        assert translated["may_change_primary_decision"] is False
+        assert translated["finite_sample_coverage_guaranteed"] is False
+
+
+def test_bootstrap_t_is_deterministic_and_finite() -> None:
+    values = np.linspace(-0.3, 0.7, 18).tolist()
+    first = bootstrap_t_sensitivity_interval(values)
+    second = bootstrap_t_sensitivity_interval(values)
+
+    assert first == second
+    assert first["estimable"] is True
+    assert first["replicates"] == 20_000
+    assert first["seed"] == 20_260_726
+    assert first["finite_studentized_replicate_fraction"] > 0.99
+    assert np.isfinite(first["lower"])
+    assert np.isfinite(first["upper"])
+    assert first["lower"] <= first["point_estimate"] <= first["upper"]
+
+
+def test_degenerate_samples_produce_explicit_point_intervals() -> None:
+    values = [1.5] * 12
+
+    for result in (
+        student_t_sensitivity_interval(values),
+        bootstrap_t_sensitivity_interval(values),
+    ):
+        assert result["estimable"] is True
+        assert result["degenerate_sample"] is True
+        assert result["lower"] == pytest.approx(1.5)
+        assert result["upper"] == pytest.approx(1.5)
+
+
+def test_companion_artifact_preserves_primary_interval_and_sources(
+    tmp_path: Path,
+) -> None:
+    freeze, analysis, freeze_sha, analysis_sha = _source_pair(tmp_path)
+    payload = _factual_payload(
+        freeze_sha=freeze_sha,
+        analysis_sha=analysis_sha,
+    )
+    effect_table = tmp_path / "effects.json"
+    _write_json(effect_table, payload)
+
+    primary = build_real_analysis_effect_report(
+        effect_table,
+        PROTOCOL,
+        method_freeze_path=freeze,
+        analysis_manifest_path=analysis,
+    )
+    first = build_real_analysis_interval_diagnostics(
+        effect_table,
+        PROTOCOL,
+        method_freeze_path=freeze,
+        analysis_manifest_path=analysis,
+    )
+    second = build_real_analysis_interval_diagnostics(
+        effect_table,
+        PROTOCOL,
+        method_freeze_path=freeze,
+        analysis_manifest_path=analysis,
+    )
+
+    assert first == second
+    assert first["diagnostic_id"] == second["diagnostic_id"]
+    assert first["source_primary_report_id"] == primary["report_id"]
+    assert first["source_verification"] == primary["source_verification"]
+    assert first["included_session_count"] == 18
+    assert first["primary_percentile_interval"]["interval"] == primary[
+        "primary_session_clustered_effect"
+    ]["confidence_interval"]
+    assert (
+        first["primary_percentile_interval"][
+            "finite_sample_coverage_guaranteed"
+        ]
+        is False
+    )
+    assert first["sensitivity_intervals"]["may_change_primary_decision"] is False
+    assert (
+        first["sensitivity_intervals"][
+            "promotion_requires_explicit_preacquisition_amendment"
+        ]
+        is True
+    )
+    assert first["interpretation"]["target_informed_selection"] is False
+    assert first["claim_boundary"]["physical_target_outcomes_used_to_choose_interval"] is False
+
+
+def test_cli_publishes_atomically_and_requires_explicit_overwrite(
+    tmp_path: Path,
+) -> None:
+    freeze, analysis, freeze_sha, analysis_sha = _source_pair(tmp_path)
+    payload = _factual_payload(
+        freeze_sha=freeze_sha,
+        analysis_sha=analysis_sha,
+    )
+    effect_table = tmp_path / "effects.json"
+    output = tmp_path / "interval-diagnostics.json"
+    _write_json(effect_table, payload)
+    arguments = [
+        str(effect_table),
+        str(PROTOCOL),
+        str(output),
+        "--method-freeze",
+        str(freeze),
+        "--analysis-manifest",
+        str(analysis),
+    ]
+
+    assert diagnostics_main(arguments) == 0
+    published = json.loads(output.read_text(encoding="utf-8"))
+    assert published["artifact_kind"] == "Causal4DRealAnalysisIntervalDiagnostics"
+    assert published["sensitivity_intervals"]["may_change_primary_decision"] is False
+
+    with pytest.raises(FileExistsError):
+        diagnostics_main(arguments)
+    assert diagnostics_main([*arguments, "--overwrite"]) == 0

--- a/tests/test_real_analysis_reporting.py
+++ b/tests/test_real_analysis_reporting.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from causal4d.cli.real_analysis_reporting import main as reporting_main
+from causal4d.execution_block_calibration import (
+    ExecutionBlockCalibrationCase,
+    evaluate_execution_block_cases,
+    fit_execution_block_conformal_calibration,
+)
+from causal4d.real_analysis_reporting import (
+    EXPECTED_OBJECT_ID,
+    EXPECTED_PREACQUISITION_SHA256,
+    EXPECTED_PROTOCOL_DESIGN_SHA256,
+    EXPECTED_PROTOCOL_ID,
+    build_real_analysis_effect_report,
+    effect_table_id_for_payload,
+    summarize_execution_block_utility,
+)
+from causal4d.real_experiment_freeze import MILESTONE_ID, SCHEMA_VERSION
+from causal4d.real_result_source_verification import (
+    REGISTERED_ANALYSIS_ARTIFACT_KIND,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL = ROOT / "configs/causal4d/sloth_multi_action_v1.json"
+
+
+def _write_json(path: Path, payload: object) -> str:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _source_pair(tmp_path: Path) -> tuple[Path, Path, str, str]:
+    freeze = tmp_path / "method-freeze.json"
+    freeze_sha = _write_json(
+        freeze,
+        {
+            "schema_version": SCHEMA_VERSION,
+            "milestone_id": MILESTONE_ID,
+            "status": "sealed",
+            "locked_before_confirmatory_collection": True,
+            "target_outcomes_observed_at_freeze": False,
+            "protocol": {"design_sha256": EXPECTED_PROTOCOL_DESIGN_SHA256},
+            "preacquisition": {
+                "amendment_sha256": EXPECTED_PREACQUISITION_SHA256
+            },
+            "analysis_contract": {
+                "target_outcomes_may_select_method_or_hyperparameters": False,
+                "optional_branches_may_change_primary_analysis": False,
+            },
+        },
+    )
+    analysis = tmp_path / "registered-analysis.json"
+    analysis_sha = _write_json(
+        analysis,
+        {
+            "schema_version": 1,
+            "artifact_kind": REGISTERED_ANALYSIS_ARTIFACT_KIND,
+            "analysis_id": "registered-real-analysis-v1",
+            "protocol_id": EXPECTED_PROTOCOL_ID,
+            "protocol_design_sha256": EXPECTED_PROTOCOL_DESIGN_SHA256,
+            "preacquisition_amendment_sha256": EXPECTED_PREACQUISITION_SHA256,
+            "method_freeze_sha256": freeze_sha,
+            "primary_analysis_locked": True,
+            "target_outcomes_may_select_method_or_hyperparameters": False,
+            "optional_branches_may_change_primary_analysis": False,
+        },
+    )
+    return freeze, analysis, freeze_sha, analysis_sha
+
+
+def _factual_payload(
+    *,
+    freeze_sha: str,
+    analysis_sha: str,
+) -> dict[str, object]:
+    protocol = json.loads(PROTOCOL.read_text(encoding="utf-8"))
+    executions = {
+        value["execution_id"]: value for value in protocol["executions"]
+    }
+    records = []
+    for split in protocol["splits"]["factual_continuation"]:
+        execution = executions[split["execution_id"]]
+        index = execution["acquisition_execution_index"]
+        baseline = 2.0 + 0.01 * index
+        records.append(
+            {
+                "unit_id": execution["execution_id"],
+                "source_execution_id": None,
+                "target_execution_id": execution["execution_id"],
+                "session_id": execution["session_id"],
+                "acquisition_execution_index": index,
+                "action_id": execution["command_profile_id"],
+                "contact_region_id": execution["contact_region_id"],
+                "realization_condition_id": execution[
+                    "realization_condition_id"
+                ],
+                "included": True,
+                "exclusion_reason": None,
+                "baseline_value": baseline,
+                "candidate_value": baseline - 1.0,
+            }
+        )
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "artifact_kind": "Causal4DRealAnalysisEffectTable",
+        "protocol_id": EXPECTED_PROTOCOL_ID,
+        "protocol_design_sha256": EXPECTED_PROTOCOL_DESIGN_SHA256,
+        "preacquisition_amendment_sha256": EXPECTED_PREACQUISITION_SHA256,
+        "method_freeze_sha256": freeze_sha,
+        "analysis_manifest_sha256": analysis_sha,
+        "endpoint": "factual_continuation",
+        "metric_id": "track_error_m",
+        "metric_unit": "m",
+        "lower_is_better": True,
+        "target_outcomes_used": True,
+        "target_informed_selection": False,
+        "object_id": EXPECTED_OBJECT_ID,
+        "records": records,
+    }
+    payload["effect_table_id"] = effect_table_id_for_payload(payload)
+    return payload
+
+
+def test_report_uses_sessions_as_the_resampling_unit(tmp_path: Path) -> None:
+    freeze, analysis, freeze_sha, analysis_sha = _source_pair(tmp_path)
+    payload = _factual_payload(
+        freeze_sha=freeze_sha,
+        analysis_sha=analysis_sha,
+    )
+    effect_table = tmp_path / "effects.json"
+    _write_json(effect_table, payload)
+
+    report = build_real_analysis_effect_report(
+        effect_table,
+        PROTOCOL,
+        method_freeze_path=freeze,
+        analysis_manifest_path=analysis,
+    )
+
+    primary = report["primary_session_clustered_effect"]
+    assert report["accounting"]["expected_unit_count"] == 36
+    assert report["accounting"]["expected_session_count"] == 18
+    assert primary["session_is_resampling_unit"] is True
+    assert primary["executions_are_not_treated_as_independent"] is True
+    assert primary["equal_session_weighted_improvement"]["mean"] == pytest.approx(1.0)
+    assert primary["confidence_interval"]["lower"] == pytest.approx(1.0)
+    assert primary["confidence_interval"]["upper"] == pytest.approx(1.0)
+    assert report["claim_boundary"]["object_class_generalization_claimed"] is False
+    assert report["design_diagnostics"][
+        "condition_comparisons_are_descriptive_only"
+    ] is True
+
+
+def test_session_weighting_survives_one_preregistered_exclusion(
+    tmp_path: Path,
+) -> None:
+    freeze, analysis, freeze_sha, analysis_sha = _source_pair(tmp_path)
+    payload = _factual_payload(
+        freeze_sha=freeze_sha,
+        analysis_sha=analysis_sha,
+    )
+    records = payload["records"]
+    assert isinstance(records, list)
+    for record in records:
+        record["candidate_value"] = record["baseline_value"]
+    first_session = records[0]["session_id"]
+    first_records = [
+        record for record in records if record["session_id"] == first_session
+    ]
+    first_records[0]["candidate_value"] = first_records[0]["baseline_value"] - 10.0
+    first_records[1]["included"] = False
+    first_records[1]["exclusion_reason"] = "preregistered technical exclusion"
+    first_records[1]["baseline_value"] = None
+    first_records[1]["candidate_value"] = None
+    payload["effect_table_id"] = effect_table_id_for_payload(payload)
+    effect_table = tmp_path / "effects.json"
+    _write_json(effect_table, payload)
+
+    report = build_real_analysis_effect_report(
+        effect_table,
+        PROTOCOL,
+        method_freeze_path=freeze,
+        analysis_manifest_path=analysis,
+    )
+
+    session_mean = report["primary_session_clustered_effect"][
+        "equal_session_weighted_improvement"
+    ]["mean"]
+    execution_mean = report["unweighted_execution_diagnostic"]["mean"]
+    assert session_mean == pytest.approx(10.0 / 18.0)
+    assert execution_mean == pytest.approx(10.0 / 35.0)
+    assert report["accounting"]["excluded_unit_count"] == 1
+
+
+def test_report_rejects_missing_or_relabelled_registered_units(
+    tmp_path: Path,
+) -> None:
+    freeze, analysis, freeze_sha, analysis_sha = _source_pair(tmp_path)
+    payload = _factual_payload(
+        freeze_sha=freeze_sha,
+        analysis_sha=analysis_sha,
+    )
+    records = payload["records"]
+    assert isinstance(records, list)
+    removed = records.pop()
+    payload["effect_table_id"] = effect_table_id_for_payload(payload)
+    effect_table = tmp_path / "missing.json"
+    _write_json(effect_table, payload)
+    with pytest.raises(ValueError, match="accounting differs"):
+        build_real_analysis_effect_report(
+            effect_table,
+            PROTOCOL,
+            method_freeze_path=freeze,
+            analysis_manifest_path=analysis,
+        )
+
+    records.append(removed)
+    records[0]["action_id"] = "target-informed-relabel"
+    payload["effect_table_id"] = effect_table_id_for_payload(payload)
+    effect_table = tmp_path / "relabelled.json"
+    _write_json(effect_table, payload)
+    with pytest.raises(ValueError, match="differs from the locked protocol"):
+        build_real_analysis_effect_report(
+            effect_table,
+            PROTOCOL,
+            method_freeze_path=freeze,
+            analysis_manifest_path=analysis,
+        )
+
+
+def test_reporting_rejects_duplicate_keys_in_bound_analysis_source(
+    tmp_path: Path,
+) -> None:
+    freeze, analysis, freeze_sha, _ = _source_pair(tmp_path)
+    duplicate_payload = (
+        "{"
+        '"schema_version":1,'
+        f'"artifact_kind":"{REGISTERED_ANALYSIS_ARTIFACT_KIND}",'
+        '"analysis_id":"first","analysis_id":"second",'
+        f'"protocol_id":"{EXPECTED_PROTOCOL_ID}",'
+        f'"protocol_design_sha256":"{EXPECTED_PROTOCOL_DESIGN_SHA256}",'
+        f'"preacquisition_amendment_sha256":"{EXPECTED_PREACQUISITION_SHA256}",'
+        f'"method_freeze_sha256":"{freeze_sha}",'
+        '"primary_analysis_locked":true,'
+        '"target_outcomes_may_select_method_or_hyperparameters":false,'
+        '"optional_branches_may_change_primary_analysis":false}'
+    ).encode("utf-8")
+    analysis.write_bytes(duplicate_payload)
+    analysis_sha = hashlib.sha256(duplicate_payload).hexdigest()
+    payload = _factual_payload(
+        freeze_sha=freeze_sha,
+        analysis_sha=analysis_sha,
+    )
+    effect_table = tmp_path / "effects.json"
+    _write_json(effect_table, payload)
+
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        build_real_analysis_effect_report(
+            effect_table,
+            PROTOCOL,
+            method_freeze_path=freeze,
+            analysis_manifest_path=analysis,
+        )
+
+
+def test_module_cli_writes_the_registered_report(tmp_path: Path) -> None:
+    freeze, analysis, freeze_sha, analysis_sha = _source_pair(tmp_path)
+    payload = _factual_payload(
+        freeze_sha=freeze_sha,
+        analysis_sha=analysis_sha,
+    )
+    effect_table = tmp_path / "effects.json"
+    output = tmp_path / "report.json"
+    _write_json(effect_table, payload)
+
+    result = reporting_main(
+        [
+            str(effect_table),
+            str(PROTOCOL),
+            str(output),
+            "--method-freeze",
+            str(freeze),
+            "--analysis-manifest",
+            str(analysis),
+            "--require-estimable",
+        ]
+    )
+
+    assert result == 0
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["accounting"]["complete"] is True
+    assert report["report_id"]
+
+
+def _calibration_case(
+    execution_id: str,
+    session_id: str,
+    role: str,
+    residual: float,
+) -> ExecutionBlockCalibrationCase:
+    mean = np.zeros((4, 2, 3), dtype=float)
+    variance = np.full_like(mean, 0.01**2)
+    truth = np.full_like(mean, residual * 0.01)
+    return ExecutionBlockCalibrationCase(
+        execution_id=execution_id,
+        session_id=session_id,
+        outer_fold_id="fold-1",
+        split_role=role,
+        prediction_case_id="sloth-object",
+        action_id="lift_low",
+        contact_region_id="left_forepaw",
+        mean_m=mean,
+        variance_m2=variance,
+        truth_m=truth,
+        valid=np.ones(mean.shape[:2], dtype=bool),
+        start_frame=1,
+    )
+
+
+def test_calibration_utility_reports_width_and_fragility() -> None:
+    fit = tuple(
+        _calibration_case(f"fit-{index}", f"fit-session-{index}", "fit", 1.0)
+        for index in range(3)
+    )
+    calibration_cases = tuple(
+        _calibration_case(
+            f"cal-{index}",
+            f"cal-session-{index}",
+            "calibration",
+            float(index + 1),
+        )
+        for index in range(9)
+    )
+    calibration = fit_execution_block_conformal_calibration(
+        fit,
+        calibration_cases,
+        expected_fit_units=3,
+    )
+    targets = (
+        _calibration_case("target-a", "target-session-a", "target", 2.0),
+        _calibration_case("target-b", "target-session-b", "target", 20.0),
+    )
+    evaluation = evaluate_execution_block_cases(targets, calibration)
+
+    summary = summarize_execution_block_utility(calibration, evaluation)
+
+    assert summary["target_execution_count"] == 2
+    assert summary["target_coordinate_count"] > 0
+    assert summary["interval_width_m"]["mean_of_execution_means"] > 0.0
+    assert summary["calibration_fragility"]["maximum_score"] >= summary[
+        "calibration_fragility"
+    ]["second_largest_score"]
+    assert summary["coverage_without_interval_width_is_sufficient"] is False
+    assert summary["fragility_may_select_threshold"] is False

--- a/tests/test_real_analysis_reporting.py
+++ b/tests/test_real_analysis_reporting.py
@@ -155,6 +155,8 @@ def test_report_uses_sessions_as_the_resampling_unit(tmp_path: Path) -> None:
         report["design_diagnostics"]["condition_comparisons_are_descriptive_only"]
         is True
     )
+    assert report["design_diagnostics"]["fully_crossed"] is True
+    assert report["design_diagnostics"]["balanced_across_actions"] is False
 
 
 def test_session_weighting_survives_one_preregistered_exclusion(
@@ -229,6 +231,30 @@ def test_report_rejects_missing_or_relabelled_registered_units(
         build_real_analysis_effect_report(
             effect_table,
             PROTOCOL,
+            method_freeze_path=freeze,
+            analysis_manifest_path=analysis,
+        )
+
+
+def test_reporting_recomputes_the_complete_protocol_digest(
+    tmp_path: Path,
+) -> None:
+    freeze, analysis, freeze_sha, analysis_sha = _source_pair(tmp_path)
+    payload = _factual_payload(
+        freeze_sha=freeze_sha,
+        analysis_sha=analysis_sha,
+    )
+    effect_table = tmp_path / "effects.json"
+    _write_json(effect_table, payload)
+    protocol = json.loads(PROTOCOL.read_text(encoding="utf-8"))
+    protocol["executions"][0]["command_profile_id"] = "tampered-action"
+    tampered_protocol = tmp_path / "tampered-protocol.json"
+    _write_json(tampered_protocol, protocol)
+
+    with pytest.raises(ValueError, match="design SHA-256 does not match"):
+        build_real_analysis_effect_report(
+            effect_table,
+            tampered_protocol,
             method_freeze_path=freeze,
             analysis_manifest_path=analysis,
         )

--- a/tests/test_real_analysis_reporting.py
+++ b/tests/test_real_analysis_reporting.py
@@ -51,9 +51,7 @@ def _source_pair(tmp_path: Path) -> tuple[Path, Path, str, str]:
             "locked_before_confirmatory_collection": True,
             "target_outcomes_observed_at_freeze": False,
             "protocol": {"design_sha256": EXPECTED_PROTOCOL_DESIGN_SHA256},
-            "preacquisition": {
-                "amendment_sha256": EXPECTED_PREACQUISITION_SHA256
-            },
+            "preacquisition": {"amendment_sha256": EXPECTED_PREACQUISITION_SHA256},
             "analysis_contract": {
                 "target_outcomes_may_select_method_or_hyperparameters": False,
                 "optional_branches_may_change_primary_analysis": False,
@@ -85,9 +83,7 @@ def _factual_payload(
     analysis_sha: str,
 ) -> dict[str, object]:
     protocol = json.loads(PROTOCOL.read_text(encoding="utf-8"))
-    executions = {
-        value["execution_id"]: value for value in protocol["executions"]
-    }
+    executions = {value["execution_id"]: value for value in protocol["executions"]}
     records = []
     for split in protocol["splits"]["factual_continuation"]:
         execution = executions[split["execution_id"]]
@@ -102,9 +98,7 @@ def _factual_payload(
                 "acquisition_execution_index": index,
                 "action_id": execution["command_profile_id"],
                 "contact_region_id": execution["contact_region_id"],
-                "realization_condition_id": execution[
-                    "realization_condition_id"
-                ],
+                "realization_condition_id": execution["realization_condition_id"],
                 "included": True,
                 "exclusion_reason": None,
                 "baseline_value": baseline,
@@ -157,9 +151,10 @@ def test_report_uses_sessions_as_the_resampling_unit(tmp_path: Path) -> None:
     assert primary["confidence_interval"]["lower"] == pytest.approx(1.0)
     assert primary["confidence_interval"]["upper"] == pytest.approx(1.0)
     assert report["claim_boundary"]["object_class_generalization_claimed"] is False
-    assert report["design_diagnostics"][
-        "condition_comparisons_are_descriptive_only"
-    ] is True
+    assert (
+        report["design_diagnostics"]["condition_comparisons_are_descriptive_only"]
+        is True
+    )
 
 
 def test_session_weighting_survives_one_preregistered_exclusion(
@@ -358,8 +353,9 @@ def test_calibration_utility_reports_width_and_fragility() -> None:
     assert summary["target_execution_count"] == 2
     assert summary["target_coordinate_count"] > 0
     assert summary["interval_width_m"]["mean_of_execution_means"] > 0.0
-    assert summary["calibration_fragility"]["maximum_score"] >= summary[
-        "calibration_fragility"
-    ]["second_largest_score"]
+    assert (
+        summary["calibration_fragility"]["maximum_score"]
+        >= summary["calibration_fragility"]["second_largest_score"]
+    )
     assert summary["coverage_without_interval_width_is_sufficient"] is False
     assert summary["fragility_may_select_threshold"] is False


### PR DESCRIPTION
## Summary

- add a closed, content-addressed `Causal4DRealAnalysisEffectTable` contract for factual, same-grasp, and new-contact endpoints;
- require exact accounting of all 36/18/12 registered target units, including explicit preregistered exclusions with no hidden target metrics;
- compute the primary paired effect by averaging within target grasp sessions and resampling sessions rather than treating 36 executions as independent;
- add deterministic 20,000-replicate session-cluster percentile intervals and candidate-better/tied/worse session counts;
- retain execution-weighted, action, contact, realization-condition, and acquisition-order summaries as explicitly non-decision-making diagnostics;
- expose the registered action-condition support matrix and prevent subgroup or drift diagnostics from changing the primary endpoint;
- add a calibration-utility summary that reports interval width, coordinate count, the frozen threshold, and all existing max/second-max/median/leave-one-session-out fragility diagnostics alongside coverage;
- make method-freeze and registered-analysis source verification hash and parse the same strict JSON bytes, rejecting duplicate keys and non-finite values; and
- document and enforce the single-object, non-safety, non-object-class-generalization claim boundary.

## Why

The confirmatory protocol contains 36 commands but only 18 independent grasp sessions. Two executions from one grasp share reset, registration, object state, and nuisance conditions, so execution-level resampling would understate uncertainty. Realization condition is also only partially crossed with action and acquisition time, making raw condition comparisons unsuitable for primary decisions. Finally, conformal coverage without interval width and calibration-score fragility can hide an unusably conservative result.

This change makes those boundaries executable before target access. Missing, additional, or relabelled protocol units fail closed, exclusions remain visible, and diagnostics cannot rescue a failed registered endpoint.

## Scientific boundary

This is additive analysis/reporting infrastructure only. It does not change:

- the frozen estimator or intervention posterior;
- the six-frame information boundary;
- the 18-session / 36-execution acquisition order;
- any target, fit, or calibration split;
- the rank-9-of-9 conformal threshold;
- quality gates, exclusions, or gate interpretation; or
- the current physical evidence count.

A positive report remains bounded to `sloth_plush_instance_1`, the registered action/contact grid, and the deployed hardware/perception/twin configuration.

## Validation

Local source-layout validation completed:

- Python byte compilation for the new module, CLI, and tests;
- an 88-column source audit;
- a deterministic synthetic end-to-end harness covering exact protocol accounting, equal-session weighting, exclusions, source verification, bootstrap identity, and report content addressing.

The harness reproduced report ID:

```text
931301d219152a9d3513222cf38b128af8c47f2480ecab78ef9f23fc653e1e80
```

GitHub Actions remains authoritative for Ruff formatting/lint, mypy, the complete Python 3.10/3.12/3.14 suite, distributions, installed CLI checks, frozen-manifest validation, and pinned BayesianPhysTwin integration.