### PR TITLE
Add unified three-repository decision trace

### DIFF
--- a/docs/decision_trace.md
+++ b/docs/decision_trace.md
@@ -1,0 +1,378 @@
+# Unified Prob4D → BayesianPhysTwin → Causal4D Decision Trace
+
+## Purpose
+
+`causal4d.decision_trace` provides an additive, content-addressed audit contract for
+one complete prediction/deployment decision across the three-repository stack.
+
+The trace answers:
+
+> Which exact observation, physical-belief, causal-inference, support, calibration,
+> and regret artifacts led to the deployed result, and was the candidate or the
+> declared baseline selected?
+
+It does not embed model payloads, trajectories, target continuations, or held-out
+losses. It records immutable artifact and decision identities and validates their
+topological relationships.
+
+The frozen estimator and the registered 18-session/36-execution physical protocol
+are unchanged.
+
+## Fixed stage order
+
+A trace contains exactly five stages:
+
+1. `prob4d_observation`
+2. `bayesian_phystwin_belief`
+3. `causal4d_abduction`
+4. `causal4d_counterfactual`
+5. `deployment`
+
+The producer is fixed by stage:
+
+| Stage | Producer |
+|---|---|
+| `prob4d_observation` | `prob4d` |
+| `bayesian_phystwin_belief` | `bayesian-phystwin` |
+| `causal4d_abduction` | `causal4d` |
+| `causal4d_counterfactual` | `causal4d` |
+| `deployment` | `causal4d` |
+
+The trace validates the graph incrementally. A stage may consume only root
+artifacts or outputs of earlier stages. Forward references, duplicate output
+identities, missing hand-offs, and producer mismatches fail closed.
+
+## Required artifact roles
+
+The root contains exactly one principal artifact for each of:
+
+```text
+factual_evidence_context
+counterfactual_query_context
+```
+
+The stage outputs must establish exactly one principal artifact for each of:
+
+```text
+prob4d_observation
+bayesian_phystwin_belief
+baseline_prediction
+causal4d_factual_posterior
+candidate_prediction
+```
+
+Additional stage-specific artifacts are allowed, but every principal role must
+remain unique.
+
+The required hand-offs are:
+
+```text
+factual_evidence_context
+  -> prob4d_observation
+
+prob4d_observation
+  -> bayesian_phystwin_belief
+  -> baseline_prediction
+
+prob4d_observation + bayesian_phystwin_belief
+  -> causal4d_factual_posterior
+
+causal4d_factual_posterior + counterfactual_query_context
+  -> candidate_prediction
+
+baseline_prediction + candidate_prediction
+  -> deployment
+```
+
+This contract exposes accidental bypasses. For example, a causal abduction stage
+cannot claim to use BayesianPhysTwin while omitting the exact physical-belief
+artifact from its inputs.
+
+## Decisions and exact fallback
+
+Each stage may reference content-addressed decisions. Recommended required
+decision names for the prospective V2 path are:
+
+```text
+prob4d_provider_acceptance
+bayesian_phystwin_acceptance
+intervention_identifiability
+action_support
+contact_v2_support
+query_calibration
+counterfactual_regret
+```
+
+The required inventory is frozen in `DecisionTraceSelection`. Candidate
+deployment is valid if and only if every named required decision is present and
+accepted.
+
+At runtime, use `build_unified_decision_trace`. It checks Python object identity:
+
+```python
+result = build_unified_decision_trace(
+    trace_name="rope-001/same-grasp",
+    protocol_id=protocol_id,
+    case_id=case_id,
+    session_id=session_id,
+    endpoint="same_grasp_transfer",
+    stack_lock_id=stack_lock["lock_id"],
+    root_artifacts=root_artifacts,
+    stages=stages,
+    required_decision_names=required_decisions,
+    baseline=baseline_prediction,
+    candidate=causal4d_candidate,
+    deployed=deployed_prediction,
+    baseline_artifact_id=baseline_prediction_id,
+    candidate_artifact_id=causal4d_candidate_id,
+)
+
+trace = result.trace
+```
+
+When a required decision rejects, `deployed` must be the exact baseline object.
+When every required decision accepts, `deployed` must be the exact candidate
+object. Reconstructed approximations do not satisfy the runtime identity check.
+
+The serialized selection records:
+
+```text
+baseline_artifact_id
+candidate_artifact_id
+deployed_artifact_id
+candidate_selected
+exact_object_identity_verified
+required_decision_names
+selection_id
+```
+
+## Target-information boundary
+
+A deployment trace has no target-continuation or target-loss field. It always
+records:
+
+```text
+target_future_observations_read = 0
+target_future_outcomes_used = false
+```
+
+Held-out target artifact roles are rejected. Metadata recursively rejects keys
+such as:
+
+```text
+evaluation_target
+held_out_target
+target_continuation
+target_future
+target_loss
+target_outcome
+target_outcomes
+```
+
+The trace may include a target case or session identity because those are
+necessary for audit and source/target separation. It may not contain the held-out
+future used to score that target.
+
+Evaluation targets and losses belong in separate registered result artifacts,
+not in the deployment decision trace.
+
+## Content addressing
+
+The following objects are independently content-addressed:
+
+```text
+DecisionTraceStage.stage_id
+DecisionTraceSelection.selection_id
+UnifiedDecisionTrace.trace_id
+```
+
+The top-level trace ID covers:
+
+- protocol, case, session, and endpoint;
+- the exact stack-lock identity;
+- root artifact references;
+- ordered stage payloads and stage IDs;
+- all decision identities, states, and reason codes;
+- final selection and required-decision inventory;
+- target-information declarations; and
+- finite immutable metadata.
+
+Changing any of these values invalidates the recorded ID.
+
+## Stack-lock binding
+
+The trace references one exact three-repository stack lock:
+
+```python
+require_decision_trace_stack_lock(trace, stack_lock)
+```
+
+This function first validates the complete external stack lock and then requires
+its `lock_id` to equal `trace.stack_lock_id`.
+
+The trace does not duplicate wheel hashes or repository revisions. Those remain
+authoritative in the existing stack-lock artifact. This avoids two competing
+copies of the same compatibility declaration.
+
+## Artifact references
+
+An artifact reference contains:
+
+```text
+artifact_id
+artifact_kind
+role
+producer
+metadata
+```
+
+`artifact_id` is a lowercase SHA-256 identity supplied by the producing contract.
+Typical references include:
+
+- a Prob4D observation-factor lineage or provider artifact;
+- a BayesianPhysTwin provider/belief artifact;
+- a Causal4D factual posterior or rollout-bank artifact;
+- a physical/Bayesian baseline forecast;
+- a Causal4D counterfactual forecast; and
+- stage-specific support or calibration artifacts.
+
+Payload bytes remain in their native repositories or result bundles.
+
+## Decision references
+
+A decision reference contains:
+
+```text
+name
+decision_id
+decision_kind
+producer
+accepted
+reasons
+metadata
+```
+
+Accepted decisions cannot contain rejection reasons. Rejected decisions must
+contain at least one stable reason code.
+
+The trace references existing decision artifacts rather than redefining their
+scientific semantics. For example:
+
+- Prob4D provider/lineage acceptance remains governed by the Prob4D contract;
+- BayesianPhysTwin provider acceptance remains governed by the BPT contract;
+- action support remains governed by `ActionSupportDecision`;
+- contact-patch finite support remains governed by `ContactV2SupportDecision`;
+- baseline-relative benefit remains governed by
+  `CounterfactualRegretDecision`.
+
+## Construction example
+
+```python
+from causal4d import (
+    DecisionTraceArtifact,
+    DecisionTraceDecision,
+    DecisionTraceStage,
+    build_unified_decision_trace,
+)
+
+factual_context = DecisionTraceArtifact(
+    artifact_id=factual_evidence_context.artifact_id,
+    artifact_kind="causal4d.FactualEvidenceContext",
+    role="factual_evidence_context",
+    producer="causal4d",
+)
+query_context = DecisionTraceArtifact(
+    artifact_id=counterfactual_query_context.artifact_id,
+    artifact_kind="causal4d.CounterfactualQueryContext",
+    role="counterfactual_query_context",
+    producer="causal4d",
+)
+
+prob4d_observation = DecisionTraceArtifact(
+    artifact_id=observation_lineage.artifact_id,
+    artifact_kind="prob4d.ObservationFactorLineage",
+    role="prob4d_observation",
+    producer="prob4d",
+)
+
+prob4d_stage = DecisionTraceStage(
+    stage_name="prob4d observation admission",
+    stage_kind="prob4d_observation",
+    producer="prob4d",
+    input_artifact_ids=(factual_context.artifact_id,),
+    output_artifacts=(prob4d_observation,),
+    decisions=(
+        DecisionTraceDecision(
+            name="prob4d_provider_acceptance",
+            decision_id=prob4d_acceptance_id,
+            decision_kind="prob4d.ProviderAcceptance",
+            producer="prob4d",
+            accepted=True,
+        ),
+    ),
+)
+```
+
+The remaining stages follow the required role graph described above.
+
+## Publication and claim-bearing loading
+
+```python
+write_decision_trace("decision-trace.json", trace)
+
+loaded = load_decision_trace("decision-trace.json")
+
+claim_trace = load_claim_bearing_decision_trace(
+    "decision-trace.json",
+    expected_trace_id=registered_trace_id,
+    expected_stack_lock_id=registered_stack_lock_id,
+    expected_protocol_id=registered_protocol_id,
+)
+```
+
+Publication is atomic and non-overwriting by default. Loading rejects:
+
+- duplicate JSON object keys;
+- non-finite JSON;
+- missing or unexpected fields;
+- malformed SHA-256 identities;
+- stage, selection, or trace ID mismatches;
+- invalid stage order or producer;
+- missing required roles or hand-offs;
+- forward artifact references;
+- missing or duplicated decisions;
+- selection/gate disagreement;
+- target-future access; and
+- stack-lock mismatch in claim-bearing use.
+
+## Recommended retained evidence
+
+For every prospective target execution, retain:
+
+1. the exact three-repository stack lock and verification report;
+2. native Prob4D observation/lineage artifacts;
+3. the BayesianPhysTwin belief/provider artifacts;
+4. Causal4D factual and counterfactual artifacts;
+5. all support, identifiability, query-calibration, and regret decisions;
+6. the unified decision trace; and
+7. a separate result artifact if a held-out target is later opened.
+
+This allows an auditor to reconstruct the decision graph without conflating
+deployment inputs with evaluation outcomes.
+
+## Scientific boundary
+
+A valid trace proves internal identity and decision-chain consistency. It does
+not prove:
+
+- that any upstream model is scientifically correct;
+- that the selected source-calibration panel is representative;
+- that the required-decision inventory is sufficient;
+- that counterfactual intervals are calibrated;
+- that accepted candidates have zero regret;
+- that the physical experiment is complete; or
+- that a prospective V2 method is eligible to revise registered results.
+
+The required-decision inventory, source panels, thresholds, and claim-bearing
+trace/stack identities must be frozen independently before target outcomes are
+opened.

--- a/src/causal4d/__init__.py
+++ b/src/causal4d/__init__.py
@@ -68,6 +68,24 @@ from causal4d.latent_contact_v2 import (
     posterior_weights_from_contact_evidence_v2,
     select_contact_v2_candidate,
 )
+from causal4d.decision_trace import (
+    DECISION_TRACE_ENDPOINTS,
+    DECISION_TRACE_PIPELINE,
+    DECISION_TRACE_SCHEMA_NAME,
+    DECISION_TRACE_SCHEMA_VERSION,
+    DECISION_TRACE_STAGE_KINDS,
+    DecisionTraceArtifact,
+    DecisionTraceBuildResult,
+    DecisionTraceDecision,
+    DecisionTraceSelection,
+    DecisionTraceStage,
+    UnifiedDecisionTrace,
+    build_unified_decision_trace,
+    load_claim_bearing_decision_trace,
+    load_decision_trace,
+    require_decision_trace_stack_lock,
+    write_decision_trace,
+)
 from causal4d.benchmark import CounterfactualBenchmarkConfig, build_protocol
 from causal4d.causal_sufficiency import (
     CausalSufficiencyResult,
@@ -185,6 +203,22 @@ from causal4d.stable_discrepancy_dynamics import (
 )
 
 __all__ = [
+    "DECISION_TRACE_ENDPOINTS",
+    "DECISION_TRACE_PIPELINE",
+    "DECISION_TRACE_SCHEMA_NAME",
+    "DECISION_TRACE_SCHEMA_VERSION",
+    "DECISION_TRACE_STAGE_KINDS",
+    "DecisionTraceArtifact",
+    "DecisionTraceBuildResult",
+    "DecisionTraceDecision",
+    "DecisionTraceSelection",
+    "DecisionTraceStage",
+    "UnifiedDecisionTrace",
+    "build_unified_decision_trace",
+    "load_claim_bearing_decision_trace",
+    "load_decision_trace",
+    "require_decision_trace_stack_lock",
+    "write_decision_trace",
     "COUNTERFACTUAL_REGRET_ENDPOINTS",
     "COUNTERFACTUAL_REGRET_SCHEMA_VERSION",
     "CounterfactualRegretCertificate",

--- a/src/causal4d/decision_trace.py
+++ b/src/causal4d/decision_trace.py
@@ -1,0 +1,1219 @@
+"""Content-addressed Prob4D -> BayesianPhysTwin -> Causal4D decision traces.
+
+The trace is an additive deployment/audit contract.  It records artifact and
+decision identities, not model payloads or target outcomes.  The fixed stage
+order makes the causal and software hand-offs explicit while preserving exact
+fallback semantics at the runtime construction boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Generic, Literal, Mapping, Sequence, TypeVar, cast
+
+from causal4d.artifact_io import load_strict_json_object, read_regular_file
+from causal4d.atomic_io import atomic_write_json
+from causal4d.immutable_json import plain_json, validated_json_mapping
+
+
+DECISION_TRACE_SCHEMA_NAME = "causal4d.decision-trace"
+DECISION_TRACE_SCHEMA_VERSION = 1
+DECISION_TRACE_PIPELINE = ("prob4d", "bayesian-phystwin", "causal4d")
+DECISION_TRACE_ENDPOINTS = (
+    "factual_continuation",
+    "same_grasp_transfer",
+    "new_contact_transfer",
+)
+DECISION_TRACE_STAGE_KINDS = (
+    "prob4d_observation",
+    "bayesian_phystwin_belief",
+    "causal4d_abduction",
+    "causal4d_counterfactual",
+    "deployment",
+)
+
+TraceProducer = Literal["prob4d", "bayesian-phystwin", "causal4d"]
+TraceEndpoint = Literal[
+    "factual_continuation",
+    "same_grasp_transfer",
+    "new_contact_transfer",
+]
+TraceStageKind = Literal[
+    "prob4d_observation",
+    "bayesian_phystwin_belief",
+    "causal4d_abduction",
+    "causal4d_counterfactual",
+    "deployment",
+]
+
+BaselineT = TypeVar("BaselineT")
+CandidateT = TypeVar("CandidateT")
+
+_STAGE_PRODUCER: dict[str, str] = {
+    "prob4d_observation": "prob4d",
+    "bayesian_phystwin_belief": "bayesian-phystwin",
+    "causal4d_abduction": "causal4d",
+    "causal4d_counterfactual": "causal4d",
+    "deployment": "causal4d",
+}
+_REQUIRED_ROOT_ROLES = {
+    "factual_evidence_context",
+    "counterfactual_query_context",
+}
+_REQUIRED_ROOT_PRODUCER = {
+    "factual_evidence_context": "causal4d",
+    "counterfactual_query_context": "causal4d",
+}
+_REQUIRED_OUTPUT_ROLES: dict[str, set[str]] = {
+    "prob4d_observation": {"prob4d_observation"},
+    "bayesian_phystwin_belief": {
+        "bayesian_phystwin_belief",
+        "baseline_prediction",
+    },
+    "causal4d_abduction": {"causal4d_factual_posterior"},
+    "causal4d_counterfactual": {"candidate_prediction"},
+    "deployment": set(),
+}
+_REQUIRED_INPUT_ROLES: dict[str, set[str]] = {
+    "prob4d_observation": {"factual_evidence_context"},
+    "bayesian_phystwin_belief": {"prob4d_observation"},
+    "causal4d_abduction": {
+        "prob4d_observation",
+        "bayesian_phystwin_belief",
+    },
+    "causal4d_counterfactual": {
+        "causal4d_factual_posterior",
+        "counterfactual_query_context",
+    },
+    "deployment": {"baseline_prediction", "candidate_prediction"},
+}
+_FORBIDDEN_TARGET_METADATA_KEYS = {
+    "evaluation_target",
+    "held_out_target",
+    "target_continuation",
+    "target_future",
+    "target_loss",
+    "target_outcome",
+    "target_outcomes",
+}
+
+
+def _canonical_bytes(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        plain_json(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _content_id(kind: str, payload: Mapping[str, Any]) -> str:
+    descriptor = {
+        "schema_name": DECISION_TRACE_SCHEMA_NAME,
+        "schema_version": DECISION_TRACE_SCHEMA_VERSION,
+        "kind": kind,
+        "payload": plain_json(payload),
+    }
+    return hashlib.sha256(_canonical_bytes(descriptor)).hexdigest()
+
+
+def _require_exact_fields(
+    values: Mapping[str, Any],
+    *,
+    fields: set[str],
+    name: str,
+) -> None:
+    if not isinstance(values, Mapping):
+        raise ValueError(f"{name} must be a JSON object")
+    if any(type(key) is not str for key in values):
+        raise ValueError(f"{name} keys must be strings")
+    actual = set(values)
+    missing = sorted(fields - actual)
+    unexpected = sorted(actual - fields)
+    if missing or unexpected:
+        raise ValueError(
+            f"{name} fields do not match the schema; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+
+
+def _require_nonempty_string(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _require_sha256(value: Any, *, name: str) -> str:
+    digest = _require_nonempty_string(value, name=name)
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _require_bool(value: Any, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a Boolean")
+    return value
+
+
+def _require_string_sequence(
+    values: Any,
+    *,
+    name: str,
+    allow_empty: bool,
+) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise ValueError(f"{name} must be a sequence of strings")
+    result = tuple(
+        _require_nonempty_string(value, name=f"{name}[{index}]")
+        for index, value in enumerate(values)
+    )
+    if not allow_empty and not result:
+        raise ValueError(f"{name} must be nonempty")
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must not contain duplicates")
+    return result
+
+
+def _require_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a JSON object")
+    return value
+
+
+def _require_list(value: Any, *, name: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be a JSON array")
+    return value
+
+
+def _reject_target_future_metadata(value: Any, *, path: str) -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            normalized = key.strip().lower().replace("-", "_")
+            if normalized in _FORBIDDEN_TARGET_METADATA_KEYS:
+                raise ValueError(
+                    f"{path}.{key} is forbidden at the target-safe decision boundary"
+                )
+            _reject_target_future_metadata(item, path=f"{path}.{key}")
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        for index, item in enumerate(value):
+            _reject_target_future_metadata(item, path=f"{path}[{index}]")
+
+
+def _validated_metadata(values: Mapping[str, Any], *, name: str) -> Mapping[str, Any]:
+    metadata = validated_json_mapping(
+        values,
+        error_message=f"{name} must contain finite JSON data",
+    )
+    _reject_target_future_metadata(metadata, path=name)
+    return metadata
+
+
+@dataclass(frozen=True)
+class DecisionTraceArtifact:
+    """Reference one immutable artifact without embedding its payload."""
+
+    artifact_id: str
+    artifact_kind: str
+    role: str
+    producer: TraceProducer
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        artifact_id = _require_sha256(self.artifact_id, name="artifact_id")
+        artifact_kind = _require_nonempty_string(
+            self.artifact_kind,
+            name="artifact_kind",
+        )
+        role = _require_nonempty_string(self.role, name="role")
+        producer = _require_nonempty_string(self.producer, name="producer")
+        if producer not in DECISION_TRACE_PIPELINE:
+            raise ValueError(f"producer must be one of {list(DECISION_TRACE_PIPELINE)}")
+        if role in {"evaluation_target", "held_out_target"}:
+            raise ValueError(
+                "held-out target artifacts are forbidden in decision traces"
+            )
+        object.__setattr__(self, "artifact_id", artifact_id)
+        object.__setattr__(self, "artifact_kind", artifact_kind)
+        object.__setattr__(self, "role", role)
+        object.__setattr__(self, "producer", producer)
+        object.__setattr__(
+            self,
+            "metadata",
+            _validated_metadata(self.metadata, name="artifact metadata"),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "artifact_id": self.artifact_id,
+            "artifact_kind": self.artifact_kind,
+            "role": self.role,
+            "producer": self.producer,
+            "metadata": plain_json(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, values: Mapping[str, Any]) -> DecisionTraceArtifact:
+        _require_exact_fields(
+            values,
+            fields={
+                "artifact_id",
+                "artifact_kind",
+                "role",
+                "producer",
+                "metadata",
+            },
+            name="decision-trace artifact",
+        )
+        producer = _require_nonempty_string(
+            values["producer"],
+            name="decision-trace artifact.producer",
+        )
+        if producer not in DECISION_TRACE_PIPELINE:
+            raise ValueError("decision-trace artifact producer is invalid")
+        return cls(
+            artifact_id=_require_sha256(
+                values["artifact_id"],
+                name="decision-trace artifact.artifact_id",
+            ),
+            artifact_kind=_require_nonempty_string(
+                values["artifact_kind"],
+                name="decision-trace artifact.artifact_kind",
+            ),
+            role=_require_nonempty_string(
+                values["role"],
+                name="decision-trace artifact.role",
+            ),
+            producer=cast(TraceProducer, producer),
+            metadata=_require_mapping(
+                values["metadata"],
+                name="decision-trace artifact.metadata",
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class DecisionTraceDecision:
+    """Reference one immutable admission/abstention decision."""
+
+    name: str
+    decision_id: str
+    decision_kind: str
+    producer: TraceProducer
+    accepted: bool
+    reasons: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        name = _require_nonempty_string(self.name, name="decision name")
+        decision_id = _require_sha256(self.decision_id, name="decision_id")
+        decision_kind = _require_nonempty_string(
+            self.decision_kind,
+            name="decision_kind",
+        )
+        producer = _require_nonempty_string(self.producer, name="producer")
+        if producer not in DECISION_TRACE_PIPELINE:
+            raise ValueError(f"producer must be one of {list(DECISION_TRACE_PIPELINE)}")
+        accepted = _require_bool(self.accepted, name="accepted")
+        reasons = _require_string_sequence(
+            self.reasons,
+            name="reasons",
+            allow_empty=True,
+        )
+        if accepted and reasons:
+            raise ValueError("accepted decisions cannot contain rejection reasons")
+        if not accepted and not reasons:
+            raise ValueError("rejected decisions require at least one reason")
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "decision_id", decision_id)
+        object.__setattr__(self, "decision_kind", decision_kind)
+        object.__setattr__(self, "producer", producer)
+        object.__setattr__(self, "accepted", accepted)
+        object.__setattr__(self, "reasons", reasons)
+        object.__setattr__(
+            self,
+            "metadata",
+            _validated_metadata(self.metadata, name="decision metadata"),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "decision_id": self.decision_id,
+            "decision_kind": self.decision_kind,
+            "producer": self.producer,
+            "accepted": self.accepted,
+            "reasons": list(self.reasons),
+            "metadata": plain_json(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, values: Mapping[str, Any]) -> DecisionTraceDecision:
+        _require_exact_fields(
+            values,
+            fields={
+                "name",
+                "decision_id",
+                "decision_kind",
+                "producer",
+                "accepted",
+                "reasons",
+                "metadata",
+            },
+            name="decision-trace decision",
+        )
+        producer = _require_nonempty_string(
+            values["producer"],
+            name="decision-trace decision.producer",
+        )
+        if producer not in DECISION_TRACE_PIPELINE:
+            raise ValueError("decision-trace decision producer is invalid")
+        return cls(
+            name=_require_nonempty_string(
+                values["name"],
+                name="decision-trace decision.name",
+            ),
+            decision_id=_require_sha256(
+                values["decision_id"],
+                name="decision-trace decision.decision_id",
+            ),
+            decision_kind=_require_nonempty_string(
+                values["decision_kind"],
+                name="decision-trace decision.decision_kind",
+            ),
+            producer=cast(TraceProducer, producer),
+            accepted=_require_bool(
+                values["accepted"],
+                name="decision-trace decision.accepted",
+            ),
+            reasons=_require_string_sequence(
+                _require_list(
+                    values["reasons"],
+                    name="decision-trace decision.reasons",
+                ),
+                name="decision-trace decision.reasons",
+                allow_empty=True,
+            ),
+            metadata=_require_mapping(
+                values["metadata"],
+                name="decision-trace decision.metadata",
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class DecisionTraceStage:
+    """One topologically ordered hand-off in the three-repository stack."""
+
+    stage_name: str
+    stage_kind: TraceStageKind
+    producer: TraceProducer
+    input_artifact_ids: tuple[str, ...]
+    output_artifacts: tuple[DecisionTraceArtifact, ...] = ()
+    decisions: tuple[DecisionTraceDecision, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        stage_name = _require_nonempty_string(self.stage_name, name="stage_name")
+        stage_kind = _require_nonempty_string(self.stage_kind, name="stage_kind")
+        if stage_kind not in DECISION_TRACE_STAGE_KINDS:
+            raise ValueError(
+                f"stage_kind must be one of {list(DECISION_TRACE_STAGE_KINDS)}"
+            )
+        producer = _require_nonempty_string(self.producer, name="producer")
+        expected_producer = _STAGE_PRODUCER[stage_kind]
+        if producer != expected_producer:
+            raise ValueError(f"{stage_kind} must be produced by {expected_producer}")
+        inputs = tuple(
+            _require_sha256(value, name=f"input_artifact_ids[{index}]")
+            for index, value in enumerate(self.input_artifact_ids)
+        )
+        if not inputs or len(set(inputs)) != len(inputs):
+            raise ValueError("input_artifact_ids must be nonempty and unique")
+        artifacts = tuple(self.output_artifacts)
+        decisions = tuple(self.decisions)
+        if stage_kind != "deployment" and not artifacts:
+            raise ValueError(f"{stage_kind} must publish at least one artifact")
+        if stage_kind == "deployment" and artifacts:
+            raise ValueError(
+                "deployment selects an existing artifact and has no outputs"
+            )
+        if any(type(value) is not DecisionTraceArtifact for value in artifacts):
+            raise ValueError(
+                "output_artifacts must contain DecisionTraceArtifact values"
+            )
+        if any(type(value) is not DecisionTraceDecision for value in decisions):
+            raise ValueError("decisions must contain DecisionTraceDecision values")
+        artifact_ids = tuple(artifact.artifact_id for artifact in artifacts)
+        if len(set(artifact_ids)) != len(artifact_ids):
+            raise ValueError("stage output artifact IDs must be unique")
+        artifact_roles = tuple(artifact.role for artifact in artifacts)
+        if len(set(artifact_roles)) != len(artifact_roles):
+            raise ValueError("stage output artifact roles must be unique")
+        if set(inputs) & set(artifact_ids):
+            raise ValueError("a stage cannot consume and publish the same artifact ID")
+        if any(artifact.producer != producer for artifact in artifacts):
+            raise ValueError("stage outputs must identify the stage producer")
+        decision_names = tuple(decision.name for decision in decisions)
+        decision_ids = tuple(decision.decision_id for decision in decisions)
+        if len(set(decision_names)) != len(decision_names):
+            raise ValueError("stage decision names must be unique")
+        if len(set(decision_ids)) != len(decision_ids):
+            raise ValueError("stage decision IDs must be unique")
+        if any(decision.producer != producer for decision in decisions):
+            raise ValueError("stage decisions must identify the stage producer")
+        object.__setattr__(self, "stage_name", stage_name)
+        object.__setattr__(self, "stage_kind", stage_kind)
+        object.__setattr__(self, "producer", producer)
+        object.__setattr__(self, "input_artifact_ids", inputs)
+        object.__setattr__(self, "output_artifacts", artifacts)
+        object.__setattr__(self, "decisions", decisions)
+        object.__setattr__(
+            self,
+            "metadata",
+            _validated_metadata(self.metadata, name="stage metadata"),
+        )
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "stage_name": self.stage_name,
+            "stage_kind": self.stage_kind,
+            "producer": self.producer,
+            "input_artifact_ids": list(self.input_artifact_ids),
+            "output_artifacts": [
+                artifact.as_dict() for artifact in self.output_artifacts
+            ],
+            "decisions": [decision.as_dict() for decision in self.decisions],
+            "metadata": plain_json(self.metadata),
+        }
+
+    @property
+    def stage_id(self) -> str:
+        return _content_id("DecisionTraceStage", self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "stage_id": self.stage_id}
+
+    @classmethod
+    def from_dict(cls, values: Mapping[str, Any]) -> DecisionTraceStage:
+        _require_exact_fields(
+            values,
+            fields={
+                "stage_id",
+                "stage_name",
+                "stage_kind",
+                "producer",
+                "input_artifact_ids",
+                "output_artifacts",
+                "decisions",
+                "metadata",
+            },
+            name="decision-trace stage",
+        )
+        stage_kind = _require_nonempty_string(
+            values["stage_kind"],
+            name="decision-trace stage.stage_kind",
+        )
+        if stage_kind not in DECISION_TRACE_STAGE_KINDS:
+            raise ValueError("decision-trace stage kind is invalid")
+        producer = _require_nonempty_string(
+            values["producer"],
+            name="decision-trace stage.producer",
+        )
+        if producer not in DECISION_TRACE_PIPELINE:
+            raise ValueError("decision-trace stage producer is invalid")
+        stage = cls(
+            stage_name=_require_nonempty_string(
+                values["stage_name"],
+                name="decision-trace stage.stage_name",
+            ),
+            stage_kind=cast(TraceStageKind, stage_kind),
+            producer=cast(TraceProducer, producer),
+            input_artifact_ids=tuple(
+                _require_sha256(
+                    value,
+                    name=f"decision-trace stage.input_artifact_ids[{index}]",
+                )
+                for index, value in enumerate(
+                    _require_list(
+                        values["input_artifact_ids"],
+                        name="decision-trace stage.input_artifact_ids",
+                    )
+                )
+            ),
+            output_artifacts=tuple(
+                DecisionTraceArtifact.from_dict(
+                    _require_mapping(
+                        value,
+                        name=f"decision-trace stage.output_artifacts[{index}]",
+                    )
+                )
+                for index, value in enumerate(
+                    _require_list(
+                        values["output_artifacts"],
+                        name="decision-trace stage.output_artifacts",
+                    )
+                )
+            ),
+            decisions=tuple(
+                DecisionTraceDecision.from_dict(
+                    _require_mapping(
+                        value,
+                        name=f"decision-trace stage.decisions[{index}]",
+                    )
+                )
+                for index, value in enumerate(
+                    _require_list(
+                        values["decisions"],
+                        name="decision-trace stage.decisions",
+                    )
+                )
+            ),
+            metadata=_require_mapping(
+                values["metadata"],
+                name="decision-trace stage.metadata",
+            ),
+        )
+        expected = _require_sha256(
+            values["stage_id"],
+            name="decision-trace stage.stage_id",
+        )
+        if stage.stage_id != expected:
+            raise ValueError("decision-trace stage_id does not match its payload")
+        return stage
+
+
+@dataclass(frozen=True)
+class DecisionTraceSelection:
+    """Bind the final deployment choice and the required decision inventory."""
+
+    baseline_artifact_id: str
+    candidate_artifact_id: str
+    deployed_artifact_id: str
+    candidate_selected: bool
+    exact_object_identity_verified: bool
+    required_decision_names: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        baseline_id = _require_sha256(
+            self.baseline_artifact_id,
+            name="baseline_artifact_id",
+        )
+        candidate_id = _require_sha256(
+            self.candidate_artifact_id,
+            name="candidate_artifact_id",
+        )
+        deployed_id = _require_sha256(
+            self.deployed_artifact_id,
+            name="deployed_artifact_id",
+        )
+        if baseline_id == candidate_id:
+            raise ValueError("baseline and candidate artifact IDs must differ")
+        selected = _require_bool(
+            self.candidate_selected,
+            name="candidate_selected",
+        )
+        identity_verified = _require_bool(
+            self.exact_object_identity_verified,
+            name="exact_object_identity_verified",
+        )
+        if not identity_verified:
+            raise ValueError("exact runtime selection identity must be verified")
+        expected = candidate_id if selected else baseline_id
+        if deployed_id != expected:
+            raise ValueError("deployed_artifact_id disagrees with candidate_selected")
+        required = _require_string_sequence(
+            self.required_decision_names,
+            name="required_decision_names",
+            allow_empty=False,
+        )
+        object.__setattr__(self, "baseline_artifact_id", baseline_id)
+        object.__setattr__(self, "candidate_artifact_id", candidate_id)
+        object.__setattr__(self, "deployed_artifact_id", deployed_id)
+        object.__setattr__(self, "candidate_selected", selected)
+        object.__setattr__(self, "exact_object_identity_verified", identity_verified)
+        object.__setattr__(self, "required_decision_names", required)
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "baseline_artifact_id": self.baseline_artifact_id,
+            "candidate_artifact_id": self.candidate_artifact_id,
+            "deployed_artifact_id": self.deployed_artifact_id,
+            "candidate_selected": self.candidate_selected,
+            "exact_object_identity_verified": self.exact_object_identity_verified,
+            "required_decision_names": list(self.required_decision_names),
+        }
+
+    @property
+    def selection_id(self) -> str:
+        return _content_id("DecisionTraceSelection", self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "selection_id": self.selection_id}
+
+    @classmethod
+    def from_dict(cls, values: Mapping[str, Any]) -> DecisionTraceSelection:
+        _require_exact_fields(
+            values,
+            fields={
+                "selection_id",
+                "baseline_artifact_id",
+                "candidate_artifact_id",
+                "deployed_artifact_id",
+                "candidate_selected",
+                "exact_object_identity_verified",
+                "required_decision_names",
+            },
+            name="decision-trace selection",
+        )
+        selection = cls(
+            baseline_artifact_id=_require_sha256(
+                values["baseline_artifact_id"],
+                name="decision-trace selection.baseline_artifact_id",
+            ),
+            candidate_artifact_id=_require_sha256(
+                values["candidate_artifact_id"],
+                name="decision-trace selection.candidate_artifact_id",
+            ),
+            deployed_artifact_id=_require_sha256(
+                values["deployed_artifact_id"],
+                name="decision-trace selection.deployed_artifact_id",
+            ),
+            candidate_selected=_require_bool(
+                values["candidate_selected"],
+                name="decision-trace selection.candidate_selected",
+            ),
+            exact_object_identity_verified=_require_bool(
+                values["exact_object_identity_verified"],
+                name="decision-trace selection.exact_object_identity_verified",
+            ),
+            required_decision_names=_require_string_sequence(
+                _require_list(
+                    values["required_decision_names"],
+                    name="decision-trace selection.required_decision_names",
+                ),
+                name="decision-trace selection.required_decision_names",
+                allow_empty=False,
+            ),
+        )
+        expected = _require_sha256(
+            values["selection_id"],
+            name="decision-trace selection.selection_id",
+        )
+        if selection.selection_id != expected:
+            raise ValueError("decision-trace selection_id does not match its payload")
+        return selection
+
+
+@dataclass(frozen=True)
+class UnifiedDecisionTrace:
+    """A target-safe, content-addressed decision DAG for the full stack."""
+
+    trace_name: str
+    protocol_id: str
+    case_id: str
+    session_id: str
+    endpoint: TraceEndpoint
+    stack_lock_id: str
+    root_artifacts: tuple[DecisionTraceArtifact, ...]
+    stages: tuple[DecisionTraceStage, ...]
+    selection: DecisionTraceSelection
+    target_future_observations_read: int = 0
+    target_future_outcomes_used: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        trace_name = _require_nonempty_string(self.trace_name, name="trace_name")
+        protocol_id = _require_nonempty_string(self.protocol_id, name="protocol_id")
+        case_id = _require_nonempty_string(self.case_id, name="case_id")
+        session_id = _require_nonempty_string(self.session_id, name="session_id")
+        endpoint = _require_nonempty_string(self.endpoint, name="endpoint")
+        if endpoint not in DECISION_TRACE_ENDPOINTS:
+            raise ValueError(
+                f"endpoint must be one of {list(DECISION_TRACE_ENDPOINTS)}"
+            )
+        stack_lock_id = _require_sha256(self.stack_lock_id, name="stack_lock_id")
+        roots = tuple(self.root_artifacts)
+        stages = tuple(self.stages)
+        if not roots or any(
+            type(value) is not DecisionTraceArtifact for value in roots
+        ):
+            raise ValueError("root_artifacts must contain DecisionTraceArtifact values")
+        if type(self.selection) is not DecisionTraceSelection:
+            raise ValueError("selection must be a DecisionTraceSelection")
+        if len(stages) != len(DECISION_TRACE_STAGE_KINDS) or any(
+            type(value) is not DecisionTraceStage for value in stages
+        ):
+            raise ValueError(
+                "stages must contain exactly the five decision-trace stages"
+            )
+        observed_stage_kinds = tuple(stage.stage_kind for stage in stages)
+        if observed_stage_kinds != DECISION_TRACE_STAGE_KINDS:
+            raise ValueError(
+                "stages must follow the fixed Prob4D -> BPT -> Causal4D order"
+            )
+        stage_names = tuple(stage.stage_name for stage in stages)
+        stage_ids = tuple(stage.stage_id for stage in stages)
+        if len(set(stage_names)) != len(stage_names):
+            raise ValueError("stage names must be unique")
+        if len(set(stage_ids)) != len(stage_ids):
+            raise ValueError("stage IDs must be unique")
+        if type(self.target_future_observations_read) is not int:
+            raise ValueError("target_future_observations_read must be an integer")
+        if self.target_future_observations_read != 0:
+            raise ValueError("decision traces must not read target-future observations")
+        if _require_bool(
+            self.target_future_outcomes_used,
+            name="target_future_outcomes_used",
+        ):
+            raise ValueError("decision traces must not use target-future outcomes")
+
+        available: dict[str, DecisionTraceArtifact] = {}
+        for artifact in roots:
+            if artifact.artifact_id in available:
+                raise ValueError("root artifact IDs must be unique")
+            available[artifact.artifact_id] = artifact
+        root_roles = {artifact.role for artifact in roots}
+        missing_root_roles = sorted(_REQUIRED_ROOT_ROLES - root_roles)
+        if missing_root_roles:
+            raise ValueError(
+                f"decision trace is missing root roles {missing_root_roles}"
+            )
+        for artifact in roots:
+            expected_producer = _REQUIRED_ROOT_PRODUCER.get(artifact.role)
+            if expected_producer is not None and artifact.producer != expected_producer:
+                raise ValueError(
+                    f"root role {artifact.role!r} must be produced by "
+                    f"{expected_producer}"
+                )
+
+        decisions_by_name: dict[str, DecisionTraceDecision] = {}
+        decision_ids: set[str] = set()
+        for stage in stages:
+            missing_inputs = sorted(
+                artifact_id
+                for artifact_id in stage.input_artifact_ids
+                if artifact_id not in available
+            )
+            if missing_inputs:
+                raise ValueError(
+                    f"{stage.stage_name} consumes unavailable or forward artifacts "
+                    f"{missing_inputs}"
+                )
+            input_roles = {
+                available[artifact_id].role for artifact_id in stage.input_artifact_ids
+            }
+            required_inputs = _REQUIRED_INPUT_ROLES[stage.stage_kind]
+            missing_input_roles = sorted(required_inputs - input_roles)
+            if missing_input_roles:
+                raise ValueError(
+                    f"{stage.stage_kind} is missing input roles {missing_input_roles}"
+                )
+            output_roles = {artifact.role for artifact in stage.output_artifacts}
+            required_outputs = _REQUIRED_OUTPUT_ROLES[stage.stage_kind]
+            missing_output_roles = sorted(required_outputs - output_roles)
+            if missing_output_roles:
+                raise ValueError(
+                    f"{stage.stage_kind} is missing output roles {missing_output_roles}"
+                )
+            for artifact in stage.output_artifacts:
+                if artifact.artifact_id in available:
+                    raise ValueError(
+                        "artifact IDs must be globally unique across trace outputs"
+                    )
+                available[artifact.artifact_id] = artifact
+            for decision in stage.decisions:
+                if decision.name in decisions_by_name:
+                    raise ValueError("decision names must be globally unique")
+                if decision.decision_id in decision_ids:
+                    raise ValueError("decision IDs must be globally unique")
+                decisions_by_name[decision.name] = decision
+                decision_ids.add(decision.decision_id)
+
+        role_index: dict[str, list[DecisionTraceArtifact]] = {}
+        for artifact in available.values():
+            role_index.setdefault(artifact.role, []).append(artifact)
+        for required_role in {
+            *_REQUIRED_ROOT_ROLES,
+            *set().union(*_REQUIRED_OUTPUT_ROLES.values()),
+        }:
+            if len(role_index.get(required_role, [])) != 1:
+                raise ValueError(
+                    f"decision trace requires exactly one artifact with role "
+                    f"{required_role!r}"
+                )
+
+        deployment = stages[-1]
+        baseline_role_id = role_index["baseline_prediction"][0].artifact_id
+        candidate_role_id = role_index["candidate_prediction"][0].artifact_id
+        if self.selection.baseline_artifact_id != baseline_role_id:
+            raise ValueError("selection baseline does not match baseline_prediction")
+        if self.selection.candidate_artifact_id != candidate_role_id:
+            raise ValueError("selection candidate does not match candidate_prediction")
+        if not {
+            self.selection.baseline_artifact_id,
+            self.selection.candidate_artifact_id,
+        }.issubset(set(deployment.input_artifact_ids)):
+            raise ValueError("deployment must consume both baseline and candidate")
+
+        missing_decisions = sorted(
+            set(self.selection.required_decision_names) - set(decisions_by_name)
+        )
+        if missing_decisions:
+            raise ValueError(
+                f"required decisions are absent from the trace: {missing_decisions}"
+            )
+        all_required_accepted = all(
+            decisions_by_name[name].accepted
+            for name in self.selection.required_decision_names
+        )
+        if self.selection.candidate_selected != all_required_accepted:
+            raise ValueError(
+                "candidate selection must equal the conjunction of required decisions"
+            )
+
+        object.__setattr__(self, "trace_name", trace_name)
+        object.__setattr__(self, "protocol_id", protocol_id)
+        object.__setattr__(self, "case_id", case_id)
+        object.__setattr__(self, "session_id", session_id)
+        object.__setattr__(self, "endpoint", endpoint)
+        object.__setattr__(self, "stack_lock_id", stack_lock_id)
+        object.__setattr__(self, "root_artifacts", roots)
+        object.__setattr__(self, "stages", stages)
+        object.__setattr__(
+            self,
+            "metadata",
+            _validated_metadata(self.metadata, name="trace metadata"),
+        )
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "trace_name": self.trace_name,
+            "protocol_id": self.protocol_id,
+            "case_id": self.case_id,
+            "session_id": self.session_id,
+            "endpoint": self.endpoint,
+            "stack_lock_id": self.stack_lock_id,
+            "root_artifacts": [artifact.as_dict() for artifact in self.root_artifacts],
+            "stages": [stage.as_dict() for stage in self.stages],
+            "selection": self.selection.as_dict(),
+            "target_future_observations_read": self.target_future_observations_read,
+            "target_future_outcomes_used": self.target_future_outcomes_used,
+            "metadata": plain_json(self.metadata),
+        }
+
+    @property
+    def trace_id(self) -> str:
+        return _content_id("UnifiedDecisionTrace", self._payload())
+
+    @property
+    def decisions(self) -> tuple[DecisionTraceDecision, ...]:
+        return tuple(decision for stage in self.stages for decision in stage.decisions)
+
+    @property
+    def artifacts(self) -> tuple[DecisionTraceArtifact, ...]:
+        return (
+            *self.root_artifacts,
+            *tuple(
+                artifact for stage in self.stages for artifact in stage.output_artifacts
+            ),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_name": DECISION_TRACE_SCHEMA_NAME,
+            "schema_version": DECISION_TRACE_SCHEMA_VERSION,
+            "trace_id": self.trace_id,
+            **self._payload(),
+        }
+
+    @classmethod
+    def from_dict(cls, values: Mapping[str, Any]) -> UnifiedDecisionTrace:
+        _require_exact_fields(
+            values,
+            fields={
+                "schema_name",
+                "schema_version",
+                "trace_id",
+                "trace_name",
+                "protocol_id",
+                "case_id",
+                "session_id",
+                "endpoint",
+                "stack_lock_id",
+                "root_artifacts",
+                "stages",
+                "selection",
+                "target_future_observations_read",
+                "target_future_outcomes_used",
+                "metadata",
+            },
+            name="decision trace",
+        )
+        if values["schema_name"] != DECISION_TRACE_SCHEMA_NAME:
+            raise ValueError("unsupported decision-trace schema name")
+        if (
+            type(values["schema_version"]) is not int
+            or values["schema_version"] != DECISION_TRACE_SCHEMA_VERSION
+        ):
+            raise ValueError("unsupported decision-trace schema version")
+        endpoint = _require_nonempty_string(
+            values["endpoint"],
+            name="decision trace.endpoint",
+        )
+        if endpoint not in DECISION_TRACE_ENDPOINTS:
+            raise ValueError("decision trace endpoint is invalid")
+        observations_read = values["target_future_observations_read"]
+        if type(observations_read) is not int:
+            raise ValueError(
+                "decision trace.target_future_observations_read must be an integer"
+            )
+        trace = cls(
+            trace_name=_require_nonempty_string(
+                values["trace_name"],
+                name="decision trace.trace_name",
+            ),
+            protocol_id=_require_nonempty_string(
+                values["protocol_id"],
+                name="decision trace.protocol_id",
+            ),
+            case_id=_require_nonempty_string(
+                values["case_id"],
+                name="decision trace.case_id",
+            ),
+            session_id=_require_nonempty_string(
+                values["session_id"],
+                name="decision trace.session_id",
+            ),
+            endpoint=cast(TraceEndpoint, endpoint),
+            stack_lock_id=_require_sha256(
+                values["stack_lock_id"],
+                name="decision trace.stack_lock_id",
+            ),
+            root_artifacts=tuple(
+                DecisionTraceArtifact.from_dict(
+                    _require_mapping(
+                        value,
+                        name=f"decision trace.root_artifacts[{index}]",
+                    )
+                )
+                for index, value in enumerate(
+                    _require_list(
+                        values["root_artifacts"],
+                        name="decision trace.root_artifacts",
+                    )
+                )
+            ),
+            stages=tuple(
+                DecisionTraceStage.from_dict(
+                    _require_mapping(
+                        value,
+                        name=f"decision trace.stages[{index}]",
+                    )
+                )
+                for index, value in enumerate(
+                    _require_list(
+                        values["stages"],
+                        name="decision trace.stages",
+                    )
+                )
+            ),
+            selection=DecisionTraceSelection.from_dict(
+                _require_mapping(
+                    values["selection"],
+                    name="decision trace.selection",
+                )
+            ),
+            target_future_observations_read=observations_read,
+            target_future_outcomes_used=_require_bool(
+                values["target_future_outcomes_used"],
+                name="decision trace.target_future_outcomes_used",
+            ),
+            metadata=_require_mapping(
+                values["metadata"],
+                name="decision trace.metadata",
+            ),
+        )
+        expected = _require_sha256(values["trace_id"], name="decision trace.trace_id")
+        if trace.trace_id != expected:
+            raise ValueError("decision trace_id does not match its payload")
+        return trace
+
+
+@dataclass(frozen=True)
+class DecisionTraceBuildResult(Generic[BaselineT, CandidateT]):
+    """Return the trace and the exact deployed runtime object together."""
+
+    trace: UnifiedDecisionTrace
+    baseline: BaselineT
+    candidate: CandidateT
+    deployed: BaselineT | CandidateT
+
+    def __post_init__(self) -> None:
+        expected = (
+            self.candidate if self.trace.selection.candidate_selected else self.baseline
+        )
+        if self.deployed is not expected:
+            raise ValueError("deployed object does not preserve exact trace selection")
+
+
+def build_unified_decision_trace(
+    *,
+    trace_name: str,
+    protocol_id: str,
+    case_id: str,
+    session_id: str,
+    endpoint: TraceEndpoint,
+    stack_lock_id: str,
+    root_artifacts: Sequence[DecisionTraceArtifact],
+    stages: Sequence[DecisionTraceStage],
+    required_decision_names: Sequence[str],
+    baseline: BaselineT,
+    candidate: CandidateT,
+    deployed: BaselineT | CandidateT,
+    baseline_artifact_id: str,
+    candidate_artifact_id: str,
+    metadata: Mapping[str, Any] | None = None,
+) -> DecisionTraceBuildResult[BaselineT, CandidateT]:
+    """Construct a trace while checking the exact runtime deployment identity."""
+
+    if baseline is candidate:
+        raise ValueError("baseline and candidate runtime objects must differ")
+    decisions = {
+        decision.name: decision for stage in stages for decision in stage.decisions
+    }
+    required = _require_string_sequence(
+        required_decision_names,
+        name="required_decision_names",
+        allow_empty=False,
+    )
+    missing = sorted(set(required) - set(decisions))
+    if missing:
+        raise ValueError(f"required decisions are absent from stages: {missing}")
+    candidate_selected = all(decisions[name].accepted for name in required)
+    expected_object: BaselineT | CandidateT = (
+        candidate if candidate_selected else baseline
+    )
+    if deployed is not expected_object:
+        raise ValueError(
+            "deployed object does not match the conjunction of required decisions"
+        )
+    selection = DecisionTraceSelection(
+        baseline_artifact_id=baseline_artifact_id,
+        candidate_artifact_id=candidate_artifact_id,
+        deployed_artifact_id=(
+            candidate_artifact_id if candidate_selected else baseline_artifact_id
+        ),
+        candidate_selected=candidate_selected,
+        exact_object_identity_verified=True,
+        required_decision_names=required,
+    )
+    trace = UnifiedDecisionTrace(
+        trace_name=trace_name,
+        protocol_id=protocol_id,
+        case_id=case_id,
+        session_id=session_id,
+        endpoint=endpoint,
+        stack_lock_id=stack_lock_id,
+        root_artifacts=tuple(root_artifacts),
+        stages=tuple(stages),
+        selection=selection,
+        metadata={} if metadata is None else metadata,
+    )
+    return DecisionTraceBuildResult(
+        trace=trace,
+        baseline=baseline,
+        candidate=candidate,
+        deployed=deployed,
+    )
+
+
+def write_decision_trace(
+    path: str | Path,
+    trace: UnifiedDecisionTrace,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Atomically publish one validated decision trace."""
+
+    if type(trace) is not UnifiedDecisionTrace:
+        raise ValueError("trace must be a UnifiedDecisionTrace")
+    atomic_write_json(path, trace.as_dict(), overwrite=overwrite)
+
+
+def load_decision_trace(path: str | Path) -> UnifiedDecisionTrace:
+    """Load a duplicate-key-safe, finite, content-addressed decision trace."""
+
+    snapshot = read_regular_file(path, name="decision trace")
+    values = load_strict_json_object(snapshot.payload, name="decision trace")
+    return UnifiedDecisionTrace.from_dict(values)
+
+
+def load_claim_bearing_decision_trace(
+    path: str | Path,
+    *,
+    expected_trace_id: str,
+    expected_stack_lock_id: str,
+    expected_protocol_id: str | None = None,
+) -> UnifiedDecisionTrace:
+    """Load a trace only when independently frozen identities match."""
+
+    trace = load_decision_trace(path)
+    trace_id = _require_sha256(expected_trace_id, name="expected_trace_id")
+    stack_lock_id = _require_sha256(
+        expected_stack_lock_id,
+        name="expected_stack_lock_id",
+    )
+    if trace.trace_id != trace_id:
+        raise ValueError("decision trace does not match expected_trace_id")
+    if trace.stack_lock_id != stack_lock_id:
+        raise ValueError("decision trace does not match expected_stack_lock_id")
+    if expected_protocol_id is not None:
+        protocol_id = _require_nonempty_string(
+            expected_protocol_id,
+            name="expected_protocol_id",
+        )
+        if trace.protocol_id != protocol_id:
+            raise ValueError("decision trace does not match expected_protocol_id")
+    return trace
+
+
+def require_decision_trace_stack_lock(
+    trace: UnifiedDecisionTrace,
+    stack_lock: Mapping[str, Any],
+) -> UnifiedDecisionTrace:
+    """Bind a trace to a fully validated external three-repository stack lock."""
+
+    from causal4d.stack_lock import validate_stack_lock
+
+    validated = validate_stack_lock(stack_lock)
+    if trace.stack_lock_id != validated["lock_id"]:
+        raise ValueError("decision trace stack_lock_id does not match the stack lock")
+    return trace
+
+
+__all__ = [
+    "DECISION_TRACE_ENDPOINTS",
+    "DECISION_TRACE_PIPELINE",
+    "DECISION_TRACE_SCHEMA_NAME",
+    "DECISION_TRACE_SCHEMA_VERSION",
+    "DECISION_TRACE_STAGE_KINDS",
+    "DecisionTraceArtifact",
+    "DecisionTraceBuildResult",
+    "DecisionTraceDecision",
+    "DecisionTraceSelection",
+    "DecisionTraceStage",
+    "UnifiedDecisionTrace",
+    "build_unified_decision_trace",
+    "load_claim_bearing_decision_trace",
+    "load_decision_trace",
+    "require_decision_trace_stack_lock",
+    "write_decision_trace",
+]

--- a/tests/test_decision_trace.py
+++ b/tests/test_decision_trace.py
@@ -1,0 +1,565 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from causal4d.decision_trace import (
+    DECISION_TRACE_STAGE_KINDS,
+    DecisionTraceArtifact,
+    DecisionTraceDecision,
+    DecisionTraceSelection,
+    DecisionTraceStage,
+    UnifiedDecisionTrace,
+    build_unified_decision_trace,
+    load_claim_bearing_decision_trace,
+    load_decision_trace,
+    require_decision_trace_stack_lock,
+    write_decision_trace,
+)
+
+
+def _id(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _artifact(
+    role: str,
+    producer: str,
+    *,
+    label: str | None = None,
+    metadata: dict[str, object] | None = None,
+) -> DecisionTraceArtifact:
+    return DecisionTraceArtifact(
+        artifact_id=_id(role if label is None else label),
+        artifact_kind=f"test.{role}",
+        role=role,
+        producer=producer,  # type: ignore[arg-type]
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def _decision(
+    name: str,
+    producer: str,
+    *,
+    accepted: bool = True,
+    reasons: tuple[str, ...] = (),
+) -> DecisionTraceDecision:
+    return DecisionTraceDecision(
+        name=name,
+        decision_id=_id(f"decision:{name}:{accepted}:{reasons}"),
+        decision_kind=f"test.{name}",
+        producer=producer,  # type: ignore[arg-type]
+        accepted=accepted,
+        reasons=reasons,
+    )
+
+
+def _trace_parts(
+    *,
+    rejected_decision: str | None = None,
+) -> tuple[
+    tuple[DecisionTraceArtifact, ...],
+    tuple[DecisionTraceStage, ...],
+    tuple[str, ...],
+    object,
+    object,
+]:
+    factual = _artifact("factual_evidence_context", "causal4d")
+    query = _artifact("counterfactual_query_context", "causal4d")
+    observation = _artifact("prob4d_observation", "prob4d")
+    belief = _artifact("bayesian_phystwin_belief", "bayesian-phystwin")
+    baseline_prediction = _artifact(
+        "baseline_prediction",
+        "bayesian-phystwin",
+    )
+    factual_posterior = _artifact("causal4d_factual_posterior", "causal4d")
+    candidate_prediction = _artifact("candidate_prediction", "causal4d")
+
+    names = (
+        "prob4d_provider_acceptance",
+        "bayesian_phystwin_acceptance",
+        "intervention_identifiability",
+        "action_support",
+        "contact_v2_support",
+        "query_calibration",
+        "counterfactual_regret",
+    )
+
+    def decision(name: str, producer: str) -> DecisionTraceDecision:
+        rejected = name == rejected_decision
+        return _decision(
+            name,
+            producer,
+            accepted=not rejected,
+            reasons=("source_regret_exceeds_limit",) if rejected else (),
+        )
+
+    stages = (
+        DecisionTraceStage(
+            stage_name="prob4d observation",
+            stage_kind="prob4d_observation",
+            producer="prob4d",
+            input_artifact_ids=(factual.artifact_id,),
+            output_artifacts=(observation,),
+            decisions=(decision(names[0], "prob4d"),),
+        ),
+        DecisionTraceStage(
+            stage_name="bayesian physical belief",
+            stage_kind="bayesian_phystwin_belief",
+            producer="bayesian-phystwin",
+            input_artifact_ids=(observation.artifact_id,),
+            output_artifacts=(belief, baseline_prediction),
+            decisions=(decision(names[1], "bayesian-phystwin"),),
+        ),
+        DecisionTraceStage(
+            stage_name="causal factual abduction",
+            stage_kind="causal4d_abduction",
+            producer="causal4d",
+            input_artifact_ids=(observation.artifact_id, belief.artifact_id),
+            output_artifacts=(factual_posterior,),
+            decisions=(
+                decision(names[2], "causal4d"),
+                decision(names[3], "causal4d"),
+                decision(names[4], "causal4d"),
+            ),
+        ),
+        DecisionTraceStage(
+            stage_name="causal counterfactual",
+            stage_kind="causal4d_counterfactual",
+            producer="causal4d",
+            input_artifact_ids=(factual_posterior.artifact_id, query.artifact_id),
+            output_artifacts=(candidate_prediction,),
+            decisions=(decision(names[5], "causal4d"),),
+        ),
+        DecisionTraceStage(
+            stage_name="deployment",
+            stage_kind="deployment",
+            producer="causal4d",
+            input_artifact_ids=(
+                baseline_prediction.artifact_id,
+                candidate_prediction.artifact_id,
+            ),
+            decisions=(decision(names[6], "causal4d"),),
+        ),
+    )
+    return (factual, query), stages, names, object(), object()
+
+
+def _build_trace(
+    *,
+    rejected_decision: str | None = None,
+) -> tuple[UnifiedDecisionTrace, object, object]:
+    roots, stages, names, baseline, candidate = _trace_parts(
+        rejected_decision=rejected_decision
+    )
+    deployed = baseline if rejected_decision is not None else candidate
+    result = build_unified_decision_trace(
+        trace_name="case trace",
+        protocol_id="protocol-v2",
+        case_id="case-001",
+        session_id="session-001",
+        endpoint="same_grasp_transfer",
+        stack_lock_id=_id("stack lock"),
+        root_artifacts=roots,
+        stages=stages,
+        required_decision_names=names,
+        baseline=baseline,
+        candidate=candidate,
+        deployed=deployed,
+        baseline_artifact_id=stages[1].output_artifacts[1].artifact_id,
+        candidate_artifact_id=stages[3].output_artifacts[0].artifact_id,
+        metadata={"operator": {"version": 1}},
+    )
+    assert result.deployed is deployed
+    return result.trace, baseline, candidate
+
+
+def test_candidate_trace_is_deterministic_and_round_trips(tmp_path: Path) -> None:
+    trace, _, _ = _build_trace()
+    assert trace.selection.candidate_selected
+    assert trace.selection.deployed_artifact_id == (
+        trace.selection.candidate_artifact_id
+    )
+    assert trace.target_future_observations_read == 0
+    assert not trace.target_future_outcomes_used
+    assert tuple(stage.stage_kind for stage in trace.stages) == (
+        DECISION_TRACE_STAGE_KINDS
+    )
+    assert trace.trace_id == UnifiedDecisionTrace.from_dict(trace.as_dict()).trace_id
+
+    path = tmp_path / "trace.json"
+    write_decision_trace(path, trace)
+    loaded = load_decision_trace(path)
+    assert loaded.trace_id == trace.trace_id
+    assert loaded.as_dict() == trace.as_dict()
+
+
+def test_rejected_gate_selects_exact_baseline_object() -> None:
+    trace, baseline, candidate = _build_trace(rejected_decision="counterfactual_regret")
+    assert not trace.selection.candidate_selected
+    assert trace.selection.deployed_artifact_id == trace.selection.baseline_artifact_id
+    roots, stages, names, _, _ = _trace_parts(rejected_decision="counterfactual_regret")
+    result = build_unified_decision_trace(
+        trace_name="case trace",
+        protocol_id="protocol-v2",
+        case_id="case-001",
+        session_id="session-001",
+        endpoint="same_grasp_transfer",
+        stack_lock_id=_id("stack lock"),
+        root_artifacts=roots,
+        stages=stages,
+        required_decision_names=names,
+        baseline=baseline,
+        candidate=candidate,
+        deployed=baseline,
+        baseline_artifact_id=stages[1].output_artifacts[1].artifact_id,
+        candidate_artifact_id=stages[3].output_artifacts[0].artifact_id,
+    )
+    assert result.deployed is baseline
+
+
+def test_builder_rejects_wrong_runtime_object() -> None:
+    roots, stages, names, baseline, candidate = _trace_parts(
+        rejected_decision="action_support"
+    )
+    with pytest.raises(ValueError, match="deployed object"):
+        build_unified_decision_trace(
+            trace_name="case trace",
+            protocol_id="protocol-v2",
+            case_id="case-001",
+            session_id="session-001",
+            endpoint="same_grasp_transfer",
+            stack_lock_id=_id("stack lock"),
+            root_artifacts=roots,
+            stages=stages,
+            required_decision_names=names,
+            baseline=baseline,
+            candidate=candidate,
+            deployed=candidate,
+            baseline_artifact_id=stages[1].output_artifacts[1].artifact_id,
+            candidate_artifact_id=stages[3].output_artifacts[0].artifact_id,
+        )
+
+
+def test_builder_rejects_same_baseline_and_candidate_object() -> None:
+    roots, stages, names, _, _ = _trace_parts()
+    shared = object()
+    with pytest.raises(ValueError, match="must differ"):
+        build_unified_decision_trace(
+            trace_name="case trace",
+            protocol_id="protocol-v2",
+            case_id="case-001",
+            session_id="session-001",
+            endpoint="same_grasp_transfer",
+            stack_lock_id=_id("stack lock"),
+            root_artifacts=roots,
+            stages=stages,
+            required_decision_names=names,
+            baseline=shared,
+            candidate=shared,
+            deployed=shared,
+            baseline_artifact_id=stages[1].output_artifacts[1].artifact_id,
+            candidate_artifact_id=stages[3].output_artifacts[0].artifact_id,
+        )
+
+
+def test_missing_required_decision_is_rejected() -> None:
+    roots, stages, names, baseline, candidate = _trace_parts()
+    with pytest.raises(ValueError, match="absent from stages"):
+        build_unified_decision_trace(
+            trace_name="case trace",
+            protocol_id="protocol-v2",
+            case_id="case-001",
+            session_id="session-001",
+            endpoint="same_grasp_transfer",
+            stack_lock_id=_id("stack lock"),
+            root_artifacts=roots,
+            stages=stages,
+            required_decision_names=(*names, "missing_gate"),
+            baseline=baseline,
+            candidate=candidate,
+            deployed=candidate,
+            baseline_artifact_id=stages[1].output_artifacts[1].artifact_id,
+            candidate_artifact_id=stages[3].output_artifacts[0].artifact_id,
+        )
+
+
+def test_direct_trace_cannot_disagree_with_gate_conjunction() -> None:
+    trace, _, _ = _build_trace(rejected_decision="action_support")
+    invalid_selection = replace(
+        trace.selection,
+        deployed_artifact_id=trace.selection.candidate_artifact_id,
+        candidate_selected=True,
+    )
+    with pytest.raises(ValueError, match="conjunction"):
+        replace(trace, selection=invalid_selection)
+
+
+def test_forward_artifact_reference_is_rejected() -> None:
+    trace, _, _ = _build_trace()
+    first = trace.stages[0]
+    invalid_first = replace(
+        first,
+        input_artifact_ids=(trace.selection.candidate_artifact_id,),
+    )
+    with pytest.raises(ValueError, match="unavailable or forward"):
+        replace(trace, stages=(invalid_first, *trace.stages[1:]))
+
+
+def test_required_input_role_is_enforced() -> None:
+    trace, _, _ = _build_trace()
+    bpt = trace.stages[1]
+    factual_id = trace.root_artifacts[0].artifact_id
+    invalid_bpt = replace(bpt, input_artifact_ids=(factual_id,))
+    with pytest.raises(ValueError, match="missing input roles"):
+        replace(trace, stages=(trace.stages[0], invalid_bpt, *trace.stages[2:]))
+
+
+def test_required_output_role_is_enforced() -> None:
+    trace, _, _ = _build_trace()
+    observation_stage = trace.stages[0]
+    wrong = replace(
+        observation_stage.output_artifacts[0],
+        role="unrelated_observation",
+    )
+    invalid_stage = replace(observation_stage, output_artifacts=(wrong,))
+    with pytest.raises(ValueError, match="missing output roles"):
+        replace(trace, stages=(invalid_stage, *trace.stages[1:]))
+
+
+def test_duplicate_output_artifact_id_is_rejected() -> None:
+    trace, _, _ = _build_trace()
+    bpt = trace.stages[1]
+    duplicate = replace(
+        bpt.output_artifacts[1],
+        artifact_id=bpt.output_artifacts[0].artifact_id,
+    )
+    with pytest.raises(ValueError, match="artifact IDs"):
+        replace(bpt, output_artifacts=(bpt.output_artifacts[0], duplicate))
+
+
+def test_required_roles_must_be_unique_globally() -> None:
+    trace, _, _ = _build_trace()
+    duplicate_root = _artifact(
+        "factual_evidence_context",
+        "causal4d",
+        label="duplicate factual",
+    )
+    with pytest.raises(ValueError, match="exactly one artifact"):
+        replace(trace, root_artifacts=(*trace.root_artifacts, duplicate_root))
+
+
+def test_stage_order_and_producer_are_fixed() -> None:
+    trace, _, _ = _build_trace()
+    with pytest.raises(ValueError, match="fixed Prob4D"):
+        replace(trace, stages=(trace.stages[1], trace.stages[0], *trace.stages[2:]))
+    with pytest.raises(ValueError, match="must be produced"):
+        replace(trace.stages[0], producer="causal4d")
+
+
+def test_deployment_has_no_new_output_artifact() -> None:
+    trace, _, _ = _build_trace()
+    with pytest.raises(ValueError, match="has no outputs"):
+        replace(
+            trace.stages[-1],
+            output_artifacts=(_artifact("deployment_receipt", "causal4d"),),
+        )
+
+
+def test_held_out_target_artifacts_and_metadata_are_forbidden() -> None:
+    with pytest.raises(ValueError, match="forbidden"):
+        _artifact("evaluation_target", "causal4d")
+    with pytest.raises(ValueError, match="target-safe"):
+        _artifact(
+            "factual_evidence_context",
+            "causal4d",
+            metadata={"target_loss": 1.0},
+        )
+    trace, _, _ = _build_trace()
+    with pytest.raises(ValueError, match="target-safe"):
+        replace(trace, metadata={"nested": {"target_future": [1, 2]}})
+
+
+def test_target_future_flags_fail_closed() -> None:
+    trace, _, _ = _build_trace()
+    with pytest.raises(ValueError, match="must not read"):
+        replace(trace, target_future_observations_read=1)
+    with pytest.raises(ValueError, match="must not use"):
+        replace(trace, target_future_outcomes_used=True)
+
+
+def test_decision_reason_contract_is_strict() -> None:
+    with pytest.raises(ValueError, match="accepted decisions"):
+        _decision("gate", "causal4d", accepted=True, reasons=("not_allowed",))
+    with pytest.raises(ValueError, match="require at least one"):
+        _decision("gate", "causal4d", accepted=False)
+
+
+def test_selection_identity_contract_is_strict() -> None:
+    trace, _, _ = _build_trace()
+    with pytest.raises(ValueError, match="must be verified"):
+        replace(trace.selection, exact_object_identity_verified=False)
+    with pytest.raises(ValueError, match="disagrees"):
+        DecisionTraceSelection(
+            baseline_artifact_id=trace.selection.baseline_artifact_id,
+            candidate_artifact_id=trace.selection.candidate_artifact_id,
+            deployed_artifact_id=trace.selection.baseline_artifact_id,
+            candidate_selected=True,
+            exact_object_identity_verified=True,
+            required_decision_names=trace.selection.required_decision_names,
+        )
+
+
+def test_nested_ids_detect_tampering() -> None:
+    trace, _, _ = _build_trace()
+    stage_payload = trace.stages[0].as_dict()
+    stage_payload["stage_name"] = "tampered"
+    with pytest.raises(ValueError, match="stage_id"):
+        DecisionTraceStage.from_dict(stage_payload)
+
+    selection_payload = trace.selection.as_dict()
+    selection_payload["candidate_selected"] = False
+    selection_payload["deployed_artifact_id"] = selection_payload[
+        "baseline_artifact_id"
+    ]
+    with pytest.raises(ValueError, match="selection_id"):
+        DecisionTraceSelection.from_dict(selection_payload)
+
+    trace_payload = trace.as_dict()
+    trace_payload["trace_name"] = "tampered"
+    with pytest.raises(ValueError, match="trace_id"):
+        UnifiedDecisionTrace.from_dict(trace_payload)
+
+
+def test_loader_rejects_duplicate_keys(tmp_path: Path) -> None:
+    trace, _, _ = _build_trace()
+    serialized = json.dumps(trace.as_dict(), sort_keys=True)
+    duplicate = serialized[:-1] + ',"trace_name":"duplicate"}'
+    path = tmp_path / "duplicate.json"
+    path.write_text(duplicate, encoding="utf-8")
+    with pytest.raises(ValueError, match="duplicate"):
+        load_decision_trace(path)
+
+
+def test_claim_bearing_loader_requires_independent_pins(tmp_path: Path) -> None:
+    trace, _, _ = _build_trace()
+    path = tmp_path / "trace.json"
+    write_decision_trace(path, trace)
+    assert (
+        load_claim_bearing_decision_trace(
+            path,
+            expected_trace_id=trace.trace_id,
+            expected_stack_lock_id=trace.stack_lock_id,
+            expected_protocol_id=trace.protocol_id,
+        ).trace_id
+        == trace.trace_id
+    )
+    with pytest.raises(ValueError, match="expected_trace_id"):
+        load_claim_bearing_decision_trace(
+            path,
+            expected_trace_id=_id("wrong"),
+            expected_stack_lock_id=trace.stack_lock_id,
+        )
+    with pytest.raises(ValueError, match="expected_stack_lock_id"):
+        load_claim_bearing_decision_trace(
+            path,
+            expected_trace_id=trace.trace_id,
+            expected_stack_lock_id=_id("wrong lock"),
+        )
+    with pytest.raises(ValueError, match="expected_protocol_id"):
+        load_claim_bearing_decision_trace(
+            path,
+            expected_trace_id=trace.trace_id,
+            expected_stack_lock_id=trace.stack_lock_id,
+            expected_protocol_id="wrong-protocol",
+        )
+
+
+def test_stack_lock_binding_uses_validated_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trace, _, _ = _build_trace()
+
+    def validate(value: object) -> dict[str, object]:
+        assert value == {"lock_id": trace.stack_lock_id}
+        return {"lock_id": trace.stack_lock_id}
+
+    monkeypatch.setattr("causal4d.stack_lock.validate_stack_lock", validate)
+    assert (
+        require_decision_trace_stack_lock(
+            trace,
+            {"lock_id": trace.stack_lock_id},
+        )
+        is trace
+    )
+
+    def mismatch(value: object) -> dict[str, object]:
+        del value
+        return {"lock_id": _id("other stack")}
+
+    monkeypatch.setattr("causal4d.stack_lock.validate_stack_lock", mismatch)
+    with pytest.raises(ValueError, match="does not match"):
+        require_decision_trace_stack_lock(trace, {})
+
+
+def test_required_root_producers_are_fixed() -> None:
+    roots, stages, names, baseline, candidate = _trace_parts()
+    bad_factual = replace(roots[0], producer="prob4d")
+    with pytest.raises(ValueError, match="root role.*must be produced"):
+        build_unified_decision_trace(
+            trace_name="case trace",
+            protocol_id="protocol-v2",
+            case_id="case-001",
+            session_id="session-001",
+            endpoint="same_grasp_transfer",
+            stack_lock_id=_id("stack lock"),
+            root_artifacts=(bad_factual, roots[1]),
+            stages=stages,
+            required_decision_names=names,
+            baseline=baseline,
+            candidate=candidate,
+            deployed=candidate,
+            baseline_artifact_id=stages[1].output_artifacts[1].artifact_id,
+            candidate_artifact_id=stages[3].output_artifacts[0].artifact_id,
+        )
+
+
+def test_selection_must_be_validated_type() -> None:
+    trace, _, _ = _build_trace()
+    with pytest.raises(ValueError, match="selection must be"):
+        replace(trace, selection=object())
+
+
+def test_metadata_is_deeply_immutable() -> None:
+    trace, _, _ = _build_trace()
+    with pytest.raises(TypeError):
+        trace.metadata["operator"] = {}  # type: ignore[index]
+    with pytest.raises(TypeError):
+        trace.metadata["operator"]["version"] = 2  # type: ignore[index]
+
+
+def test_metadata_order_does_not_change_content_identity() -> None:
+    trace, _, _ = _build_trace()
+    reordered = replace(
+        trace,
+        metadata={"z": 2, "a": {"y": 1, "x": 0}},
+    )
+    same = replace(
+        trace,
+        metadata={"a": {"x": 0, "y": 1}, "z": 2},
+    )
+    assert reordered.trace_id == same.trace_id
+
+
+def test_write_is_non_overwriting_by_default(tmp_path: Path) -> None:
+    trace, _, _ = _build_trace()
+    path = tmp_path / "trace.json"
+    write_decision_trace(path, trace)
+    with pytest.raises(FileExistsError):
+        write_decision_trace(path, trace)
+    write_decision_trace(path, trace, overwrite=True)


### PR DESCRIPTION
## Summary

Add an additive, target-safe, content-addressed decision DAG for one complete Prob4D → BayesianPhysTwin → Causal4D prediction and deployment decision.

The trace binds:

- the exact three-repository stack lock;
- factual-evidence and counterfactual-query provenance contexts;
- the admitted Prob4D observation artifact;
- BayesianPhysTwin belief and baseline-prediction artifacts;
- Causal4D factual posterior and counterfactual candidate artifacts;
- every required support, identifiability, calibration, provider, and regret decision; and
- the exact baseline or candidate artifact finally deployed.

## Contract

The stage order and producer are fixed:

1. `prob4d_observation` — Prob4D
2. `bayesian_phystwin_belief` — BayesianPhysTwin
3. `causal4d_abduction` — Causal4D
4. `causal4d_counterfactual` — Causal4D
5. `deployment` — Causal4D

The trace rejects forward references, missing required hand-offs, duplicate artifact or decision identities, root/stage producer drift, selection/gate disagreement, stack-lock mismatch, and held-out target outcomes. Runtime construction verifies exact Python object identity: one rejecting required decision must deploy the caller-provided baseline object; all required decisions passing must deploy the exact candidate object.

Principal artifact roles are unique and enforce the full hand-off graph:

```text
factual_evidence_context
  -> prob4d_observation
  -> bayesian_phystwin_belief + baseline_prediction

prob4d_observation + bayesian_phystwin_belief
  -> causal4d_factual_posterior

causal4d_factual_posterior + counterfactual_query_context
  -> candidate_prediction

baseline_prediction + candidate_prediction
  -> deployment
```

## Target boundary

The trace has no evaluation-target, continuation, or loss payload. It records exactly:

```text
target_future_observations_read = 0
target_future_outcomes_used = false
```

Evaluation targets remain separate registered result artifacts.

## Final product

Exact head:

```text
29fd9f3bd4a23877306d5266b2c319dac7fb5d89
```

This is one commit on combined P1–P4 main revision `31ffd1f44ead918c3687ffa4c9b1187fbf68be2d` and changes exactly four product files:

```text
docs/decision_trace.md
src/causal4d/__init__.py
src/causal4d/decision_trace.py
tests/test_decision_trace.py
```

The implementation provides strict atomic JSON publication/loading, duplicate-key rejection, independently pinned claim-bearing loading, external stack-lock validation, stage/selection/trace content IDs, deeply immutable finite metadata, and exact baseline/candidate runtime identity enforcement.

## Validation

Focused validation covers deterministic round trips, exact fallback identity, candidate identity, malformed runtime selections, missing required decisions, gate-conjunction disagreement, forward references, missing hand-offs, duplicate output IDs, global role uniqueness, fixed stage order and producers, root-producer enforcement, target-artifact and target-metadata rejection, target-future declarations, accepted/rejected reason contracts, nested ID tampering, duplicate JSON keys, claim-bearing pins, validated stack-lock binding, deep immutability, canonical metadata ordering, and non-overwriting publication.

Authoritative validation of the clean head is fully green:

- `CI and release` run `31175449577`: Ruff/types, complete core suites on Python 3.10/3.12/3.14, wheel and source-distribution builds, installed wheel/sdist CLI checks, deterministic result bundles, frozen milestone verification, and pinned BayesianPhysTwin installed-wheel integration passed;
- `Extended compatibility` run `31175449571`: Python 3.11/3.13 and exact declared dependency-floor suites passed;
- `Security scanning` run `31175449578`: runtime dependency audit and CodeQL for Python and GitHub Actions passed; and
- `Causal4D merge gate` run `31175449627`: the actual pull-request merge result passed repository quality checks, the complete default suite, distribution validation, and pinned BayesianPhysTwin installed-wheel integration.

## Scientific boundary

This is integration and reproducibility infrastructure. It does not change the frozen estimator, registered 18-session/36-execution experiment, source panels, thresholds, target split, evidence count, or any existing result. A valid trace establishes identity and chain consistency, not model correctness or prospective V2 promotion.