### PR TITLE
Add graph-valued contact posterior diagnostics

### DIFF
--- a/docs/causal4d_graph_contact_measure.md
+++ b/docs/causal4d_graph_contact_measure.md
@@ -1,0 +1,84 @@
+# Graph-valued contact posterior
+
+`causal4d.graph_contact_measure.GraphContactMeasure` is an immutable,
+diagnostic-only representation of posterior mass over one or more contact nodes on
+an object graph. It complements exact-node accuracy with topology-aware uncertainty
+without changing the frozen Causal4D estimator or any registered gate.
+
+## Why use it
+
+An exact contact label can be too brittle when neighboring mesh nodes induce nearly
+equivalent physical responses. The measure keeps the complete discrete posterior and
+adds:
+
+- canonical, permutation-invariant multi-contact states;
+- deterministic MAP and tie-closed highest-mass credible states;
+- graph-Bayes contact estimates under minimum mean assignment distance;
+- exact and one-hop credible-region coverage;
+- posterior expected graph error and pairwise graph dispersion;
+- node-marginal contact probabilities for visualization; and
+- content identities for both the graph-distance matrix and posterior measure.
+
+The one-hop metric is an additional diagnostic. It does not replace the frozen exact
+contact criterion.
+
+## Example
+
+```python
+import numpy as np
+
+from causal4d.graph_contact_measure import (
+    GraphContactMeasure,
+    all_pairs_shortest_path_distances,
+)
+
+# Four-node chain: 0 -- 1 -- 2 -- 3
+distances = all_pairs_shortest_path_distances(
+    4,
+    [(0, 1), (1, 2), (2, 3)],
+)
+measure = GraphContactMeasure.from_weighted_contacts(
+    contacts=[(0,), (1,), (3,)],
+    weights=np.asarray([0.5, 0.3, 0.2]),
+    graph_distances=distances,
+)
+report = measure.as_record(0.8, truth=(2,))
+```
+
+Here the 80% credible states are nodes 0 and 1. Exact credible coverage of node 2 is
+false, while one-hop credible coverage is true. The report still retains the exact
+truth probability, MAP graph error, posterior expected graph error, and graph-Bayes
+risk, so the relaxed diagnostic cannot hide exact-node performance.
+
+## Distance units
+
+`all_pairs_shortest_path_distances` produces unweighted shortest-path distances.
+Consequently, radius `1.0` means one graph edge, not one metre or one mesh-cell width.
+Comparisons across differently discretized meshes require a separately registered
+mapping or a physically scaled distance matrix; the helper does not infer one.
+
+## Interpretation
+
+Treat topology-aware quantities as an attribution aid, not as a replacement success
+criterion. A one-hop recovery can distinguish a localized contact miss from a remote
+or diffuse posterior, but the registered exact-node result remains unchanged. Report
+both quantities together whenever a relaxed radius is shown.
+
+The graph-distance matrix is part of the measure identity. The same probabilities on
+a different mesh topology are therefore a different diagnostic object, even when the
+node labels happen to match. This prevents results from being compared across
+incompatible graph registrations without an explicit transformation.
+
+## Multi-contact states
+
+Node order is not semantic. `(4, 0)` and `(0, 4)` are canonicalized and their masses
+are aggregated. All support states must have the same cardinality. Distances between
+multi-contact states use an optimal one-to-one assignment; both minimum mean and
+minimum bottleneck graph distances are available.
+
+## Boundary
+
+The class summarizes an existing posterior only. It does not read future frames,
+change contact hypotheses or weights, widen the intervention bank, tune thresholds,
+or authorize confirmatory acquisition. `as_record()` marks output as
+`diagnostic_only=true` and includes deterministic SHA-256 identities.

--- a/docs/causal4d_graph_contact_measure.md
+++ b/docs/causal4d_graph_contact_measure.md
@@ -69,6 +69,11 @@ a different mesh topology are therefore a different diagnostic object, even when
 node labels happen to match. This prevents results from being compared across
 incompatible graph registrations without an explicit transformation.
 
+The graph-Bayes estimate minimizes posterior expected assignment distance over the
+retained posterior support. It does not synthesize an unrepresented contact subset.
+Expanding the admissible decision space requires an explicit method change and must
+not be inferred from this diagnostic summary.
+
 ## Multi-contact states
 
 Node order is not semantic. `(4, 0)` and `(0, 4)` are canonicalized and their masses

--- a/src/causal4d/graph_contact_distance.py
+++ b/src/causal4d/graph_contact_distance.py
@@ -1,0 +1,217 @@
+"""Graph-distance primitives for unordered contact-node sets."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Iterable, Sequence
+import operator
+
+import numpy as np
+from scipy.optimize import linear_sum_assignment
+
+from causal4d.immutable_array import readonly_array
+
+
+ContactNodes = tuple[int, ...]
+_DISTANCE_RTOL = 1e-12
+_DISTANCE_ATOL = 1e-12
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _node_index(value: object, *, name: str) -> int:
+    _require(not isinstance(value, (bool, np.bool_)), f"{name} must be an integer")
+    try:
+        result = operator.index(value)
+    except TypeError as error:
+        raise ValueError(f"{name} must be an integer") from error
+    return int(result)
+
+
+def _canonical_contact_nodes(
+    values: Iterable[object],
+    *,
+    node_count: int,
+    name: str,
+) -> ContactNodes:
+    _require(
+        not isinstance(values, (str, bytes)),
+        f"{name} must be an iterable of node indices",
+    )
+    try:
+        nodes = tuple(_node_index(value, name=f"{name} node") for value in values)
+    except TypeError as error:
+        raise ValueError(f"{name} must be an iterable of node indices") from error
+    _require(nodes, f"{name} must contain at least one node")
+    _require(len(set(nodes)) == len(nodes), f"{name} contains duplicate nodes")
+    for node in nodes:
+        _require(
+            0 <= node < node_count,
+            f"{name} node {node} is outside [0, {node_count})",
+        )
+    return tuple(sorted(nodes))
+
+
+def _validated_distance_matrix(
+    values: np.ndarray | Sequence[Sequence[float]],
+) -> np.ndarray:
+    matrix = np.asarray(values, dtype=float)
+    _require(
+        matrix.ndim == 2 and matrix.shape[0] == matrix.shape[1] and matrix.shape[0] > 0,
+        "graph distances must be a nonempty square matrix",
+    )
+    _require(np.all(np.isfinite(matrix)), "graph distances must be finite")
+    _require(np.all(matrix >= 0.0), "graph distances must be nonnegative")
+    _require(
+        np.allclose(
+            matrix,
+            matrix.T,
+            rtol=_DISTANCE_RTOL,
+            atol=_DISTANCE_ATOL,
+        ),
+        "graph distances must be symmetric",
+    )
+    _require(
+        np.allclose(
+            np.diag(matrix),
+            0.0,
+            rtol=0.0,
+            atol=_DISTANCE_ATOL,
+        ),
+        "graph-distance diagonal must be zero",
+    )
+    canonical = np.array(matrix, dtype=float, copy=True, order="C")
+    canonical[canonical == 0.0] = 0.0
+    return readonly_array(canonical, dtype=float)
+
+
+def all_pairs_shortest_path_distances(
+    node_count: int,
+    edges: Iterable[Sequence[object]],
+) -> np.ndarray:
+    """Return immutable unweighted distances for a connected undirected graph."""
+
+    count = _node_index(node_count, name="node_count")
+    _require(count > 0, "node_count must be positive")
+    adjacency = [set() for _ in range(count)]
+    for edge_index, raw_edge in enumerate(edges):
+        _require(
+            not isinstance(raw_edge, (str, bytes)),
+            f"edge {edge_index} must contain two node indices",
+        )
+        try:
+            edge = tuple(raw_edge)
+        except TypeError as error:
+            raise ValueError(
+                f"edge {edge_index} must contain two node indices"
+            ) from error
+        _require(
+            len(edge) == 2,
+            f"edge {edge_index} must contain exactly two node indices",
+        )
+        first = _node_index(edge[0], name=f"edge {edge_index} first node")
+        second = _node_index(edge[1], name=f"edge {edge_index} second node")
+        _require(
+            0 <= first < count and 0 <= second < count,
+            f"edge {edge_index} contains an out-of-range node",
+        )
+        _require(first != second, f"edge {edge_index} is a self-edge")
+        adjacency[first].add(second)
+        adjacency[second].add(first)
+
+    distances = np.full((count, count), np.inf, dtype=float)
+    for source in range(count):
+        distances[source, source] = 0.0
+        frontier: deque[int] = deque([source])
+        while frontier:
+            node = frontier.popleft()
+            candidate = distances[source, node] + 1.0
+            for neighbor in sorted(adjacency[node]):
+                if candidate < distances[source, neighbor]:
+                    distances[source, neighbor] = candidate
+                    frontier.append(neighbor)
+    _require(np.all(np.isfinite(distances)), "contact graph must be connected")
+    return readonly_array(distances, dtype=float)
+
+
+def _minimum_bottleneck_cost(costs: np.ndarray) -> float:
+    size = costs.shape[0]
+
+    def has_complete_matching(threshold: float) -> bool:
+        matched_left = [-1] * size
+
+        def augment(right: int, visited: list[bool]) -> bool:
+            for left in range(size):
+                if costs[left, right] > threshold or visited[left]:
+                    continue
+                visited[left] = True
+                if matched_left[left] < 0 or augment(
+                    matched_left[left],
+                    visited,
+                ):
+                    matched_left[left] = right
+                    return True
+            return False
+
+        return all(augment(right, [False] * size) for right in range(size))
+
+    for threshold in np.unique(costs):
+        if has_complete_matching(float(threshold)):
+            return float(threshold)
+    raise RuntimeError("finite assignment costs did not admit a complete matching")
+
+
+def _contact_costs(
+    first: Iterable[object],
+    second: Iterable[object],
+    graph_distances: np.ndarray | Sequence[Sequence[float]],
+) -> np.ndarray:
+    matrix = _validated_distance_matrix(graph_distances)
+    first_nodes = _canonical_contact_nodes(
+        first,
+        node_count=matrix.shape[0],
+        name="first contact",
+    )
+    second_nodes = _canonical_contact_nodes(
+        second,
+        node_count=matrix.shape[0],
+        name="second contact",
+    )
+    _require(
+        len(first_nodes) == len(second_nodes),
+        "contact states must have equal cardinality",
+    )
+    return matrix[np.ix_(first_nodes, second_nodes)]
+
+
+def mean_assignment_graph_distance(
+    first: Iterable[object],
+    second: Iterable[object],
+    graph_distances: np.ndarray | Sequence[Sequence[float]],
+) -> float:
+    """Return minimum mean graph distance under one-to-one assignment."""
+
+    costs = _contact_costs(first, second, graph_distances)
+    rows, columns = linear_sum_assignment(costs)
+    return float(np.mean(costs[rows, columns]))
+
+
+def bottleneck_assignment_graph_distance(
+    first: Iterable[object],
+    second: Iterable[object],
+    graph_distances: np.ndarray | Sequence[Sequence[float]],
+) -> float:
+    """Return minimum possible maximum distance under one-to-one assignment."""
+
+    return _minimum_bottleneck_cost(_contact_costs(first, second, graph_distances))
+
+
+__all__ = [
+    "ContactNodes",
+    "all_pairs_shortest_path_distances",
+    "bottleneck_assignment_graph_distance",
+    "mean_assignment_graph_distance",
+]

--- a/src/causal4d/graph_contact_measure.py
+++ b/src/causal4d/graph_contact_measure.py
@@ -1,0 +1,570 @@
+"""Immutable, topology-aware summaries of graph-valued contact posteriors.
+
+This module summarizes an already computed posterior. It does not change the frozen
+Causal4D estimator, likelihood, intervention bank, or registered thresholds.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+import hashlib
+import json
+import math
+from types import MappingProxyType
+from typing import Any
+
+import numpy as np
+
+from causal4d.graph_contact_distance import (
+    ContactNodes,
+    _canonical_contact_nodes,
+    _minimum_bottleneck_cost,
+    _require,
+    _validated_distance_matrix,
+    all_pairs_shortest_path_distances,
+    bottleneck_assignment_graph_distance,
+    mean_assignment_graph_distance,
+)
+
+
+GRAPH_CONTACT_MEASURE_SCHEMA_VERSION = 1
+GRAPH_CONTACT_MEASURE_ARTIFACT_KIND = "Causal4DGraphContactMeasure"
+_PROBABILITY_RTOL = 1e-10
+_PROBABILITY_ATOL = 1e-12
+_TIE_RTOL = 1e-12
+_TIE_ATOL = 1e-15
+
+
+def _stable_sum(values: Iterable[float]) -> float:
+    """Return a permutation-invariant finite sum for nonnegative probabilities."""
+
+    return math.fsum(sorted(float(value) for value in values))
+
+
+@dataclass(frozen=True, eq=False)
+class GraphContactMeasure:
+    """Posterior measure over equal-cardinality, unordered graph contacts."""
+
+    support: tuple[ContactNodes, ...]
+    probabilities: tuple[float, ...]
+    graph_distances: np.ndarray = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        matrix = _validated_distance_matrix(self.graph_distances)
+        _require(self.support, "contact posterior support must be nonempty")
+        _require(
+            len(self.support) == len(self.probabilities),
+            "contact probabilities must align with support",
+        )
+        canonical = tuple(
+            _canonical_contact_nodes(
+                state,
+                node_count=matrix.shape[0],
+                name=f"support state {index}",
+            )
+            for index, state in enumerate(self.support)
+        )
+        _require(
+            len(set(canonical)) == len(canonical),
+            "contact posterior support contains duplicate states",
+        )
+        cardinality = len(canonical[0])
+        _require(
+            all(len(state) == cardinality for state in canonical),
+            "contact posterior states must have equal cardinality",
+        )
+        values = np.asarray(self.probabilities, dtype=float)
+        _require(
+            values.shape == (len(canonical),),
+            "contact probabilities must be one-dimensional",
+        )
+        _require(np.all(np.isfinite(values)), "contact probabilities must be finite")
+        _require(
+            np.all(values >= 0.0),
+            "contact probabilities must be nonnegative",
+        )
+        ordered = sorted(zip(canonical, values, strict=True))
+        canonical = tuple(state for state, _ in ordered)
+        values = tuple(float(probability) for _, probability in ordered)
+        total = _stable_sum(values)
+        _require(
+            math.isclose(
+                total,
+                1.0,
+                rel_tol=_PROBABILITY_RTOL,
+                abs_tol=_PROBABILITY_ATOL,
+            ),
+            "contact probabilities must sum to one",
+        )
+        object.__setattr__(self, "support", canonical)
+        normalized = tuple(value / total for value in values)
+        object.__setattr__(
+            self,
+            "probabilities",
+            tuple(0.0 if value == 0.0 else value for value in normalized),
+        )
+        object.__setattr__(self, "graph_distances", matrix)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, GraphContactMeasure):
+            return False
+        return bool(
+            self.support == other.support
+            and self.probabilities == other.probabilities
+            and np.array_equal(self.graph_distances, other.graph_distances)
+        )
+
+    def __hash__(self) -> int:
+        return int(self.measure_sha256[:16], 16)
+
+    @classmethod
+    def from_weighted_contacts(
+        cls,
+        contacts: Sequence[Iterable[object]],
+        weights: Sequence[float] | np.ndarray,
+        graph_distances: np.ndarray | Sequence[Sequence[float]],
+    ) -> GraphContactMeasure:
+        """Canonicalize and aggregate weighted contact hypotheses."""
+
+        matrix = _validated_distance_matrix(graph_distances)
+        raw_contacts = tuple(contacts)
+        values = np.asarray(weights, dtype=float)
+        _require(raw_contacts, "contact posterior support must be nonempty")
+        _require(
+            values.shape == (len(raw_contacts),),
+            "contact weights must align with support",
+        )
+        _require(np.all(np.isfinite(values)), "contact weights must be finite")
+        _require(np.all(values >= 0.0), "contact weights must be nonnegative")
+        total = _stable_sum(values)
+        _require(
+            math.isclose(
+                total,
+                1.0,
+                rel_tol=_PROBABILITY_RTOL,
+                abs_tol=_PROBABILITY_ATOL,
+            ),
+            "contact weights must sum to one",
+        )
+        grouped: defaultdict[ContactNodes, list[float]] = defaultdict(list)
+        cardinality: int | None = None
+        for index, (contact, weight) in enumerate(
+            zip(raw_contacts, values, strict=True)
+        ):
+            state = _canonical_contact_nodes(
+                contact,
+                node_count=matrix.shape[0],
+                name=f"contact state {index}",
+            )
+            cardinality = len(state) if cardinality is None else cardinality
+            _require(
+                len(state) == cardinality,
+                "contact posterior states must have equal cardinality",
+            )
+            grouped[state].append(float(weight))
+        support = tuple(sorted(grouped))
+        return cls(
+            support,
+            tuple(_stable_sum(grouped[state]) / total for state in support),
+            matrix,
+        )
+
+    @classmethod
+    def from_contact_states(
+        cls,
+        states: Sequence[object],
+        weights: Sequence[float] | np.ndarray,
+        graph_distances: np.ndarray | Sequence[Sequence[float]],
+    ) -> GraphContactMeasure:
+        """Build from Causal4D states exposing a ``contact_nodes`` attribute."""
+
+        contacts: list[Iterable[object]] = []
+        for index, state in enumerate(states):
+            try:
+                contacts.append(getattr(state, "contact_nodes"))
+            except AttributeError as error:
+                raise ValueError(
+                    f"contact state {index} has no contact_nodes attribute"
+                ) from error
+        return cls.from_weighted_contacts(contacts, weights, graph_distances)
+
+    @property
+    def node_count(self) -> int:
+        return int(self.graph_distances.shape[0])
+
+    @property
+    def contact_cardinality(self) -> int:
+        return len(self.support[0])
+
+    @property
+    def probability_map(self) -> Mapping[ContactNodes, float]:
+        return MappingProxyType(
+            dict(zip(self.support, self.probabilities, strict=True))
+        )
+
+    def _state(self, values: Iterable[object], *, name: str) -> ContactNodes:
+        state = _canonical_contact_nodes(
+            values,
+            node_count=self.node_count,
+            name=name,
+        )
+        _require(
+            len(state) == self.contact_cardinality,
+            f"{name} must have cardinality {self.contact_cardinality}",
+        )
+        return state
+
+    def mean_distance(
+        self,
+        first: Iterable[object],
+        second: Iterable[object],
+    ) -> float:
+        return mean_assignment_graph_distance(
+            self._state(first, name="first contact"),
+            self._state(second, name="second contact"),
+            self.graph_distances,
+        )
+
+    def bottleneck_distance(
+        self,
+        first: Iterable[object],
+        second: Iterable[object],
+    ) -> float:
+        first_state = self._state(first, name="first contact")
+        second_state = self._state(second, name="second contact")
+        costs = self.graph_distances[np.ix_(first_state, second_state)]
+        return _minimum_bottleneck_cost(costs)
+
+    @property
+    def entropy(self) -> float:
+        positive = np.asarray(
+            [value for value in self.probabilities if value > 0.0],
+            dtype=float,
+        )
+        return -float(np.sum(positive * np.log(positive)))
+
+    @property
+    def normalized_entropy(self) -> float:
+        return (
+            float(self.entropy / math.log(len(self.support)))
+            if len(self.support) > 1
+            else 0.0
+        )
+
+    @property
+    def effective_support_size(self) -> float:
+        values = np.asarray(self.probabilities)
+        return float(1.0 / np.sum(np.square(values)))
+
+    @property
+    def graph_distances_sha256(self) -> str:
+        canonical = np.asarray(self.graph_distances, dtype="<f8", order="C")
+        digest = hashlib.sha256()
+        digest.update(json.dumps(list(canonical.shape)).encode("ascii"))
+        digest.update(b"\0")
+        digest.update(canonical.tobytes(order="C"))
+        return digest.hexdigest()
+
+    @property
+    def measure_sha256(self) -> str:
+        payload = {
+            "schema_version": GRAPH_CONTACT_MEASURE_SCHEMA_VERSION,
+            "artifact_kind": GRAPH_CONTACT_MEASURE_ARTIFACT_KIND,
+            "support": [list(state) for state in self.support],
+            "probabilities": list(self.probabilities),
+            "graph_distances_sha256": self.graph_distances_sha256,
+        }
+        data = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        return hashlib.sha256(data).hexdigest()
+
+    @property
+    def map_probability(self) -> float:
+        return max(self.probabilities)
+
+    @property
+    def map_states(self) -> tuple[ContactNodes, ...]:
+        return tuple(
+            state
+            for state, probability in zip(
+                self.support,
+                self.probabilities,
+                strict=True,
+            )
+            if math.isclose(
+                probability,
+                self.map_probability,
+                rel_tol=_TIE_RTOL,
+                abs_tol=_TIE_ATOL,
+            )
+        )
+
+    @property
+    def map_state(self) -> ContactNodes:
+        return self.map_states[0]
+
+    def credible_states(
+        self,
+        confidence_level: float,
+        *,
+        close_boundary_ties: bool = True,
+    ) -> tuple[ContactNodes, ...]:
+        confidence = float(confidence_level)
+        _require(
+            math.isfinite(confidence) and 0.0 < confidence < 1.0,
+            "confidence_level must be finite and in (0, 1)",
+        )
+        ordered = sorted(
+            zip(self.support, self.probabilities, strict=True),
+            key=lambda item: (-item[1], item[0]),
+        )
+        selected: list[ContactNodes] = []
+        cumulative = 0.0
+        boundary: float | None = None
+        for state, probability in ordered:
+            selected.append(state)
+            cumulative += probability
+            if cumulative >= confidence:
+                boundary = probability
+                break
+        if close_boundary_ties and boundary is not None:
+            for state, probability in ordered[len(selected) :]:
+                if not math.isclose(
+                    probability,
+                    boundary,
+                    rel_tol=_TIE_RTOL,
+                    abs_tol=_TIE_ATOL,
+                ):
+                    break
+                selected.append(state)
+        return tuple(selected)
+
+    def credible_region_nodes(
+        self,
+        confidence_level: float,
+        *,
+        radius: float = 0.0,
+        close_boundary_ties: bool = True,
+    ) -> tuple[int, ...]:
+        radius_value = float(radius)
+        _require(
+            math.isfinite(radius_value) and radius_value >= 0.0,
+            "credible-region radius must be finite and nonnegative",
+        )
+        states = self.credible_states(
+            confidence_level,
+            close_boundary_ties=close_boundary_ties,
+        )
+        seeds = sorted({node for state in states for node in state})
+        nearest = np.min(self.graph_distances[:, seeds], axis=1)
+        return tuple(int(node) for node in np.flatnonzero(nearest <= radius_value))
+
+    def credible_radius_covered(
+        self,
+        truth: Iterable[object],
+        confidence_level: float,
+        *,
+        radius: float,
+        close_boundary_ties: bool = True,
+    ) -> bool:
+        truth_state = self._state(truth, name="truth contact")
+        radius_value = float(radius)
+        _require(
+            math.isfinite(radius_value) and radius_value >= 0.0,
+            "credible-coverage radius must be finite and nonnegative",
+        )
+        return any(
+            self.bottleneck_distance(state, truth_state) <= radius_value
+            for state in self.credible_states(
+                confidence_level,
+                close_boundary_ties=close_boundary_ties,
+            )
+        )
+
+    @property
+    def node_marginal_probabilities(self) -> tuple[float, ...]:
+        values = np.zeros(self.node_count)
+        for state, probability in zip(
+            self.support,
+            self.probabilities,
+            strict=True,
+        ):
+            values[list(state)] += probability
+        return tuple(float(value) for value in values)
+
+    def expected_mean_distance(self, reference: Iterable[object]) -> float:
+        reference_state = self._state(reference, name="reference contact")
+        return float(
+            sum(
+                probability * self.mean_distance(state, reference_state)
+                for state, probability in zip(
+                    self.support,
+                    self.probabilities,
+                    strict=True,
+                )
+            )
+        )
+
+    def expected_bottleneck_distance(self, reference: Iterable[object]) -> float:
+        reference_state = self._state(reference, name="reference contact")
+        return float(
+            sum(
+                probability * self.bottleneck_distance(state, reference_state)
+                for state, probability in zip(
+                    self.support,
+                    self.probabilities,
+                    strict=True,
+                )
+            )
+        )
+
+    @property
+    def expected_pairwise_mean_distance(self) -> float:
+        total = 0.0
+        for first_index, first in enumerate(self.support):
+            for second_index in range(first_index + 1, len(self.support)):
+                total += (
+                    2.0
+                    * self.probabilities[first_index]
+                    * self.probabilities[second_index]
+                    * self.mean_distance(first, self.support[second_index])
+                )
+        return float(total)
+
+    def _candidate_risks(self) -> tuple[float, ...]:
+        return tuple(self.expected_mean_distance(state) for state in self.support)
+
+    @property
+    def graph_bayes_risk(self) -> float:
+        return min(self._candidate_risks())
+
+    @property
+    def graph_bayes_states(self) -> tuple[ContactNodes, ...]:
+        risks = self._candidate_risks()
+        minimum = min(risks)
+        return tuple(
+            state
+            for state, risk in zip(self.support, risks, strict=True)
+            if math.isclose(
+                risk,
+                minimum,
+                rel_tol=_TIE_RTOL,
+                abs_tol=_TIE_ATOL,
+            )
+        )
+
+    @property
+    def graph_bayes_state(self) -> ContactNodes:
+        return self.graph_bayes_states[0]
+
+    def energy_style_score(self, truth: Iterable[object]) -> float:
+        """Return E[d(Z, truth)] - 0.5 E[d(Z, Z')]."""
+
+        return float(
+            self.expected_mean_distance(truth)
+            - 0.5 * self.expected_pairwise_mean_distance
+        )
+
+    def as_record(
+        self,
+        confidence_level: float,
+        *,
+        truth: Iterable[object] | None = None,
+    ) -> dict[str, Any]:
+        """Return a deterministic JSON-compatible diagnostic record."""
+
+        credible = self.credible_states(confidence_level)
+        region = self.credible_region_nodes(confidence_level)
+        one_hop = self.credible_region_nodes(confidence_level, radius=1.0)
+        record: dict[str, Any] = {
+            "schema_version": GRAPH_CONTACT_MEASURE_SCHEMA_VERSION,
+            "artifact_kind": GRAPH_CONTACT_MEASURE_ARTIFACT_KIND,
+            "measure_sha256": self.measure_sha256,
+            "graph_distances_sha256": self.graph_distances_sha256,
+            "diagnostic_only": True,
+            "contact_cardinality": self.contact_cardinality,
+            "support_size": len(self.support),
+            "entropy": self.entropy,
+            "normalized_entropy": self.normalized_entropy,
+            "effective_support_size": self.effective_support_size,
+            "support": [
+                {"contact_nodes": list(state), "probability": probability}
+                for state, probability in zip(
+                    self.support,
+                    self.probabilities,
+                    strict=True,
+                )
+            ],
+            "map_contact_nodes": list(self.map_state),
+            "map_contact_states": [list(state) for state in self.map_states],
+            "map_probability": self.map_probability,
+            "credible_contact_states": [list(state) for state in credible],
+            "credible_contact_state_count": len(credible),
+            "credible_region_nodes": list(region),
+            "credible_region_node_count": len(region),
+            "one_hop_credible_region_nodes": list(one_hop),
+            "one_hop_credible_region_node_count": len(one_hop),
+            "graph_bayes_contact_nodes": list(self.graph_bayes_state),
+            "graph_bayes_contact_states": [
+                list(state) for state in self.graph_bayes_states
+            ],
+            "graph_bayes_risk": self.graph_bayes_risk,
+            "expected_pairwise_mean_graph_distance": (
+                self.expected_pairwise_mean_distance
+            ),
+            "node_marginal_probabilities": list(self.node_marginal_probabilities),
+        }
+        if truth is None:
+            return record
+        truth_state = self._state(truth, name="truth contact")
+        record.update(
+            {
+                "truth_contact_nodes": list(truth_state),
+                "truth_probability": self.probability_map.get(truth_state, 0.0),
+                "map_mean_assignment_graph_distance": self.mean_distance(
+                    self.map_state,
+                    truth_state,
+                ),
+                "map_bottleneck_assignment_graph_distance": (
+                    self.bottleneck_distance(self.map_state, truth_state)
+                ),
+                "graph_bayes_mean_assignment_graph_distance": (
+                    self.mean_distance(self.graph_bayes_state, truth_state)
+                ),
+                "posterior_expected_mean_assignment_graph_distance": (
+                    self.expected_mean_distance(truth_state)
+                ),
+                "posterior_expected_bottleneck_assignment_graph_distance": (
+                    self.expected_bottleneck_distance(truth_state)
+                ),
+                "credible_exact_covered": self.credible_radius_covered(
+                    truth_state,
+                    confidence_level,
+                    radius=0.0,
+                ),
+                "credible_one_hop_covered": self.credible_radius_covered(
+                    truth_state,
+                    confidence_level,
+                    radius=1.0,
+                ),
+                "graph_energy_style_score": self.energy_style_score(truth_state),
+            }
+        )
+        return record
+
+
+__all__ = [
+    "ContactNodes",
+    "GRAPH_CONTACT_MEASURE_ARTIFACT_KIND",
+    "GRAPH_CONTACT_MEASURE_SCHEMA_VERSION",
+    "GraphContactMeasure",
+    "all_pairs_shortest_path_distances",
+    "bottleneck_assignment_graph_distance",
+    "mean_assignment_graph_distance",
+]

--- a/tests/test_graph_contact_measure.py
+++ b/tests/test_graph_contact_measure.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from causal4d.graph_contact_measure import (
+    GraphContactMeasure,
+    all_pairs_shortest_path_distances,
+    bottleneck_assignment_graph_distance,
+    mean_assignment_graph_distance,
+)
+
+
+def _line(node_count: int) -> np.ndarray:
+    return all_pairs_shortest_path_distances(
+        node_count,
+        [(node, node + 1) for node in range(node_count - 1)],
+    )
+
+
+def test_measure_aggregates_permuted_support_deterministically() -> None:
+    measure = GraphContactMeasure.from_weighted_contacts(
+        [(3,), (0,), (1,), (3,)],
+        np.asarray([0.1, 0.5, 0.3, 0.1]),
+        _line(4),
+    )
+
+    assert measure.support == ((0,), (1,), (3,))
+    assert measure.probabilities == pytest.approx((0.5, 0.3, 0.2))
+    assert measure.map_state == (0,)
+    assert measure.map_states == ((0,),)
+    assert measure.credible_states(0.8) == ((0,), (1,))
+    assert measure.node_marginal_probabilities == pytest.approx((0.5, 0.3, 0.0, 0.2))
+    assert measure.entropy > 0.0
+    assert 0.0 < measure.normalized_entropy < 1.0
+    assert measure.effective_support_size > 1.0
+    assert len(measure.graph_distances_sha256) == 64
+    assert len(measure.measure_sha256) == 64
+    with pytest.raises(ValueError, match="read-only"):
+        measure.graph_distances[0, 1] = 100.0
+    with pytest.raises(ValueError, match="WRITEABLE flag"):
+        measure.graph_distances.setflags(write=True)
+
+
+def test_aggregation_identity_is_independent_of_hypothesis_order() -> None:
+    contacts = [
+        (0,),
+        (1,),
+        (0,),
+        (1,),
+        (0,),
+        (1,),
+        (0,),
+        (1,),
+        (0,),
+        (1,),
+    ]
+    weights = [
+        0.9259554437470779,
+        0.01726796332422633,
+        3.0873415330523455e-09,
+        1.8050451298364748e-12,
+        2.0120903868730362e-07,
+        1.5025737857946074e-09,
+        0.056770777154068246,
+        1.3944648782111336e-11,
+        4.0746671855770216e-08,
+        5.5692132519611315e-06,
+    ]
+    permutation = [5, 4, 9, 6, 0, 1, 7, 2, 8, 3]
+    first = GraphContactMeasure.from_weighted_contacts(
+        contacts,
+        weights,
+        _line(2),
+    )
+    second = GraphContactMeasure.from_weighted_contacts(
+        [contacts[index] for index in permutation],
+        [weights[index] for index in permutation],
+        _line(2),
+    )
+
+    assert first.probabilities == second.probabilities
+    assert first.measure_sha256 == second.measure_sha256
+    assert first == second
+    assert hash(first) == hash(second)
+
+
+def test_equality_includes_graph_topology() -> None:
+    line = _line(3)
+    triangle = all_pairs_shortest_path_distances(
+        3,
+        [(0, 1), (1, 2), (0, 2)],
+    )
+    first = GraphContactMeasure.from_weighted_contacts([(0,)], [1.0], line)
+    same = GraphContactMeasure.from_weighted_contacts([(0,)], [1.0], line)
+    different_graph = GraphContactMeasure.from_weighted_contacts(
+        [(0,)],
+        [1.0],
+        triangle,
+    )
+
+    assert first == same
+    assert hash(first) == hash(same)
+    assert first != different_graph
+    assert first != object()
+
+
+def test_signed_zero_has_one_canonical_identity() -> None:
+    positive_graph = np.asarray([[0.0, 1.0], [1.0, 0.0]])
+    negative_graph = np.asarray([[-0.0, 1.0], [1.0, -0.0]])
+    positive = GraphContactMeasure(
+        ((0,), (1,)),
+        (0.0, 1.0),
+        positive_graph,
+    )
+    negative = GraphContactMeasure(
+        ((0,), (1,)),
+        (-0.0, 1.0),
+        negative_graph,
+    )
+
+    assert positive == negative
+    assert hash(positive) == hash(negative)
+    assert positive.measure_sha256 == negative.measure_sha256
+    assert positive.graph_distances_sha256 == negative.graph_distances_sha256
+
+
+def test_record_is_strict_deterministic_json() -> None:
+    measure = GraphContactMeasure.from_weighted_contacts(
+        [(0,), (1,)],
+        [0.75, 0.25],
+        _line(2),
+    )
+
+    first = json.dumps(
+        measure.as_record(0.8, truth=(1,)),
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    second = json.dumps(
+        measure.as_record(0.8, truth=(1,)),
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    assert first == second
+
+
+def test_direct_construction_canonicalizes_support_order_and_identity() -> None:
+    distances = _line(3)
+    first = GraphContactMeasure(((2,), (0,)), (0.4, 0.6), distances)
+    second = GraphContactMeasure(((0,), (2,)), (0.6, 0.4), distances)
+
+    assert first.support == ((0,), (2,))
+    assert first.probabilities == pytest.approx((0.6, 0.4))
+    assert first.measure_sha256 == second.measure_sha256
+
+
+def test_contact_state_adapter_uses_existing_contact_nodes_contract() -> None:
+    states = [
+        SimpleNamespace(contact_nodes=(0,)),
+        SimpleNamespace(contact_nodes=(1,)),
+    ]
+    measure = GraphContactMeasure.from_contact_states(
+        states,
+        [0.7, 0.3],
+        _line(2),
+    )
+
+    assert measure.support == ((0,), (1,))
+    with pytest.raises(ValueError, match="no contact_nodes"):
+        GraphContactMeasure.from_contact_states(
+            [object()],
+            [1.0],
+            _line(2),
+        )
+
+
+def test_graph_bayes_tie_and_expected_distances() -> None:
+    measure = GraphContactMeasure.from_weighted_contacts(
+        [(0,), (1,), (3,)],
+        [0.5, 0.3, 0.2],
+        _line(4),
+    )
+
+    assert measure.expected_mean_distance((0,)) == pytest.approx(0.9)
+    assert measure.expected_pairwise_mean_distance == pytest.approx(1.14)
+    assert measure.graph_bayes_risk == pytest.approx(0.9)
+    assert measure.graph_bayes_states == ((0,), (1,))
+    assert measure.graph_bayes_state == (0,)
+    assert measure.energy_style_score((0,)) == pytest.approx(0.33)
+
+
+def test_credible_region_and_radius_coverage_are_topology_aware() -> None:
+    measure = GraphContactMeasure.from_weighted_contacts(
+        [(0,), (1,), (3,)],
+        [0.5, 0.3, 0.2],
+        _line(4),
+    )
+    record = measure.as_record(0.8, truth=(2,))
+
+    assert measure.credible_region_nodes(0.8) == (0, 1)
+    assert measure.credible_region_nodes(0.8, radius=1.0) == (0, 1, 2)
+    assert measure.credible_radius_covered((2,), 0.8, radius=0.0) is False
+    assert measure.credible_radius_covered((2,), 0.8, radius=1.0) is True
+    assert record["credible_exact_covered"] is False
+    assert record["credible_one_hop_covered"] is True
+    assert record["posterior_expected_mean_assignment_graph_distance"] == (
+        pytest.approx(1.5)
+    )
+    assert record["truth_probability"] == 0.0
+    assert record["diagnostic_only"] is True
+    assert record["measure_sha256"] == measure.measure_sha256
+
+
+def test_multi_contact_states_are_unordered_and_use_optimal_assignment() -> None:
+    distances = _line(5)
+    measure = GraphContactMeasure.from_weighted_contacts(
+        [(0, 4), (4, 0), (1, 3)],
+        [0.25, 0.25, 0.5],
+        distances,
+    )
+
+    assert measure.support == ((0, 4), (1, 3))
+    assert measure.probabilities == pytest.approx((0.5, 0.5))
+    assert measure.map_states == ((0, 4), (1, 3))
+    assert measure.credible_states(0.5) == ((0, 4), (1, 3))
+    assert measure.credible_states(
+        0.5,
+        close_boundary_ties=False,
+    ) == ((0, 4),)
+    assert measure.mean_distance((4, 0), (1, 3)) == 1.0
+    assert measure.bottleneck_distance((4, 0), (1, 3)) == 1.0
+    assert mean_assignment_graph_distance((4, 0), (1, 3), distances) == 1.0
+    assert (
+        bottleneck_assignment_graph_distance(
+            (4, 0),
+            (1, 3),
+            distances,
+        )
+        == 1.0
+    )
+
+
+def test_true_bottleneck_assignment_is_not_tied_to_minimum_sum_assignment() -> None:
+    distances = all_pairs_shortest_path_distances(
+        5,
+        [(0, 3), (0, 4), (1, 0), (3, 2), (4, 3)],
+    )
+    measure = GraphContactMeasure.from_weighted_contacts(
+        [(1, 4), (2, 4)],
+        [0.5, 0.5],
+        distances,
+    )
+
+    # Minimum-sum assignment uses costs (3, 0), while the bottleneck-optimal
+    # assignment uses (2, 2). The two summaries therefore solve different tasks.
+    assert measure.mean_distance((1, 4), (2, 4)) == 1.5
+    assert measure.bottleneck_distance((1, 4), (2, 4)) == 2.0
+
+
+@pytest.mark.parametrize(
+    ("contacts", "weights", "message"),
+    [
+        ([(0,), (1, 2)], [0.5, 0.5], "equal cardinality"),
+        ([(0, 0)], [1.0], "duplicate nodes"),
+        ([(False,)], [1.0], "must be an integer"),
+        ([(0,)], [0.9], "sum to one"),
+        ([(0,)], [-1.0], "nonnegative"),
+        ([(0,)], [float("nan")], "finite"),
+    ],
+)
+def test_measure_rejects_invalid_support_or_weights(
+    contacts: list[tuple[object, ...]],
+    weights: list[float],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        GraphContactMeasure.from_weighted_contacts(contacts, weights, _line(3))
+
+
+def test_graph_validation_rejects_disconnection_and_bad_distance_matrix() -> None:
+    with pytest.raises(ValueError, match="connected"):
+        all_pairs_shortest_path_distances(3, [(0, 1)])
+    with pytest.raises(ValueError, match="symmetric"):
+        GraphContactMeasure.from_weighted_contacts(
+            [(0,)],
+            [1.0],
+            np.asarray([[0.0, 1.0], [2.0, 0.0]]),
+        )


### PR DESCRIPTION
## Summary

- add connected-graph shortest-path and unordered contact-assignment distance primitives;
- add an immutable `GraphContactMeasure` over equal-cardinality contact-node sets;
- canonicalize node order, aggregate repeated hypotheses, preserve zero-mass support entries, and strictly validate probability mass and graph distances;
- make aggregated probabilities and content identities invariant to caller hypothesis order through stable sorted summation;
- make equality and hashing include the graph topology, rather than comparing posterior mass while silently ignoring the distance matrix;
- canonicalize signed zero in probabilities and distance matrices so equality, hashing, and serialized content identities obey the same equivalence relation;
- store graph-distance matrices through the repository's bytes-backed `readonly_array` helper, so callers cannot re-enable the NumPy `WRITEABLE` flag;
- provide deterministic MAP tie sets, tie-closed highest-mass credible states, graph-Bayes estimates, expected graph error, pairwise posterior dispersion, and node-marginal contact probabilities;
- distinguish minimum-mean assignment distance from the true minimum-bottleneck assignment distance used for exact and one-hop credible-region coverage;
- emit strict JSON-compatible diagnostic records with exact-node quantities retained alongside relaxed topology-aware quantities; and
- document graph-distance units, support-restricted Bayes decisions, the scientific boundary, and focused invariant/adversarial tests.

## Why

The controlled contact study shows that exact-node misses can be adjacent graph nodes while trajectory prediction still improves. This reusable representation reports that uncertainty without replacing or weakening exact-node accuracy and supports unordered multi-contact hypotheses rather than one scalar node label.

## Scientific boundary

This is an opt-in diagnostic and method-development primitive only. It does not alter the frozen estimator, contact weights, intervention bank, likelihood, six-frame information boundary, registered exact-node threshold, acquisition protocol, or claim-bearing result schema. `as_record()` explicitly reports `diagnostic_only=true`; one-hop coverage is additive and cannot hide exact truth probability or exact credible coverage.

Graph radii from `all_pairs_shortest_path_distances` are unweighted edge counts. The graph-Bayes decision is restricted to retained posterior support; expanding that decision space requires an explicit method change.

## Exact scope and validation

The authoritative head is:

```text
0e2ce12ce135dd26fd2e16070604b451c8b06f6a
```

It contains only the four intended product files. That exact head passed:

- the Causal4D merge gate, including complete pytest, distributions, and pinned BayesianPhysTwin installed-wheel integration;
- CI/release on Python 3.10, 3.12, and 3.14, installed wheel/sdist CLI checks, deterministic bundles, and frozen-manifest validation;
- extended Python 3.11/3.13 and declared dependency-floor compatibility;
- Ruff lint and incremental formatting, the complete stable type-check surface, and strict syntax compilation;
- resolved-runtime dependency auditing; and
- CodeQL for Python and GitHub Actions.

Focused validation covers deterministic support aggregation, exact and tie-closed credible sets, true bottleneck matching, multi-contact permutation invariance, immutable graph storage, topology-aware equality/hashing, signed-zero canonicalization, strict serialization, and invalid-input rejection.

The merge is guarded by the exact head SHA.

<!-- exact-head-validation: passed head=0e2ce12ce135dd26fd2e16070604b451c8b06f6a -->