### PR TITLE
Add low-rank covariance scoring to grouped likelihoods

### DIFF
--- a/docs/structured_grouped_likelihood.md
+++ b/docs/structured_grouped_likelihood.md
@@ -11,7 +11,9 @@ low-rank factor:  U, with C = U U^T
 The existing dense `component_group_covariance_m2` path remains unchanged. The
 optional `component_group_covariance_factor_m` path is intended for shared gauge,
 graph-discrepancy, camera-bias, or other low-rank uncertainty where forming one
-full covariance matrix for every posterior component would be wasteful.
+full covariance matrix for every posterior component would be wasteful. The
+factor API is additive and opt-in; no producer is silently converted from dense
+to structured covariance.
 
 ## Numerical method
 

--- a/docs/structured_grouped_likelihood.md
+++ b/docs/structured_grouped_likelihood.md
@@ -1,0 +1,90 @@
+# Structured covariance in grouped likelihoods
+
+`causal4d.grouped_likelihood` accepts component-specific correlated uncertainty
+in two equivalent forms:
+
+```text
+dense covariance: C
+low-rank factor:  U, with C = U U^T
+```
+
+The existing dense `component_group_covariance_m2` path remains unchanged. The
+optional `component_group_covariance_factor_m` path is intended for shared gauge,
+graph-discrepancy, camera-bias, or other low-rank uncertainty where forming one
+full covariance matrix for every posterior component would be wasteful.
+
+## Numerical method
+
+For a base covariance `B` and factor `U`, the Student-t likelihood needs the
+log determinant and quadratic form of:
+
+```text
+B + U U^T
+```
+
+The structured path computes these quantities with:
+
+1. a Cholesky factorization of `B`;
+2. whitening of the residual and `U`;
+3. the matrix determinant lemma for the log determinant; and
+4. the Woodbury identity for the Mahalanobis term.
+
+Only the rank-by-rank system `I + U^T B^-1 U` is factorized after the base
+Cholesky. The implementation does not form `U U^T`, does not use a dense
+inverse, and does not call the dense `slogdet` path.
+
+## API
+
+For one observation group:
+
+```python
+score, responsibility = group_log_likelihood(
+    predicted_values_m,
+    group,
+    additive_variance_m2=component_diagonal_variance,
+    additive_covariance_factor_m=component_factor_m,
+)
+```
+
+For a complete grouped update:
+
+```python
+posterior, diagnostics = posterior_weights_from_grouped_evidence(
+    prior_weights,
+    predicted_components_m,
+    evidence,
+    prefix_frame_count=prefix_frame_count,
+    component_group_covariance_factor_m={
+        "graph-discrepancy": graph_factor_m,
+        "shared-gauge": gauge_factor_m,
+    },
+)
+```
+
+Each factor has units of meters and must broadcast to:
+
+```text
+component_shape + (group_coordinate_count, rank)
+```
+
+The resulting covariance contribution is therefore measured in square meters.
+The dense covariance, diagonal variance, and low-rank factor arguments may be
+combined only when they represent distinct uncertainty sources. Supplying the
+same uncertainty through more than one representation would double count it.
+
+`GroupLikelihoodDiagnostics.low_rank_covariance_group_ids` records the groups
+that used the structured path. `full_covariance_group_ids` continues to identify
+groups with explicit dense component covariance.
+
+## Compatibility and claim boundary
+
+The default path is byte-for-byte API compatible: callers that do not provide a
+factor use the original dense Student-t implementation. Existing frozen
+experiments and result identities are unchanged.
+
+Tests compare structured and explicitly materialized dense covariance updates
+for mixture scores, nominal responsibilities, and normalized posterior weights.
+They also verify broadcasting, fail-closed factor validation, diagnostics, and
+that the structured path does not call dense determinant evaluation. These are
+numerical and engineering guarantees, not new empirical accuracy or calibration
+evidence.

--- a/src/causal4d/grouped_likelihood.py
+++ b/src/causal4d/grouped_likelihood.py
@@ -21,6 +21,24 @@ class GroupLikelihoodDiagnostics:
     effective_group_weights: tuple[float, ...]
     nominal_responsibilities: np.ndarray
     full_covariance_group_ids: tuple[str, ...] = ()
+    low_rank_covariance_group_ids: tuple[str, ...] = ()
+
+
+def _student_t_log_density_from_terms(
+    *,
+    dimension: int,
+    degrees_of_freedom: float,
+    log_determinant: np.ndarray,
+    mahalanobis: np.ndarray,
+) -> np.ndarray:
+    normalization = (
+        lgamma(0.5 * (degrees_of_freedom + dimension))
+        - lgamma(0.5 * degrees_of_freedom)
+        - 0.5 * (dimension * np.log(degrees_of_freedom * np.pi) + log_determinant)
+    )
+    return normalization - 0.5 * (degrees_of_freedom + dimension) * np.log1p(
+        mahalanobis / degrees_of_freedom
+    )
 
 
 def _multivariate_student_t_log_density(
@@ -43,13 +61,11 @@ def _multivariate_student_t_log_density(
         raise ValueError("Student-t scale matrix must be positive definite")
     solved = np.linalg.solve(scale, values[..., None])[..., 0]
     mahalanobis = np.einsum("...i,...i->...", values, solved)
-    normalization = (
-        lgamma(0.5 * (degrees_of_freedom + dimension))
-        - lgamma(0.5 * degrees_of_freedom)
-        - 0.5 * (dimension * np.log(degrees_of_freedom * np.pi) + log_determinant)
-    )
-    return normalization - 0.5 * (degrees_of_freedom + dimension) * np.log1p(
-        mahalanobis / degrees_of_freedom
+    return _student_t_log_density_from_terms(
+        dimension=dimension,
+        degrees_of_freedom=degrees_of_freedom,
+        log_determinant=log_determinant,
+        mahalanobis=mahalanobis,
     )
 
 
@@ -84,18 +100,158 @@ def _broadcast_additive_covariance(
     return covariance
 
 
+def _broadcast_additive_covariance_factor(
+    values: np.ndarray,
+    *,
+    leading_shape: tuple[int, ...],
+    dimension: int,
+) -> np.ndarray:
+    factor = np.asarray(values, dtype=float)
+    if factor.ndim < 2 or factor.shape[-2] != dimension or factor.shape[-1] < 1:
+        raise ValueError(
+            "additive_covariance_factor_m must end in "
+            "(coordinate, positive_rank)"
+        )
+    rank = factor.shape[-1]
+    try:
+        factor = np.broadcast_to(
+            factor,
+            (*leading_shape, dimension, rank),
+        )
+    except ValueError as error:
+        raise ValueError(
+            "additive_covariance_factor_m must broadcast to component leading "
+            "dimensions and end in (coordinate, rank)"
+        ) from error
+    if not np.all(np.isfinite(factor)):
+        raise ValueError("additive covariance factor must be finite")
+    return factor
+
+
+def _multivariate_student_t_log_density_low_rank(
+    residual: np.ndarray,
+    base_covariance_m2: np.ndarray,
+    covariance_factor_m: np.ndarray,
+    *,
+    degrees_of_freedom: float,
+    covariance_multiplier: float = 1.0,
+) -> np.ndarray:
+    """Evaluate Student-t density for ``base + factor @ factor.T``.
+
+    The implementation uses Cholesky whitening plus the matrix determinant lemma
+    and Woodbury identity. It never materializes the low-rank covariance update.
+    """
+
+    values = np.asarray(residual, dtype=float)
+    dimension = values.shape[-1]
+    leading_shape = values.shape[:-1]
+    base = np.asarray(base_covariance_m2, dtype=float)
+    if base.shape[-2:] != (dimension, dimension):
+        raise ValueError("base_covariance_m2 must end in (coordinate, coordinate)")
+    try:
+        base = np.broadcast_to(base, (*leading_shape, dimension, dimension))
+    except ValueError as error:
+        raise ValueError(
+            "base_covariance_m2 must broadcast to the residual leading dimensions"
+        ) from error
+    if not np.all(np.isfinite(base)):
+        raise ValueError("base covariance must be finite")
+    factor = _broadcast_additive_covariance_factor(
+        covariance_factor_m,
+        leading_shape=leading_shape,
+        dimension=dimension,
+    )
+    try:
+        base_cholesky = np.linalg.cholesky(base)
+    except np.linalg.LinAlgError as error:
+        raise ValueError("base covariance must be positive definite") from error
+
+    whitened_residual = np.linalg.solve(
+        base_cholesky,
+        values[..., None],
+    )[..., 0]
+    whitened_factor = np.linalg.solve(base_cholesky, factor)
+    rank = factor.shape[-1]
+    low_rank_system = np.eye(rank) + np.einsum(
+        "...ir,...is->...rs",
+        whitened_factor,
+        whitened_factor,
+    )
+    try:
+        low_rank_cholesky = np.linalg.cholesky(low_rank_system)
+    except np.linalg.LinAlgError as error:
+        raise ValueError(
+            "low-rank covariance system must be positive definite"
+        ) from error
+
+    projected_residual = np.einsum(
+        "...ir,...i->...r",
+        whitened_factor,
+        whitened_residual,
+    )
+    whitened_projection = np.linalg.solve(
+        low_rank_cholesky,
+        projected_residual[..., None],
+    )[..., 0]
+    base_quadratic = np.einsum(
+        "...i,...i->...",
+        whitened_residual,
+        whitened_residual,
+    )
+    correction_quadratic = np.einsum(
+        "...r,...r->...",
+        whitened_projection,
+        whitened_projection,
+    )
+    covariance_quadratic = np.maximum(
+        base_quadratic - correction_quadratic,
+        0.0,
+    )
+    base_log_determinant = 2.0 * np.sum(
+        np.log(np.diagonal(base_cholesky, axis1=-2, axis2=-1)),
+        axis=-1,
+    )
+    low_rank_log_determinant = 2.0 * np.sum(
+        np.log(np.diagonal(low_rank_cholesky, axis1=-2, axis2=-1)),
+        axis=-1,
+    )
+    scale_multiplier = (
+        (degrees_of_freedom - 2.0)
+        / degrees_of_freedom
+        * covariance_multiplier
+    )
+    if not np.isfinite(scale_multiplier) or scale_multiplier <= 0.0:
+        raise ValueError("Student-t covariance multiplier must be positive")
+    log_determinant = (
+        base_log_determinant
+        + low_rank_log_determinant
+        + dimension * np.log(scale_multiplier)
+    )
+    mahalanobis = covariance_quadratic / scale_multiplier
+    return _student_t_log_density_from_terms(
+        dimension=dimension,
+        degrees_of_freedom=degrees_of_freedom,
+        log_determinant=log_determinant,
+        mahalanobis=mahalanobis,
+    )
+
+
 def group_log_likelihood(
     predicted_values_m: np.ndarray,
     group: ObservationGroup,
     *,
     additive_variance_m2: np.ndarray | None = None,
     additive_covariance_m2: np.ndarray | None = None,
+    additive_covariance_factor_m: np.ndarray | None = None,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Return robust mixture log likelihood and posterior nominal responsibility.
 
-    ``additive_covariance_m2`` preserves component-specific correlation. The
-    legacy ``additive_variance_m2`` argument remains a diagonal convenience and
-    can be combined with the full covariance term.
+    ``additive_covariance_m2`` preserves component-specific dense correlation.
+    ``additive_covariance_factor_m`` represents a positive-semidefinite update as
+    ``factor @ factor.T`` and is evaluated without forming that dense matrix. The
+    legacy ``additive_variance_m2`` argument remains a diagonal convenience; all
+    three forms can be combined without double counting when they represent
+    distinct uncertainty sources.
     """
 
     predictions = np.asarray(predicted_values_m, dtype=float)
@@ -120,17 +276,37 @@ def group_log_likelihood(
             leading_shape=predictions.shape[:-1],
             dimension=group.coordinate_count,
         )
-    nominal = _multivariate_student_t_log_density(
-        residual,
-        covariance,
-        degrees_of_freedom=group.degrees_of_freedom,
-    )
-    outlier = _multivariate_student_t_log_density(
-        residual,
-        covariance,
-        degrees_of_freedom=group.degrees_of_freedom,
-        covariance_multiplier=group.outlier_scale_multiplier,
-    )
+    if additive_covariance_factor_m is None:
+        nominal = _multivariate_student_t_log_density(
+            residual,
+            covariance,
+            degrees_of_freedom=group.degrees_of_freedom,
+        )
+        outlier = _multivariate_student_t_log_density(
+            residual,
+            covariance,
+            degrees_of_freedom=group.degrees_of_freedom,
+            covariance_multiplier=group.outlier_scale_multiplier,
+        )
+    else:
+        factor = _broadcast_additive_covariance_factor(
+            additive_covariance_factor_m,
+            leading_shape=predictions.shape[:-1],
+            dimension=group.coordinate_count,
+        )
+        nominal = _multivariate_student_t_log_density_low_rank(
+            residual,
+            covariance,
+            factor,
+            degrees_of_freedom=group.degrees_of_freedom,
+        )
+        outlier = _multivariate_student_t_log_density_low_rank(
+            residual,
+            covariance,
+            factor,
+            degrees_of_freedom=group.degrees_of_freedom,
+            covariance_multiplier=group.outlier_scale_multiplier,
+        )
     log_nominal_component = np.log(group.prior_nominal_probability) + nominal
     log_outlier_component = np.log1p(-group.prior_nominal_probability) + outlier
     log_mixture = np.logaddexp(log_nominal_component, log_outlier_component)
@@ -145,13 +321,15 @@ def grouped_component_log_likelihoods(
     prefix_frame_count: int,
     component_variance_m2: np.ndarray | None = None,
     component_group_covariance_m2: Mapping[str, np.ndarray] | None = None,
+    component_group_covariance_factor_m: Mapping[str, np.ndarray] | None = None,
 ) -> tuple[np.ndarray, GroupLikelihoodDiagnostics]:
     """Score arbitrary leading component dimensions against grouped O-plus evidence.
 
-    ``component_group_covariance_m2`` maps a group ID to a covariance that is
-    broadcastable to ``component_shape + (group_coordinate, group_coordinate)``.
-    It is intended for low-rank graph discrepancy, shared camera bias, gauge, or
-    other correlated component uncertainty that would be lost by diagonalization.
+    ``component_group_covariance_m2`` maps group IDs to dense covariance updates.
+    ``component_group_covariance_factor_m`` maps group IDs to low-rank factors in
+    meters. Each factor must broadcast to
+    ``component_shape + (group_coordinate, rank)`` and contributes
+    ``factor @ factor.T`` without dense materialization.
     """
 
     components = np.asarray(predicted_components_m, dtype=float)
@@ -172,29 +350,42 @@ def grouped_component_log_likelihoods(
         if np.any(~np.isfinite(variance)) or np.any(variance < 0.0):
             raise ValueError("component variances must be finite and nonnegative")
     covariance_by_group = dict(component_group_covariance_m2 or {})
+    factor_by_group = dict(component_group_covariance_factor_m or {})
     known_group_ids = {group.group_id for group in evidence.groups}
-    unknown = set(covariance_by_group) - known_group_ids
-    if unknown:
+    unknown_covariance = set(covariance_by_group) - known_group_ids
+    if unknown_covariance:
         raise ValueError(
-            f"component covariance references unknown groups: {sorted(unknown)}"
+            "component covariance references unknown groups: "
+            f"{sorted(unknown_covariance)}"
+        )
+    unknown_factor = set(factor_by_group) - known_group_ids
+    if unknown_factor:
+        raise ValueError(
+            "component covariance factor references unknown groups: "
+            f"{sorted(unknown_factor)}"
         )
     total = np.zeros(leading_shape, dtype=float)
     responsibilities = []
     effective_weights = evidence.effective_group_weights
     full_covariance_groups = []
+    low_rank_covariance_groups = []
     for group, weight in zip(evidence.groups, effective_weights, strict=True):
         selected = group.selected_predictions(components)
         selected_variance = (
             None if variance is None else group.selected_predictions(variance)
         )
         selected_covariance = covariance_by_group.get(group.group_id)
+        selected_factor = factor_by_group.get(group.group_id)
         if selected_covariance is not None:
             full_covariance_groups.append(group.group_id)
+        if selected_factor is not None:
+            low_rank_covariance_groups.append(group.group_id)
         log_likelihood, responsibility = group_log_likelihood(
             selected,
             group,
             additive_variance_m2=selected_variance,
             additive_covariance_m2=selected_covariance,
+            additive_covariance_factor_m=selected_factor,
         )
         total += weight * log_likelihood
         responsibilities.append(responsibility)
@@ -203,6 +394,7 @@ def grouped_component_log_likelihoods(
         effective_group_weights=effective_weights,
         nominal_responsibilities=np.stack(responsibilities, axis=-1),
         full_covariance_group_ids=tuple(full_covariance_groups),
+        low_rank_covariance_group_ids=tuple(low_rank_covariance_groups),
     )
     return total, diagnostics
 
@@ -215,6 +407,7 @@ def posterior_weights_from_grouped_evidence(
     prefix_frame_count: int,
     component_variance_m2: np.ndarray | None = None,
     component_group_covariance_m2: Mapping[str, np.ndarray] | None = None,
+    component_group_covariance_factor_m: Mapping[str, np.ndarray] | None = None,
 ) -> tuple[np.ndarray, GroupLikelihoodDiagnostics]:
     """Apply grouped evidence to finite component support in log space."""
 
@@ -229,6 +422,9 @@ def posterior_weights_from_grouped_evidence(
         prefix_frame_count=prefix_frame_count,
         component_variance_m2=component_variance_m2,
         component_group_covariance_m2=component_group_covariance_m2,
+        component_group_covariance_factor_m=(
+            component_group_covariance_factor_m
+        ),
     )
     log_posterior = log_weights_from_probabilities(prior, name="prior_weights") + score
     maximum = float(np.max(log_posterior))

--- a/tests/test_grouped_likelihood_low_rank.py
+++ b/tests/test_grouped_likelihood_low_rank.py
@@ -1,0 +1,179 @@
+import numpy as np
+import pytest
+
+from causal4d.grouped_likelihood import (
+    group_log_likelihood,
+    grouped_component_log_likelihoods,
+    posterior_weights_from_grouped_evidence,
+)
+from causal4d.observation_evidence import (
+    GroupedObservationEvidence,
+    ObservationGroup,
+)
+
+
+def _group(dimension: int, *, group_id: str = "structured") -> ObservationGroup:
+    generator = np.random.default_rng(4)
+    matrix = generator.normal(size=(dimension, dimension))
+    covariance = matrix @ matrix.T + 0.25 * np.eye(dimension)
+    return ObservationGroup(
+        group_id=group_id,
+        values_m=generator.normal(scale=0.1, size=dimension),
+        frame_indices=np.ones(dimension, dtype=np.int64),
+        node_indices=np.zeros(dimension, dtype=np.int64),
+        coordinate_indices=np.arange(dimension, dtype=np.int64),
+        covariance_m2=covariance,
+        contributor_ids=(f"unit:{group_id}",),
+        prior_nominal_probability=0.91,
+        outlier_scale_multiplier=30.0,
+        degrees_of_freedom=5.0,
+        source_id="unit",
+    )
+
+
+def test_low_rank_factor_matches_dense_covariance_update() -> None:
+    generator = np.random.default_rng(9)
+    dimension = 7
+    predictions = generator.normal(size=(2, 3, dimension))
+    factor = generator.normal(scale=0.15, size=(2, 3, dimension, 2))
+    dense = np.einsum("...ir,...jr->...ij", factor, factor)
+    additive_variance = generator.uniform(0.01, 0.05, size=predictions.shape)
+    group = _group(dimension)
+
+    dense_score, dense_responsibility = group_log_likelihood(
+        predictions,
+        group,
+        additive_variance_m2=additive_variance,
+        additive_covariance_m2=dense,
+    )
+    factor_score, factor_responsibility = group_log_likelihood(
+        predictions,
+        group,
+        additive_variance_m2=additive_variance,
+        additive_covariance_factor_m=factor,
+    )
+
+    np.testing.assert_allclose(factor_score, dense_score, rtol=1e-11, atol=1e-11)
+    np.testing.assert_allclose(
+        factor_responsibility,
+        dense_responsibility,
+        rtol=1e-11,
+        atol=1e-11,
+    )
+
+
+def test_low_rank_path_does_not_use_dense_slogdet(monkeypatch) -> None:
+    def forbidden_slogdet(*_args, **_kwargs):
+        raise AssertionError("low-rank scoring must not use a dense determinant")
+
+    monkeypatch.setattr(np.linalg, "slogdet", forbidden_slogdet)
+    predictions = np.asarray([[0.2, -0.1, 0.3]])
+    factor = np.asarray([[0.1], [0.2], [-0.1]])
+
+    score, responsibility = group_log_likelihood(
+        predictions,
+        _group(3),
+        additive_covariance_factor_m=factor,
+    )
+
+    assert np.all(np.isfinite(score))
+    assert np.all((responsibility > 0.0) & (responsibility < 1.0))
+
+
+def test_grouped_factor_broadcasts_and_records_structured_groups() -> None:
+    group = ObservationGroup(
+        group_id="factor",
+        values_m=np.zeros(2),
+        frame_indices=np.asarray([1, 1]),
+        node_indices=np.asarray([0, 0]),
+        coordinate_indices=np.asarray([0, 1]),
+        covariance_m2=np.eye(2) * 0.2,
+        contributor_ids=("unit:factor",),
+        source_id="unit",
+    )
+    evidence = GroupedObservationEvidence(groups=(group,))
+    components = np.zeros((2, 3, 3, 1, 2))
+    components[0, :, 1, 0] = [0.5, 0.5]
+    components[1, :, 1, 0] = [0.5, -0.5]
+    factor = np.broadcast_to(
+        np.asarray([[0.4], [0.4]]),
+        (3, 2, 1),
+    )
+
+    score, diagnostics = grouped_component_log_likelihoods(
+        components,
+        evidence,
+        prefix_frame_count=2,
+        component_group_covariance_factor_m={"factor": factor},
+    )
+
+    assert score.shape == (2, 3)
+    assert np.all(score[0] > score[1])
+    assert diagnostics.full_covariance_group_ids == ()
+    assert diagnostics.low_rank_covariance_group_ids == ("factor",)
+
+
+def test_structured_and_dense_paths_produce_identical_posteriors() -> None:
+    generator = np.random.default_rng(12)
+    group = _group(3)
+    evidence = GroupedObservationEvidence(groups=(group,))
+    components = generator.normal(size=(4, 3, 1, 3))
+    factor = generator.normal(scale=0.1, size=(4, 3, 2))
+    dense = np.einsum("...ir,...jr->...ij", factor, factor)
+    prior = np.asarray([0.1, 0.2, 0.3, 0.4])
+
+    dense_posterior, _ = posterior_weights_from_grouped_evidence(
+        prior,
+        components,
+        evidence,
+        prefix_frame_count=2,
+        component_group_covariance_m2={"structured": dense},
+    )
+    factor_posterior, diagnostics = posterior_weights_from_grouped_evidence(
+        prior,
+        components,
+        evidence,
+        prefix_frame_count=2,
+        component_group_covariance_factor_m={"structured": factor},
+    )
+
+    np.testing.assert_allclose(
+        factor_posterior,
+        dense_posterior,
+        rtol=1e-11,
+        atol=1e-11,
+    )
+    assert np.isclose(np.sum(factor_posterior), 1.0)
+    assert diagnostics.low_rank_covariance_group_ids == ("structured",)
+
+
+def test_invalid_low_rank_factors_fail_closed() -> None:
+    group = _group(3)
+    predictions = np.zeros((2, 3))
+
+    with pytest.raises(ValueError, match="positive_rank"):
+        group_log_likelihood(
+            predictions,
+            group,
+            additive_covariance_factor_m=np.empty((3, 0)),
+        )
+    invalid = np.ones((3, 1))
+    invalid[0, 0] = np.nan
+    with pytest.raises(ValueError, match="factor must be finite"):
+        group_log_likelihood(
+            predictions,
+            group,
+            additive_covariance_factor_m=invalid,
+        )
+
+    evidence = GroupedObservationEvidence(groups=(group,))
+    components = np.zeros((2, 3, 1, 3))
+    with pytest.raises(ValueError, match="unknown groups"):
+        grouped_component_log_likelihoods(
+            components,
+            evidence,
+            prefix_frame_count=2,
+            component_group_covariance_factor_m={
+                "unknown": np.ones((3, 1))
+            },
+        )


### PR DESCRIPTION
## Summary

- add an optional `component_group_covariance_factor_m` path for grouped robust likelihoods;
- represent correlated uncertainty as `U U^T` with factors in meters;
- compute Student-t log determinants and Mahalanobis terms with Cholesky whitening, the matrix determinant lemma, and the Woodbury identity;
- avoid materializing the dense low-rank covariance update, explicit inverses, and the dense `slogdet` path;
- preserve the original dense and diagonal covariance APIs unchanged;
- allow diagonal, dense, and low-rank contributions to be combined when they represent distinct uncertainty sources;
- record structured use separately in `GroupLikelihoodDiagnostics.low_rank_covariance_group_ids`; and
- add dense/structured parity tests for mixture scores, nominal responsibilities, and posterior weights, plus broadcasting and fail-closed validation tests.

## Motivation

Prob4D gauge uncertainty and BayesianPhysTwin/Causal4D graph discrepancy can have low effective rank but large grouped observation dimension. The existing implementation requires a full covariance per component. This change provides an exact structured evaluation path whose expensive update is rank-by-rank rather than coordinate-by-coordinate.

## Compatibility and scientific boundary

Callers that do not pass a factor execute the existing dense implementation. No frozen benchmark, default estimator, artifact schema, or result identity changes. The new tests establish numerical equivalence to explicitly materialized covariance at tight tolerance; they are engineering evidence, not a new accuracy or calibration result.

## Local validation

- Python byte compilation passed.
- An isolated numerical harness passed all five new tests.
- Random batched rank-2 factors agreed with explicit dense covariance for mixture scores and responsibilities at `rtol=atol=1e-11`.
- Structured and dense posterior weights agreed at the same tolerance.
- All changed Python lines are at most 88 characters.

GitHub Actions remains authoritative for the complete suite and packaging matrix.