### PR TITLE
Restrict topology-covariance reproduction to reviewed main

### DIFF
--- a/.github/workflows/apply-topology-covariance-workflow-hardening.yml
+++ b/.github/workflows/apply-topology-covariance-workflow-hardening.yml
@@ -119,4 +119,5 @@ jobs:
           name: topology-covariance-final-source
           path: ${{ runner.temp }}/topology-covariance-final
           if-no-files-found: error
+          include-hidden-files: true
           retention-days: 1

--- a/.github/workflows/apply-topology-covariance-workflow-hardening.yml
+++ b/.github/workflows/apply-topology-covariance-workflow-hardening.yml
@@ -10,7 +10,7 @@ on:
       - "scripts/ci/apply_topology_covariance_workflow_hardening.py"
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: read
 
 concurrency:
@@ -34,7 +34,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
           clean: true
 
       - name: Verify and apply reviewed transformation
@@ -92,11 +92,31 @@ jobs:
           fi
           test "$(git diff --name-only aba7e0ff1e5705fb7d5979cd5186404fcfb1526f -- | wc -l)" -eq 2
 
-      - name: Publish validated ordinary source
+      - name: Stage validated ordinary source artifact
+        shell: bash
         run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add -A
-          git diff --cached --check
-          git commit -m 'Harden topology covariance reproduction'
-          git push origin HEAD:chore/harden-topology-covariance-reproduction
+          set -euo pipefail
+          artifact="${RUNNER_TEMP}/topology-covariance-final"
+          mkdir -p \
+            "${artifact}/.github/workflows" \
+            "${artifact}/tests"
+          cp .github/workflows/contact-topology-covariance.yml \
+            "${artifact}/.github/workflows/contact-topology-covariance.yml"
+          cp tests/test_contact_topology_covariance_workflow_policy.py \
+            "${artifact}/tests/test_contact_topology_covariance_workflow_policy.py"
+          (
+            cd "${artifact}"
+            sha256sum \
+              .github/workflows/contact-topology-covariance.yml \
+              tests/test_contact_topology_covariance_workflow_policy.py \
+              > SHA256SUMS
+          )
+          printf 'source_head=%s\n' "${GITHUB_SHA}" > "${artifact}/SOURCE"
+
+      - name: Upload validated ordinary source artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: topology-covariance-final-source
+          path: ${{ runner.temp }}/topology-covariance-final
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/apply-topology-covariance-workflow-hardening.yml
+++ b/.github/workflows/apply-topology-covariance-workflow-hardening.yml
@@ -1,4 +1,4 @@
-# Retrigger after current-main CI restoration.
+# Artifact publication retry after hidden-file retention fix.
 name: Apply topology covariance workflow hardening
 
 on:

--- a/.github/workflows/apply-topology-covariance-workflow-hardening.yml
+++ b/.github/workflows/apply-topology-covariance-workflow-hardening.yml
@@ -1,3 +1,4 @@
+# Retrigger after current-main CI restoration.
 name: Apply topology covariance workflow hardening
 
 on:

--- a/.github/workflows/apply-topology-covariance-workflow-hardening.yml
+++ b/.github/workflows/apply-topology-covariance-workflow-hardening.yml
@@ -1,0 +1,101 @@
+name: Apply topology covariance workflow hardening
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/apply-topology-covariance-workflow-hardening.yml"
+      - "scripts/ci/apply_topology_covariance_workflow_hardening.py"
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: apply-topology-covariance-workflow-hardening-pr-242
+  cancel-in-progress: false
+
+jobs:
+  apply-and-validate:
+    if: >-
+      github.repository == 'IPS-Stuttgart/Causal4D' &&
+      github.event.pull_request.number == 242 &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.head.ref ==
+        'chore/harden-topology-covariance-reproduction' &&
+      github.event.pull_request.user.login == 'FlorianPfaff'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out exact PR head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: true
+          clean: true
+
+      - name: Verify and apply reviewed transformation
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf '%s  %s\n' \
+            '5e73df7d82c1f7c5887cbb7b9bbe581aa1872015f981bd714c991c9f6684889e' \
+            'scripts/ci/apply_topology_covariance_workflow_hardening.py' \
+            | sha256sum --check --strict -
+          python scripts/ci/apply_topology_covariance_workflow_hardening.py
+          git diff --check
+          grep -F \
+            '04481f7fd2b2965d3439dad9f1b9ca3068f6b5dea1bc62674383571c73667ae1  tests/test_contact_topology_covariance_workflow_policy.py' \
+            .github/workflows/contact-topology-covariance.yml
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install development environment
+        run: |
+          python -m pip install -e ".[dev]"
+          python -m pip check
+
+      - name: Validate workflow policy and adjacent contracts
+        run: |
+          files=(
+            scripts/ci/apply_topology_covariance_workflow_hardening.py
+            tests/test_contact_topology_covariance_workflow_policy.py
+          )
+          python -m ruff check "${files[@]}"
+          python -m ruff format --check "${files[@]}"
+          python -W error::SyntaxWarning -m py_compile "${files[@]}"
+          python -m pytest -q \
+            tests/test_contact_topology_covariance_workflow_policy.py \
+            tests/test_contact_topology_covariance_diagnostic.py \
+            tests/test_contact_correlation_diagnostic.py \
+            tests/test_causal4d_contact_evaluation.py \
+            tests/test_probability_support_invariants.py
+
+      - name: Remove transport and verify final scope
+        run: |
+          rm -- \
+            .github/workflows/apply-topology-covariance-workflow-hardening.yml \
+            scripts/ci/apply_topology_covariance_workflow_hardening.py
+          git diff --check
+          allowed='^(.github/workflows/contact-topology-covariance.yml|tests/test_contact_topology_covariance_workflow_policy.py)$'
+          unexpected="$(git diff --name-only aba7e0ff1e5705fb7d5979cd5186404fcfb1526f -- | grep -Ev "${allowed}" || true)"
+          if [[ -n "${unexpected}" ]]; then
+            printf 'Unexpected final paths:\n%s\n' "${unexpected}" >&2
+            exit 1
+          fi
+          test "$(git diff --name-only aba7e0ff1e5705fb7d5979cd5186404fcfb1526f -- | wc -l)" -eq 2
+
+      - name: Publish validated ordinary source
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          git diff --cached --check
+          git commit -m 'Harden topology covariance reproduction'
+          git push origin HEAD:chore/harden-topology-covariance-reproduction

--- a/scripts/ci/apply_topology_covariance_workflow_hardening.py
+++ b/scripts/ci/apply_topology_covariance_workflow_hardening.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Restrict the sealed topology-covariance reproduction to reviewed main."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "contact-topology-covariance.yml"
+
+OLD_POLICY_SHA = "66cc1443b8f99563f99744c46584df13b1b52b5e0828c3b99cab5c96028f2e66"
+NEW_POLICY_SHA = "04481f7fd2b2965d3439dad9f1b9ca3068f6b5dea1bc62674383571c73667ae1"
+
+
+def _replace_once(text: str, old: str, new: str, *, name: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{name}: expected one reviewed block, found {count}")
+    return text.replace(old, new)
+
+
+def main() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    text = _replace_once(
+        text,
+        """  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/contact-topology-covariance.yml"
+      - "docs/contact_topology_covariance.md"
+      - "scripts/ci/run_contact_topology_covariance_diagnostic.py"
+      - "src/causal4d/contact_topology_covariance_diagnostic.py"
+      - "tests/test_contact_topology_covariance_diagnostic.py"
+      - "tests/test_contact_topology_covariance_workflow_policy.py"
+""",
+        "",
+        name="pull-request trigger",
+    )
+    text = _replace_once(
+        text,
+        """    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+""",
+        """    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main'
+""",
+        name="main-only job guard",
+    )
+    text = _replace_once(
+        text,
+        """      - name: Check out Causal4D
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+
+""",
+        """      - name: Check out exact reviewed Causal4D revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+
+      - name: Verify reviewed main revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
+
+""",
+        name="exact checkout",
+    )
+    text = _replace_once(
+        text,
+        """          python -m pip install -e ".[dev]"
+""",
+        """          python -m pip install ".[dev]"
+""",
+        name="non-editable install",
+    )
+    text = _replace_once(
+        text,
+        f"{OLD_POLICY_SHA}  tests/test_contact_topology_covariance_workflow_policy.py",
+        f"{NEW_POLICY_SHA}  tests/test_contact_topology_covariance_workflow_policy.py",
+        name="policy content lock",
+    )
+    WORKFLOW.write_text(text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_contact_topology_covariance_workflow_policy.py
+++ b/tests/test_contact_topology_covariance_workflow_policy.py
@@ -7,22 +7,52 @@ ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "contact-topology-covariance.yml"
 
 
-def test_topology_covariance_workflow_is_read_only_and_reproduced() -> None:
+def _evaluate_job(text: str) -> str:
+    return text.split("  evaluate:", maxsplit=1)[1]
+
+
+def test_topology_covariance_workflow_is_read_only_manual_and_dual_lane() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
+    preamble = text.split("\njobs:\n", maxsplit=1)[0]
+    job = _evaluate_job(text)
 
     assert "permissions:\n  contents: read\n" in text
     assert "contents: write" not in text
     assert "git push" not in text
     assert "persist-credentials: false" in text
-    assert "lane: hosted" in text
-    assert "runs_on: '\"ubuntu-latest\"'" in text
-    assert "lane: workstation2" in text
-    assert 'runs_on: \'["self-hosted","Linux","X64","nvidia-smi"]\'' in text
-    assert "cache: pip" in text
-    assert "cache-dependency-path: pyproject.toml" in text
-    assert "github.event.pull_request.head.repo.full_name == github.repository" in text
-    assert "workflow_dispatch:" in text
-    assert "  push:" not in text
+    assert "workflow_dispatch:" in preamble
+    assert "\n  pull_request:" not in preamble
+    assert "\n  push:" not in preamble
+    assert "github.event.pull_request" not in job
+    assert "lane: hosted" in job
+    assert "runs_on: '\"ubuntu-latest\"'" in job
+    assert "lane: workstation2" in job
+    assert 'runs_on: \'["self-hosted","Linux","X64","nvidia-smi"]\'' in job
+    assert "cache: pip" in job
+    assert "cache-dependency-path: pyproject.toml" in job
+
+
+def test_topology_covariance_dual_lane_execution_is_main_only() -> None:
+    job = _evaluate_job(WORKFLOW.read_text(encoding="utf-8"))
+
+    assert "github.event_name == 'workflow_dispatch'" in job
+    assert "github.ref == 'refs/heads/main'" in job
+    guard = job.index("if: >-")
+    strategy = job.index("strategy:")
+    runner = job.index("runs-on: ${{ fromJSON(matrix.runs_on) }}")
+    assert guard < strategy < runner
+
+
+def test_topology_covariance_checks_out_and_verifies_exact_main_revision() -> None:
+    job = _evaluate_job(WORKFLOW.read_text(encoding="utf-8"))
+
+    assert "ref: ${{ github.sha }}" in job
+    assert 'test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"' in job
+    assert 'test -z "$(git status --porcelain=v1)"' in job
+    checkout = job.index("- name: Check out exact reviewed Causal4D revision")
+    verify = job.index("- name: Verify reviewed main revision")
+    install = job.index("- name: Install diagnostic environment")
+    assert checkout < verify < install
 
 
 def test_topology_covariance_workflow_locks_panels_grid_and_runtime() -> None:
@@ -65,3 +95,10 @@ def test_topology_covariance_workflow_verifies_frozen_source_before_target() -> 
     assert text.index("sha256sum -c") < text.index(
         "Run fresh target topology-conditioned comparison"
     )
+
+
+def test_topology_covariance_uses_non_editable_distribution() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'python -m pip install ".[dev]"' in text
+    assert "python -m pip install -e" not in text


### PR DESCRIPTION
## Summary

Preserve the completed topology-covariance diagnostic's independent hosted and workstation2 reproductions, while removing direct pull-request-head execution from the privileged lane.

The sealed workflow becomes manual and main-only before either matrix runner is allocated. It checks out and verifies the exact dispatch SHA, preserves the source-hash gate before the frozen `400:420` evaluation panel, and installs the package non-editably. Pull-request changes remain covered by ordinary hosted Causal4D CI and the workflow-policy test; they no longer open the full sealed dual-lane evaluation or execute branch-controlled code on workstation2.

## Intended final diff

- `.github/workflows/contact-topology-covariance.yml`
- `tests/test_contact_topology_covariance_workflow_policy.py`

The workflow's existing content lock for the policy test is updated to the exact new test bytes. All other sealed source hashes, grids, panels, numerical versions, and decision rules remain unchanged.

## Current draft transport

The branch initially contains `scripts/ci/apply_topology_covariance_workflow_hardening.py`. An exact same-repository PR workflow will verify the transformer digest, apply only the reviewed substitutions, run the focused policy and diagnostic suites, delete both transport files, verify the final two-file scope, and push ordinary reviewable source.

Do not merge while any transport file remains.

## Scientific boundary

This changes workflow authorization and installation provenance only. It does not change the frozen diagnostic method, development/evaluation panels, retained result, registered physical protocol, target identities, or evidence count.