### PR TITLE
Add structured uncertainty and functional support certification

### DIFF
--- a/docs/conditional_uncertainty_and_functional_support.md
+++ b/docs/conditional_uncertainty_and_functional_support.md
@@ -88,9 +88,13 @@ This preserves the exact weighted metric while bounding pairwise working memory
 to fixed component blocks.
 
 All thresholds are mandatory constructor arguments and should be frozen from
-source-only data before target evaluation. The certificate fails if any source
-action fails any threshold and binds the policy, per-action metrics, input
-content hashes, and source artifact IDs into one deterministic certificate ID.
+source-only data before target evaluation. Every source-action artifact and the
+resulting certificate bind `target_outcomes_used=false`; constructors reject a
+true or non-Boolean declaration. This records the no-target-access boundary in
+the content identity rather than leaving it only in documentation. The
+certificate fails if any source action fails any threshold and binds the policy,
+per-action metrics, input content hashes, and source artifact IDs into one
+deterministic certificate ID.
 
 ```python
 from causal4d.functional_support_v1 import (
@@ -105,6 +109,7 @@ source_case = FunctionalSupportActionV1(
     full_weights=full_weights,
     reduced_trajectories_m=reduced_components,
     reduced_weights=reduced_weights,
+    target_outcomes_used=False,
 )
 policy = FunctionalSupportPolicyV1(
     maximum_normalized_mean_error=0.05,

--- a/docs/conditional_uncertainty_and_functional_support.md
+++ b/docs/conditional_uncertainty_and_functional_support.md
@@ -82,6 +82,11 @@ For every source action, the certificate compares:
 - maximum marginal interval-endpoint error; and
 - weighted energy distance using trajectory RMS as the ground metric.
 
+The energy-distance expectation uses Gram-matrix blocks rather than allocating a
+`full_component × reduced_component × trajectory_dimension` difference tensor.
+This preserves the exact weighted metric while bounding pairwise working memory
+to fixed component blocks.
+
 All thresholds are mandatory constructor arguments and should be frozen from
 source-only data before target evaluation. The certificate fails if any source
 action fails any threshold and binds the policy, per-action metrics, input

--- a/docs/conditional_uncertainty_and_functional_support.md
+++ b/docs/conditional_uncertainty_and_functional_support.md
@@ -61,7 +61,12 @@ trajectory covariance according to
 
 The dense joint covariance is intended for NEES, calibration, and covariance
 consistency checks. It is deliberately not produced by default because its
-storage is quadratic in the number of queried trajectory coordinates.
+storage is quadratic in the number of queried trajectory coordinates. The
+function checks `maximum_joint_dimension` before entering either dense `einsum`
+allocation; the default limit is 2,048 coordinates. Raising the limit is an
+explicit operator decision. The rejection reports the requested dimension and
+the minimum byte count of the dense covariance so an unexpectedly long query
+cannot silently exhaust a workstation or CI runner.
 
 ## Functional support certificate
 

--- a/docs/conditional_uncertainty_and_functional_support.md
+++ b/docs/conditional_uncertainty_and_functional_support.md
@@ -1,0 +1,116 @@
+# Structured conditional uncertainty and functional support certification
+
+This prospective extension closes two limitations of the latent-contact-v2 path
+without changing the registered estimator, the frozen physical protocol, or any
+existing artifact identity.
+
+## Structured conditional uncertainty
+
+`causal4d.conditional_uncertainty_v2` augments a
+`ContactPatchRolloutBankV2` with two conditional uncertainty terms:
+
+- componentwise independent residual variance, broadcast to the state/parameter
+  rollout components and added to the bank's existing noise floor; and
+- shared or component-specific Gaussian low-rank trajectory modes.
+
+Every uncertainty object requires upstream artifact IDs and receives a
+content-derived ID. Low-rank modes are projected through the existing
+`LinearContactObservationGroup` operators before contact-evidence scoring. This
+preserves correlations for positions, increments, or any other admitted linear
+query instead of converting them prematurely to a diagonal variance.
+
+```python
+from causal4d.conditional_uncertainty_v2 import (
+    ConditionalPredictiveUncertaintyV2,
+    joint_predictive_moments_with_conditional_uncertainty_v2,
+    posterior_weights_with_conditional_uncertainty_v2,
+    predictive_distribution_with_conditional_uncertainty_v2,
+)
+
+uncertainty = ConditionalPredictiveUncertaintyV2(
+    source_artifact_ids=(prob4d_belief_id, bpt_covariance_id),
+    independent_variance_m2=residual_variance_m2,
+    low_rank_factors_m=graph_mode_factors_m,
+)
+
+joint_weights, diagnostics = (
+    posterior_weights_with_conditional_uncertainty_v2(
+        bank,
+        evidence,
+        uncertainty,
+        prefix_frame_count=prefix_frame_count,
+    )
+)
+prediction = predictive_distribution_with_conditional_uncertainty_v2(
+    bank,
+    uncertainty,
+    joint_weights,
+)
+```
+
+The marginal predictive distribution uses exact one-dimensional
+Gaussian-mixture quantiles. For bounded diagnostic windows,
+`joint_predictive_moments_with_conditional_uncertainty_v2` materializes the full
+trajectory covariance according to
+
+\[
+\operatorname{Cov}(Y)=
+\mathbb{E}[\operatorname{Cov}(Y\mid Z,\Theta)] +
+\operatorname{Cov}(\mathbb{E}[Y\mid Z,\Theta]).
+\]
+
+The dense joint covariance is intended for NEES, calibration, and covariance
+consistency checks. It is deliberately not produced by default because its
+storage is quadratic in the number of queried trajectory coordinates.
+
+## Functional support certificate
+
+`causal4d.functional_support_v1` checks a finite parameter/support reduction in
+rollout space on a frozen source-action library. It does not treat reassigned
+probability mass or parameter-space moment preservation as sufficient evidence
+for nonlinear predictive equivalence.
+
+For every source action, the certificate compares:
+
+- predictive mean RMSE normalized by the full predictive scale;
+- predictive variance-trace error;
+- maximum marginal interval-endpoint error; and
+- weighted energy distance using trajectory RMS as the ground metric.
+
+All thresholds are mandatory constructor arguments and should be frozen from
+source-only data before target evaluation. The certificate fails if any source
+action fails any threshold and binds the policy, per-action metrics, input
+content hashes, and source artifact IDs into one deterministic certificate ID.
+
+```python
+from causal4d.functional_support_v1 import (
+    FunctionalSupportActionV1,
+    FunctionalSupportPolicyV1,
+    certify_functional_support_v1,
+)
+
+source_case = FunctionalSupportActionV1(
+    action_id="source-object/session-03/action-02",
+    full_trajectories_m=full_components,
+    full_weights=full_weights,
+    reduced_trajectories_m=reduced_components,
+    reduced_weights=reduced_weights,
+)
+policy = FunctionalSupportPolicyV1(
+    maximum_normalized_mean_error=0.05,
+    maximum_variance_trace_relative_error=0.10,
+    maximum_interval_endpoint_error_m=0.002,
+    maximum_energy_distance_m=0.002,
+    minimum_action_count=12,
+)
+certificate = certify_functional_support_v1(
+    source_actions,
+    policy=policy,
+    source_artifact_ids=(source_freeze_id, simulator_build_id),
+)
+```
+
+An accepted certificate supports only the frozen source-action query family and
+thresholds. It does not establish target-domain accuracy, physical confirmation,
+or promotion of latent-contact v2. Those require the separately registered
+prospective evaluation and physical experiment.

--- a/src/causal4d/conditional_uncertainty_v2.py
+++ b/src/causal4d/conditional_uncertainty_v2.py
@@ -1,0 +1,498 @@
+"""Prospective structured conditional uncertainty for latent-contact v2.
+
+The registered estimator and the existing :mod:`causal4d.latent_contact_v2`
+rollout-bank contract remain unchanged.  This additive module supplies a
+provenance-bearing uncertainty layer that can be projected through the existing
+linear observation groups and can expose the full law-of-total-covariance result
+for joint calibration diagnostics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+from causal4d.baselines import PredictiveDistribution
+from causal4d.contracts import array_sha256
+from causal4d.immutable_array import readonly_array
+from causal4d.immutable_json import plain_json, validated_json_mapping
+from causal4d.latent_contact_v2 import (
+    ContactLikelihoodV2Diagnostics,
+    ContactObservationEvidenceV2,
+    ContactPatchRolloutBankV2,
+    gaussian_mixture_quantiles,
+    posterior_weights_from_contact_evidence_v2,
+)
+
+
+CONDITIONAL_UNCERTAINTY_V2_SCHEMA_VERSION = 1
+
+
+def _canonical_sha256(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        plain_json(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _require_nonempty_string(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _validated_string_tuple(values: Any, *, name: str) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise ValueError(f"{name} must be a sequence of strings")
+    result = tuple(
+        _require_nonempty_string(value, name=f"{name}[{index}]")
+        for index, value in enumerate(values)
+    )
+    if not result:
+        raise ValueError(f"{name} must be nonempty")
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must be unique")
+    return result
+
+
+def _finite_nonnegative_float(value: Any, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(
+        value,
+        (int, float, np.integer, np.floating),
+    ):
+        raise ValueError(f"{name} must be a finite nonnegative number")
+    result = float(value)
+    if not np.isfinite(result) or result < 0.0:
+        raise ValueError(f"{name} must be a finite nonnegative number")
+    return result
+
+
+def _finite_positive_float(value: Any, *, name: str) -> float:
+    result = _finite_nonnegative_float(value, name=name)
+    if result <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return result
+
+
+def _normalized_weights(
+    values: np.ndarray,
+    *,
+    expected_shape: tuple[int, ...],
+) -> np.ndarray:
+    weights = np.asarray(values, dtype=float)
+    if weights.shape != expected_shape:
+        raise ValueError(f"joint_weights must have shape {expected_shape}")
+    if not np.all(np.isfinite(weights)) or np.any(weights < 0.0):
+        raise ValueError("joint_weights must be finite and nonnegative")
+    total = float(np.sum(weights))
+    if total <= 0.0:
+        raise ValueError("joint_weights must contain positive mass")
+    return weights / total
+
+
+@dataclass(frozen=True)
+class ConditionalPredictiveUncertaintyV2:
+    """Diagonal residual variance plus Gaussian low-rank trajectory modes.
+
+    ``independent_variance_m2`` must broadcast to the rollout-bank trajectory
+    shape ``(state, particle, frame, node, coordinate)``.  It is added to the
+    bank's existing scalar variance floor.
+
+    ``low_rank_factors_m`` may be shared or component-specific.  Its final four
+    axes are ``(rank, frame, node, coordinate)``; any leading axes must broadcast
+    to ``(state, particle)``.  For one component, factors ``F`` define the
+    correlated conditional covariance ``F.T @ F`` after flattening the queried
+    trajectory coordinates.
+    """
+
+    source_artifact_ids: tuple[str, ...]
+    independent_variance_m2: np.ndarray = field(
+        default_factory=lambda: np.asarray(0.0, dtype=float)
+    )
+    low_rank_factors_m: np.ndarray | None = None
+    uncertainty_id: str = "conditional_predictive_uncertainty_v2"
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        source_ids = _validated_string_tuple(
+            self.source_artifact_ids,
+            name="source_artifact_ids",
+        )
+        independent = readonly_array(self.independent_variance_m2, dtype=float)
+        if not np.all(np.isfinite(independent)) or np.any(independent < 0.0):
+            raise ValueError(
+                "independent_variance_m2 must be finite and nonnegative"
+            )
+        factors = None
+        if self.low_rank_factors_m is not None:
+            factors = readonly_array(self.low_rank_factors_m, dtype=float)
+            if factors.ndim < 4 or factors.shape[-4] < 1:
+                raise ValueError(
+                    "low_rank_factors_m must end in "
+                    "(positive rank, frame, node, coordinate)"
+                )
+            if not np.all(np.isfinite(factors)):
+                raise ValueError("low_rank_factors_m must be finite")
+        uncertainty_id = _require_nonempty_string(
+            self.uncertainty_id,
+            name="uncertainty_id",
+        )
+        metadata = validated_json_mapping(
+            self.metadata,
+            error_message="uncertainty metadata must contain finite JSON data",
+        )
+        object.__setattr__(self, "source_artifact_ids", source_ids)
+        object.__setattr__(self, "independent_variance_m2", independent)
+        object.__setattr__(self, "low_rank_factors_m", factors)
+        object.__setattr__(self, "uncertainty_id", uncertainty_id)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def artifact_id(self) -> str:
+        return _canonical_sha256(
+            {
+                "schema_version": CONDITIONAL_UNCERTAINTY_V2_SCHEMA_VERSION,
+                "artifact_kind": "Causal4DConditionalPredictiveUncertaintyV2",
+                "uncertainty_id": self.uncertainty_id,
+                "source_artifact_ids": list(self.source_artifact_ids),
+                "independent_variance_sha256": array_sha256(
+                    self.independent_variance_m2
+                ),
+                "low_rank_factors_sha256": (
+                    None
+                    if self.low_rank_factors_m is None
+                    else array_sha256(self.low_rank_factors_m)
+                ),
+                "metadata": plain_json(self.metadata),
+            }
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": CONDITIONAL_UNCERTAINTY_V2_SCHEMA_VERSION,
+            "artifact_kind": "Causal4DConditionalPredictiveUncertaintyV2",
+            "artifact_id": self.artifact_id,
+            "uncertainty_id": self.uncertainty_id,
+            "source_artifact_ids": list(self.source_artifact_ids),
+            "independent_variance_sha256": array_sha256(
+                self.independent_variance_m2
+            ),
+            "low_rank_factors_sha256": (
+                None
+                if self.low_rank_factors_m is None
+                else array_sha256(self.low_rank_factors_m)
+            ),
+            "metadata": plain_json(self.metadata),
+        }
+
+    def independent_component_variance_m2(
+        self,
+        bank: ContactPatchRolloutBankV2,
+    ) -> np.ndarray:
+        """Return broadcast residual variance including the bank noise floor."""
+
+        target_shape = bank.trajectories_m.shape
+        try:
+            variance = np.broadcast_to(
+                np.asarray(self.independent_variance_m2, dtype=float),
+                target_shape,
+            )
+        except ValueError as error:
+            raise ValueError(
+                "independent_variance_m2 cannot broadcast to rollout components"
+            ) from error
+        result = variance + bank.variance_floor_m2
+        if not np.all(np.isfinite(result)) or np.any(result <= 0.0):
+            raise ValueError("combined independent component variance must be positive")
+        return result
+
+    def component_low_rank_factors_m(
+        self,
+        bank: ContactPatchRolloutBankV2,
+    ) -> np.ndarray | None:
+        """Broadcast low-rank factors to every state/parameter component."""
+
+        if self.low_rank_factors_m is None:
+            return None
+        rank = self.low_rank_factors_m.shape[-4]
+        target_shape = (
+            *bank.trajectories_m.shape[:-3],
+            rank,
+            *bank.trajectories_m.shape[-3:],
+        )
+        try:
+            return np.broadcast_to(self.low_rank_factors_m, target_shape)
+        except ValueError as error:
+            raise ValueError(
+                "low_rank_factors_m cannot broadcast to rollout components"
+            ) from error
+
+    def marginal_component_variance_m2(
+        self,
+        bank: ContactPatchRolloutBankV2,
+    ) -> np.ndarray:
+        """Return each Gaussian component's coordinatewise marginal variance."""
+
+        variance = self.independent_component_variance_m2(bank).copy()
+        factors = self.component_low_rank_factors_m(bank)
+        if factors is not None:
+            variance += np.sum(np.square(factors), axis=-4)
+        return variance
+
+    def component_group_covariance_m2(
+        self,
+        bank: ContactPatchRolloutBankV2,
+        evidence: ContactObservationEvidenceV2,
+    ) -> dict[str, np.ndarray]:
+        """Project correlated modes through every existing linear group."""
+
+        factors = self.component_low_rank_factors_m(bank)
+        if factors is None:
+            return {}
+        result: dict[str, np.ndarray] = {}
+        for group in evidence.groups:
+            projected = group.apply(factors)
+            result[group.group_id] = np.einsum(
+                "...ri,...rj->...ij",
+                projected,
+                projected,
+            )
+        return result
+
+
+@dataclass(frozen=True)
+class JointPredictiveMomentsV2:
+    """Full joint trajectory covariance for calibration and NEES diagnostics."""
+
+    method: str
+    mean: np.ndarray
+    covariance_m2: np.ndarray
+    source_artifact_ids: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        method = _require_nonempty_string(self.method, name="method")
+        mean = readonly_array(self.mean, dtype=float)
+        covariance = readonly_array(self.covariance_m2, dtype=float)
+        source_ids = _validated_string_tuple(
+            self.source_artifact_ids,
+            name="source_artifact_ids",
+        )
+        if mean.ndim != 3:
+            raise ValueError(
+                "joint predictive mean must have shape (frame, node, coordinate)"
+            )
+        dimension = int(np.prod(mean.shape))
+        if covariance.shape != (dimension, dimension):
+            raise ValueError(
+                "joint predictive covariance must match the flattened mean"
+            )
+        if not np.all(np.isfinite(mean)) or not np.all(np.isfinite(covariance)):
+            raise ValueError("joint predictive moments must be finite")
+        if not np.allclose(
+            covariance,
+            covariance.T,
+            atol=1e-12,
+            rtol=1e-10,
+        ):
+            raise ValueError("joint predictive covariance must be symmetric")
+        minimum_eigenvalue = float(np.min(np.linalg.eigvalsh(covariance)))
+        if minimum_eigenvalue < -1e-10:
+            raise ValueError(
+                "joint predictive covariance must be positive semidefinite"
+            )
+        object.__setattr__(self, "method", method)
+        object.__setattr__(self, "mean", mean)
+        object.__setattr__(self, "covariance_m2", covariance)
+        object.__setattr__(self, "source_artifact_ids", source_ids)
+
+    @property
+    def variance_m2(self) -> np.ndarray:
+        diagonal = np.diag(self.covariance_m2).reshape(self.mean.shape)
+        return readonly_array(diagonal, dtype=float)
+
+    @property
+    def artifact_id(self) -> str:
+        return _canonical_sha256(
+            {
+                "schema_version": CONDITIONAL_UNCERTAINTY_V2_SCHEMA_VERSION,
+                "artifact_kind": "Causal4DJointPredictiveMomentsV2",
+                "method": self.method,
+                "mean_sha256": array_sha256(self.mean),
+                "covariance_sha256": array_sha256(self.covariance_m2),
+                "source_artifact_ids": list(self.source_artifact_ids),
+            }
+        )
+
+
+def _combined_group_covariances(
+    structured: Mapping[str, np.ndarray],
+    additional: Mapping[str, np.ndarray] | None,
+) -> dict[str, np.ndarray]:
+    result = {key: np.asarray(value, dtype=float) for key, value in structured.items()}
+    for key, value in dict(additional or {}).items():
+        additive = np.asarray(value, dtype=float)
+        if key in result:
+            try:
+                result[key] = result[key] + additive
+            except ValueError as error:
+                raise ValueError(
+                    f"additional covariance for group {key!r} cannot broadcast"
+                ) from error
+        else:
+            result[key] = additive
+    return result
+
+
+def posterior_weights_with_conditional_uncertainty_v2(
+    bank: ContactPatchRolloutBankV2,
+    evidence: ContactObservationEvidenceV2,
+    uncertainty: ConditionalPredictiveUncertaintyV2,
+    *,
+    prefix_frame_count: int,
+    additional_group_covariance_m2: Mapping[str, np.ndarray] | None = None,
+) -> tuple[np.ndarray, ContactLikelihoodV2Diagnostics]:
+    """Update joint component weights with diagonal and correlated uncertainty."""
+
+    group_covariance = _combined_group_covariances(
+        uncertainty.component_group_covariance_m2(bank, evidence),
+        additional_group_covariance_m2,
+    )
+    return posterior_weights_from_contact_evidence_v2(
+        bank.prior_joint_weights,
+        bank.trajectories_m,
+        evidence,
+        prefix_frame_count=prefix_frame_count,
+        component_variance_m2=(
+            uncertainty.independent_component_variance_m2(bank)
+        ),
+        component_group_covariance_m2=group_covariance,
+    )
+
+
+def predictive_distribution_with_conditional_uncertainty_v2(
+    bank: ContactPatchRolloutBankV2,
+    uncertainty: ConditionalPredictiveUncertaintyV2,
+    joint_weights: np.ndarray | None = None,
+    *,
+    method: str = "latent_contact_patch_v2_structured_uncertainty",
+    conditional_variance_multiplier: float = 1.0,
+    include_intervals: bool = True,
+) -> PredictiveDistribution:
+    """Mix component-specific marginal Gaussian uncertainty exactly."""
+
+    weights = _normalized_weights(
+        bank.prior_joint_weights if joint_weights is None else joint_weights,
+        expected_shape=bank.prior_joint_weights.shape,
+    )
+    multiplier = _finite_positive_float(
+        conditional_variance_multiplier,
+        name="conditional_variance_multiplier",
+    )
+    flat_weights = weights.reshape(-1)
+    components = bank.trajectories_m.reshape(
+        -1,
+        *bank.trajectories_m.shape[-3:],
+    )
+    conditional_variance = (
+        multiplier
+        * uncertainty.marginal_component_variance_m2(bank).reshape(
+            components.shape
+        )
+    )
+    mean = np.sum(flat_weights[:, None, None, None] * components, axis=0)
+    variance = np.sum(
+        flat_weights[:, None, None, None]
+        * (conditional_variance + np.square(components - mean[None, ...])),
+        axis=0,
+    )
+    if not include_intervals:
+        return PredictiveDistribution(method=method, mean=mean, variance=variance)
+    tail = 0.5 * (1.0 - bank.confidence_level)
+    interval = gaussian_mixture_quantiles(
+        components,
+        conditional_variance,
+        flat_weights,
+        (tail, 1.0 - tail),
+    )
+    return PredictiveDistribution(
+        method=method,
+        mean=mean,
+        variance=variance,
+        interval_lower=interval[0],
+        interval_upper=interval[1],
+    )
+
+
+def joint_predictive_moments_with_conditional_uncertainty_v2(
+    bank: ContactPatchRolloutBankV2,
+    uncertainty: ConditionalPredictiveUncertaintyV2,
+    joint_weights: np.ndarray | None = None,
+    *,
+    method: str = "latent_contact_patch_v2_structured_uncertainty",
+    conditional_variance_multiplier: float = 1.0,
+) -> JointPredictiveMomentsV2:
+    """Apply the full law of total covariance in flattened trajectory space.
+
+    This diagnostic intentionally materializes a dense ``D x D`` covariance and
+    should therefore be used only for bounded query windows.
+    """
+
+    weights = _normalized_weights(
+        bank.prior_joint_weights if joint_weights is None else joint_weights,
+        expected_shape=bank.prior_joint_weights.shape,
+    ).reshape(-1)
+    multiplier = _finite_positive_float(
+        conditional_variance_multiplier,
+        name="conditional_variance_multiplier",
+    )
+    components = bank.trajectories_m.reshape(
+        -1,
+        int(np.prod(bank.trajectories_m.shape[-3:])),
+    )
+    mean_flat = np.sum(weights[:, None] * components, axis=0)
+    centered = components - mean_flat[None, :]
+    covariance = np.einsum("k,ki,kj->ij", weights, centered, centered)
+
+    independent = uncertainty.independent_component_variance_m2(bank).reshape(
+        components.shape
+    )
+    covariance += np.diag(
+        multiplier * np.sum(weights[:, None] * independent, axis=0)
+    )
+    factors = uncertainty.component_low_rank_factors_m(bank)
+    if factors is not None:
+        flat_factors = factors.reshape(
+            len(weights),
+            factors.shape[-4],
+            components.shape[1],
+        )
+        covariance += multiplier * np.einsum(
+            "k,kri,krj->ij",
+            weights,
+            flat_factors,
+            flat_factors,
+        )
+    covariance = 0.5 * (covariance + covariance.T)
+    return JointPredictiveMomentsV2(
+        method=method,
+        mean=mean_flat.reshape(bank.trajectories_m.shape[-3:]),
+        covariance_m2=covariance,
+        source_artifact_ids=(bank.bank_id, uncertainty.artifact_id),
+    )
+
+
+__all__ = [
+    "CONDITIONAL_UNCERTAINTY_V2_SCHEMA_VERSION",
+    "ConditionalPredictiveUncertaintyV2",
+    "JointPredictiveMomentsV2",
+    "joint_predictive_moments_with_conditional_uncertainty_v2",
+    "posterior_weights_with_conditional_uncertainty_v2",
+    "predictive_distribution_with_conditional_uncertainty_v2",
+]

--- a/src/causal4d/conditional_uncertainty_v2.py
+++ b/src/causal4d/conditional_uncertainty_v2.py
@@ -127,9 +127,7 @@ class ConditionalPredictiveUncertaintyV2:
         )
         independent = readonly_array(self.independent_variance_m2, dtype=float)
         if not np.all(np.isfinite(independent)) or np.any(independent < 0.0):
-            raise ValueError(
-                "independent_variance_m2 must be finite and nonnegative"
-            )
+            raise ValueError("independent_variance_m2 must be finite and nonnegative")
         factors = None
         if self.low_rank_factors_m is not None:
             factors = readonly_array(self.low_rank_factors_m, dtype=float)
@@ -181,9 +179,7 @@ class ConditionalPredictiveUncertaintyV2:
             "artifact_id": self.artifact_id,
             "uncertainty_id": self.uncertainty_id,
             "source_artifact_ids": list(self.source_artifact_ids),
-            "independent_variance_sha256": array_sha256(
-                self.independent_variance_m2
-            ),
+            "independent_variance_sha256": array_sha256(self.independent_variance_m2),
             "low_rank_factors_sha256": (
                 None
                 if self.low_rank_factors_m is None
@@ -369,9 +365,7 @@ def posterior_weights_with_conditional_uncertainty_v2(
         bank.trajectories_m,
         evidence,
         prefix_frame_count=prefix_frame_count,
-        component_variance_m2=(
-            uncertainty.independent_component_variance_m2(bank)
-        ),
+        component_variance_m2=(uncertainty.independent_component_variance_m2(bank)),
         component_group_covariance_m2=group_covariance,
     )
 
@@ -400,12 +394,9 @@ def predictive_distribution_with_conditional_uncertainty_v2(
         -1,
         *bank.trajectories_m.shape[-3:],
     )
-    conditional_variance = (
-        multiplier
-        * uncertainty.marginal_component_variance_m2(bank).reshape(
-            components.shape
-        )
-    )
+    conditional_variance = multiplier * uncertainty.marginal_component_variance_m2(
+        bank
+    ).reshape(components.shape)
     mean = np.sum(flat_weights[:, None, None, None] * components, axis=0)
     variance = np.sum(
         flat_weights[:, None, None, None]
@@ -463,9 +454,7 @@ def joint_predictive_moments_with_conditional_uncertainty_v2(
     independent = uncertainty.independent_component_variance_m2(bank).reshape(
         components.shape
     )
-    covariance += np.diag(
-        multiplier * np.sum(weights[:, None] * independent, axis=0)
-    )
+    covariance += np.diag(multiplier * np.sum(weights[:, None] * independent, axis=0))
     factors = uncertainty.component_low_rank_factors_m(bank)
     if factors is not None:
         flat_factors = factors.reshape(

--- a/src/causal4d/conditional_uncertainty_v2.py
+++ b/src/causal4d/conditional_uncertainty_v2.py
@@ -1,7 +1,7 @@
 """Prospective structured conditional uncertainty for latent-contact v2.
 
 The registered estimator and the existing :mod:`causal4d.latent_contact_v2`
-rollout-bank contract remain unchanged.  This additive module supplies a
+rollout-bank contract remain unchanged. This additive module supplies a
 provenance-bearing uncertainty layer that can be projected through the existing
 linear observation groups and can expose the full law-of-total-covariance result
 for joint calibration diagnostics.
@@ -30,6 +30,7 @@ from causal4d.latent_contact_v2 import (
 
 
 CONDITIONAL_UNCERTAINTY_V2_SCHEMA_VERSION = 1
+DEFAULT_MAXIMUM_JOINT_DIMENSION = 2048
 
 
 def _canonical_sha256(payload: Mapping[str, Any]) -> str:
@@ -81,6 +82,18 @@ def _finite_positive_float(value: Any, *, name: str) -> float:
     return result
 
 
+def _positive_integer(value: Any, *, name: str) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(
+        value,
+        (int, np.integer),
+    ):
+        raise ValueError(f"{name} must be a positive integer")
+    result = int(value)
+    if result < 1:
+        raise ValueError(f"{name} must be a positive integer")
+    return result
+
+
 def _normalized_weights(
     values: np.ndarray,
     *,
@@ -102,12 +115,12 @@ class ConditionalPredictiveUncertaintyV2:
     """Diagonal residual variance plus Gaussian low-rank trajectory modes.
 
     ``independent_variance_m2`` must broadcast to the rollout-bank trajectory
-    shape ``(state, particle, frame, node, coordinate)``.  It is added to the
+    shape ``(state, particle, frame, node, coordinate)``. It is added to the
     bank's existing scalar variance floor.
 
-    ``low_rank_factors_m`` may be shared or component-specific.  Its final four
+    ``low_rank_factors_m`` may be shared or component-specific. Its final four
     axes are ``(rank, frame, node, coordinate)``; any leading axes must broadcast
-    to ``(state, particle)``.  For one component, factors ``F`` define the
+    to ``(state, particle)``. For one component, factors ``F`` define the
     correlated conditional covariance ``F.T @ F`` after flattening the queried
     trajectory coordinates.
     """
@@ -428,13 +441,27 @@ def joint_predictive_moments_with_conditional_uncertainty_v2(
     *,
     method: str = "latent_contact_patch_v2_structured_uncertainty",
     conditional_variance_multiplier: float = 1.0,
+    maximum_joint_dimension: int = DEFAULT_MAXIMUM_JOINT_DIMENSION,
 ) -> JointPredictiveMomentsV2:
     """Apply the full law of total covariance in flattened trajectory space.
 
-    This diagnostic intentionally materializes a dense ``D x D`` covariance and
-    should therefore be used only for bounded query windows.
+    This diagnostic intentionally materializes a dense ``D x D`` covariance.
+    ``maximum_joint_dimension`` is checked before any quadratic allocation and
+    must be raised explicitly for larger bounded diagnostics.
     """
 
+    dimension = int(np.prod(bank.trajectories_m.shape[-3:]))
+    maximum_dimension = _positive_integer(
+        maximum_joint_dimension,
+        name="maximum_joint_dimension",
+    )
+    if dimension > maximum_dimension:
+        dense_bytes = dimension * dimension * np.dtype(float).itemsize
+        raise ValueError(
+            "joint predictive dimension exceeds maximum_joint_dimension: "
+            f"dimension={dimension}, maximum={maximum_dimension}, "
+            f"dense_covariance_bytes={dense_bytes}"
+        )
     weights = _normalized_weights(
         bank.prior_joint_weights if joint_weights is None else joint_weights,
         expected_shape=bank.prior_joint_weights.shape,
@@ -443,10 +470,7 @@ def joint_predictive_moments_with_conditional_uncertainty_v2(
         conditional_variance_multiplier,
         name="conditional_variance_multiplier",
     )
-    components = bank.trajectories_m.reshape(
-        -1,
-        int(np.prod(bank.trajectories_m.shape[-3:])),
-    )
+    components = bank.trajectories_m.reshape(-1, dimension)
     mean_flat = np.sum(weights[:, None] * components, axis=0)
     centered = components - mean_flat[None, :]
     covariance = np.einsum("k,ki,kj->ij", weights, centered, centered)
@@ -479,6 +503,7 @@ def joint_predictive_moments_with_conditional_uncertainty_v2(
 
 __all__ = [
     "CONDITIONAL_UNCERTAINTY_V2_SCHEMA_VERSION",
+    "DEFAULT_MAXIMUM_JOINT_DIMENSION",
     "ConditionalPredictiveUncertaintyV2",
     "JointPredictiveMomentsV2",
     "joint_predictive_moments_with_conditional_uncertainty_v2",

--- a/src/causal4d/functional_support_v1.py
+++ b/src/causal4d/functional_support_v1.py
@@ -1,0 +1,604 @@
+"""Source-only rollout-space certification for finite-support reductions.
+
+Parameter-space moments are useful diagnostics but do not certify that a
+nonlinear simulator preserves the query distribution.  This additive module
+compares full and reduced support directly on a frozen source-action library.
+It does not inspect target outcomes and it does not alter the registered
+estimator or the existing latent-contact-v2 support decision.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+from causal4d.contracts import array_sha256
+from causal4d.immutable_array import readonly_array
+from causal4d.immutable_json import plain_json, validated_json_mapping
+from causal4d.latent_contact_v2 import gaussian_mixture_quantiles
+
+
+FUNCTIONAL_SUPPORT_CERTIFICATE_SCHEMA_VERSION = 1
+
+
+def _canonical_sha256(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        plain_json(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _require_nonempty_string(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _validated_string_tuple(values: Any, *, name: str) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise ValueError(f"{name} must be a sequence of strings")
+    result = tuple(
+        _require_nonempty_string(value, name=f"{name}[{index}]")
+        for index, value in enumerate(values)
+    )
+    if not result:
+        raise ValueError(f"{name} must be nonempty")
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must be unique")
+    return result
+
+
+def _finite_nonnegative_float(value: Any, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(
+        value,
+        (int, float, np.integer, np.floating),
+    ):
+        raise ValueError(f"{name} must be a finite nonnegative number")
+    result = float(value)
+    if not np.isfinite(result) or result < 0.0:
+        raise ValueError(f"{name} must be a finite nonnegative number")
+    return result
+
+
+def _finite_positive_float(value: Any, *, name: str) -> float:
+    result = _finite_nonnegative_float(value, name=name)
+    if result <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return result
+
+
+def _normalized_weights(
+    values: np.ndarray,
+    *,
+    count: int,
+    name: str,
+) -> np.ndarray:
+    weights = readonly_array(values, dtype=float)
+    if weights.shape != (count,):
+        raise ValueError(f"{name} must have shape ({count},)")
+    if not np.all(np.isfinite(weights)) or np.any(weights < 0.0):
+        raise ValueError(f"{name} must be finite and nonnegative")
+    total = float(np.sum(weights))
+    if total <= 0.0:
+        raise ValueError(f"{name} must contain positive mass")
+    return readonly_array(weights / total, dtype=float)
+
+
+@dataclass(frozen=True)
+class FunctionalSupportActionV1:
+    """Full and reduced predictive components for one frozen source action."""
+
+    action_id: str
+    full_trajectories_m: np.ndarray
+    full_weights: np.ndarray
+    reduced_trajectories_m: np.ndarray
+    reduced_weights: np.ndarray
+    full_component_variance_m2: np.ndarray | None = None
+    reduced_component_variance_m2: np.ndarray | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        action_id = _require_nonempty_string(self.action_id, name="action_id")
+        full = readonly_array(self.full_trajectories_m, dtype=float)
+        reduced = readonly_array(self.reduced_trajectories_m, dtype=float)
+        if full.ndim != 4 or reduced.ndim != 4:
+            raise ValueError(
+                "support trajectories must have shape "
+                "(component, frame, node, coordinate)"
+            )
+        if full.shape[1:] != reduced.shape[1:]:
+            raise ValueError("full and reduced trajectories must share query shape")
+        if full.shape[0] < 1 or reduced.shape[0] < 1:
+            raise ValueError("support trajectories must contain components")
+        if not np.all(np.isfinite(full)) or not np.all(np.isfinite(reduced)):
+            raise ValueError("support trajectories must be finite")
+        full_weights = _normalized_weights(
+            self.full_weights,
+            count=full.shape[0],
+            name="full_weights",
+        )
+        reduced_weights = _normalized_weights(
+            self.reduced_weights,
+            count=reduced.shape[0],
+            name="reduced_weights",
+        )
+        full_variance = self._validated_optional_variance(
+            self.full_component_variance_m2,
+            full.shape,
+            name="full_component_variance_m2",
+        )
+        reduced_variance = self._validated_optional_variance(
+            self.reduced_component_variance_m2,
+            reduced.shape,
+            name="reduced_component_variance_m2",
+        )
+        metadata = validated_json_mapping(
+            self.metadata,
+            error_message="support-action metadata must contain finite JSON data",
+        )
+        object.__setattr__(self, "action_id", action_id)
+        object.__setattr__(self, "full_trajectories_m", full)
+        object.__setattr__(self, "full_weights", full_weights)
+        object.__setattr__(self, "reduced_trajectories_m", reduced)
+        object.__setattr__(self, "reduced_weights", reduced_weights)
+        object.__setattr__(self, "full_component_variance_m2", full_variance)
+        object.__setattr__(
+            self,
+            "reduced_component_variance_m2",
+            reduced_variance,
+        )
+        object.__setattr__(self, "metadata", metadata)
+
+    @staticmethod
+    def _validated_optional_variance(
+        values: np.ndarray | None,
+        trajectory_shape: tuple[int, ...],
+        *,
+        name: str,
+    ) -> np.ndarray | None:
+        if values is None:
+            return None
+        variance = readonly_array(values, dtype=float)
+        try:
+            broadcast = np.broadcast_to(variance, trajectory_shape)
+        except ValueError as error:
+            raise ValueError(f"{name} cannot broadcast to trajectories") from error
+        if not np.all(np.isfinite(broadcast)) or np.any(broadcast < 0.0):
+            raise ValueError(f"{name} must be finite and nonnegative")
+        return variance
+
+    @property
+    def action_artifact_id(self) -> str:
+        return _canonical_sha256(
+            {
+                "schema_version": FUNCTIONAL_SUPPORT_CERTIFICATE_SCHEMA_VERSION,
+                "artifact_kind": "Causal4DFunctionalSupportActionV1",
+                "action_id": self.action_id,
+                "full_trajectories_sha256": array_sha256(
+                    self.full_trajectories_m
+                ),
+                "full_weights_sha256": array_sha256(self.full_weights),
+                "reduced_trajectories_sha256": array_sha256(
+                    self.reduced_trajectories_m
+                ),
+                "reduced_weights_sha256": array_sha256(self.reduced_weights),
+                "full_component_variance_sha256": (
+                    None
+                    if self.full_component_variance_m2 is None
+                    else array_sha256(self.full_component_variance_m2)
+                ),
+                "reduced_component_variance_sha256": (
+                    None
+                    if self.reduced_component_variance_m2 is None
+                    else array_sha256(self.reduced_component_variance_m2)
+                ),
+                "metadata": plain_json(self.metadata),
+            }
+        )
+
+
+@dataclass(frozen=True)
+class FunctionalSupportPolicyV1:
+    """Source-frozen thresholds for rollout-space support preservation."""
+
+    maximum_normalized_mean_error: float
+    maximum_variance_trace_relative_error: float
+    maximum_interval_endpoint_error_m: float
+    maximum_energy_distance_m: float
+    confidence_level: float = 0.90
+    variance_floor_m2: float = 1e-12
+    normalization_floor_m: float = 1e-6
+    minimum_action_count: int = 1
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "maximum_normalized_mean_error",
+            _finite_nonnegative_float(
+                self.maximum_normalized_mean_error,
+                name="maximum_normalized_mean_error",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "maximum_variance_trace_relative_error",
+            _finite_nonnegative_float(
+                self.maximum_variance_trace_relative_error,
+                name="maximum_variance_trace_relative_error",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "maximum_interval_endpoint_error_m",
+            _finite_nonnegative_float(
+                self.maximum_interval_endpoint_error_m,
+                name="maximum_interval_endpoint_error_m",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "maximum_energy_distance_m",
+            _finite_nonnegative_float(
+                self.maximum_energy_distance_m,
+                name="maximum_energy_distance_m",
+            ),
+        )
+        confidence = _finite_positive_float(
+            self.confidence_level,
+            name="confidence_level",
+        )
+        if confidence >= 1.0:
+            raise ValueError("confidence_level must be less than one")
+        object.__setattr__(self, "confidence_level", confidence)
+        object.__setattr__(
+            self,
+            "variance_floor_m2",
+            _finite_positive_float(
+                self.variance_floor_m2,
+                name="variance_floor_m2",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "normalization_floor_m",
+            _finite_positive_float(
+                self.normalization_floor_m,
+                name="normalization_floor_m",
+            ),
+        )
+        if type(self.minimum_action_count) is not int or self.minimum_action_count < 1:
+            raise ValueError("minimum_action_count must be a positive integer")
+
+
+@dataclass(frozen=True)
+class FunctionalSupportActionMetricsV1:
+    action_id: str
+    full_component_count: int
+    reduced_component_count: int
+    mean_rmse_m: float
+    normalization_scale_m: float
+    normalized_mean_error: float
+    full_variance_trace_m2: float
+    reduced_variance_trace_m2: float
+    variance_trace_relative_error: float
+    maximum_interval_endpoint_error_m: float
+    energy_distance_m: float
+    accepted: bool
+    reasons: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        _require_nonempty_string(self.action_id, name="action_id")
+        if self.full_component_count < 1 or self.reduced_component_count < 1:
+            raise ValueError("action metrics require positive component counts")
+        for name in (
+            "mean_rmse_m",
+            "normalization_scale_m",
+            "normalized_mean_error",
+            "full_variance_trace_m2",
+            "reduced_variance_trace_m2",
+            "variance_trace_relative_error",
+            "maximum_interval_endpoint_error_m",
+            "energy_distance_m",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _finite_nonnegative_float(getattr(self, name), name=name),
+            )
+        reasons = tuple(self.reasons)
+        if self.accepted and reasons:
+            raise ValueError("accepted action metrics cannot contain reasons")
+        if not self.accepted and not reasons:
+            raise ValueError("rejected action metrics require reasons")
+        if len(set(reasons)) != len(reasons):
+            raise ValueError("action rejection reasons must be unique")
+        object.__setattr__(self, "reasons", reasons)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "action_id": self.action_id,
+            "full_component_count": self.full_component_count,
+            "reduced_component_count": self.reduced_component_count,
+            "mean_rmse_m": self.mean_rmse_m,
+            "normalization_scale_m": self.normalization_scale_m,
+            "normalized_mean_error": self.normalized_mean_error,
+            "full_variance_trace_m2": self.full_variance_trace_m2,
+            "reduced_variance_trace_m2": self.reduced_variance_trace_m2,
+            "variance_trace_relative_error": (
+                self.variance_trace_relative_error
+            ),
+            "maximum_interval_endpoint_error_m": (
+                self.maximum_interval_endpoint_error_m
+            ),
+            "energy_distance_m": self.energy_distance_m,
+            "accepted": self.accepted,
+            "reasons": list(self.reasons),
+        }
+
+
+@dataclass(frozen=True)
+class FunctionalSupportCertificateV1:
+    """Fail-closed certificate over independent frozen source actions."""
+
+    accepted: bool
+    reasons: tuple[str, ...]
+    action_metrics: tuple[FunctionalSupportActionMetricsV1, ...]
+    policy: FunctionalSupportPolicyV1
+    source_artifact_ids: tuple[str, ...]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        metrics = tuple(self.action_metrics)
+        if len(metrics) < self.policy.minimum_action_count:
+            raise ValueError("certificate has fewer actions than required by policy")
+        action_ids = tuple(metric.action_id for metric in metrics)
+        if len(set(action_ids)) != len(action_ids):
+            raise ValueError("certificate action IDs must be unique")
+        reasons = tuple(self.reasons)
+        expected_reasons = tuple(
+            f"{metric.action_id}:{reason}"
+            for metric in metrics
+            for reason in metric.reasons
+        )
+        expected_accepted = not expected_reasons
+        if self.accepted is not expected_accepted or reasons != expected_reasons:
+            raise ValueError(
+                "certificate decision must exactly match its action metrics"
+            )
+        if len(set(reasons)) != len(reasons):
+            raise ValueError("certificate rejection reasons must be unique")
+        source_ids = _validated_string_tuple(
+            self.source_artifact_ids,
+            name="source_artifact_ids",
+        )
+        metadata = validated_json_mapping(
+            self.metadata,
+            error_message="certificate metadata must contain finite JSON data",
+        )
+        object.__setattr__(self, "reasons", reasons)
+        object.__setattr__(self, "action_metrics", metrics)
+        object.__setattr__(self, "source_artifact_ids", source_ids)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def certificate_id(self) -> str:
+        return _canonical_sha256(
+            {
+                "schema_version": FUNCTIONAL_SUPPORT_CERTIFICATE_SCHEMA_VERSION,
+                "artifact_kind": "Causal4DFunctionalSupportCertificateV1",
+                "accepted": self.accepted,
+                "reasons": list(self.reasons),
+                "action_metrics": [metric.as_dict() for metric in self.action_metrics],
+                "policy": asdict(self.policy),
+                "source_artifact_ids": list(self.source_artifact_ids),
+                "metadata": plain_json(self.metadata),
+            }
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": FUNCTIONAL_SUPPORT_CERTIFICATE_SCHEMA_VERSION,
+            "artifact_kind": "Causal4DFunctionalSupportCertificateV1",
+            "certificate_id": self.certificate_id,
+            "accepted": self.accepted,
+            "reasons": list(self.reasons),
+            "action_metrics": [metric.as_dict() for metric in self.action_metrics],
+            "policy": asdict(self.policy),
+            "source_artifact_ids": list(self.source_artifact_ids),
+            "metadata": plain_json(self.metadata),
+        }
+
+
+def _component_variance(
+    values: np.ndarray | None,
+    trajectories: np.ndarray,
+    *,
+    floor_m2: float,
+) -> np.ndarray:
+    if values is None:
+        return np.full_like(trajectories, floor_m2, dtype=float)
+    return np.broadcast_to(values, trajectories.shape) + floor_m2
+
+
+def _mixture_mean_and_variance(
+    trajectories: np.ndarray,
+    weights: np.ndarray,
+    component_variance_m2: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    mean = np.sum(weights[:, None, None, None] * trajectories, axis=0)
+    variance = np.sum(
+        weights[:, None, None, None]
+        * (component_variance_m2 + np.square(trajectories - mean[None, ...])),
+        axis=0,
+    )
+    return mean, variance
+
+
+def _rms_pairwise_distance(first: np.ndarray, second: np.ndarray) -> np.ndarray:
+    first_flat = first.reshape(first.shape[0], -1)
+    second_flat = second.reshape(second.shape[0], -1)
+    difference = first_flat[:, None, :] - second_flat[None, :, :]
+    return np.sqrt(np.mean(np.square(difference), axis=-1))
+
+
+def _weighted_energy_distance_m(
+    full: np.ndarray,
+    full_weights: np.ndarray,
+    reduced: np.ndarray,
+    reduced_weights: np.ndarray,
+) -> float:
+    cross = _rms_pairwise_distance(full, reduced)
+    full_pair = _rms_pairwise_distance(full, full)
+    reduced_pair = _rms_pairwise_distance(reduced, reduced)
+    value = (
+        2.0 * float(np.einsum("i,j,ij->", full_weights, reduced_weights, cross))
+        - float(np.einsum("i,j,ij->", full_weights, full_weights, full_pair))
+        - float(
+            np.einsum(
+                "i,j,ij->",
+                reduced_weights,
+                reduced_weights,
+                reduced_pair,
+            )
+        )
+    )
+    return max(value, 0.0)
+
+
+def _evaluate_action(
+    action: FunctionalSupportActionV1,
+    policy: FunctionalSupportPolicyV1,
+) -> FunctionalSupportActionMetricsV1:
+    full_variance = _component_variance(
+        action.full_component_variance_m2,
+        action.full_trajectories_m,
+        floor_m2=policy.variance_floor_m2,
+    )
+    reduced_variance = _component_variance(
+        action.reduced_component_variance_m2,
+        action.reduced_trajectories_m,
+        floor_m2=policy.variance_floor_m2,
+    )
+    full_mean, full_predictive_variance = _mixture_mean_and_variance(
+        action.full_trajectories_m,
+        action.full_weights,
+        full_variance,
+    )
+    reduced_mean, reduced_predictive_variance = _mixture_mean_and_variance(
+        action.reduced_trajectories_m,
+        action.reduced_weights,
+        reduced_variance,
+    )
+    mean_rmse = float(np.sqrt(np.mean(np.square(reduced_mean - full_mean))))
+    normalization_scale = max(
+        float(np.sqrt(np.mean(full_predictive_variance))),
+        policy.normalization_floor_m,
+    )
+    normalized_mean_error = mean_rmse / normalization_scale
+    full_trace = float(np.sum(full_predictive_variance))
+    reduced_trace = float(np.sum(reduced_predictive_variance))
+    trace_relative_error = abs(reduced_trace - full_trace) / max(
+        full_trace,
+        np.finfo(float).tiny,
+    )
+    tail = 0.5 * (1.0 - policy.confidence_level)
+    full_interval = gaussian_mixture_quantiles(
+        action.full_trajectories_m,
+        full_variance,
+        action.full_weights,
+        (tail, 1.0 - tail),
+    )
+    reduced_interval = gaussian_mixture_quantiles(
+        action.reduced_trajectories_m,
+        reduced_variance,
+        action.reduced_weights,
+        (tail, 1.0 - tail),
+    )
+    interval_error = float(np.max(np.abs(reduced_interval - full_interval)))
+    energy_distance = _weighted_energy_distance_m(
+        action.full_trajectories_m,
+        action.full_weights,
+        action.reduced_trajectories_m,
+        action.reduced_weights,
+    )
+
+    reasons: list[str] = []
+    if normalized_mean_error > policy.maximum_normalized_mean_error:
+        reasons.append("normalized_mean_error_exceeds_limit")
+    if trace_relative_error > policy.maximum_variance_trace_relative_error:
+        reasons.append("variance_trace_relative_error_exceeds_limit")
+    if interval_error > policy.maximum_interval_endpoint_error_m:
+        reasons.append("interval_endpoint_error_exceeds_limit")
+    if energy_distance > policy.maximum_energy_distance_m:
+        reasons.append("energy_distance_exceeds_limit")
+    return FunctionalSupportActionMetricsV1(
+        action_id=action.action_id,
+        full_component_count=action.full_trajectories_m.shape[0],
+        reduced_component_count=action.reduced_trajectories_m.shape[0],
+        mean_rmse_m=mean_rmse,
+        normalization_scale_m=normalization_scale,
+        normalized_mean_error=normalized_mean_error,
+        full_variance_trace_m2=full_trace,
+        reduced_variance_trace_m2=reduced_trace,
+        variance_trace_relative_error=trace_relative_error,
+        maximum_interval_endpoint_error_m=interval_error,
+        energy_distance_m=energy_distance,
+        accepted=not reasons,
+        reasons=tuple(reasons),
+    )
+
+
+def certify_functional_support_v1(
+    actions: Sequence[FunctionalSupportActionV1],
+    *,
+    policy: FunctionalSupportPolicyV1,
+    source_artifact_ids: Sequence[str],
+    metadata: Mapping[str, Any] | None = None,
+) -> FunctionalSupportCertificateV1:
+    """Certify a reduction on a frozen source-action library, failing closed."""
+
+    action_tuple = tuple(actions)
+    if len(action_tuple) < policy.minimum_action_count:
+        raise ValueError("insufficient source actions for functional certification")
+    if any(type(action) is not FunctionalSupportActionV1 for action in action_tuple):
+        raise ValueError("actions must contain FunctionalSupportActionV1 values")
+    if len({action.action_id for action in action_tuple}) != len(action_tuple):
+        raise ValueError("source action IDs must be unique")
+    metrics = tuple(_evaluate_action(action, policy) for action in action_tuple)
+    reasons = tuple(
+        f"{metric.action_id}:{reason}"
+        for metric in metrics
+        for reason in metric.reasons
+    )
+    source_ids = _validated_string_tuple(
+        source_artifact_ids,
+        name="source_artifact_ids",
+    )
+    provenance = source_ids + tuple(
+        action.action_artifact_id for action in action_tuple
+    )
+    return FunctionalSupportCertificateV1(
+        accepted=not reasons,
+        reasons=reasons,
+        action_metrics=metrics,
+        policy=policy,
+        source_artifact_ids=provenance,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+__all__ = [
+    "FUNCTIONAL_SUPPORT_CERTIFICATE_SCHEMA_VERSION",
+    "FunctionalSupportActionMetricsV1",
+    "FunctionalSupportActionV1",
+    "FunctionalSupportCertificateV1",
+    "FunctionalSupportPolicyV1",
+    "certify_functional_support_v1",
+]

--- a/src/causal4d/functional_support_v1.py
+++ b/src/causal4d/functional_support_v1.py
@@ -181,9 +181,7 @@ class FunctionalSupportActionV1:
                 "schema_version": FUNCTIONAL_SUPPORT_CERTIFICATE_SCHEMA_VERSION,
                 "artifact_kind": "Causal4DFunctionalSupportActionV1",
                 "action_id": self.action_id,
-                "full_trajectories_sha256": array_sha256(
-                    self.full_trajectories_m
-                ),
+                "full_trajectories_sha256": array_sha256(self.full_trajectories_m),
                 "full_weights_sha256": array_sha256(self.full_weights),
                 "reduced_trajectories_sha256": array_sha256(
                     self.reduced_trajectories_m
@@ -331,9 +329,7 @@ class FunctionalSupportActionMetricsV1:
             "normalized_mean_error": self.normalized_mean_error,
             "full_variance_trace_m2": self.full_variance_trace_m2,
             "reduced_variance_trace_m2": self.reduced_variance_trace_m2,
-            "variance_trace_relative_error": (
-                self.variance_trace_relative_error
-            ),
+            "variance_trace_relative_error": (self.variance_trace_relative_error),
             "maximum_interval_endpoint_error_m": (
                 self.maximum_interval_endpoint_error_m
             ),

--- a/src/causal4d/functional_support_v1.py
+++ b/src/causal4d/functional_support_v1.py
@@ -1,7 +1,7 @@
 """Source-only rollout-space certification for finite-support reductions.
 
 Parameter-space moments are useful diagnostics but do not certify that a
-nonlinear simulator preserves the query distribution.  This additive module
+nonlinear simulator preserves the query distribution. This additive module
 compares full and reduced support directly on a frozen source-action library.
 It does not inspect target outcomes and it does not alter the registered
 estimator or the existing latent-contact-v2 support decision.
@@ -23,6 +23,7 @@ from causal4d.latent_contact_v2 import gaussian_mixture_quantiles
 
 
 FUNCTIONAL_SUPPORT_CERTIFICATE_SCHEMA_VERSION = 1
+_ENERGY_DISTANCE_BLOCK_SIZE = 256
 
 
 def _canonical_sha256(payload: Mapping[str, Any]) -> str:
@@ -437,11 +438,57 @@ def _mixture_mean_and_variance(
     return mean, variance
 
 
-def _rms_pairwise_distance(first: np.ndarray, second: np.ndarray) -> np.ndarray:
+def _weighted_rms_distance_expectation(
+    first: np.ndarray,
+    first_weights: np.ndarray,
+    second: np.ndarray,
+    second_weights: np.ndarray,
+) -> float:
+    """Return E[d(X, Y)] with bounded pairwise working memory."""
+
     first_flat = first.reshape(first.shape[0], -1)
     second_flat = second.reshape(second.shape[0], -1)
-    difference = first_flat[:, None, :] - second_flat[None, :, :]
-    return np.sqrt(np.mean(np.square(difference), axis=-1))
+    coordinate_count = first_flat.shape[1]
+    if coordinate_count < 1 or second_flat.shape[1] != coordinate_count:
+        raise ValueError("energy-distance supports must share a nonempty query")
+    total = 0.0
+    for first_start in range(0, len(first_flat), _ENERGY_DISTANCE_BLOCK_SIZE):
+        first_stop = min(
+            first_start + _ENERGY_DISTANCE_BLOCK_SIZE,
+            len(first_flat),
+        )
+        first_block = first_flat[first_start:first_stop]
+        first_block_weights = first_weights[first_start:first_stop]
+        first_squared_norm = np.einsum("id,id->i", first_block, first_block)
+        for second_start in range(0, len(second_flat), _ENERGY_DISTANCE_BLOCK_SIZE):
+            second_stop = min(
+                second_start + _ENERGY_DISTANCE_BLOCK_SIZE,
+                len(second_flat),
+            )
+            second_block = second_flat[second_start:second_stop]
+            second_block_weights = second_weights[second_start:second_stop]
+            second_squared_norm = np.einsum("jd,jd->j", second_block, second_block)
+            squared_distance = (
+                first_squared_norm[:, None]
+                + second_squared_norm[None, :]
+                - 2.0 * (first_block @ second_block.T)
+            )
+            if not np.all(np.isfinite(squared_distance)):
+                raise ValueError("energy-distance pairwise distances must be finite")
+            distance = np.sqrt(
+                np.maximum(squared_distance, 0.0) / coordinate_count
+            )
+            total += float(
+                np.einsum(
+                    "i,j,ij->",
+                    first_block_weights,
+                    second_block_weights,
+                    distance,
+                )
+            )
+    if not np.isfinite(total) or total < 0.0:
+        raise ValueError("weighted pairwise distance must be finite and nonnegative")
+    return total
 
 
 def _weighted_energy_distance_m(
@@ -450,21 +497,29 @@ def _weighted_energy_distance_m(
     reduced: np.ndarray,
     reduced_weights: np.ndarray,
 ) -> float:
-    cross = _rms_pairwise_distance(full, reduced)
-    full_pair = _rms_pairwise_distance(full, full)
-    reduced_pair = _rms_pairwise_distance(reduced, reduced)
     value = (
-        2.0 * float(np.einsum("i,j,ij->", full_weights, reduced_weights, cross))
-        - float(np.einsum("i,j,ij->", full_weights, full_weights, full_pair))
-        - float(
-            np.einsum(
-                "i,j,ij->",
-                reduced_weights,
-                reduced_weights,
-                reduced_pair,
-            )
+        2.0
+        * _weighted_rms_distance_expectation(
+            full,
+            full_weights,
+            reduced,
+            reduced_weights,
+        )
+        - _weighted_rms_distance_expectation(
+            full,
+            full_weights,
+            full,
+            full_weights,
+        )
+        - _weighted_rms_distance_expectation(
+            reduced,
+            reduced_weights,
+            reduced,
+            reduced_weights,
         )
     )
+    if not np.isfinite(value):
+        raise ValueError("energy distance must be finite")
     return max(value, 0.0)
 
 

--- a/src/causal4d/functional_support_v1.py
+++ b/src/causal4d/functional_support_v1.py
@@ -92,6 +92,14 @@ def _normalized_weights(
     return readonly_array(weights / total, dtype=float)
 
 
+def _require_no_target_access(value: Any, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a boolean")
+    if value:
+        raise ValueError(f"{name} must be false for source-only certification")
+    return False
+
+
 @dataclass(frozen=True)
 class FunctionalSupportActionV1:
     """Full and reduced predictive components for one frozen source action."""
@@ -103,6 +111,7 @@ class FunctionalSupportActionV1:
     reduced_weights: np.ndarray
     full_component_variance_m2: np.ndarray | None = None
     reduced_component_variance_m2: np.ndarray | None = None
+    target_outcomes_used: bool = False
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -140,6 +149,10 @@ class FunctionalSupportActionV1:
             reduced.shape,
             name="reduced_component_variance_m2",
         )
+        target_outcomes_used = _require_no_target_access(
+            self.target_outcomes_used,
+            name="target_outcomes_used",
+        )
         metadata = validated_json_mapping(
             self.metadata,
             error_message="support-action metadata must contain finite JSON data",
@@ -155,6 +168,7 @@ class FunctionalSupportActionV1:
             "reduced_component_variance_m2",
             reduced_variance,
         )
+        object.__setattr__(self, "target_outcomes_used", target_outcomes_used)
         object.__setattr__(self, "metadata", metadata)
 
     @staticmethod
@@ -198,6 +212,7 @@ class FunctionalSupportActionV1:
                     if self.reduced_component_variance_m2 is None
                     else array_sha256(self.reduced_component_variance_m2)
                 ),
+                "target_outcomes_used": self.target_outcomes_used,
                 "metadata": plain_json(self.metadata),
             }
         )
@@ -330,7 +345,7 @@ class FunctionalSupportActionMetricsV1:
             "normalized_mean_error": self.normalized_mean_error,
             "full_variance_trace_m2": self.full_variance_trace_m2,
             "reduced_variance_trace_m2": self.reduced_variance_trace_m2,
-            "variance_trace_relative_error": (self.variance_trace_relative_error),
+            "variance_trace_relative_error": self.variance_trace_relative_error,
             "maximum_interval_endpoint_error_m": (
                 self.maximum_interval_endpoint_error_m
             ),
@@ -349,6 +364,7 @@ class FunctionalSupportCertificateV1:
     action_metrics: tuple[FunctionalSupportActionMetricsV1, ...]
     policy: FunctionalSupportPolicyV1
     source_artifact_ids: tuple[str, ...]
+    target_outcomes_used: bool = False
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -375,6 +391,10 @@ class FunctionalSupportCertificateV1:
             self.source_artifact_ids,
             name="source_artifact_ids",
         )
+        target_outcomes_used = _require_no_target_access(
+            self.target_outcomes_used,
+            name="target_outcomes_used",
+        )
         metadata = validated_json_mapping(
             self.metadata,
             error_message="certificate metadata must contain finite JSON data",
@@ -382,6 +402,7 @@ class FunctionalSupportCertificateV1:
         object.__setattr__(self, "reasons", reasons)
         object.__setattr__(self, "action_metrics", metrics)
         object.__setattr__(self, "source_artifact_ids", source_ids)
+        object.__setattr__(self, "target_outcomes_used", target_outcomes_used)
         object.__setattr__(self, "metadata", metadata)
 
     @property
@@ -395,6 +416,7 @@ class FunctionalSupportCertificateV1:
                 "action_metrics": [metric.as_dict() for metric in self.action_metrics],
                 "policy": asdict(self.policy),
                 "source_artifact_ids": list(self.source_artifact_ids),
+                "target_outcomes_used": self.target_outcomes_used,
                 "metadata": plain_json(self.metadata),
             }
         )
@@ -409,6 +431,7 @@ class FunctionalSupportCertificateV1:
             "action_metrics": [metric.as_dict() for metric in self.action_metrics],
             "policy": asdict(self.policy),
             "source_artifact_ids": list(self.source_artifact_ids),
+            "target_outcomes_used": self.target_outcomes_used,
             "metadata": plain_json(self.metadata),
         }
 
@@ -622,6 +645,8 @@ def certify_functional_support_v1(
         raise ValueError("actions must contain FunctionalSupportActionV1 values")
     if len({action.action_id for action in action_tuple}) != len(action_tuple):
         raise ValueError("source action IDs must be unique")
+    if any(action.target_outcomes_used for action in action_tuple):
+        raise ValueError("source actions must not use target outcomes")
     metrics = tuple(_evaluate_action(action, policy) for action in action_tuple)
     reasons = tuple(
         f"{metric.action_id}:{reason}"
@@ -641,6 +666,7 @@ def certify_functional_support_v1(
         action_metrics=metrics,
         policy=policy,
         source_artifact_ids=provenance,
+        target_outcomes_used=False,
         metadata={} if metadata is None else metadata,
     )
 

--- a/tests/test_conditional_uncertainty_dimension_guard.py
+++ b/tests/test_conditional_uncertainty_dimension_guard.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import causal4d.conditional_uncertainty_v2 as uncertainty_module
+from causal4d.baselines import ParameterPosterior
+from causal4d.conditional_uncertainty_v2 import (
+    ConditionalPredictiveUncertaintyV2,
+    joint_predictive_moments_with_conditional_uncertainty_v2,
+)
+from causal4d.contact_inference import ContactPrior, LatentContactConfig
+from causal4d.latent_contact_v2 import (
+    ContactV2SupportPolicy,
+    GraphContactPatchModelV2,
+    build_contact_patch_rollout_bank_v2,
+)
+from causal4d.simulator import (
+    Action,
+    GraphObject,
+    PhysicalParameters,
+    SimulatorConfig,
+)
+
+
+def _bank():
+    graph = GraphObject(
+        name="guard-chain",
+        rest_positions=np.asarray(((0.0, 0.0), (1.0, 0.0), (2.0, 0.0))),
+        edges=((0, 1), (1, 2)),
+        mass=1.0,
+        support_stiffness=0.2,
+        true_parameters=PhysicalParameters(1.0, 0.4, 1.0),
+        sensor_nodes=(0, 1, 2),
+    )
+    force = np.zeros((5, 1, 2), dtype=float)
+    force[:, 0, 0] = np.linspace(0.2, 0.6, 5)
+    action = Action(
+        action_id="push",
+        split="test",
+        contact_nodes=(1,),
+        commanded_forces=force,
+    )
+    particles = np.asarray(
+        ((0.8, 0.3, 0.8), (1.0, 0.4, 1.0), (1.2, 0.5, 1.2)),
+        dtype=float,
+    )
+    weights = np.asarray((0.2, 0.5, 0.3), dtype=float)
+    posterior = ParameterPosterior(
+        particles=particles,
+        weights=weights,
+        log_likelihood=np.log(weights),
+    )
+    config = LatentContactConfig(
+        gain_values=(1.0,),
+        delay_values=(0,),
+        slip_values=(0.0,),
+        rotation_values_deg=(0.0,),
+        parameter_particle_count=3,
+    )
+    prior = ContactPrior(
+        shift_probability=0.25,
+        gain_probabilities=(1.0,),
+        delay_probabilities=(1.0,),
+        slip_probabilities=(1.0,),
+        rotation_probabilities=(1.0,),
+        source_objects=("source",),
+        source_condition_count=1,
+        source_action_split="train",
+    )
+    model = GraphContactPatchModelV2(
+        prior=prior,
+        config=config,
+        patch_spreads=(0.0,),
+        patch_spread_probabilities=(1.0,),
+        maximum_joint_patches=8,
+    )
+    return build_contact_patch_rollout_bank_v2(
+        graph,
+        action,
+        posterior,
+        model,
+        simulator_config=SimulatorConfig(frame_count=action.frame_count, dt=0.03),
+        support_policy=ContactV2SupportPolicy(maximum_parameter_count=2),
+        variance_floor_m2=1e-6,
+        confidence_level=0.9,
+    )
+
+
+def test_dimension_guard_runs_before_quadratic_allocation(monkeypatch) -> None:
+    bank = _bank()
+    uncertainty = ConditionalPredictiveUncertaintyV2(
+        source_artifact_ids=("source",),
+    )
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("quadratic allocation path was entered")
+
+    monkeypatch.setattr(uncertainty_module.np, "einsum", forbidden)
+    with pytest.raises(
+        ValueError,
+        match="dimension exceeds maximum_joint_dimension",
+    ):
+        joint_predictive_moments_with_conditional_uncertainty_v2(
+            bank,
+            uncertainty,
+            maximum_joint_dimension=1,
+        )
+
+
+@pytest.mark.parametrize("value", [0, -1, True, 1.5])
+def test_dimension_guard_requires_a_positive_integer(value) -> None:
+    bank = _bank()
+    uncertainty = ConditionalPredictiveUncertaintyV2(
+        source_artifact_ids=("source",),
+    )
+
+    with pytest.raises(ValueError, match="positive integer"):
+        joint_predictive_moments_with_conditional_uncertainty_v2(
+            bank,
+            uncertainty,
+            maximum_joint_dimension=value,
+        )

--- a/tests/test_conditional_uncertainty_v2.py
+++ b/tests/test_conditional_uncertainty_v2.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import causal4d.conditional_uncertainty_v2 as uncertainty_module
+from causal4d.baselines import ParameterPosterior
+from causal4d.conditional_uncertainty_v2 import (
+    ConditionalPredictiveUncertaintyV2,
+    joint_predictive_moments_with_conditional_uncertainty_v2,
+    posterior_weights_with_conditional_uncertainty_v2,
+    predictive_distribution_with_conditional_uncertainty_v2,
+)
+from causal4d.contact_inference import ContactPrior, LatentContactConfig
+from causal4d.latent_contact_v2 import (
+    ContactObservationEvidenceV2,
+    ContactV2SupportPolicy,
+    GraphContactPatchModelV2,
+    LinearContactObservationGroup,
+    build_contact_patch_rollout_bank_v2,
+)
+from causal4d.simulator import (
+    Action,
+    GraphObject,
+    PhysicalParameters,
+    SimulatorConfig,
+)
+
+
+def _graph() -> GraphObject:
+    return GraphObject(
+        name="chain3",
+        rest_positions=np.asarray(((0.0, 0.0), (1.0, 0.0), (2.0, 0.0))),
+        edges=((0, 1), (1, 2)),
+        mass=1.0,
+        support_stiffness=0.2,
+        true_parameters=PhysicalParameters(1.0, 0.4, 1.0),
+        sensor_nodes=(0, 1, 2),
+    )
+
+
+def _action(frame_count: int = 6) -> Action:
+    force = np.zeros((frame_count - 1, 1, 2), dtype=float)
+    force[:, 0, 0] = np.linspace(0.2, 0.6, frame_count - 1)
+    return Action(
+        action_id="push",
+        split="test",
+        contact_nodes=(1,),
+        commanded_forces=force,
+    )
+
+
+def _posterior() -> ParameterPosterior:
+    particles = np.asarray(
+        (
+            (0.8, 0.3, 0.8),
+            (1.0, 0.4, 1.0),
+            (1.2, 0.5, 1.2),
+            (1.4, 0.6, 1.4),
+        ),
+        dtype=float,
+    )
+    weights = np.asarray((0.15, 0.45, 0.30, 0.10), dtype=float)
+    return ParameterPosterior(
+        particles=particles,
+        weights=weights,
+        log_likelihood=np.log(weights),
+    )
+
+
+def _contact_model() -> GraphContactPatchModelV2:
+    config = LatentContactConfig(
+        gain_values=(1.0,),
+        delay_values=(0,),
+        slip_values=(0.0,),
+        rotation_values_deg=(0.0,),
+        parameter_particle_count=3,
+    )
+    prior = ContactPrior(
+        shift_probability=0.25,
+        gain_probabilities=(1.0,),
+        delay_probabilities=(1.0,),
+        slip_probabilities=(1.0,),
+        rotation_probabilities=(1.0,),
+        source_objects=("source",),
+        source_condition_count=1,
+        source_action_split="train",
+    )
+    return GraphContactPatchModelV2(
+        prior=prior,
+        config=config,
+        patch_spreads=(0.0, 0.5),
+        patch_spread_probabilities=(0.7, 0.3),
+        maximum_joint_patches=16,
+    )
+
+
+@pytest.fixture(scope="module")
+def bank():
+    action = _action()
+    return build_contact_patch_rollout_bank_v2(
+        _graph(),
+        action,
+        _posterior(),
+        _contact_model(),
+        simulator_config=SimulatorConfig(frame_count=action.frame_count, dt=0.03),
+        support_policy=ContactV2SupportPolicy(maximum_parameter_count=2),
+        variance_floor_m2=1e-6,
+        confidence_level=0.9,
+    )
+
+
+def _difference_group() -> LinearContactObservationGroup:
+    return LinearContactObservationGroup(
+        group_id="difference",
+        values_m=np.asarray((0.0,)),
+        row_indices=np.asarray((0, 0)),
+        frame_indices=np.asarray((0, 1)),
+        node_indices=np.asarray((0, 0)),
+        coordinate_indices=np.asarray((0, 0)),
+        coefficients=np.asarray((-1.0, 1.0)),
+        covariance_m2=np.asarray(((1e-4,),)),
+        contributor_ids=("camera",),
+    )
+
+
+def test_low_rank_mode_projects_through_linear_group(bank) -> None:
+    factors = np.zeros(
+        (1, *bank.trajectories_m.shape[-3:]),
+        dtype=float,
+    )
+    factors[0, 0, 0, 0] = 1.0
+    factors[0, 1, 0, 0] = 3.0
+    uncertainty = ConditionalPredictiveUncertaintyV2(
+        source_artifact_ids=("prob4d-mode-belief",),
+        low_rank_factors_m=factors,
+    )
+    evidence = ContactObservationEvidenceV2((_difference_group(),))
+    covariance = uncertainty.component_group_covariance_m2(bank, evidence)
+    projected = covariance["difference"]
+    assert projected.shape == (*bank.prior_joint_weights.shape, 1, 1)
+    assert np.allclose(projected[..., 0, 0], 4.0)
+
+
+def test_joint_covariance_diagonal_matches_marginal_prediction(bank) -> None:
+    independent = np.full(bank.trajectories_m.shape[-3:], 2e-6)
+    factors = np.zeros(
+        (1, *bank.trajectories_m.shape[-3:]),
+        dtype=float,
+    )
+    factors[0, 0, 0, 0] = 1e-3
+    factors[0, 0, 0, 1] = 2e-3
+    uncertainty = ConditionalPredictiveUncertaintyV2(
+        source_artifact_ids=("bpt-conditional-covariance",),
+        independent_variance_m2=independent,
+        low_rank_factors_m=factors,
+    )
+    weights = np.zeros_like(bank.prior_joint_weights)
+    weights[0, 0] = 1.0
+    marginal = predictive_distribution_with_conditional_uncertainty_v2(
+        bank,
+        uncertainty,
+        weights,
+        include_intervals=False,
+    )
+    joint = joint_predictive_moments_with_conditional_uncertainty_v2(
+        bank,
+        uncertainty,
+        weights,
+    )
+    assert np.allclose(joint.variance_m2, marginal.variance)
+    assert joint.covariance_m2[0, 1] == pytest.approx(2e-6)
+    assert joint.source_artifact_ids == (bank.bank_id, uncertainty.artifact_id)
+
+
+def test_weight_update_receives_residual_and_correlated_terms(
+    bank,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    factors = np.zeros(
+        (1, *bank.trajectories_m.shape[-3:]),
+        dtype=float,
+    )
+    factors[0, 0, 0, 0] = 1.0
+    factors[0, 1, 0, 0] = 2.0
+    uncertainty = ConditionalPredictiveUncertaintyV2(
+        source_artifact_ids=("conditional-source",),
+        independent_variance_m2=0.5,
+        low_rank_factors_m=factors,
+    )
+    evidence = ContactObservationEvidenceV2((_difference_group(),))
+    captured: dict[str, object] = {}
+
+    def capture(
+        prior_weights: np.ndarray,
+        predicted_components_m: np.ndarray,
+        supplied_evidence: ContactObservationEvidenceV2,
+        **kwargs: object,
+    ) -> tuple[np.ndarray, object]:
+        captured.update(kwargs)
+        return prior_weights, object()
+
+    monkeypatch.setattr(
+        uncertainty_module,
+        "posterior_weights_from_contact_evidence_v2",
+        capture,
+    )
+    weights, _ = posterior_weights_with_conditional_uncertainty_v2(
+        bank,
+        evidence,
+        uncertainty,
+        prefix_frame_count=2,
+    )
+    assert np.array_equal(weights, bank.prior_joint_weights)
+    assert np.allclose(
+        captured["component_variance_m2"],
+        0.5 + bank.variance_floor_m2,
+    )
+    group_covariance = captured["component_group_covariance_m2"]
+    assert isinstance(group_covariance, dict)
+    assert np.allclose(group_covariance["difference"], 1.0)
+
+
+def test_uncertainty_identity_binds_provenance_and_arrays_are_immutable() -> None:
+    first = ConditionalPredictiveUncertaintyV2(
+        source_artifact_ids=("source-a",),
+        independent_variance_m2=np.asarray(0.1),
+    )
+    second = ConditionalPredictiveUncertaintyV2(
+        source_artifact_ids=("source-b",),
+        independent_variance_m2=np.asarray(0.1),
+    )
+    assert first.artifact_id != second.artifact_id
+    with pytest.raises(ValueError):
+        first.independent_variance_m2.setflags(write=True)

--- a/tests/test_functional_support_energy_blocks.py
+++ b/tests/test_functional_support_energy_blocks.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from causal4d.functional_support_v1 import _weighted_energy_distance_m
+
+
+def _direct_energy_distance(
+    full: np.ndarray,
+    full_weights: np.ndarray,
+    reduced: np.ndarray,
+    reduced_weights: np.ndarray,
+) -> float:
+    def pairwise(first: np.ndarray, second: np.ndarray) -> np.ndarray:
+        difference = first.reshape(first.shape[0], -1)[:, None, :] - second.reshape(
+            second.shape[0], -1
+        )[None, :, :]
+        return np.sqrt(np.mean(np.square(difference), axis=-1))
+
+    cross = pairwise(full, reduced)
+    full_pair = pairwise(full, full)
+    reduced_pair = pairwise(reduced, reduced)
+    value = (
+        2.0 * np.einsum("i,j,ij->", full_weights, reduced_weights, cross)
+        - np.einsum("i,j,ij->", full_weights, full_weights, full_pair)
+        - np.einsum(
+            "i,j,ij->",
+            reduced_weights,
+            reduced_weights,
+            reduced_pair,
+        )
+    )
+    return max(float(value), 0.0)
+
+
+def test_blockwise_energy_distance_matches_direct_definition() -> None:
+    rng = np.random.default_rng(41)
+    full = rng.normal(size=(7, 3, 2, 2))
+    reduced = rng.normal(size=(5, 3, 2, 2))
+    full_weights = rng.uniform(size=len(full))
+    reduced_weights = rng.uniform(size=len(reduced))
+    full_weights /= np.sum(full_weights)
+    reduced_weights /= np.sum(reduced_weights)
+
+    observed = _weighted_energy_distance_m(
+        full,
+        full_weights,
+        reduced,
+        reduced_weights,
+    )
+    expected = _direct_energy_distance(
+        full,
+        full_weights,
+        reduced,
+        reduced_weights,
+    )
+
+    assert observed == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_blockwise_energy_distance_is_zero_for_identical_support() -> None:
+    rng = np.random.default_rng(17)
+    support = rng.normal(size=(11, 4, 3, 2))
+    weights = rng.uniform(size=len(support))
+    weights /= np.sum(weights)
+
+    assert _weighted_energy_distance_m(
+        support,
+        weights,
+        support.copy(),
+        weights.copy(),
+    ) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_blockwise_energy_distance_crosses_internal_block_boundary() -> None:
+    full = np.arange(300 * 2, dtype=float).reshape(300, 1, 1, 2) / 1000.0
+    reduced = full[::3].copy()
+    full_weights = np.full(len(full), 1.0 / len(full))
+    reduced_weights = np.full(len(reduced), 1.0 / len(reduced))
+
+    value = _weighted_energy_distance_m(
+        full,
+        full_weights,
+        reduced,
+        reduced_weights,
+    )
+
+    assert np.isfinite(value)
+    assert value >= 0.0
+
+
+def test_blockwise_energy_distance_rejects_overflow() -> None:
+    full = np.full((2, 1, 1, 1), np.finfo(float).max)
+    reduced = -full
+    weights = np.asarray((0.5, 0.5))
+
+    with np.errstate(over="ignore", invalid="ignore"):
+        with pytest.raises(ValueError, match="pairwise distances must be finite"):
+            _weighted_energy_distance_m(full, weights, reduced, weights)

--- a/tests/test_functional_support_source_scope.py
+++ b/tests/test_functional_support_source_scope.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from causal4d.functional_support_v1 import (
+    FunctionalSupportActionV1,
+    FunctionalSupportCertificateV1,
+    FunctionalSupportPolicyV1,
+    certify_functional_support_v1,
+)
+
+
+def _action(**overrides) -> FunctionalSupportActionV1:
+    values = {
+        "action_id": "source-session-1/action-1",
+        "full_trajectories_m": np.zeros((1, 2, 1, 1)),
+        "full_weights": np.ones(1),
+        "reduced_trajectories_m": np.zeros((1, 2, 1, 1)),
+        "reduced_weights": np.ones(1),
+    }
+    values.update(overrides)
+    return FunctionalSupportActionV1(**values)
+
+
+def _policy() -> FunctionalSupportPolicyV1:
+    return FunctionalSupportPolicyV1(
+        maximum_normalized_mean_error=0.0,
+        maximum_variance_trace_relative_error=0.0,
+        maximum_interval_endpoint_error_m=0.0,
+        maximum_energy_distance_m=0.0,
+    )
+
+
+def test_action_rejects_target_outcome_access() -> None:
+    with pytest.raises(ValueError, match="must be false"):
+        _action(target_outcomes_used=True)
+    with pytest.raises(ValueError, match="must be a boolean"):
+        _action(target_outcomes_used=0)
+
+
+def test_certificate_binds_no_target_access_declaration() -> None:
+    certificate = certify_functional_support_v1(
+        (_action(),),
+        policy=_policy(),
+        source_artifact_ids=("source-freeze",),
+    )
+
+    assert certificate.accepted is True
+    assert certificate.target_outcomes_used is False
+    assert certificate.as_dict()["target_outcomes_used"] is False
+    assert certificate.source_artifact_ids[0] == "source-freeze"
+
+
+def test_direct_certificate_construction_rejects_target_access() -> None:
+    certificate = certify_functional_support_v1(
+        (_action(),),
+        policy=_policy(),
+        source_artifact_ids=("source-freeze",),
+    )
+
+    with pytest.raises(ValueError, match="must be false"):
+        FunctionalSupportCertificateV1(
+            accepted=certificate.accepted,
+            reasons=certificate.reasons,
+            action_metrics=certificate.action_metrics,
+            policy=certificate.policy,
+            source_artifact_ids=certificate.source_artifact_ids,
+            target_outcomes_used=True,
+        )

--- a/tests/test_functional_support_v1.py
+++ b/tests/test_functional_support_v1.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from causal4d.functional_support_v1 import (
+    FunctionalSupportActionV1,
+    FunctionalSupportCertificateV1,
+    FunctionalSupportPolicyV1,
+    certify_functional_support_v1,
+)
+
+
+def _policy(**overrides: float | int) -> FunctionalSupportPolicyV1:
+    values: dict[str, float | int] = {
+        "maximum_normalized_mean_error": 0.05,
+        "maximum_variance_trace_relative_error": 0.05,
+        "maximum_interval_endpoint_error_m": 0.05,
+        "maximum_energy_distance_m": 0.05,
+        "variance_floor_m2": 1e-4,
+    }
+    values.update(overrides)
+    return FunctionalSupportPolicyV1(**values)
+
+
+def test_identical_predictive_support_is_certified() -> None:
+    trajectories = np.asarray(
+        (
+            (((-1.0, 0.0),),),
+            (((1.0, 0.0),),),
+        )
+    )
+    action = FunctionalSupportActionV1(
+        action_id="source-action",
+        full_trajectories_m=trajectories,
+        full_weights=np.asarray((0.5, 0.5)),
+        reduced_trajectories_m=trajectories.copy(),
+        reduced_weights=np.asarray((0.5, 0.5)),
+    )
+    certificate = certify_functional_support_v1(
+        (action,),
+        policy=_policy(),
+        source_artifact_ids=("source-freeze",),
+    )
+    assert certificate.accepted
+    assert certificate.reasons == ()
+    metrics = certificate.action_metrics[0]
+    assert metrics.normalized_mean_error == pytest.approx(0.0)
+    assert metrics.energy_distance_m == pytest.approx(0.0)
+
+
+def test_mean_preserving_support_collapse_is_rejected() -> None:
+    full = np.asarray(
+        (
+            (((-1.0, 0.0),),),
+            (((1.0, 0.0),),),
+        )
+    )
+    reduced = np.asarray(((((0.0, 0.0),),),))
+    action = FunctionalSupportActionV1(
+        action_id="source-action",
+        full_trajectories_m=full,
+        full_weights=np.asarray((0.5, 0.5)),
+        reduced_trajectories_m=reduced,
+        reduced_weights=np.asarray((1.0,)),
+    )
+    certificate = certify_functional_support_v1(
+        (action,),
+        policy=_policy(),
+        source_artifact_ids=("source-freeze",),
+    )
+    assert not certificate.accepted
+    metrics = certificate.action_metrics[0]
+    assert metrics.mean_rmse_m == pytest.approx(0.0)
+    assert "source-action:variance_trace_relative_error_exceeds_limit" in (
+        certificate.reasons
+    )
+    assert "source-action:interval_endpoint_error_exceeds_limit" in (
+        certificate.reasons
+    )
+    assert "source-action:energy_distance_exceeds_limit" in certificate.reasons
+
+
+def test_certificate_fails_on_the_worst_source_action() -> None:
+    exact = np.asarray(((((0.0, 0.0),),),))
+    shifted = np.asarray(((((0.2, 0.0),),),))
+    good = FunctionalSupportActionV1(
+        "good",
+        exact,
+        np.asarray((1.0,)),
+        exact,
+        np.asarray((1.0,)),
+    )
+    bad = FunctionalSupportActionV1(
+        "bad",
+        exact,
+        np.asarray((1.0,)),
+        shifted,
+        np.asarray((1.0,)),
+    )
+    certificate = certify_functional_support_v1(
+        (good, bad),
+        policy=_policy(minimum_action_count=2),
+        source_artifact_ids=("source-library",),
+    )
+    assert not certificate.accepted
+    assert certificate.action_metrics[0].accepted
+    assert not certificate.action_metrics[1].accepted
+    assert all(reason.startswith("bad:") for reason in certificate.reasons)
+
+
+def test_certificate_identity_binds_source_provenance() -> None:
+    trajectories = np.asarray(((((0.0, 0.0),),),))
+    action = FunctionalSupportActionV1(
+        "source-action",
+        trajectories,
+        np.asarray((1.0,)),
+        trajectories,
+        np.asarray((1.0,)),
+    )
+    first = certify_functional_support_v1(
+        (action,),
+        policy=_policy(),
+        source_artifact_ids=("freeze-a",),
+    )
+    second = certify_functional_support_v1(
+        (action,),
+        policy=_policy(),
+        source_artifact_ids=("freeze-b",),
+    )
+    assert first.certificate_id != second.certificate_id
+    with pytest.raises(ValueError, match="sequence of strings"):
+        certify_functional_support_v1(
+            (action,),
+            policy=_policy(),
+            source_artifact_ids="not-a-sequence",
+        )
+
+
+def test_certificate_decision_must_match_action_metrics() -> None:
+    trajectories = np.asarray(((((0.0, 0.0),),),))
+    action = FunctionalSupportActionV1(
+        "source-action",
+        trajectories,
+        np.asarray((1.0,)),
+        trajectories,
+        np.asarray((1.0,)),
+    )
+    certificate = certify_functional_support_v1(
+        (action,),
+        policy=_policy(),
+        source_artifact_ids=("freeze",),
+    )
+    with pytest.raises(ValueError, match="exactly match"):
+        replace(
+            certificate,
+            accepted=False,
+            reasons=("invented",),
+        )
+    assert isinstance(certificate, FunctionalSupportCertificateV1)
+    with pytest.raises(ValueError):
+        action.full_trajectories_m.setflags(write=True)


### PR DESCRIPTION
## Summary

- add `ConditionalPredictiveUncertaintyV2` with content-addressed provenance, broadcast residual variance, and shared or component-specific low-rank trajectory modes;
- project correlated modes through the existing `LinearContactObservationGroup` operators during latent-contact-v2 weight updates;
- add exact marginal Gaussian-mixture prediction plus optional dense law-of-total-covariance moments for bounded joint calibration and NEES diagnostics;
- reject oversized dense joint diagnostics before any quadratic allocation and report the requested byte footprint;
- add source-only `FunctionalSupportCertificateV1`, which evaluates finite reductions in rollout space using normalized mean error, variance-trace error, interval-endpoint error, and weighted energy distance;
- compute energy distance with bounded Gram-matrix blocks rather than an `N × M × trajectory_dimension` difference tensor;
- bind `target_outcomes_used=false` into every source-action and certificate identity and reject true or non-Boolean declarations; and
- add real-bank integration, dimension-guard, blockwise-energy, source-scope, adversarial, and certificate tests plus a scientific-boundary document.

## Why

The current latent-contact-v2 rollout bank supplies every component with one scalar variance floor. In addition, a weighted parameter coreset can report full represented probability mass while still changing the nonlinear predictive distribution. This PR adds the missing conditional-uncertainty and functional-certification layers without changing existing v2 behavior.

## Numerical and provenance boundaries

- conditional diagonal variance is added exactly once, including the rollout bank's existing floor;
- low-rank factors are projected through each registered linear observation operator before robust likelihood scoring;
- marginal prediction uses exact one-dimensional Gaussian-mixture quantiles;
- full joint moments use the complete law of total covariance;
- dense covariance construction is opt-in and dimension-bounded before allocation;
- energy distance retains the exact weighted trajectory-RMS definition while bounding working memory to fixed component blocks;
- support actions and certificates are immutable, content-addressed, source-artifact-bound, and explicitly record that no target outcomes were used.

## Validation

The original branch validation established:

- `python -m py_compile` for both modules and their initial tests;
- Ruff check and format validation;
- 9 focused structured-uncertainty/functional-support tests;
- 26 directly affected latent-contact/parameter-support regression tests;
- 1,370 core tests passed with 16 expected skips against the previous green source distribution; and
- an isolated wheel build/import plus focused installed-wheel tests.

The final review added focused regressions for:

- pre-allocation rejection of oversized dense covariance diagnostics;
- invalid dimension limits;
- blockwise energy-distance equivalence to the direct definition;
- the internal block boundary and overflow failure path; and
- action/certificate target-access declarations.

Exact-head repository workflows on `ec4e5d952a00ad0950328ba3d0f6a27c944c6e68` are queued because of the current hosted-runner backlog. They remain authoritative for the complete Python/provider/security matrix; no queued run is represented as passed.

## Scientific boundary

This is prospective, additive infrastructure. It changes no registered estimator, threshold, dataset split, acquisition order, frozen artifact, evidence count, target-access rule, or frozen 18-session/36-execution result. An accepted functional certificate applies only to its frozen source-action query family and does not establish target-domain accuracy, physical confirmation, or promotion of latent-contact v2.