### PR TITLE
Reject stale preacquisition operator actions before execution

### DIFF
--- a/docs/causal4d_preacquisition_next_action_validation.md
+++ b/docs/causal4d_preacquisition_next_action_validation.md
@@ -1,0 +1,115 @@
+# Pre-acquisition next-action freshness validation
+
+A `next-action` report is a content-addressed snapshot of the registered
+pre-acquisition state. It does not reserve a physical execution, freeze another
+operator out, or remain valid after evidence changes. Before performing a
+physical or claim-bearing action, validate that the saved report is still the
+current hash-verified decision.
+
+## Usage
+
+Generate the operator report:
+
+```bash
+causal4d protocol readiness next-action \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  --output-json \
+  /data/causal4d-sloth-multi-action-v1/operator/next-action.json
+```
+
+Immediately before acting, run:
+
+```bash
+causal4d protocol readiness next-action-validate \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  /data/causal4d-sloth-multi-action-v1/operator/next-action.json \
+  --output-json \
+  /data/causal4d-sloth-multi-action-v1/operator/next-action-validation.json
+```
+
+Only `current=true` and `safe_to_execute=true` authorize use of the saved action.
+The validator always rebuilds readiness and source-panel status with file hashing
+enabled; there is no structure-only mode.
+
+## Validation contract
+
+The command requires that:
+
+- the decision is an ordinary, nonsymlinked JSON file;
+- duplicate keys and non-finite JSON values are absent;
+- the artifact kind and operator-flow schema are supported;
+- target outcomes and registered-method changes remain forbidden;
+- the decision's portable evidence and host-local status SHA-256 values
+  recompute exactly;
+- its recorded repository and dataset roots equal the current roots;
+- a newly built, hash-verified next-action decision has the same portable
+  evidence SHA-256;
+- the action category, action ID, source execution ID, and source session ID are
+  unchanged; and
+- the decision file remains byte-identical while current evidence is rebuilt.
+
+Any changed prerequisite, newly published source execution, altered operational
+gate, method-freeze transition, changed artifact hash, or competing operator's
+progress makes the decision stale.
+
+## Result artifact
+
+A successful validation records:
+
+- the decision file path, byte count, and SHA-256;
+- the decision and current portable evidence identities;
+- the decision and current host-local status identities;
+- the exact action, execution, and session identity;
+- the current readiness and source-panel evidence identities;
+- `file_hashes_verified=true`;
+- `current=true`;
+- `safe_to_execute=true`;
+- `changes_registered_method=false`; and
+- `target_outcomes_used=false`.
+
+The report has a portable `evidence_sha256` that excludes mount-local paths,
+file bytes, and host-local status values, plus an exact host-local
+`status_sha256`.
+
+## Stale-action handling
+
+A stale decision returns exit code `2` through the grouped readiness CLI. Do not
+perform its physical acquisition, approval, freeze, or publication command.
+Regenerate `next-action.json`, inspect the newly selected action, and validate it
+again immediately before use.
+
+This prevents duplicated source sessions when two operators read the same old
+status, prevents acting after a gate or method-freeze transition, and ensures
+that a relocated report cannot silently retain commands for the wrong checkout
+or evidence tree.
+
+## Relationship to staged publication
+
+Freshness validation occurs before the physical operation. For a source-panel
+execution, the later staged-manifest preflight remains mandatory:
+
+```text
+validate current next action
+        ↓
+perform the registered physical source execution
+        ↓
+validate staged manifest and every referenced artifact
+        ↓
+review the preflight report
+        ↓
+publish exactly once
+```
+
+The two checks cover different races. Next-action validation prevents acting on
+stale registered progress; staged preflight prevents publishing malformed or
+changing evidence after acquisition.
+
+## Scientific boundary
+
+Freshness validation is operational provenance only. It does not reserve an
+execution, modify evidence, update the estimator, change a threshold or split,
+or increment any physical evidence count. A successful report proves only that
+the saved operator action matched the current hash-verified state at validation
+time.

--- a/src/causal4d/cli/preacquisition_readiness.py
+++ b/src/causal4d/cli/preacquisition_readiness.py
@@ -11,6 +11,10 @@ from causal4d.operator_registry import (
     scaffold_operator_registry,
     seal_operator_registry,
 )
+from causal4d.preacquisition_next_action_validation import (
+    validate_preacquisition_next_action_report,
+    write_preacquisition_next_action_validation,
+)
 from causal4d.preacquisition_readiness import (
     GATE_PATHS,
     build_preacquisition_readiness,
@@ -139,6 +143,15 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="inspect structure only; the suggested action cannot authorize collection",
     )
+
+    next_action_validate = subparsers.add_parser(
+        "next-action-validate",
+        help="require a persisted action to equal the current hash-verified decision",
+    )
+    next_action_validate.add_argument("repository_root")
+    next_action_validate.add_argument("dataset_root")
+    next_action_validate.add_argument("decision_json")
+    next_action_validate.add_argument("--output-json")
     return parser
 
 
@@ -204,6 +217,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             if args.output_markdown:
                 write_preacquisition_next_action_markdown(
                     args.output_markdown,
+                    result,
+                )
+        elif args.command == "next-action-validate":
+            result = validate_preacquisition_next_action_report(
+                args.repository_root,
+                args.dataset_root,
+                args.decision_json,
+            )
+            if args.output_json:
+                write_preacquisition_next_action_validation(
+                    args.output_json,
                     result,
                 )
         else:

--- a/src/causal4d/preacquisition_next_action_validation.py
+++ b/src/causal4d/preacquisition_next_action_validation.py
@@ -1,0 +1,210 @@
+"""Validate a persisted pre-acquisition action immediately before use."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from causal4d.acquisition_flight_common import (
+    _assert_no_symlink_components,
+    _require,
+)
+from causal4d.atomic_io import atomic_write_json
+from causal4d.preacquisition_next_action import (
+    NEXT_ACTION_ARTIFACT_KIND,
+    next_action_evidence_sha256,
+    next_action_status_sha256,
+)
+from causal4d.preacquisition_operator_flow import (
+    NEXT_ACTION_SCHEMA_VERSION,
+    build_preacquisition_operator_next_action,
+)
+from causal4d.preacquisition_readiness_contracts import (
+    _canonical_sha256,
+    _read_json_mapping,
+    _sha256_file,
+)
+
+NEXT_ACTION_VALIDATION_SCHEMA_VERSION = 1
+NEXT_ACTION_VALIDATION_ARTIFACT_KIND = "Causal4DPreacquisitionNextActionValidation"
+
+
+def _action_identity(decision: Mapping[str, Any]) -> dict[str, Any]:
+    action = decision.get("action")
+    _require(isinstance(action, Mapping), "next-action decision has no action object")
+    registered = action.get("registered_execution")
+    execution_id = None
+    session_id = None
+    if isinstance(registered, Mapping):
+        execution_id = registered.get("execution_id")
+        session_id = registered.get("session_id")
+    return {
+        "action_id": action.get("action_id"),
+        "category": action.get("category"),
+        "execution_id": execution_id,
+        "session_id": session_id,
+    }
+
+
+def _validate_decision_envelope(decision: Mapping[str, Any]) -> None:
+    _require(
+        decision.get("schema_version") == NEXT_ACTION_SCHEMA_VERSION,
+        "unsupported next-action decision schema",
+    )
+    _require(
+        decision.get("artifact_kind") == NEXT_ACTION_ARTIFACT_KIND,
+        "unexpected next-action artifact kind",
+    )
+    _require(
+        decision.get("target_outcomes_used") is False,
+        "target outcomes entered the next-action decision",
+    )
+    action = decision.get("action")
+    _require(isinstance(action, Mapping), "next-action decision has no action object")
+    _require(
+        action.get("target_outcomes_permitted") is False,
+        "next-action decision permits target outcomes",
+    )
+    _require(
+        action.get("changes_registered_method") is False,
+        "next-action decision permits a registered-method change",
+    )
+    _require(
+        decision.get("evidence_sha256") == next_action_evidence_sha256(decision),
+        "next-action evidence SHA-256 mismatch",
+    )
+    _require(
+        decision.get("status_sha256") == next_action_status_sha256(decision),
+        "next-action status SHA-256 mismatch",
+    )
+
+
+def next_action_validation_evidence_sha256(values: Mapping[str, Any]) -> str:
+    """Return a mount-independent digest for one freshness validation."""
+
+    payload = deepcopy(dict(values))
+    for field in (
+        "repository_root",
+        "dataset_root",
+        "decision_json",
+        "decision_file_sha256",
+        "decision_file_bytes",
+        "decision_status_sha256",
+        "current_status_sha256",
+        "evidence_sha256",
+        "status_sha256",
+    ):
+        payload.pop(field, None)
+    return _canonical_sha256(payload, omitted_field="evidence_sha256")
+
+
+def next_action_validation_status_sha256(values: Mapping[str, Any]) -> str:
+    """Return the digest of the exact host-local freshness validation."""
+
+    return _canonical_sha256(values, omitted_field="status_sha256")
+
+
+def validate_preacquisition_next_action_report(
+    repository_root: str | Path,
+    dataset_root: str | Path,
+    decision_json: str | Path,
+) -> dict[str, Any]:
+    """Require a persisted action to equal the current hash-verified decision."""
+
+    repository = Path(repository_root).resolve()
+    dataset = Path(dataset_root).resolve()
+    source = Path(decision_json)
+    _assert_no_symlink_components(source, name="next-action decision")
+    _require(source.is_file(), "next-action decision is missing")
+    source = source.resolve(strict=True)
+    decision_digest_before, decision_bytes_before = _sha256_file(source)
+    decision = _read_json_mapping(source, name="next-action decision")
+    _validate_decision_envelope(decision)
+
+    _require(
+        decision.get("repository_root") == str(repository),
+        "next-action repository root differs from the current checkout",
+    )
+    _require(
+        decision.get("dataset_root") == str(dataset),
+        "next-action dataset root differs from the current evidence tree",
+    )
+
+    current = build_preacquisition_operator_next_action(
+        repository,
+        dataset,
+        verify_file_hashes=True,
+    )
+    _validate_decision_envelope(current)
+    decision_digest_after, decision_bytes_after = _sha256_file(source)
+    _require(
+        (decision_digest_after, decision_bytes_after)
+        == (decision_digest_before, decision_bytes_before),
+        "next-action decision changed during validation",
+    )
+
+    supplied_identity = _action_identity(decision)
+    current_identity = _action_identity(current)
+    _require(
+        decision.get("evidence_sha256") == current.get("evidence_sha256"),
+        "next-action decision is stale",
+    )
+    _require(
+        supplied_identity == current_identity,
+        "next-action identity differs from the current decision",
+    )
+
+    report: dict[str, Any] = {
+        "schema_version": NEXT_ACTION_VALIDATION_SCHEMA_VERSION,
+        "artifact_kind": NEXT_ACTION_VALIDATION_ARTIFACT_KIND,
+        "protocol_id": current["protocol_id"],
+        "protocol_design_sha256": current["protocol_design_sha256"],
+        "preacquisition_plan_id": current["preacquisition_plan_id"],
+        "preacquisition_amendment_sha256": current["preacquisition_amendment_sha256"],
+        "repository_root": str(repository),
+        "dataset_root": str(dataset),
+        "decision_json": str(source),
+        "decision_file_sha256": decision_digest_after,
+        "decision_file_bytes": decision_bytes_after,
+        "decision_evidence_sha256": decision["evidence_sha256"],
+        "decision_status_sha256": decision["status_sha256"],
+        "current_evidence_sha256": current["evidence_sha256"],
+        "current_status_sha256": current["status_sha256"],
+        "action_identity": current_identity,
+        "readiness_evidence_sha256": current.get("readiness_evidence_sha256"),
+        "source_panel_evidence_sha256": current.get("source_panel_evidence_sha256"),
+        "current": True,
+        "safe_to_execute": True,
+        "file_hashes_verified": True,
+        "changes_registered_method": False,
+        "target_outcomes_used": False,
+        "valid": True,
+        "complete": True,
+        "passed": True,
+    }
+    report["evidence_sha256"] = next_action_validation_evidence_sha256(report)
+    report["status_sha256"] = next_action_validation_status_sha256(report)
+    return report
+
+
+def write_preacquisition_next_action_validation(
+    path: str | Path,
+    report: Mapping[str, Any],
+) -> Path:
+    """Atomically write one derived freshness-validation report."""
+
+    output = Path(path)
+    atomic_write_json(output, dict(report))
+    return output
+
+
+__all__ = [
+    "NEXT_ACTION_VALIDATION_ARTIFACT_KIND",
+    "NEXT_ACTION_VALIDATION_SCHEMA_VERSION",
+    "next_action_validation_evidence_sha256",
+    "next_action_validation_status_sha256",
+    "validate_preacquisition_next_action_report",
+    "write_preacquisition_next_action_validation",
+]

--- a/tests/test_preacquisition_next_action_validation.py
+++ b/tests/test_preacquisition_next_action_validation.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+import causal4d.preacquisition_next_action_validation as validation
+from causal4d.cli import preacquisition_readiness as readiness_cli
+from causal4d.preacquisition_next_action import (
+    NEXT_ACTION_ARTIFACT_KIND,
+    next_action_evidence_sha256,
+    next_action_status_sha256,
+)
+from causal4d.preacquisition_operator_flow import NEXT_ACTION_SCHEMA_VERSION
+
+
+def _decision(repository: Path, dataset: Path) -> dict:
+    result = {
+        "schema_version": NEXT_ACTION_SCHEMA_VERSION,
+        "artifact_kind": NEXT_ACTION_ARTIFACT_KIND,
+        "operator_flow_schema_version": 1,
+        "protocol_id": "protocol",
+        "protocol_design_sha256": "a" * 64,
+        "preacquisition_plan_id": "plan",
+        "preacquisition_amendment_sha256": "b" * 64,
+        "repository_root": str(repository.resolve()),
+        "dataset_root": str(dataset.resolve()),
+        "readiness_evidence_sha256": "c" * 64,
+        "readiness_status_sha256": "d" * 64,
+        "source_panel_evidence_sha256": "e" * 64,
+        "source_panel_status_sha256": "f" * 64,
+        "readiness_valid": True,
+        "source_panel_valid": True,
+        "ready": False,
+        "complete": False,
+        "passed": False,
+        "valid": True,
+        "target_outcomes_used": False,
+        "action": {
+            "action_id": "acquire_next_source_panel_execution",
+            "category": "physical_source_execution",
+            "title": "Acquire source-01",
+            "operator_role": "acquisition_operator",
+            "physical_acquisition_required": True,
+            "automatable": False,
+            "changes_registered_method": False,
+            "target_outcomes_permitted": False,
+            "command_argv": ["causal4d", "protocol", "readiness", "status"],
+            "command_text": "causal4d protocol readiness status",
+            "completion_check_argv": [
+                "causal4d",
+                "protocol",
+                "readiness",
+                "next-action",
+            ],
+            "completion_check_text": ("causal4d protocol readiness next-action"),
+            "after_completion_argv": None,
+            "after_completion_text": None,
+            "post_acquisition_verification_argv": [
+                "causal4d",
+                "protocol",
+                "readiness",
+                "source-panel-verify-staged",
+            ],
+            "post_acquisition_verification_text": (
+                "causal4d protocol readiness source-panel-verify-staged"
+            ),
+            "preflight_report_path": str(dataset / "operator/preflight.json"),
+            "independent_review_required_before_publication": True,
+            "claim_bearing_publication_argv": [
+                "causal4d",
+                "protocol",
+                "readiness",
+                "source-panel-publish",
+            ],
+            "claim_bearing_publication_text": (
+                "causal4d protocol readiness source-panel-publish"
+            ),
+            "operator_sequence": [
+                "acquire_registered_source_execution",
+                "verify_staged_manifest_and_artifacts",
+                "independent_review_of_preflight_report",
+                "publish_exactly_once",
+                "recompute_next_action",
+            ],
+            "input_paths": [str(dataset / "template.json")],
+            "output_paths": [str(dataset / "staging/source-01.json")],
+            "blocking_items": [],
+            "registered_execution": {
+                "execution_id": "source-01",
+                "session_id": "session-01",
+                "command_profile_id": "lift_high",
+            },
+        },
+    }
+    result["evidence_sha256"] = next_action_evidence_sha256(result)
+    result["status_sha256"] = next_action_status_sha256(result)
+    return result
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_current_decision_passes_with_exact_action_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    dataset = tmp_path / "dataset"
+    repository.mkdir()
+    dataset.mkdir()
+    decision = _decision(repository, dataset)
+    source = tmp_path / "operator" / "next-action.json"
+    _write(source, decision)
+    monkeypatch.setattr(
+        validation,
+        "build_preacquisition_operator_next_action",
+        lambda *args, **kwargs: deepcopy(decision),
+    )
+
+    report = validation.validate_preacquisition_next_action_report(
+        repository,
+        dataset,
+        source,
+    )
+
+    assert report["current"] is True
+    assert report["safe_to_execute"] is True
+    assert report["file_hashes_verified"] is True
+    assert report["action_identity"] == {
+        "action_id": "acquire_next_source_panel_execution",
+        "category": "physical_source_execution",
+        "execution_id": "source-01",
+        "session_id": "session-01",
+    }
+    assert report["decision_evidence_sha256"] == decision["evidence_sha256"]
+    assert report["current_evidence_sha256"] == decision["evidence_sha256"]
+    assert report["evidence_sha256"] == (
+        validation.next_action_validation_evidence_sha256(report)
+    )
+    assert report["status_sha256"] == (
+        validation.next_action_validation_status_sha256(report)
+    )
+
+
+def test_stale_decision_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    dataset = tmp_path / "dataset"
+    repository.mkdir()
+    dataset.mkdir()
+    decision = _decision(repository, dataset)
+    source = tmp_path / "next-action.json"
+    _write(source, decision)
+    current = deepcopy(decision)
+    current["source_panel_evidence_sha256"] = "0" * 64
+    current.pop("evidence_sha256")
+    current.pop("status_sha256")
+    current["evidence_sha256"] = next_action_evidence_sha256(current)
+    current["status_sha256"] = next_action_status_sha256(current)
+    monkeypatch.setattr(
+        validation,
+        "build_preacquisition_operator_next_action",
+        lambda *args, **kwargs: current,
+    )
+
+    with pytest.raises(ValueError, match="decision is stale"):
+        validation.validate_preacquisition_next_action_report(
+            repository,
+            dataset,
+            source,
+        )
+
+
+def test_tampered_decision_hash_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    dataset = tmp_path / "dataset"
+    repository.mkdir()
+    dataset.mkdir()
+    decision = _decision(repository, dataset)
+    decision["action"]["action_id"] = "changed-after-hashing"
+    source = tmp_path / "next-action.json"
+    _write(source, decision)
+    monkeypatch.setattr(
+        validation,
+        "build_preacquisition_operator_next_action",
+        lambda *args, **kwargs: decision,
+    )
+
+    with pytest.raises(ValueError, match="evidence SHA-256 mismatch"):
+        validation.validate_preacquisition_next_action_report(
+            repository,
+            dataset,
+            source,
+        )
+
+
+def test_mount_mismatch_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    dataset = tmp_path / "dataset"
+    other = tmp_path / "other"
+    repository.mkdir()
+    dataset.mkdir()
+    other.mkdir()
+    decision = _decision(repository, dataset)
+    source = tmp_path / "next-action.json"
+    _write(source, decision)
+    monkeypatch.setattr(
+        validation,
+        "build_preacquisition_operator_next_action",
+        lambda *args, **kwargs: decision,
+    )
+
+    with pytest.raises(ValueError, match="dataset root differs"):
+        validation.validate_preacquisition_next_action_report(
+            repository,
+            other,
+            source,
+        )
+
+
+def test_symlinked_decision_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    dataset = tmp_path / "dataset"
+    repository.mkdir()
+    dataset.mkdir()
+    decision = _decision(repository, dataset)
+    actual = tmp_path / "actual.json"
+    source = tmp_path / "next-action.json"
+    _write(actual, decision)
+    source.symlink_to(actual)
+    monkeypatch.setattr(
+        validation,
+        "build_preacquisition_operator_next_action",
+        lambda *args, **kwargs: decision,
+    )
+
+    with pytest.raises(ValueError, match="symlink component"):
+        validation.validate_preacquisition_next_action_report(
+            repository,
+            dataset,
+            source,
+        )
+
+
+def test_decision_mutation_during_validation_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    dataset = tmp_path / "dataset"
+    repository.mkdir()
+    dataset.mkdir()
+    decision = _decision(repository, dataset)
+    source = tmp_path / "next-action.json"
+    _write(source, decision)
+
+    def build(*args, **kwargs):
+        del args, kwargs
+        source.write_bytes(source.read_bytes() + b"\n")
+        return deepcopy(decision)
+
+    monkeypatch.setattr(
+        validation,
+        "build_preacquisition_operator_next_action",
+        build,
+    )
+
+    with pytest.raises(ValueError, match="changed during validation"):
+        validation.validate_preacquisition_next_action_report(
+            repository,
+            dataset,
+            source,
+        )
+
+
+def test_validation_digest_is_mount_independent() -> None:
+    report = {
+        "repository_root": "/repo-a",
+        "dataset_root": "/data-a",
+        "decision_json": "/data-a/operator/next.json",
+        "decision_file_sha256": "a" * 64,
+        "decision_file_bytes": 123,
+        "decision_evidence_sha256": "b" * 64,
+        "decision_status_sha256": "c" * 64,
+        "current_evidence_sha256": "b" * 64,
+        "current_status_sha256": "d" * 64,
+        "action_identity": {"action_id": "source", "execution_id": "one"},
+        "current": True,
+        "safe_to_execute": True,
+    }
+    relocated = deepcopy(report)
+    relocated["repository_root"] = "/repo-b"
+    relocated["dataset_root"] = "/data-b"
+    relocated["decision_json"] = "/data-b/operator/next.json"
+    relocated["decision_file_sha256"] = "e" * 64
+    relocated["decision_file_bytes"] = 456
+    relocated["decision_status_sha256"] = "f" * 64
+    relocated["current_status_sha256"] = "0" * 64
+
+    assert validation.next_action_validation_evidence_sha256(report) == (
+        validation.next_action_validation_evidence_sha256(relocated)
+    )
+
+
+def test_cli_validates_and_writes_report(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    report = {
+        "valid": True,
+        "complete": True,
+        "passed": True,
+        "current": True,
+        "safe_to_execute": True,
+    }
+    output = tmp_path / "validation.json"
+    written: list[Path] = []
+    monkeypatch.setattr(
+        readiness_cli,
+        "validate_preacquisition_next_action_report",
+        lambda *args: report,
+    )
+    monkeypatch.setattr(
+        readiness_cli,
+        "write_preacquisition_next_action_validation",
+        lambda path, value: written.append(Path(path)) or Path(path),
+    )
+
+    code = readiness_cli.main(
+        [
+            "next-action-validate",
+            "/repo",
+            "/dataset",
+            "/dataset/operator/next-action.json",
+            "--output-json",
+            str(output),
+        ]
+    )
+
+    assert code == 0
+    assert written == [output]
+
+
+def test_validation_report_writer_is_atomic(tmp_path: Path) -> None:
+    output = tmp_path / "operator" / "validation.json"
+    report = {
+        "valid": True,
+        "complete": True,
+        "passed": True,
+        "target_outcomes_used": False,
+    }
+
+    assert (
+        validation.write_preacquisition_next_action_validation(
+            output,
+            report,
+        )
+        == output
+    )
+    assert json.loads(output.read_text(encoding="utf-8")) == report


### PR DESCRIPTION
## Summary

- add `causal4d protocol readiness next-action-validate` as a fail-closed freshness check for persisted operator decisions;
- load the decision through the strict JSON boundary, reject symlinks, and recompute both its portable evidence SHA-256 and exact host-local status SHA-256;
- require the decision's repository and dataset roots to match the current deployed checkout and evidence tree;
- rebuild the complete operator-sequenced next action with file hashing enabled and require exact equality of the portable evidence identity;
- separately bind the action ID, category, source execution ID, and source session ID so stale physical work cannot proceed under a relabelled action;
- re-snapshot the decision file after current evidence is rebuilt and reject mutation during validation;
- emit a content-addressed validation report with `current=true`, `safe_to_execute=true`, and `file_hashes_verified=true`; and
- add focused stale-state, tamper, mount, symlink, concurrent-mutation, portability, CLI, and atomic-publication tests plus an operator runbook.

## Why

A next-action report is a snapshot, not a reservation. Two operators can read the same source-panel status, or a gate can be sealed between report generation and execution. Without a freshness check, an operator may perform an expensive duplicate physical source session even though exactly-once publication would later reject it.

The command is intended immediately before physical acquisition, approval, freeze, or publication. Any intervening prerequisite, source-panel, gate, freeze, artifact, or checkout change makes the saved report stale and returns exit code 2.

## Exact validated scope

```text
base: a833fff2b44401b1f91b6edc94373ac4bc2dfdb2
head: 78785a881bbf2d065dd0df7a17a2aa143cddad83
changed files: 4
```

The product surface is limited to:

- `docs/causal4d_preacquisition_next_action_validation.md`
- `src/causal4d/cli/preacquisition_readiness.py`
- `src/causal4d/preacquisition_next_action_validation.py`
- `tests/test_preacquisition_next_action_validation.py`

## Authoritative validation

All checks passed on exact head `78785a881bbf2d065dd0df7a17a2aa143cddad83`:

- Causal4D merge gate: run `31144125126`;
- CI and release: run `31144125261`;
- Extended compatibility: run `31144125135`; and
- Security scanning: run `31144125198`.

These runs cover the actual merge result, complete default suite, Python 3.10/3.12/3.14, declared compatibility versions, distributions and installed artifacts, pinned BayesianPhysTwin integration, dependency audit, and CodeQL.

## Scientific and safety boundary

This is operational provenance only. It does not reserve an execution, mutate evidence, alter the estimator, change a split or threshold, authorize target access, or increment a physical evidence count. Passing proves only that the saved action matched the current hash-verified state at validation time.