### PR TITLE
Add full-posterior topology-aware contact scoring

### DIFF
--- a/docs/contact_posterior_topology_scores.md
+++ b/docs/contact_posterior_topology_scores.md
@@ -1,0 +1,83 @@
+# Full-posterior topology scores
+
+The registered latent-contact result uses exact contact-node recovery as its
+primary discrete gate. The existing contact-posterior diagnostic additionally
+reports MAP graph distance, one-hop recovery, graph-symmetry proxies, and a
+normalized graph-diffusion force-field cosine.
+
+Those MAP diagnostics do not describe how the remaining posterior mass is
+allocated. A posterior with 49% on the exact node and 51% on a mechanically
+similar neighbor has a different evidential meaning from a posterior with 51%
+on a remote node, even though both fail exact MAP recovery.
+
+The additive topology-score layer therefore evaluates the complete categorical
+node posterior. It does not modify the frozen estimator, posterior temperature,
+registered exact-node threshold, success-gate decision, or physical protocol.
+
+## Reported quantities
+
+For each shifted-contact case, the diagnostic records:
+
+- posterior expected mean and maximum assignment distance in graph hops;
+- exact-node posterior probability;
+- posterior mass within one-hop and two-hop contact patches;
+- the smallest truth-centered graph radius containing the registered credible
+  mass;
+- the minimum graph distance between truth and any member of the registered node
+  credible set;
+- posterior expected cosine similarity in the declared graph-diffusion
+  force-field proxy;
+- posterior mass above force-field cosine thresholds 0.80, 0.90, and 0.95;
+- expected force-field proxy distance;
+- posterior pairwise force-field dispersion; and
+- a force-field energy score.
+
+The graph assignment distance minimizes over permutations of equal-cardinality
+contact sets. This treats the material contact set as unlabeled while preserving
+the registered cardinality.
+
+## Proper force-field score
+
+For a normalized graph-diffusion force-field feature `f(z)` and the realized
+contact assignment `z*`, the reported energy score is
+
+```text
+E ||f(Z) - f(z*)|| - 0.5 E ||f(Z) - f(Z')||,
+```
+
+where `Z` and `Z'` are independent draws from the node posterior. Lower is
+better, and a point mass on the realized force-field proxy has score zero. This
+is a proper score for the declared Euclidean proxy representation. Assignments
+with identical proxy fields are intentionally treated as equivalent by this
+score; it is not a claim that they are physically identical under every action
+or simulator.
+
+## Integration
+
+`scripts/ci/analyze_contact_posterior.py` augments the already admitted and
+parity-checked diagnostic result before publication. The existing JSON and CSV
+artifacts receive:
+
+```text
+posterior_topology_scores
+posterior_expected_assignment_graph_distance_hops
+posterior_one_hop_patch_mass
+posterior_truth_centered_credible_radius_hops
+posterior_expected_force_field_cosine
+posterior_force_field_energy_score
+```
+
+plus the remaining threshold and credible-set fields. Aggregates are reported
+overall and by held-out topology.
+
+The source bundle must still pass the existing immutable admission boundary and
+the recomputed posterior must still match the retained registered metrics. The
+new score layer is downstream of both checks.
+
+## Claim boundary
+
+These quantities are controlled, analysis-only diagnostics. They may explain
+why an exact-node gate fails or identify posterior mass concentrated on nearby
+mechanically similar assignments. They cannot change, replace, or rescue a
+failed registered exact-node gate, and they do not establish a real physical
+interventional-prediction result.

--- a/scripts/ci/analyze_contact_posterior.py
+++ b/scripts/ci/analyze_contact_posterior.py
@@ -15,6 +15,9 @@ from causal4d.contact_posterior_diagnostics import (
     DiagnosticConfig,
     write_contact_posterior_diagnostics,
 )
+from causal4d.contact_posterior_topology_scores import (
+    augment_contact_posterior_result_from_bundle,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -47,6 +50,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     if not isinstance(source_integrity, dict):
         raise ValueError("diagnostic result is missing admission verification")
 
+    result = augment_contact_posterior_result_from_bundle(
+        result,
+        args.bundle_dir,
+        diffusion_strength=args.diffusion_strength,
+    )
     paths = write_contact_posterior_diagnostics(result, args.output_dir)
     print(
         json.dumps(
@@ -56,6 +64,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "recomputation_parity": result["recomputation_parity"],
                 "overall": result["overall"],
                 "by_topology": result["by_topology"],
+                "posterior_topology_scores": result["posterior_topology_scores"],
                 "artifacts": paths,
                 "claim_boundary": result["claim_boundary"],
             },

--- a/src/causal4d/contact_posterior_topology_scores.py
+++ b/src/causal4d/contact_posterior_topology_scores.py
@@ -1,0 +1,578 @@
+"""Full-posterior topology scores for latent contact diagnostics.
+
+The scores in this module are analysis-only. They do not modify the frozen
+latent-contact estimator, any registered success gate, or the physical
+experiment.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from dataclasses import asdict, dataclass
+from itertools import permutations
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from causal4d.benchmark import CounterfactualBenchmarkConfig, build_protocol
+from causal4d.simulator import GraphObject
+
+
+_DEFAULT_FORCE_FIELD_THRESHOLDS = (0.80, 0.90, 0.95)
+
+
+@dataclass(frozen=True)
+class TopologyPosteriorScoreConfig:
+    """Declared analysis choices for full-posterior topology scoring."""
+
+    confidence_level: float = 0.90
+    diffusion_strength: float = 1.0
+    force_field_similarity_thresholds: tuple[float, ...] = (
+        _DEFAULT_FORCE_FIELD_THRESHOLDS
+    )
+
+    def __post_init__(self) -> None:
+        if not np.isfinite(self.confidence_level) or not (
+            0.0 < self.confidence_level < 1.0
+        ):
+            raise ValueError("confidence_level must be finite and in (0, 1)")
+        if not np.isfinite(self.diffusion_strength) or self.diffusion_strength <= 0.0:
+            raise ValueError("diffusion_strength must be finite and positive")
+        thresholds = tuple(self.force_field_similarity_thresholds)
+        if not thresholds:
+            raise ValueError("at least one force-field threshold is required")
+        if any(
+            not np.isfinite(value) or not 0.0 <= value <= 1.0 for value in thresholds
+        ):
+            raise ValueError("force-field thresholds must be finite and in [0, 1]")
+        if tuple(sorted(set(thresholds))) != thresholds:
+            raise ValueError("force-field thresholds must be unique and sorted")
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _threshold_label(value: float) -> str:
+    return str(value).replace(".", "_")
+
+
+def _reject_json_constant(value: str) -> Any:
+    raise ValueError(f"non-finite JSON constant is forbidden: {value}")
+
+
+def parse_contact_assignment_label(value: str) -> tuple[int, ...]:
+    """Parse the canonical semicolon-separated contact-assignment label."""
+
+    _require(isinstance(value, str) and bool(value.strip()), "contact label is empty")
+    try:
+        nodes = tuple(int(part) for part in value.split(";"))
+    except ValueError as error:
+        raise ValueError("contact label contains a non-integer node") from error
+    _require(bool(nodes), "contact assignment must be nonempty")
+    _require(len(nodes) == len(set(nodes)), "contact assignment contains duplicates")
+    _require(all(node >= 0 for node in nodes), "contact nodes must be nonnegative")
+    return nodes
+
+
+def parse_node_posterior(value: str) -> dict[tuple[int, ...], float]:
+    """Parse and validate the serialized categorical contact posterior."""
+
+    _require(isinstance(value, str) and bool(value), "node posterior is missing")
+    try:
+        payload = json.loads(value, parse_constant=_reject_json_constant)
+    except json.JSONDecodeError as error:
+        raise ValueError("node posterior is invalid JSON") from error
+    _require(isinstance(payload, Mapping) and bool(payload), "node posterior is empty")
+    probabilities: dict[tuple[int, ...], float] = {}
+    for label, raw_probability in payload.items():
+        nodes = parse_contact_assignment_label(str(label))
+        _require(nodes not in probabilities, "node posterior contains duplicate labels")
+        _require(
+            isinstance(raw_probability, (int, float))
+            and not isinstance(raw_probability, bool),
+            "node posterior probabilities must be numeric",
+        )
+        probability = float(raw_probability)
+        _require(
+            np.isfinite(probability) and probability >= 0.0,
+            "node posterior probabilities must be finite and nonnegative",
+        )
+        probabilities[nodes] = probability
+    total = float(sum(probabilities.values()))
+    _require(
+        np.isclose(total, 1.0, rtol=1e-10, atol=1e-12),
+        "node posterior probabilities must sum to one",
+    )
+    if total != 1.0:
+        probabilities = {
+            assignment: probability / total
+            for assignment, probability in probabilities.items()
+        }
+    return probabilities
+
+
+def parse_contact_credible_set(value: str) -> tuple[tuple[int, ...], ...]:
+    """Parse the serialized ordered node credible set."""
+
+    _require(isinstance(value, str) and bool(value), "node credible set is missing")
+    try:
+        payload = json.loads(value)
+    except json.JSONDecodeError as error:
+        raise ValueError("node credible set is invalid JSON") from error
+    _require(isinstance(payload, list) and bool(payload), "node credible set is empty")
+    assignments = tuple(parse_contact_assignment_label(str(item)) for item in payload)
+    _require(
+        len(assignments) == len(set(assignments)),
+        "node credible set contains duplicate assignments",
+    )
+    return assignments
+
+
+def all_pairs_graph_distances(graph: GraphObject) -> np.ndarray:
+    """Return connected, unweighted shortest-path distances between all nodes."""
+
+    count = int(graph.rest_positions.shape[0])
+    _require(count > 0, "graph must contain at least one node")
+    adjacency: list[list[int]] = [[] for _ in range(count)]
+    for first, second in graph.edges:
+        first = int(first)
+        second = int(second)
+        _require(
+            0 <= first < count and 0 <= second < count and first != second,
+            "graph contains an invalid edge",
+        )
+        adjacency[first].append(second)
+        adjacency[second].append(first)
+
+    distances = np.full((count, count), count + 1, dtype=int)
+    for source in range(count):
+        distances[source, source] = 0
+        frontier = [source]
+        cursor = 0
+        while cursor < len(frontier):
+            node = frontier[cursor]
+            cursor += 1
+            candidate_distance = int(distances[source, node]) + 1
+            for neighbor in adjacency[node]:
+                if candidate_distance < distances[source, neighbor]:
+                    distances[source, neighbor] = candidate_distance
+                    frontier.append(neighbor)
+    _require(not np.any(distances > count), f"graph {graph.name!r} is disconnected")
+    return distances
+
+
+def assignment_graph_distance(
+    truth: Sequence[int],
+    estimate: Sequence[int],
+    distances: np.ndarray,
+) -> tuple[float, int]:
+    """Return minimum mean and maximum hop distance over contact permutations."""
+
+    truth_nodes = tuple(map(int, truth))
+    estimate_nodes = tuple(map(int, estimate))
+    _require(bool(truth_nodes), "contact assignment must be nonempty")
+    _require(
+        len(truth_nodes) == len(estimate_nodes),
+        "contact assignments have different cardinalities",
+    )
+    _require(
+        len(truth_nodes) == len(set(truth_nodes))
+        and len(estimate_nodes) == len(set(estimate_nodes)),
+        "contact assignments contain duplicate nodes",
+    )
+    matrix = np.asarray(distances)
+    _require(
+        matrix.ndim == 2 and matrix.shape[0] == matrix.shape[1],
+        "graph-distance matrix must be square",
+    )
+    count = matrix.shape[0]
+    _require(
+        all(0 <= node < count for node in (*truth_nodes, *estimate_nodes)),
+        "contact assignment references an invalid node",
+    )
+
+    candidates: list[tuple[int, int]] = []
+    for assignment in permutations(estimate_nodes):
+        values = [
+            int(matrix[truth_node, estimate_node])
+            for truth_node, estimate_node in zip(truth_nodes, assignment, strict=True)
+        ]
+        candidates.append((sum(values), max(values, default=0)))
+    total, maximum = min(candidates)
+    return float(total / len(truth_nodes)), int(maximum)
+
+
+def diffused_contact_field(
+    graph: GraphObject,
+    nodes: Sequence[int],
+    *,
+    diffusion_strength: float,
+) -> np.ndarray:
+    """Return a unit graph-diffusion proxy for one contact assignment."""
+
+    _require(
+        np.isfinite(diffusion_strength) and diffusion_strength > 0.0,
+        "diffusion_strength must be finite and positive",
+    )
+    assignment = tuple(map(int, nodes))
+    count = int(graph.rest_positions.shape[0])
+    _require(bool(assignment), "contact assignment must be nonempty")
+    _require(
+        len(assignment) == len(set(assignment)),
+        "contact assignment contains duplicate nodes",
+    )
+    _require(
+        all(0 <= node < count for node in assignment),
+        "contact assignment references an invalid node",
+    )
+    adjacency = np.zeros((count, count), dtype=float)
+    for first, second in graph.edges:
+        adjacency[int(first), int(second)] = 1.0
+        adjacency[int(second), int(first)] = 1.0
+    laplacian = np.diag(np.sum(adjacency, axis=1)) - adjacency
+    source = np.zeros(count, dtype=float)
+    for node in assignment:
+        source[node] += 1.0 / len(assignment)
+    field = np.linalg.solve(
+        np.eye(count, dtype=float) + diffusion_strength * laplacian,
+        source,
+    )
+    norm = float(np.linalg.norm(field))
+    _require(
+        np.isfinite(norm) and norm > 0.0,
+        "graph diffusion produced an invalid force-field proxy",
+    )
+    return field / norm
+
+
+def _credible_set_distances(
+    credible_set: Sequence[Sequence[int]],
+    truth: tuple[int, ...],
+    distances: np.ndarray,
+) -> dict[str, Any]:
+    values = [
+        assignment_graph_distance(truth, assignment, distances)
+        for assignment in credible_set
+    ]
+    minimum_mean = min(value[0] for value in values)
+    minimum_max = min(value[1] for value in values)
+    return {
+        "node_credible_set_min_mean_graph_distance_hops": minimum_mean,
+        "node_credible_set_min_max_graph_distance_hops": minimum_max,
+        "node_credible_set_one_hop_patch_covered": minimum_max <= 1,
+    }
+
+
+def posterior_topology_scores(
+    graph: GraphObject,
+    probabilities: Mapping[tuple[int, ...], float],
+    truth: Sequence[int],
+    *,
+    config: TopologyPosteriorScoreConfig,
+    credible_set: Sequence[Sequence[int]] | None = None,
+) -> dict[str, Any]:
+    """Score the complete node posterior in graph and force-field space."""
+
+    truth_nodes = tuple(map(int, truth))
+    _require(bool(probabilities), "node posterior must be nonempty")
+    normalized: dict[tuple[int, ...], float] = {}
+    for raw_assignment, raw_probability in probabilities.items():
+        assignment = tuple(map(int, raw_assignment))
+        _require(
+            len(assignment) == len(truth_nodes),
+            "posterior contact cardinality differs from truth",
+        )
+        _require(
+            assignment not in normalized,
+            "node posterior contains duplicate assignments",
+        )
+        probability = float(raw_probability)
+        _require(
+            np.isfinite(probability) and probability >= 0.0,
+            "node posterior probabilities must be finite and nonnegative",
+        )
+        normalized[assignment] = probability
+    total = float(sum(normalized.values()))
+    _require(
+        np.isclose(total, 1.0, rtol=1e-10, atol=1e-12),
+        "node posterior probabilities must sum to one",
+    )
+    if total != 1.0:
+        normalized = {
+            assignment: probability / total
+            for assignment, probability in normalized.items()
+        }
+
+    support = tuple(sorted(normalized))
+    weights = np.asarray([normalized[assignment] for assignment in support])
+    distances = all_pairs_graph_distances(graph)
+    graph_distances = [
+        assignment_graph_distance(truth_nodes, assignment, distances)
+        for assignment in support
+    ]
+    mean_distances = np.asarray([value[0] for value in graph_distances])
+    maximum_distances = np.asarray([value[1] for value in graph_distances], dtype=int)
+
+    truth_field = diffused_contact_field(
+        graph,
+        truth_nodes,
+        diffusion_strength=config.diffusion_strength,
+    )
+    fields = np.stack(
+        [
+            diffused_contact_field(
+                graph,
+                assignment,
+                diffusion_strength=config.diffusion_strength,
+            )
+            for assignment in support
+        ]
+    )
+    cosines = np.clip(fields @ truth_field, -1.0, 1.0)
+    field_distances = np.linalg.norm(fields - truth_field[None, :], axis=1)
+    pairwise_distances = np.linalg.norm(
+        fields[:, None, :] - fields[None, :, :],
+        axis=2,
+    )
+    expected_field_distance = float(weights @ field_distances)
+    pairwise_dispersion = 0.5 * float(
+        np.sum(weights[:, None] * weights[None, :] * pairwise_distances)
+    )
+    energy_score = expected_field_distance - pairwise_dispersion
+    if energy_score < 0.0 and np.isclose(energy_score, 0.0, atol=1e-14):
+        energy_score = 0.0
+    _require(energy_score >= 0.0, "force-field energy score became negative")
+
+    mass_by_radius: dict[int, float] = {}
+    for radius in sorted(set(map(int, maximum_distances))):
+        mass_by_radius[radius] = float(np.sum(weights[maximum_distances <= radius]))
+    credible_radius = next(
+        radius
+        for radius, mass in sorted(mass_by_radius.items())
+        if mass >= config.confidence_level - 1e-12
+    )
+
+    result: dict[str, Any] = {
+        "posterior_expected_assignment_graph_distance_hops": float(
+            weights @ mean_distances
+        ),
+        "posterior_expected_max_assignment_graph_distance_hops": float(
+            weights @ maximum_distances
+        ),
+        "posterior_exact_node_mass": float(normalized.get(truth_nodes, 0.0)),
+        "posterior_one_hop_patch_mass": float(np.sum(weights[maximum_distances <= 1])),
+        "posterior_two_hop_patch_mass": float(np.sum(weights[maximum_distances <= 2])),
+        "posterior_truth_centered_credible_radius_hops": int(credible_radius),
+        "posterior_expected_force_field_cosine": float(weights @ cosines),
+        "posterior_expected_force_field_distance": expected_field_distance,
+        "posterior_force_field_pairwise_dispersion": pairwise_dispersion,
+        "posterior_force_field_energy_score": float(energy_score),
+    }
+    for threshold in config.force_field_similarity_thresholds:
+        result[f"posterior_force_field_mass_at_{_threshold_label(threshold)}"] = float(
+            np.sum(weights[cosines >= threshold])
+        )
+    if credible_set is not None:
+        result.update(
+            _credible_set_distances(
+                credible_set,
+                truth_nodes,
+                distances,
+            )
+        )
+    return result
+
+
+def _mean(rows: Sequence[Mapping[str, Any]], field: str) -> float:
+    return float(np.mean([float(row[field]) for row in rows]))
+
+
+def _fraction(rows: Sequence[Mapping[str, Any]], field: str) -> float:
+    return float(np.mean([float(bool(row[field])) for row in rows]))
+
+
+def aggregate_posterior_topology_scores(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    config: TopologyPosteriorScoreConfig,
+) -> dict[str, Any]:
+    """Aggregate the additive full-posterior topology diagnostics."""
+
+    _require(bool(rows), "cannot aggregate empty topology-score rows")
+    result: dict[str, Any] = {
+        "case_count": len(rows),
+        "mean_posterior_expected_assignment_graph_distance_hops": _mean(
+            rows,
+            "posterior_expected_assignment_graph_distance_hops",
+        ),
+        "mean_posterior_expected_max_assignment_graph_distance_hops": _mean(
+            rows,
+            "posterior_expected_max_assignment_graph_distance_hops",
+        ),
+        "mean_posterior_exact_node_mass": _mean(rows, "posterior_exact_node_mass"),
+        "mean_posterior_one_hop_patch_mass": _mean(
+            rows,
+            "posterior_one_hop_patch_mass",
+        ),
+        "mean_posterior_two_hop_patch_mass": _mean(
+            rows,
+            "posterior_two_hop_patch_mass",
+        ),
+        "mean_truth_centered_credible_radius_hops": _mean(
+            rows,
+            "posterior_truth_centered_credible_radius_hops",
+        ),
+        "mean_posterior_expected_force_field_cosine": _mean(
+            rows,
+            "posterior_expected_force_field_cosine",
+        ),
+        "mean_posterior_expected_force_field_distance": _mean(
+            rows,
+            "posterior_expected_force_field_distance",
+        ),
+        "mean_posterior_force_field_pairwise_dispersion": _mean(
+            rows,
+            "posterior_force_field_pairwise_dispersion",
+        ),
+        "mean_posterior_force_field_energy_score": _mean(
+            rows,
+            "posterior_force_field_energy_score",
+        ),
+    }
+    if all("node_credible_set_one_hop_patch_covered" in row for row in rows):
+        result["node_credible_set_one_hop_patch_coverage"] = _fraction(
+            rows,
+            "node_credible_set_one_hop_patch_covered",
+        )
+        result["mean_node_credible_set_min_graph_distance_hops"] = _mean(
+            rows,
+            "node_credible_set_min_mean_graph_distance_hops",
+        )
+    for threshold in config.force_field_similarity_thresholds:
+        field = f"posterior_force_field_mass_at_{_threshold_label(threshold)}"
+        result[f"mean_{field}"] = _mean(rows, field)
+    return result
+
+
+def augment_contact_posterior_result(
+    result: Mapping[str, Any],
+    *,
+    graphs: Mapping[str, GraphObject],
+    config: TopologyPosteriorScoreConfig,
+) -> dict[str, Any]:
+    """Add full-posterior topology scores to one admitted diagnostic result."""
+
+    output = deepcopy(dict(result))
+    source_rows = output.get("rows")
+    _require(
+        isinstance(source_rows, list) and bool(source_rows),
+        "diagnostic rows missing",
+    )
+    rows: list[dict[str, Any]] = []
+    for raw_row in source_rows:
+        _require(isinstance(raw_row, Mapping), "diagnostic row must be an object")
+        row = dict(raw_row)
+        object_name = str(row.get("object"))
+        _require(object_name in graphs, f"unknown diagnostic topology: {object_name}")
+        probabilities = parse_node_posterior(str(row.get("node_posterior", "")))
+        truth = parse_contact_assignment_label(str(row.get("node_truth", "")))
+        credible_set = parse_contact_credible_set(str(row.get("node_credible_set", "")))
+        row.update(
+            posterior_topology_scores(
+                graphs[object_name],
+                probabilities,
+                truth,
+                config=config,
+                credible_set=credible_set,
+            )
+        )
+        rows.append(row)
+
+    overall = aggregate_posterior_topology_scores(rows, config=config)
+    by_topology = [
+        {
+            "object": object_name,
+            **aggregate_posterior_topology_scores(
+                [row for row in rows if str(row["object"]) == object_name],
+                config=config,
+            ),
+        }
+        for object_name in sorted({str(row["object"]) for row in rows})
+    ]
+    output["rows"] = rows
+    output["posterior_topology_scores"] = {
+        "schema_version": 1,
+        "artifact_kind": "Causal4DContactPosteriorTopologyScores",
+        "config": config.as_dict(),
+        "overall": overall,
+        "by_topology": by_topology,
+        "registered_success_gates_unchanged": True,
+        "claim_boundary": (
+            "Additive controlled diagnostic only. Exact-node gates, thresholds, "
+            "the frozen estimator, and the registered physical experiment are "
+            "unchanged. The force-field energy score is proper only for the "
+            "declared graph-diffusion proxy representation."
+        ),
+    }
+    output["registered_gate_status_unchanged"] = True
+    original_boundary = str(output.get("claim_boundary", "")).strip()
+    addition = (
+        " Full-posterior graph transport and force-field energy scores are "
+        "analysis-only and cannot rescue a failed registered exact-node gate."
+    )
+    output["claim_boundary"] = original_boundary + addition
+    return output
+
+
+def augment_contact_posterior_result_from_bundle(
+    result: Mapping[str, Any],
+    bundle_directory: str | Path,
+    *,
+    diffusion_strength: float,
+) -> dict[str, Any]:
+    """Load registered graph/config identities and add posterior topology scores."""
+
+    bundle = Path(bundle_directory).resolve()
+    summary_path = bundle / "summary.json"
+    _require(summary_path.is_file(), "bundle summary.json is missing")
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    benchmark_config = CounterfactualBenchmarkConfig(
+        **dict(summary["benchmark_config"])
+    )
+    contact_config = dict(summary["contact_config"])
+    confidence_level = float(contact_config["confidence_level"])
+    graphs = {
+        protocol.graph_object.name: protocol.graph_object
+        for protocol in build_protocol(benchmark_config)
+    }
+    return augment_contact_posterior_result(
+        result,
+        graphs=graphs,
+        config=TopologyPosteriorScoreConfig(
+            confidence_level=confidence_level,
+            diffusion_strength=diffusion_strength,
+        ),
+    )
+
+
+__all__ = [
+    "TopologyPosteriorScoreConfig",
+    "aggregate_posterior_topology_scores",
+    "all_pairs_graph_distances",
+    "assignment_graph_distance",
+    "augment_contact_posterior_result",
+    "augment_contact_posterior_result_from_bundle",
+    "diffused_contact_field",
+    "parse_contact_assignment_label",
+    "parse_contact_credible_set",
+    "parse_node_posterior",
+    "posterior_topology_scores",
+]

--- a/tests/test_contact_posterior_topology_scores.py
+++ b/tests/test_contact_posterior_topology_scores.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from causal4d.contact_posterior_topology_scores import (
+    TopologyPosteriorScoreConfig,
+    all_pairs_graph_distances,
+    assignment_graph_distance,
+    augment_contact_posterior_result,
+    parse_contact_credible_set,
+    parse_node_posterior,
+    posterior_topology_scores,
+)
+from causal4d.simulator import GraphObject, PhysicalParameters
+
+
+def _graph(
+    *,
+    name: str = "path",
+    positions: np.ndarray | None = None,
+    edges: tuple[tuple[int, int], ...] = ((0, 1), (1, 2)),
+) -> GraphObject:
+    if positions is None:
+        positions = np.asarray(((0.0, 0.0), (1.0, 0.0), (2.0, 0.0)))
+    return GraphObject(
+        name=name,
+        rest_positions=positions,
+        edges=edges,
+        mass=1.0,
+        support_stiffness=0.0,
+        true_parameters=PhysicalParameters(
+            stiffness=1.0,
+            damping=1.0,
+            contact_gain=1.0,
+        ),
+        sensor_nodes=(0, positions.shape[0] - 1),
+    )
+
+
+def _config(*, confidence_level: float = 0.8) -> TopologyPosteriorScoreConfig:
+    return TopologyPosteriorScoreConfig(
+        confidence_level=confidence_level,
+        diffusion_strength=1.0,
+    )
+
+
+def test_node_posterior_and_credible_set_parsing_is_strict() -> None:
+    posterior = parse_node_posterior('{"0":0.25,"1":0.75}')
+    credible = parse_contact_credible_set('["1","0"]')
+
+    assert posterior == {(0,): 0.25, (1,): 0.75}
+    assert credible == ((1,), (0,))
+    with pytest.raises(ValueError, match="sum to one"):
+        parse_node_posterior('{"0":0.2,"1":0.2}')
+    with pytest.raises(ValueError, match="non-finite JSON constant"):
+        parse_node_posterior('{"0":NaN,"1":1.0}')
+    with pytest.raises(ValueError, match="duplicate assignments"):
+        parse_contact_credible_set('["0","0"]')
+
+
+def test_assignment_graph_distance_is_permutation_invariant() -> None:
+    graph = _graph()
+    distances = all_pairs_graph_distances(graph)
+
+    assert assignment_graph_distance((0, 2), (2, 0), distances) == (0.0, 0)
+    assert assignment_graph_distance((0,), (2,), distances) == (2.0, 2)
+
+
+def test_full_posterior_reports_transport_mass_and_credible_radius() -> None:
+    graph = _graph()
+    result = posterior_topology_scores(
+        graph,
+        {(0,): 0.2, (1,): 0.6, (2,): 0.2},
+        (0,),
+        config=_config(),
+        credible_set=((1,), (0,)),
+    )
+
+    assert result["posterior_expected_assignment_graph_distance_hops"] == (
+        pytest.approx(1.0)
+    )
+    assert result["posterior_expected_max_assignment_graph_distance_hops"] == (
+        pytest.approx(1.0)
+    )
+    assert result["posterior_exact_node_mass"] == pytest.approx(0.2)
+    assert result["posterior_one_hop_patch_mass"] == pytest.approx(0.8)
+    assert result["posterior_two_hop_patch_mass"] == pytest.approx(1.0)
+    assert result["posterior_truth_centered_credible_radius_hops"] == 1
+    assert result["node_credible_set_min_mean_graph_distance_hops"] == 0.0
+    assert result["node_credible_set_one_hop_patch_covered"] is True
+
+
+def test_force_field_energy_score_rewards_truth_and_calibrated_spread() -> None:
+    graph = _graph()
+    truth = posterior_topology_scores(
+        graph,
+        {(0,): 1.0},
+        (0,),
+        config=_config(),
+    )
+    mixture = posterior_topology_scores(
+        graph,
+        {(0,): 0.5, (1,): 0.5},
+        (0,),
+        config=_config(),
+    )
+    wrong = posterior_topology_scores(
+        graph,
+        {(1,): 1.0},
+        (0,),
+        config=_config(),
+    )
+
+    assert truth["posterior_force_field_energy_score"] == pytest.approx(0.0)
+    assert 0.0 < mixture["posterior_force_field_energy_score"]
+    assert (
+        mixture["posterior_force_field_energy_score"]
+        < (wrong["posterior_force_field_energy_score"])
+    )
+    assert truth["posterior_expected_force_field_cosine"] == pytest.approx(1.0)
+    assert wrong["posterior_expected_force_field_cosine"] < 1.0
+
+
+def test_force_field_mass_thresholds_use_the_complete_posterior() -> None:
+    graph = _graph()
+    result = posterior_topology_scores(
+        graph,
+        {(0,): 0.7, (2,): 0.3},
+        (0,),
+        config=_config(),
+    )
+
+    assert result["posterior_force_field_mass_at_0_8"] == pytest.approx(0.7)
+    assert result["posterior_force_field_mass_at_0_9"] == pytest.approx(0.7)
+    assert result["posterior_force_field_mass_at_0_95"] == pytest.approx(0.7)
+
+
+def test_disconnected_graph_is_rejected() -> None:
+    graph = _graph(
+        name="disconnected",
+        positions=np.asarray(((0.0, 0.0), (1.0, 0.0), (3.0, 0.0), (4.0, 0.0))),
+        edges=((0, 1), (2, 3)),
+    )
+
+    with pytest.raises(ValueError, match="disconnected"):
+        all_pairs_graph_distances(graph)
+
+
+def test_augmentation_is_additive_and_keeps_registered_gates_unchanged() -> None:
+    graph = _graph()
+    result = {
+        "schema_version": 1,
+        "claim_boundary": "Controlled diagnostic only.",
+        "registered_gate_status_unchanged": True,
+        "rows": [
+            {
+                "seed": 1,
+                "object": graph.name,
+                "world_condition": "shifted_contact",
+                "setting": "online_adaptation",
+                "node_truth": "0",
+                "node_posterior": json.dumps(
+                    {"0": 0.2, "1": 0.6, "2": 0.2},
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+                "node_credible_set": '["1","0"]',
+            }
+        ],
+    }
+
+    augmented = augment_contact_posterior_result(
+        result,
+        graphs={graph.name: graph},
+        config=_config(),
+    )
+
+    scores = augmented["posterior_topology_scores"]
+    row = augmented["rows"][0]
+    assert scores["schema_version"] == 1
+    assert scores["registered_success_gates_unchanged"] is True
+    assert scores["overall"]["case_count"] == 1
+    assert scores["by_topology"][0]["object"] == graph.name
+    assert row["posterior_one_hop_patch_mass"] == pytest.approx(0.8)
+    assert augmented["registered_gate_status_unchanged"] is True
+    assert "cannot rescue" in augmented["claim_boundary"]
+
+
+def test_configuration_rejects_undeclared_or_unsorted_thresholds() -> None:
+    with pytest.raises(ValueError, match="unique and sorted"):
+        TopologyPosteriorScoreConfig(
+            force_field_similarity_thresholds=(0.9, 0.8),
+        )
+    with pytest.raises(ValueError, match=r"in \[0, 1\]"):
+        TopologyPosteriorScoreConfig(
+            force_field_similarity_thresholds=(1.1,),
+        )

--- a/tests/test_contact_posterior_workflow_policy.py
+++ b/tests/test_contact_posterior_workflow_policy.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "contact-posterior-diagnostics.yml"
+ANALYZER = ROOT / "scripts" / "ci" / "analyze_contact_posterior.py"
 
 
 def test_contact_diagnostic_workflow_is_read_only_and_uses_grouped_cli() -> None:
@@ -16,10 +17,7 @@ def test_contact_diagnostic_workflow_is_read_only_and_uses_grouped_cli() -> None
     assert "causal4d.cli.latent_contact_benchmark" not in text
     assert "default: github-hosted" in text
     assert "'ubuntu-latest'" in text
-    assert (
-        "fromJSON('[\"self-hosted\",\"Linux\",\"X64\",\"nvidia-smi\"]')"
-        in text
-    )
+    assert 'fromJSON(\'["self-hosted","Linux","X64","nvidia-smi"]\')' in text
 
 
 def test_contact_diagnostic_caches_only_on_hosted_runners() -> None:
@@ -34,3 +32,13 @@ def test_contact_diagnostic_caches_only_on_hosted_runners() -> None:
     assert "        if: inputs.runner == 'self-hosted'\n" in text
     assert text.count("          cache: pip\n") == 1
     assert text.index(hosted) < text.index(self_hosted) < text.index(install)
+
+
+def test_contact_analyzer_scores_full_posterior_after_admission_and_parity() -> None:
+    text = ANALYZER.read_text(encoding="utf-8")
+
+    admission = text.index("analyze_admitted_contact_posterior_bundle(")
+    topology = text.index("augment_contact_posterior_result_from_bundle(")
+    publication = text.index("write_contact_posterior_diagnostics(")
+    assert admission < topology < publication
+    assert '"posterior_topology_scores"' in text


### PR DESCRIPTION
## Summary

- add full-posterior graph-transport diagnostics for the latent contact-node posterior rather than evaluating only its MAP assignment;
- report posterior expected mean/max assignment distance, exact-node mass, one-hop and two-hop patch mass, and the truth-centered credible radius;
- evaluate the registered node credible set by its minimum graph distance to truth and one-hop patch coverage;
- score the complete posterior in the existing normalized graph-diffusion force-field proxy using expected cosine, threshold masses, expected distance, pairwise dispersion, and an energy score;
- aggregate the additive scores overall and by held-out topology;
- integrate scoring only after immutable source admission and retained-posterior parity checks, before the existing JSON/CSV diagnostic publication; and
- document the proxy, proper-score interpretation, and strict non-rescue claim boundary.

## Why

The existing diagnostic evaluates exact MAP recovery, one-hop neighbors, graph/sensor symmetry proxies, force-field similarity, and downstream trajectory gain, but not the allocation of the remaining posterior mass. A 49%/51% split between the true node and an adjacent mechanically similar node should not be interpreted like a confident remote-node error, even though both fail exact MAP recovery.

The new energy score is proper for the declared Euclidean graph-diffusion proxy representation:

```text
E ||f(Z) - f(z*)|| - 0.5 E ||f(Z) - f(Z')||
```

## Scientific boundary

This is an additive controlled diagnostic only. It does not modify the frozen latent-contact estimator, hypothesis support, likelihood, posterior temperature, exact-node threshold, success-gate result, or registered physical experiment. Full-posterior topology scores may explain a failed exact-node gate; they cannot replace or rescue it. Force-field equivalence is asserted only in the declared graph-diffusion proxy representation, not as universal physical equivalence.

## Exact scope

```text
base: 7faf8486991ef99fda694df94e92efde78c1bf2a
head: e62faf5586526bb8f07163d5d2a050db10dd7766
```

The branch is one commit ahead of current `main` and changes exactly five product files.

## Validation

The exact head and its synthetic merge result passed:

- Ruff, changed-file formatting, and the complete MyPy surface;
- core suites on Python 3.10, 3.12, and 3.14;
- wheel and sdist builds, metadata, and installed command surfaces;
- deterministic result-bundle and frozen-manifest checks;
- extended compatibility and dependency-floor checks;
- runtime dependency audit and CodeQL for Python and Actions;
- complete merge-result suite and distributions; and
- pinned BayesianPhysTwin installed-wheel integration.

An earlier independent-seed run over the identical five scientific file blobs passed immutable source admission and recomputation parity and produced 60 shifted-online cases:

- exact-node MAP accuracy: `45/60 = 75%`;
- one-hop MAP recovery: `100%`;
- mean exact-node posterior mass: `0.7184`;
- mean one-hop posterior mass: `1.0000`;
- one-hop credible-set coverage: `100%`;
- mean posterior expected graph distance: `0.2816` hops;
- mean expected force-field cosine: `0.9795`; and
- mean force-field energy score: `0.02916`.

The registered exact-node result remains failed and unchanged. The current exact-head duplicate diagnostic is still recomputing under the workflow’s 180-minute timeout; the only intervening base change is #218’s typing-only repair in the skipped PR #193 stability utility, so it does not alter the independent-seed benchmark, admission, posterior recomputation, or topology-score implementation.

The PR is ready for review and merge.

<!-- exact-head-validation: queued -->