### PR TITLE
Harden remaining self-hosted operational dispatches

### DIFF
--- a/.github/workflows/apply-remaining-self-hosted-dispatch-hardening.yml
+++ b/.github/workflows/apply-remaining-self-hosted-dispatch-hardening.yml
@@ -10,7 +10,7 @@ on:
       - "scripts/ci/apply_remaining_self_hosted_dispatch_hardening.py"
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: read
 
 concurrency:
@@ -34,7 +34,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
           clean: true
 
       - name: Verify and apply reviewed transformations
@@ -93,11 +93,43 @@ jobs:
           fi
           test "$(git diff --name-only aba7e0ff1e5705fb7d5979cd5186404fcfb1526f -- | wc -l)" -eq 6
 
-      - name: Publish validated ordinary source
+      - name: Stage validated ordinary source artifact
+        shell: bash
         run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add -A
-          git diff --cached --check
-          git commit -m 'Harden remaining self-hosted dispatches'
-          git push origin HEAD:chore/harden-remaining-self-hosted-dispatches
+          set -euo pipefail
+          artifact="${RUNNER_TEMP}/remaining-self-hosted-final"
+          mkdir -p \
+            "${artifact}/.github/workflows" \
+            "${artifact}/tests"
+          cp .github/workflows/deform360-filament-support.yml \
+            "${artifact}/.github/workflows/deform360-filament-support.yml"
+          cp .github/workflows/contact-posterior-concentration.yml \
+            "${artifact}/.github/workflows/contact-posterior-concentration.yml"
+          cp .github/workflows/controlled-demo-video.yml \
+            "${artifact}/.github/workflows/controlled-demo-video.yml"
+          cp tests/test_deform360_filament_support_workflow_policy.py \
+            "${artifact}/tests/test_deform360_filament_support_workflow_policy.py"
+          cp tests/test_contact_concentration_workflow_policy.py \
+            "${artifact}/tests/test_contact_concentration_workflow_policy.py"
+          cp tests/test_controlled_demo_video_workflow_policy.py \
+            "${artifact}/tests/test_controlled_demo_video_workflow_policy.py"
+          (
+            cd "${artifact}"
+            sha256sum \
+              .github/workflows/deform360-filament-support.yml \
+              .github/workflows/contact-posterior-concentration.yml \
+              .github/workflows/controlled-demo-video.yml \
+              tests/test_deform360_filament_support_workflow_policy.py \
+              tests/test_contact_concentration_workflow_policy.py \
+              tests/test_controlled_demo_video_workflow_policy.py \
+              > SHA256SUMS
+          )
+          printf 'source_head=%s\n' "${GITHUB_SHA}" > "${artifact}/SOURCE"
+
+      - name: Upload validated ordinary source artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: remaining-self-hosted-final-source
+          path: ${{ runner.temp }}/remaining-self-hosted-final
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/apply-remaining-self-hosted-dispatch-hardening.yml
+++ b/.github/workflows/apply-remaining-self-hosted-dispatch-hardening.yml
@@ -132,4 +132,5 @@ jobs:
           name: remaining-self-hosted-final-source
           path: ${{ runner.temp }}/remaining-self-hosted-final
           if-no-files-found: error
+          include-hidden-files: true
           retention-days: 1

--- a/.github/workflows/apply-remaining-self-hosted-dispatch-hardening.yml
+++ b/.github/workflows/apply-remaining-self-hosted-dispatch-hardening.yml
@@ -59,7 +59,7 @@ jobs:
           python -m pip install -e ".[dev]" matplotlib pillow imageio-ffmpeg
           python -m pip check
 
-      - name: Validate workflow policy and adjacent contracts
+      - name: Format and validate workflow policy and adjacent contracts
         run: |
           files=(
             scripts/ci/apply_remaining_self_hosted_dispatch_hardening.py
@@ -67,6 +67,7 @@ jobs:
             tests/test_contact_concentration_workflow_policy.py
             tests/test_controlled_demo_video_workflow_policy.py
           )
+          python -m ruff format "${files[@]}"
           python -m ruff check "${files[@]}"
           python -m ruff format --check "${files[@]}"
           python -W error::SyntaxWarning -m py_compile "${files[@]}"

--- a/.github/workflows/apply-remaining-self-hosted-dispatch-hardening.yml
+++ b/.github/workflows/apply-remaining-self-hosted-dispatch-hardening.yml
@@ -1,3 +1,4 @@
+# Retrigger after current-main CI restoration.
 name: Apply remaining self-hosted dispatch hardening
 
 on:

--- a/.github/workflows/apply-remaining-self-hosted-dispatch-hardening.yml
+++ b/.github/workflows/apply-remaining-self-hosted-dispatch-hardening.yml
@@ -1,0 +1,101 @@
+name: Apply remaining self-hosted dispatch hardening
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/apply-remaining-self-hosted-dispatch-hardening.yml"
+      - "scripts/ci/apply_remaining_self_hosted_dispatch_hardening.py"
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: apply-remaining-self-hosted-dispatch-hardening-pr-241
+  cancel-in-progress: false
+
+jobs:
+  apply-and-validate:
+    if: >-
+      github.repository == 'IPS-Stuttgart/Causal4D' &&
+      github.event.pull_request.number == 241 &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.head.ref ==
+        'chore/harden-remaining-self-hosted-dispatches' &&
+      github.event.pull_request.user.login == 'FlorianPfaff'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out exact PR head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: true
+          clean: true
+
+      - name: Verify and apply reviewed transformations
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf '%s  %s\n' \
+            '2a3864db5107daa3c89f79f21eeb3c3f07d4fa62b386d12e37b4a8d20f222ea3' \
+            'scripts/ci/apply_remaining_self_hosted_dispatch_hardening.py' \
+            | sha256sum --check --strict -
+          python scripts/ci/apply_remaining_self_hosted_dispatch_hardening.py
+          git diff --check
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install development and demo dependencies
+        run: |
+          python -m pip install -e ".[dev]" matplotlib pillow imageio-ffmpeg
+          python -m pip check
+
+      - name: Validate workflow policy and adjacent contracts
+        run: |
+          files=(
+            scripts/ci/apply_remaining_self_hosted_dispatch_hardening.py
+            tests/test_deform360_filament_support_workflow_policy.py
+            tests/test_contact_concentration_workflow_policy.py
+            tests/test_controlled_demo_video_workflow_policy.py
+          )
+          python -m ruff check "${files[@]}"
+          python -m ruff format --check "${files[@]}"
+          python -W error::SyntaxWarning -m py_compile "${files[@]}"
+          python -m pytest -q \
+            tests/test_deform360_filament_support_workflow_policy.py \
+            tests/test_deform360_filament_support.py \
+            tests/test_contact_concentration_workflow_policy.py \
+            tests/test_contact_concentration_diagnostic.py \
+            tests/test_controlled_demo_video_workflow_policy.py \
+            tests/test_dynamic_contact_demo.py
+
+      - name: Remove transport and verify final scope
+        run: |
+          rm -- \
+            .github/workflows/apply-remaining-self-hosted-dispatch-hardening.yml \
+            scripts/ci/apply_remaining_self_hosted_dispatch_hardening.py
+          git diff --check
+          allowed='^(.github/workflows/deform360-filament-support.yml|.github/workflows/contact-posterior-concentration.yml|.github/workflows/controlled-demo-video.yml|tests/test_deform360_filament_support_workflow_policy.py|tests/test_contact_concentration_workflow_policy.py|tests/test_controlled_demo_video_workflow_policy.py)$'
+          unexpected="$(git diff --name-only aba7e0ff1e5705fb7d5979cd5186404fcfb1526f -- | grep -Ev "${allowed}" || true)"
+          if [[ -n "${unexpected}" ]]; then
+            printf 'Unexpected final paths:\n%s\n' "${unexpected}" >&2
+            exit 1
+          fi
+          test "$(git diff --name-only aba7e0ff1e5705fb7d5979cd5186404fcfb1526f -- | wc -l)" -eq 6
+
+      - name: Publish validated ordinary source
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          git diff --cached --check
+          git commit -m 'Harden remaining self-hosted dispatches'
+          git push origin HEAD:chore/harden-remaining-self-hosted-dispatches

--- a/scripts/ci/apply_remaining_self_hosted_dispatch_hardening.py
+++ b/scripts/ci/apply_remaining_self_hosted_dispatch_hardening.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Apply main-only exact-SHA guards to remaining self-hosted workflows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FILAMENT = ROOT / ".github" / "workflows" / "deform360-filament-support.yml"
+CONCENTRATION = (
+    ROOT / ".github" / "workflows" / "contact-posterior-concentration.yml"
+)
+DEMO = ROOT / ".github" / "workflows" / "controlled-demo-video.yml"
+
+
+def _replace_once(text: str, old: str, new: str, *, name: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{name}: expected one reviewed block, found {count}")
+    return text.replace(old, new)
+
+
+def _harden_filament() -> None:
+    text = FILAMENT.read_text(encoding="utf-8")
+    text = _replace_once(
+        text,
+        """    if: >-
+      (github.event_name == 'workflow_dispatch' && inputs.run_source_diagnostic) ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+""",
+        """    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      inputs.run_source_diagnostic
+""",
+        name="filament source-job guard",
+    )
+    text = _replace_once(
+        text,
+        """      - name: Check out Causal4D with parent history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          clean: true
+          fetch-depth: 0
+
+""",
+        """      - name: Check out exact reviewed Causal4D revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 0
+
+      - name: Verify reviewed main revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
+
+""",
+        name="filament checkout",
+    )
+    FILAMENT.write_text(text, encoding="utf-8")
+
+
+def _harden_concentration() -> None:
+    text = CONCENTRATION.read_text(encoding="utf-8")
+    text = _replace_once(
+        text,
+        """      - "tests/test_contact_concentration_diagnostic.py"
+""",
+        """      - "tests/test_contact_concentration_diagnostic.py"
+      - "tests/test_contact_concentration_workflow_policy.py"
+""",
+        name="concentration trigger coverage",
+    )
+    text = _replace_once(
+        text,
+        """    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+""",
+        """    if: >-
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'workflow_dispatch' &&
+       (inputs.runner != 'self-hosted' ||
+        github.ref == 'refs/heads/main'))
+""",
+        name="concentration runner guard",
+    )
+    text = _replace_once(
+        text,
+        """      - name: Check out Causal4D
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+
+""",
+        """      - name: Check out exact Causal4D revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+
+      - name: Verify exact clean revision
+        env:
+          EXPECTED_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${EXPECTED_SHA}"
+          test -z "$(git status --porcelain=v1)"
+
+""",
+        name="concentration checkout",
+    )
+    text = _replace_once(
+        text,
+        """.contact-concentration-venv/bin/python -m pip install -e ".[dev]"
+""",
+        """.contact-concentration-venv/bin/python -m pip install ".[dev]"
+""",
+        name="concentration non-editable install",
+    )
+    CONCENTRATION.write_text(text, encoding="utf-8")
+
+
+def _harden_demo() -> None:
+    text = DEMO.read_text(encoding="utf-8")
+    text = _replace_once(
+        text,
+        """  render:
+    name: Render controlled MP4, GIF, and poster
+    runs-on: >-
+""",
+        """  render:
+    name: Render controlled MP4, GIF, and poster
+    if: >-
+      inputs.runner != 'self-hosted' ||
+      github.ref == 'refs/heads/main'
+    runs-on: >-
+""",
+        name="controlled-demo runner guard",
+    )
+    text = _replace_once(
+        text,
+        """      - name: Check out Causal4D
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+""",
+        """      - name: Check out exact reviewed Causal4D revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          clean: true
+
+      - name: Verify reviewed dispatch revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
+
+""",
+        name="controlled-demo checkout",
+    )
+    text = _replace_once(
+        text,
+        """          python -m pip install -e . matplotlib pillow imageio-ffmpeg
+""",
+        """          python -m pip install . matplotlib pillow imageio-ffmpeg
+""",
+        name="controlled-demo non-editable install",
+    )
+    DEMO.write_text(text, encoding="utf-8")
+
+
+def main() -> None:
+    _harden_filament()
+    _harden_concentration()
+    _harden_demo()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_contact_concentration_workflow_policy.py
+++ b/tests/test_contact_concentration_workflow_policy.py
@@ -5,6 +5,11 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "contact-posterior-concentration.yml"
+EXACT_REVISION = "${{ github.event.pull_request.head.sha || github.sha }}"
+
+
+def _evaluate_job(text: str) -> str:
+    return text.split("  evaluate:", maxsplit=1)[1]
 
 
 def test_concentration_workflow_is_read_only_and_runner_selectable() -> None:
@@ -23,6 +28,27 @@ def test_concentration_workflow_is_read_only_and_runner_selectable() -> None:
     assert "github.event.pull_request.head.repo.full_name == github.repository" in text
     assert "workflow_dispatch:" in text
     assert "  push:" not in text
+
+
+def test_concentration_self_hosted_dispatch_is_main_only() -> None:
+    job = _evaluate_job(WORKFLOW.read_text(encoding="utf-8"))
+
+    assert "github.event_name == 'workflow_dispatch'" in job
+    assert "inputs.runner != 'self-hosted'" in job
+    assert "github.ref == 'refs/heads/main'" in job
+    assert "github.event.pull_request.head.repo.full_name == github.repository" in job
+
+
+def test_concentration_checks_out_and_verifies_exact_revision() -> None:
+    job = _evaluate_job(WORKFLOW.read_text(encoding="utf-8"))
+
+    assert f"ref: {EXACT_REVISION}" in job
+    assert f"EXPECTED_SHA: {EXACT_REVISION}" in job
+    assert 'test "$(git rev-parse HEAD)" = "${EXPECTED_SHA}"' in job
+    checkout = job.index("- name: Check out exact Causal4D revision")
+    verify = job.index("- name: Verify exact clean revision")
+    install = job.index("- name: Install isolated diagnostic environment")
+    assert checkout < verify < install
 
 
 def test_concentration_workflow_caches_only_on_hosted_runners() -> None:

--- a/tests/test_controlled_demo_video_workflow_policy.py
+++ b/tests/test_controlled_demo_video_workflow_policy.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "controlled-demo-video.yml"
+
+
+def _render_job(text: str) -> str:
+    return text.split("  render:", maxsplit=1)[1]
+
+
+def test_controlled_demo_workflow_is_read_only_and_runner_selectable() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "permissions:\n  contents: read\n" in text
+    assert "workflow_dispatch:" in text
+    assert "default: github-hosted" in text
+    assert "'ubuntu-latest'" in text
+    assert (
+        "fromJSON('[\"self-hosted\",\"Linux\",\"X64\",\"collaborator-demo\"]')"
+        in text
+    )
+    assert "persist-credentials: false" in text
+    assert "contents: write" not in text
+    assert "git push" not in text
+
+
+def test_controlled_demo_self_hosted_dispatch_is_main_only() -> None:
+    job = _render_job(WORKFLOW.read_text(encoding="utf-8"))
+
+    assert "inputs.runner != 'self-hosted'" in job
+    assert "github.ref == 'refs/heads/main'" in job
+    assert "runs-on:" in job
+
+
+def test_controlled_demo_checks_out_and_verifies_exact_dispatch_revision() -> None:
+    job = _render_job(WORKFLOW.read_text(encoding="utf-8"))
+
+    assert "ref: ${{ github.sha }}" in job
+    assert "clean: true" in job
+    assert 'test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"' in job
+    checkout = job.index("- name: Check out exact reviewed Causal4D revision")
+    verify = job.index("- name: Verify reviewed dispatch revision")
+    install = job.index("- name: Install controlled-demo renderer")
+    assert checkout < verify < install
+
+
+def test_controlled_demo_installs_non_editable_distribution() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "python -m pip install . matplotlib pillow imageio-ffmpeg" in text
+    assert "python -m pip install -e ." not in text
+    assert "python -m pip check" in text
+
+
+def test_controlled_demo_verifies_and_uploads_complete_bundle() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    required = (
+        "causal4d_dynamic_contact_demo.mp4",
+        "causal4d_dynamic_contact_demo.gif",
+        "causal4d_dynamic_contact_poster.png",
+        "summary.json",
+        "summary.md",
+        "SHA256SUMS",
+    )
+    for name in required:
+        assert name in text
+    assert "if-no-files-found: error" in text
+    assert "retention-days: 30" in text

--- a/tests/test_deform360_filament_support_workflow_policy.py
+++ b/tests/test_deform360_filament_support_workflow_policy.py
@@ -5,16 +5,39 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github/workflows/deform360-filament-support.yml"
+EXACT_REVISION = "${{ github.sha }}"
+
+
+def _source_job(text: str) -> str:
+    return text.split("  source-diagnostic:", maxsplit=1)[1]
 
 
 def test_filament_support_workflow_is_read_only_and_source_scoped() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
+    source_job = _source_job(text)
+
     assert "permissions:\n  contents: read" in text
-    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
-    assert "github.event.pull_request.head.repo.full_name == github.repository" in text
+    assert "pull_request:" in text
     assert "workflow_dispatch:" in text
     assert "run_source_diagnostic:" in text
+    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in source_job
+    assert "github.event_name == 'workflow_dispatch'" in source_job
+    assert "github.ref == 'refs/heads/main'" in source_job
+    assert "github.event.pull_request.head" not in source_job
     assert "target" not in text.lower()
+
+
+def test_filament_source_job_checks_out_and_verifies_exact_main_revision() -> None:
+    source_job = _source_job(WORKFLOW.read_text(encoding="utf-8"))
+
+    assert f"ref: {EXACT_REVISION}" in source_job
+    assert "persist-credentials: false" in source_job
+    assert "clean: true" in source_job
+    assert 'test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"' in source_job
+    checkout = source_job.index("- name: Check out exact reviewed Causal4D revision")
+    verify = source_job.index("- name: Verify reviewed main revision")
+    execute = source_job.index("- name: Initialize source-evidence directory")
+    assert checkout < verify < execute
 
 
 def test_filament_support_workflow_runs_the_locked_surface() -> None:
@@ -43,7 +66,6 @@ def test_filament_support_workflow_runs_the_locked_surface() -> None:
 
 
 def test_self_hosted_lane_does_not_enable_actions_pip_cache() -> None:
-    text = WORKFLOW.read_text(encoding="utf-8")
-    source_job = text.split("  source-diagnostic:", maxsplit=1)[1]
+    source_job = _source_job(WORKFLOW.read_text(encoding="utf-8"))
     assert "actions/setup-python" not in source_job
     assert "cache: pip" not in source_job


### PR DESCRIPTION
## Summary

Harden the three remaining straightforward workflows that allow callers to select a self-hosted runner:

- `deform360-filament-support.yml`;
- `contact-posterior-concentration.yml`; and
- `controlled-demo-video.yml`.

Hosted pull-request and ordinary hosted manual execution remain available. Self-hosted execution becomes main-only before runner allocation, and each operational job checks out and verifies the exact reviewed SHA before repository code executes. Editable package installs are removed from the concentration and collaborator-demo evidence paths.

## Intended final diff

- `.github/workflows/deform360-filament-support.yml`
- `.github/workflows/contact-posterior-concentration.yml`
- `.github/workflows/controlled-demo-video.yml`
- `tests/test_deform360_filament_support_workflow_policy.py`
- `tests/test_contact_concentration_workflow_policy.py`
- `tests/test_controlled_demo_video_workflow_policy.py`

## Current draft transport

The branch initially contains `scripts/ci/apply_remaining_self_hosted_dispatch_hardening.py`. An exact same-repository PR workflow will verify its SHA-256, apply only the reviewed transformations, run the focused workflow-policy and adjacent contract suites, delete both transport files, verify the final six-file allowlist, and push ordinary reviewable source.

Do not merge while any transport file remains.

## Excluded scope

`contact-topology-covariance.yml` is intentionally excluded. It combines hosted and workstation2 execution in one matrix and needs a separate split plus explicit evaluation/data-access semantics rather than the simple manual-runner guard used here.

## Scientific boundary

This is workflow authorization and distribution-provenance hardening. It changes no estimator, source/target split, threshold, retained result, registered physical protocol, or evidence count.