### PR TITLE
Add fail-closed acquisition guidance and staged-source publication flow

### DIFF
--- a/docs/causal4d_preacquisition_next_action.md
+++ b/docs/causal4d_preacquisition_next_action.md
@@ -1,0 +1,153 @@
+# Pre-acquisition next-action decision
+
+The registered physical experiment has several independent prerequisite,
+source-panel, approval, freeze, and software-lineage gates. The authoritative
+status commands remain the source of truth, but their complete blocker lists are
+not an operator runbook.
+
+`causal4d protocol readiness next-action` derives exactly one admissible next
+step from the current hash-verified readiness and source-panel status. It does
+not create evidence, repair invalid artifacts, choose scientific settings, or
+inspect target outcomes.
+
+## Usage
+
+```bash
+causal4d protocol readiness next-action \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  --output-json \
+  /data/causal4d-sloth-multi-action-v1/operator/next-action.json \
+  --output-markdown \
+  /data/causal4d-sloth-multi-action-v1/operator/next-action.md
+```
+
+File hashes are verified by default. `--skip-file-hashes` is available for a
+structure-only inspection, but such a run can never authorize confirmatory
+collection. When all logical evidence is present, the resulting action remains
+`run_final_hash_verified_readiness_gate` until a hash-verified decision passes.
+
+The command returns:
+
+- exit code `0` only when the readiness decision already authorizes the first
+  confirmatory execution;
+- exit code `3` for a valid but incomplete state with one prescribed next action;
+- exit code `2` when present evidence is malformed, contradictory, out of order,
+  or otherwise invalid.
+
+## Deterministic action order
+
+The decision follows the registered information order. It emits the first
+applicable action from this sequence:
+
+1. create the registered real-dataset scaffold when the dataset root is absent
+   or empty;
+2. create the non-overwriting pre-acquisition gate and source-panel templates;
+3. scaffold and seal the operator identity registry;
+4. stop on malformed evidence, chronology violations, unexpected source-panel
+   entries, or confirmatory collection that began before readiness;
+5. complete the fixed object registration, slip pilot, shared timebase, and
+   independently reviewed contact registration;
+6. acquire, verify, independently review, and publish exactly the next
+   registered source-panel execution;
+7. seal source-panel completion, actuator synchronization, support/gravity, and
+   nonconfirmatory end-to-end dry-run gates;
+8. seal the exact clean method freeze;
+9. obtain an independent freeze attestation;
+10. seal the deployed software environment;
+11. run the final hash-verified readiness gate; and
+12. validate the freeze and begin only the first registered confirmatory session.
+
+The source-panel action includes the exact execution ID, session ID, registered
+command profile, manifest template, staging destination, preflight-report path,
+and exactly-once publication command. It never skips ahead or selects a
+different source execution.
+
+## Source-panel publication sequence
+
+A physical source execution has an irreversible claim-bearing publication step.
+The next-action artifact therefore represents five explicit phases:
+
+```text
+acquire registered execution
+        ↓
+verify staged manifest and every referenced artifact
+        ↓
+independently review the content-addressed preflight report
+        ↓
+publish the manifest exactly once
+        ↓
+recompute the next action
+```
+
+The preflight command is emitted under
+`post_acquisition_verification_argv` and writes the path recorded in
+`preflight_report_path`. The publication command is separate under
+`claim_bearing_publication_argv`; it is never presented as the immediate
+post-acquisition command. `independent_review_required_before_publication=true`
+records the human decision boundary explicitly.
+
+Publication reruns all registered validation and hash checks. A preflight report
+is a snapshot and never reserves the next execution slot or counts as physical
+evidence.
+
+## Output contract
+
+The JSON report is content addressed and contains:
+
+- the protocol, design, pre-acquisition plan, and amendment identities;
+- the source readiness and source-panel evidence/status identities;
+- one `action` object with a stable `action_id` and category;
+- an argv representation and shell-rendered form for executable commands;
+- required inputs, outputs, and operator role;
+- explicit post-acquisition verification and claim-bearing publication commands
+  when applicable;
+- whether independent review is required before publication;
+- the completion check that should be run after the action sequence;
+- whether physical acquisition is required;
+- whether the action is mechanically automatable;
+- a portable `evidence_sha256` that normalizes repository and dataset mount
+  points; and
+- an exact host-local `status_sha256`.
+
+Every action records:
+
+```json
+{
+  "changes_registered_method": false,
+  "target_outcomes_permitted": false
+}
+```
+
+The Markdown report renders the same sequence for an acquisition operator. Both
+formats are derived artifacts and may be overwritten by a newer status
+snapshot; they are never counted as experimental evidence.
+
+## Invalid evidence
+
+An invalid state always yields `stop_and_repair_invalid_evidence`. The command
+lists the detected malformed prerequisites, invalid gates, chronology blockers,
+source-panel blockers, or premature-collection condition. It deliberately does
+not synthesize a repair command because a method-affecting defect may require a
+new protocol version rather than mutation of the current registration.
+
+The operator must resolve the first invalid boundary under the applicable
+runbook and independent-review policy, then rerun the decision command.
+
+## Scientific boundary
+
+This interface is operational provenance only. It does not modify:
+
+- the frozen estimator or intervention posterior;
+- the six-frame causal information boundary;
+- the 12-source-execution or 36-confirmatory-execution order;
+- any fit, calibration, or target split;
+- a quality gate, exclusion rule, conformal threshold, or analysis decision;
+- the physical evidence count; or
+- the distinction between controlled counterfactual evidence and real held-out
+  interventional prediction.
+
+A `begin_first_confirmatory_session` action is emitted only when the existing
+readiness status already has `ready=true`, all requested hashes were verified,
+and `first_confirmatory_execution_allowed=true` follows from the registered
+collection gate.

--- a/docs/causal4d_source_panel_staging_preflight.md
+++ b/docs/causal4d_source_panel_staging_preflight.md
@@ -1,0 +1,100 @@
+# Source-panel staging preflight
+
+Physical source-panel acquisition is expensive, and the final manifest is
+published exactly once. A malformed manifest, wrong artifact checksum, or
+concurrently changing source file should therefore be detected before the
+non-overwriting publication step.
+
+`causal4d protocol readiness source-panel-verify-staged` performs the same
+claim-boundary checks needed for admission while leaving the claim-bearing
+source registry unchanged. It verifies that the staging file:
+
+- is an ordinary file directly below `dataset_root/staging`, with no symlinked
+  path component;
+- is named exactly `<next-execution-id>.json`;
+- is exactly the next registered source execution and session;
+- has the exact schema of the registered manifest template;
+- contains no target-outcome field, including nested fields;
+- marks the source execution complete, included, and free of quality-gate
+  failures;
+- retains the source-only and nonconfirmatory information boundary;
+- references only admissible artifacts whose byte counts and SHA-256 values
+  match;
+- remains byte-identical throughout validation;
+- retains byte-identical referenced artifacts throughout validation;
+- leaves the hash-verified source-panel status unchanged; and
+- does not collide with an already published final manifest.
+
+## Operator flow
+
+Fill the registered staging manifest and place every referenced artifact below
+the dataset root. Then run:
+
+```bash
+causal4d protocol readiness source-panel-verify-staged \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  /data/causal4d-sloth-multi-action-v1/staging/source-lift_high-r1.json \
+  --output-json \
+  /data/causal4d-sloth-multi-action-v1/operator/source-lift_high-r1-preflight.json
+```
+
+A successful result has:
+
+```text
+safe_to_publish=true
+published=false
+claim_bearing_evidence_mutated=false
+changes_registered_method=false
+source_panel_status_stable=true
+target_outcomes_used=false
+```
+
+It also records the exact staged-manifest checksum, a complete post-validation
+snapshot of every referenced artifact, the stable source-panel status identity,
+the expected one-step progress, and the exact publication command. The report is
+derived operator evidence; it does not count as a physical execution and does
+not reserve the next execution slot.
+
+After independent review, publish with the command returned by the report. The
+reviewer should compare the content-addressed report with the staged manifest
+and artifact inventory; a successful preflight is not itself an approval.
+
+```bash
+causal4d protocol readiness source-panel-publish \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  /data/causal4d-sloth-multi-action-v1/staging/source-lift_high-r1.json
+```
+
+Publication reruns all validation. This matters because a preflight report is a
+snapshot: a staging file or referenced artifact changed afterward is rejected,
+and concurrent publication remains protected by the existing exactly-once final
+write.
+
+## Mutation and concurrency boundary
+
+The preflight hashes the staging manifest before parsing and after complete
+validation. It also snapshots every referenced artifact before and after the
+registered validator runs. Any changed byte count, SHA-256 value, artifact path,
+or source-panel status identity fails the preflight.
+
+These checks close mutations that occur while the report is being constructed.
+They cannot reserve files after the command returns. The exactly-once publisher
+therefore remains authoritative and reruns every check immediately before
+publication.
+
+## Exit behavior
+
+The command returns `0` only after complete read-only validation. Invalid,
+out-of-order, target-informed, symlinked, misnamed, missing, changing, or
+checksum-inconsistent staging evidence returns `2` through the readiness CLI's
+normal fail-closed error contract.
+
+## Scientific boundary
+
+The preflight does not modify the estimator, intervention posterior, source or
+target split, six-frame information boundary, quality gates, exclusion rules,
+physical evidence count, or registered analysis. It never authorizes
+confirmatory collection and never converts a staged file into claim-bearing
+evidence.

--- a/src/causal4d/cli/preacquisition_readiness.py
+++ b/src/causal4d/cli/preacquisition_readiness.py
@@ -6,6 +6,7 @@ import argparse
 import json
 from collections.abc import Sequence
 
+from causal4d import preacquisition_operator_flow as _operator_flow
 from causal4d.operator_registry import (
     scaffold_operator_registry,
     seal_operator_registry,
@@ -22,7 +23,20 @@ from causal4d.preacquisition_source_panel_control import (
     publish_source_panel_manifest,
     write_source_panel_status,
 )
+from causal4d.preacquisition_source_panel_staging import (
+    verify_source_panel_manifest_staging,
+    write_source_panel_staging_preflight,
+)
 
+build_preacquisition_next_action = (
+    _operator_flow.build_preacquisition_operator_next_action
+)
+write_preacquisition_next_action = (
+    _operator_flow.write_preacquisition_operator_next_action
+)
+write_preacquisition_next_action_markdown = (
+    _operator_flow.write_preacquisition_operator_next_action_markdown
+)
 
 _VALID_BUT_INCOMPLETE = 3
 
@@ -79,6 +93,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="return exit code 3 while the valid source panel is incomplete",
     )
 
+    source_verify = subparsers.add_parser(
+        "source-panel-verify-staged",
+        help=(
+            "hash-verify exactly the next staged source manifest without publishing it"
+        ),
+    )
+    source_verify.add_argument("repository_root")
+    source_verify.add_argument("dataset_root")
+    source_verify.add_argument("source_json")
+    source_verify.add_argument("--output-json")
+
     source_publish = subparsers.add_parser(
         "source-panel-publish",
         help="hash-verify and publish exactly the next source execution manifest",
@@ -99,6 +124,20 @@ def build_parser() -> argparse.ArgumentParser:
         "--require-ready",
         action="store_true",
         help="return exit code 3 when evidence is valid but incomplete",
+    )
+
+    next_action = subparsers.add_parser(
+        "next-action",
+        help="derive exactly one admissible operator action from current evidence",
+    )
+    next_action.add_argument("repository_root")
+    next_action.add_argument("dataset_root")
+    next_action.add_argument("--output-json")
+    next_action.add_argument("--output-markdown")
+    next_action.add_argument(
+        "--skip-file-hashes",
+        action="store_true",
+        help="inspect structure only; the suggested action cannot authorize collection",
     )
     return parser
 
@@ -140,12 +179,33 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             if args.output_json:
                 write_source_panel_status(args.output_json, result)
+        elif args.command == "source-panel-verify-staged":
+            result = verify_source_panel_manifest_staging(
+                args.repository_root,
+                args.dataset_root,
+                args.source_json,
+            )
+            if args.output_json:
+                write_source_panel_staging_preflight(args.output_json, result)
         elif args.command == "source-panel-publish":
             result = publish_source_panel_manifest(
                 args.repository_root,
                 args.dataset_root,
                 args.source_json,
             )
+        elif args.command == "next-action":
+            result = build_preacquisition_next_action(
+                args.repository_root,
+                args.dataset_root,
+                verify_file_hashes=not args.skip_file_hashes,
+            )
+            if args.output_json:
+                write_preacquisition_next_action(args.output_json, result)
+            if args.output_markdown:
+                write_preacquisition_next_action_markdown(
+                    args.output_markdown,
+                    result,
+                )
         else:
             result = build_preacquisition_readiness(
                 args.repository_root,
@@ -180,6 +240,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         if not result["valid"]:
             return 2
         if args.require_complete and not result["complete"]:
+            return _VALID_BUT_INCOMPLETE
+    if args.command == "next-action":
+        if not result["valid"]:
+            return 2
+        if not result["ready"]:
             return _VALID_BUT_INCOMPLETE
     return 0
 

--- a/src/causal4d/preacquisition_next_action.py
+++ b/src/causal4d/preacquisition_next_action.py
@@ -1,0 +1,701 @@
+"""Derive one fail-closed operator action from pre-acquisition evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shlex
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from causal4d.atomic_io import atomic_write_json, atomic_write_text
+from causal4d.preacquisition_readiness import build_preacquisition_readiness
+from causal4d.preacquisition_readiness_contracts import (
+    GATE_PATHS,
+    PROTOCOL_PATH,
+    load_registered_preacquisition_chain,
+)
+from causal4d.preacquisition_source_panel_control import build_source_panel_status
+
+NEXT_ACTION_SCHEMA_VERSION = 1
+NEXT_ACTION_ARTIFACT_KIND = "Causal4DPreacquisitionNextAction"
+
+_MANUAL = {
+    "object_registration": (
+        "Complete the fixed-object registration",
+        "object_registration.template.json",
+        "object_registration.json",
+        False,
+    ),
+    "slip_pilot": (
+        "Complete the preregistered slip go/no-go pilot",
+        "slip_pilot.template.json",
+        "slip_pilot.json",
+        True,
+    ),
+    "timebase_calibration": (
+        "Complete and approve the shared timebase calibration",
+        "timebase_calibration.template.json",
+        "timebase_calibration.json",
+        True,
+    ),
+    "contact_registration": (
+        "Publish the independently reviewed contact registration",
+        "contact_registration.staging.json",
+        "contact_registration.json",
+        False,
+    ),
+}
+_GATE = {
+    "signature_panel_complete": (
+        "Seal the completed 12-execution source panel",
+        "gate_approver",
+        False,
+    ),
+    "actuator_sync_passed": (
+        "Complete and seal actuator synchronization evidence",
+        "gate_approver",
+        True,
+    ),
+    "support_registration_passed": (
+        "Complete and seal support and gravity registration",
+        "gate_approver",
+        True,
+    ),
+    "end_to_end_dry_run_passed": (
+        "Complete and seal the nonconfirmatory end-to-end dry run",
+        "gate_approver",
+        True,
+    ),
+    "software_environment_locked": (
+        "Complete and seal the deployed software environment",
+        "software_environment_approver",
+        False,
+    ),
+}
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _cmd(*parts: object) -> list[str]:
+    return ["causal4d", *(str(part) for part in parts)]
+
+
+def _readiness(operation: str, *parts: object) -> list[str]:
+    return _cmd("protocol", "readiness", operation, *parts)
+
+
+def _freeze(operation: str, *parts: object) -> list[str]:
+    return _cmd("protocol", "freeze", operation, *parts)
+
+
+def _real(operation: str, *parts: object) -> list[str]:
+    return _cmd("protocol", "real", operation, *parts)
+
+
+def _action(
+    action_id: str,
+    title: str,
+    role: str,
+    *,
+    category: str,
+    command: Sequence[str] | None = None,
+    completion: Sequence[str] | None = None,
+    after: Sequence[str] | None = None,
+    inputs: Sequence[str] = (),
+    outputs: Sequence[str] = (),
+    blockers: Sequence[str] = (),
+    physical: bool = False,
+    automatable: bool = False,
+    execution: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    def pair(argv: Sequence[str] | None) -> tuple[list[str] | None, str | None]:
+        values = None if argv is None else list(argv)
+        return values, None if values is None else shlex.join(values)
+
+    command_argv, command_text = pair(command)
+    completion_argv, completion_text = pair(completion)
+    after_argv, after_text = pair(after)
+    result: dict[str, Any] = {
+        "action_id": action_id,
+        "category": category,
+        "title": title,
+        "operator_role": role,
+        "physical_acquisition_required": physical,
+        "automatable": automatable,
+        "changes_registered_method": False,
+        "target_outcomes_permitted": False,
+        "command_argv": command_argv,
+        "command_text": command_text,
+        "completion_check_argv": completion_argv,
+        "completion_check_text": completion_text,
+        "after_completion_argv": after_argv,
+        "after_completion_text": after_text,
+        "input_paths": list(inputs),
+        "output_paths": list(outputs),
+        "blocking_items": list(blockers),
+    }
+    if execution is not None:
+        result["registered_execution"] = deepcopy(dict(execution))
+    return result
+
+
+def _digest(value: Any) -> str:
+    data = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), allow_nan=False
+    ).encode()
+    return hashlib.sha256(data).hexdigest()
+
+
+def _portable(value: Any, repository: str, dataset: str) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): _portable(item, repository, dataset)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_portable(item, repository, dataset) for item in value]
+    if isinstance(value, str):
+        value = value.replace(repository, "${REPOSITORY_ROOT}") if repository else value
+        value = value.replace(dataset, "${DATASET_ROOT}") if dataset else value
+    return deepcopy(value)
+
+
+def next_action_evidence_sha256(values: Mapping[str, Any]) -> str:
+    """Return a mount-independent digest of one logical decision."""
+
+    payload = deepcopy(dict(values))
+    repository = str(payload.pop("repository_root", ""))
+    dataset = str(payload.pop("dataset_root", ""))
+    payload.pop("evidence_sha256", None)
+    payload.pop("status_sha256", None)
+    return _digest(_portable(payload, repository, dataset))
+
+
+def next_action_status_sha256(values: Mapping[str, Any]) -> str:
+    """Return the digest of the exact host-local decision."""
+
+    payload = deepcopy(dict(values))
+    payload.pop("status_sha256", None)
+    return _digest(payload)
+
+
+def _pending(status: Mapping[str, Any], section: str, name: str) -> bool:
+    value = status.get(section, {}).get(name, {})
+    missing = (
+        "missing_prerequisites"
+        if section == "prerequisites"
+        else "missing_or_template_gates"
+    )
+    return bool(
+        name in status.get(missing, [])
+        or not value.get("present")
+        or value.get("template") is True
+        or value.get("identity_pending") is True
+    )
+
+
+def _invalid(readiness: Mapping[str, Any], source: Mapping[str, Any]) -> list[str]:
+    values = [
+        *(
+            f"prerequisite_invalid:{name}"
+            for name in readiness.get("malformed_prerequisites", [])
+        ),
+        *(f"gate_invalid:{name}" for name in readiness.get("malformed_gates", [])),
+        *(str(value) for value in readiness.get("chronology_blockers", [])),
+    ]
+    if source.get("valid") is not True:
+        values.extend(str(value) for value in source.get("blockers", []))
+    if readiness.get("confirmatory_collection", {}).get("not_started") is False:
+        values.append("confirmatory_collection_already_started")
+    return list(dict.fromkeys(values))
+
+
+def _manual_action(name: str, repository: str, dataset: str) -> dict[str, Any]:
+    title, template, output, physical = _MANUAL[name]
+    root = Path(dataset)
+    protocol = Path(repository) / PROTOCOL_PATH
+    return _action(
+        f"complete_{name}",
+        title,
+        "acquisition_operator_and_independent_reviewer",
+        category="manual_evidence",
+        completion=_real(
+            "status",
+            protocol,
+            dataset,
+            "--repository-root",
+            repository,
+            "--verify-file-hashes",
+        ),
+        inputs=[str(root / template)],
+        outputs=[str(root / output)],
+        physical=physical,
+    )
+
+
+def _gate_action(gate: str, repository: str, dataset: str) -> dict[str, Any]:
+    title, role, physical = _GATE[gate]
+    path = str(Path(dataset) / GATE_PATHS[gate])
+    return _action(
+        f"complete_and_seal_{gate}",
+        title,
+        role,
+        category="seal_gate",
+        command=_readiness(
+            "seal-gate",
+            repository,
+            dataset,
+            gate,
+            "--approved-by",
+            "<registered-operator-id>",
+        ),
+        completion=_readiness("next-action", repository, dataset),
+        inputs=[path],
+        outputs=[path],
+        physical=physical,
+    )
+
+
+def _derive_action(
+    readiness: Mapping[str, Any],
+    source: Mapping[str, Any],
+    repository: str,
+    dataset: str,
+) -> dict[str, Any]:
+    root = Path(dataset)
+    protocol = Path(repository) / PROTOCOL_PATH
+    next_check = _readiness("next-action", repository, dataset)
+    gates = readiness.get("operational_gates", {})
+    if (
+        bool(gates)
+        and all(not value.get("present") for value in gates.values())
+        or len(source.get("missing_template_ids", [])) == 12
+    ):
+        return _action(
+            "scaffold_preacquisition_evidence",
+            "Scaffold the non-overwriting pre-acquisition evidence tree",
+            "acquisition_operator",
+            category="scaffold",
+            command=_readiness("scaffold", repository, dataset),
+            completion=next_check,
+            outputs=[str(root / "preacquisition")],
+            automatable=True,
+        )
+
+    invalid = _invalid(readiness, source)
+    if invalid:
+        return _action(
+            "stop_and_repair_invalid_evidence",
+            "Stop and repair the first invalid evidence boundary",
+            "principal_investigator_and_independent_verifier",
+            category="invalid_evidence",
+            command=_readiness("status", repository, dataset, "--verify-file-hashes"),
+            completion=next_check,
+            blockers=invalid or list(readiness.get("blockers", [])),
+        )
+
+    registry = readiness.get("prerequisites", {}).get("operator_registry", {})
+    if _pending(readiness, "prerequisites", "operator_registry"):
+        template = str(root / "preacquisition/operator_registry.template.json")
+        operation = (
+            "scaffold-operator-registry"
+            if not registry.get("present")
+            else "seal-operator-registry"
+        )
+        arguments: list[object] = [repository, dataset]
+        if operation == "seal-operator-registry":
+            arguments.extend([template, "--sealed-by", "<registered-operator-id>"])
+        return _action(
+            operation.replace("-", "_"),
+            (
+                "Scaffold the protocol-bound operator identity registry"
+                if operation.startswith("scaffold")
+                else "Complete and seal the operator identity registry"
+            ),
+            "principal_investigator",
+            category=(
+                "scaffold" if operation.startswith("scaffold") else "manual_evidence"
+            ),
+            command=_readiness(operation, *arguments),
+            completion=next_check,
+            inputs=[] if operation.startswith("scaffold") else [template],
+            outputs=[
+                template
+                if operation.startswith("scaffold")
+                else str(root / "preacquisition/operator_registry.json")
+            ],
+            automatable=operation.startswith("scaffold"),
+        )
+
+    if readiness.get("valid") is not True:
+        return _action(
+            "stop_and_repair_invalid_evidence",
+            "Stop and repair the first invalid evidence boundary",
+            "principal_investigator_and_independent_verifier",
+            category="invalid_evidence",
+            command=_readiness("status", repository, dataset, "--verify-file-hashes"),
+            completion=next_check,
+            blockers=list(readiness.get("blockers", [])),
+        )
+
+    if any(
+        _pending(readiness, "prerequisites", name)
+        for name in ("dataset_protocol", "acquisition_schedule")
+    ):
+        return _action(
+            "scaffold_registered_dataset",
+            "Create the registered real-experiment dataset scaffold",
+            "acquisition_operator",
+            category="scaffold",
+            command=_real("scaffold", protocol, dataset),
+            completion=next_check,
+            outputs=[dataset],
+            automatable=True,
+        )
+
+    for name in _MANUAL:
+        if _pending(readiness, "prerequisites", name):
+            return _manual_action(name, repository, dataset)
+
+    if source.get("complete") is not True:
+        execution = source.get("next_execution")
+        _require(isinstance(execution, Mapping), "next source execution is missing")
+        execution_id = str(execution["execution_id"])
+        staging = str(root / "staging" / f"{execution_id}.json")
+        return _action(
+            "acquire_next_source_panel_execution",
+            f"Acquire registered source execution {execution_id}",
+            "acquisition_operator",
+            category="physical_source_execution",
+            command=_readiness(
+                "source-panel-status",
+                repository,
+                dataset,
+                "--verify-file-hashes",
+            ),
+            after=_readiness("source-panel-publish", repository, dataset, staging),
+            completion=next_check,
+            inputs=[str(root / str(execution["template_path"]))],
+            outputs=[staging, str(root / str(execution["manifest_path"]))],
+            physical=True,
+            execution=execution,
+        )
+
+    for gate in (
+        "signature_panel_complete",
+        "actuator_sync_passed",
+        "support_registration_passed",
+        "end_to_end_dry_run_passed",
+    ):
+        if _pending(readiness, "operational_gates", gate):
+            return _gate_action(gate, repository, dataset)
+
+    freeze = str(root / "method_freeze.json")
+    if _pending(readiness, "prerequisites", "method_freeze"):
+        return _action(
+            "seal_method_freeze",
+            "Seal the exact clean acquisition checkout",
+            "freezer",
+            category="freeze",
+            command=_freeze(
+                "seal",
+                repository,
+                freeze,
+                "--frozen-by",
+                "<registered-freezer-id>",
+            ),
+            completion=next_check,
+            outputs=[freeze],
+        )
+
+    if _pending(readiness, "prerequisites", "method_freeze_validation"):
+        attestation = str(root / "method_freeze_validation.json")
+        return _action(
+            "attest_method_freeze",
+            "Independently attest the sealed method freeze",
+            "independent_verifier",
+            category="attest",
+            command=_freeze(
+                "attest",
+                freeze,
+                protocol,
+                repository,
+                attestation,
+                "--verified-by",
+                "<registered-independent-verifier-id>",
+            ),
+            completion=next_check,
+            inputs=[freeze],
+            outputs=[attestation],
+        )
+
+    if _pending(readiness, "operational_gates", "software_environment_locked"):
+        return _gate_action("software_environment_locked", repository, dataset)
+
+    if readiness.get("verify_file_hashes") is not True:
+        return _action(
+            "run_final_hash_verified_readiness_gate",
+            "Run the final hash-verified readiness gate",
+            "independent_verifier",
+            category="final_verification",
+            command=_readiness(
+                "status",
+                repository,
+                dataset,
+                "--verify-file-hashes",
+                "--require-ready",
+            ),
+            completion=next_check,
+            automatable=True,
+        )
+
+    if readiness.get("ready") is True:
+        return _action(
+            "begin_first_confirmatory_session",
+            "Validate the freeze and begin the first registered session",
+            "acquisition_operator",
+            category="confirmatory_execution",
+            command=_freeze("validate", freeze, repository),
+            completion=_real(
+                "status",
+                protocol,
+                dataset,
+                "--repository-root",
+                repository,
+                "--verify-file-hashes",
+            ),
+            inputs=[freeze, str(root / "acquisition_schedule.csv")],
+            physical=True,
+        )
+
+    return _action(
+        "rerun_readiness_diagnostics",
+        "Rerun the complete readiness diagnostics",
+        "independent_verifier",
+        category="final_verification",
+        command=_readiness("status", repository, dataset, "--verify-file-hashes"),
+        completion=next_check,
+        blockers=list(readiness.get("blockers", [])),
+    )
+
+
+def _decision(
+    identity: Mapping[str, Any],
+    repository: str,
+    dataset: str,
+    action: Mapping[str, Any],
+    readiness: Mapping[str, Any] | None = None,
+    source: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    ready = readiness is not None and readiness.get("ready") is True
+
+    def value(status: Mapping[str, Any] | None, key: str) -> Any:
+        return None if status is None else status.get(key)
+
+    result: dict[str, Any] = {
+        "schema_version": NEXT_ACTION_SCHEMA_VERSION,
+        "artifact_kind": NEXT_ACTION_ARTIFACT_KIND,
+        **dict(identity),
+        "repository_root": repository,
+        "dataset_root": dataset,
+        "readiness_evidence_sha256": value(readiness, "evidence_sha256"),
+        "readiness_status_sha256": value(readiness, "status_sha256"),
+        "source_panel_evidence_sha256": value(source, "evidence_sha256"),
+        "source_panel_status_sha256": value(source, "status_sha256"),
+        "readiness_valid": (
+            None if readiness is None else readiness.get("valid") is True
+        ),
+        "source_panel_valid": None if source is None else source.get("valid") is True,
+        "ready": ready,
+        "complete": ready,
+        "passed": ready,
+        "valid": action.get("category") != "invalid_evidence",
+        "action": deepcopy(dict(action)),
+        "target_outcomes_used": False,
+    }
+    result["evidence_sha256"] = next_action_evidence_sha256(result)
+    result["status_sha256"] = next_action_status_sha256(result)
+    return result
+
+
+def derive_preacquisition_next_action(
+    readiness: Mapping[str, Any],
+    source_panel: Mapping[str, Any],
+    *,
+    repository_root: str | Path,
+    dataset_root: str | Path,
+) -> dict[str, Any]:
+    """Derive exactly one target-free action from status snapshots."""
+
+    repository = str(Path(repository_root).resolve())
+    dataset = str(Path(dataset_root).resolve())
+    identity = {
+        "protocol_id": readiness.get("protocol_id"),
+        "protocol_design_sha256": readiness.get("protocol_design_sha256"),
+        "preacquisition_plan_id": readiness.get("preacquisition_plan_id"),
+        "preacquisition_amendment_sha256": readiness.get(
+            "preacquisition_amendment_sha256"
+        ),
+    }
+    for name, value in identity.items():
+        _require(isinstance(value, str) and value, f"readiness {name} is missing")
+        _require(value == source_panel.get(name), f"status {name} values differ")
+    _require(
+        source_panel.get("target_outcomes_used") is False,
+        "source-panel status admits target outcomes",
+    )
+    return _decision(
+        identity,
+        repository,
+        dataset,
+        _derive_action(readiness, source_panel, repository, dataset),
+        readiness,
+        source_panel,
+    )
+
+
+def _scaffold_decision(repository: Path, dataset: Path) -> dict[str, Any]:
+    protocol, _, _, v4 = load_registered_preacquisition_chain(repository)
+    repository_text = str(repository.resolve())
+    dataset_text = str(dataset.resolve())
+    identity = {
+        "protocol_id": protocol["protocol_id"],
+        "protocol_design_sha256": protocol["design_sha256"],
+        "preacquisition_plan_id": v4["plan_id"],
+        "preacquisition_amendment_sha256": v4["amendment_sha256"],
+    }
+    action = _action(
+        "scaffold_registered_dataset",
+        "Create the registered real-experiment dataset scaffold",
+        "acquisition_operator",
+        category="scaffold",
+        command=_real("scaffold", Path(repository_text) / PROTOCOL_PATH, dataset_text),
+        completion=_readiness("next-action", repository_text, dataset_text),
+        outputs=[dataset_text],
+        automatable=True,
+    )
+    return _decision(identity, repository_text, dataset_text, action)
+
+
+def build_preacquisition_next_action(
+    repository_root: str | Path,
+    dataset_root: str | Path,
+    *,
+    verify_file_hashes: bool = True,
+) -> dict[str, Any]:
+    """Inspect current evidence and derive one operator-facing action."""
+
+    repository = Path(repository_root)
+    dataset = Path(dataset_root)
+    _require(repository.is_dir(), "repository root must exist")
+    if not dataset.exists():
+        return _scaffold_decision(repository, dataset)
+    _require(not dataset.is_symlink(), "dataset root must not be a symlink")
+    _require(dataset.is_dir(), "dataset root must be a directory")
+    if not any(dataset.iterdir()):
+        return _scaffold_decision(repository, dataset)
+    readiness = build_preacquisition_readiness(
+        repository, dataset, verify_file_hashes=verify_file_hashes
+    )
+    source = build_source_panel_status(
+        repository, dataset, verify_file_hashes=verify_file_hashes
+    )
+    return derive_preacquisition_next_action(
+        readiness,
+        source,
+        repository_root=repository,
+        dataset_root=dataset,
+    )
+
+
+def render_preacquisition_next_action_markdown(
+    decision: Mapping[str, Any],
+) -> str:
+    """Render a deterministic operator report from one decision."""
+
+    action = decision["action"]
+    lines = [
+        "# Causal4D pre-acquisition next action",
+        "",
+        f"- Protocol: `{decision['protocol_id']}`",
+        f"- Valid: `{str(decision['valid']).lower()}`",
+        f"- Ready: `{str(decision['ready']).lower()}`",
+        "- Target outcomes permitted: `false`",
+        "",
+        f"## {action['title']}",
+        "",
+        f"- Action ID: `{action['action_id']}`",
+        f"- Operator role: `{action['operator_role']}`",
+        "- Physical acquisition required: "
+        f"`{str(action['physical_acquisition_required']).lower()}`",
+    ]
+    for heading, field in (
+        ("Command", "command_text"),
+        ("Publish after completion", "after_completion_text"),
+        ("Completion check", "completion_check_text"),
+    ):
+        if action.get(field):
+            lines += ["", f"### {heading}", "", "```bash", str(action[field]), "```"]
+    if action.get("blocking_items"):
+        lines += ["", "### Blocking items", ""]
+        lines += [f"- `{item}`" for item in action["blocking_items"]]
+    execution = action.get("registered_execution")
+    if isinstance(execution, Mapping):
+        lines += [
+            "",
+            "### Registered source execution",
+            "",
+            f"- Execution: `{execution['execution_id']}`",
+            f"- Session: `{execution['session_id']}`",
+            f"- Command profile: `{execution['command_profile_id']}`",
+        ]
+    lines += [
+        "",
+        "---",
+        "",
+        f"Evidence SHA-256: `{decision['evidence_sha256']}`  ",
+        f"Host-local status SHA-256: `{decision['status_sha256']}`",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def write_preacquisition_next_action(
+    path: str | Path,
+    decision: Mapping[str, Any],
+) -> Path:
+    """Atomically write one machine-readable operator decision."""
+
+    output = Path(path)
+    atomic_write_json(output, dict(decision))
+    return output
+
+
+def write_preacquisition_next_action_markdown(
+    path: str | Path,
+    decision: Mapping[str, Any],
+) -> Path:
+    """Atomically write one human-readable operator decision."""
+
+    output = Path(path)
+    atomic_write_text(output, render_preacquisition_next_action_markdown(decision))
+    return output
+
+
+__all__ = [
+    "NEXT_ACTION_ARTIFACT_KIND",
+    "NEXT_ACTION_SCHEMA_VERSION",
+    "build_preacquisition_next_action",
+    "derive_preacquisition_next_action",
+    "next_action_evidence_sha256",
+    "next_action_status_sha256",
+    "render_preacquisition_next_action_markdown",
+    "write_preacquisition_next_action",
+    "write_preacquisition_next_action_markdown",
+]

--- a/src/causal4d/preacquisition_operator_flow.py
+++ b/src/causal4d/preacquisition_operator_flow.py
@@ -1,0 +1,271 @@
+"""Operator sequencing for pre-acquisition next-action decisions."""
+
+from __future__ import annotations
+
+import shlex
+from collections.abc import Mapping
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from causal4d.atomic_io import atomic_write_json, atomic_write_text
+from causal4d.preacquisition_next_action import (
+    build_preacquisition_next_action as _build_next_action,
+    derive_preacquisition_next_action as _derive_next_action,
+    next_action_evidence_sha256,
+    next_action_status_sha256,
+)
+
+OPERATOR_FLOW_SCHEMA_VERSION = 1
+NEXT_ACTION_SCHEMA_VERSION = 2
+
+
+def _command_pair(argv: list[str]) -> tuple[list[str], str]:
+    return argv, shlex.join(argv)
+
+
+def _expected_publication_command(
+    repository_root: str,
+    dataset_root: str,
+    staging_path: str,
+) -> list[str]:
+    return [
+        "causal4d",
+        "protocol",
+        "readiness",
+        "source-panel-publish",
+        repository_root,
+        dataset_root,
+        staging_path,
+    ]
+
+
+def enrich_preacquisition_next_action(
+    decision: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Insert the staged preflight before claim-bearing source publication."""
+
+    result = deepcopy(dict(decision))
+    action_value = result.get("action")
+    if not isinstance(action_value, Mapping):
+        raise ValueError("next-action decision has no action object")
+    action = deepcopy(dict(action_value))
+    result["schema_version"] = NEXT_ACTION_SCHEMA_VERSION
+    result["operator_flow_schema_version"] = OPERATOR_FLOW_SCHEMA_VERSION
+
+    if action.get("action_id") == "acquire_next_source_panel_execution":
+        repository = result.get("repository_root")
+        dataset = result.get("dataset_root")
+        execution = action.get("registered_execution")
+        if not isinstance(repository, str) or not repository:
+            raise ValueError("next-action repository root is missing")
+        if not isinstance(dataset, str) or not dataset:
+            raise ValueError("next-action dataset root is missing")
+        if not isinstance(execution, Mapping):
+            raise ValueError("registered source execution is missing")
+        execution_id = execution.get("execution_id")
+        if not isinstance(execution_id, str) or not execution_id:
+            raise ValueError("registered source execution id is missing")
+
+        root = Path(dataset)
+        staging = str(root / "staging" / f"{execution_id}.json")
+        preflight = str(root / "operator" / f"{execution_id}-preflight.json")
+        expected_publication = _expected_publication_command(
+            repository,
+            dataset,
+            staging,
+        )
+        legacy_publication = action.get("after_completion_argv")
+        if legacy_publication != expected_publication:
+            raise ValueError(
+                "source action publication command differs from the registered path"
+            )
+
+        verification_argv, verification_text = _command_pair(
+            [
+                "causal4d",
+                "protocol",
+                "readiness",
+                "source-panel-verify-staged",
+                repository,
+                dataset,
+                staging,
+                "--output-json",
+                preflight,
+            ]
+        )
+        publication_argv, publication_text = _command_pair(expected_publication)
+        action["after_completion_argv"] = None
+        action["after_completion_text"] = None
+        action["post_acquisition_verification_argv"] = verification_argv
+        action["post_acquisition_verification_text"] = verification_text
+        action["preflight_report_path"] = preflight
+        action["independent_review_required_before_publication"] = True
+        action["claim_bearing_publication_argv"] = publication_argv
+        action["claim_bearing_publication_text"] = publication_text
+        action["operator_sequence"] = [
+            "acquire_registered_source_execution",
+            "verify_staged_manifest_and_artifacts",
+            "independent_review_of_preflight_report",
+            "publish_exactly_once",
+            "recompute_next_action",
+        ]
+        outputs = list(action.get("output_paths", []))
+        if preflight not in outputs:
+            outputs.insert(1 if outputs else 0, preflight)
+        action["output_paths"] = outputs
+    else:
+        action.setdefault("post_acquisition_verification_argv", None)
+        action.setdefault("post_acquisition_verification_text", None)
+        action.setdefault("preflight_report_path", None)
+        action.setdefault("independent_review_required_before_publication", False)
+        action.setdefault("claim_bearing_publication_argv", None)
+        action.setdefault("claim_bearing_publication_text", None)
+        action.setdefault("operator_sequence", [])
+
+    result["action"] = action
+    result.pop("evidence_sha256", None)
+    result.pop("status_sha256", None)
+    result["evidence_sha256"] = next_action_evidence_sha256(result)
+    result["status_sha256"] = next_action_status_sha256(result)
+    return result
+
+
+def build_preacquisition_operator_next_action(
+    repository_root: str | Path,
+    dataset_root: str | Path,
+    *,
+    verify_file_hashes: bool = True,
+) -> dict[str, Any]:
+    """Build one decision with explicit verification and publication stages."""
+
+    return enrich_preacquisition_next_action(
+        _build_next_action(
+            repository_root,
+            dataset_root,
+            verify_file_hashes=verify_file_hashes,
+        )
+    )
+
+
+def derive_preacquisition_operator_next_action(
+    readiness: Mapping[str, Any],
+    source_panel: Mapping[str, Any],
+    *,
+    repository_root: str | Path,
+    dataset_root: str | Path,
+) -> dict[str, Any]:
+    """Derive an operator-sequenced decision from validated status snapshots."""
+
+    return enrich_preacquisition_next_action(
+        _derive_next_action(
+            readiness,
+            source_panel,
+            repository_root=repository_root,
+            dataset_root=dataset_root,
+        )
+    )
+
+
+def render_preacquisition_operator_next_action_markdown(
+    decision: Mapping[str, Any],
+) -> str:
+    """Render the explicit operator sequence without collapsing publication."""
+
+    action = decision.get("action")
+    if not isinstance(action, Mapping):
+        raise ValueError("next-action decision has no action object")
+    lines = [
+        "# Causal4D pre-acquisition next action",
+        "",
+        f"- Protocol: `{decision['protocol_id']}`",
+        f"- Valid: `{str(decision['valid']).lower()}`",
+        f"- Ready: `{str(decision['ready']).lower()}`",
+        "- Target outcomes permitted: `false`",
+        "",
+        f"## {action['title']}",
+        "",
+        f"- Action ID: `{action['action_id']}`",
+        f"- Operator role: `{action['operator_role']}`",
+        "- Physical acquisition required: "
+        f"`{str(action['physical_acquisition_required']).lower()}`",
+    ]
+    sections = (
+        ("Command", "command_text"),
+        ("Verify staged evidence", "post_acquisition_verification_text"),
+        (
+            "Publish after independent review",
+            "claim_bearing_publication_text",
+        ),
+        ("Completion check", "completion_check_text"),
+    )
+    for heading, field in sections:
+        value = action.get(field)
+        if value:
+            lines += ["", f"### {heading}", "", "```bash", str(value), "```"]
+    if action.get("independent_review_required_before_publication") is True:
+        lines += [
+            "",
+            "Publication is claim-bearing and requires independent review of the ",
+            "content-addressed preflight report before the publication command is run.",
+        ]
+    blockers = action.get("blocking_items")
+    if isinstance(blockers, list) and blockers:
+        lines += ["", "### Blocking items", ""]
+        lines += [f"- `{item}`" for item in blockers]
+    execution = action.get("registered_execution")
+    if isinstance(execution, Mapping):
+        lines += [
+            "",
+            "### Registered source execution",
+            "",
+            f"- Execution: `{execution['execution_id']}`",
+            f"- Session: `{execution['session_id']}`",
+            f"- Command profile: `{execution['command_profile_id']}`",
+        ]
+    lines += [
+        "",
+        "---",
+        "",
+        f"Evidence SHA-256: `{decision['evidence_sha256']}`  ",
+        f"Host-local status SHA-256: `{decision['status_sha256']}`",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def write_preacquisition_operator_next_action(
+    path: str | Path,
+    decision: Mapping[str, Any],
+) -> Path:
+    """Atomically write one operator-sequenced JSON decision."""
+
+    output = Path(path)
+    atomic_write_json(output, dict(decision))
+    return output
+
+
+def write_preacquisition_operator_next_action_markdown(
+    path: str | Path,
+    decision: Mapping[str, Any],
+) -> Path:
+    """Atomically write one operator-sequenced Markdown report."""
+
+    output = Path(path)
+    atomic_write_text(
+        output,
+        render_preacquisition_operator_next_action_markdown(decision),
+    )
+    return output
+
+
+__all__ = [
+    "NEXT_ACTION_SCHEMA_VERSION",
+    "OPERATOR_FLOW_SCHEMA_VERSION",
+    "build_preacquisition_operator_next_action",
+    "derive_preacquisition_operator_next_action",
+    "enrich_preacquisition_next_action",
+    "render_preacquisition_operator_next_action_markdown",
+    "write_preacquisition_operator_next_action",
+    "write_preacquisition_operator_next_action_markdown",
+]

--- a/src/causal4d/preacquisition_source_panel_staging.py
+++ b/src/causal4d/preacquisition_source_panel_staging.py
@@ -1,0 +1,329 @@
+"""Read-only preflight validation for a staged physical source manifest."""
+
+from __future__ import annotations
+
+import shlex
+from collections.abc import Mapping
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from causal4d.acquisition_flight_common import (
+    _assert_no_symlink_components,
+    _assert_ordinary_file_or_missing,
+    _reject_target_outcomes,
+    _require,
+)
+from causal4d.atomic_io import atomic_write_json
+from causal4d.preacquisition_readiness_contracts import (
+    SOURCE_PANEL_MANIFEST_PATH,
+    _canonical_sha256,
+    _read_json_mapping,
+    _resolved_dataset_file,
+    _safe_relative_path,
+    _sha256_file,
+    load_registered_preacquisition_chain,
+    source_panel_execution_manifest_template,
+)
+from causal4d.preacquisition_source_panel_control import build_source_panel_status
+from causal4d.preacquisition_source_validation import (
+    _validate_source_execution_manifest,
+)
+
+SOURCE_PANEL_STAGING_PREFLIGHT_SCHEMA_VERSION = 1
+SOURCE_PANEL_STAGING_PREFLIGHT_ARTIFACT_KIND = "Causal4DSourcePanelStagingPreflight"
+
+
+def source_panel_staging_evidence_sha256(values: Mapping[str, Any]) -> str:
+    """Return a mount-independent digest of one staging preflight result."""
+
+    payload = deepcopy(dict(values))
+    for field in (
+        "repository_root",
+        "dataset_root",
+        "source_json",
+        "source_panel_status_sha256_before",
+        "evidence_sha256",
+        "status_sha256",
+    ):
+        payload.pop(field, None)
+    command = payload.get("publication_command_argv")
+    if isinstance(command, list) and len(command) == 7:
+        normalized_command = list(command)
+        normalized_command[4] = "${REPOSITORY_ROOT}"
+        normalized_command[5] = "${DATASET_ROOT}"
+        normalized_command[6] = "${DATASET_ROOT}/" + str(
+            values["source_manifest_relative_path"]
+        )
+        payload["publication_command_argv"] = normalized_command
+    payload.pop("publication_command_text", None)
+    return _canonical_sha256(payload, omitted_field="evidence_sha256")
+
+
+def source_panel_staging_status_sha256(values: Mapping[str, Any]) -> str:
+    """Return the digest of the exact host-local staging preflight result."""
+
+    return _canonical_sha256(values, omitted_field="status_sha256")
+
+
+def _resolved_dataset_root(dataset_root: str | Path) -> Path:
+    candidate = Path(dataset_root)
+    _assert_no_symlink_components(candidate, name="dataset root")
+    _require(candidate.is_dir(), "dataset root must exist")
+    return candidate.resolve()
+
+
+def _resolved_staging_file(
+    dataset_root: Path,
+    source_json: str | Path,
+    *,
+    execution_id: str,
+) -> tuple[Path, str]:
+    source = Path(source_json)
+    _assert_no_symlink_components(source, name="source-panel staging manifest")
+    _require(source.is_file(), "source-panel staging manifest is missing")
+    resolved = source.resolve(strict=True)
+    try:
+        relative = resolved.relative_to(dataset_root)
+    except ValueError as error:
+        raise ValueError(
+            "source-panel staging manifest must be directly below dataset_root/staging"
+        ) from error
+    _require(
+        relative.parent == Path("staging"),
+        "source-panel staging manifest must be directly below dataset_root/staging",
+    )
+    _require(
+        relative.name == f"{execution_id}.json",
+        "source-panel staging filename must match the next execution id",
+    )
+    staging_root = dataset_root / "staging"
+    _assert_no_symlink_components(staging_root, name="source-panel staging directory")
+    _require(staging_root.is_dir(), "source-panel staging directory is missing")
+    return resolved, relative.as_posix()
+
+
+def _artifact_snapshot(
+    dataset_root: Path,
+    artifacts: Any,
+    *,
+    verify_declared: bool,
+) -> list[dict[str, Any]]:
+    _require(isinstance(artifacts, list), "source execution artifacts are invalid")
+    snapshots: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, descriptor in enumerate(artifacts):
+        _require(
+            isinstance(descriptor, Mapping),
+            f"source execution artifact {index} is invalid",
+        )
+        relative = _safe_relative_path(
+            descriptor.get("path"),
+            name=f"source execution artifact {index}",
+        )
+        relative_text = relative.as_posix()
+        _require(
+            relative_text not in seen,
+            f"source execution artifacts contain a duplicate path: {relative_text}",
+        )
+        path = _resolved_dataset_file(
+            dataset_root,
+            relative,
+            name=f"source execution artifact {index}",
+        )
+        digest, byte_count = _sha256_file(path)
+        if verify_declared:
+            _require(
+                descriptor.get("sha256") == digest,
+                f"source execution artifact {index} checksum mismatch",
+            )
+            declared_bytes = descriptor.get("bytes")
+            _require(
+                type(declared_bytes) is int and declared_bytes == byte_count,
+                f"source execution artifact {index} byte count mismatch",
+            )
+        seen.add(relative_text)
+        snapshots.append(
+            {
+                "path": relative_text,
+                "sha256": digest,
+                "bytes": byte_count,
+            }
+        )
+    _require(bool(snapshots), "source execution artifacts must be nonempty")
+    return snapshots
+
+
+def verify_source_panel_manifest_staging(
+    repository_root: str | Path,
+    dataset_root: str | Path,
+    source_json: str | Path,
+) -> dict[str, Any]:
+    """Hash-verify exactly the next staged source manifest without publication."""
+
+    protocol, _, _, v4 = load_registered_preacquisition_chain(repository_root)
+    root = _resolved_dataset_root(dataset_root)
+    status_before = build_source_panel_status(
+        repository_root,
+        root,
+        verify_file_hashes=True,
+    )
+    _require(status_before["valid"] is True, "source-panel status is invalid")
+    _require(status_before["complete"] is False, "source panel is already complete")
+    next_execution = status_before.get("next_execution")
+    _require(isinstance(next_execution, Mapping), "source panel has no next execution")
+    _require(
+        next_execution.get("template_present") is True
+        and next_execution.get("template_valid") is True,
+        "next source-panel manifest template is missing or invalid",
+    )
+
+    execution_id = str(next_execution["execution_id"])
+    session_id = str(next_execution["session_id"])
+    source, source_relative = _resolved_staging_file(
+        root,
+        source_json,
+        execution_id=execution_id,
+    )
+    source_digest_before, source_bytes_before = _sha256_file(source)
+    payload = _read_json_mapping(source, name="source-panel staging manifest")
+    _reject_target_outcomes(payload)
+    expected_template = source_panel_execution_manifest_template(
+        next_execution,
+        protocol,
+        v4,
+    )
+    _require(
+        set(payload) == set(expected_template),
+        "source-panel manifest fields differ from schema version 1",
+    )
+    _require(
+        payload.get("execution_id") == execution_id,
+        "source-panel manifest is not the next registered execution",
+    )
+    _require(
+        payload.get("session_id") == session_id,
+        "source-panel manifest names the wrong session",
+    )
+    artifacts_before = _artifact_snapshot(
+        root,
+        payload.get("artifacts"),
+        verify_declared=True,
+    )
+    _validate_source_execution_manifest(
+        root,
+        source_relative,
+        protocol=protocol,
+        v4=v4,
+        execution_id=execution_id,
+        session_id=session_id,
+        verify_file_hashes=True,
+    )
+    source_digest, source_bytes = _sha256_file(source)
+    _require(
+        (source_digest, source_bytes) == (source_digest_before, source_bytes_before),
+        "source-panel staging manifest changed during validation",
+    )
+    artifacts_after = _artifact_snapshot(
+        root,
+        payload.get("artifacts"),
+        verify_declared=False,
+    )
+    _require(
+        artifacts_after == artifacts_before,
+        "source-panel artifacts changed during validation",
+    )
+
+    final_relative = SOURCE_PANEL_MANIFEST_PATH.format(execution_id=execution_id)
+    final_path = root / final_relative
+    _assert_ordinary_file_or_missing(final_path, name="source-panel manifest")
+    _require(not final_path.exists(), "source-panel manifest already exists")
+
+    status_after = build_source_panel_status(
+        repository_root,
+        root,
+        verify_file_hashes=True,
+    )
+    _require(
+        status_after["status_sha256"] == status_before["status_sha256"],
+        "source-panel status changed during staged preflight",
+    )
+    _require(
+        not final_path.exists(),
+        "staged preflight unexpectedly created the final source manifest",
+    )
+
+    repository = str(Path(repository_root).resolve())
+    publication_command = [
+        "causal4d",
+        "protocol",
+        "readiness",
+        "source-panel-publish",
+        repository,
+        str(root),
+        str(source),
+    ]
+    result: dict[str, Any] = {
+        "schema_version": SOURCE_PANEL_STAGING_PREFLIGHT_SCHEMA_VERSION,
+        "artifact_kind": SOURCE_PANEL_STAGING_PREFLIGHT_ARTIFACT_KIND,
+        "protocol_id": protocol["protocol_id"],
+        "protocol_design_sha256": protocol["design_sha256"],
+        "preacquisition_plan_id": v4["plan_id"],
+        "preacquisition_amendment_sha256": v4["amendment_sha256"],
+        "repository_root": repository,
+        "dataset_root": str(root),
+        "source_json": str(source),
+        "source_manifest_relative_path": source_relative,
+        "source_manifest_sha256": source_digest,
+        "source_manifest_bytes": source_bytes,
+        "execution_id": execution_id,
+        "session_id": session_id,
+        "source_panel_execution_index": next_execution["source_panel_execution_index"],
+        "command_profile_id": next_execution["command_profile_id"],
+        "artifact_count": len(artifacts_after),
+        "artifacts": artifacts_after,
+        "final_manifest_path": final_relative,
+        "final_manifest_present": False,
+        "specified_executions": status_before["specified_executions"],
+        "validated_executions_before": status_before["validated_executions"],
+        "validated_executions_after_publication": (
+            status_before["validated_executions"] + 1
+        ),
+        "source_panel_evidence_sha256_before": status_before["evidence_sha256"],
+        "source_panel_status_sha256_before": status_before["status_sha256"],
+        "source_panel_status_stable": True,
+        "publication_command_argv": publication_command,
+        "publication_command_text": shlex.join(publication_command),
+        "safe_to_publish": True,
+        "published": False,
+        "claim_bearing_evidence_mutated": False,
+        "changes_registered_method": False,
+        "valid": True,
+        "complete": True,
+        "passed": True,
+        "target_outcomes_used": False,
+    }
+    result["evidence_sha256"] = source_panel_staging_evidence_sha256(result)
+    result["status_sha256"] = source_panel_staging_status_sha256(result)
+    return result
+
+
+def write_source_panel_staging_preflight(
+    path: str | Path,
+    result: Mapping[str, Any],
+) -> Path:
+    """Atomically replace one derived staging-preflight report."""
+
+    output = Path(path)
+    atomic_write_json(output, dict(result))
+    return output
+
+
+__all__ = [
+    "SOURCE_PANEL_STAGING_PREFLIGHT_ARTIFACT_KIND",
+    "SOURCE_PANEL_STAGING_PREFLIGHT_SCHEMA_VERSION",
+    "source_panel_staging_evidence_sha256",
+    "source_panel_staging_status_sha256",
+    "verify_source_panel_manifest_staging",
+    "write_source_panel_staging_preflight",
+]

--- a/tests/test_preacquisition_next_action.py
+++ b/tests/test_preacquisition_next_action.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+from causal4d.cli import preacquisition_readiness as readiness_cli
+from causal4d.preacquisition_next_action import (
+    derive_preacquisition_next_action,
+    next_action_evidence_sha256,
+    render_preacquisition_next_action_markdown,
+)
+
+
+def _prerequisite(*, present: bool = True, valid: bool = True, template=False):
+    return {
+        "present": present,
+        "valid": valid,
+        "template": template,
+        "error": None if valid else "invalid",
+    }
+
+
+def _gate(*, present: bool = True, valid: bool = True, template=False):
+    return {
+        "present": present,
+        "valid": valid,
+        "template": template,
+        "identity_pending": False,
+        "error": None if valid else "invalid",
+    }
+
+
+def _readiness() -> dict:
+    prerequisites = {
+        name: _prerequisite()
+        for name in (
+            "dataset_protocol",
+            "acquisition_schedule",
+            "object_registration",
+            "slip_pilot",
+            "timebase_calibration",
+            "contact_registration",
+            "operator_registry",
+            "operator_identity_bindings",
+            "method_freeze",
+            "method_freeze_validation",
+        )
+    }
+    gates = {
+        name: _gate()
+        for name in (
+            "signature_panel_complete",
+            "actuator_sync_passed",
+            "support_registration_passed",
+            "end_to_end_dry_run_passed",
+            "software_environment_locked",
+        )
+    }
+    return {
+        "schema_version": 2,
+        "artifact_kind": "PreacquisitionReadinessStatus",
+        "protocol_id": "protocol",
+        "protocol_design_sha256": "a" * 64,
+        "preacquisition_plan_id": "plan",
+        "preacquisition_amendment_sha256": "b" * 64,
+        "dataset_root": "/data/run",
+        "verify_file_hashes": True,
+        "prerequisites": prerequisites,
+        "operational_gates": gates,
+        "missing_prerequisites": [],
+        "malformed_prerequisites": [],
+        "missing_or_template_gates": [],
+        "malformed_gates": [],
+        "chronology_blockers": [],
+        "blockers": [],
+        "confirmatory_collection": {
+            "manifest_executions": 0,
+            "acquired_executions": 0,
+            "validated_executions": 0,
+            "not_started": True,
+        },
+        "evidence_sha256": "c" * 64,
+        "status_sha256": "d" * 64,
+        "valid": True,
+        "ready": False,
+    }
+
+
+def _source_panel(*, complete: bool = True) -> dict:
+    return {
+        "schema_version": 1,
+        "artifact_kind": "Causal4DSourcePanelStatus",
+        "protocol_id": "protocol",
+        "protocol_design_sha256": "a" * 64,
+        "preacquisition_plan_id": "plan",
+        "preacquisition_amendment_sha256": "b" * 64,
+        "dataset_root": "/data/run",
+        "verify_file_hashes": True,
+        "specified_executions": 12,
+        "validated_executions": 12 if complete else 0,
+        "missing_template_ids": [],
+        "blockers": [],
+        "next_execution": None,
+        "evidence_sha256": "e" * 64,
+        "status_sha256": "f" * 64,
+        "valid": True,
+        "complete": complete,
+        "target_outcomes_used": False,
+    }
+
+
+def _derive(readiness: dict, source_panel: dict) -> dict:
+    return derive_preacquisition_next_action(
+        readiness,
+        source_panel,
+        repository_root="/repo",
+        dataset_root="/data/run",
+    )
+
+
+def test_missing_preacquisition_scaffold_is_the_only_action() -> None:
+    readiness = _readiness()
+    for gate in readiness["operational_gates"].values():
+        gate.update(present=False, valid=False)
+    source = _source_panel(complete=False)
+    source["valid"] = False
+    source["missing_template_ids"] = [f"source-{index}" for index in range(12)]
+
+    decision = _derive(readiness, source)
+
+    assert decision["valid"] is True
+    assert decision["action"]["action_id"] == "scaffold_preacquisition_evidence"
+    assert decision["action"]["automatable"] is True
+    assert "readiness scaffold" in decision["action"]["command_text"]
+
+
+def test_missing_operator_registry_precedes_physical_work() -> None:
+    readiness = _readiness()
+    readiness["prerequisites"]["operator_registry"] = _prerequisite(
+        present=False, valid=False
+    )
+    readiness["missing_prerequisites"] = ["operator_registry"]
+
+    decision = _derive(readiness, _source_panel())
+
+    assert decision["action"]["action_id"] == "scaffold_operator_registry"
+    assert decision["action"]["physical_acquisition_required"] is False
+
+
+def test_malformed_evidence_precedes_missing_operator_registry() -> None:
+    readiness = _readiness()
+    readiness["prerequisites"]["operator_registry"] = _prerequisite(
+        present=False, valid=False
+    )
+    readiness["missing_prerequisites"] = ["operator_registry"]
+    readiness["valid"] = False
+    readiness["malformed_gates"] = ["actuator_sync_passed"]
+    readiness["blockers"] = ["gate_invalid:actuator_sync_passed"]
+
+    decision = _derive(readiness, _source_panel())
+
+    assert decision["valid"] is False
+    assert decision["action"]["action_id"] == "stop_and_repair_invalid_evidence"
+    assert decision["action"]["blocking_items"] == ["gate_invalid:actuator_sync_passed"]
+
+
+def test_manual_prerequisite_names_exact_paths() -> None:
+    readiness = _readiness()
+    readiness["prerequisites"]["object_registration"] = _prerequisite(
+        present=False, valid=False
+    )
+    readiness["missing_prerequisites"] = ["object_registration"]
+
+    decision = _derive(readiness, _source_panel())
+
+    action = decision["action"]
+    assert action["action_id"] == "complete_object_registration"
+    assert action["command_argv"] is None
+    assert action["output_paths"] == ["/data/run/object_registration.json"]
+    assert "protocol real status" in action["completion_check_text"]
+
+
+def test_source_panel_action_binds_exact_registered_execution() -> None:
+    readiness = _readiness()
+    source = _source_panel(complete=False)
+    source["next_execution"] = {
+        "execution_id": "source-03",
+        "session_id": "session-03",
+        "command_profile_id": "lift-high",
+        "template_path": (
+            "preacquisition/source_panel/executions/source-03/manifest.template.json"
+        ),
+        "manifest_path": (
+            "preacquisition/source_panel/executions/source-03/manifest.json"
+        ),
+        "profile": {"id": "lift-high", "speed": "high"},
+    }
+
+    decision = _derive(readiness, source)
+
+    action = decision["action"]
+    assert action["action_id"] == "acquire_next_source_panel_execution"
+    assert action["physical_acquisition_required"] is True
+    assert action["registered_execution"]["execution_id"] == "source-03"
+    assert action["after_completion_argv"][-1] == "/data/run/staging/source-03.json"
+
+
+def test_freeze_attestation_and_software_gate_are_strictly_ordered() -> None:
+    readiness = _readiness()
+    readiness["prerequisites"]["method_freeze"] = _prerequisite(
+        present=False, valid=False
+    )
+    readiness["missing_prerequisites"] = ["method_freeze"]
+    decision = _derive(readiness, _source_panel())
+    assert decision["action"]["action_id"] == "seal_method_freeze"
+
+    readiness = _readiness()
+    readiness["prerequisites"]["method_freeze_validation"] = _prerequisite(
+        present=False, valid=False
+    )
+    readiness["missing_prerequisites"] = ["method_freeze_validation"]
+    decision = _derive(readiness, _source_panel())
+    assert decision["action"]["action_id"] == "attest_method_freeze"
+
+    readiness = _readiness()
+    readiness["operational_gates"]["software_environment_locked"] = _gate(
+        template=True, valid=False
+    )
+    readiness["missing_or_template_gates"] = ["software_environment_locked"]
+    decision = _derive(readiness, _source_panel())
+    assert decision["action"]["action_id"] == (
+        "complete_and_seal_software_environment_locked"
+    )
+
+
+def test_invalid_evidence_never_suggests_an_automatic_repair() -> None:
+    readiness = _readiness()
+    readiness["valid"] = False
+    readiness["malformed_gates"] = ["actuator_sync_passed"]
+    readiness["blockers"] = ["gate_invalid:actuator_sync_passed"]
+
+    decision = _derive(readiness, _source_panel())
+
+    action = decision["action"]
+    assert decision["valid"] is False
+    assert action["action_id"] == "stop_and_repair_invalid_evidence"
+    assert action["automatable"] is False
+    assert action["target_outcomes_permitted"] is False
+
+
+def test_ready_state_authorizes_only_locked_order() -> None:
+    readiness = _readiness()
+    readiness["ready"] = True
+
+    decision = _derive(readiness, _source_panel())
+
+    action = decision["action"]
+    assert decision["ready"] is True
+    assert action["action_id"] == "begin_first_confirmatory_session"
+    assert "freeze validate" in action["command_text"]
+    assert action["physical_acquisition_required"] is True
+
+
+def test_portable_evidence_hash_ignores_mount_points() -> None:
+    first = _derive(_readiness(), _source_panel())
+    second = deepcopy(first)
+    second["repository_root"] = "/different/repo"
+    second["dataset_root"] = "/different/data"
+    for field in ("command_argv", "completion_check_argv", "after_completion_argv"):
+        argv = second["action"].get(field)
+        if argv:
+            second["action"][field] = [
+                value.replace("/repo", "/different/repo").replace(
+                    "/data/run", "/different/data"
+                )
+                for value in argv
+            ]
+    for field in ("command_text", "completion_check_text", "after_completion_text"):
+        value = second["action"].get(field)
+        if value:
+            second["action"][field] = value.replace("/repo", "/different/repo").replace(
+                "/data/run", "/different/data"
+            )
+    second.pop("evidence_sha256")
+    second.pop("status_sha256")
+
+    assert next_action_evidence_sha256(first) == next_action_evidence_sha256(second)
+
+
+def test_markdown_contains_action_and_content_id() -> None:
+    decision = _derive(_readiness(), _source_panel())
+
+    markdown = render_preacquisition_next_action_markdown(decision)
+
+    assert "# Causal4D pre-acquisition next action" in markdown
+    assert decision["action"]["action_id"] in markdown
+    assert decision["evidence_sha256"] in markdown
+    assert "Target outcomes permitted: `false`" in markdown
+
+
+def test_cli_parser_exposes_hash_verified_next_action_by_default() -> None:
+    args = readiness_cli.build_parser().parse_args(
+        ["next-action", "/repo", "/data/run"]
+    )
+
+    assert args.command == "next-action"
+    assert args.skip_file_hashes is False
+
+
+def test_cli_returns_incomplete_exit_code_and_writes_reports(
+    monkeypatch, tmp_path: Path
+) -> None:
+    decision = _derive(_readiness(), _source_panel())
+    written: list[tuple[str, Path]] = []
+    monkeypatch.setattr(
+        readiness_cli,
+        "build_preacquisition_next_action",
+        lambda *args, **kwargs: decision,
+    )
+    monkeypatch.setattr(
+        readiness_cli,
+        "write_preacquisition_next_action",
+        lambda path, value: written.append(("json", Path(path))) or Path(path),
+    )
+    monkeypatch.setattr(
+        readiness_cli,
+        "write_preacquisition_next_action_markdown",
+        lambda path, value: written.append(("markdown", Path(path))) or Path(path),
+    )
+    output_json = tmp_path / "next-action.json"
+    output_markdown = tmp_path / "next-action.md"
+
+    exit_code = readiness_cli.main(
+        [
+            "next-action",
+            "/repo",
+            "/data/run",
+            "--output-json",
+            str(output_json),
+            "--output-markdown",
+            str(output_markdown),
+        ]
+    )
+
+    assert exit_code == 3
+    assert written == [("json", output_json), ("markdown", output_markdown)]

--- a/tests/test_preacquisition_operator_flow.py
+++ b/tests/test_preacquisition_operator_flow.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+import causal4d.preacquisition_operator_flow as operator_flow
+from causal4d.preacquisition_next_action import (
+    next_action_evidence_sha256,
+    next_action_status_sha256,
+)
+
+
+def _source_decision() -> dict:
+    repository = "/opt/causal4d-frozen"
+    dataset = "/data/causal4d"
+    execution_id = "source-lift_high-r1"
+    staging = f"{dataset}/staging/{execution_id}.json"
+    publication = [
+        "causal4d",
+        "protocol",
+        "readiness",
+        "source-panel-publish",
+        repository,
+        dataset,
+        staging,
+    ]
+    decision = {
+        "schema_version": 1,
+        "artifact_kind": "Causal4DPreacquisitionNextAction",
+        "protocol_id": "protocol",
+        "protocol_design_sha256": "a" * 64,
+        "preacquisition_plan_id": "plan",
+        "preacquisition_amendment_sha256": "b" * 64,
+        "repository_root": repository,
+        "dataset_root": dataset,
+        "readiness_evidence_sha256": "c" * 64,
+        "readiness_status_sha256": "d" * 64,
+        "source_panel_evidence_sha256": "e" * 64,
+        "source_panel_status_sha256": "f" * 64,
+        "readiness_valid": True,
+        "source_panel_valid": True,
+        "ready": False,
+        "complete": False,
+        "passed": False,
+        "valid": True,
+        "target_outcomes_used": False,
+        "action": {
+            "action_id": "acquire_next_source_panel_execution",
+            "category": "physical_source_execution",
+            "title": f"Acquire registered source execution {execution_id}",
+            "operator_role": "acquisition_operator",
+            "physical_acquisition_required": True,
+            "automatable": False,
+            "changes_registered_method": False,
+            "target_outcomes_permitted": False,
+            "command_argv": [
+                "causal4d",
+                "protocol",
+                "readiness",
+                "source-panel-status",
+                repository,
+                dataset,
+                "--verify-file-hashes",
+            ],
+            "command_text": (
+                "causal4d protocol readiness source-panel-status "
+                f"{repository} {dataset} --verify-file-hashes"
+            ),
+            "completion_check_argv": [
+                "causal4d",
+                "protocol",
+                "readiness",
+                "next-action",
+                repository,
+                dataset,
+            ],
+            "completion_check_text": (
+                f"causal4d protocol readiness next-action {repository} {dataset}"
+            ),
+            "after_completion_argv": publication,
+            "after_completion_text": " ".join(publication),
+            "input_paths": [f"{dataset}/template.json"],
+            "output_paths": [staging, f"{dataset}/final.json"],
+            "blocking_items": [],
+            "registered_execution": {
+                "execution_id": execution_id,
+                "session_id": execution_id,
+                "command_profile_id": "lift_high",
+            },
+        },
+    }
+    decision["evidence_sha256"] = next_action_evidence_sha256(decision)
+    decision["status_sha256"] = next_action_status_sha256(decision)
+    return decision
+
+
+def test_source_action_inserts_preflight_and_independent_review() -> None:
+    result = operator_flow.enrich_preacquisition_next_action(_source_decision())
+
+    action = result["action"]
+    assert result["schema_version"] == 2
+    assert result["operator_flow_schema_version"] == 1
+    assert action["after_completion_argv"] is None
+    assert action["after_completion_text"] is None
+    assert action["post_acquisition_verification_argv"][3] == (
+        "source-panel-verify-staged"
+    )
+    assert action["post_acquisition_verification_argv"][-2] == "--output-json"
+    assert action["preflight_report_path"].endswith(
+        "source-lift_high-r1-preflight.json"
+    )
+    assert action["independent_review_required_before_publication"] is True
+    assert action["claim_bearing_publication_argv"][3] == "source-panel-publish"
+    assert action["operator_sequence"] == [
+        "acquire_registered_source_execution",
+        "verify_staged_manifest_and_artifacts",
+        "independent_review_of_preflight_report",
+        "publish_exactly_once",
+        "recompute_next_action",
+    ]
+    assert action["preflight_report_path"] in action["output_paths"]
+    assert result["evidence_sha256"] == next_action_evidence_sha256(result)
+    assert result["status_sha256"] == next_action_status_sha256(result)
+
+
+def test_non_source_action_gets_explicit_empty_publication_boundary() -> None:
+    decision = _source_decision()
+    decision["action"] = {
+        **decision["action"],
+        "action_id": "seal_method_freeze",
+        "category": "freeze",
+        "after_completion_argv": None,
+        "after_completion_text": None,
+        "registered_execution": None,
+    }
+
+    result = operator_flow.enrich_preacquisition_next_action(decision)
+
+    action = result["action"]
+    assert action["post_acquisition_verification_argv"] is None
+    assert action["claim_bearing_publication_argv"] is None
+    assert action["independent_review_required_before_publication"] is False
+    assert action["operator_sequence"] == []
+
+
+def test_source_action_rejects_drifted_publication_command() -> None:
+    decision = _source_decision()
+    decision["action"]["after_completion_argv"][-1] = "/wrong/staging.json"
+
+    with pytest.raises(ValueError, match="publication command differs"):
+        operator_flow.enrich_preacquisition_next_action(decision)
+
+
+def test_source_action_requires_registered_execution_identity() -> None:
+    decision = _source_decision()
+    decision["action"].pop("registered_execution")
+
+    with pytest.raises(ValueError, match="registered source execution is missing"):
+        operator_flow.enrich_preacquisition_next_action(decision)
+
+
+def test_markdown_orders_verification_before_publication() -> None:
+    result = operator_flow.enrich_preacquisition_next_action(_source_decision())
+
+    markdown = operator_flow.render_preacquisition_operator_next_action_markdown(result)
+
+    verification = markdown.index("### Verify staged evidence")
+    publication = markdown.index("### Publish after independent review")
+    completion = markdown.index("### Completion check")
+    assert verification < publication < completion
+    assert "requires independent review" in markdown
+    assert result["evidence_sha256"] in markdown
+
+
+def test_operator_flow_hash_is_mount_independent() -> None:
+    first = operator_flow.enrich_preacquisition_next_action(_source_decision())
+    second = deepcopy(first)
+    old_repository = second["repository_root"]
+    old_dataset = second["dataset_root"]
+    second["repository_root"] = "/relocated/repository"
+    second["dataset_root"] = "/relocated/dataset"
+
+    def relocate(value):
+        if isinstance(value, dict):
+            return {key: relocate(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [relocate(item) for item in value]
+        if isinstance(value, str):
+            return value.replace(old_repository, second["repository_root"]).replace(
+                old_dataset, second["dataset_root"]
+            )
+        return value
+
+    second["action"] = relocate(second["action"])
+    second.pop("evidence_sha256")
+    second.pop("status_sha256")
+
+    assert next_action_evidence_sha256(first) == next_action_evidence_sha256(second)
+
+
+def test_build_wrapper_enriches_underlying_decision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        operator_flow,
+        "_build_next_action",
+        lambda *args, **kwargs: _source_decision(),
+    )
+
+    result = operator_flow.build_preacquisition_operator_next_action(
+        "/repo",
+        "/data",
+    )
+
+    assert result["action"]["post_acquisition_verification_argv"] is not None
+
+
+def test_json_and_markdown_writers_are_atomic(tmp_path: Path) -> None:
+    result = operator_flow.enrich_preacquisition_next_action(_source_decision())
+    json_path = tmp_path / "operator" / "next.json"
+    markdown_path = tmp_path / "operator" / "next.md"
+
+    assert (
+        operator_flow.write_preacquisition_operator_next_action(
+            json_path,
+            result,
+        )
+        == json_path
+    )
+    assert (
+        operator_flow.write_preacquisition_operator_next_action_markdown(
+            markdown_path,
+            result,
+        )
+        == markdown_path
+    )
+    assert json_path.is_file()
+    assert markdown_path.is_file()
+    assert "Verify staged evidence" in markdown_path.read_text(encoding="utf-8")

--- a/tests/test_preacquisition_source_panel_staging.py
+++ b/tests/test_preacquisition_source_panel_staging.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+import causal4d.preacquisition_source_panel_control as source_control
+import causal4d.preacquisition_source_panel_staging as staging
+from causal4d.cli import preacquisition_readiness as readiness_cli
+from causal4d.preacquisition_readiness_contracts import (
+    SOURCE_PANEL_MANIFEST_PATH,
+    SOURCE_PANEL_MANIFEST_TEMPLATE_PATH,
+    source_panel_execution_manifest_template,
+)
+
+
+def _registered_values() -> tuple[dict, dict, dict]:
+    protocol = {
+        "protocol_id": "test-protocol",
+        "design_sha256": "a" * 64,
+    }
+    profiles = [
+        {"id": "lift_high", "amplitude_m": 0.08},
+        {"id": "lower_high", "amplitude_m": 0.08},
+        {"id": "lift_high_slow", "amplitude_m": 0.08},
+        {"id": "lift_high_long_hold", "amplitude_m": 0.08},
+    ]
+    executions: list[dict] = []
+    for profile in profiles:
+        for replicate in range(1, 4):
+            identifier = f"source-{profile['id']}-r{replicate}"
+            executions.append(
+                {
+                    "execution_id": identifier,
+                    "session_id": identifier,
+                    "command_profile_id": profile["id"],
+                    "contact_region_id": "upper_torso",
+                    "realization_condition_id": "nominal",
+                    "replicate": replicate,
+                    "fresh_reset_and_fresh_grasp": True,
+                    "confirmatory_fold_member": False,
+                }
+            )
+    v2 = {
+        "preacquisition_signature_panel": {
+            "executions": executions,
+            "profiles": profiles,
+        }
+    }
+    v4 = {
+        "plan_id": "test-preacquisition-v4",
+        "amendment_sha256": "b" * 64,
+    }
+    return protocol, v2, v4
+
+
+def _patch_chain(monkeypatch: pytest.MonkeyPatch) -> tuple[dict, dict, dict]:
+    protocol, v2, v4 = _registered_values()
+
+    def loader(repository_root):
+        del repository_root
+        return protocol, v2, {}, v4
+
+    monkeypatch.setattr(
+        source_control,
+        "load_registered_preacquisition_chain",
+        loader,
+    )
+    monkeypatch.setattr(
+        staging,
+        "load_registered_preacquisition_chain",
+        loader,
+    )
+    return protocol, v2, v4
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _descriptor(root: Path, relative: str) -> dict:
+    data = (root / relative).read_bytes()
+    return {
+        "path": relative,
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "bytes": len(data),
+    }
+
+
+def _scaffold(root: Path, protocol: dict, v2: dict, v4: dict) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    executions = v2["preacquisition_signature_panel"]["executions"]
+    for execution in executions:
+        relative = SOURCE_PANEL_MANIFEST_TEMPLATE_PATH.format(
+            execution_id=execution["execution_id"]
+        )
+        template = source_panel_execution_manifest_template(
+            execution,
+            protocol,
+            v4,
+        )
+        _write_json(root / relative, template)
+
+
+def _completed_manifest(
+    root: Path,
+    execution: dict,
+    protocol: dict,
+    v4: dict,
+    *,
+    bad_digest: bool = False,
+) -> dict:
+    execution_id = execution["execution_id"]
+    artifact_relative = f"preacquisition/source_panel/executions/{execution_id}/raw.bin"
+    artifact_path = root / artifact_relative
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    artifact_path.write_bytes(f"physical-source:{execution_id}".encode())
+    descriptor = _descriptor(root, artifact_relative)
+    if bad_digest:
+        descriptor["sha256"] = "0" * 64
+    manifest = source_panel_execution_manifest_template(
+        execution,
+        protocol,
+        v4,
+    )
+    manifest.update(
+        {
+            "status": "complete",
+            "included": True,
+            "quality_gate_failures": [],
+            "started_at_utc": "2026-08-04T08:00:00Z",
+            "ended_at_utc": "2026-08-04T08:01:00Z",
+            "artifacts": [descriptor],
+        }
+    )
+    return manifest
+
+
+def _staged_path(root: Path, execution: dict) -> Path:
+    return root / "staging" / f"{execution['execution_id']}.json"
+
+
+def test_preflight_verifies_next_manifest_without_publication(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    protocol, v2, v4 = _patch_chain(monkeypatch)
+    _scaffold(tmp_path, protocol, v2, v4)
+    first = v2["preacquisition_signature_panel"]["executions"][0]
+    source = _staged_path(tmp_path, first)
+    manifest = _completed_manifest(tmp_path, first, protocol, v4)
+    _write_json(source, manifest)
+
+    result = staging.verify_source_panel_manifest_staging(
+        tmp_path,
+        tmp_path,
+        source,
+    )
+
+    final = tmp_path / SOURCE_PANEL_MANIFEST_PATH.format(
+        execution_id=first["execution_id"]
+    )
+    assert result["safe_to_publish"] is True
+    assert result["published"] is False
+    assert result["claim_bearing_evidence_mutated"] is False
+    assert result["changes_registered_method"] is False
+    assert result["source_panel_status_stable"] is True
+    assert result["execution_id"] == first["execution_id"]
+    assert result["validated_executions_before"] == 0
+    assert result["validated_executions_after_publication"] == 1
+    assert result["artifact_count"] == 1
+    assert result["artifacts"] == manifest["artifacts"]
+    assert result["target_outcomes_used"] is False
+    assert result["evidence_sha256"] == (
+        staging.source_panel_staging_evidence_sha256(result)
+    )
+    assert result["status_sha256"] == (
+        staging.source_panel_staging_status_sha256(result)
+    )
+    assert not final.exists()
+
+
+def test_preflight_evidence_hash_is_mount_independent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    protocol, v2, v4 = _patch_chain(monkeypatch)
+    _scaffold(tmp_path, protocol, v2, v4)
+    first = v2["preacquisition_signature_panel"]["executions"][0]
+    source = _staged_path(tmp_path, first)
+    _write_json(source, _completed_manifest(tmp_path, first, protocol, v4))
+    result = staging.verify_source_panel_manifest_staging(
+        tmp_path,
+        tmp_path,
+        source,
+    )
+    relocated = deepcopy(result)
+    relocated["repository_root"] = "/relocated/repository"
+    relocated["dataset_root"] = "/relocated/dataset"
+    relocated["source_json"] = (
+        "/relocated/dataset/" + result["source_manifest_relative_path"]
+    )
+    relocated["source_panel_status_sha256_before"] = "0" * 64
+    relocated["publication_command_argv"][4:] = [
+        relocated["repository_root"],
+        relocated["dataset_root"],
+        relocated["source_json"],
+    ]
+    relocated["publication_command_text"] = "host-specific command"
+    relocated.pop("evidence_sha256")
+    relocated.pop("status_sha256")
+
+    assert staging.source_panel_staging_evidence_sha256(result) == (
+        staging.source_panel_staging_evidence_sha256(relocated)
+    )
+
+
+def test_preflight_requires_exact_staging_filename(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    protocol, v2, v4 = _patch_chain(monkeypatch)
+    _scaffold(tmp_path, protocol, v2, v4)
+    first = v2["preacquisition_signature_panel"]["executions"][0]
+    source = tmp_path / "staging" / "wrong.json"
+    _write_json(source, _completed_manifest(tmp_path, first, protocol, v4))
+
+    with pytest.raises(ValueError, match="filename must match"):
+        staging.verify_source_panel_manifest_staging(
+            tmp_path,
+            tmp_path,
+            source,
+        )
+
+
+def test_preflight_rejects_bad_artifact_hash_without_publication(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    protocol, v2, v4 = _patch_chain(monkeypatch)
+    _scaffold(tmp_path, protocol, v2, v4)
+    first = v2["preacquisition_signature_panel"]["executions"][0]
+    source = _staged_path(tmp_path, first)
+    _write_json(
+        source,
+        _completed_manifest(
+            tmp_path,
+            first,
+            protocol,
+            v4,
+            bad_digest=True,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="checksum mismatch"):
+        staging.verify_source_panel_manifest_staging(tmp_path, tmp_path, source)
+
+    final = tmp_path / SOURCE_PANEL_MANIFEST_PATH.format(
+        execution_id=first["execution_id"]
+    )
+    assert not final.exists()
+
+
+def test_preflight_rejects_nonnext_execution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    protocol, v2, v4 = _patch_chain(monkeypatch)
+    _scaffold(tmp_path, protocol, v2, v4)
+    first, second = v2["preacquisition_signature_panel"]["executions"][:2]
+    source = _staged_path(tmp_path, first)
+    _write_json(source, _completed_manifest(tmp_path, second, protocol, v4))
+
+    with pytest.raises(ValueError, match="next registered execution"):
+        staging.verify_source_panel_manifest_staging(tmp_path, tmp_path, source)
+
+
+def test_preflight_rejects_symlinked_staging_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    protocol, v2, v4 = _patch_chain(monkeypatch)
+    _scaffold(tmp_path, protocol, v2, v4)
+    first = v2["preacquisition_signature_panel"]["executions"][0]
+    actual = tmp_path / "actual.json"
+    alias = _staged_path(tmp_path, first)
+    _write_json(actual, _completed_manifest(tmp_path, first, protocol, v4))
+    alias.parent.mkdir(parents=True)
+    alias.symlink_to(actual)
+
+    with pytest.raises(ValueError, match="symlink component"):
+        staging.verify_source_panel_manifest_staging(tmp_path, tmp_path, alias)
+
+
+def test_preflight_rejects_staging_file_outside_dataset(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    protocol, v2, v4 = _patch_chain(monkeypatch)
+    dataset = tmp_path / "dataset"
+    _scaffold(dataset, protocol, v2, v4)
+    first = v2["preacquisition_signature_panel"]["executions"][0]
+    source = tmp_path / f"{first['execution_id']}.json"
+    _write_json(source, _completed_manifest(dataset, first, protocol, v4))
+
+    with pytest.raises(ValueError, match="directly below dataset_root/staging"):
+        staging.verify_source_panel_manifest_staging(tmp_path, dataset, source)
+
+
+def test_preflight_rejects_file_inside_dataset_but_outside_staging(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    protocol, v2, v4 = _patch_chain(monkeypatch)
+    _scaffold(tmp_path, protocol, v2, v4)
+    first = v2["preacquisition_signature_panel"]["executions"][0]
+    source = tmp_path / "operator" / f"{first['execution_id']}.json"
+    _write_json(source, _completed_manifest(tmp_path, first, protocol, v4))
+
+    with pytest.raises(ValueError, match="directly below dataset_root/staging"):
+        staging.verify_source_panel_manifest_staging(tmp_path, tmp_path, source)
+
+
+def test_preflight_rejects_staging_file_mutation_during_validation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    protocol, v2, v4 = _patch_chain(monkeypatch)
+    _scaffold(tmp_path, protocol, v2, v4)
+    first = v2["preacquisition_signature_panel"]["executions"][0]
+    source = _staged_path(tmp_path, first)
+    _write_json(source, _completed_manifest(tmp_path, first, protocol, v4))
+    validate = staging._validate_source_execution_manifest
+
+    def validate_then_mutate(*args, **kwargs) -> None:
+        validate(*args, **kwargs)
+        source.write_bytes(source.read_bytes() + b"\n")
+
+    monkeypatch.setattr(
+        staging,
+        "_validate_source_execution_manifest",
+        validate_then_mutate,
+    )
+
+    with pytest.raises(ValueError, match="changed during validation"):
+        staging.verify_source_panel_manifest_staging(tmp_path, tmp_path, source)
+
+    final = tmp_path / SOURCE_PANEL_MANIFEST_PATH.format(
+        execution_id=first["execution_id"]
+    )
+    assert not final.exists()
+
+
+def test_preflight_rejects_artifact_mutation_during_validation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    protocol, v2, v4 = _patch_chain(monkeypatch)
+    _scaffold(tmp_path, protocol, v2, v4)
+    first = v2["preacquisition_signature_panel"]["executions"][0]
+    source = _staged_path(tmp_path, first)
+    manifest = _completed_manifest(tmp_path, first, protocol, v4)
+    _write_json(source, manifest)
+    artifact = tmp_path / manifest["artifacts"][0]["path"]
+    validate = staging._validate_source_execution_manifest
+
+    def validate_then_mutate(*args, **kwargs) -> None:
+        validate(*args, **kwargs)
+        artifact.write_bytes(artifact.read_bytes() + b"x")
+
+    monkeypatch.setattr(
+        staging,
+        "_validate_source_execution_manifest",
+        validate_then_mutate,
+    )
+
+    with pytest.raises(ValueError, match="artifacts changed during validation"):
+        staging.verify_source_panel_manifest_staging(tmp_path, tmp_path, source)
+
+
+def test_preflight_rejects_source_panel_status_change(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    protocol, v2, v4 = _patch_chain(monkeypatch)
+    _scaffold(tmp_path, protocol, v2, v4)
+    first = v2["preacquisition_signature_panel"]["executions"][0]
+    source = _staged_path(tmp_path, first)
+    _write_json(source, _completed_manifest(tmp_path, first, protocol, v4))
+    build = staging.build_source_panel_status
+    calls = 0
+
+    def changing_status(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        status = build(*args, **kwargs)
+        if calls == 2:
+            status = deepcopy(status)
+            status["status_sha256"] = "0" * 64
+        return status
+
+    monkeypatch.setattr(staging, "build_source_panel_status", changing_status)
+
+    with pytest.raises(ValueError, match="status changed"):
+        staging.verify_source_panel_manifest_staging(tmp_path, tmp_path, source)
+
+
+def test_preflight_rejects_nested_target_outcomes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    protocol, v2, v4 = _patch_chain(monkeypatch)
+    _scaffold(tmp_path, protocol, v2, v4)
+    first = v2["preacquisition_signature_panel"]["executions"][0]
+    manifest = _completed_manifest(tmp_path, first, protocol, v4)
+    manifest["artifacts"][0]["target_metrics"] = {"rmse": 0.0}
+    source = _staged_path(tmp_path, first)
+    _write_json(source, manifest)
+
+    with pytest.raises(ValueError, match="target-outcome fields"):
+        staging.verify_source_panel_manifest_staging(tmp_path, tmp_path, source)
+
+
+def test_cli_exposes_preflight_and_writes_report(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    result = {
+        "valid": True,
+        "complete": True,
+        "passed": True,
+        "safe_to_publish": True,
+    }
+    written: list[Path] = []
+    monkeypatch.setattr(
+        readiness_cli,
+        "verify_source_panel_manifest_staging",
+        lambda *args: result,
+    )
+    monkeypatch.setattr(
+        readiness_cli,
+        "write_source_panel_staging_preflight",
+        lambda path, value: written.append(Path(path)) or Path(path),
+    )
+    output = tmp_path / "preflight.json"
+
+    code = readiness_cli.main(
+        [
+            "source-panel-verify-staged",
+            "/repo",
+            "/data/run",
+            "/data/run/staging/source-01.json",
+            "--output-json",
+            str(output),
+        ]
+    )
+
+    assert code == 0
+    assert written == [output]


### PR DESCRIPTION
## Summary

- add `causal4d protocol readiness next-action`, deriving exactly one admissible operator step from the existing hash-verified readiness and source-panel contracts;
- preserve the registered ordering across scaffolding, operator identity, physical prerequisites, the exact next source execution, operational gates, method freeze, independent attestation, software sealing, final verification, and first-session authorization;
- add `source-panel-verify-staged` as a read-only admission preflight before exactly-once publication;
- require the exact `dataset_root/staging/<next-execution-id>.json` path, strict schema and next-session identity, recursive target-outcome exclusion, and complete artifact hash/byte verification;
- snapshot the staged manifest, every referenced artifact, and the hash-bound source-panel status before and after validation, rejecting any mutation or concurrent progress;
- prove that preflight leaves the final manifest absent and emit a content-addressed report bound to the exact publication command;
- represent the source operator sequence explicitly as acquisition → staged verification → independent review → exactly-once publication → recomputed next action;
- remove direct publication from the immediate post-acquisition command and bind verification and claim-bearing publication under separate argv/text fields; and
- add focused success, tamper, mutation, path, ordering, portability, rendering, atomic-publication, and CLI regressions.

## Why

The acquisition control plane is fail closed, but operators need both a concise deterministic next step and a safe way to catch malformed or changing evidence before a final manifest is published exactly once. A successful preflight remains a non-reserving snapshot: the publisher reruns all checks, while an independent reviewer can inspect the content-addressed report before claim-bearing publication.

## Scientific and safety boundary

This is operational guidance only. It does not change the frozen estimator, intervention posterior, six-frame information boundary, source/confirmatory acquisition order, fit/calibration/target split, quality gates, exclusions, conformal threshold, evidence count, or claim interpretation.

Every action records `changes_registered_method=false` and `target_outcomes_permitted=false`. The preflight records `safe_to_publish=true`, `published=false`, `claim_bearing_evidence_mutated=false`, and `source_panel_status_stable=true`. A first confirmatory-session action is emitted only from the existing hash-verified `ready=true` decision.

## Exact scope and validation

The authoritative product head is:

```text
7a685e4a26b3f39006bb61bbe4c39566159a77e9
```

It is one nine-file product commit on current `main`. That exact head passed:

- the Causal4D merge gate, including the complete default test suite, distributions, and pinned BayesianPhysTwin installed-wheel integration;
- CI/release on Python 3.10, 3.12, and 3.14, installed wheel and source-distribution CLI checks, deterministic bundle production, and frozen-manifest validation;
- extended Python 3.11/3.13 and declared dependency-floor compatibility;
- resolved-runtime dependency auditing; and
- CodeQL analysis for Python and GitHub Actions.

The merge is guarded by that exact head SHA.

<!-- exact-head-validation: passed head=7a685e4a26b3f39006bb61bbe4c39566159a77e9 -->