### PR TITLE
Focus CLI help on stable workflows

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -11,6 +11,33 @@ Every operation is a typed, lazily imported grouped route. Root help, command
 inventory, migration lookup, and metadata validation do not import optional
 BayesianPhysTwin, Warp, vision, or GPU dependencies.
 
+## Focused discovery
+
+The default root help intentionally shows only `stable` routes. This gives new
+users the supported reproduction, evidence, calibration, and protocol surface
+without mixing it with diagnostics, prospective experiments, public-study
+utilities, or archived paths:
+
+```bash
+causal4d --help
+```
+
+The complete catalog remains available without importing command modules:
+
+```bash
+causal4d --help-all
+causal4d commands list
+causal4d commands list --lifecycle stable
+causal4d commands list --lifecycle diagnostic --lifecycle experimental
+causal4d commands list --claim-bearing --json
+```
+
+`--help-all` includes an explicit lifecycle label after every summary. Lifecycle
+filters are repeatable and combine as a union. `--claim-bearing` can be combined
+with lifecycle and removed-executable filters. An unfiltered
+`causal4d commands list --json` remains the complete machine-readable inventory,
+so the focused help view does not hide or delete any route.
+
 ## Stable workflows
 
 ```bash
@@ -74,6 +101,8 @@ surfaces; current releases do not recreate them.
 
 ## Contribution rule
 
-New command functionality must be added to the grouped registry. Adding another
-`[project.scripts]` entry is a packaging-policy violation. Installed wheel and
-source-distribution CI invokes `--help` for every registered grouped route.
+New command functionality must be added to the grouped registry and assigned a
+lifecycle. Adding another `[project.scripts]` entry is a packaging-policy
+violation. Installed wheel and source-distribution CI invokes `--help` for every
+registered grouped route, including commands that the focused root help does not
+show by default.

--- a/src/causal4d/cli/root.py
+++ b/src/causal4d/cli/root.py
@@ -11,11 +11,21 @@ import sys
 
 from causal4d.cli.command_registry import (
     CommandSpec,
+    Lifecycle,
     command_inventory,
     find_command,
     grouped_commands,
     historical_commands,
     validate_runtime_command_inventory,
+)
+
+
+LIFECYCLE_ORDER: tuple[Lifecycle, ...] = (
+    "stable",
+    "diagnostic",
+    "experimental",
+    "public-study",
+    "archive",
 )
 
 
@@ -26,10 +36,29 @@ def _version() -> str:
         return "unknown"
 
 
-def _root_help() -> str:
+def _grouped_help_lines(
+    commands: Sequence[CommandSpec],
+    *,
+    include_lifecycle: bool,
+) -> list[str]:
     groups: dict[str, list[CommandSpec]] = {}
-    for command in grouped_commands():
+    for command in commands:
         groups.setdefault(command.route[0], []).append(command)
+    lines: list[str] = []
+    for group, group_commands in groups.items():
+        lines.append(f"  {group}")
+        for command in group_commands:
+            suffix = " ".join(command.route[1:])
+            lifecycle = f" [{command.lifecycle}]" if include_lifecycle else ""
+            lines.append(f"    {suffix:<40} {command.summary}{lifecycle}")
+    return lines
+
+
+def _root_help(*, include_all: bool = False) -> str:
+    commands = grouped_commands()
+    if not include_all:
+        commands = tuple(command for command in commands if command.lifecycle == "stable")
+    route_heading = "all registered routes:" if include_all else "stable routes:"
     lines = [
         "usage: causal4d <group> <command> [arguments]",
         "       causal4d stack {create,verify} ...",
@@ -37,13 +66,19 @@ def _root_help() -> str:
         "",
         "Single executable for all Causal4D commands. Modules are imported lazily.",
         "",
-        "groups:",
+        route_heading,
+        *_grouped_help_lines(commands, include_lifecycle=include_all),
     ]
-    for group, commands in groups.items():
-        lines.append(f"  {group}")
-        for command in commands:
-            suffix = " ".join(command.route[1:])
-            lines.append(f"    {suffix:<40} {command.summary}")
+    if not include_all:
+        lines.extend(
+            (
+                "",
+                "Only stable routes are shown above.",
+                "Use 'causal4d --help-all' for diagnostic, experimental,",
+                "public-study, and archive routes, or filter the registry with",
+                "'causal4d commands list --lifecycle <lifecycle>'.",
+            )
+        )
     lines.extend(
         (
             "",
@@ -53,7 +88,8 @@ def _root_help() -> str:
             "  stack verify --lock PATH --lock-only [--json]",
             "",
             "introspection:",
-            "  commands list [--json] [--removed-only]",
+            "  commands list [--json] [--removed-only] [--claim-bearing]",
+            "                [--lifecycle LIFECYCLE]",
             "  commands describe <route-or-removed-executable> [--json]",
             "  commands migrate <removed-executable> [--json]",
             "  commands validate [--json] [--require-installed]",
@@ -94,8 +130,26 @@ def _commands_list(arguments: Sequence[str]) -> int:
     parser = argparse.ArgumentParser(prog="causal4d commands list")
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--removed-only", action="store_true")
+    parser.add_argument(
+        "--lifecycle",
+        action="append",
+        choices=LIFECYCLE_ORDER,
+        help="Include only this lifecycle; repeat to select several.",
+    )
+    parser.add_argument(
+        "--claim-bearing",
+        action="store_true",
+        help="Include only routes that can publish claim-bearing evidence.",
+    )
     parsed = parser.parse_args(arguments)
     inventory = command_inventory(removed_only=parsed.removed_only)
+    if parsed.lifecycle:
+        allowed = frozenset(parsed.lifecycle)
+        inventory = tuple(
+            command for command in inventory if command.lifecycle in allowed
+        )
+    if parsed.claim_bearing:
+        inventory = tuple(command for command in inventory if command.claim_bearing)
     if parsed.json:
         print(json.dumps([command.as_dict() for command in inventory], indent=2))
     else:
@@ -105,7 +159,13 @@ def _commands_list(arguments: Sequence[str]) -> int:
                 if command.historical_name
                 else ""
             )
-            print(f"{command.route_name:<52} {command.lifecycle:<12}{historical}")
+            claim = "claim-bearing" if command.claim_bearing else ""
+            print(
+                f"{command.route_name:<52} "
+                f"{command.lifecycle:<12} "
+                f"{claim:<13} "
+                f"{command.summary}{historical}"
+            )
     return 0
 
 
@@ -201,7 +261,11 @@ def _commands(arguments: Sequence[str]) -> int:
     if not arguments or arguments[0] in {"-h", "--help"}:
         print(
             "usage: causal4d commands {list,describe,migrate,validate} ...\n\n"
-            "Inspect current routes and removed executable migrations."
+            "Inspect current routes and removed executable migrations.\n\n"
+            "List filters:\n"
+            "  --lifecycle {stable,diagnostic,experimental,public-study,archive}\n"
+            "  --claim-bearing\n"
+            "  --removed-only"
         )
         return 0
     operation, *remaining = arguments
@@ -252,6 +316,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     arguments = list(sys.argv[1:] if argv is None else argv)
     if not arguments or arguments[0] in {"-h", "--help"}:
         print(_root_help())
+        return 0
+    if arguments[0] == "--help-all":
+        print(_root_help(include_all=True))
         return 0
     if arguments[0] == "--version":
         print(_version())

--- a/tests/test_causal4d_focused_help.py
+++ b/tests/test_causal4d_focused_help.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+
+from causal4d.cli import root
+
+
+def test_default_help_shows_stable_routes_only(capsys) -> None:
+    assert root.main(["--help"]) == 0
+    output = capsys.readouterr().out
+
+    assert "stable routes:" in output
+    assert "counterfactual" in output
+    assert "protocol" in output
+    assert "dynamic-contact" not in output
+    assert "forecast-v1" not in output
+    assert "Only stable routes are shown" in output
+    assert "causal4d --help-all" in output
+
+
+def test_help_all_shows_lifecycle_labels_without_importing_commands(capsys) -> None:
+    assert root.main(["--help-all"]) == 0
+    output = capsys.readouterr().out
+
+    assert "all registered routes:" in output
+    assert "dynamic-contact" in output
+    assert "forecast-v1" in output
+    assert "[experimental]" in output
+    assert "[archive]" in output
+
+
+def test_inventory_filters_by_lifecycle_and_claim_boundary(capsys) -> None:
+    assert root.main(
+        [
+            "commands",
+            "list",
+            "--lifecycle",
+            "stable",
+            "--claim-bearing",
+            "--json",
+        ]
+    ) == 0
+    inventory = json.loads(capsys.readouterr().out)
+
+    assert inventory
+    assert all(item["lifecycle"] == "stable" for item in inventory)
+    assert all(item["claim_bearing"] is True for item in inventory)
+    assert any(item["route"] == ["protocol", "real"] for item in inventory)
+
+
+def test_inventory_accepts_multiple_lifecycle_filters(capsys) -> None:
+    assert root.main(
+        [
+            "commands",
+            "list",
+            "--lifecycle",
+            "diagnostic",
+            "--lifecycle",
+            "experimental",
+            "--json",
+        ]
+    ) == 0
+    inventory = json.loads(capsys.readouterr().out)
+
+    observed = {item["lifecycle"] for item in inventory}
+    assert observed == {"diagnostic", "experimental"}
+    assert all(item["lifecycle"] not in {"stable", "archive"} for item in inventory)
+
+
+def test_unfiltered_json_inventory_remains_complete(capsys) -> None:
+    assert root.main(["commands", "list", "--json"]) == 0
+    inventory = json.loads(capsys.readouterr().out)
+
+    lifecycles = {item["lifecycle"] for item in inventory}
+    assert lifecycles == {
+        "stable",
+        "diagnostic",
+        "experimental",
+        "public-study",
+        "archive",
+    }


### PR DESCRIPTION
## Summary

Make the single `causal4d` executable easier to approach without removing, renaming, or eagerly importing any registered command.

## Changes

- make `causal4d --help` show only routes whose registry lifecycle is `stable`;
- add `causal4d --help-all` for the complete route catalog with explicit lifecycle labels;
- add repeatable `causal4d commands list --lifecycle ...` filtering;
- add `causal4d commands list --claim-bearing` filtering;
- keep unfiltered `commands list` and `commands list --json` complete and backward compatible;
- include summaries and claim-bearing markers in the text inventory;
- preserve lazy imports for root help and every introspection operation; and
- document the focused/default and exhaustive discovery paths.

## Validation

Focused tests cover:

- stable-only default help;
- complete lifecycle-labelled help;
- lifecycle plus claim-bearing filters;
- multiple lifecycle filters; and
- completeness of the unfiltered JSON inventory.

Repository CI remains authoritative for Ruff formatting, all supported Python versions, installed wheel/sdist help checks, the historical 67-command migration inventory, and the complete suite.

## Boundary

This changes presentation and filtering only. It does not remove a route, modify a command target, change a lifecycle classification, add a console script, import optional dependencies during discovery, or alter any estimator, protocol, dataset, evidence threshold, physical execution, or `claim_ready` state.