### PR TITLE
Publish content-addressed three-repository stack locks

### DIFF
--- a/.github/workflows/bayesian-phystwin-provider-compatibility.yml
+++ b/.github/workflows/bayesian-phystwin-provider-compatibility.yml
@@ -11,10 +11,13 @@ on:
       - "docs/ci.md"
       - "docs/molmo_visual_inputs_v2.md"
       - "docs/prob4d_provider_attestation.md"
+      - "docs/stack_lock.md"
       - "pyproject.toml"
       - "src/causal4d/bpt_belief.py"
       - "src/causal4d/claim_bearing_observation_lineage.py"
       - "src/causal4d/cli/molmo_phystwin_forecast_v2.py"
+      - "src/causal4d/cli/root.py"
+      - "src/causal4d/cli/stack.py"
       - "src/causal4d/molmo_visual_inputs_v2.py"
       - "src/causal4d/observation_lineage.py"
       - "src/causal4d/phystwin_backend.py"
@@ -27,6 +30,7 @@ on:
       - "src/causal4d/provider_contract.py"
       - "src/causal4d/replay_provider_contract.py"
       - "src/causal4d/rollout_cache.py"
+      - "src/causal4d/stack_lock.py"
       - "tests/test_bpt_provider_import_boundary.py"
       - "tests/test_bpt_provider_integration.py"
       - "tests/test_causal4d_bpt_belief.py"
@@ -38,6 +42,7 @@ on:
       - "tests/test_prob4d_stream_contract_version.py"
       - "tests/test_replay_provider_contract.py"
       - "tests/test_rollout_cache.py"
+      - "tests/test_stack_lock.py"
       - "tests/test_three_repository_workflow_policy.py"
   push:
     branches: [main]
@@ -49,10 +54,13 @@ on:
       - "docs/ci.md"
       - "docs/molmo_visual_inputs_v2.md"
       - "docs/prob4d_provider_attestation.md"
+      - "docs/stack_lock.md"
       - "pyproject.toml"
       - "src/causal4d/bpt_belief.py"
       - "src/causal4d/claim_bearing_observation_lineage.py"
       - "src/causal4d/cli/molmo_phystwin_forecast_v2.py"
+      - "src/causal4d/cli/root.py"
+      - "src/causal4d/cli/stack.py"
       - "src/causal4d/molmo_visual_inputs_v2.py"
       - "src/causal4d/observation_lineage.py"
       - "src/causal4d/phystwin_backend.py"
@@ -65,6 +73,7 @@ on:
       - "src/causal4d/provider_contract.py"
       - "src/causal4d/replay_provider_contract.py"
       - "src/causal4d/rollout_cache.py"
+      - "src/causal4d/stack_lock.py"
       - "tests/test_bpt_provider_import_boundary.py"
       - "tests/test_bpt_provider_integration.py"
       - "tests/test_causal4d_bpt_belief.py"
@@ -76,6 +85,7 @@ on:
       - "tests/test_prob4d_stream_contract_version.py"
       - "tests/test_replay_provider_contract.py"
       - "tests/test_rollout_cache.py"
+      - "tests/test_stack_lock.py"
       - "tests/test_three_repository_workflow_policy.py"
   workflow_dispatch:
   schedule:
@@ -178,6 +188,50 @@ jobs:
             opencv-python-headless
           "$venv/bin/python" -m pip check
 
+      - name: Create and verify content-addressed stack lock
+        run: |
+          set -o pipefail
+          venv="$RUNNER_TEMP/three-repository-venv"
+          wheelhouse="$RUNNER_TEMP/three-repository-wheelhouse"
+          lock="$RUNNER_TEMP/three-repository-stack-lock.json"
+          create_output="$RUNNER_TEMP/three-repository-stack-lock-create.json"
+          report="$RUNNER_TEMP/three-repository-stack-lock-verification.json"
+          mapfile -t wheels < <(find "$wheelhouse" -maxdepth 1 -name '*.whl' -print | sort)
+
+          create=("$venv/bin/causal4d" stack create)
+          for wheel in "${wheels[@]}"; do
+            create+=(--wheel "$wheel")
+          done
+          create+=(
+            --revision "prob4d=${{ steps.revisions.outputs.prob4d }}"
+            --revision "bayesian-phystwin=${{ steps.revisions.outputs.bpt }}"
+            --revision "causal4d=${{ steps.revisions.outputs.causal4d }}"
+            --output "$lock"
+            --json
+          )
+          "${create[@]}" > "$create_output"
+          cmp "$lock" "$create_output"
+
+          verify=("$venv/bin/causal4d" stack verify --lock "$lock")
+          for wheel in "${wheels[@]}"; do
+            verify+=(--wheel "$wheel")
+          done
+          verify+=(--json)
+          "${verify[@]}" | tee "$report"
+          "$venv/bin/python" -m json.tool "$lock" >/dev/null
+          "$venv/bin/python" -m json.tool "$report" >/dev/null
+          STACK_REPORT="$report" "$venv/bin/python" - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads(Path(os.environ["STACK_REPORT"]).read_text())
+          if report.get("valid") is not True:
+              raise SystemExit("stack-lock verification did not pass")
+          if report.get("wheel_set", {}).get("verified") is not True:
+              raise SystemExit("stack-lock wheel identities were not verified")
+          PY
+
       - name: Run the isolated three-repository compatibility path
         run: |
           set -o pipefail
@@ -246,11 +300,30 @@ jobs:
               "$GITHUB_WORKSPACE/causal4d/tests/test_rollout_cache.py" \
               "$GITHUB_WORKSPACE/causal4d/tests/test_observation_lineage.py" \
               "$GITHUB_WORKSPACE/causal4d/tests/test_prob4d_joint_contract_fixture.py" \
-              "$GITHUB_WORKSPACE/causal4d/tests/test_prob4d_stream_contract_version.py"
+              "$GITHUB_WORKSPACE/causal4d/tests/test_prob4d_stream_contract_version.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_stack_lock.py"
 
       - name: Publish compatibility summary
         if: always()
         run: |
+          if [[ -f "$RUNNER_TEMP/three-repository-stack-lock.json" ]]; then
+            {
+              echo "### Content-addressed stack lock"
+              echo
+              echo '```json'
+              cat "$RUNNER_TEMP/three-repository-stack-lock.json"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [[ -f "$RUNNER_TEMP/three-repository-stack-lock-verification.json" ]]; then
+            {
+              echo "### Stack-lock verification"
+              echo
+              echo '```json'
+              cat "$RUNNER_TEMP/three-repository-stack-lock-verification.json"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
           if [[ -f "$RUNNER_TEMP/three-repository-summary.json" ]]; then
             {
               echo "### Compatibility path"
@@ -279,16 +352,19 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Upload golden-path diagnostics
+      - name: Upload golden-path diagnostics and locked wheels
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: three-repository-installed-wheel-golden-path
           path: |
+            ${{ runner.temp }}/three-repository-wheelhouse/*.whl
+            ${{ runner.temp }}/three-repository-wheel-sha256.txt
+            ${{ runner.temp }}/three-repository-stack-lock.json
+            ${{ runner.temp }}/three-repository-stack-lock-verification.json
             ${{ runner.temp }}/three-repository-summary.json
             ${{ runner.temp }}/three-repository-golden-path.log
             ${{ runner.temp }}/three-repository-provider-v2-summary.json
             ${{ runner.temp }}/three-repository-provider-v2.log
-            ${{ runner.temp }}/three-repository-wheel-sha256.txt
           if-no-files-found: warn
-          retention-days: 7
+          retention-days: 14

--- a/docs/stack_lock.md
+++ b/docs/stack_lock.md
@@ -1,0 +1,83 @@
+# Three-repository stack locks
+
+Causal4D can publish a content-addressed compatibility lock for the exact
+Prob4D, BayesianPhysTwin, and Causal4D wheels exercised together. The lock is a
+portable release and CI artifact: it binds the three wheel contents to their
+reported package versions, exact tested source revisions, required provider
+modules, and the fixed `Prob4D -> BayesianPhysTwin -> Causal4D` pipeline.
+
+## Create a lock
+
+Build all three wheels first, then provide one wheel and one exact 40-character
+source revision for every distribution:
+
+```bash
+causal4d stack create \
+  --wheel wheelhouse/prob4d-0.3.0-py3-none-any.whl \
+  --wheel wheelhouse/bayesian_phystwin-0.4.0-py3-none-any.whl \
+  --wheel wheelhouse/causal4d-0.5.0-py3-none-any.whl \
+  --revision prob4d=<PROB4D_COMMIT> \
+  --revision bayesian-phystwin=<BPT_COMMIT> \
+  --revision causal4d=<CAUSAL4D_COMMIT> \
+  --output causal4d-stack-lock.json
+```
+
+Creation fails unless the wheel metadata contains exactly the three canonical
+distributions and every source revision is present. The output is written
+atomically and is not replaced unless `--force` is supplied.
+
+The `lock_id` is the SHA-256 digest of the canonical JSON payload excluding the
+`lock_id` field itself. Distribution order, source repositories, required
+provider-v2 modules, and compatibility declarations are schema-locked, so a
+consumer cannot silently reinterpret the artifact.
+
+## Verify exact wheel artifacts
+
+Pass the lock and all three wheel files:
+
+```bash
+causal4d stack verify \
+  --lock causal4d-stack-lock.json \
+  --wheel wheelhouse/prob4d-0.3.0-py3-none-any.whl \
+  --wheel wheelhouse/bayesian_phystwin-0.4.0-py3-none-any.whl \
+  --wheel wheelhouse/causal4d-0.5.0-py3-none-any.whl \
+  --json
+```
+
+Verification re-reads wheel metadata and checks each distribution's canonical
+name, version, byte size, and SHA-256 digest. Renaming a downloaded wheel does
+not invalidate it; changing its contents does. Duplicate distributions,
+missing wheels, unexpected wheels, malformed metadata, duplicate JSON keys,
+and a mismatched `lock_id` fail closed.
+
+For diagnostics that only need to establish that the lock document itself is
+untampered, use the explicit weaker mode:
+
+```bash
+causal4d stack verify \
+  --lock causal4d-stack-lock.json \
+  --lock-only
+```
+
+`--lock-only` does **not** verify the wheel artifacts and cannot be combined
+with `--wheel`.
+
+## Evidence boundary
+
+A stack lock proves artifact identity and records the source revisions that the
+producer reports for those artifacts. It does not independently prove that the
+wheels were built from those revisions; that provenance remains the
+responsibility of the build workflow and its checkout, clean-tree, and build
+attestations. It also does not prove that an arbitrary installed environment is
+using the locked wheels.
+
+The three-repository installed-wheel workflow supplies the stronger context: it
+checks out immutable source revisions, builds the wheels, records their hashes,
+creates and re-verifies the stack lock with the installed Causal4D CLI, then
+runs the isolated golden path, strict claim-bearing provider-v2 attestation,
+and cross-repository contract tests. The lock and verification report are
+published alongside those diagnostics.
+
+A passing stack lock is packaging and compatibility evidence only. It does not
+change `claim_ready`, replace prospective calibration, or count as one of the
+frozen confirmatory physical executions.

--- a/src/causal4d/cli/root.py
+++ b/src/causal4d/cli/root.py
@@ -32,6 +32,7 @@ def _root_help() -> str:
         groups.setdefault(command.route[0], []).append(command)
     lines = [
         "usage: causal4d <group> <command> [arguments]",
+        "       causal4d stack {create,verify} ...",
         "       causal4d commands {list,describe,migrate,validate} ...",
         "",
         "Single executable for all Causal4D commands. Modules are imported lazily.",
@@ -45,6 +46,11 @@ def _root_help() -> str:
             lines.append(f"    {suffix:<40} {command.summary}")
     lines.extend(
         (
+            "",
+            "stack locks:",
+            "  stack create --wheel PATH ... --revision DISTRIBUTION=SHA ...",
+            "  stack verify --lock PATH --wheel PATH ... [--json]",
+            "  stack verify --lock PATH --lock-only [--json]",
             "",
             "introspection:",
             "  commands list [--json] [--removed-only]",
@@ -210,6 +216,11 @@ def _commands(arguments: Sequence[str]) -> int:
     raise SystemExit(f"unknown commands operation: {operation}")
 
 
+def _stack(arguments: Sequence[str]) -> int:
+    function = getattr(import_module("causal4d.cli.stack"), "main")
+    return int(function(list(arguments)) or 0)
+
+
 def _resolve_route(arguments: Sequence[str]) -> tuple[CommandSpec, list[str]]:
     for command in sorted(
         grouped_commands(),
@@ -245,6 +256,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     if arguments[0] == "--version":
         print(_version())
         return 0
+    if arguments[0] == "stack":
+        return _stack(arguments[1:])
     if arguments[0] == "commands":
         return _commands(arguments[1:])
     if arguments[0].startswith("causal4d-") and _print_removed_migration(arguments[0]):

--- a/src/causal4d/cli/stack.py
+++ b/src/causal4d/cli/stack.py
@@ -1,0 +1,157 @@
+"""Create and verify content-addressed three-repository stack locks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+import sys
+
+from packaging.utils import canonicalize_name
+
+from causal4d.stack_lock import (
+    STACK_PIPELINE,
+    build_stack_lock,
+    load_stack_lock,
+    verify_stack_lock,
+    write_stack_lock,
+)
+
+
+def _revision(value: str) -> tuple[str, str]:
+    name, separator, revision = value.partition("=")
+    if not separator:
+        raise argparse.ArgumentTypeError("revision must use DISTRIBUTION=SHA syntax")
+    canonical_name = canonicalize_name(name)
+    if canonical_name not in STACK_PIPELINE:
+        raise argparse.ArgumentTypeError(
+            f"unsupported stack distribution: {canonical_name}"
+        )
+    if len(revision) != 40 or any(
+        character not in "0123456789abcdefABCDEF" for character in revision
+    ):
+        raise argparse.ArgumentTypeError(
+            "revision must be a 40-character hexadecimal commit SHA"
+        )
+    return canonical_name, revision.lower()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="causal4d stack",
+        description=(
+            "Create or verify a content-addressed Prob4D -> "
+            "BayesianPhysTwin -> Causal4D wheel lock."
+        ),
+    )
+    subparsers = parser.add_subparsers(dest="operation", required=True)
+
+    create = subparsers.add_parser(
+        "create",
+        help="Create a deterministic stack lock from three wheel files.",
+    )
+    create.add_argument(
+        "--wheel",
+        action="append",
+        type=Path,
+        required=True,
+        metavar="PATH",
+        help="Wheel path; provide exactly one for each stack distribution.",
+    )
+    create.add_argument(
+        "--revision",
+        action="append",
+        type=_revision,
+        required=True,
+        metavar="DISTRIBUTION=SHA",
+        help="Exact tested source revision; provide one per distribution.",
+    )
+    create.add_argument("--output", type=Path, required=True)
+    create.add_argument(
+        "--force",
+        action="store_true",
+        help="Replace an existing output lock.",
+    )
+    create.add_argument("--json", action="store_true")
+
+    verify = subparsers.add_parser(
+        "verify",
+        help="Validate a stack lock and exact wheel identities.",
+    )
+    verify.add_argument("--lock", type=Path, required=True)
+    verify.add_argument(
+        "--wheel",
+        action="append",
+        type=Path,
+        default=[],
+        metavar="PATH",
+        help="Wheel path; provide all three unless --lock-only is used.",
+    )
+    verify.add_argument(
+        "--lock-only",
+        action="store_true",
+        help="Validate only the lock structure and content digest.",
+    )
+    verify.add_argument("--json", action="store_true")
+    return parser
+
+
+def _create(parsed: argparse.Namespace) -> int:
+    revisions: dict[str, str] = {}
+    for name, revision in parsed.revision:
+        if name in revisions:
+            raise ValueError(f"duplicate source revision for {name}")
+        revisions[name] = revision
+    lock = build_stack_lock(
+        parsed.wheel,
+        source_revisions=revisions,
+    )
+    write_stack_lock(parsed.output, lock, overwrite=parsed.force)
+    if parsed.json:
+        print(json.dumps(lock, indent=2, sort_keys=True))
+    else:
+        print(f"stack lock: {lock['lock_id']}")
+        print(f"output: {parsed.output}")
+    return 0
+
+
+def _verify(parsed: argparse.Namespace) -> int:
+    if parsed.lock_only and parsed.wheel:
+        raise ValueError("--lock-only cannot be combined with --wheel")
+    if not parsed.lock_only and not parsed.wheel:
+        raise ValueError("provide all three --wheel paths or use --lock-only")
+    lock = load_stack_lock(parsed.lock)
+    report = verify_stack_lock(
+        lock,
+        wheel_paths=parsed.wheel,
+        require_wheels=not parsed.lock_only,
+    )
+    if parsed.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        state = "valid" if report["valid"] else "invalid"
+        print(f"stack lock: {state}")
+        print(f"lock id: {report['lock_id']}")
+        print(f"wheel identities verified: {report['wheel_set']['verified']}")
+        for error in report["errors"]:
+            print(f"error: {error}")
+    return 0 if report["valid"] else 2
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _parser()
+    parsed = parser.parse_args(argv)
+    try:
+        if parsed.operation == "create":
+            return _create(parsed)
+        if parsed.operation == "verify":
+            return _verify(parsed)
+    except (OSError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    raise AssertionError(f"unhandled stack operation: {parsed.operation}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d/stack_lock.py
+++ b/src/causal4d/stack_lock.py
@@ -1,0 +1,518 @@
+"""Content-addressed wheel locks for the Prob4D -> BPT -> Causal4D stack."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from email.parser import Parser
+from pathlib import Path
+from typing import Any
+from zipfile import BadZipFile, ZipFile
+
+from packaging.utils import canonicalize_name
+from packaging.version import InvalidVersion, Version
+
+from causal4d.atomic_io import atomic_write_json
+from causal4d.immutable_json import plain_json
+
+STACK_LOCK_SCHEMA_NAME = "causal4d.stack-lock"
+STACK_LOCK_SCHEMA_VERSION = 1
+STACK_VERIFICATION_SCHEMA_NAME = "causal4d.stack-verification"
+STACK_VERIFICATION_SCHEMA_VERSION = 1
+STACK_LOCK_GENERATOR = "causal4d stack create"
+STACK_PIPELINE = ("prob4d", "bayesian-phystwin", "causal4d")
+
+SOURCE_REPOSITORIES = {
+    "prob4d": "IPS-Stuttgart/Prob4D",
+    "bayesian-phystwin": "IPS-Stuttgart/BayesianPhysTwin",
+    "causal4d": "IPS-Stuttgart/Causal4D",
+}
+REQUIRED_MODULES = {
+    "prob4d": (
+        "prob4d.provider_v2",
+        "prob4d.provider_v2_loading",
+    ),
+    "bayesian-phystwin": (
+        "bayesian_phystwin.causal4d_provider_v2",
+        "bayesian_phystwin.causal4d_belief_provider_v2",
+    ),
+    "causal4d": (
+        "causal4d.claim_bearing_observation_lineage",
+        "causal4d.belief_provider_v2_contract",
+    ),
+}
+
+_HEX_40 = re.compile(r"[0-9a-f]{40}")
+_HEX_64 = re.compile(r"[0-9a-f]{64}")
+
+
+@dataclass(frozen=True)
+class WheelIdentity:
+    """Identity extracted from one wheel without importing or installing it."""
+
+    name: str
+    version: str
+    filename: str
+    sha256: str
+    size_bytes: int
+    path: Path
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_json_text(text: str, *, label: str) -> Any:
+    def object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"{label} contains duplicate key {key!r}")
+            result[key] = value
+        return result
+
+    def reject_constant(value: str) -> None:
+        raise ValueError(f"{label} contains non-finite value {value}")
+
+    try:
+        return json.loads(
+            text,
+            object_pairs_hook=object_pairs,
+            parse_constant=reject_constant,
+        )
+    except json.JSONDecodeError as error:
+        raise ValueError(f"{label} is not valid JSON") from error
+
+
+def _canonical_payload_bytes(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        plain_json(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _payload_id(payload: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_payload_bytes(payload)).hexdigest()
+
+
+def _canonical_version(value: str, *, label: str) -> str:
+    _require(isinstance(value, str) and bool(value), f"{label} must be nonempty")
+    try:
+        normalized = str(Version(value))
+    except InvalidVersion as error:
+        raise ValueError(f"{label} is invalid: {value!r}") from error
+    _require(normalized == value, f"{label} must use canonical form {normalized!r}")
+    return normalized
+
+
+def _normalize_revisions(revisions: Mapping[str, str]) -> dict[str, str]:
+    normalized: dict[str, str] = {}
+    for raw_name, raw_revision in revisions.items():
+        name = canonicalize_name(raw_name)
+        _require(name not in normalized, f"duplicate source revision for {name}")
+        revision = str(raw_revision).lower()
+        _require(
+            _HEX_40.fullmatch(revision) is not None,
+            f"source revision for {name} must be a 40-character hexadecimal SHA",
+        )
+        normalized[name] = revision
+    expected = set(STACK_PIPELINE)
+    observed = set(normalized)
+    _require(
+        observed == expected,
+        "source revisions must cover exactly "
+        f"{sorted(expected)}; missing={sorted(expected - observed)}, "
+        f"unexpected={sorted(observed - expected)}",
+    )
+    return normalized
+
+
+def inspect_wheel(path: str | Path) -> WheelIdentity:
+    """Return the content and metadata identity of one wheel file."""
+
+    wheel_path = Path(path).resolve()
+    _require(wheel_path.is_file(), f"wheel does not exist: {wheel_path}")
+    _require(wheel_path.suffix == ".whl", f"wheel path must end in .whl: {wheel_path}")
+    try:
+        with ZipFile(wheel_path) as archive:
+            metadata_members = sorted(
+                name
+                for name in archive.namelist()
+                if name.endswith(".dist-info/METADATA")
+            )
+            _require(
+                len(metadata_members) == 1,
+                f"wheel must contain exactly one .dist-info/METADATA: {wheel_path}",
+            )
+            metadata_text = archive.read(metadata_members[0]).decode("utf-8")
+    except (BadZipFile, UnicodeDecodeError, KeyError) as error:
+        raise ValueError(f"wheel metadata cannot be read: {wheel_path}") from error
+
+    message = Parser().parsestr(metadata_text)
+    raw_name = message.get("Name")
+    raw_version = message.get("Version")
+    _require(raw_name is not None, f"wheel metadata has no Name: {wheel_path}")
+    _require(raw_version is not None, f"wheel metadata has no Version: {wheel_path}")
+    name = canonicalize_name(raw_name)
+    version = _canonical_version(raw_version, label=f"wheel version for {name}")
+    return WheelIdentity(
+        name=name,
+        version=version,
+        filename=wheel_path.name,
+        sha256=_sha256_file(wheel_path),
+        size_bytes=wheel_path.stat().st_size,
+        path=wheel_path,
+    )
+
+
+def build_stack_lock(
+    wheel_paths: Sequence[str | Path],
+    *,
+    source_revisions: Mapping[str, str],
+) -> dict[str, Any]:
+    """Build a deterministic lock from exactly the three compatibility wheels."""
+
+    revisions = _normalize_revisions(source_revisions)
+    identities: dict[str, WheelIdentity] = {}
+    for path in wheel_paths:
+        identity = inspect_wheel(path)
+        _require(
+            identity.name not in identities,
+            f"duplicate wheel for distribution {identity.name}",
+        )
+        identities[identity.name] = identity
+    expected = set(STACK_PIPELINE)
+    observed = set(identities)
+    _require(
+        observed == expected,
+        "wheel set must contain exactly "
+        f"{sorted(expected)}; missing={sorted(expected - observed)}, "
+        f"unexpected={sorted(observed - expected)}",
+    )
+
+    distributions = []
+    for name in STACK_PIPELINE:
+        identity = identities[name]
+        distributions.append(
+            {
+                "name": name,
+                "version": identity.version,
+                "wheel": {
+                    "filename": identity.filename,
+                    "sha256": identity.sha256,
+                    "size_bytes": identity.size_bytes,
+                },
+                "source": {
+                    "repository": SOURCE_REPOSITORIES[name],
+                    "revision": revisions[name],
+                },
+                "required_modules": list(REQUIRED_MODULES[name]),
+            }
+        )
+    payload: dict[str, Any] = {
+        "schema_name": STACK_LOCK_SCHEMA_NAME,
+        "schema_version": STACK_LOCK_SCHEMA_VERSION,
+        "generated_by": STACK_LOCK_GENERATOR,
+        "compatibility": {
+            "pipeline": list(STACK_PIPELINE),
+            "claim_bearing_provider_v2_required": True,
+            "wheel_identity_required": True,
+        },
+        "distributions": distributions,
+    }
+    return {**payload, "lock_id": _payload_id(payload)}
+
+
+def _validate_distribution(entry: Any, *, expected_name: str) -> None:
+    _require(isinstance(entry, dict), "stack distribution entries must be objects")
+    _require(
+        set(entry) == {"name", "version", "wheel", "source", "required_modules"},
+        f"stack entry for {expected_name} has unexpected fields",
+    )
+    _require(entry["name"] == expected_name, "stack distribution order is invalid")
+    _canonical_version(entry["version"], label=f"locked version for {expected_name}")
+
+    wheel = entry["wheel"]
+    _require(
+        isinstance(wheel, dict),
+        f"wheel record for {expected_name} must be an object",
+    )
+    _require(
+        set(wheel) == {"filename", "sha256", "size_bytes"},
+        f"wheel record for {expected_name} has unexpected fields",
+    )
+    filename = wheel["filename"]
+    _require(
+        isinstance(filename, str)
+        and bool(filename)
+        and Path(filename).name == filename
+        and filename.endswith(".whl"),
+        f"wheel filename for {expected_name} is invalid",
+    )
+    _require(
+        isinstance(wheel["sha256"], str)
+        and _HEX_64.fullmatch(wheel["sha256"]) is not None,
+        f"wheel SHA-256 for {expected_name} is invalid",
+    )
+    _require(
+        isinstance(wheel["size_bytes"], int)
+        and not isinstance(wheel["size_bytes"], bool)
+        and wheel["size_bytes"] > 0,
+        f"wheel size for {expected_name} must be a positive integer",
+    )
+
+    source = entry["source"]
+    _require(
+        isinstance(source, dict),
+        f"source record for {expected_name} must be an object",
+    )
+    _require(
+        set(source) == {"repository", "revision"},
+        f"source record for {expected_name} has unexpected fields",
+    )
+    _require(
+        source["repository"] == SOURCE_REPOSITORIES[expected_name],
+        f"source repository for {expected_name} is not canonical",
+    )
+    _require(
+        isinstance(source["revision"], str)
+        and _HEX_40.fullmatch(source["revision"]) is not None,
+        f"source revision for {expected_name} is invalid",
+    )
+    _require(
+        entry["required_modules"] == list(REQUIRED_MODULES[expected_name]),
+        f"required modules for {expected_name} are invalid",
+    )
+
+
+def validate_stack_lock(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate a stack lock and return ordinary finite JSON containers."""
+
+    try:
+        normalized = json.loads(
+            json.dumps(plain_json(value), sort_keys=True, allow_nan=False)
+        )
+    except (TypeError, ValueError) as error:
+        raise ValueError("stack lock must be finite JSON data") from error
+    _require(isinstance(normalized, dict), "stack lock must be a JSON object")
+    _require(
+        set(normalized)
+        == {
+            "schema_name",
+            "schema_version",
+            "generated_by",
+            "compatibility",
+            "distributions",
+            "lock_id",
+        },
+        "stack lock has missing or unexpected top-level fields",
+    )
+    _require(
+        normalized["schema_name"] == STACK_LOCK_SCHEMA_NAME,
+        "unsupported stack-lock schema name",
+    )
+    _require(
+        normalized["schema_version"] == STACK_LOCK_SCHEMA_VERSION,
+        "unsupported stack-lock schema version",
+    )
+    _require(
+        normalized["generated_by"] == STACK_LOCK_GENERATOR,
+        "unsupported stack-lock generator",
+    )
+
+    compatibility = normalized["compatibility"]
+    _require(isinstance(compatibility, dict), "stack compatibility must be an object")
+    _require(
+        compatibility
+        == {
+            "pipeline": list(STACK_PIPELINE),
+            "claim_bearing_provider_v2_required": True,
+            "wheel_identity_required": True,
+        },
+        "stack compatibility declaration is invalid",
+    )
+
+    distributions = normalized["distributions"]
+    _require(isinstance(distributions, list), "stack distributions must be an array")
+    _require(
+        len(distributions) == len(STACK_PIPELINE),
+        "stack lock must contain exactly three distributions",
+    )
+    for expected_name, entry in zip(STACK_PIPELINE, distributions, strict=True):
+        _validate_distribution(entry, expected_name=expected_name)
+
+    lock_id = normalized["lock_id"]
+    _require(
+        isinstance(lock_id, str) and _HEX_64.fullmatch(lock_id) is not None,
+        "stack lock_id is invalid",
+    )
+    payload_without_id = {
+        key: item for key, item in normalized.items() if key != "lock_id"
+    }
+    _require(
+        lock_id == _payload_id(payload_without_id),
+        "stack lock_id does not match its payload",
+    )
+    return normalized
+
+
+def load_stack_lock(path: str | Path) -> dict[str, Any]:
+    """Load a duplicate-key-safe stack lock from JSON."""
+
+    lock_path = Path(path)
+    try:
+        text = lock_path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise ValueError(f"stack lock cannot be read: {lock_path}") from error
+    value = _load_json_text(text, label="stack lock")
+    _require(isinstance(value, dict), "stack lock must be a JSON object")
+    return validate_stack_lock(value)
+
+
+def write_stack_lock(
+    path: str | Path,
+    lock: Mapping[str, Any],
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Validate and atomically publish a stack lock."""
+
+    atomic_write_json(path, validate_stack_lock(lock), overwrite=overwrite)
+
+
+def verify_stack_lock(
+    lock: Mapping[str, Any],
+    *,
+    wheel_paths: Sequence[str | Path] = (),
+    require_wheels: bool = True,
+) -> dict[str, Any]:
+    """Verify lock integrity and, when supplied, exact wheel identities."""
+
+    validated = validate_stack_lock(lock)
+    expected = {entry["name"]: entry for entry in validated["distributions"]}
+    if not wheel_paths:
+        errors: list[str] = []
+        if require_wheels:
+            errors.append("exact verification requires all three locked wheels")
+        return {
+            "schema_name": STACK_VERIFICATION_SCHEMA_NAME,
+            "schema_version": STACK_VERIFICATION_SCHEMA_VERSION,
+            "lock_id": validated["lock_id"],
+            "valid": not errors,
+            "requirements": {"wheels": require_wheels},
+            "wheel_set": {
+                "provided": False,
+                "complete": False,
+                "verified": False,
+                "entries": [],
+            },
+            "errors": errors,
+        }
+
+    observed: dict[str, WheelIdentity] = {}
+    errors: list[str] = []
+    for path in wheel_paths:
+        try:
+            identity = inspect_wheel(path)
+        except ValueError as error:
+            errors.append(str(error))
+            continue
+        if identity.name in observed:
+            errors.append(f"duplicate wheel for distribution {identity.name}")
+            continue
+        observed[identity.name] = identity
+
+    entries = []
+    for name in STACK_PIPELINE:
+        locked = expected[name]
+        identity = observed.get(name)
+        if identity is None:
+            entries.append(
+                {
+                    "name": name,
+                    "path": None,
+                    "expected_version": locked["version"],
+                    "observed_version": None,
+                    "expected_sha256": locked["wheel"]["sha256"],
+                    "observed_sha256": None,
+                    "valid": False,
+                }
+            )
+            continue
+        valid = (
+            identity.version == locked["version"]
+            and identity.sha256 == locked["wheel"]["sha256"]
+            and identity.size_bytes == locked["wheel"]["size_bytes"]
+        )
+        if not valid:
+            errors.append(f"wheel identity mismatch for {name}")
+        entries.append(
+            {
+                "name": name,
+                "path": str(identity.path),
+                "expected_version": locked["version"],
+                "observed_version": identity.version,
+                "expected_sha256": locked["wheel"]["sha256"],
+                "observed_sha256": identity.sha256,
+                "valid": valid,
+            }
+        )
+
+    expected_names = set(expected)
+    observed_names = set(observed)
+    complete = expected_names == observed_names
+    if wheel_paths and not complete:
+        errors.append(
+            "provided wheels do not match locked distributions: "
+            f"missing={sorted(expected_names - observed_names)}, "
+            f"unexpected={sorted(observed_names - expected_names)}"
+        )
+    wheels_verified = complete and not errors and all(item["valid"] for item in entries)
+    if require_wheels and not wheels_verified:
+        errors.append("exact verification requires all three locked wheels")
+    valid = not errors and (wheels_verified or not require_wheels)
+    return {
+        "schema_name": STACK_VERIFICATION_SCHEMA_NAME,
+        "schema_version": STACK_VERIFICATION_SCHEMA_VERSION,
+        "lock_id": validated["lock_id"],
+        "valid": valid,
+        "requirements": {"wheels": require_wheels},
+        "wheel_set": {
+            "provided": bool(wheel_paths),
+            "complete": complete,
+            "verified": wheels_verified,
+            "entries": entries,
+        },
+        "errors": errors,
+    }
+
+
+__all__ = [
+    "REQUIRED_MODULES",
+    "SOURCE_REPOSITORIES",
+    "STACK_LOCK_SCHEMA_NAME",
+    "STACK_LOCK_SCHEMA_VERSION",
+    "STACK_PIPELINE",
+    "WheelIdentity",
+    "build_stack_lock",
+    "inspect_wheel",
+    "load_stack_lock",
+    "validate_stack_lock",
+    "verify_stack_lock",
+    "write_stack_lock",
+]

--- a/tests/test_stack_lock.py
+++ b/tests/test_stack_lock.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from zipfile import ZipFile
+
+import pytest
+
+from causal4d import stack_lock
+from causal4d.cli import root
+from causal4d.cli.stack import main as stack_main
+
+
+REVISIONS = {
+    "prob4d": "1" * 40,
+    "bayesian-phystwin": "2" * 40,
+    "causal4d": "3" * 40,
+}
+
+
+def _write_wheel(tmp_path: Path, name: str, version: str) -> Path:
+    token = name.replace("-", "_")
+    path = tmp_path / f"{token}-{version}-py3-none-any.whl"
+    dist_info = f"{token}-{version}.dist-info"
+    with ZipFile(path, "w") as archive:
+        archive.writestr(
+            f"{dist_info}/METADATA",
+            (
+                "Metadata-Version: 2.1\n"
+                f"Name: {name}\n"
+                f"Version: {version}\n"
+            ),
+        )
+        archive.writestr(
+            f"{dist_info}/WHEEL",
+            "Wheel-Version: 1.0\nTag: py3-none-any\n",
+        )
+    return path
+
+
+def _stack_wheels(tmp_path: Path) -> dict[str, Path]:
+    return {
+        "prob4d": _write_wheel(tmp_path, "prob4d", "0.3.0"),
+        "bayesian-phystwin": _write_wheel(
+            tmp_path,
+            "bayesian-phystwin",
+            "0.4.0",
+        ),
+        "causal4d": _write_wheel(tmp_path, "causal4d", "0.5.0"),
+    }
+
+
+def test_stack_lock_is_deterministic_and_pipeline_ordered(tmp_path: Path) -> None:
+    wheels = _stack_wheels(tmp_path)
+    paths = list(reversed(tuple(wheels.values())))
+
+    first = stack_lock.build_stack_lock(
+        paths,
+        source_revisions=REVISIONS,
+    )
+    second = stack_lock.build_stack_lock(
+        paths,
+        source_revisions=REVISIONS,
+    )
+
+    assert first == second
+    assert [item["name"] for item in first["distributions"]] == list(
+        stack_lock.STACK_PIPELINE
+    )
+    assert len(first["lock_id"]) == 64
+    assert stack_lock.validate_stack_lock(first) == first
+
+
+def test_stack_lock_roundtrip_rejects_tampering_and_duplicate_keys(
+    tmp_path: Path,
+) -> None:
+    wheels = _stack_wheels(tmp_path)
+    lock = stack_lock.build_stack_lock(
+        list(wheels.values()),
+        source_revisions=REVISIONS,
+    )
+    path = tmp_path / "stack-lock.json"
+    stack_lock.write_stack_lock(path, lock)
+
+    assert stack_lock.load_stack_lock(path) == lock
+
+    tampered = deepcopy(lock)
+    tampered["distributions"][0]["wheel"]["size_bytes"] += 1
+    path.write_text(json.dumps(tampered), encoding="utf-8")
+    with pytest.raises(ValueError, match="lock_id does not match"):
+        stack_lock.load_stack_lock(path)
+
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text(
+        '{"schema_name":"first","schema_name":"second"}',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="duplicate key"):
+        stack_lock.load_stack_lock(duplicate)
+
+
+def test_stack_lock_verifies_exact_wheels_and_detects_drift(tmp_path: Path) -> None:
+    wheels = _stack_wheels(tmp_path)
+    lock = stack_lock.build_stack_lock(
+        list(wheels.values()),
+        source_revisions=REVISIONS,
+    )
+
+    report = stack_lock.verify_stack_lock(
+        lock,
+        wheel_paths=list(wheels.values()),
+    )
+    assert report["valid"] is True
+    assert report["wheel_set"]["verified"] is True
+
+    renamed = tmp_path / "downloaded-prob4d.whl"
+    wheels["prob4d"].rename(renamed)
+    wheels["prob4d"] = renamed
+    assert stack_lock.verify_stack_lock(
+        lock,
+        wheel_paths=list(wheels.values()),
+    )["valid"]
+
+    with wheels["causal4d"].open("ab") as handle:
+        handle.write(b"tamper")
+    drifted = stack_lock.verify_stack_lock(
+        lock,
+        wheel_paths=list(wheels.values()),
+    )
+    assert drifted["valid"] is False
+    assert any(
+        "wheel identity mismatch for causal4d" in item
+        for item in drifted["errors"]
+    )
+
+
+def test_stack_cli_creates_and_verifies_lock(tmp_path: Path, capsys) -> None:
+    wheels = _stack_wheels(tmp_path)
+    output = tmp_path / "stack-lock.json"
+    create_arguments = ["create"]
+    for path in wheels.values():
+        create_arguments.extend(("--wheel", str(path)))
+    for name, revision in REVISIONS.items():
+        create_arguments.extend(("--revision", f"{name}={revision}"))
+    create_arguments.extend(("--output", str(output), "--json"))
+
+    assert stack_main(create_arguments) == 0
+    created = json.loads(capsys.readouterr().out)
+    assert created["lock_id"] == stack_lock.load_stack_lock(output)["lock_id"]
+
+    verify_arguments = ["verify", "--lock", str(output), "--json"]
+    for path in wheels.values():
+        verify_arguments.extend(("--wheel", str(path)))
+    assert stack_main(verify_arguments) == 0
+    verified = json.loads(capsys.readouterr().out)
+    assert verified["valid"] is True
+
+    assert stack_main(
+        ["verify", "--lock", str(output), "--lock-only", "--json"]
+    ) == 0
+    lock_only = json.loads(capsys.readouterr().out)
+    assert lock_only["valid"] is True
+    assert lock_only["wheel_set"]["verified"] is False
+
+
+def test_root_routes_stack_operations_lazily(monkeypatch, capsys) -> None:
+    assert root.main(["--help"]) == 0
+    assert "causal4d stack {create,verify}" in capsys.readouterr().out
+
+    received: list[str] = []
+
+    def command_main(arguments):
+        received.extend(arguments)
+        return 9
+
+    def fake_import(name: str):
+        assert name == "causal4d.cli.stack"
+        return SimpleNamespace(main=command_main)
+
+    monkeypatch.setattr(root, "import_module", fake_import)
+    result = root.main(["stack", "verify", "--lock", "lock.json", "--lock-only"])
+    assert result == 9
+    assert received == ["verify", "--lock", "lock.json", "--lock-only"]

--- a/tests/test_stack_lock.py
+++ b/tests/test_stack_lock.py
@@ -13,6 +13,10 @@ from causal4d.cli import root
 from causal4d.cli.stack import main as stack_main
 
 
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = (
+    ROOT / ".github" / "workflows" / "bayesian-phystwin-provider-compatibility.yml"
+)
 REVISIONS = {
     "prob4d": "1" * 40,
     "bayesian-phystwin": "2" * 40,
@@ -183,3 +187,24 @@ def test_root_routes_stack_operations_lazily(monkeypatch, capsys) -> None:
     result = root.main(["stack", "verify", "--lock", "lock.json", "--lock-only"])
     assert result == 9
     assert received == ["verify", "--lock", "lock.json", "--lock-only"]
+
+
+def test_three_repository_workflow_publishes_locked_wheels() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    for path in (
+        "docs/stack_lock.md",
+        "src/causal4d/cli/root.py",
+        "src/causal4d/cli/stack.py",
+        "src/causal4d/stack_lock.py",
+        "tests/test_stack_lock.py",
+    ):
+        assert text.count(f'"{path}"') == 2
+    assert "Create and verify content-addressed stack lock" in text
+    assert '"$venv/bin/causal4d" stack create' in text
+    assert '"$venv/bin/causal4d" stack verify' in text
+    assert 'cmp "$lock" "$create_output"' in text
+    assert "three-repository-stack-lock.json" in text
+    assert "three-repository-stack-lock-verification.json" in text
+    assert "${{ runner.temp }}/three-repository-wheelhouse/*.whl" in text
+    assert "Upload golden-path diagnostics and locked wheels" in text

--- a/tests/test_stack_lock.py
+++ b/tests/test_stack_lock.py
@@ -31,11 +31,7 @@ def _write_wheel(tmp_path: Path, name: str, version: str) -> Path:
     with ZipFile(path, "w") as archive:
         archive.writestr(
             f"{dist_info}/METADATA",
-            (
-                "Metadata-Version: 2.1\n"
-                f"Name: {name}\n"
-                f"Version: {version}\n"
-            ),
+            (f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n"),
         )
         archive.writestr(
             f"{dist_info}/WHEEL",
@@ -135,8 +131,7 @@ def test_stack_lock_verifies_exact_wheels_and_detects_drift(tmp_path: Path) -> N
     )
     assert drifted["valid"] is False
     assert any(
-        "wheel identity mismatch for causal4d" in item
-        for item in drifted["errors"]
+        "wheel identity mismatch for causal4d" in item for item in drifted["errors"]
     )
 
 
@@ -161,9 +156,7 @@ def test_stack_cli_creates_and_verifies_lock(tmp_path: Path, capsys) -> None:
     verified = json.loads(capsys.readouterr().out)
     assert verified["valid"] is True
 
-    assert stack_main(
-        ["verify", "--lock", str(output), "--lock-only", "--json"]
-    ) == 0
+    assert stack_main(["verify", "--lock", str(output), "--lock-only", "--json"]) == 0
     lock_only = json.loads(capsys.readouterr().out)
     assert lock_only["valid"] is True
     assert lock_only["wheel_set"]["verified"] is False


### PR DESCRIPTION
## Summary

Expose the already-tested Prob4D -> BayesianPhysTwin -> Causal4D wheel combination as a portable, content-addressed stack lock instead of leaving artifact identities only in workflow logs.

## Changes

- add strict `causal4d.stack-lock` schema v1 support;
- extract canonical distribution names and versions directly from wheel `METADATA`;
- bind wheel SHA-256, byte size, exact tested source revision, canonical source repository, required provider-v2 modules, and pipeline order;
- derive `lock_id` from canonical JSON and reject duplicate keys, malformed wheels, missing or unexpected distributions, noncanonical versions, and payload tampering;
- add lazy single-CLI routes:
  - `causal4d stack create`
  - `causal4d stack verify`;
- distinguish exact three-wheel verification from explicit weaker `--lock-only` validation;
- make the installed-wheel workflow create and re-verify the lock using the installed Causal4D wheel;
- publish the lock, verification report, exact wheels, wheel hashes, provider-v2 attestation, and golden-path diagnostics in one artifact; and
- document the evidence boundary: packaging/compatibility evidence only, not physical confirmation or `claim_ready` evidence.

## Exact-head evidence

All pull-request workflows passed on `410dd312fd456d7f8acd90ae2a5041d8f3d202c2`:

- CI and release;
- Causal4D merge gate;
- security scanning, including Python and Actions CodeQL;
- extended compatibility; and
- three-repository installed-wheel compatibility.

The installed-wheel workflow built the three wheels, created the lock with the installed Causal4D CLI, verified it against those exact wheel bytes, ran the isolated golden path, ran the strict claim-bearing provider-v2 attestation, and passed the selected cross-repository contract suite.

Generated evidence:

- lock ID: `21d888359daeb58f20796a5ce18ab741f4dd89804cb9413679c6f7dc68a4be56`;
- exact-wheel verification: `valid=true`, `complete=true`, `verified=true`, no errors;
- workflow artifact ID: `8987780564`;
- workflow artifact SHA-256: `b9d8733186f539c3cdb638e4ee5d9996044db98739065edfed0d850efc2a5b2f`;
- artifact contents include all three wheels, wheel hash list, stack lock, verification report, golden-path summary/log, and provider-v2 summary/log.

Unit tests cover deterministic lock generation, duplicate-key rejection, digest tampering, renamed wheel acceptance, content drift rejection, CLI round trips, lazy root routing, and workflow publication policy.

## Boundary

This change does not alter estimators, simulators, posterior updates, calibration data, evidence thresholds, dataset splits, frozen experiment commands, or target-access policy. A valid stack lock proves packaging identity and compatibility metadata; it does not by itself prove physical evidence, arbitrary installation state, or `claim_ready`.