### PR TITLE
Superseded by #238: Reject mixed-coordinate endpoint cancellation

### DIFF
--- a/.github/workflows/_branch_linear_observation_translation_fix.yml
+++ b/.github/workflows/_branch_linear_observation_translation_fix.yml
@@ -6,9 +6,16 @@ on:
     paths:
       - ".github/workflows/_branch_linear_observation_translation_fix.yml"
       - "scripts/ci/apply_linear_observation_translation_fix.py"
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/_branch_linear_observation_translation_fix.yml"
+      - "scripts/ci/apply_linear_observation_translation_fix.py"
 
 permissions:
   contents: write
+  pull-requests: read
 
 concurrency:
   group: branch-linear-observation-translation-fix
@@ -18,14 +25,20 @@ jobs:
   apply-and-validate:
     if: >-
       github.repository == 'IPS-Stuttgart/Causal4D' &&
-      github.ref == 'refs/heads/fix/linear-observation-translation-neutrality'
+      ((github.event_name == 'push' &&
+        github.ref == 'refs/heads/fix/linear-observation-translation-neutrality') ||
+       (github.event_name == 'pull_request' &&
+        github.event.pull_request.number == 234 &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.head.ref ==
+          'fix/linear-observation-translation-neutrality'))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Check out exact branch revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           persist-credentials: true
           clean: true

--- a/.github/workflows/_branch_linear_observation_translation_fix.yml
+++ b/.github/workflows/_branch_linear_observation_translation_fix.yml
@@ -1,11 +1,6 @@
 name: Branch linear-observation translation fix
 
 on:
-  push:
-    branches: [fix/linear-observation-translation-neutrality]
-    paths:
-      - ".github/workflows/_branch_linear_observation_translation_fix.yml"
-      - "scripts/ci/apply_linear_observation_translation_fix.py"
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
@@ -18,27 +13,25 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: branch-linear-observation-translation-fix
-  cancel-in-progress: true
+  group: branch-linear-observation-translation-fix-pr-234
+  cancel-in-progress: false
 
 jobs:
   apply-and-validate:
     if: >-
       github.repository == 'IPS-Stuttgart/Causal4D' &&
-      ((github.event_name == 'push' &&
-        github.ref == 'refs/heads/fix/linear-observation-translation-neutrality') ||
-       (github.event_name == 'pull_request' &&
-        github.event.pull_request.number == 234 &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.pull_request.head.ref ==
-          'fix/linear-observation-translation-neutrality'))
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.number == 234 &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.head.ref ==
+        'fix/linear-observation-translation-neutrality'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Check out exact branch revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: true
           clean: true

--- a/.github/workflows/_branch_linear_observation_translation_fix.yml
+++ b/.github/workflows/_branch_linear_observation_translation_fix.yml
@@ -1,0 +1,86 @@
+name: Branch linear-observation translation fix
+
+on:
+  push:
+    branches: [fix/linear-observation-translation-neutrality]
+    paths:
+      - ".github/workflows/_branch_linear_observation_translation_fix.yml"
+      - "scripts/ci/apply_linear_observation_translation_fix.py"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: branch-linear-observation-translation-fix
+  cancel-in-progress: true
+
+jobs:
+  apply-and-validate:
+    if: >-
+      github.repository == 'IPS-Stuttgart/Causal4D' &&
+      github.ref == 'refs/heads/fix/linear-observation-translation-neutrality'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact branch revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: true
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Apply exact reviewed source change
+        run: python scripts/ci/apply_linear_observation_translation_fix.py
+
+      - name: Install development environment
+        run: |
+          python -m pip install -e ".[dev]"
+          python -m pip check
+
+      - name: Format and lint retained changes
+        run: |
+          python -m ruff format \
+            src/causal4d/latent_contact_v2.py \
+            tests/test_linear_contact_observation_translation.py
+          python -m ruff check \
+            src/causal4d/latent_contact_v2.py \
+            tests/test_linear_contact_observation_translation.py
+          python -m ruff format --check \
+            src/causal4d/latent_contact_v2.py \
+            tests/test_linear_contact_observation_translation.py
+
+      - name: Run focused and adjacent contracts
+        run: |
+          python -m pytest -q \
+            tests/test_linear_contact_observation_translation.py \
+            tests/test_latent_contact_v2.py \
+            tests/test_contact_posterior_diagnostics.py
+          python -m py_compile src/causal4d/latent_contact_v2.py
+
+      - name: Remove branch transport and verify final scope
+        run: |
+          rm -- \
+            .github/workflows/_branch_linear_observation_translation_fix.yml \
+            scripts/ci/apply_linear_observation_translation_fix.py
+          git diff --check
+          allowed='^(docs/linear_observation_translation_neutrality.md|src/causal4d/latent_contact_v2.py|tests/test_linear_contact_observation_translation.py)$'
+          unexpected="$(git diff --name-only 2c2ef42620adb5c77b14104b390beddf69118efa -- | grep -Ev "${allowed}" || true)"
+          if [[ -n "${unexpected}" ]]; then
+            printf 'Unexpected final paths:\n%s\n' "${unexpected}" >&2
+            exit 1
+          fi
+
+      - name: Commit validated final source
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          git commit -m 'Enforce coordinate-wise endpoint contrasts'
+          git push origin HEAD:fix/linear-observation-translation-neutrality

--- a/docs/linear_observation_translation_neutrality.md
+++ b/docs/linear_observation_translation_neutrality.md
@@ -1,0 +1,35 @@
+# Translation-neutral linear observation contrasts
+
+`LinearContactObservationGroup` may include frame zero only to form a registered
+response contrast. Frame zero is not a fresh absolute endpoint observation.
+
+For Cartesian trajectories, ordinary translation acts independently on each
+coordinate. A row is therefore translation-neutral only when, for every
+coordinate used by that row, its operator coefficients sum to zero:
+
+```text
+for every row r and coordinate c:
+    sum(a_j for terms j in row r with coordinate c) = 0
+```
+
+A global coefficient sum is insufficient. For example,
+
+```text
++x(frame 0) - y(frame 1)
+```
+
+has global sum zero but changes under translation because the unmatched `x` and
+`y` masses cannot cancel each other. It would reuse the endpoint as an absolute
+observation and is rejected.
+
+Valid examples include same-coordinate temporal differences and weighted
+multi-node contrasts such as:
+
+```text
+-x_node0(frame 0) + 0.5 x_node0(frame 1) + 0.5 x_node1(frame 1)
+```
+
+Rows without frame-zero terms retain their existing semantics. This validation
+changes only malformed endpoint contrasts; it does not change the frozen
+`v0.3.0-causal4d-aip` estimator, the registered 18-session/36-execution
+protocol, evidence counts, or target-access rules.

--- a/scripts/ci/apply_linear_observation_translation_fix.py
+++ b/scripts/ci/apply_linear_observation_translation_fix.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Apply the coordinate-wise endpoint-contrast validation change."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TARGET = ROOT / "src" / "causal4d" / "latent_contact_v2.py"
+
+OLD = '''        for row in np.unique(rows[frames == 0]):
+            row_terms = rows == row
+            if not np.isclose(
+                float(np.sum(coefficients[row_terms])),
+                0.0,
+                atol=1e-12,
+                rtol=1e-12,
+            ):
+                raise ValueError(
+                    "endpoint frame zero may appear only in a zero-sum contrast"
+                )
+            if not np.any(frames[row_terms] > 0):
+                raise ValueError("endpoint contrasts require a positive response frame")
+'''
+
+NEW = '''        for row in np.unique(rows[frames == 0]):
+            row_terms = rows == row
+            for coordinate in np.unique(coordinates[row_terms]):
+                coordinate_terms = row_terms & (coordinates == coordinate)
+                if not np.isclose(
+                    float(np.sum(coefficients[coordinate_terms])),
+                    0.0,
+                    atol=1e-12,
+                    rtol=1e-12,
+                ):
+                    raise ValueError(
+                        "endpoint frame zero may appear only in a "
+                        "coordinate-wise zero-sum contrast"
+                    )
+            if not np.any(frames[row_terms] > 0):
+                raise ValueError("endpoint contrasts require a positive response frame")
+'''
+
+
+def main() -> None:
+    text = TARGET.read_text(encoding="utf-8")
+    count = text.count(OLD)
+    if count != 1:
+        raise SystemExit(
+            "expected exactly one reviewed endpoint validation block, "
+            f"found {count}"
+        )
+    TARGET.write_text(text.replace(OLD, NEW), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_linear_contact_observation_translation.py
+++ b/tests/test_linear_contact_observation_translation.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from causal4d.latent_contact_v2 import LinearContactObservationGroup
+
+
+def _group(
+    *,
+    frame_indices: list[int],
+    node_indices: list[int],
+    coordinate_indices: list[int],
+    coefficients: list[float],
+) -> LinearContactObservationGroup:
+    term_count = len(frame_indices)
+    assert len(node_indices) == term_count
+    assert len(coordinate_indices) == term_count
+    assert len(coefficients) == term_count
+    return LinearContactObservationGroup(
+        group_id="translation-neutrality-test",
+        values_m=np.zeros(1),
+        row_indices=np.zeros(term_count, dtype=int),
+        frame_indices=np.asarray(frame_indices, dtype=int),
+        node_indices=np.asarray(node_indices, dtype=int),
+        coordinate_indices=np.asarray(coordinate_indices, dtype=int),
+        coefficients=np.asarray(coefficients, dtype=float),
+        covariance_m2=np.eye(1),
+        contributor_ids=("registered-endpoint", "registered-response"),
+        source_id="adversarial-contract-test",
+    )
+
+
+def test_mixed_coordinate_endpoint_cancellation_is_rejected() -> None:
+    with pytest.raises(ValueError, match="coordinate-wise zero-sum contrast"):
+        _group(
+            frame_indices=[0, 1],
+            node_indices=[0, 0],
+            coordinate_indices=[0, 1],
+            coefficients=[1.0, -1.0],
+        )
+
+
+def test_global_zero_sum_cannot_hide_coordinate_translation_mass() -> None:
+    with pytest.raises(ValueError, match="coordinate-wise zero-sum contrast"):
+        _group(
+            frame_indices=[0, 1, 1],
+            node_indices=[0, 0, 0],
+            coordinate_indices=[0, 0, 1],
+            coefficients=[-1.0, 0.5, 0.5],
+        )
+
+
+def test_same_coordinate_response_difference_remains_valid() -> None:
+    group = _group(
+        frame_indices=[0, 1],
+        node_indices=[0, 0],
+        coordinate_indices=[0, 0],
+        coefficients=[-1.0, 1.0],
+    )
+    trajectory = np.zeros((2, 1, 2), dtype=float)
+    trajectory[0, 0, 0] = 1.25
+    trajectory[1, 0, 0] = 3.75
+
+    np.testing.assert_allclose(group.apply(trajectory), [2.5])
+
+
+def test_multi_node_same_coordinate_contrast_remains_valid() -> None:
+    group = _group(
+        frame_indices=[0, 1, 1],
+        node_indices=[0, 0, 1],
+        coordinate_indices=[0, 0, 0],
+        coefficients=[-1.0, 0.5, 0.5],
+    )
+    trajectory = np.zeros((2, 2, 2), dtype=float)
+    trajectory[0, 0, 0] = 1.0
+    trajectory[1, 0, 0] = 3.0
+    trajectory[1, 1, 0] = 5.0
+
+    np.testing.assert_allclose(group.apply(trajectory), [3.0])
+
+
+def test_each_coordinate_may_have_its_own_valid_difference() -> None:
+    group = _group(
+        frame_indices=[0, 1, 0, 1],
+        node_indices=[0, 0, 0, 0],
+        coordinate_indices=[0, 0, 1, 1],
+        coefficients=[-1.0, 1.0, -2.0, 2.0],
+    )
+    trajectory = np.zeros((2, 1, 2), dtype=float)
+    trajectory[0, 0] = [1.0, 2.0]
+    trajectory[1, 0] = [4.0, 5.0]
+
+    np.testing.assert_allclose(group.apply(trajectory), [9.0])


### PR DESCRIPTION
Superseded by #238, which targets the same issue (#233) with a single checksum-bound repair, broader invariance coverage, and a clearer final three-file diff.

This branch never applied its source transformer and still contains temporary transport machinery, so it is closed rather than merged. No scientific result, frozen protocol, or physical evidence count is changed.