### PR TITLE
Require two-person review before source-panel publication

### DIFF
--- a/docs/causal4d_source_panel_review_receipt.md
+++ b/docs/causal4d_source_panel_review_receipt.md
@@ -1,0 +1,112 @@
+# Two-person source-panel publication receipt
+
+A successful staged preflight proves that the next source manifest and all
+referenced artifacts are valid at one instant. It does not prove that a second
+person inspected the result, and it must not allow the same person to approve
+and publish claim-bearing evidence under two operator aliases.
+
+The review-receipt flow adds a registered two-person boundary before the
+existing exactly-once publisher.
+
+## Operator sequence
+
+```text
+acquire registered source execution
+        ↓
+hash-verify staged manifest and artifacts
+        ↓
+registered reviewer seals a content-addressed receipt
+        ↓
+distinct registered publisher reruns validation and publishes exactly once
+        ↓
+recompute readiness and the next action
+```
+
+The reviewer must be active in the sealed operator registry with either the
+`gate_approver` or `independent_verifier` role. The publisher must be another
+active registered person. Distinct operator IDs are insufficient: the two
+records must have different `person_identity_sha256` values.
+
+## Review command
+
+After the staged preflight succeeds, a reviewer runs:
+
+```bash
+causal4d protocol readiness source-panel-review-staged \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  /data/causal4d-sloth-multi-action-v1/staging/<execution-id>.json \
+  --reviewed-by <registered-reviewer-id>
+```
+
+The command reruns the complete preflight. It writes the receipt exactly once to:
+
+```text
+staging/reviews/<execution-id>.json
+```
+
+The review timestamp must follow execution completion, and the sealed operator
+registry must predate the review. The receipt binds:
+
+- protocol and pre-acquisition amendment identities;
+- execution and independent-session identities;
+- staged manifest path, SHA-256, and byte count;
+- source execution completion timestamp;
+- portable and host-local staged-preflight identities;
+- the source-panel evidence identity before publication;
+- the exact operator-registry identity;
+- reviewer operator ID, person identity, and active roles;
+- review timestamp; and
+- the explicit no-target-outcomes and no-method-change boundary.
+
+The receipt carries its own canonical `artifact_sha256`. Publication refuses a
+modified or relocated receipt.
+
+## Publication command
+
+A distinct registered publisher runs:
+
+```bash
+causal4d protocol readiness source-panel-publish \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  /data/causal4d-sloth-multi-action-v1/staging/<execution-id>.json \
+  --review-receipt \
+  /data/causal4d-sloth-multi-action-v1/staging/reviews/<execution-id>.json \
+  --published-by <registered-publisher-id>
+```
+
+The claim-bearing CLI has no receipt-free route. Before publication it:
+
+1. reruns the complete staged preflight;
+2. verifies the receipt path and canonical digest;
+3. verifies every receipt field against the current preflight;
+4. revalidates the sealed operator registry;
+5. resolves reviewer and publisher as active operators;
+6. proves person-level independence;
+7. checks receipt stability while validation runs; and
+8. invokes the existing exactly-once publisher, which validates all source
+   artifacts again immediately before the final write.
+
+The publication result includes both operator identities, the review-receipt
+file descriptor, the bound preflight evidence identity, and
+`independent_people=true`.
+
+## Failure handling
+
+A receipt becomes stale if the staged manifest, any referenced artifact, the
+source-panel prefix, or the operator registry changes. Generate a fresh
+preflight and a new receipt. A receipt path is non-overwriting; do not edit or
+replace an existing receipt to rescue a failed publication.
+
+Self-review, duplicate person identities under different operator IDs, inactive
+operators, unsupported reviewer roles, review before execution completion,
+receipt-field drift, target-outcome fields, symlinks, and noncanonical receipt
+paths fail closed before the final manifest can be created.
+
+## Scientific boundary
+
+The receipt does not make an execution valid, increment evidence count, reserve
+the next source slot, alter the estimator, or authorize confirmatory collection.
+It records only that a registered second person reviewed the current source
+preflight before a distinct registered person invoked exactly-once publication.

--- a/src/causal4d/cli/preacquisition_readiness.py
+++ b/src/causal4d/cli/preacquisition_readiness.py
@@ -24,8 +24,13 @@ from causal4d.preacquisition_readiness import (
 )
 from causal4d.preacquisition_source_panel_control import (
     build_source_panel_status,
-    publish_source_panel_manifest,
     write_source_panel_status,
+)
+from causal4d.preacquisition_source_panel_review import (
+    review_source_panel_manifest_staging,
+)
+from causal4d.preacquisition_source_panel_review_publication import (
+    publish_reviewed_source_panel_manifest,
 )
 from causal4d.preacquisition_source_panel_staging import (
     verify_source_panel_manifest_staging,
@@ -108,13 +113,25 @@ def build_parser() -> argparse.ArgumentParser:
     source_verify.add_argument("source_json")
     source_verify.add_argument("--output-json")
 
+    source_review = subparsers.add_parser(
+        "source-panel-review-staged",
+        help="publish a registered human review receipt for the current preflight",
+    )
+    source_review.add_argument("repository_root")
+    source_review.add_argument("dataset_root")
+    source_review.add_argument("source_json")
+    source_review.add_argument("--reviewed-by", required=True)
+    source_review.add_argument("--reviewed-at-utc")
+
     source_publish = subparsers.add_parser(
         "source-panel-publish",
-        help="hash-verify and publish exactly the next source execution manifest",
+        help="publish the reviewed next source execution manifest exactly once",
     )
     source_publish.add_argument("repository_root")
     source_publish.add_argument("dataset_root")
     source_publish.add_argument("source_json")
+    source_publish.add_argument("--review-receipt", required=True)
+    source_publish.add_argument("--published-by", required=True)
 
     status = subparsers.add_parser(
         "status",
@@ -200,11 +217,21 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             if args.output_json:
                 write_source_panel_staging_preflight(args.output_json, result)
-        elif args.command == "source-panel-publish":
-            result = publish_source_panel_manifest(
+        elif args.command == "source-panel-review-staged":
+            result = review_source_panel_manifest_staging(
                 args.repository_root,
                 args.dataset_root,
                 args.source_json,
+                reviewed_by=args.reviewed_by,
+                reviewed_at_utc=args.reviewed_at_utc,
+            )
+        elif args.command == "source-panel-publish":
+            result = publish_reviewed_source_panel_manifest(
+                args.repository_root,
+                args.dataset_root,
+                args.source_json,
+                review_receipt_json=args.review_receipt,
+                published_by=args.published_by,
             )
         elif args.command == "next-action":
             result = build_preacquisition_next_action(

--- a/src/causal4d/preacquisition_operator_flow.py
+++ b/src/causal4d/preacquisition_operator_flow.py
@@ -43,7 +43,7 @@ def _expected_publication_command(
 def enrich_preacquisition_next_action(
     decision: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Insert the staged preflight before claim-bearing source publication."""
+    """Insert staged verification and two-person review before publication."""
 
     result = deepcopy(dict(decision))
     action_value = result.get("action")
@@ -70,6 +70,7 @@ def enrich_preacquisition_next_action(
         root = Path(dataset)
         staging = str(root / "staging" / f"{execution_id}.json")
         preflight = str(root / "operator" / f"{execution_id}-preflight.json")
+        receipt = str(root / "staging" / "reviews" / f"{execution_id}.json")
         expected_publication = _expected_publication_command(
             repository,
             dataset,
@@ -94,12 +95,39 @@ def enrich_preacquisition_next_action(
                 preflight,
             ]
         )
-        publication_argv, publication_text = _command_pair(expected_publication)
+        review_argv, review_text = _command_pair(
+            [
+                "causal4d",
+                "protocol",
+                "readiness",
+                "source-panel-review-staged",
+                repository,
+                dataset,
+                staging,
+                "--reviewed-by",
+                "<registered-reviewer-id>",
+            ]
+        )
+        publication_argv, publication_text = _command_pair(
+            [
+                *expected_publication,
+                "--review-receipt",
+                receipt,
+                "--published-by",
+                "<registered-publisher-id>",
+            ]
+        )
         action["after_completion_argv"] = None
         action["after_completion_text"] = None
         action["post_acquisition_verification_argv"] = verification_argv
         action["post_acquisition_verification_text"] = verification_text
         action["preflight_report_path"] = preflight
+        action["staged_review_argv"] = review_argv
+        action["staged_review_text"] = review_text
+        action["review_receipt_path"] = receipt
+        action["two_person_publication_required"] = True
+        action["reviewer_identity_placeholder"] = "<registered-reviewer-id>"
+        action["publisher_identity_placeholder"] = "<registered-publisher-id>"
         action["independent_review_required_before_publication"] = True
         action["claim_bearing_publication_argv"] = publication_argv
         action["claim_bearing_publication_text"] = publication_text
@@ -111,13 +139,20 @@ def enrich_preacquisition_next_action(
             "recompute_next_action",
         ]
         outputs = list(action.get("output_paths", []))
-        if preflight not in outputs:
-            outputs.insert(1 if outputs else 0, preflight)
+        for index, path in enumerate((preflight, receipt), start=1):
+            if path not in outputs:
+                outputs.insert(min(index, len(outputs)), path)
         action["output_paths"] = outputs
     else:
         action.setdefault("post_acquisition_verification_argv", None)
         action.setdefault("post_acquisition_verification_text", None)
         action.setdefault("preflight_report_path", None)
+        action.setdefault("staged_review_argv", None)
+        action.setdefault("staged_review_text", None)
+        action.setdefault("review_receipt_path", None)
+        action.setdefault("two_person_publication_required", False)
+        action.setdefault("reviewer_identity_placeholder", None)
+        action.setdefault("publisher_identity_placeholder", None)
         action.setdefault("independent_review_required_before_publication", False)
         action.setdefault("claim_bearing_publication_argv", None)
         action.setdefault("claim_bearing_publication_text", None)
@@ -193,6 +228,7 @@ def render_preacquisition_operator_next_action_markdown(
     sections = (
         ("Command", "command_text"),
         ("Verify staged evidence", "post_acquisition_verification_text"),
+        ("Review and seal receipt", "staged_review_text"),
         (
             "Publish after independent review",
             "claim_bearing_publication_text",
@@ -206,8 +242,8 @@ def render_preacquisition_operator_next_action_markdown(
     if action.get("independent_review_required_before_publication") is True:
         lines += [
             "",
-            "Publication is claim-bearing and requires independent review of the ",
-            "content-addressed preflight report before the publication command is run.",
+            "Publication is claim-bearing and requires independent review by a ",
+            "registered reviewer plus publication by a distinct registered person.",
         ]
     blockers = action.get("blocking_items")
     if isinstance(blockers, list) and blockers:

--- a/src/causal4d/preacquisition_source_panel_review.py
+++ b/src/causal4d/preacquisition_source_panel_review.py
@@ -1,0 +1,406 @@
+"""Two-person review receipts for staged source-panel publication."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from causal4d.acquisition_flight_common import (
+    _assert_no_symlink_components,
+    _parse_utc,
+    _reject_target_outcomes,
+    _require,
+)
+from causal4d.atomic_io import atomic_write_json
+from causal4d.operator_registry import (
+    ROLE_GATE_APPROVER,
+    ROLE_INDEPENDENT_VERIFIER,
+    load_registered_operator_registry,
+    require_distinct_operator_people,
+    require_registry_precedes_event,
+    resolve_operator,
+)
+from causal4d.preacquisition_readiness_contracts import (
+    _canonical_sha256,
+    _read_json_mapping,
+    _sha256_file,
+    load_registered_preacquisition_chain,
+)
+from causal4d.preacquisition_source_panel_staging import (
+    verify_source_panel_manifest_staging,
+)
+
+SOURCE_PANEL_REVIEW_RECEIPT_SCHEMA_VERSION = 1
+SOURCE_PANEL_REVIEW_RECEIPT_ARTIFACT_KIND = "Causal4DSourcePanelStagingReviewReceipt"
+_REVIEWER_ROLES = frozenset({ROLE_GATE_APPROVER, ROLE_INDEPENDENT_VERIFIER})
+_RECEIPT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "artifact_kind",
+        "protocol_id",
+        "protocol_design_sha256",
+        "preacquisition_plan_id",
+        "preacquisition_amendment_sha256",
+        "execution_id",
+        "session_id",
+        "source_manifest_relative_path",
+        "source_manifest_sha256",
+        "source_manifest_bytes",
+        "source_execution_ended_at_utc",
+        "staging_preflight_evidence_sha256",
+        "staging_preflight_status_sha256",
+        "source_panel_evidence_sha256_before",
+        "operator_registry_artifact_sha256",
+        "reviewer_operator_id",
+        "reviewer_person_identity_sha256",
+        "reviewer_roles",
+        "reviewed_at_utc",
+        "approved_for_exactly_once_publication",
+        "changes_registered_method",
+        "target_outcomes_used",
+        "artifact_sha256",
+    }
+)
+
+
+def source_panel_review_receipt_sha256(values: Mapping[str, Any]) -> str:
+    """Return the canonical digest sealing one review receipt."""
+
+    return _canonical_sha256(values, omitted_field="artifact_sha256")
+
+
+def _registry(
+    repository_root: str | Path,
+    dataset_root: str | Path,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    result, registry = load_registered_operator_registry(
+        repository_root,
+        dataset_root,
+    )
+    _require(
+        result.get("valid") is True and isinstance(registry, Mapping),
+        str(result.get("error") or "operator registry is invalid"),
+    )
+    return result, dict(registry)
+
+
+def _source_end_time(source_json: Path, expected_sha256: str) -> str:
+    digest_before, _ = _sha256_file(source_json)
+    _require(
+        digest_before == expected_sha256,
+        "staged source manifest changed after preflight",
+    )
+    payload = _read_json_mapping(source_json, name="source-panel staging manifest")
+    _reject_target_outcomes(payload)
+    ended_at = payload.get("ended_at_utc")
+    ended = _parse_utc(ended_at, name="source execution ended_at_utc")
+    digest_after, _ = _sha256_file(source_json)
+    _require(
+        digest_after == digest_before,
+        "staged source manifest changed during review",
+    )
+    return ended.isoformat().replace("+00:00", "Z")
+
+
+def build_source_panel_review_receipt(
+    repository_root: str | Path,
+    dataset_root: str | Path,
+    source_json: str | Path,
+    *,
+    reviewed_by: str,
+    reviewed_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Re-run preflight and bind one registered human review."""
+
+    protocol, _, _, v4 = load_registered_preacquisition_chain(repository_root)
+    preflight = verify_source_panel_manifest_staging(
+        repository_root,
+        dataset_root,
+        source_json,
+    )
+    registry_result, registry = _registry(repository_root, dataset_root)
+    reviewer = resolve_operator(
+        registry,
+        reviewed_by,
+        any_role=_REVIEWER_ROLES,
+        name="source-panel staging reviewer",
+    )
+    timestamp = reviewed_at_utc or datetime.now(timezone.utc).isoformat()
+    reviewed_at = _parse_utc(timestamp, name="source-panel review timestamp")
+    require_registry_precedes_event(
+        registry,
+        timestamp,
+        event_name="source-panel staging review",
+    )
+
+    source = Path(source_json).resolve(strict=True)
+    ended_at_text = _source_end_time(
+        source,
+        str(preflight["source_manifest_sha256"]),
+    )
+    ended_at = _parse_utc(
+        ended_at_text,
+        name="source execution ended_at_utc",
+    )
+    _require(
+        reviewed_at >= ended_at,
+        "source-panel review predates execution completion",
+    )
+
+    receipt: dict[str, Any] = {
+        "schema_version": SOURCE_PANEL_REVIEW_RECEIPT_SCHEMA_VERSION,
+        "artifact_kind": SOURCE_PANEL_REVIEW_RECEIPT_ARTIFACT_KIND,
+        "protocol_id": protocol["protocol_id"],
+        "protocol_design_sha256": protocol["design_sha256"],
+        "preacquisition_plan_id": v4["plan_id"],
+        "preacquisition_amendment_sha256": v4["amendment_sha256"],
+        "execution_id": preflight["execution_id"],
+        "session_id": preflight["session_id"],
+        "source_manifest_relative_path": preflight["source_manifest_relative_path"],
+        "source_manifest_sha256": preflight["source_manifest_sha256"],
+        "source_manifest_bytes": preflight["source_manifest_bytes"],
+        "source_execution_ended_at_utc": ended_at_text,
+        "staging_preflight_evidence_sha256": preflight["evidence_sha256"],
+        "staging_preflight_status_sha256": preflight["status_sha256"],
+        "source_panel_evidence_sha256_before": preflight[
+            "source_panel_evidence_sha256_before"
+        ],
+        "operator_registry_artifact_sha256": registry_result["artifact_sha256"],
+        "reviewer_operator_id": reviewer["operator_id"],
+        "reviewer_person_identity_sha256": reviewer["person_identity_sha256"],
+        "reviewer_roles": sorted(reviewer["roles"]),
+        "reviewed_at_utc": reviewed_at.isoformat().replace("+00:00", "Z"),
+        "approved_for_exactly_once_publication": True,
+        "changes_registered_method": False,
+        "target_outcomes_used": False,
+        "artifact_sha256": None,
+    }
+    receipt["artifact_sha256"] = source_panel_review_receipt_sha256(receipt)
+    return receipt
+
+
+def source_panel_review_receipt_path(
+    dataset_root: str | Path,
+    execution_id: str,
+) -> Path:
+    """Return the canonical once-only receipt path."""
+
+    return Path(dataset_root) / "staging" / "reviews" / f"{execution_id}.json"
+
+
+def write_source_panel_review_receipt(
+    dataset_root: str | Path,
+    receipt: Mapping[str, Any],
+) -> Path:
+    """Atomically publish one non-overwriting review receipt."""
+
+    execution_id = receipt.get("execution_id")
+    _require(
+        isinstance(execution_id, str) and bool(execution_id),
+        "review receipt execution id is missing",
+    )
+    target = source_panel_review_receipt_path(dataset_root, execution_id)
+    atomic_write_json(target, dict(receipt), overwrite=False)
+    return target
+
+
+def review_source_panel_manifest_staging(
+    repository_root: str | Path,
+    dataset_root: str | Path,
+    source_json: str | Path,
+    *,
+    reviewed_by: str,
+    reviewed_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build and publish one canonical review receipt."""
+
+    receipt = build_source_panel_review_receipt(
+        repository_root,
+        dataset_root,
+        source_json,
+        reviewed_by=reviewed_by,
+        reviewed_at_utc=reviewed_at_utc,
+    )
+    output = write_source_panel_review_receipt(dataset_root, receipt)
+    digest, byte_count = _sha256_file(output)
+    return {
+        **receipt,
+        "receipt_file": {
+            "path": output.resolve()
+            .relative_to(Path(dataset_root).resolve())
+            .as_posix(),
+            "sha256": digest,
+            "bytes": byte_count,
+        },
+        "output": str(output.resolve()),
+        "passed": True,
+    }
+
+
+def _validate_receipt_fields(receipt: Mapping[str, Any]) -> None:
+    _require(
+        set(receipt) == _RECEIPT_FIELDS,
+        "source-panel review receipt fields differ from schema version 1",
+    )
+    _require(
+        receipt.get("schema_version") == SOURCE_PANEL_REVIEW_RECEIPT_SCHEMA_VERSION,
+        "unsupported source-panel review receipt schema",
+    )
+    _require(
+        receipt.get("artifact_kind") == SOURCE_PANEL_REVIEW_RECEIPT_ARTIFACT_KIND,
+        "unexpected source-panel review receipt artifact kind",
+    )
+    _require(
+        receipt.get("approved_for_exactly_once_publication") is True,
+        "source-panel review receipt does not approve publication",
+    )
+    _require(
+        receipt.get("changes_registered_method") is False,
+        "source-panel review receipt permits a registered-method change",
+    )
+    _require(
+        receipt.get("target_outcomes_used") is False,
+        "target outcomes entered source-panel review",
+    )
+    _require(
+        receipt.get("artifact_sha256") == source_panel_review_receipt_sha256(receipt),
+        "source-panel review receipt digest mismatch",
+    )
+
+
+def validate_source_panel_review_receipt(
+    repository_root: str | Path,
+    dataset_root: str | Path,
+    source_json: str | Path,
+    receipt_json: str | Path | None,
+    *,
+    published_by: str | None,
+) -> dict[str, Any]:
+    """Require a current review and a distinct registered publisher."""
+
+    _require(receipt_json is not None, "source-panel review receipt is required")
+    _require(
+        isinstance(published_by, str) and bool(published_by),
+        "source-panel publisher id is required",
+    )
+    preflight = verify_source_panel_manifest_staging(
+        repository_root,
+        dataset_root,
+        source_json,
+    )
+    root = Path(dataset_root).resolve()
+    expected_path = source_panel_review_receipt_path(
+        root,
+        str(preflight["execution_id"]),
+    ).resolve()
+    receipt_path = Path(receipt_json)
+    _assert_no_symlink_components(receipt_path, name="source-panel review receipt")
+    _require(receipt_path.is_file(), "source-panel review receipt is missing")
+    receipt_path = receipt_path.resolve(strict=True)
+    _require(
+        receipt_path == expected_path,
+        "source-panel review receipt is not at the canonical execution path",
+    )
+    digest_before, bytes_before = _sha256_file(receipt_path)
+    receipt = _read_json_mapping(receipt_path, name="source-panel review receipt")
+    _reject_target_outcomes(receipt)
+    _validate_receipt_fields(receipt)
+
+    registry_result, registry = _registry(repository_root, dataset_root)
+    reviewer = resolve_operator(
+        registry,
+        receipt.get("reviewer_operator_id"),
+        any_role=_REVIEWER_ROLES,
+        name="source-panel staging reviewer",
+    )
+    publisher = resolve_operator(
+        registry,
+        published_by,
+        name="source-panel publisher",
+    )
+    require_distinct_operator_people(
+        reviewer,
+        publisher,
+        relationship=(
+            "source-panel staging review and publication require distinct people"
+        ),
+    )
+    require_registry_precedes_event(
+        registry,
+        receipt.get("reviewed_at_utc"),
+        event_name="source-panel staging review",
+    )
+
+    expected = {
+        "protocol_id": preflight["protocol_id"],
+        "protocol_design_sha256": preflight["protocol_design_sha256"],
+        "preacquisition_plan_id": preflight["preacquisition_plan_id"],
+        "preacquisition_amendment_sha256": preflight["preacquisition_amendment_sha256"],
+        "execution_id": preflight["execution_id"],
+        "session_id": preflight["session_id"],
+        "source_manifest_relative_path": preflight["source_manifest_relative_path"],
+        "source_manifest_sha256": preflight["source_manifest_sha256"],
+        "source_manifest_bytes": preflight["source_manifest_bytes"],
+        "staging_preflight_evidence_sha256": preflight["evidence_sha256"],
+        "staging_preflight_status_sha256": preflight["status_sha256"],
+        "source_panel_evidence_sha256_before": preflight[
+            "source_panel_evidence_sha256_before"
+        ],
+        "operator_registry_artifact_sha256": registry_result["artifact_sha256"],
+        "reviewer_person_identity_sha256": reviewer["person_identity_sha256"],
+        "reviewer_roles": sorted(reviewer["roles"]),
+    }
+    for field, value in expected.items():
+        _require(
+            receipt.get(field) == value,
+            f"source-panel review receipt {field} mismatch",
+        )
+    ended_at = _parse_utc(
+        receipt.get("source_execution_ended_at_utc"),
+        name="source execution ended_at_utc",
+    )
+    reviewed_at = _parse_utc(
+        receipt.get("reviewed_at_utc"),
+        name="source-panel review timestamp",
+    )
+    _require(
+        reviewed_at >= ended_at,
+        "source-panel review predates execution completion",
+    )
+    digest_after, bytes_after = _sha256_file(receipt_path)
+    _require(
+        (digest_after, bytes_after) == (digest_before, bytes_before),
+        "source-panel review receipt changed during validation",
+    )
+    return {
+        "passed": True,
+        "execution_id": preflight["execution_id"],
+        "session_id": preflight["session_id"],
+        "review_receipt": {
+            "path": receipt_path.relative_to(root).as_posix(),
+            "sha256": digest_after,
+            "bytes": bytes_after,
+            "artifact_sha256": receipt["artifact_sha256"],
+        },
+        "reviewer_operator_id": reviewer["operator_id"],
+        "reviewer_person_identity_sha256": reviewer["person_identity_sha256"],
+        "publisher_operator_id": publisher["operator_id"],
+        "publisher_person_identity_sha256": publisher["person_identity_sha256"],
+        "independent_people": True,
+        "preflight_evidence_sha256": preflight["evidence_sha256"],
+        "target_outcomes_used": False,
+    }
+
+
+__all__ = [
+    "SOURCE_PANEL_REVIEW_RECEIPT_ARTIFACT_KIND",
+    "SOURCE_PANEL_REVIEW_RECEIPT_SCHEMA_VERSION",
+    "build_source_panel_review_receipt",
+    "review_source_panel_manifest_staging",
+    "source_panel_review_receipt_path",
+    "source_panel_review_receipt_sha256",
+    "validate_source_panel_review_receipt",
+    "write_source_panel_review_receipt",
+]

--- a/src/causal4d/preacquisition_source_panel_review_publication.py
+++ b/src/causal4d/preacquisition_source_panel_review_publication.py
@@ -1,0 +1,228 @@
+"""Review-gated publication for staged physical source evidence."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from causal4d.acquisition_flight_common import (
+    _assert_no_symlink_components,
+    _assert_ordinary_file_or_missing,
+    _reject_target_outcomes,
+    _require,
+)
+from causal4d.atomic_io import atomic_write_binary
+from causal4d.preacquisition_readiness_contracts import (
+    SOURCE_PANEL_MANIFEST_PATH,
+    _read_json_mapping,
+    _sha256_file,
+    load_registered_preacquisition_chain,
+    source_panel_execution_manifest_template,
+)
+from causal4d.preacquisition_source_panel_control import (
+    _resolved_dataset_root,
+    _write_manifest_payload,
+    build_source_panel_status,
+)
+from causal4d.preacquisition_source_panel_review import (
+    validate_source_panel_review_receipt,
+)
+from causal4d.preacquisition_source_panel_staging import (
+    verify_source_panel_manifest_staging,
+)
+from causal4d.preacquisition_source_validation import (
+    _validate_source_execution_manifest,
+)
+
+
+def publish_source_panel_manifest(
+    repository_root: str | Path,
+    dataset_root: str | Path,
+    source_json: str | Path,
+    *,
+    review: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Atomically publish only the source bytes bound by a validated review."""
+
+    preflight = verify_source_panel_manifest_staging(
+        repository_root,
+        dataset_root,
+        source_json,
+    )
+    _require(
+        preflight["evidence_sha256"] == review["preflight_evidence_sha256"],
+        "source-panel preflight changed after receipt validation",
+    )
+    _require(
+        preflight["execution_id"] == review["execution_id"],
+        "reviewed source execution changed before publication",
+    )
+    _require(
+        preflight["session_id"] == review["session_id"],
+        "reviewed source session changed before publication",
+    )
+
+    protocol, _, _, v4 = load_registered_preacquisition_chain(repository_root)
+    root = _resolved_dataset_root(dataset_root)
+    status_before = build_source_panel_status(
+        repository_root,
+        root,
+        verify_file_hashes=True,
+    )
+    _require(status_before["valid"] is True, "source-panel status is invalid")
+    _require(status_before["complete"] is False, "source panel is already complete")
+    _require(
+        status_before["status_sha256"]
+        == preflight["source_panel_status_sha256_before"],
+        "source-panel status changed after the reviewed preflight",
+    )
+    next_execution = status_before.get("next_execution")
+    _require(isinstance(next_execution, Mapping), "source panel has no next execution")
+    _require(
+        next_execution.get("template_present") is True
+        and next_execution.get("template_valid") is True,
+        "next source-panel manifest template is missing or invalid",
+    )
+
+    source = Path(source_json)
+    _assert_no_symlink_components(source, name="source-panel publication source")
+    _require(source.is_file(), "source-panel publication source is missing")
+    source = source.resolve(strict=True)
+    digest_before, bytes_before = _sha256_file(source)
+    _require(
+        digest_before == preflight["source_manifest_sha256"],
+        "staged source bytes differ from the reviewed preflight",
+    )
+    _require(
+        bytes_before == preflight["source_manifest_bytes"],
+        "staged source byte count differs from the reviewed preflight",
+    )
+    payload = _read_json_mapping(source, name="source-panel publication source")
+    _reject_target_outcomes(payload)
+    digest_after, bytes_after = _sha256_file(source)
+    _require(
+        (digest_after, bytes_after) == (digest_before, bytes_before),
+        "source-panel publication source changed while being read",
+    )
+
+    expected_template = source_panel_execution_manifest_template(
+        next_execution,
+        protocol,
+        v4,
+    )
+    _require(
+        set(payload) == set(expected_template),
+        "source-panel manifest fields differ from schema version 1",
+    )
+    execution_id = str(next_execution["execution_id"])
+    session_id = str(next_execution["session_id"])
+    _require(
+        payload.get("execution_id") == execution_id,
+        "source-panel manifest is not the next registered execution",
+    )
+    _require(
+        payload.get("session_id") == session_id,
+        "source-panel manifest names the wrong session",
+    )
+
+    manifest_relative = SOURCE_PANEL_MANIFEST_PATH.format(execution_id=execution_id)
+    final_path = root / manifest_relative
+    _assert_ordinary_file_or_missing(final_path, name="source-panel manifest")
+    _require(not final_path.exists(), "source-panel manifest already exists")
+    final_path.parent.mkdir(parents=True, exist_ok=True)
+    _assert_no_symlink_components(
+        final_path.parent,
+        name="source-panel manifest parent",
+    )
+
+    def validate(temporary: Path) -> None:
+        relative = temporary.resolve().relative_to(root).as_posix()
+        _validate_source_execution_manifest(
+            root,
+            relative,
+            protocol=protocol,
+            v4=v4,
+            execution_id=execution_id,
+            session_id=session_id,
+            verify_file_hashes=True,
+        )
+
+    atomic_write_binary(
+        final_path,
+        lambda handle: _write_manifest_payload(handle, payload),
+        overwrite=False,
+        validate=validate,
+    )
+    digest, byte_count = _sha256_file(final_path)
+    status_after = build_source_panel_status(
+        repository_root,
+        root,
+        verify_file_hashes=True,
+    )
+    _require(
+        status_after["valid"] is True,
+        "published source-panel status is invalid",
+    )
+    _require(
+        execution_id in status_after["completed_execution_ids"],
+        "published source-panel manifest was not admitted",
+    )
+    return {
+        "passed": True,
+        "execution_id": execution_id,
+        "session_id": session_id,
+        "published_manifest": {
+            "path": manifest_relative,
+            "sha256": digest,
+            "bytes": byte_count,
+        },
+        "source_panel_status": status_after,
+        "staging_preflight_evidence_sha256": preflight["evidence_sha256"],
+        "reviewed_source_manifest_sha256": digest_before,
+        "reviewed_source_manifest_bytes": bytes_before,
+        "target_outcomes_used": False,
+    }
+
+
+def publish_reviewed_source_panel_manifest(
+    repository_root: str | Path,
+    dataset_root: str | Path,
+    source_json: str | Path,
+    *,
+    review_receipt_json: str | Path,
+    published_by: str,
+) -> dict[str, Any]:
+    """Require a current independent receipt, then publish exactly once."""
+
+    review = validate_source_panel_review_receipt(
+        repository_root,
+        dataset_root,
+        source_json,
+        review_receipt_json,
+        published_by=published_by,
+    )
+    published = publish_source_panel_manifest(
+        repository_root,
+        dataset_root,
+        source_json,
+        review=review,
+    )
+    if review["execution_id"] != published["execution_id"]:
+        raise RuntimeError("reviewed and published source executions differ")
+    if review["session_id"] != published["session_id"]:
+        raise RuntimeError("reviewed and published source sessions differ")
+    return {
+        **published,
+        "review_receipt": review["review_receipt"],
+        "reviewer_operator_id": review["reviewer_operator_id"],
+        "reviewer_person_identity_sha256": review["reviewer_person_identity_sha256"],
+        "publisher_operator_id": review["publisher_operator_id"],
+        "publisher_person_identity_sha256": review["publisher_person_identity_sha256"],
+        "independent_people": review["independent_people"],
+        "review_required": True,
+        "target_outcomes_used": False,
+    }
+
+
+__all__ = ["publish_reviewed_source_panel_manifest"]

--- a/tests/test_preacquisition_source_panel_review.py
+++ b/tests/test_preacquisition_source_panel_review.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+import causal4d.preacquisition_source_panel_review as review
+import causal4d.preacquisition_source_panel_review_publication as publication
+from causal4d.cli import preacquisition_readiness as readiness_cli
+
+
+def _operator(
+    operator_id: str,
+    person_digest: str,
+    roles: list[str],
+) -> dict:
+    return {
+        "operator_id": operator_id,
+        "person_identity_sha256": person_digest,
+        "active": True,
+        "roles": sorted(roles),
+    }
+
+
+def _registry(*, same_person: bool = False) -> tuple[dict, dict]:
+    reviewer_digest = "1" * 64
+    publisher_digest = reviewer_digest if same_person else "2" * 64
+    registry = {
+        "sealed_at_utc": "2026-08-04T07:00:00Z",
+        "operators": [
+            _operator("reviewer", reviewer_digest, ["gate_approver"]),
+            _operator("publisher", publisher_digest, ["freezer"]),
+        ],
+    }
+    result = {
+        "valid": True,
+        "artifact_sha256": "3" * 64,
+        "error": None,
+    }
+    return result, registry
+
+
+def _preflight(source: Path) -> dict:
+    data = source.read_bytes()
+    return {
+        "protocol_id": "protocol",
+        "protocol_design_sha256": "a" * 64,
+        "preacquisition_plan_id": "plan",
+        "preacquisition_amendment_sha256": "b" * 64,
+        "execution_id": "source-01",
+        "session_id": "session-01",
+        "source_manifest_relative_path": "staging/source-01.json",
+        "source_manifest_sha256": hashlib.sha256(data).hexdigest(),
+        "source_manifest_bytes": len(data),
+        "source_panel_evidence_sha256_before": "c" * 64,
+        "evidence_sha256": "d" * 64,
+        "status_sha256": "e" * 64,
+    }
+
+
+def _patch(
+    monkeypatch: pytest.MonkeyPatch,
+    source: Path,
+    *,
+    same_person: bool = False,
+) -> dict:
+    preflight = _preflight(source)
+    registry_result, registry = _registry(same_person=same_person)
+    monkeypatch.setattr(
+        review,
+        "load_registered_preacquisition_chain",
+        lambda root: (
+            {
+                "protocol_id": "protocol",
+                "design_sha256": "a" * 64,
+            },
+            {},
+            {},
+            {
+                "plan_id": "plan",
+                "amendment_sha256": "b" * 64,
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        review,
+        "verify_source_panel_manifest_staging",
+        lambda *args: deepcopy(preflight),
+    )
+    monkeypatch.setattr(
+        review,
+        "_registry",
+        lambda *args: (deepcopy(registry_result), deepcopy(registry)),
+    )
+    return preflight
+
+
+def _write_source(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "ended_at_utc": "2026-08-04T08:01:00Z",
+                "target_outcomes_used": False,
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_review_receipt_binds_preflight_and_registered_reviewer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "staging" / "source-01.json"
+    _write_source(source)
+    preflight = _patch(monkeypatch, source)
+
+    receipt = review.build_source_panel_review_receipt(
+        tmp_path,
+        tmp_path,
+        source,
+        reviewed_by="reviewer",
+        reviewed_at_utc="2026-08-04T08:02:00Z",
+    )
+
+    assert receipt["execution_id"] == "source-01"
+    assert receipt["staging_preflight_evidence_sha256"] == preflight["evidence_sha256"]
+    assert receipt["source_manifest_sha256"] == preflight["source_manifest_sha256"]
+    assert receipt["reviewer_operator_id"] == "reviewer"
+    assert receipt["reviewer_roles"] == ["gate_approver"]
+    assert receipt["approved_for_exactly_once_publication"] is True
+    assert receipt["target_outcomes_used"] is False
+    assert receipt["artifact_sha256"] == (
+        review.source_panel_review_receipt_sha256(receipt)
+    )
+
+
+def test_review_cannot_predate_execution_completion(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "staging" / "source-01.json"
+    _write_source(source)
+    _patch(monkeypatch, source)
+
+    with pytest.raises(ValueError, match="predates execution completion"):
+        review.build_source_panel_review_receipt(
+            tmp_path,
+            tmp_path,
+            source,
+            reviewed_by="reviewer",
+            reviewed_at_utc="2026-08-04T08:00:00Z",
+        )
+
+
+def test_review_receipt_is_published_once_at_canonical_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "staging" / "source-01.json"
+    _write_source(source)
+    _patch(monkeypatch, source)
+    receipt = review.build_source_panel_review_receipt(
+        tmp_path,
+        tmp_path,
+        source,
+        reviewed_by="reviewer",
+        reviewed_at_utc="2026-08-04T08:02:00Z",
+    )
+
+    output = review.write_source_panel_review_receipt(tmp_path, receipt)
+
+    assert output == tmp_path / "staging" / "reviews" / "source-01.json"
+    assert json.loads(output.read_text(encoding="utf-8")) == receipt
+    with pytest.raises(FileExistsError):
+        review.write_source_panel_review_receipt(tmp_path, receipt)
+
+
+def _write_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    source: Path,
+) -> tuple[Path, dict]:
+    _patch(monkeypatch, source)
+    receipt = review.build_source_panel_review_receipt(
+        tmp_path,
+        tmp_path,
+        source,
+        reviewed_by="reviewer",
+        reviewed_at_utc="2026-08-04T08:02:00Z",
+    )
+    path = review.write_source_panel_review_receipt(tmp_path, receipt)
+    return path, receipt
+
+
+def test_publication_validation_requires_distinct_people(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "staging" / "source-01.json"
+    _write_source(source)
+    receipt_path, _ = _write_receipt(monkeypatch, tmp_path, source)
+
+    result = review.validate_source_panel_review_receipt(
+        tmp_path,
+        tmp_path,
+        source,
+        receipt_path,
+        published_by="publisher",
+    )
+
+    assert result["independent_people"] is True
+    assert result["reviewer_operator_id"] == "reviewer"
+    assert result["publisher_operator_id"] == "publisher"
+    assert result["review_receipt"]["path"] == ("staging/reviews/source-01.json")
+
+
+def test_self_review_and_publication_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "staging" / "source-01.json"
+    _write_source(source)
+    _patch(monkeypatch, source, same_person=True)
+    receipt = review.build_source_panel_review_receipt(
+        tmp_path,
+        tmp_path,
+        source,
+        reviewed_by="reviewer",
+        reviewed_at_utc="2026-08-04T08:02:00Z",
+    )
+    receipt_path = review.write_source_panel_review_receipt(tmp_path, receipt)
+
+    with pytest.raises(ValueError, match="require distinct people"):
+        review.validate_source_panel_review_receipt(
+            tmp_path,
+            tmp_path,
+            source,
+            receipt_path,
+            published_by="publisher",
+        )
+
+
+def test_stale_receipt_is_rejected_after_source_change(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "staging" / "source-01.json"
+    _write_source(source)
+    receipt_path, _ = _write_receipt(monkeypatch, tmp_path, source)
+    changed = _preflight(source)
+    changed["evidence_sha256"] = "0" * 64
+    monkeypatch.setattr(
+        review,
+        "verify_source_panel_manifest_staging",
+        lambda *args: deepcopy(changed),
+    )
+
+    with pytest.raises(ValueError, match="preflight_evidence_sha256 mismatch"):
+        review.validate_source_panel_review_receipt(
+            tmp_path,
+            tmp_path,
+            source,
+            receipt_path,
+            published_by="publisher",
+        )
+
+
+def test_receipt_digest_tamper_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "staging" / "source-01.json"
+    _write_source(source)
+    receipt_path, receipt = _write_receipt(monkeypatch, tmp_path, source)
+    receipt["reviewed_at_utc"] = "2026-08-04T08:03:00Z"
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="receipt digest mismatch"):
+        review.validate_source_panel_review_receipt(
+            tmp_path,
+            tmp_path,
+            source,
+            receipt_path,
+            published_by="publisher",
+        )
+
+
+def test_reviewed_publisher_validates_before_claim_bearing_write(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(
+        publication,
+        "validate_source_panel_review_receipt",
+        lambda *args, **kwargs: (
+            calls.append("review")
+            or {
+                "execution_id": "source-01",
+                "session_id": "session-01",
+                "review_receipt": {"path": "receipt.json"},
+                "reviewer_operator_id": "reviewer",
+                "reviewer_person_identity_sha256": "1" * 64,
+                "publisher_operator_id": "publisher",
+                "publisher_person_identity_sha256": "2" * 64,
+                "independent_people": True,
+                "preflight_evidence_sha256": "3" * 64,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        publication,
+        "publish_source_panel_manifest",
+        lambda *args, **kwargs: (
+            calls.append("publish")
+            or {
+                "passed": True,
+                "execution_id": "source-01",
+                "session_id": "session-01",
+                "target_outcomes_used": False,
+            }
+        ),
+    )
+
+    result = publication.publish_reviewed_source_panel_manifest(
+        tmp_path,
+        tmp_path,
+        tmp_path / "source.json",
+        review_receipt_json=tmp_path / "receipt.json",
+        published_by="publisher",
+    )
+
+    assert calls == ["review", "publish"]
+    assert result["review_required"] is True
+    assert result["independent_people"] is True
+
+
+def test_cli_requires_receipt_and_publisher_for_publication() -> None:
+    parser = readiness_cli.build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["source-panel-publish", "repo", "dataset", "source.json"])
+    args = parser.parse_args(
+        [
+            "source-panel-publish",
+            "repo",
+            "dataset",
+            "source.json",
+            "--review-receipt",
+            "receipt.json",
+            "--published-by",
+            "publisher",
+        ]
+    )
+    assert args.review_receipt == "receipt.json"
+    assert args.published_by == "publisher"
+
+
+def test_cli_review_and_publication_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(
+        readiness_cli,
+        "review_source_panel_manifest_staging",
+        lambda *args, **kwargs: calls.append("review") or {"passed": True},
+    )
+    monkeypatch.setattr(
+        readiness_cli,
+        "publish_reviewed_source_panel_manifest",
+        lambda *args, **kwargs: calls.append("publish") or {"passed": True},
+    )
+
+    assert (
+        readiness_cli.main(
+            [
+                "source-panel-review-staged",
+                "repo",
+                "dataset",
+                "source.json",
+                "--reviewed-by",
+                "reviewer",
+            ]
+        )
+        == 0
+    )
+    assert (
+        readiness_cli.main(
+            [
+                "source-panel-publish",
+                "repo",
+                "dataset",
+                "source.json",
+                "--review-receipt",
+                "receipt.json",
+                "--published-by",
+                "publisher",
+            ]
+        )
+        == 0
+    )
+    assert calls == ["review", "publish"]


### PR DESCRIPTION
## Summary

- add a canonical `Causal4DSourcePanelStagingReviewReceipt` bound to the exact staged manifest, source-panel prefix, preflight evidence, operator registry, reviewer identity, and review timestamp;
- add `causal4d protocol readiness source-panel-review-staged`, which reruns the complete preflight and writes the receipt exactly once to `staging/reviews/<execution-id>.json`;
- require the reviewer to be an active registered `gate_approver` or `independent_verifier`, require review after physical execution completion, and bind the receipt to the sealed registry identity;
- make claim-bearing `source-panel-publish` require both `--review-receipt` and `--published-by`;
- rerun staged preflight and source-panel status at publication time, detect receipt mutation, and require reviewer and publisher to have distinct `person_identity_sha256` values;
- snapshot the exact reviewed source bytes immediately before parsing, reject source mutation while reading, and write only that reviewed in-memory payload;
- retain atomic temporary-manifest validation so every referenced source artifact is hash-verified again immediately before the final exactly-once write;
- extend next-action artifacts with the canonical receipt path, executable review command, registered reviewer/publisher placeholders, and `two_person_publication_required=true`; and
- preserve the merged `next-action-validate` command while composing the review commands into the same readiness CLI.

## Why

The acquisition flow makes independent review explicit in the operator sequence, but an instruction alone is not a claim-bearing control. This change turns that boundary into an executable two-person contract: a content-addressed review receipt from one registered person must be validated before another registered person can publish the final source manifest.

The receipt is a snapshot, not a reservation. Publication reruns the preflight and exactly-once admission. The reviewed source digest is checked immediately before and after the publisher reads the staging file, while the temporary final manifest rehashes every referenced artifact.

## Exact scope

```text
base: decbceb9a6565103393cd3504f10b7b122a65323
head: 044f3cbb59fcb590c127fa6b6e0a79afcffa2803
commits ahead: 1
changed files: 6
```

The readiness CLI retains all merged stale-action validation routes from #215 and adds the review-gated source publication routes.

## Scientific and safety boundary

This is operational provenance only. It does not validate a physical execution, reserve the next source slot, increment evidence count, modify the estimator, change a threshold or split, authorize target access, or alter the registered analysis. The receipt records only that one registered person reviewed the current source preflight before a distinct registered person invoked exactly-once publication.

## Exact-head validation

The exact head and its synthetic merge result passed:

- Ruff lint, changed-file formatting, and the complete MyPy surface;
- core suites on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- exact declared runtime dependency floors;
- wheel and sdist builds, metadata validation, and every installed CLI help route;
- deterministic result-bundle production, verification, archive, and clean consumption;
- frozen milestone-manifest validation;
- pinned BayesianPhysTwin installed-wheel integration;
- runtime dependency audit;
- CodeQL for Python and GitHub Actions; and
- the complete synthetic merge-result suite and distribution build.

The PR is ready for review and merge.