### PR TITLE
Add permanent exact-head pull-request validation

### DIFF
--- a/.github/workflows/exact-head-validation.yml
+++ b/.github/workflows/exact-head-validation.yml
@@ -1,0 +1,420 @@
+name: Exact pull-request head validation
+
+"on":
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to validate at its current exact head
+        required: true
+        type: number
+  schedule:
+    - cron: "17 * * * *"
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: exact-head-validation-${{ github.event_name }}-${{ inputs.pr_number || 'queue' }}
+  cancel-in-progress: false
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  select:
+    name: Select one immutable pull-request head
+    runs-on: ubuntu-latest
+    outputs:
+      has_target: ${{ steps.select.outputs.has_target }}
+      pr_number: ${{ steps.select.outputs.pr_number }}
+      head_sha: ${{ steps.select.outputs.head_sha }}
+      base_sha: ${{ steps.select.outputs.base_sha }}
+      base_ref: ${{ steps.select.outputs.base_ref }}
+    steps:
+      - name: Resolve a same-repository pull request
+        id: select
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          from urllib.request import Request, urlopen
+
+          marker = "<!-- exact-head-validation: queued -->"
+          repository = os.environ["REPOSITORY"]
+          token = os.environ["GITHUB_TOKEN"]
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+
+          def api(path: str):
+              request = Request(
+                  f"https://api.github.com/repos/{repository}/{path}",
+                  headers=headers,
+              )
+              with urlopen(request) as response:
+                  return json.load(response)
+
+          if os.environ["WORKFLOW_REF"] != "refs/heads/main":
+              raise SystemExit("workflow must execute from the default main branch")
+
+          requested = os.environ.get("INPUT_PR_NUMBER", "").strip()
+          if os.environ["EVENT_NAME"] == "workflow_dispatch":
+              numbers = [int(requested)]
+          else:
+              pulls = api("pulls?state=open&per_page=100&sort=created&direction=asc")
+              numbers = [
+                  int(pull["number"])
+                  for pull in pulls
+                  if marker in (pull.get("body") or "")
+              ][:1]
+
+          output = Path(os.environ["GITHUB_OUTPUT"])
+          if not numbers:
+              with output.open("a", encoding="utf-8") as handle:
+                  handle.write("has_target=false\n")
+                  handle.write("pr_number=0\n")
+                  handle.write("head_sha=\n")
+                  handle.write("base_sha=\n")
+                  handle.write("base_ref=\n")
+              raise SystemExit(0)
+
+          pull = api(f"pulls/{numbers[0]}")
+          if pull["state"] != "open":
+              raise SystemExit("pull request must be open")
+          if pull["head"]["repo"]["full_name"] != repository:
+              raise SystemExit("exact-head validation accepts same-repository PRs only")
+          if pull["base"]["repo"]["full_name"] != repository:
+              raise SystemExit("pull request base repository does not match")
+          if pull["base"]["ref"] != "main":
+              raise SystemExit("exact-head validation accepts main-targeted PRs only")
+
+          values = {
+              "has_target": "true",
+              "pr_number": str(pull["number"]),
+              "head_sha": pull["head"]["sha"],
+              "base_sha": pull["base"]["sha"],
+              "base_ref": pull["base"]["ref"],
+          }
+          with output.open("a", encoding="utf-8") as handle:
+              for key, value in values.items():
+                  handle.write(f"{key}={value}\n")
+          PY
+
+  core:
+    name: Core-only / Python ${{ matrix.python-version }}
+    needs: select
+    if: needs.select.outputs.has_target == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12", "3.14"]
+    steps:
+      - name: Check out the selected exact head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.select.outputs.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Verify immutable checkout identity
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.select.outputs.head_sha }}
+          EXPECTED_BASE_SHA: ${{ needs.select.outputs.base_sha }}
+        run: |
+          test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          git cat-file -e "$EXPECTED_BASE_SHA^{commit}"
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install core and development dependencies
+        run: python -m pip install -e ".[dev]"
+      - name: Reject syntax warnings
+        run: |
+          PYTHONPYCACHEPREFIX="$RUNNER_TEMP/python-syntax-cache" \
+            python -W error::SyntaxWarning -m compileall -q -f src tests scripts
+      - name: Assert optional runtimes are absent
+        run: |
+          python - <<'PY'
+          import importlib.util
+
+          forbidden = ("bayesian_phystwin", "cv2", "torch", "warp")
+          present = [name for name in forbidden if importlib.util.find_spec(name)]
+          if present:
+              raise SystemExit(f"optional dependencies leaked into core job: {present}")
+          PY
+      - name: Run the complete default suite
+        run: |
+          python -m pytest \
+            --junitxml="pytest-exact-head-${{ matrix.python-version }}.xml"
+      - name: Recheck current pull-request head
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.select.outputs.pr_number }}
+          EXPECTED_HEAD_SHA: ${{ needs.select.outputs.head_sha }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from urllib.request import Request, urlopen
+
+          request = Request(
+              "https://api.github.com/repos/"
+              f"{os.environ['REPOSITORY']}/pulls/{os.environ['PR_NUMBER']}",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urlopen(request) as response:
+              pull = json.load(response)
+          if pull["head"]["sha"] != os.environ["EXPECTED_HEAD_SHA"]:
+              raise SystemExit("pull-request head changed during exact-head validation")
+          PY
+      - name: Upload core test report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: exact-head-${{ needs.select.outputs.pr_number }}-py${{ matrix.python-version }}
+          path: pytest-exact-head-${{ matrix.python-version }}.xml
+
+  quality-package-provider:
+    name: Quality, distributions, and pinned provider
+    needs: select
+    if: needs.select.outputs.has_target == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out the selected exact head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.select.outputs.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Verify immutable checkout identity
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.select.outputs.head_sha }}
+          EXPECTED_BASE_SHA: ${{ needs.select.outputs.base_sha }}
+        run: |
+          test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          git cat-file -e "$EXPECTED_BASE_SHA^{commit}"
+      - name: Verify current-base merge compatibility
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.select.outputs.head_sha }}
+          EXPECTED_BASE_SHA: ${{ needs.select.outputs.base_sha }}
+        run: |
+          git merge-tree --write-tree "$EXPECTED_BASE_SHA" "$EXPECTED_HEAD_SHA" \
+            > merge-tree-sha.txt
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install development tools
+        run: python -m pip install -e ".[dev]"
+      - name: Run quality checks
+        env:
+          BASE_SHA: ${{ needs.select.outputs.base_sha }}
+          HEAD_SHA: ${{ needs.select.outputs.head_sha }}
+        run: |
+          PYTHONPYCACHEPREFIX="$RUNNER_TEMP/python-syntax-cache" \
+            python -W error::SyntaxWarning -m compileall -q -f src tests scripts
+          python -m ruff check .
+          python scripts/ci/changed_python_files.py \
+            --base "$BASE_SHA" --head "$HEAD_SHA" > changed-python.txt
+          mapfile -t files < changed-python.txt
+          if (( ${#files[@]} )); then
+            python -m ruff format --check "${files[@]}"
+          fi
+          python -m mypy --python-version 3.12 \
+            scripts/ci \
+            src/causal4d/atomic_io.py \
+            src/causal4d/result_bundle_publication.py \
+            src/causal4d/trusted_pickle.py \
+            src/causal4d/immutable_array.py \
+            src/causal4d/immutable_json.py \
+            src/causal4d/provider_contract.py \
+            src/causal4d/belief_provider_v2_contract.py \
+            src/causal4d/replay_provider_contract.py
+      - name: Build and validate distributions
+        run: |
+          python -m build
+          python -m twine check dist/*
+      - name: Read exact Bayesian-PhysTwin pin
+        id: pin
+        run: echo "sha=$(python scripts/ci/read_bpt_pin.py)" >> "$GITHUB_OUTPUT"
+      - name: Check out pinned Bayesian-PhysTwin
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/BayesianPhysTwin
+          ref: ${{ steps.pin.outputs.sha }}
+          path: _bpt
+          persist-credentials: false
+      - name: Build installed-wheel integration pair
+        run: |
+          wheelhouse="$RUNNER_TEMP/exact-head-wheelhouse"
+          mkdir -p "$wheelhouse"
+          python -m build --wheel --outdir "$wheelhouse" .
+          python -m build --wheel --outdir "$wheelhouse" ./_bpt
+          test "$(find "$wheelhouse" -maxdepth 1 -name '*.whl' | wc -l)" -eq 2
+      - name: Install and test the pinned provider pair
+        env:
+          CAUSAL4D_REQUIRE_BPT_PROVIDER: "1"
+        run: |
+          wheelhouse="$RUNNER_TEMP/exact-head-wheelhouse"
+          venv="$RUNNER_TEMP/exact-head-venv"
+          python -m venv "$venv"
+          "$venv/bin/python" -m pip install --upgrade pip
+          "$venv/bin/python" -m pip install "$wheelhouse"/*.whl pytest
+          "$venv/bin/python" -m pip check
+          "$venv/bin/python" scripts/ci/run_bpt_integration_tests.py
+      - name: Recheck current pull-request head
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.select.outputs.pr_number }}
+          EXPECTED_HEAD_SHA: ${{ needs.select.outputs.head_sha }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from urllib.request import Request, urlopen
+
+          request = Request(
+              "https://api.github.com/repos/"
+              f"{os.environ['REPOSITORY']}/pulls/{os.environ['PR_NUMBER']}",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urlopen(request) as response:
+              pull = json.load(response)
+          if pull["head"]["sha"] != os.environ["EXPECTED_HEAD_SHA"]:
+              raise SystemExit("pull-request head changed during exact-head validation")
+          PY
+      - name: Upload distributions and exact identities
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: exact-head-${{ needs.select.outputs.pr_number }}-package-provider
+          path: |
+            dist/*
+            changed-python.txt
+            merge-tree-sha.txt
+
+  attest:
+    name: Publish exact-head result
+    needs: [select, core, quality-package-provider]
+    if: always() && needs.select.outputs.has_target == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Recheck head and publish one-shot result
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.select.outputs.pr_number }}
+          EXPECTED_HEAD_SHA: ${{ needs.select.outputs.head_sha }}
+          EXPECTED_BASE_SHA: ${{ needs.select.outputs.base_sha }}
+          CORE_RESULT: ${{ needs.core.result }}
+          QUALITY_RESULT: ${{ needs.quality-package-provider.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from urllib.request import Request, urlopen
+
+          repository = os.environ["REPOSITORY"]
+          pr_number = os.environ["PR_NUMBER"]
+          token = os.environ["GITHUB_TOKEN"]
+          expected_head = os.environ["EXPECTED_HEAD_SHA"]
+          marker = "<!-- exact-head-validation: queued -->"
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "Content-Type": "application/json",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+
+          def request(method: str, path: str, payload=None):
+              data = None if payload is None else json.dumps(payload).encode("utf-8")
+              item = Request(
+                  f"https://api.github.com/repos/{repository}/{path}",
+                  data=data,
+                  headers=headers,
+                  method=method,
+              )
+              with urlopen(item) as response:
+                  return json.load(response)
+
+          pull = request("GET", f"pulls/{pr_number}")
+          head_current = pull["head"]["sha"] == expected_head
+          passed = (
+              os.environ["CORE_RESULT"] == "success"
+              and os.environ["QUALITY_RESULT"] == "success"
+              and head_current
+          )
+          result = "passed" if passed else "failed"
+          record = {
+              "schema_version": 1,
+              "artifact_kind": "Causal4DExactHeadValidation",
+              "repository": repository,
+              "pull_request_number": int(pr_number),
+              "head_sha": expected_head,
+              "base_sha": os.environ["EXPECTED_BASE_SHA"],
+              "head_still_current": head_current,
+              "core_result": os.environ["CORE_RESULT"],
+              "quality_package_provider_result": os.environ["QUALITY_RESULT"],
+              "result": result,
+              "completed_at_utc": datetime.now(timezone.utc).isoformat(),
+              "run_url": os.environ["RUN_URL"],
+          }
+          with open("exact-head-validation.json", "w", encoding="utf-8") as handle:
+              json.dump(record, handle, sort_keys=True, indent=2, allow_nan=False)
+              handle.write("\n")
+
+          body = pull.get("body") or ""
+          completion = (
+              "<!-- exact-head-validation: "
+              f"{result} head={expected_head} run={os.environ['RUN_URL']} -->"
+          )
+          if marker in body:
+              body = body.replace(marker, completion, 1)
+              request("PATCH", f"pulls/{pr_number}", {"body": body})
+
+          comment = (
+              f"Exact-head validation **{result}** for `{expected_head}`. "
+              f"Core matrix: `{os.environ['CORE_RESULT']}`; quality/package/"
+              f"provider: `{os.environ['QUALITY_RESULT']}`; "
+              f"head still current: `{str(head_current).lower()}`. "
+              f"Run: {os.environ['RUN_URL']}"
+          )
+          request("POST", f"issues/{pr_number}/comments", {"body": comment})
+          if not passed:
+              raise SystemExit("exact-head validation did not pass")
+          PY
+      - name: Upload the validation record
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: exact-head-${{ needs.select.outputs.pr_number }}-attestation
+          path: exact-head-validation.json

--- a/docs/exact_head_validation.md
+++ b/docs/exact_head_validation.md
@@ -1,0 +1,66 @@
+# Exact pull-request head validation
+
+GitHub App or automation-authored pull-request events do not always enqueue the
+repository's ordinary `pull_request` workflows. Causal4D therefore has one
+permanent, read-mostly validation workflow for an explicitly selected immutable
+same-repository pull-request head:
+
+```text
+.github/workflows/exact-head-validation.yml
+```
+
+It is an engineering validation path. It does not access physical data, inspect
+target outcomes, mutate registered evidence, or authorize acquisition.
+
+## Requesting validation
+
+A maintainer can dispatch **Exact pull-request head validation** with a pull
+request number. For automation that cannot dispatch workflows, place this exact
+marker once in the pull-request body:
+
+```html
+<!-- exact-head-validation: queued -->
+```
+
+The hourly scheduled run selects at most one queued pull request, oldest first.
+Only open pull requests whose head and base are both in this repository and whose
+base branch is `main` are admissible. Fork heads are rejected.
+
+The marker is one-shot. The final job replaces it with a completion marker bound
+to the exact head SHA, result, and Actions run URL. A new head requires a new
+queue marker; an earlier successful result must not be interpreted as evidence
+for later commits.
+
+## Validation boundary
+
+The selected head SHA and base SHA are resolved from GitHub before execution.
+Every validation job checks out the exact head with persisted credentials
+disabled, records both identities, and re-reads the pull request after testing.
+A head movement during the run makes the validation fail.
+
+The workflow runs:
+
+- the complete default suite on Python 3.10, 3.12, and 3.14;
+- syntax-warning rejection and byte compilation;
+- Ruff lint and incremental formatting checks;
+- MyPy over the stable contracts and CI utilities;
+- wheel and source-distribution builds with Twine validation; and
+- the exact pinned BayesianPhysTwin installed-wheel integration.
+
+The final `Causal4DExactHeadValidation` JSON artifact records the pull request,
+head SHA, base SHA, component job results, whether the head remained current,
+and the workflow run URL. The pull-request comment is a human-readable pointer;
+the uploaded JSON and Actions logs are the validation evidence.
+
+## Security and claim boundary
+
+The schedule uses the workflow from the default branch, never code-defined
+workflow permissions from the pull-request head. It accepts only
+same-repository heads, checks out without persisted credentials, and supplies
+the write-capable token only to narrowly scoped GitHub API steps. Test processes
+do not receive that token.
+
+Passing establishes software validation for the named bytes. It is not physical
+experiment evidence, empirical model evidence, independent scientific review, or
+a substitute for the registered pre-acquisition readiness and method-freeze
+gates.

--- a/tests/test_exact_head_validation_workflow_policy.py
+++ b/tests/test_exact_head_validation_workflow_policy.py
@@ -1,0 +1,60 @@
+"""Policy checks for the permanent exact-head validation workflow."""
+
+from pathlib import Path
+
+
+WORKFLOW = Path(".github/workflows/exact-head-validation.yml")
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_exact_head_validation_has_manual_and_scheduled_queue() -> None:
+    text = _workflow_text()
+    assert "workflow_dispatch:" in text
+    assert "schedule:" in text
+    assert '<!-- exact-head-validation: queued -->' in text
+    assert "same-repository PRs only" in text
+    assert 'pull["base"]["ref"] != "main"' in text
+    assert 'WORKFLOW_REF"] != "refs/heads/main"' in text
+
+
+def test_exact_head_checkout_is_immutable_and_uncredentialed() -> None:
+    text = _workflow_text()
+    assert "ref: ${{ needs.select.outputs.head_sha }}" in text
+    assert text.count("fetch-depth: 0") >= 2
+    assert text.count("persist-credentials: false") >= 3
+    assert text.count("git rev-parse HEAD") >= 2
+    assert text.count("pull-request head changed during exact-head validation") >= 2
+    assert "git merge-tree --write-tree" in text
+    assert "pull_request_target" not in text
+    assert "contents: write" not in text
+
+
+def test_exact_head_validation_matches_authoritative_stack() -> None:
+    text = _workflow_text()
+    for version in ('"3.10"', '"3.12"', '"3.14"'):
+        assert version in text
+    for command in (
+        "python -W error::SyntaxWarning -m compileall",
+        "python -m pytest",
+        "python -m ruff check .",
+        "python -m ruff format --check",
+        "python -m mypy --python-version 3.12",
+        "python -m build",
+        "python -m twine check dist/*",
+        "python scripts/ci/read_bpt_pin.py",
+        "scripts/ci/run_bpt_integration_tests.py",
+    ):
+        assert command in text
+
+
+def test_exact_head_result_is_bound_and_one_shot() -> None:
+    text = _workflow_text()
+    assert '"artifact_kind": "Causal4DExactHeadValidation"' in text
+    assert '"head_sha": expected_head' in text
+    assert '"base_sha": os.environ["EXPECTED_BASE_SHA"]' in text
+    assert '"head_still_current": head_current' in text
+    assert "exact-head-validation.json" in text
+    assert "body.replace(marker, completion, 1)" in text


### PR DESCRIPTION
## Summary

- add a permanent `workflow_dispatch` and hourly scheduled exact-head validator;
- accept only open same-repository pull requests targeting `main`;
- select at most one queued PR through the one-shot body marker documented in `docs/exact_head_validation.md`;
- check out the exact immutable head SHA without persisted credentials and bind the current base SHA;
- run the complete Python 3.10/3.12/3.14 suites, SyntaxWarning rejection, Ruff, incremental formatting, MyPy, distributions, current-base merge compatibility, and the pinned BayesianPhysTwin installed-wheel integration;
- recheck the PR head after validation and publish a content-addressable JSON record plus a PR comment;
- replace the queue marker with an exact-SHA completion marker so results cannot be silently reused for later commits; and
- add repository policy tests for the trigger, security, immutable-checkout, validation-stack, and attestation boundaries.

## Why

Connector- or automation-authored pull-request events have repeatedly failed to enqueue the ordinary `pull_request` workflows, leading to temporary validation workflows and cleanup commits. This provides one reusable default-branch workflow that can be manually dispatched or consume a one-shot scheduled queue without adding PR-specific workflow files to `main`.

## Security boundary

The workflow definition comes from `main` for scheduled execution, rejects fork heads and non-`main` bases, checks out with `persist-credentials: false`, and supplies the write-capable token only to narrow GitHub API steps. Test processes do not receive the token. Manual dispatches from a non-`main` workflow ref fail closed.

## Scientific boundary

This is software-validation infrastructure only. It accesses no physical data or target outcomes, mutates no registered evidence, changes no estimator or analysis rule, and cannot authorize acquisition.

## Validation performed before publication

- YAML parsed successfully with the declared trigger and permissions;
- the new Python policy test byte-compiled successfully;
- branch comparison is exactly three added files and no existing product code changes;
- all action references reuse the repository's existing pinned checkout/setup/upload revisions;
- no remote Actions success is claimed for this bootstrap PR, because the capability being added is the missing permanent validation path.