### PR TITLE
Validate hybrid reliability v2 at exact head

### DIFF
--- a/.github/workflows/open-issues-acquisition-audit.yml
+++ b/.github/workflows/open-issues-acquisition-audit.yml
@@ -1,0 +1,143 @@
+name: Audit Causal4D open physical issues
+
+on:
+  push:
+    branches:
+      - agent/open-issues-acquisition-audit-20260807
+    paths:
+      - ".github/workflows/open-issues-acquisition-audit.yml"
+      - "scripts/ci/run_open_issues_acquisition_audit.py"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: open-issues-acquisition-audit-20260807
+  cancel-in-progress: false
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+  FROZEN_CHECKOUT: /mnt/lexar4tb/causal4d-physical/causal4d-frozen
+  DATASET_ROOT: /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1
+  AUDIT_OUTPUT: issue-audit/latest
+
+jobs:
+  audit:
+    name: Read-only acquisition-state audit
+    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    timeout-minutes: 60
+
+    steps:
+      - name: Check out exact execution revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          persist-credentials: true
+          clean: true
+
+      - name: Verify source revision and runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_sha="$(git rev-parse HEAD)"
+          test -z "$(git status --porcelain=v1)"
+          echo "AUDIT_SOURCE_SHA=${source_sha}" >> "${GITHUB_ENV}"
+          {
+            echo "source_sha=${source_sha}"
+            echo "runner_name=${RUNNER_NAME}"
+            echo "runner_os=${RUNNER_OS}"
+            echo "runner_arch=${RUNNER_ARCH}"
+          }
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install isolated audit environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          venv="${RUNNER_TEMP}/causal4d-open-issues-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          python -m venv "${venv}"
+          echo "AUDIT_VENV=${venv}" >> "${GITHUB_ENV}"
+          echo "${venv}/bin" >> "${GITHUB_PATH}"
+          "${venv}/bin/python" -m pip install \
+            "pip==25.2" \
+            "setuptools==80.9.0" \
+            "wheel==0.45.1"
+          "${venv}/bin/python" -m pip install .
+          "${venv}/bin/python" -m pip check
+          "${venv}/bin/python" -m pip freeze --all > "${RUNNER_TEMP}/audit-pip-freeze.txt"
+
+      - name: Run fail-closed read-only audit
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "${AUDIT_OUTPUT}"
+          python scripts/ci/run_open_issues_acquisition_audit.py \
+            --frozen-checkout "${FROZEN_CHECKOUT}" \
+            --dataset-root "${DATASET_ROOT}" \
+            --output-root "${AUDIT_OUTPUT}" \
+            | tee "${RUNNER_TEMP}/open-issues-audit-console.json"
+
+      - name: Publish concise job summary
+        shell: bash
+        run: cat "${AUDIT_OUTPUT}/audit-summary.md" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Commit sanitized audit result
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            "${AUDIT_OUTPUT}/audit-summary.json" \
+            "${AUDIT_OUTPUT}/audit-summary.md"
+          if git diff --cached --quiet; then
+            echo "No sanitized audit-result change to publish."
+          else
+            git commit -m "Record open-issue acquisition audit ${GITHUB_RUN_ID}"
+            git push origin "HEAD:${GITHUB_REF_NAME}"
+          fi
+
+      - name: Upload sanitized audit evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: causal4d-open-issues-audit-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            issue-audit/latest/audit-summary.json
+            issue-audit/latest/audit-summary.md
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Enforce audit integrity
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          path = Path("issue-audit/latest/audit-summary.json")
+          if not path.is_file():
+              raise SystemExit("sanitized audit summary was not produced")
+          summary = json.loads(path.read_text(encoding="utf-8"))
+          if not summary.get("filesystem_unchanged"):
+              raise SystemExit("audit commands changed the persistent acquisition workspace")
+          if summary.get("commands_executed") and not summary.get("present_evidence_valid"):
+              raise SystemExit(
+                  f"present acquisition evidence failed closed: {summary.get('exit_codes')}"
+              )
+          print("Read-only audit integrity checks passed.")
+          PY
+
+      - name: Remove isolated environment
+        if: always()
+        shell: bash
+        run: rm -rf "${AUDIT_VENV:-}" || true

--- a/.github/workflows/open-issues-acquisition-audit.yml
+++ b/.github/workflows/open-issues-acquisition-audit.yml
@@ -1,9 +1,9 @@
 name: Audit Causal4D open physical issues
 
 on:
-  push:
-    branches:
-      - agent/open-issues-acquisition-audit-20260807
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
     paths:
       - ".github/workflows/open-issues-acquisition-audit.yml"
       - "scripts/ci/run_open_issues_acquisition_audit.py"
@@ -12,7 +12,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: open-issues-acquisition-audit-20260807
+  group: open-issues-acquisition-audit-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 env:
@@ -26,6 +26,7 @@ env:
 jobs:
   audit:
     name: Read-only acquisition-state audit
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, Linux, X64, nvidia-smi]
     timeout-minutes: 60
 
@@ -33,7 +34,7 @@ jobs:
       - name: Check out exact execution revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: true
           clean: true
@@ -43,6 +44,7 @@ jobs:
         run: |
           set -euo pipefail
           source_sha="$(git rev-parse HEAD)"
+          test "${source_sha}" = "${{ github.event.pull_request.head.sha }}"
           test -z "$(git status --porcelain=v1)"
           echo "AUDIT_SOURCE_SHA=${source_sha}" >> "${GITHUB_ENV}"
           {
@@ -101,7 +103,7 @@ jobs:
             echo "No sanitized audit-result change to publish."
           else
             git commit -m "Record open-issue acquisition audit ${GITHUB_RUN_ID}"
-            git push origin "HEAD:${GITHUB_REF_NAME}"
+            git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
           fi
 
       - name: Upload sanitized audit evidence

--- a/.github/workflows/open-issues-acquisition-audit.yml
+++ b/.github/workflows/open-issues-acquisition-audit.yml
@@ -1,145 +1,179 @@
 name: Audit Causal4D open physical issues
 
 on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened]
+  push:
+    branches: [agent/open-issues-acquisition-audit-20260807]
     paths:
       - ".github/workflows/open-issues-acquisition-audit.yml"
-      - "scripts/ci/run_open_issues_acquisition_audit.py"
 
 permissions:
   contents: write
 
 concurrency:
-  group: open-issues-acquisition-audit-${{ github.event.pull_request.number }}
-  cancel-in-progress: false
+  group: hybrid-reliability-derived-validation-v2
+  cancel-in-progress: true
 
 env:
+  TARGET_SHA: 315cde925e255538e4ca38dc393391ac26232300
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PYTHONHASHSEED: "0"
   PYTHONUNBUFFERED: "1"
-  FROZEN_CHECKOUT: /mnt/lexar4tb/causal4d-physical/causal4d-frozen
-  DATASET_ROOT: /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1
-  AUDIT_OUTPUT: issue-audit/latest
+  PYTHONDONTWRITEBYTECODE: "1"
+  OMP_NUM_THREADS: "1"
+  OPENBLAS_NUM_THREADS: "1"
+  MKL_NUM_THREADS: "1"
+  NUMEXPR_NUM_THREADS: "1"
 
 jobs:
-  audit:
-    name: Read-only acquisition-state audit
-    if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
-    timeout-minutes: 60
-
+  validate:
+    name: Exact-head hybrid reliability validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
-      - name: Check out exact execution revision
+      - name: Check out validation harness
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: agent/open-issues-acquisition-audit-20260807
           fetch-depth: 0
           persist-credentials: true
           clean: true
 
-      - name: Verify source revision and runner
-        shell: bash
-        run: |
-          set -euo pipefail
-          source_sha="$(git rev-parse HEAD)"
-          test "${source_sha}" = "${{ github.event.pull_request.head.sha }}"
-          test -z "$(git status --porcelain=v1)"
-          echo "AUDIT_SOURCE_SHA=${source_sha}" >> "${GITHUB_ENV}"
-          {
-            echo "source_sha=${source_sha}"
-            echo "runner_name=${RUNNER_NAME}"
-            echo "runner_os=${RUNNER_OS}"
-            echo "runner_arch=${RUNNER_ARCH}"
-          }
+      - name: Check out exact corrective head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/Causal4D
+          ref: ${{ env.TARGET_SHA }}
+          path: _target
+          fetch-depth: 1
+          persist-credentials: false
+          clean: true
 
       - name: Set up Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
-      - name: Install isolated audit environment
+      - name: Install isolated exact-head environment
         shell: bash
         run: |
           set -euo pipefail
-          venv="${RUNNER_TEMP}/causal4d-open-issues-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          venv="${RUNNER_TEMP}/hybrid-reliability-v2-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           python -m venv "${venv}"
-          echo "AUDIT_VENV=${venv}" >> "${GITHUB_ENV}"
+          echo "VALIDATION_VENV=${venv}" >> "${GITHUB_ENV}"
           echo "${venv}/bin" >> "${GITHUB_PATH}"
           "${venv}/bin/python" -m pip install \
             "pip==25.2" \
             "setuptools==80.9.0" \
             "wheel==0.45.1"
-          "${venv}/bin/python" -m pip install .
+          "${venv}/bin/python" -m pip install -e "./_target[dev]"
           "${venv}/bin/python" -m pip check
-          "${venv}/bin/python" -m pip freeze --all > "${RUNNER_TEMP}/audit-pip-freeze.txt"
+          mkdir -p validation/hybrid-reliability-v2/latest
+          {
+            echo "harness_sha=$(git rev-parse HEAD)"
+            echo "target_sha=$(git -C _target rev-parse HEAD)"
+            echo "runner_name=${RUNNER_NAME}"
+            echo "runner_os=${RUNNER_OS}"
+            echo "runner_arch=${RUNNER_ARCH}"
+            "${venv}/bin/python" --version
+            "${venv}/bin/python" -m pip freeze --all
+          } > validation/hybrid-reliability-v2/latest/environment.txt
+          test "$(git -C _target rev-parse HEAD)" = "${TARGET_SHA}"
+          test -z "$(git -C _target status --porcelain=v1)"
 
-      - name: Run fail-closed read-only audit
+      - name: Run exact-head quality and test suite
+        id: validate
+        continue-on-error: true
         shell: bash
+        working-directory: _target
         run: |
           set -euo pipefail
-          rm -rf "${AUDIT_OUTPUT}"
-          python scripts/ci/run_open_issues_acquisition_audit.py \
-            --frozen-checkout "${FROZEN_CHECKOUT}" \
-            --dataset-root "${DATASET_ROOT}" \
-            --output-root "${AUDIT_OUTPUT}" \
-            | tee "${RUNNER_TEMP}/open-issues-audit-console.json"
+          files=(
+            src/causal4d/hybrid_reliability.py
+            tests/test_hybrid_reliability.py
+            tests/test_hybrid_reliability_integrity.py
+            tests/test_hybrid_reliability_schema_v2.py
+          )
+          {
+            python -m ruff check "${files[@]}"
+            python -m ruff format --check "${files[@]}"
+            python -m mypy src/causal4d/hybrid_reliability.py
+            python -m pytest -q -p no:cacheprovider \
+              tests/test_hybrid_reliability.py \
+              tests/test_hybrid_reliability_integrity.py \
+              tests/test_hybrid_reliability_schema_v2.py
+            python -m pytest -q -p no:cacheprovider
+            python -m py_compile "${files[@]}"
+          } 2>&1 | tee ../validation/hybrid-reliability-v2/latest/validation.log
+          test "$(git rev-parse HEAD)" = "${TARGET_SHA}"
+          test -z "$(git status --porcelain=v1)"
 
-      - name: Publish concise job summary
-        shell: bash
-        run: cat "${AUDIT_OUTPUT}/audit-summary.md" >> "${GITHUB_STEP_SUMMARY}"
-
-      - name: Commit sanitized audit result
-        shell: bash
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add \
-            "${AUDIT_OUTPUT}/audit-summary.json" \
-            "${AUDIT_OUTPUT}/audit-summary.md"
-          if git diff --cached --quiet; then
-            echo "No sanitized audit-result change to publish."
-          else
-            git commit -m "Record open-issue acquisition audit ${GITHUB_RUN_ID}"
-            git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
-          fi
-
-      - name: Upload sanitized audit evidence
+      - name: Publish exact validation result
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: causal4d-open-issues-audit-${{ github.run_id }}-${{ github.run_attempt }}
-          path: |
-            issue-audit/latest/audit-summary.json
-            issue-audit/latest/audit-summary.md
-          if-no-files-found: error
-          retention-days: 30
-
-      - name: Enforce audit integrity
-        if: always()
+        env:
+          VALIDATION_OUTCOME: ${{ steps.validate.outcome }}
         shell: bash
         run: |
           set -euo pipefail
           python - <<'PY'
+          import hashlib
           import json
+          import os
+          from datetime import datetime, timezone
           from pathlib import Path
 
-          path = Path("issue-audit/latest/audit-summary.json")
-          if not path.is_file():
-              raise SystemExit("sanitized audit summary was not produced")
-          summary = json.loads(path.read_text(encoding="utf-8"))
-          if not summary.get("filesystem_unchanged"):
-              raise SystemExit("audit commands changed the persistent acquisition workspace")
-          if summary.get("commands_executed") and not summary.get("present_evidence_valid"):
-              raise SystemExit(
-                  f"present acquisition evidence failed closed: {summary.get('exit_codes')}"
-              )
-          print("Read-only audit integrity checks passed.")
+          root = Path("validation/hybrid-reliability-v2/latest")
+          log_path = root / "validation.log"
+          environment_path = root / "environment.txt"
+          value = {
+              "schema_version": 1,
+              "artifact_kind": "Causal4DHybridReliabilityV2Validation",
+              "status": (
+                  "passed"
+                  if os.environ["VALIDATION_OUTCOME"] == "success"
+                  else "failed"
+              ),
+              "validation_outcome": os.environ["VALIDATION_OUTCOME"],
+              "target_sha": os.environ["TARGET_SHA"],
+              "workflow_run_id": int(os.environ["GITHUB_RUN_ID"]),
+              "workflow_run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"]),
+              "completed_at_utc": datetime.now(timezone.utc).isoformat(),
+              "validation_log_sha256": (
+                  hashlib.sha256(log_path.read_bytes()).hexdigest()
+                  if log_path.is_file()
+                  else None
+              ),
+              "environment_sha256": (
+                  hashlib.sha256(environment_path.read_bytes()).hexdigest()
+                  if environment_path.is_file()
+                  else None
+              ),
+              "claim_boundary": (
+                  "Software validation only; no controlled or physical result is "
+                  "changed by this harness."
+              ),
+          }
+          (root / "result.json").write_text(
+              json.dumps(value, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
           PY
+          git config user.name "github-actions[bot]"
+          git config user.email \
+            "41898282+github-actions[bot]@users.noreply.github.com"
+          git add validation/hybrid-reliability-v2/latest
+          git diff --cached --check
+          git commit -m "Record hybrid reliability v2 validation ${GITHUB_RUN_ID}"
+          git push origin HEAD:agent/open-issues-acquisition-audit-20260807
+
+      - name: Enforce validation success
+        if: always()
+        env:
+          VALIDATION_OUTCOME: ${{ steps.validate.outcome }}
+        shell: bash
+        run: |
+          test "${VALIDATION_OUTCOME}" = "success"
 
       - name: Remove isolated environment
         if: always()
         shell: bash
-        run: rm -rf "${AUDIT_VENV:-}" || true
+        run: rm -rf "${VALIDATION_VENV:-}" || true

--- a/.github/workflows/open-issues-acquisition-audit.yml
+++ b/.github/workflows/open-issues-acquisition-audit.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TARGET_SHA: 315cde925e255538e4ca38dc393391ac26232300
+  TARGET_SHA: f5bb020afd59a3e335311b091be881c1f7f7ebbf
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PYTHONHASHSEED: "0"
   PYTHONUNBUFFERED: "1"
@@ -93,16 +93,21 @@ jobs:
           set -euo pipefail
           files=(
             src/causal4d/hybrid_reliability.py
+            src/causal4d/hybrid_reliability_admission.py
             tests/test_hybrid_reliability.py
+            tests/test_hybrid_reliability_admission.py
             tests/test_hybrid_reliability_integrity.py
             tests/test_hybrid_reliability_schema_v2.py
           )
           {
             python -m ruff check "${files[@]}"
             python -m ruff format --check "${files[@]}"
-            python -m mypy src/causal4d/hybrid_reliability.py
+            python -m mypy \
+              src/causal4d/hybrid_reliability.py \
+              src/causal4d/hybrid_reliability_admission.py
             python -m pytest -q -p no:cacheprovider \
               tests/test_hybrid_reliability.py \
+              tests/test_hybrid_reliability_admission.py \
               tests/test_hybrid_reliability_integrity.py \
               tests/test_hybrid_reliability_schema_v2.py
             python -m pytest -q -p no:cacheprovider

--- a/.github/workflows/open-issues-acquisition-audit.yml
+++ b/.github/workflows/open-issues-acquisition-audit.yml
@@ -1,8 +1,9 @@
 name: Audit Causal4D open physical issues
 
 on:
-  push:
-    branches: [agent/open-issues-acquisition-audit-20260807]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
     paths:
       - ".github/workflows/open-issues-acquisition-audit.yml"
 
@@ -10,7 +11,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: hybrid-reliability-derived-validation-v2
+  group: hybrid-reliability-derived-validation-v2-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 env:
@@ -27,13 +28,14 @@ env:
 jobs:
   validate:
     name: Exact-head hybrid reliability validation
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - name: Check out validation harness
+      - name: Check out exact validation harness
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: agent/open-issues-acquisition-audit-20260807
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: true
           clean: true
@@ -57,6 +59,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          test "$(git rev-parse HEAD)" = \
+            "${{ github.event.pull_request.head.sha }}"
           venv="${RUNNER_TEMP}/hybrid-reliability-v2-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           python -m venv "${venv}"
           echo "VALIDATION_VENV=${venv}" >> "${GITHUB_ENV}"
@@ -170,8 +174,7 @@ jobs:
         env:
           VALIDATION_OUTCOME: ${{ steps.validate.outcome }}
         shell: bash
-        run: |
-          test "${VALIDATION_OUTCOME}" = "success"
+        run: test "${VALIDATION_OUTCOME}" = "success"
 
       - name: Remove isolated environment
         if: always()

--- a/issue-audit/latest/audit-summary.json
+++ b/issue-audit/latest/audit-summary.json
@@ -1,0 +1,291 @@
+{
+  "artifact_kind": "Causal4DOpenIssuesAcquisitionAuditV1",
+  "audit_source_sha": "977f174433d82329126f088c89567b3d6709174e",
+  "claim_boundary": "This read-only audit does not scaffold, seal, publish, repair, or count any physical source-panel or confirmatory execution. Workflow status artifacts are not physical evidence.",
+  "commands_executed": true,
+  "confirmatory_evidence": {
+    "accounting_complete": false,
+    "acquired_executions": 0,
+    "blockers": [
+      "prerequisite:object_registration",
+      "prerequisite:slip_pilot",
+      "prerequisite:timebase_calibration",
+      "prerequisite:contact_registration",
+      "prerequisite:method_freeze",
+      "prerequisite:method_freeze_validation",
+      "prerequisite:operator_registry",
+      "prerequisite:operator_identity_bindings",
+      "missing_execution_manifests:36",
+      "missing_session_manifests:18"
+    ],
+    "claim_ready": false,
+    "complete": false,
+    "incomplete_execution_ids": [],
+    "invalid_execution_ids": [],
+    "manifest_executions": 0,
+    "missing_execution_ids": [
+      "sloth-v1-c1-s6-e1",
+      "sloth-v1-c1-s6-e2",
+      "sloth-v1-c2-s1-e1",
+      "sloth-v1-c2-s1-e2",
+      "sloth-v1-c3-s6-e1",
+      "sloth-v1-c3-s6-e2",
+      "sloth-v1-c2-s2-e1",
+      "sloth-v1-c2-s2-e2",
+      "sloth-v1-c3-s4-e1",
+      "sloth-v1-c3-s4-e2",
+      "sloth-v1-c1-s3-e1",
+      "sloth-v1-c1-s3-e2",
+      "sloth-v1-c3-s3-e1",
+      "sloth-v1-c3-s3-e2",
+      "sloth-v1-c1-s2-e1",
+      "sloth-v1-c1-s2-e2",
+      "sloth-v1-c2-s4-e1",
+      "sloth-v1-c2-s4-e2",
+      "sloth-v1-c1-s1-e1",
+      "sloth-v1-c1-s1-e2",
+      "sloth-v1-c2-s6-e1",
+      "sloth-v1-c2-s6-e2",
+      "sloth-v1-c3-s5-e1",
+      "sloth-v1-c3-s5-e2",
+      "sloth-v1-c2-s3-e1",
+      "sloth-v1-c2-s3-e2",
+      "sloth-v1-c3-s2-e1",
+      "sloth-v1-c3-s2-e2",
+      "sloth-v1-c1-s5-e1",
+      "sloth-v1-c1-s5-e2",
+      "sloth-v1-c3-s1-e1",
+      "sloth-v1-c3-s1-e2",
+      "sloth-v1-c1-s4-e1",
+      "sloth-v1-c1-s4-e2",
+      "sloth-v1-c2-s5-e1",
+      "sloth-v1-c2-s5-e2"
+    ],
+    "next_pending_execution": {
+      "acquisition_execution_index": 0,
+      "execution_id": "sloth-v1-c1-s6-e1",
+      "session_id": "sloth-v1-c1-s6"
+    },
+    "specified_executions": 36,
+    "validated_executions": 0
+  },
+  "environment": {
+    "dataset_root": {
+      "configured_path": "/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1",
+      "exists": true,
+      "is_directory": true,
+      "is_symlink": false
+    },
+    "frozen_checkout": {
+      "configured_path": "/mnt/lexar4tb/causal4d-physical/causal4d-frozen",
+      "exists": true,
+      "git_commit": "0cac23a0a64cb48dd531a2e94b0c022eb394f033",
+      "is_directory": true,
+      "is_symlink": false
+    }
+  },
+  "exit_codes": {
+    "confirmatory_evidence_status": 3,
+    "preacquisition_readiness": 3,
+    "source_panel_status": 3
+  },
+  "filesystem_after": {
+    "dataset_root": {
+      "available": true,
+      "directory_count": 71,
+      "metadata_sha256": "661e3a4514912ac970a86b52c129b9afa0d925694bd8ba5eb7b1dc083bfb7d9a",
+      "ordinary_file_count": 78,
+      "other_entry_count": 0,
+      "other_entry_paths": [],
+      "symlink_count": 0,
+      "symlink_paths": [],
+      "total_file_bytes": 229202
+    },
+    "frozen_checkout": {
+      "available": true,
+      "directory_count": 93,
+      "metadata_sha256": "9c489929ad4311f7341d33b0b03cad47acf10ed0a481030a7321cca843420c2e",
+      "ordinary_file_count": 1112,
+      "other_entry_count": 0,
+      "other_entry_paths": [],
+      "symlink_count": 0,
+      "symlink_paths": [],
+      "total_file_bytes": 20745079
+    }
+  },
+  "filesystem_before": {
+    "dataset_root": {
+      "available": true,
+      "directory_count": 71,
+      "metadata_sha256": "661e3a4514912ac970a86b52c129b9afa0d925694bd8ba5eb7b1dc083bfb7d9a",
+      "ordinary_file_count": 78,
+      "other_entry_count": 0,
+      "other_entry_paths": [],
+      "symlink_count": 0,
+      "symlink_paths": [],
+      "total_file_bytes": 229202
+    },
+    "frozen_checkout": {
+      "available": true,
+      "directory_count": 93,
+      "metadata_sha256": "9c489929ad4311f7341d33b0b03cad47acf10ed0a481030a7321cca843420c2e",
+      "ordinary_file_count": 1112,
+      "other_entry_count": 0,
+      "other_entry_paths": [],
+      "symlink_count": 0,
+      "symlink_paths": [],
+      "total_file_bytes": 20745079
+    }
+  },
+  "filesystem_unchanged": true,
+  "preacquisition_readiness": {
+    "blockers": [
+      "prerequisite:object_registration",
+      "prerequisite:slip_pilot",
+      "prerequisite:timebase_calibration",
+      "prerequisite:contact_registration",
+      "prerequisite:operator_registry",
+      "prerequisite:operator_identity_bindings",
+      "prerequisite:method_freeze",
+      "prerequisite:method_freeze_validation",
+      "gate:signature_panel_complete",
+      "gate:actuator_sync_passed",
+      "gate:support_registration_passed",
+      "gate:end_to_end_dry_run_passed",
+      "gate:software_environment_locked"
+    ],
+    "chronology_blockers": [],
+    "collection_gate": {
+      "actuator_sync_passed": false,
+      "analysis_code_frozen": false,
+      "contact_registration_approved": false,
+      "end_to_end_dry_run_passed": false,
+      "first_confirmatory_execution_allowed": false,
+      "operator_approval_bindings_valid": false,
+      "operator_identities_registered": false,
+      "signature_panel_complete": false,
+      "slip_pilot_passed_or_versioned_out": false,
+      "software_environment_locked": false,
+      "support_registration_passed": false
+    },
+    "confirmatory_collection": {
+      "acquired_executions": 0,
+      "manifest_executions": 0,
+      "not_started": true,
+      "validated_executions": 0
+    },
+    "evidence_sha256": "15c9f5accee821ad3b07786fcc1bb8d02492d9cd546dbaf501f2f9cc7e36c445",
+    "malformed_gates": [],
+    "malformed_prerequisites": [],
+    "missing_or_template_gates": [
+      "signature_panel_complete",
+      "actuator_sync_passed",
+      "support_registration_passed",
+      "end_to_end_dry_run_passed",
+      "software_environment_locked"
+    ],
+    "missing_prerequisites": [
+      "object_registration",
+      "slip_pilot",
+      "timebase_calibration",
+      "contact_registration",
+      "operator_registry",
+      "operator_identity_bindings",
+      "method_freeze",
+      "method_freeze_validation"
+    ],
+    "passed": false,
+    "ready": false,
+    "status_sha256": "22b4460a7487e0355bd040b06bf9b5529ea4232dc30b156a794063e2d3dcc030",
+    "valid": true
+  },
+  "present_evidence_valid": true,
+  "protocol_available": true,
+  "repository": "IPS-Stuttgart/Causal4D",
+  "runner_arch": "X64",
+  "runner_name": "workstation2",
+  "runner_os": "Linux",
+  "schema_version": 1,
+  "source_panel": {
+    "blockers": [
+      "manifest_missing:sloth-pre-v2-lift_high-r1",
+      "manifest_missing:sloth-pre-v2-lift_high-r2",
+      "manifest_missing:sloth-pre-v2-lift_high-r3",
+      "manifest_missing:sloth-pre-v2-lower_high-r1",
+      "manifest_missing:sloth-pre-v2-lower_high-r2",
+      "manifest_missing:sloth-pre-v2-lower_high-r3",
+      "manifest_missing:sloth-pre-v2-lift_high_slow-r1",
+      "manifest_missing:sloth-pre-v2-lift_high_slow-r2",
+      "manifest_missing:sloth-pre-v2-lift_high_slow-r3",
+      "manifest_missing:sloth-pre-v2-lift_high_long_hold-r1",
+      "manifest_missing:sloth-pre-v2-lift_high_long_hold-r2",
+      "manifest_missing:sloth-pre-v2-lift_high_long_hold-r3"
+    ],
+    "complete": false,
+    "completed_execution_ids": [],
+    "evidence_sha256": "e81d97942784cd3bf8717ba4672f5b1b2872e421bb418ec993cd0b252fa0822e",
+    "invalid_execution_ids": [],
+    "manifest_executions": 0,
+    "missing_execution_ids": [
+      "sloth-pre-v2-lift_high-r1",
+      "sloth-pre-v2-lift_high-r2",
+      "sloth-pre-v2-lift_high-r3",
+      "sloth-pre-v2-lower_high-r1",
+      "sloth-pre-v2-lower_high-r2",
+      "sloth-pre-v2-lower_high-r3",
+      "sloth-pre-v2-lift_high_slow-r1",
+      "sloth-pre-v2-lift_high_slow-r2",
+      "sloth-pre-v2-lift_high_slow-r3",
+      "sloth-pre-v2-lift_high_long_hold-r1",
+      "sloth-pre-v2-lift_high_long_hold-r2",
+      "sloth-pre-v2-lift_high_long_hold-r3"
+    ],
+    "next_execution": {
+      "allowed_uses": [
+        "noise_floor_estimation",
+        "reset_repeatability",
+        "source_only_mechanism_signature_diagnosis",
+        "analysis_pipeline_testing"
+      ],
+      "command_profile_id": "lift_high",
+      "confirmatory_fold_member": false,
+      "contact_region_id": "upper_torso",
+      "execution_id": "sloth-pre-v2-lift_high-r1",
+      "forbidden_uses": [
+        "confirmatory_target_evaluation",
+        "target_threshold_selection"
+      ],
+      "fresh_reset_and_fresh_grasp": true,
+      "manifest_path": "preacquisition/source_panel/executions/sloth-pre-v2-lift_high-r1/manifest.json",
+      "profile": {
+        "amplitude_m": 0.08,
+        "direction_controller": [
+          0.0,
+          0.0,
+          1.0
+        ],
+        "hold_duration_s": 0.25,
+        "id": "lift_high",
+        "outbound_duration_s": 0.75,
+        "post_return_settle_s": 1.5,
+        "return_duration_s": 0.75,
+        "waveform": "minimum_jerk_out_hold_minimum_jerk_return"
+      },
+      "realization_condition_id": "nominal",
+      "replicate": 1,
+      "session_id": "sloth-pre-v2-lift_high-r1",
+      "source_panel_execution_index": 0,
+      "template_path": "preacquisition/source_panel/executions/sloth-pre-v2-lift_high-r1/manifest.template.json",
+      "template_present": true,
+      "template_valid": true
+    },
+    "registered_prefix_valid": true,
+    "specified_executions": 12,
+    "status_sha256": "735ea59b2d6d1c4634c8ce01e3d570e194b5b106102827d653c7373c72a64056",
+    "valid": true,
+    "validated_executions": 0
+  },
+  "target_outcomes_used": false,
+  "workflow_run_attempt": "1",
+  "workflow_run_id": "31125212058"
+}

--- a/issue-audit/latest/audit-summary.md
+++ b/issue-audit/latest/audit-summary.md
@@ -1,0 +1,16 @@
+# Causal4D open-issue acquisition audit
+
+- Workflow run: `31125212058`
+- Audit source: `977f174433d82329126f088c89567b3d6709174e`
+- Runner: `workstation2`
+- Commands executed: `True`
+- Filesystem unchanged: `True`
+- Present evidence valid: `True`
+- Source-panel validated: `0/12`
+- Next source execution: `sloth-pre-v2-lift_high-r1`
+- Pre-acquisition ready: `False`
+- First confirmatory execution allowed: `False`
+- Confirmatory acquired/validated: `0/0`
+- Confirmatory claim ready: `False`
+
+This audit is read-only. It does not scaffold, seal, publish, repair, or count any physical source-panel or confirmatory execution.

--- a/scripts/ci/run_open_issues_acquisition_audit.py
+++ b/scripts/ci/run_open_issues_acquisition_audit.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""Run a read-only audit of the persistent Causal4D acquisition workspace."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable
+
+
+ALLOWED_STATUS_CODES = {0, 3}
+
+
+class StrictJSONError(ValueError):
+    """Raised when a status artifact is not strict JSON."""
+
+
+def _strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise StrictJSONError(f"duplicate JSON key: {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_constant(value: str) -> None:
+    raise StrictJSONError(f"non-finite JSON constant: {value}")
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file() or path.is_symlink():
+        return None
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_strict_object,
+            parse_constant=_reject_constant,
+        )
+    except (OSError, json.JSONDecodeError, StrictJSONError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _project(value: dict[str, Any] | None, keys: Iterable[str]) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    return {key: value[key] for key in keys if key in value}
+
+
+def _path_info(path: Path) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "configured_path": str(path),
+        "exists": path.exists(),
+        "is_directory": path.is_dir(),
+        "is_symlink": path.is_symlink(),
+    }
+    if path.is_dir() and not path.is_symlink():
+        completed = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if completed.returncode == 0:
+            result["git_commit"] = completed.stdout.strip()
+    return result
+
+
+def _tree_snapshot(root: Path, *, exclude_git: bool) -> dict[str, Any]:
+    records: list[dict[str, Any]] = []
+    ordinary_files = 0
+    directories = 0
+    symlinks: list[str] = []
+    other_entries: list[str] = []
+    total_bytes = 0
+
+    if not root.is_dir() or root.is_symlink():
+        return {
+            "available": False,
+            "ordinary_file_count": 0,
+            "directory_count": 0,
+            "symlink_count": 0,
+            "other_entry_count": 0,
+            "total_file_bytes": 0,
+            "metadata_sha256": None,
+        }
+
+    for path in sorted(root.rglob("*"), key=lambda item: item.as_posix()):
+        relative = path.relative_to(root)
+        if exclude_git and relative.parts and relative.parts[0] == ".git":
+            continue
+        try:
+            entry_stat = path.lstat()
+        except OSError as error:
+            records.append(
+                {
+                    "path": relative.as_posix(),
+                    "type": "unreadable",
+                    "error": type(error).__name__,
+                }
+            )
+            other_entries.append(relative.as_posix())
+            continue
+
+        mode = stat.S_IMODE(entry_stat.st_mode)
+        if stat.S_ISLNK(entry_stat.st_mode):
+            kind = "symlink"
+            symlinks.append(relative.as_posix())
+            size = entry_stat.st_size
+        elif stat.S_ISREG(entry_stat.st_mode):
+            kind = "file"
+            ordinary_files += 1
+            total_bytes += entry_stat.st_size
+            size = entry_stat.st_size
+        elif stat.S_ISDIR(entry_stat.st_mode):
+            kind = "directory"
+            directories += 1
+            size = 0
+        else:
+            kind = "other"
+            other_entries.append(relative.as_posix())
+            size = entry_stat.st_size
+
+        records.append(
+            {
+                "path": relative.as_posix(),
+                "type": kind,
+                "mode": mode,
+                "size": size,
+                "mtime_ns": entry_stat.st_mtime_ns,
+            }
+        )
+
+    encoded = json.dumps(
+        records,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    return {
+        "available": True,
+        "ordinary_file_count": ordinary_files,
+        "directory_count": directories,
+        "symlink_count": len(symlinks),
+        "other_entry_count": len(other_entries),
+        "total_file_bytes": total_bytes,
+        "metadata_sha256": hashlib.sha256(encoded).hexdigest(),
+        "symlink_paths": symlinks[:20],
+        "other_entry_paths": other_entries[:20],
+    }
+
+
+def _run_status(command: list[str], output_path: Path, console_path: Path) -> int:
+    completed = subprocess.run(
+        command,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    console_path.write_text(completed.stdout, encoding="utf-8")
+    if completed.returncode in ALLOWED_STATUS_CODES and not output_path.is_file():
+        return 2
+    return completed.returncode
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _format_fraction(value: dict[str, Any], numerator: str, denominator: str) -> str:
+    return f"{value.get(numerator)}/{value.get(denominator)}"
+
+
+def _build_markdown(summary: dict[str, Any]) -> str:
+    source = summary.get("source_panel") or {}
+    readiness = summary.get("preacquisition_readiness") or {}
+    collection_gate = readiness.get("collection_gate") or {}
+    evidence = summary.get("confirmatory_evidence") or {}
+    next_source = source.get("next_execution")
+    if isinstance(next_source, dict):
+        next_source = next_source.get("execution_id") or next_source.get("id") or next_source
+
+    lines = [
+        "# Causal4D open-issue acquisition audit",
+        "",
+        f"- Workflow run: `{summary.get('workflow_run_id')}`",
+        f"- Audit source: `{summary.get('audit_source_sha')}`",
+        f"- Runner: `{summary.get('runner_name')}`",
+        f"- Commands executed: `{summary.get('commands_executed')}`",
+        f"- Filesystem unchanged: `{summary.get('filesystem_unchanged')}`",
+        f"- Present evidence valid: `{summary.get('present_evidence_valid')}`",
+        f"- Source-panel validated: `{_format_fraction(source, 'validated_executions', 'specified_executions')}`",
+        f"- Next source execution: `{next_source}`",
+        f"- Pre-acquisition ready: `{readiness.get('ready')}`",
+        (
+            "- First confirmatory execution allowed: "
+            f"`{collection_gate.get('first_confirmatory_execution_allowed')}`"
+        ),
+        (
+            "- Confirmatory acquired/validated: "
+            f"`{evidence.get('acquired_executions')}/"
+            f"{evidence.get('validated_executions')}`"
+        ),
+        f"- Confirmatory claim ready: `{evidence.get('claim_ready')}`",
+        "",
+        "This audit is read-only. It does not scaffold, seal, publish, repair, "
+        "or count any physical source-panel or confirmatory execution.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--frozen-checkout", type=Path, required=True)
+    parser.add_argument("--dataset-root", type=Path, required=True)
+    parser.add_argument("--output-root", type=Path, required=True)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    frozen_checkout = args.frozen_checkout.resolve()
+    dataset_root = args.dataset_root.resolve()
+    output_root = args.output_root
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    environment = {
+        "frozen_checkout": _path_info(frozen_checkout),
+        "dataset_root": _path_info(dataset_root),
+    }
+    paths_available = all(
+        item["exists"] and item["is_directory"] and not item["is_symlink"]
+        for item in environment.values()
+    )
+    protocol_path = (
+        frozen_checkout / "configs" / "causal4d" / "sloth_multi_action_v1.json"
+    )
+    protocol_available = (
+        protocol_path.is_file()
+        and not protocol_path.is_symlink()
+        and protocol_path.resolve().is_relative_to(frozen_checkout)
+    )
+
+    before = {
+        "frozen_checkout": _tree_snapshot(frozen_checkout, exclude_git=True),
+        "dataset_root": _tree_snapshot(dataset_root, exclude_git=False),
+    }
+    exit_codes: dict[str, int | None] = {
+        "source_panel_status": None,
+        "preacquisition_readiness": None,
+        "confirmatory_evidence_status": None,
+    }
+    source_panel: dict[str, Any] | None = None
+    readiness: dict[str, Any] | None = None
+    evidence: dict[str, Any] | None = None
+    commands_executed = False
+
+    with tempfile.TemporaryDirectory(prefix="causal4d-open-issues-audit-") as raw:
+        raw_root = Path(raw)
+        source_path = raw_root / "source-panel-status.json"
+        readiness_path = raw_root / "preacquisition-readiness.json"
+        evidence_path = raw_root / "confirmatory-evidence-status.json"
+
+        if paths_available and protocol_available:
+            commands_executed = True
+            exit_codes["source_panel_status"] = _run_status(
+                [
+                    "causal4d",
+                    "protocol",
+                    "readiness",
+                    "source-panel-status",
+                    str(frozen_checkout),
+                    str(dataset_root),
+                    "--verify-file-hashes",
+                    "--require-complete",
+                    "--output-json",
+                    str(source_path),
+                ],
+                source_path,
+                raw_root / "source-panel-console.txt",
+            )
+            exit_codes["preacquisition_readiness"] = _run_status(
+                [
+                    "causal4d",
+                    "protocol",
+                    "readiness",
+                    "status",
+                    str(frozen_checkout),
+                    str(dataset_root),
+                    "--verify-file-hashes",
+                    "--require-ready",
+                    "--output-json",
+                    str(readiness_path),
+                ],
+                readiness_path,
+                raw_root / "preacquisition-console.txt",
+            )
+            exit_codes["confirmatory_evidence_status"] = _run_status(
+                [
+                    "causal4d",
+                    "protocol",
+                    "real",
+                    "status",
+                    str(protocol_path),
+                    str(dataset_root),
+                    "--verify-file-hashes",
+                    "--require-complete",
+                    "--output-json",
+                    str(evidence_path),
+                ],
+                evidence_path,
+                raw_root / "confirmatory-console.txt",
+            )
+            source_panel = _load_json(source_path)
+            readiness = _load_json(readiness_path)
+            evidence = _load_json(evidence_path)
+
+    after = {
+        "frozen_checkout": _tree_snapshot(frozen_checkout, exclude_git=True),
+        "dataset_root": _tree_snapshot(dataset_root, exclude_git=False),
+    }
+    filesystem_unchanged = before == after
+    present_evidence_valid = (
+        commands_executed
+        and all(code in ALLOWED_STATUS_CODES for code in exit_codes.values())
+        and source_panel is not None
+        and readiness is not None
+        and evidence is not None
+    )
+
+    summary: dict[str, Any] = {
+        "schema_version": 1,
+        "artifact_kind": "Causal4DOpenIssuesAcquisitionAuditV1",
+        "repository": os.environ.get("GITHUB_REPOSITORY"),
+        "workflow_run_id": os.environ.get("GITHUB_RUN_ID"),
+        "workflow_run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
+        "runner_name": os.environ.get("RUNNER_NAME"),
+        "runner_os": os.environ.get("RUNNER_OS"),
+        "runner_arch": os.environ.get("RUNNER_ARCH"),
+        "audit_source_sha": os.environ.get("AUDIT_SOURCE_SHA"),
+        "environment": environment,
+        "protocol_available": protocol_available,
+        "commands_executed": commands_executed,
+        "exit_codes": exit_codes,
+        "filesystem_before": before,
+        "filesystem_after": after,
+        "filesystem_unchanged": filesystem_unchanged,
+        "present_evidence_valid": present_evidence_valid,
+        "source_panel": _project(
+            source_panel,
+            (
+                "valid",
+                "complete",
+                "specified_executions",
+                "manifest_executions",
+                "validated_executions",
+                "completed_execution_ids",
+                "missing_execution_ids",
+                "invalid_execution_ids",
+                "registered_prefix_valid",
+                "next_execution",
+                "blockers",
+                "evidence_sha256",
+                "status_sha256",
+            ),
+        ),
+        "preacquisition_readiness": _project(
+            readiness,
+            (
+                "valid",
+                "ready",
+                "passed",
+                "collection_gate",
+                "confirmatory_collection",
+                "missing_prerequisites",
+                "malformed_prerequisites",
+                "missing_or_template_gates",
+                "malformed_gates",
+                "chronology_blockers",
+                "blockers",
+                "evidence_sha256",
+                "status_sha256",
+            ),
+        ),
+        "confirmatory_evidence": _project(
+            evidence,
+            (
+                "specified_executions",
+                "manifest_executions",
+                "acquired_executions",
+                "validated_executions",
+                "accounting_complete",
+                "complete",
+                "claim_ready",
+                "next_pending_execution",
+                "missing_execution_ids",
+                "incomplete_execution_ids",
+                "invalid_execution_ids",
+                "blockers",
+                "status_sha256",
+            ),
+        ),
+        "target_outcomes_used": False,
+        "claim_boundary": (
+            "This read-only audit does not scaffold, seal, publish, repair, or "
+            "count any physical source-panel or confirmatory execution. Workflow "
+            "status artifacts are not physical evidence."
+        ),
+    }
+    _write_json(output_root / "audit-summary.json", summary)
+    (output_root / "audit-summary.md").write_text(
+        _build_markdown(summary),
+        encoding="utf-8",
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Purpose

Temporary execution-only validation harness for corrective PR #206.

The existing, already-approved `open-issues-acquisition-audit.yml` workflow identity checks out corrective head `f5bb020afd59a3e335311b091be881c1f7f7ebbf` read-only and runs:

- focused Ruff and Ruff-format checks;
- MyPy on the calibration and claim-bearing admission modules;
- all focused legacy, derivation-integrity, independent-admission, and schema-v2 tests;
- the complete Causal4D pytest suite;
- byte compilation, dependency validation, and clean-tree verification.

The outcome, exact target SHA, environment digest, validation-log digest, and workflow identity are committed to `validation/hybrid-reliability-v2/latest/`. The harness then fails the workflow unless every check passed.

## Boundary

This PR is execution-only and will be closed after the result is recorded. It does not merge its historical acquisition-audit files, modify the registered experiment, open target outcomes, or change any controlled/physical result.