### PR TITLE
Harden contact-posterior self-hosted diagnostics

### DIFF
--- a/.github/workflows/apply-contact-diagnostic-runner-hardening.yml
+++ b/.github/workflows/apply-contact-diagnostic-runner-hardening.yml
@@ -116,4 +116,5 @@ jobs:
           name: contact-diagnostic-final-source
           path: ${{ runner.temp }}/contact-diagnostic-final
           if-no-files-found: error
+          include-hidden-files: true
           retention-days: 1

--- a/.github/workflows/apply-contact-diagnostic-runner-hardening.yml
+++ b/.github/workflows/apply-contact-diagnostic-runner-hardening.yml
@@ -10,7 +10,7 @@ on:
       - "scripts/ci/apply_contact_diagnostic_runner_hardening.py"
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: read
 
 concurrency:
@@ -34,7 +34,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
           clean: true
 
       - name: Verify and apply reviewed transformation
@@ -89,11 +89,31 @@ jobs:
           fi
           test "$(git diff --name-only 249d462983578b7935fa735f8631c2b161572103 -- | wc -l)" -eq 2
 
-      - name: Publish validated ordinary source
+      - name: Stage validated ordinary source artifact
+        shell: bash
         run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add -A
-          git diff --cached --check
-          git commit -m 'Harden contact-posterior runner authorization'
-          git push origin HEAD:chore/harden-contact-diagnostic-runner
+          set -euo pipefail
+          artifact="${RUNNER_TEMP}/contact-diagnostic-final"
+          mkdir -p \
+            "${artifact}/.github/workflows" \
+            "${artifact}/tests"
+          cp .github/workflows/contact-posterior-diagnostics.yml \
+            "${artifact}/.github/workflows/contact-posterior-diagnostics.yml"
+          cp tests/test_contact_posterior_workflow_policy.py \
+            "${artifact}/tests/test_contact_posterior_workflow_policy.py"
+          (
+            cd "${artifact}"
+            sha256sum \
+              .github/workflows/contact-posterior-diagnostics.yml \
+              tests/test_contact_posterior_workflow_policy.py \
+              > SHA256SUMS
+          )
+          printf 'source_head=%s\n' "${GITHUB_SHA}" > "${artifact}/SOURCE"
+
+      - name: Upload validated ordinary source artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: contact-diagnostic-final-source
+          path: ${{ runner.temp }}/contact-diagnostic-final
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/apply-contact-diagnostic-runner-hardening.yml
+++ b/.github/workflows/apply-contact-diagnostic-runner-hardening.yml
@@ -1,14 +1,16 @@
 name: Publish validated contact-diagnostic hardening source
 
 on:
-  push:
-    branches: [chore/harden-contact-diagnostic-runner]
+  pull_request:
+    branches: [main]
+    types: [synchronize, reopened]
     paths:
       - ".github/workflows/apply-contact-diagnostic-runner-hardening.yml"
       - "scripts/ci/apply_contact_diagnostic_runner_hardening.py"
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: publish-contact-diagnostic-hardening-source
@@ -18,14 +20,18 @@ jobs:
   apply-and-validate:
     if: >-
       github.repository == 'IPS-Stuttgart/Causal4D' &&
-      github.ref == 'refs/heads/chore/harden-contact-diagnostic-runner'
+      github.event.pull_request.number == 240 &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.head.ref ==
+        'chore/harden-contact-diagnostic-runner' &&
+      github.event.pull_request.user.login == 'FlorianPfaff'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - name: Check out exact branch head
+      - name: Check out exact PR head
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
           clean: true
@@ -34,7 +40,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test "$(git rev-parse HEAD)" = "${{ github.event.pull_request.head.sha }}"
           printf '%s  %s\n' \
             '4f0a82330e8c900fa0129c02b0617bef8517b51a42ca20f8293485b18ae1c3c0' \
             'scripts/ci/apply_contact_diagnostic_runner_hardening.py' \
@@ -101,8 +107,6 @@ jobs:
           cp .github/workflows/contact-posterior-diagnostics.yml \
             "${artifact}/.github/workflows/contact-posterior-diagnostics.yml"
           cp tests/test_contact_posterior_workflow_policy.py \
-            "${artifact}/tests/test_contact-posterior-workflow-policy.py"
-          mv "${artifact}/tests/test_contact-posterior-workflow-policy.py" \
             "${artifact}/tests/test_contact_posterior_workflow_policy.py"
           (
             cd "${artifact}"
@@ -111,7 +115,7 @@ jobs:
               tests/test_contact_posterior_workflow_policy.py \
               > SHA256SUMS
           )
-          printf 'source_head=%s\n' "${GITHUB_SHA}" > "${artifact}/SOURCE"
+          printf 'source_head=%s\n' "${{ github.event.pull_request.head.sha }}" > "${artifact}/SOURCE"
 
       - name: Upload validated ordinary source artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0

--- a/.github/workflows/apply-contact-diagnostic-runner-hardening.yml
+++ b/.github/workflows/apply-contact-diagnostic-runner-hardening.yml
@@ -1,0 +1,98 @@
+name: Apply contact-diagnostic runner hardening
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/apply-contact-diagnostic-runner-hardening.yml"
+      - "scripts/ci/apply_contact_diagnostic_runner_hardening.py"
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: apply-contact-diagnostic-runner-hardening-pr-240
+  cancel-in-progress: false
+
+jobs:
+  apply-and-validate:
+    if: >-
+      github.repository == 'IPS-Stuttgart/Causal4D' &&
+      github.event.pull_request.number == 240 &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.head.ref ==
+        'chore/harden-contact-diagnostic-runner' &&
+      github.event.pull_request.user.login == 'FlorianPfaff'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Check out exact PR head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: true
+          clean: true
+
+      - name: Verify and apply reviewed transformation
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf '%s  %s\n' \
+            'df4ad23abe101849fbbc80627cde54d9f59072cb1168d997d443bee128af667a' \
+            'scripts/ci/apply_contact_diagnostic_runner_hardening.py' \
+            | sha256sum --check --strict -
+          python scripts/ci/apply_contact_diagnostic_runner_hardening.py
+          git diff --check
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install development environment
+        run: |
+          python -m pip install -e ".[dev]"
+          python -m pip check
+
+      - name: Validate workflow policy and adjacent contracts
+        run: |
+          python -m ruff check \
+            scripts/ci/apply_contact_diagnostic_runner_hardening.py \
+            tests/test_contact_posterior_workflow_policy.py
+          python -m ruff format --check \
+            scripts/ci/apply_contact_diagnostic_runner_hardening.py \
+            tests/test_contact_posterior_workflow_policy.py
+          python -W error::SyntaxWarning -m py_compile \
+            scripts/ci/apply_contact_diagnostic_runner_hardening.py \
+            tests/test_contact_posterior_workflow_policy.py
+          python -m pytest -q \
+            tests/test_contact_posterior_workflow_policy.py \
+            tests/test_contact_posterior_diagnostics.py \
+            tests/test_contact_posterior_admission.py
+
+      - name: Remove transport and verify final scope
+        run: |
+          rm -- \
+            .github/workflows/apply-contact-diagnostic-runner-hardening.yml \
+            scripts/ci/apply_contact_diagnostic_runner_hardening.py
+          git diff --check
+          allowed='^(.github/workflows/contact-posterior-diagnostics.yml|tests/test_contact_posterior_workflow_policy.py)$'
+          unexpected="$(git diff --name-only 249d462983578b7935fa735f8631c2b161572103 -- | grep -Ev "${allowed}" || true)"
+          if [[ -n "${unexpected}" ]]; then
+            printf 'Unexpected final paths:\n%s\n' "${unexpected}" >&2
+            exit 1
+          fi
+          test "$(git diff --name-only 249d462983578b7935fa735f8631c2b161572103 -- | wc -l)" -eq 2
+
+      - name: Publish validated ordinary source
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          git diff --cached --check
+          git commit -m 'Harden contact-posterior runner authorization'
+          git push origin HEAD:chore/harden-contact-diagnostic-runner

--- a/.github/workflows/apply-contact-diagnostic-runner-hardening.yml
+++ b/.github/workflows/apply-contact-diagnostic-runner-hardening.yml
@@ -1,38 +1,31 @@
-# Retrigger after current-main CI restoration.
-name: Apply contact-diagnostic runner hardening
+name: Publish validated contact-diagnostic hardening source
 
 on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened]
+  push:
+    branches: [chore/harden-contact-diagnostic-runner]
     paths:
       - ".github/workflows/apply-contact-diagnostic-runner-hardening.yml"
       - "scripts/ci/apply_contact_diagnostic_runner_hardening.py"
 
 permissions:
   contents: read
-  pull-requests: read
 
 concurrency:
-  group: apply-contact-diagnostic-runner-hardening-pr-240
+  group: publish-contact-diagnostic-hardening-source
   cancel-in-progress: false
 
 jobs:
   apply-and-validate:
     if: >-
       github.repository == 'IPS-Stuttgart/Causal4D' &&
-      github.event.pull_request.number == 240 &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.head.ref ==
-        'chore/harden-contact-diagnostic-runner' &&
-      github.event.pull_request.user.login == 'FlorianPfaff'
+      github.ref == 'refs/heads/chore/harden-contact-diagnostic-runner'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - name: Check out exact PR head
+      - name: Check out exact branch head
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
           clean: true
@@ -41,12 +34,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
           printf '%s  %s\n' \
             '4f0a82330e8c900fa0129c02b0617bef8517b51a42ca20f8293485b18ae1c3c0' \
             'scripts/ci/apply_contact_diagnostic_runner_hardening.py' \
             | sha256sum --check --strict -
           python scripts/ci/apply_contact_diagnostic_runner_hardening.py
-          git diff --check
 
       - name: Set up Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -59,14 +52,20 @@ jobs:
           python -m pip install -e ".[dev]"
           python -m pip check
 
-      - name: Validate workflow policy and adjacent contracts
+      - name: Canonicalize and validate workflow policy and adjacent contracts
+        shell: bash
         run: |
+          set -euo pipefail
+          python -m ruff format \
+            scripts/ci/apply_contact_diagnostic_runner_hardening.py \
+            tests/test_contact_posterior_workflow_policy.py
           python -m ruff check \
             scripts/ci/apply_contact_diagnostic_runner_hardening.py \
             tests/test_contact_posterior_workflow_policy.py
           python -m ruff format --check \
             scripts/ci/apply_contact_diagnostic_runner_hardening.py \
             tests/test_contact_posterior_workflow_policy.py
+          git diff --check
           python -W error::SyntaxWarning -m py_compile \
             scripts/ci/apply_contact_diagnostic_runner_hardening.py \
             tests/test_contact_posterior_workflow_policy.py
@@ -76,7 +75,9 @@ jobs:
             tests/test_contact_posterior_admission.py
 
       - name: Remove transport and verify final scope
+        shell: bash
         run: |
+          set -euo pipefail
           rm -- \
             .github/workflows/apply-contact-diagnostic-runner-hardening.yml \
             scripts/ci/apply_contact_diagnostic_runner_hardening.py
@@ -100,6 +101,8 @@ jobs:
           cp .github/workflows/contact-posterior-diagnostics.yml \
             "${artifact}/.github/workflows/contact-posterior-diagnostics.yml"
           cp tests/test_contact_posterior_workflow_policy.py \
+            "${artifact}/tests/test_contact-posterior-workflow-policy.py"
+          mv "${artifact}/tests/test_contact-posterior-workflow-policy.py" \
             "${artifact}/tests/test_contact_posterior_workflow_policy.py"
           (
             cd "${artifact}"

--- a/.github/workflows/apply-contact-diagnostic-runner-hardening.yml
+++ b/.github/workflows/apply-contact-diagnostic-runner-hardening.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           set -euo pipefail
           printf '%s  %s\n' \
-            'df4ad23abe101849fbbc80627cde54d9f59072cb1168d997d443bee128af667a' \
+            '4f0a82330e8c900fa0129c02b0617bef8517b51a42ca20f8293485b18ae1c3c0' \
             'scripts/ci/apply_contact_diagnostic_runner_hardening.py' \
             | sha256sum --check --strict -
           python scripts/ci/apply_contact_diagnostic_runner_hardening.py

--- a/.github/workflows/apply-contact-diagnostic-runner-hardening.yml
+++ b/.github/workflows/apply-contact-diagnostic-runner-hardening.yml
@@ -1,3 +1,4 @@
+# Retrigger after current-main CI restoration.
 name: Apply contact-diagnostic runner hardening
 
 on:

--- a/scripts/ci/apply_contact_diagnostic_runner_hardening.py
+++ b/scripts/ci/apply_contact_diagnostic_runner_hardening.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Apply the reviewed contact-diagnostic runner-boundary cleanup."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "contact-posterior-diagnostics.yml"
+POLICY = ROOT / "tests" / "test_contact_posterior_workflow_policy.py"
+
+OLD_JOB_IF = """    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.head.ref !=
+        'ci/pr193-latent-contact-stability-main-v2'
+      )
+"""
+NEW_JOB_IF = """    if: >-
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'workflow_dispatch' &&
+       (inputs.runner != 'self-hosted' ||
+        github.ref == 'refs/heads/main'))
+"""
+
+OLD_CHECKOUT = """      - name: Check out Causal4D
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+
+"""
+NEW_CHECKOUT = """      - name: Check out exact Causal4D revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+
+      - name: Verify exact clean revision
+        env:
+          EXPECTED_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${EXPECTED_SHA}"
+          test -z "$(git status --porcelain=v1)"
+
+"""
+
+POLICY_APPEND = '''
+
+
+def test_contact_diagnostic_self_hosted_dispatch_is_main_only() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "github.event_name == 'workflow_dispatch'" in text
+    assert "inputs.runner != 'self-hosted'" in text
+    assert "github.ref == 'refs/heads/main'" in text
+    assert "ref: ${{ github.event.pull_request.head.sha || github.sha }}" in text
+    assert "EXPECTED_SHA: ${{ github.event.pull_request.head.sha || github.sha }}" in text
+    assert 'test "$(git rev-parse HEAD)" = "${EXPECTED_SHA}"' in text
+
+
+def test_completed_pr193_self_hosted_job_is_not_live() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "latent-contact-stability:" not in text
+    assert "ci/pr193-latent-contact-stability-main-v2" not in text
+    assert 'DIAGNOSTIC_SEEDS: "3000:3500"' not in text
+'''
+
+
+def _replace_once(text: str, old: str, new: str, *, name: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{name}: expected one reviewed block, found {count}")
+    return text.replace(old, new)
+
+
+def main() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    workflow = _replace_once(workflow, OLD_JOB_IF, NEW_JOB_IF, name="job guard")
+    workflow = _replace_once(workflow, OLD_CHECKOUT, NEW_CHECKOUT, name="checkout")
+
+    stale_marker = "\n  latent-contact-stability:\n"
+    if workflow.count(stale_marker) != 1:
+        raise SystemExit("expected one completed latent-contact-stability job")
+    workflow = workflow.split(stale_marker, maxsplit=1)[0].rstrip() + "\n"
+    WORKFLOW.write_text(workflow, encoding="utf-8")
+
+    policy = POLICY.read_text(encoding="utf-8")
+    if "test_contact_diagnostic_self_hosted_dispatch_is_main_only" in policy:
+        raise SystemExit("policy additions are already present")
+    POLICY.write_text(policy.rstrip() + POLICY_APPEND + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Harden `.github/workflows/contact-posterior-diagnostics.yml` without changing the diagnostic implementation:

- keep pull-request validation on GitHub-hosted infrastructure;
- require optional self-hosted manual dispatches to originate from reviewed `main`;
- check out and verify the exact PR-head or dispatch SHA before repository code executes; and
- remove the completed special PR-193 500-seed self-hosted job from the live permanent workflow.

Issue #209 records that the PR-193 study completed and its evidence was published. Preserving the script and retained artifacts is useful; preserving a branch-name-triggered workstation job is not.

## Intended final diff

- `.github/workflows/contact-posterior-diagnostics.yml`
- `tests/test_contact_posterior_workflow_policy.py`

## Current draft transport

This draft initially contains `scripts/ci/apply_contact_diagnostic_runner_hardening.py`. A checksum-verified, exact-PR GitHub-hosted workflow will apply the reviewed transformation, run the focused policy and diagnostic tests, delete both transport files, verify the final two-file scope, and push the ordinary reviewable result.

Do not merge while any transport file remains.

## Scientific boundary

This changes workflow authorization and removes obsolete execution machinery only. It does not change the latent-contact benchmark, thresholds, retained PR-193 result, physical protocol, target-access rules, or evidence count.