### PR TITLE
Seal a self-contained registered real-analysis manifest

### DIFF
--- a/docs/registered_real_analysis_manifest.md
+++ b/docs/registered_real_analysis_manifest.md
@@ -1,0 +1,102 @@
+# Registered real-analysis manifest
+
+The confirmatory Causal4D analysis is now sealed as one self-contained,
+content-addressed manifest after the method freeze and before target access. The
+manifest does not change the estimator, protocol, split, calibration threshold,
+or reporting rules. It makes the rules already distributed across the protocol,
+method freeze, and reporting implementation independently inspectable in one
+artifact.
+
+## Seal the manifest
+
+Run this from the exact clean checkout referenced by `method_freeze.json`:
+
+```bash
+causal4d protocol real analysis-manifest-seal \
+  /opt/causal4d-frozen \
+  configs/causal4d/sloth_multi_action_v1.json \
+  /data/causal4d-sloth-multi-action-v1/method_freeze.json \
+  /data/causal4d-sloth-multi-action-v1/registered-analysis.json \
+  --registered-by "<independent-registrar>"
+```
+
+The command revalidates the protocol, every method-freeze file digest, the exact
+Causal4D and BayesianPhysTwin revisions, and the frozen analysis and reporting
+contracts. Publication is atomic and non-overwriting. The output records both:
+
+- `analysis_id`: the canonical SHA-256 of the logical manifest excluding its own
+  identity field; and
+- the exact file SHA-256 and byte count used by readiness, evidence, and result
+  artifacts.
+
+A second publication to the same path fails. A changed method freeze, protocol,
+bootstrap rule, comparison arm, calibration rule, endpoint inventory, or claim
+boundary produces a different identity or fails validation.
+
+## Revalidate retained bytes
+
+```bash
+causal4d protocol real analysis-manifest-validate \
+  /opt/causal4d-frozen \
+  configs/causal4d/sloth_multi_action_v1.json \
+  /data/causal4d-sloth-multi-action-v1/method_freeze.json \
+  /data/causal4d-sloth-multi-action-v1/registered-analysis.json
+```
+
+Validation reopens all three source files and verifies their exact identities.
+The result is target-free and cannot authorize acquisition by itself.
+
+## Readiness admission
+
+The canonical `causal4d protocol readiness status` path requires
+`registered-analysis.json` as a first-class prerequisite. It verifies the exact
+method-freeze SHA-256, protocol and amendment identities, Causal4D and
+BayesianPhysTwin revisions, manifest content identity, and registration
+chronology. The collection gate exposes:
+
+```text
+primary_analysis_registered=true
+```
+
+A missing, malformed, consistently re-addressed policy change, pre-freeze
+registration, or software-identity mismatch keeps
+`first_confirmatory_execution_allowed=false`. The lower-level readiness evaluator
+retains an explicit opt-in for isolated contract tests, but the canonical
+repository-and-dataset builder always enables this prerequisite.
+
+## Bound analysis contract
+
+Schema version 2 closes and content-addresses:
+
+- the protocol, v4 amendment, method freeze, Causal4D revision, and pinned
+  BayesianPhysTwin revision;
+- the six-frame causal prefix and zero-future-frame selection boundary;
+- the exact primary and diagnostic command entrypoints;
+- nominal PhysTwin, BayesianPhysTwin with nominal realized intervention, frozen
+  Causal4D, and the diagnostic intervention oracle as distinct arms;
+- complete factual, same-grasp, and new-contact endpoint inventories;
+- equal-target-session effects with 20,000 deterministic session bootstrap
+  replicates at 95% confidence;
+- the 12-fold execution-block calibration contract with nine independent
+  calibration units, rank 9 of 9, and no target threshold reselection;
+- complete failure and preregistered-exclusion accounting;
+- the obligation to report success or a well-powered negative result; and
+- the same-object, non-SOTA, non-safety, and non-raw-covariance-calibration claim
+  boundary.
+
+The coarse nine-unit calibration design is therefore visible in the primary
+analysis artifact rather than discoverable only from prose. Fragility diagnostics
+remain mandatory and cannot select another threshold.
+
+## Compatibility
+
+The result-source verifier continues to accept historical schema-version-1
+manifests for already frozen consumers. New confirmatory acquisition should use
+the schema-version-2 sealing command. Schema 2 is strict: even a consistently
+re-addressed policy change is rejected when any fixed analysis field differs.
+
+## Scientific boundary
+
+The manifest is preregistration infrastructure, not empirical evidence. It reads
+no physical target outcome, does not increment the `0/36` acquisition count, and
+cannot rescue a failed factual, transfer, new-contact, or calibration gate.

--- a/src/causal4d/cli/real_protocol.py
+++ b/src/causal4d/cli/real_protocol.py
@@ -22,6 +22,10 @@ from causal4d.real_protocol import (
     write_acquisition_schedule,
     write_protocol,
 )
+from causal4d.registered_real_analysis import (
+    seal_registered_real_analysis_manifest,
+    validate_registered_real_analysis_sources,
+)
 
 INCOMPLETE_EVIDENCE_EXIT_CODE = 3
 
@@ -52,6 +56,26 @@ def build_parser() -> argparse.ArgumentParser:
     )
     scaffold.add_argument("protocol_json")
     scaffold.add_argument("output_root")
+
+    analysis_seal = subparsers.add_parser(
+        "analysis-manifest-seal",
+        help="seal the content-addressed registered primary-analysis contract",
+    )
+    analysis_seal.add_argument("repository_root")
+    analysis_seal.add_argument("protocol_json")
+    analysis_seal.add_argument("method_freeze_json")
+    analysis_seal.add_argument("output_json")
+    analysis_seal.add_argument("--registered-by", required=True)
+    analysis_seal.add_argument("--registered-at-utc")
+
+    analysis_validate = subparsers.add_parser(
+        "analysis-manifest-validate",
+        help="reopen and validate the protocol, freeze, and analysis manifest",
+    )
+    analysis_validate.add_argument("repository_root")
+    analysis_validate.add_argument("protocol_json")
+    analysis_validate.add_argument("method_freeze_json")
+    analysis_validate.add_argument("analysis_manifest_json")
 
     status = subparsers.add_parser(
         "status",
@@ -122,6 +146,22 @@ def main(argv: Sequence[str] | None = None) -> int:
                 **result,
                 **scaffold_real_evidence_v2_templates(protocol, args.output_root),
             }
+        elif args.command == "analysis-manifest-seal":
+            result = seal_registered_real_analysis_manifest(
+                args.repository_root,
+                args.protocol_json,
+                args.method_freeze_json,
+                args.output_json,
+                registered_by=args.registered_by,
+                registered_at_utc=args.registered_at_utc,
+            )
+        elif args.command == "analysis-manifest-validate":
+            result = validate_registered_real_analysis_sources(
+                args.repository_root,
+                args.protocol_json,
+                args.method_freeze_json,
+                args.analysis_manifest_json,
+            )
         elif args.command == "status":
             result = build_real_evidence_status(
                 load_protocol(args.protocol_json),

--- a/src/causal4d/preacquisition_readiness.py
+++ b/src/causal4d/preacquisition_readiness.py
@@ -32,6 +32,9 @@ from causal4d.preacquisition_readiness_contracts import (
     source_panel_execution_manifest_template,
 )
 from causal4d.real_evidence_contract_v2 import build_real_evidence_status
+from causal4d.registered_real_analysis_prerequisite import (
+    validate_registered_real_analysis_prerequisite,
+)
 
 
 def _publish_template(
@@ -149,6 +152,7 @@ def evaluate_preacquisition_readiness(
     real_status: Mapping[str, Any],
     *,
     verify_file_hashes: bool,
+    require_registered_analysis: bool = False,
 ) -> dict[str, Any]:
     """Derive all collection gates from validated artifacts and chronology."""
 
@@ -156,6 +160,14 @@ def evaluate_preacquisition_readiness(
     prerequisites = {
         str(name): dict(value) for name, value in real_status["prerequisites"].items()
     }
+    if require_registered_analysis:
+        prerequisites["registered_analysis"] = (
+            validate_registered_real_analysis_prerequisite(
+                protocol,
+                root,
+                prerequisites["method_freeze"],
+            )
+        )
     operator_registry_result, operator_registry = load_operator_registry_prerequisite(
         protocol, v4, root
     )
@@ -185,6 +197,8 @@ def evaluate_preacquisition_readiness(
         "method_freeze",
         "method_freeze_validation",
     )
+    if require_registered_analysis:
+        prerequisite_names = (*prerequisite_names, "registered_analysis")
     missing_prerequisites = [
         name
         for name in prerequisite_names
@@ -336,6 +350,10 @@ def evaluate_preacquisition_readiness(
             "valid"
         ],
     }
+    if require_registered_analysis:
+        flags["primary_analysis_registered"] = prerequisites["registered_analysis"].get(
+            "valid", False
+        )
     ready = not blockers and all(flags.values())
     flags["first_confirmatory_execution_allowed"] = ready
     valid = (
@@ -352,6 +370,7 @@ def evaluate_preacquisition_readiness(
         "preacquisition_amendment_sha256": v4["amendment_sha256"],
         "dataset_root": str(root.resolve()),
         "verify_file_hashes": verify_file_hashes,
+        "registered_analysis_required": require_registered_analysis,
         "prerequisites": {
             name: dict(prerequisites[name]) for name in prerequisite_names
         },
@@ -400,6 +419,7 @@ def build_preacquisition_readiness(
         dataset_root,
         real_status,
         verify_file_hashes=verify_file_hashes,
+        require_registered_analysis=True,
     )
 
 

--- a/src/causal4d/real_result_source_verification.py
+++ b/src/causal4d/real_result_source_verification.py
@@ -10,9 +10,13 @@ from typing import Any, Final, Protocol, cast
 
 from causal4d.artifact_io import load_strict_json_object, read_regular_file
 from causal4d.real_experiment_freeze import MILESTONE_ID, SCHEMA_VERSION
+from causal4d.registered_real_analysis import (
+    REGISTERED_ANALYSIS_ARTIFACT_KIND,
+    REGISTERED_ANALYSIS_SCHEMA_VERSION,
+    validate_registered_real_analysis_manifest,
+)
 
-REGISTERED_ANALYSIS_SCHEMA_VERSION: Final = 1
-REGISTERED_ANALYSIS_ARTIFACT_KIND: Final = "Causal4DRegisteredRealAnalysisManifest"
+LEGACY_REGISTERED_ANALYSIS_SCHEMA_VERSION: Final = 1
 SOURCE_VERIFICATION_SCHEMA_VERSION: Final = 1
 SOURCE_VERIFICATION_ARTIFACT_KIND: Final = "Causal4DRealResultSourceVerification"
 
@@ -134,14 +138,10 @@ def _validate_method_freeze(
     )
 
 
-def _validate_registered_analysis(
+def _validate_legacy_registered_analysis(
     payload: Mapping[str, Any],
     binding: RealResultSourceBinding,
 ) -> None:
-    _require(
-        payload.get("schema_version") == REGISTERED_ANALYSIS_SCHEMA_VERSION,
-        "registered analysis manifest uses an unsupported schema",
-    )
     _require(
         payload.get("artifact_kind") == REGISTERED_ANALYSIS_ARTIFACT_KIND,
         "unexpected registered analysis artifact kind",
@@ -176,6 +176,28 @@ def _validate_registered_analysis(
         payload.get("optional_branches_may_change_primary_analysis") is False,
         "registered analysis manifest permits optional-branch rescue",
     )
+
+
+def _validate_registered_analysis(
+    payload: Mapping[str, Any],
+    binding: RealResultSourceBinding,
+) -> None:
+    schema = payload.get("schema_version")
+    if schema == LEGACY_REGISTERED_ANALYSIS_SCHEMA_VERSION:
+        _validate_legacy_registered_analysis(payload, binding)
+        return
+    if schema == REGISTERED_ANALYSIS_SCHEMA_VERSION:
+        validate_registered_real_analysis_manifest(
+            payload,
+            expected_protocol_id=binding.protocol_id,
+            expected_protocol_design_sha256=binding.protocol_design_sha256,
+            expected_preacquisition_amendment_sha256=(
+                binding.preacquisition_amendment_sha256
+            ),
+            expected_method_freeze_sha256=binding.method_freeze_sha256,
+        )
+        return
+    raise ValueError("registered analysis manifest uses an unsupported schema")
 
 
 def verify_real_result_sources(
@@ -272,6 +294,7 @@ def validate_real_result_source_verification(
 
 
 __all__ = [
+    "LEGACY_REGISTERED_ANALYSIS_SCHEMA_VERSION",
     "REGISTERED_ANALYSIS_ARTIFACT_KIND",
     "REGISTERED_ANALYSIS_SCHEMA_VERSION",
     "RealResultSourceBinding",

--- a/src/causal4d/registered_real_analysis.py
+++ b/src/causal4d/registered_real_analysis.py
@@ -1,0 +1,678 @@
+"""Content-addressed registered analysis for the physical Causal4D protocol."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Final, cast
+
+from causal4d.artifact_io import load_strict_json_object, read_regular_file
+from causal4d.atomic_io import atomic_write_json
+from causal4d.execution_block_calibration import (
+    EXECUTION_BLOCK_CALIBRATION_UNIT,
+    EXECUTION_BLOCK_SCORE_KIND,
+)
+from causal4d.real_experiment_freeze import (
+    DIAGNOSTIC_ONLY_ANALYSIS_ENTRYPOINTS,
+    MILESTONE_ID,
+    REQUIRED_ANALYSIS_ENTRYPOINTS,
+    SCHEMA_VERSION as METHOD_FREEZE_SCHEMA_VERSION,
+    validate_method_freeze_manifest,
+    validate_repository_checkout,
+)
+from causal4d.real_protocol import load_protocol, validate_protocol
+
+REGISTERED_ANALYSIS_SCHEMA_VERSION: Final = 2
+REGISTERED_ANALYSIS_ARTIFACT_KIND: Final = "Causal4DRegisteredRealAnalysisManifest"
+REGISTERED_ANALYSIS_STATUS: Final = "sealed"
+EXPECTED_PROTOCOL_ID: Final = "causal4d-sloth-multi-action-v1"
+EXPECTED_PROTOCOL_DESIGN_SHA256: Final = (
+    "6d61f2bea96af0ba04faaf3476990b58cd87e0a9c826420c254a012dec647968"
+)
+EXPECTED_PREACQUISITION_SHA256: Final = (
+    "0e167538a7824e5ec053031d8359d4e9b4ff89ad61a85666400a86c2a88ac42f"
+)
+EXPECTED_OBJECT_ID: Final = "sloth_plush_instance_1"
+BOOTSTRAP_REPLICATES: Final = 20_000
+BOOTSTRAP_SEED: Final = 20_260_726
+BOOTSTRAP_CONFIDENCE_LEVEL: Final = 0.95
+
+_TOP_LEVEL_FIELDS = frozenset(
+    {
+        "schema_version",
+        "artifact_kind",
+        "analysis_id",
+        "status",
+        "registered_at_utc",
+        "registered_by",
+        "milestone_id",
+        "protocol_id",
+        "protocol_design_sha256",
+        "preacquisition_amendment_sha256",
+        "method_freeze_sha256",
+        "software",
+        "primary_analysis_locked",
+        "locked_before_target_access",
+        "target_outcomes_observed_at_registration",
+        "target_outcomes_may_select_method_or_hyperparameters",
+        "optional_branches_may_change_primary_analysis",
+        "information_boundary",
+        "command_contract",
+        "comparison_arms",
+        "effect_reporting",
+        "confirmatory_calibration",
+        "failure_and_exclusion_policy",
+        "reporting_contract",
+        "claim_boundary",
+    }
+)
+
+_INFORMATION_BOUNDARY = {
+    "allowed_observation_prefix_frames": 6,
+    "future_frames_read_before_prediction": 0,
+    "target_outcomes_available_for_selection": False,
+    "individual_real_counterfactual_ground_truth_claimed": False,
+    "real_evaluation_semantics": (
+        "held_out_interventional_prediction_from_matched_initial_conditions"
+    ),
+}
+_COMMAND_CONTRACT = {
+    "primary_entrypoints": list(REQUIRED_ANALYSIS_ENTRYPOINTS),
+    "diagnostic_only_entrypoints": list(DIAGNOSTIC_ONLY_ANALYSIS_ENTRYPOINTS),
+}
+_COMPARISON_ARMS = [
+    {
+        "arm_id": "nominal_phystwin",
+        "role": "baseline",
+        "twin_uncertainty": False,
+        "realized_intervention_inference": False,
+    },
+    {
+        "arm_id": "bayesian_phystwin_nominal_z",
+        "role": "baseline",
+        "twin_uncertainty": True,
+        "realized_intervention_inference": False,
+    },
+    {
+        "arm_id": "frozen_causal4d",
+        "role": "primary_candidate",
+        "twin_uncertainty": True,
+        "realized_intervention_inference": True,
+    },
+    {
+        "arm_id": "intervention_oracle",
+        "role": "diagnostic_only",
+        "twin_uncertainty": True,
+        "realized_intervention_inference": "oracle",
+    },
+]
+_EXPECTED_ENDPOINT_INVENTORY = [
+    {
+        "endpoint_id": "factual_continuation",
+        "split_key": "factual_continuation",
+        "registered_units": 36,
+        "target_sessions": 18,
+        "primary_estimate": "equal_target_session_mean_candidate_minus_baseline",
+        "interval_method": "target_session_percentile_bootstrap",
+    },
+    {
+        "endpoint_id": "same_grasp_transfer",
+        "split_key": "same_grasp_intervention_prediction",
+        "registered_units": 18,
+        "target_sessions": 18,
+        "primary_estimate": "equal_target_session_mean_candidate_minus_baseline",
+        "interval_method": "target_session_percentile_bootstrap",
+    },
+    {
+        "endpoint_id": "new_contact_transfer",
+        "split_key": "new_contact_intervention_prediction",
+        "registered_units": 12,
+        "target_sessions": 12,
+        "primary_estimate": "equal_target_session_mean_candidate_minus_baseline",
+        "interval_method": "target_session_percentile_bootstrap",
+    },
+]
+_EFFECT_REPORTING = {
+    "resampling_unit": "target_grasp_session",
+    "equal_session_weighting": True,
+    "bootstrap_replicates": BOOTSTRAP_REPLICATES,
+    "bootstrap_seed": BOOTSTRAP_SEED,
+    "confidence_level": BOOTSTRAP_CONFIDENCE_LEVEL,
+    "execution_mean_role": "diagnostic_only",
+    "endpoint_inventory": _EXPECTED_ENDPOINT_INVENTORY,
+}
+_CONFIRMATORY_CALIBRATION = {
+    "entrypoint": "causal4d calibration execution-block",
+    "confidence_level": 0.90,
+    "outer_fold_count": 12,
+    "expected_calibration_units_per_outer_fold": 9,
+    "order_statistic_rank_one_based": 9,
+    "calibration_unit": EXECUTION_BLOCK_CALIBRATION_UNIT,
+    "score_kind": EXECUTION_BLOCK_SCORE_KIND,
+    "target_threshold_reselection_allowed": False,
+    "pooled_coordinate_conformal_claimed": False,
+    "worst_group_coverage_guarantee_claimed": False,
+}
+_FAILURE_AND_EXCLUSION_POLICY = {
+    "all_registered_units_accounted_for": True,
+    "technical_failures_retained": True,
+    "excluded_units_retain_reason_without_target_metric_values": True,
+    "silent_replacement_forbidden": True,
+    "target_outcomes_may_not_select_exclusions": True,
+}
+_REPORTING_CONTRACT = {
+    "report_success_or_well_powered_negative_result": True,
+    "report_all_36_executions_or_preregistered_exclusions": True,
+    "report_independent_execution_calibration": True,
+    "report_effect_intervals_and_replay_reset_variance": True,
+    "optional_semantic_or_public_data_results_cannot_rescue_primary_failure": True,
+    "factual_same_grasp_new_contact_and_calibration_reported_separately": True,
+    "calibration_cannot_rescue_failed_prediction_gates": True,
+}
+_CLAIM_BOUNDARY = {
+    "object_id": EXPECTED_OBJECT_ID,
+    "physical_object_count": 1,
+    "registered_contact_region_count": 3,
+    "registered_action_profile_count": 4,
+    "object_class_generalization_claimed": False,
+    "raw_covariance_calibration_claimed": False,
+    "general_robot_safety_claimed": False,
+}
+_ENDPOINT_SPECS = (
+    ("factual_continuation", "factual_continuation", "execution_id"),
+    (
+        "same_grasp_transfer",
+        "same_grasp_intervention_prediction",
+        "target_execution_id",
+    ),
+    (
+        "new_contact_transfer",
+        "new_contact_intervention_prediction",
+        "target_execution_id",
+    ),
+)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    _require(isinstance(value, Mapping), f"{name} must be a JSON object")
+    _require(all(type(key) is str for key in value), f"{name} keys must be strings")
+    return cast(Mapping[str, Any], value)
+
+
+def _nonempty_string(value: Any, *, name: str) -> str:
+    _require(type(value) is str and bool(value.strip()), f"{name} is missing")
+    return value
+
+
+def _sha(value: Any, *, name: str, length: int) -> str:
+    _require(
+        type(value) is str
+        and len(value) == length
+        and all(character in "0123456789abcdef" for character in value),
+        f"{name} must be a lowercase {length}-hex digest",
+    )
+    return value
+
+
+def _utc_timestamp(value: Any, *, name: str) -> str:
+    text = _nonempty_string(value, name=name)
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(f"{name} is not ISO 8601") from error
+    _require(parsed.tzinfo is not None, f"{name} must include a timezone")
+    _require(
+        parsed.utcoffset() == timezone.utc.utcoffset(parsed),
+        f"{name} must use UTC",
+    )
+    return text
+
+
+def _canonical_sha256(payload: Mapping[str, Any], *, omitted: str) -> str:
+    values = dict(payload)
+    values.pop(omitted, None)
+    encoded = json.dumps(
+        values,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def analysis_id_for_payload(payload: Mapping[str, Any]) -> str:
+    """Return the content identity of a registered-analysis manifest."""
+
+    return _canonical_sha256(payload, omitted="analysis_id")
+
+
+def _require_equal(actual: Any, expected: Any, *, name: str) -> None:
+    _require(actual == expected, f"registered analysis {name} changed")
+
+
+def _endpoint_inventory(protocol: Mapping[str, Any]) -> list[dict[str, Any]]:
+    executions = protocol.get("executions")
+    _require(isinstance(executions, list), "protocol executions are missing")
+    session_by_execution: dict[str, str] = {}
+    for position, raw in enumerate(executions):
+        execution = _mapping(raw, name=f"execution {position}")
+        execution_id = _nonempty_string(
+            execution.get("execution_id"),
+            name=f"execution {position} id",
+        )
+        session_by_execution[execution_id] = _nonempty_string(
+            execution.get("session_id"),
+            name=f"execution {position} session",
+        )
+    splits = _mapping(protocol.get("splits"), name="protocol splits")
+    inventory: list[dict[str, Any]] = []
+    for endpoint_id, split_key, target_field in _ENDPOINT_SPECS:
+        units = splits.get(split_key)
+        _require(isinstance(units, list), f"{split_key} split is missing")
+        targets = [
+            _nonempty_string(
+                _mapping(unit, name=f"{split_key} unit").get(target_field),
+                name=f"{split_key} target",
+            )
+            for unit in units
+        ]
+        _require(len(targets) == len(set(targets)), f"{split_key} targets duplicate")
+        _require(
+            all(target in session_by_execution for target in targets),
+            f"{split_key} contains an unknown target",
+        )
+        inventory.append(
+            {
+                "endpoint_id": endpoint_id,
+                "split_key": split_key,
+                "registered_units": len(targets),
+                "target_sessions": len(
+                    {session_by_execution[target] for target in targets}
+                ),
+                "primary_estimate": (
+                    "equal_target_session_mean_candidate_minus_baseline"
+                ),
+                "interval_method": "target_session_percentile_bootstrap",
+            }
+        )
+    _require_equal(inventory, _EXPECTED_ENDPOINT_INVENTORY, name="endpoint inventory")
+    return inventory
+
+
+def _validate_freeze_contract(freeze: Mapping[str, Any]) -> Mapping[str, Any]:
+    _require_equal(
+        freeze.get("schema_version"),
+        METHOD_FREEZE_SCHEMA_VERSION,
+        name="method-freeze schema",
+    )
+    _require_equal(freeze.get("milestone_id"), MILESTONE_ID, name="milestone")
+    _require_equal(freeze.get("status"), "sealed", name="method-freeze status")
+    analysis = _mapping(freeze.get("analysis_contract"), name="analysis contract")
+    _require_equal(
+        analysis.get("entrypoints"),
+        list(REQUIRED_ANALYSIS_ENTRYPOINTS),
+        name="primary entrypoints",
+    )
+    _require_equal(
+        analysis.get("diagnostic_only_entrypoints"),
+        list(DIAGNOSTIC_ONLY_ANALYSIS_ENTRYPOINTS),
+        name="diagnostic entrypoints",
+    )
+    _require_equal(
+        analysis.get("allowed_observation_prefix_frames"),
+        6,
+        name="observation prefix",
+    )
+    _require_equal(
+        analysis.get("confirmatory_calibration"),
+        _CONFIRMATORY_CALIBRATION,
+        name="confirmatory calibration",
+    )
+    _require_equal(
+        analysis.get("target_outcomes_may_select_method_or_hyperparameters"),
+        False,
+        name="target-selection boundary",
+    )
+    _require_equal(
+        analysis.get("optional_branches_may_change_primary_analysis"),
+        False,
+        name="optional-branch boundary",
+    )
+    return analysis
+
+
+def build_registered_real_analysis_manifest(
+    protocol: Mapping[str, Any],
+    method_freeze: Mapping[str, Any],
+    *,
+    method_freeze_sha256: str,
+    registered_by: str,
+    registered_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the complete primary-analysis contract from locked sources."""
+
+    validate_protocol(protocol)
+    _require_equal(protocol.get("protocol_id"), EXPECTED_PROTOCOL_ID, name="protocol")
+    _require_equal(
+        protocol.get("design_sha256"),
+        EXPECTED_PROTOCOL_DESIGN_SHA256,
+        name="protocol digest",
+    )
+    object_record = _mapping(protocol.get("object"), name="protocol object")
+    _require_equal(object_record.get("object_id"), EXPECTED_OBJECT_ID, name="object")
+    _sha(method_freeze_sha256, name="method freeze SHA-256", length=64)
+    _validate_freeze_contract(method_freeze)
+    protocol_record = _mapping(method_freeze.get("protocol"), name="freeze protocol")
+    preacquisition = _mapping(
+        method_freeze.get("preacquisition"),
+        name="freeze preacquisition",
+    )
+    _require_equal(
+        protocol_record.get("design_sha256"),
+        EXPECTED_PROTOCOL_DESIGN_SHA256,
+        name="freeze protocol digest",
+    )
+    _require_equal(
+        preacquisition.get("amendment_sha256"),
+        EXPECTED_PREACQUISITION_SHA256,
+        name="preacquisition digest",
+    )
+    causal4d = _mapping(method_freeze.get("causal4d"), name="freeze Causal4D")
+    bpt = _mapping(method_freeze.get("bayesian_phystwin"), name="freeze BPT")
+    reporting = _mapping(
+        method_freeze.get("reporting_contract"),
+        name="reporting contract",
+    )
+    expected_freeze_reporting = dict(_REPORTING_CONTRACT)
+    expected_freeze_reporting.pop(
+        "factual_same_grasp_new_contact_and_calibration_reported_separately"
+    )
+    expected_freeze_reporting.pop("calibration_cannot_rescue_failed_prediction_gates")
+    _require_equal(
+        dict(reporting),
+        expected_freeze_reporting,
+        name="freeze reporting contract",
+    )
+
+    manifest: dict[str, Any] = {
+        "schema_version": REGISTERED_ANALYSIS_SCHEMA_VERSION,
+        "artifact_kind": REGISTERED_ANALYSIS_ARTIFACT_KIND,
+        "analysis_id": "",
+        "status": REGISTERED_ANALYSIS_STATUS,
+        "registered_at_utc": _utc_timestamp(
+            registered_at_utc or datetime.now(timezone.utc).isoformat(),
+            name="registration timestamp",
+        ),
+        "registered_by": _nonempty_string(
+            registered_by,
+            name="registered_by",
+        ).strip(),
+        "milestone_id": MILESTONE_ID,
+        "protocol_id": EXPECTED_PROTOCOL_ID,
+        "protocol_design_sha256": EXPECTED_PROTOCOL_DESIGN_SHA256,
+        "preacquisition_amendment_sha256": EXPECTED_PREACQUISITION_SHA256,
+        "method_freeze_sha256": method_freeze_sha256,
+        "software": {
+            "causal4d_commit_sha": _sha(
+                causal4d.get("commit_sha"),
+                name="Causal4D commit",
+                length=40,
+            ),
+            "bayesian_phystwin_commit_sha": _sha(
+                bpt.get("commit_sha"),
+                name="BayesianPhysTwin commit",
+                length=40,
+            ),
+            "observation_provider_bound_by_software_environment_gate": True,
+            "prob4d_may_change_primary_analysis": False,
+        },
+        "primary_analysis_locked": True,
+        "locked_before_target_access": True,
+        "target_outcomes_observed_at_registration": False,
+        "target_outcomes_may_select_method_or_hyperparameters": False,
+        "optional_branches_may_change_primary_analysis": False,
+        "information_boundary": dict(_INFORMATION_BOUNDARY),
+        "command_contract": dict(_COMMAND_CONTRACT),
+        "comparison_arms": [dict(arm) for arm in _COMPARISON_ARMS],
+        "effect_reporting": {
+            **dict(_EFFECT_REPORTING),
+            "endpoint_inventory": _endpoint_inventory(protocol),
+        },
+        "confirmatory_calibration": dict(_CONFIRMATORY_CALIBRATION),
+        "failure_and_exclusion_policy": dict(_FAILURE_AND_EXCLUSION_POLICY),
+        "reporting_contract": dict(_REPORTING_CONTRACT),
+        "claim_boundary": dict(_CLAIM_BOUNDARY),
+    }
+    manifest["analysis_id"] = analysis_id_for_payload(manifest)
+    return validate_registered_real_analysis_manifest(manifest)
+
+
+def validate_registered_real_analysis_manifest(
+    payload: Mapping[str, Any],
+    *,
+    expected_protocol_id: str = EXPECTED_PROTOCOL_ID,
+    expected_protocol_design_sha256: str = EXPECTED_PROTOCOL_DESIGN_SHA256,
+    expected_preacquisition_amendment_sha256: str = EXPECTED_PREACQUISITION_SHA256,
+    expected_method_freeze_sha256: str | None = None,
+) -> dict[str, Any]:
+    """Validate a closed, self-contained registered-analysis manifest."""
+
+    values = _mapping(payload, name="registered analysis manifest")
+    _require_equal(set(values), set(_TOP_LEVEL_FIELDS), name="top-level fields")
+    for name, expected in (
+        ("schema_version", REGISTERED_ANALYSIS_SCHEMA_VERSION),
+        ("artifact_kind", REGISTERED_ANALYSIS_ARTIFACT_KIND),
+        ("status", REGISTERED_ANALYSIS_STATUS),
+        ("milestone_id", MILESTONE_ID),
+        ("protocol_id", expected_protocol_id),
+        ("protocol_design_sha256", expected_protocol_design_sha256),
+        (
+            "preacquisition_amendment_sha256",
+            expected_preacquisition_amendment_sha256,
+        ),
+        ("primary_analysis_locked", True),
+        ("locked_before_target_access", True),
+        ("target_outcomes_observed_at_registration", False),
+        ("target_outcomes_may_select_method_or_hyperparameters", False),
+        ("optional_branches_may_change_primary_analysis", False),
+    ):
+        _require_equal(values[name], expected, name=name)
+    _utc_timestamp(values["registered_at_utc"], name="registered_at_utc")
+    _nonempty_string(values["registered_by"], name="registered_by")
+    method_sha = _sha(
+        values["method_freeze_sha256"],
+        name="method_freeze_sha256",
+        length=64,
+    )
+    if expected_method_freeze_sha256 is not None:
+        _require_equal(method_sha, expected_method_freeze_sha256, name="freeze digest")
+
+    software = _mapping(values["software"], name="software")
+    _require_equal(
+        set(software),
+        {
+            "causal4d_commit_sha",
+            "bayesian_phystwin_commit_sha",
+            "observation_provider_bound_by_software_environment_gate",
+            "prob4d_may_change_primary_analysis",
+        },
+        name="software fields",
+    )
+    _sha(software["causal4d_commit_sha"], name="Causal4D commit", length=40)
+    _sha(
+        software["bayesian_phystwin_commit_sha"],
+        name="BayesianPhysTwin commit",
+        length=40,
+    )
+    _require_equal(
+        software["observation_provider_bound_by_software_environment_gate"],
+        True,
+        name="observation provider gate",
+    )
+    _require_equal(
+        software["prob4d_may_change_primary_analysis"],
+        False,
+        name="Prob4D boundary",
+    )
+    for name, expected in (
+        ("information_boundary", _INFORMATION_BOUNDARY),
+        ("command_contract", _COMMAND_CONTRACT),
+        ("comparison_arms", _COMPARISON_ARMS),
+        ("effect_reporting", _EFFECT_REPORTING),
+        ("confirmatory_calibration", _CONFIRMATORY_CALIBRATION),
+        ("failure_and_exclusion_policy", _FAILURE_AND_EXCLUSION_POLICY),
+        ("reporting_contract", _REPORTING_CONTRACT),
+        ("claim_boundary", _CLAIM_BOUNDARY),
+    ):
+        _require_equal(values[name], expected, name=name)
+    analysis_id = _sha(values["analysis_id"], name="analysis_id", length=64)
+    _require_equal(
+        analysis_id,
+        analysis_id_for_payload(values),
+        name="analysis_id",
+    )
+    return dict(values)
+
+
+def load_registered_real_analysis_manifest(
+    path: str | Path,
+) -> tuple[dict[str, Any], str, int]:
+    """Load and validate one exact-byte registered-analysis file."""
+
+    snapshot = read_regular_file(path, name="registered analysis manifest")
+    payload = load_strict_json_object(
+        snapshot.payload,
+        name="registered analysis manifest",
+    )
+    return (
+        validate_registered_real_analysis_manifest(payload),
+        snapshot.sha256,
+        snapshot.byte_count,
+    )
+
+
+def write_registered_real_analysis_manifest(
+    path: str | Path,
+    manifest: Mapping[str, Any],
+) -> Path:
+    """Publish a registered-analysis manifest atomically and exactly once."""
+
+    output = Path(path)
+    atomic_write_json(
+        output,
+        validate_registered_real_analysis_manifest(manifest),
+        overwrite=False,
+    )
+    return output
+
+
+def seal_registered_real_analysis_manifest(
+    repository_root: str | Path,
+    protocol_path: str | Path,
+    method_freeze_path: str | Path,
+    output_path: str | Path,
+    *,
+    registered_by: str,
+    registered_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Validate frozen sources and publish their complete analysis contract."""
+
+    root = Path(repository_root)
+    protocol = load_protocol(protocol_path)
+    freeze_snapshot = read_regular_file(method_freeze_path, name="method freeze")
+    freeze = load_strict_json_object(freeze_snapshot.payload, name="method freeze")
+    validate_method_freeze_manifest(freeze, root, verify_files=True)
+    validate_repository_checkout(freeze, root)
+    manifest = build_registered_real_analysis_manifest(
+        protocol,
+        freeze,
+        method_freeze_sha256=freeze_snapshot.sha256,
+        registered_by=registered_by,
+        registered_at_utc=registered_at_utc,
+    )
+    output = write_registered_real_analysis_manifest(output_path, manifest)
+    snapshot = read_regular_file(output, name="registered analysis manifest")
+    return {
+        "passed": True,
+        "analysis_id": manifest["analysis_id"],
+        "path": str(output.resolve()),
+        "sha256": snapshot.sha256,
+        "bytes": snapshot.byte_count,
+        "method_freeze_sha256": freeze_snapshot.sha256,
+        "target_outcomes_used": False,
+    }
+
+
+def validate_registered_real_analysis_sources(
+    repository_root: str | Path,
+    protocol_path: str | Path,
+    method_freeze_path: str | Path,
+    analysis_manifest_path: str | Path,
+) -> dict[str, Any]:
+    """Reopen and validate the exact protocol, freeze, and analysis bytes."""
+
+    root = Path(repository_root)
+    protocol = load_protocol(protocol_path)
+    validate_protocol(protocol)
+    freeze_snapshot = read_regular_file(method_freeze_path, name="method freeze")
+    freeze = load_strict_json_object(freeze_snapshot.payload, name="method freeze")
+    validate_method_freeze_manifest(freeze, root, verify_files=True)
+    validate_repository_checkout(freeze, root)
+    manifest, manifest_sha, manifest_bytes = load_registered_real_analysis_manifest(
+        analysis_manifest_path
+    )
+    validate_registered_real_analysis_manifest(
+        manifest,
+        expected_protocol_id=str(protocol["protocol_id"]),
+        expected_protocol_design_sha256=str(protocol["design_sha256"]),
+        expected_preacquisition_amendment_sha256=str(
+            freeze["preacquisition"]["amendment_sha256"]
+        ),
+        expected_method_freeze_sha256=freeze_snapshot.sha256,
+    )
+    _require_equal(
+        manifest["software"]["causal4d_commit_sha"],
+        freeze["causal4d"]["commit_sha"],
+        name="Causal4D commit",
+    )
+    _require_equal(
+        manifest["software"]["bayesian_phystwin_commit_sha"],
+        freeze["bayesian_phystwin"]["commit_sha"],
+        name="BayesianPhysTwin commit",
+    )
+    return {
+        "passed": True,
+        "analysis_id": manifest["analysis_id"],
+        "analysis_manifest_sha256": manifest_sha,
+        "analysis_manifest_bytes": manifest_bytes,
+        "method_freeze_sha256": freeze_snapshot.sha256,
+        "target_outcomes_used": False,
+    }
+
+
+__all__ = [
+    "BOOTSTRAP_CONFIDENCE_LEVEL",
+    "BOOTSTRAP_REPLICATES",
+    "BOOTSTRAP_SEED",
+    "EXPECTED_OBJECT_ID",
+    "EXPECTED_PREACQUISITION_SHA256",
+    "EXPECTED_PROTOCOL_DESIGN_SHA256",
+    "EXPECTED_PROTOCOL_ID",
+    "REGISTERED_ANALYSIS_ARTIFACT_KIND",
+    "REGISTERED_ANALYSIS_SCHEMA_VERSION",
+    "analysis_id_for_payload",
+    "build_registered_real_analysis_manifest",
+    "load_registered_real_analysis_manifest",
+    "seal_registered_real_analysis_manifest",
+    "validate_registered_real_analysis_manifest",
+    "validate_registered_real_analysis_sources",
+    "write_registered_real_analysis_manifest",
+]

--- a/src/causal4d/registered_real_analysis_prerequisite.py
+++ b/src/causal4d/registered_real_analysis_prerequisite.py
@@ -1,0 +1,132 @@
+"""Readiness prerequisite for the exact registered real-analysis manifest."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, cast
+
+from causal4d.artifact_io import load_strict_json_object, read_regular_file
+from causal4d.real_evidence_common import _error_text, _parse_utc_timestamp
+from causal4d.registered_real_analysis import (
+    validate_registered_real_analysis_manifest,
+)
+
+REGISTERED_ANALYSIS_PATH = "registered-analysis.json"
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def validate_registered_real_analysis_prerequisite(
+    protocol: Mapping[str, Any],
+    dataset_root: str | Path,
+    method_freeze_result: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate the exact analysis registration needed to authorize collection."""
+
+    root = Path(dataset_root)
+    path = root / REGISTERED_ANALYSIS_PATH
+    result: dict[str, Any] = {
+        "path": str(path.resolve()),
+        "present": path.is_file(),
+        "template": False,
+        "valid": False,
+        "error": None,
+    }
+    if not result["present"]:
+        result["error"] = f"{REGISTERED_ANALYSIS_PATH} is missing"
+        return result
+
+    try:
+        _require(
+            method_freeze_result.get("valid") is True,
+            "registered analysis requires a valid method freeze",
+        )
+        expected_freeze_sha = method_freeze_result.get("sha256")
+        _require(
+            isinstance(expected_freeze_sha, str) and len(expected_freeze_sha) == 64,
+            "method-freeze SHA-256 is unavailable",
+        )
+        freeze_path = root / "method_freeze.json"
+        freeze_snapshot = read_regular_file(freeze_path, name="method freeze")
+        _require(
+            freeze_snapshot.sha256 == expected_freeze_sha,
+            "registered analysis prerequisite sees a different method freeze",
+        )
+        freeze = load_strict_json_object(
+            freeze_snapshot.payload,
+            name="method freeze",
+        )
+        analysis_snapshot = read_regular_file(
+            path,
+            name="registered analysis manifest",
+        )
+        analysis = load_strict_json_object(
+            analysis_snapshot.payload,
+            name="registered analysis manifest",
+        )
+        preacquisition = freeze.get("preacquisition")
+        _require(
+            isinstance(preacquisition, Mapping),
+            "method freeze lacks pre-acquisition provenance",
+        )
+        validated = validate_registered_real_analysis_manifest(
+            analysis,
+            expected_protocol_id=str(protocol["protocol_id"]),
+            expected_protocol_design_sha256=str(protocol["design_sha256"]),
+            expected_preacquisition_amendment_sha256=str(
+                preacquisition["amendment_sha256"]
+            ),
+            expected_method_freeze_sha256=expected_freeze_sha,
+        )
+        causal4d = freeze.get("causal4d")
+        bpt = freeze.get("bayesian_phystwin")
+        _require(
+            isinstance(causal4d, Mapping) and isinstance(bpt, Mapping),
+            "method freeze lacks software provenance",
+        )
+        software = cast(Mapping[str, Any], validated["software"])
+        _require(
+            software["causal4d_commit_sha"] == causal4d.get("commit_sha"),
+            "registered analysis binds a different Causal4D commit",
+        )
+        _require(
+            software["bayesian_phystwin_commit_sha"] == bpt.get("commit_sha"),
+            "registered analysis binds a different BayesianPhysTwin commit",
+        )
+        registered_at = _parse_utc_timestamp(
+            validated["registered_at_utc"],
+            name="registered analysis registered_at_utc",
+        )
+        frozen_at = _parse_utc_timestamp(
+            freeze.get("frozen_at_utc"),
+            name="method freeze frozen_at_utc",
+        )
+        _require(
+            registered_at >= frozen_at,
+            "registered analysis predates the method freeze",
+        )
+        result.update(
+            {
+                "valid": True,
+                "analysis_id": validated["analysis_id"],
+                "registered_at_utc": validated["registered_at_utc"],
+                "registered_by": validated["registered_by"],
+                "method_freeze_sha256": expected_freeze_sha,
+                "sha256": analysis_snapshot.sha256,
+                "bytes": analysis_snapshot.byte_count,
+                "target_outcomes_used": False,
+            }
+        )
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        result["error"] = _error_text(error)
+    return result
+
+
+__all__ = [
+    "REGISTERED_ANALYSIS_PATH",
+    "validate_registered_real_analysis_prerequisite",
+]

--- a/tests/test_registered_real_analysis.py
+++ b/tests/test_registered_real_analysis.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from causal4d.cli.real_protocol import build_parser
+from causal4d.real_experiment_freeze import MILESTONE_ID, SCHEMA_VERSION
+from causal4d.real_protocol import load_protocol
+from causal4d.real_result_source_verification import verify_real_result_sources
+from causal4d.registered_real_analysis import (
+    BOOTSTRAP_REPLICATES,
+    BOOTSTRAP_SEED,
+    EXPECTED_PREACQUISITION_SHA256,
+    EXPECTED_PROTOCOL_DESIGN_SHA256,
+    EXPECTED_PROTOCOL_ID,
+    analysis_id_for_payload,
+    build_registered_real_analysis_manifest,
+    validate_registered_real_analysis_manifest,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL = ROOT / "configs/causal4d/sloth_multi_action_v1.json"
+
+
+def _method_freeze() -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "milestone_id": MILESTONE_ID,
+        "status": "sealed",
+        "locked_before_confirmatory_collection": True,
+        "target_outcomes_observed_at_freeze": False,
+        "causal4d": {"commit_sha": "a" * 40},
+        "bayesian_phystwin": {"commit_sha": "b" * 40},
+        "protocol": {"design_sha256": EXPECTED_PROTOCOL_DESIGN_SHA256},
+        "preacquisition": {
+            "amendment_sha256": EXPECTED_PREACQUISITION_SHA256,
+        },
+        "analysis_contract": {
+            "entrypoints": [
+                "causal4d protocol real",
+                "causal4d calibration execution-block",
+                "causal4d evidence physical-counterfactual evaluate",
+            ],
+            "diagnostic_only_entrypoints": ["causal4d calibration real"],
+            "allowed_observation_prefix_frames": 6,
+            "confirmatory_calibration": {
+                "entrypoint": "causal4d calibration execution-block",
+                "confidence_level": 0.90,
+                "outer_fold_count": 12,
+                "expected_calibration_units_per_outer_fold": 9,
+                "order_statistic_rank_one_based": 9,
+                "calibration_unit": (
+                    "one preregistered execution per independent session"
+                ),
+                "score_kind": "max_abs_standardized_coordinate_v1",
+                "target_threshold_reselection_allowed": False,
+                "pooled_coordinate_conformal_claimed": False,
+                "worst_group_coverage_guarantee_claimed": False,
+            },
+            "target_outcomes_may_select_method_or_hyperparameters": False,
+            "optional_branches_may_change_primary_analysis": False,
+        },
+        "reporting_contract": {
+            "report_success_or_well_powered_negative_result": True,
+            "report_all_36_executions_or_preregistered_exclusions": True,
+            "report_independent_execution_calibration": True,
+            "report_effect_intervals_and_replay_reset_variance": True,
+            (
+                "optional_semantic_or_public_data_results_cannot_rescue_primary_failure"
+            ): True,
+        },
+    }
+
+
+def _build(method_freeze_sha256: str = "c" * 64) -> dict[str, object]:
+    return build_registered_real_analysis_manifest(
+        load_protocol(PROTOCOL),
+        _method_freeze(),
+        method_freeze_sha256=method_freeze_sha256,
+        registered_by="independent-registrar",
+        registered_at_utc="2026-08-07T00:00:00+00:00",
+    )
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> str:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_manifest_is_complete_content_addressed_and_protocol_derived() -> None:
+    manifest = _build()
+
+    assert manifest["analysis_id"] == analysis_id_for_payload(manifest)
+    assert manifest["effect_reporting"]["bootstrap_replicates"] == (
+        BOOTSTRAP_REPLICATES
+    )
+    assert manifest["effect_reporting"]["bootstrap_seed"] == BOOTSTRAP_SEED
+    inventory = manifest["effect_reporting"]["endpoint_inventory"]
+    assert [entry["registered_units"] for entry in inventory] == [36, 18, 12]
+    assert [entry["target_sessions"] for entry in inventory] == [18, 18, 12]
+    assert manifest["confirmatory_calibration"]["order_statistic_rank_one_based"] == 9
+    assert manifest["comparison_arms"][-1]["role"] == "diagnostic_only"
+
+    restored = validate_registered_real_analysis_manifest(
+        manifest,
+        expected_method_freeze_sha256="c" * 64,
+    )
+    assert restored == manifest
+
+
+def test_manifest_rejects_consistently_readdressed_policy_tampering() -> None:
+    manifest = _build()
+    tampered = copy.deepcopy(manifest)
+    tampered["effect_reporting"]["bootstrap_seed"] += 1
+    tampered["analysis_id"] = analysis_id_for_payload(tampered)
+
+    with pytest.raises(ValueError, match="effect_reporting changed"):
+        validate_registered_real_analysis_manifest(tampered)
+
+    tampered = copy.deepcopy(manifest)
+    tampered["comparison_arms"][2]["role"] = "diagnostic_only"
+    tampered["analysis_id"] = analysis_id_for_payload(tampered)
+    with pytest.raises(ValueError, match="comparison_arms changed"):
+        validate_registered_real_analysis_manifest(tampered)
+
+
+def test_source_verification_accepts_schema_v2_and_rejects_target_access(
+    tmp_path: Path,
+) -> None:
+    freeze_path = tmp_path / "method-freeze.json"
+    freeze_sha = _write_json(freeze_path, _method_freeze())
+    manifest = _build(freeze_sha)
+    analysis_path = tmp_path / "registered-analysis.json"
+    analysis_sha = _write_json(analysis_path, manifest)
+
+    @dataclass(frozen=True)
+    class Binding:
+        protocol_id: str = EXPECTED_PROTOCOL_ID
+        protocol_design_sha256: str = EXPECTED_PROTOCOL_DESIGN_SHA256
+        preacquisition_amendment_sha256: str = EXPECTED_PREACQUISITION_SHA256
+        method_freeze_sha256: str = freeze_sha
+        analysis_manifest_sha256: str = analysis_sha
+
+    verification = verify_real_result_sources(
+        Binding(),
+        method_freeze_path=freeze_path,
+        analysis_manifest_path=analysis_path,
+    )
+    assert verification["registered_analysis_manifest"]["sha256"] == analysis_sha
+
+    tampered = copy.deepcopy(manifest)
+    tampered["target_outcomes_observed_at_registration"] = True
+    tampered["analysis_id"] = analysis_id_for_payload(tampered)
+    _write_json(analysis_path, tampered)
+    tampered_sha = hashlib.sha256(analysis_path.read_bytes()).hexdigest()
+
+    @dataclass(frozen=True)
+    class TamperedBinding:
+        protocol_id: str = EXPECTED_PROTOCOL_ID
+        protocol_design_sha256: str = EXPECTED_PROTOCOL_DESIGN_SHA256
+        preacquisition_amendment_sha256: str = EXPECTED_PREACQUISITION_SHA256
+        method_freeze_sha256: str = freeze_sha
+        analysis_manifest_sha256: str = tampered_sha
+
+    with pytest.raises(ValueError, match="target_outcomes_observed.*changed"):
+        verify_real_result_sources(
+            TamperedBinding(),
+            method_freeze_path=freeze_path,
+            analysis_manifest_path=analysis_path,
+        )
+
+
+def test_real_protocol_cli_exposes_analysis_manifest_routes() -> None:
+    parser = build_parser()
+    seal = parser.parse_args(
+        [
+            "analysis-manifest-seal",
+            "/repo",
+            "protocol.json",
+            "freeze.json",
+            "analysis.json",
+            "--registered-by",
+            "reviewer",
+        ]
+    )
+    assert seal.command == "analysis-manifest-seal"
+    validate = parser.parse_args(
+        [
+            "analysis-manifest-validate",
+            "/repo",
+            "protocol.json",
+            "freeze.json",
+            "analysis.json",
+        ]
+    )
+    assert validate.command == "analysis-manifest-validate"

--- a/tests/test_registered_real_analysis_readiness.py
+++ b/tests/test_registered_real_analysis_readiness.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+from pathlib import Path
+
+import causal4d.preacquisition_readiness as readiness_module
+from causal4d.real_experiment_freeze import MILESTONE_ID, SCHEMA_VERSION
+from causal4d.real_protocol import load_protocol
+from causal4d.registered_real_analysis import (
+    EXPECTED_PREACQUISITION_SHA256,
+    analysis_id_for_payload,
+    build_registered_real_analysis_manifest,
+)
+from causal4d.registered_real_analysis_prerequisite import (
+    validate_registered_real_analysis_prerequisite,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL_PATH = ROOT / "configs/causal4d/sloth_multi_action_v1.json"
+
+
+def _freeze() -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "milestone_id": MILESTONE_ID,
+        "status": "sealed",
+        "frozen_at_utc": "2026-08-07T00:00:00+00:00",
+        "locked_before_confirmatory_collection": True,
+        "target_outcomes_observed_at_freeze": False,
+        "causal4d": {"commit_sha": "a" * 40},
+        "bayesian_phystwin": {"commit_sha": "b" * 40},
+        "protocol": {
+            "design_sha256": (
+                "6d61f2bea96af0ba04faaf3476990b58cd87e0a9c826420c254a012dec647968"
+            )
+        },
+        "preacquisition": {
+            "amendment_sha256": EXPECTED_PREACQUISITION_SHA256,
+        },
+        "analysis_contract": {
+            "entrypoints": [
+                "causal4d protocol real",
+                "causal4d calibration execution-block",
+                "causal4d evidence physical-counterfactual evaluate",
+            ],
+            "diagnostic_only_entrypoints": ["causal4d calibration real"],
+            "allowed_observation_prefix_frames": 6,
+            "confirmatory_calibration": {
+                "entrypoint": "causal4d calibration execution-block",
+                "confidence_level": 0.90,
+                "outer_fold_count": 12,
+                "expected_calibration_units_per_outer_fold": 9,
+                "order_statistic_rank_one_based": 9,
+                "calibration_unit": (
+                    "one preregistered execution per independent session"
+                ),
+                "score_kind": "max_abs_standardized_coordinate_v1",
+                "target_threshold_reselection_allowed": False,
+                "pooled_coordinate_conformal_claimed": False,
+                "worst_group_coverage_guarantee_claimed": False,
+            },
+            "target_outcomes_may_select_method_or_hyperparameters": False,
+            "optional_branches_may_change_primary_analysis": False,
+        },
+        "reporting_contract": {
+            "report_success_or_well_powered_negative_result": True,
+            "report_all_36_executions_or_preregistered_exclusions": True,
+            "report_independent_execution_calibration": True,
+            "report_effect_intervals_and_replay_reset_variance": True,
+            (
+                "optional_semantic_or_public_data_results_cannot_rescue_primary_failure"
+            ): True,
+        },
+    }
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> str:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _ready_fixture(tmp_path: Path) -> tuple[dict[str, object], dict[str, object]]:
+    protocol = load_protocol(PROTOCOL_PATH)
+    freeze = _freeze()
+    freeze_sha = _write_json(tmp_path / "method_freeze.json", freeze)
+    analysis = build_registered_real_analysis_manifest(
+        protocol,
+        freeze,
+        method_freeze_sha256=freeze_sha,
+        registered_by="independent-registrar",
+        registered_at_utc="2026-08-07T00:30:00+00:00",
+    )
+    _write_json(tmp_path / "registered-analysis.json", analysis)
+    return protocol, {
+        "valid": True,
+        "sha256": freeze_sha,
+    }
+
+
+def test_registered_analysis_is_a_valid_readiness_prerequisite(tmp_path: Path) -> None:
+    protocol, freeze_result = _ready_fixture(tmp_path)
+
+    result = validate_registered_real_analysis_prerequisite(
+        protocol,
+        tmp_path,
+        freeze_result,
+    )
+
+    assert result["valid"]
+    assert result["analysis_id"]
+    assert result["target_outcomes_used"] is False
+    assert (
+        result["sha256"]
+        == hashlib.sha256(
+            (tmp_path / "registered-analysis.json").read_bytes()
+        ).hexdigest()
+    )
+
+
+def test_registered_analysis_rejects_policy_tampering(tmp_path: Path) -> None:
+    protocol, freeze_result = _ready_fixture(tmp_path)
+    path = tmp_path / "registered-analysis.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["confirmatory_calibration"]["target_threshold_reselection_allowed"] = True
+    payload["analysis_id"] = analysis_id_for_payload(payload)
+    _write_json(path, payload)
+
+    result = validate_registered_real_analysis_prerequisite(
+        protocol,
+        tmp_path,
+        freeze_result,
+    )
+
+    assert not result["valid"]
+    assert "confirmatory_calibration changed" in result["error"]
+
+
+def test_registered_analysis_must_follow_the_method_freeze(tmp_path: Path) -> None:
+    protocol, freeze_result = _ready_fixture(tmp_path)
+    path = tmp_path / "registered-analysis.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["registered_at_utc"] = "2026-08-06T23:59:59+00:00"
+    payload["analysis_id"] = analysis_id_for_payload(payload)
+    _write_json(path, payload)
+
+    result = validate_registered_real_analysis_prerequisite(
+        protocol,
+        tmp_path,
+        freeze_result,
+    )
+
+    assert not result["valid"]
+    assert "predates the method freeze" in result["error"]
+
+
+def test_canonical_readiness_builder_requires_registered_analysis() -> None:
+    parameter = inspect.signature(
+        readiness_module.evaluate_preacquisition_readiness
+    ).parameters["require_registered_analysis"]
+    assert parameter.default is False
+    source = inspect.getsource(readiness_module.build_preacquisition_readiness)
+    assert "require_registered_analysis=True" in source


### PR DESCRIPTION
## Summary

- add a strict, content-addressed schema-v2 `Causal4DRegisteredRealAnalysisManifest`;
- derive and lock the complete factual, same-grasp, and new-contact endpoint inventory from the validated physical protocol;
- bind the exact method-freeze SHA-256, Causal4D revision, BayesianPhysTwin revision, six-frame information boundary, primary/diagnostic command routes, comparison arms, failure policy, reporting obligations, and claim boundary;
- make equal-target-session weighting, 20,000 deterministic session bootstrap replicates, 95% intervals, and execution-mean diagnostic status explicit in the manifest;
- expose the coarse confirmatory calibration design directly: 12 folds, nine independent calibration units, rank 9 of 9, no target threshold reselection, no pooled-coordinate claim, and no worst-group guarantee;
- add `causal4d protocol real analysis-manifest-seal` and `analysis-manifest-validate` routes that require the exact clean method-freeze checkout and publish atomically without replacement;
- require the exact schema-v2 manifest as a first-class prerequisite of the canonical pre-acquisition readiness builder and expose `primary_analysis_registered` in the collection gate;
- reject a missing manifest, changed method-freeze identity, software-revision mismatch, consistently re-addressed policy change, target-informed registration, or registration timestamp preceding the method freeze;
- retain historical schema-v1 source verification while applying closed-field and fixed-policy validation to schema v2; and
- add focused protocol-derived inventory, content identity, policy-tamper, chronology, target-access, source-verification, readiness-admission, and CLI tests.

## Why

The existing registered-analysis template binds seven high-level fields, while endpoint accounting, resampling, calibration, comparison, exclusion, and claim rules are distributed across the method freeze, protocol, reporting code, and documentation. The readiness gate also did not previously open and validate that file. This change makes the already locked rules independently inspectable in one exact artifact and refuses collection until the artifact is valid.

## Scientific boundary

This is preregistration and provenance infrastructure only. It changes no estimator, rollout bank, intervention posterior, protocol split, calibration threshold, endpoint decision, or target outcome. It does not increment the `0/36` physical evidence count and cannot rescue a failed primary gate. The manifest does not authorize acquisition alone; it is one required input to the existing hash-verified readiness decision.

## Validation performed

- all eight published Git blobs were assembled into one commit on current `main` revision `7faf8486991ef99fda694df94e92efde78c1bf2a`;
- Python byte compilation passed for the new analysis contract, readiness prerequisite, readiness integration, CLI, source verifier, and focused tests;
- the original focused analysis-contract suite passed locally: `4 passed`;
- branch comparison is exactly one commit, eight files, and no overlap with the merged latent-contact typing repair;
- all added Python and Markdown lines satisfy the repository's 88-column limit;
- no remote Actions success is claimed until the permanent exact-head workflow reports on the current head.

## Exact-head validation

Queued for the permanent default-branch validator. The result must name current head `262c2ec2392d9be95a1cb042ec2f475f47297dd0`.

<!-- exact-head-validation: queued -->