### PR TITLE
Retrigger trusted hosted PR 193 study

### DIFF
--- a/scientific-trigger/pr193-hosted.txt
+++ b/scientific-trigger/pr193-hosted.txt
@@ -1,4 +1,5 @@
 target_sha=fa6a64b2442474321e453e9e8fdccd591e0a282d
 study=registered-design-power-fragility,controlled-standard
-runner=ubuntu-latest
+runner=ubuntu-22.04
 ready_for_execution=true
+trigger_revision=2


### PR DESCRIPTION
Updates only the inert trigger record so the already-trusted push workflow reruns on `ubuntu-22.04`. The workflow evaluates immutable target SHA `fa6a64b2442474321e453e9e8fdccd591e0a282d`, publishes compact summaries, and keeps raw execution outputs artifact-only.