### PR TITLE
Reject mixed-coordinate frame-zero cancellation

### DIFF
--- a/docs/latent_contact_v2.md
+++ b/docs/latent_contact_v2.md
@@ -28,9 +28,12 @@ Student-t nominal/outlier mixture. The normalization term, including the
 log-determinant of the declared covariance, is retained. Consequently a component
 cannot improve its likelihood merely by reporting a larger covariance.
 
-Endpoint frame zero may appear only in a zero-sum contrast. The standard dense
-builder therefore includes the endpoint-to-first-response increment while still
-forbidding direct reuse of the endpoint as new O-plus evidence.
+Endpoint frame zero may appear only in a translation-neutral contrast whose
+coefficients sum to zero **separately for every Cartesian coordinate**. The
+standard dense builder therefore includes endpoint-to-first-response increments
+while forbidding direct reuse of the endpoint as new O-plus evidence. Global
+cross-coordinate cancellation, such as `+x_0-y_1`, is invalid because an ordinary
+translation changes the resulting scalar.
 
 The convenience constructor supports:
 

--- a/src/causal4d/latent_contact_v2.py
+++ b/src/causal4d/latent_contact_v2.py
@@ -156,8 +156,9 @@ class LinearContactObservationGroup:
     The sparse operator is represented by parallel term vectors.  For term ``k``,
     ``coefficients[k]`` multiplies the rollout scalar selected by frame, node, and
     coordinate indices and contributes it to ``row_indices[k]``.  Endpoint frame
-    zero may appear only in a zero-sum contrast, which admits endpoint-to-first-
-    response increments without treating the endpoint as a fresh observation.
+    zero may appear only in a translation-neutral, zero-sum contrast for every
+    coordinate, which admits endpoint-to-first-response increments without
+    treating the endpoint as a fresh absolute observation.
     """
 
     group_id: str
@@ -223,15 +224,18 @@ class LinearContactObservationGroup:
         )
         for row in np.unique(rows[frames == 0]):
             row_terms = rows == row
-            if not np.isclose(
-                float(np.sum(coefficients[row_terms])),
-                0.0,
-                atol=1e-12,
-                rtol=1e-12,
-            ):
-                raise ValueError(
-                    "endpoint frame zero may appear only in a zero-sum contrast"
-                )
+            for coordinate in np.unique(coordinates[row_terms]):
+                coordinate_terms = row_terms & (coordinates == coordinate)
+                if not np.isclose(
+                    float(np.sum(coefficients[coordinate_terms])),
+                    0.0,
+                    atol=1e-12,
+                    rtol=1e-12,
+                ):
+                    raise ValueError(
+                        "endpoint frame zero may appear only in a "
+                        "translation-neutral zero-sum contrast per coordinate"
+                    )
             if not np.any(frames[row_terms] > 0):
                 raise ValueError("endpoint contrasts require a positive response frame")
         prior = _finite_float(

--- a/tests/test_linear_contact_observation_invariance.py
+++ b/tests/test_linear_contact_observation_invariance.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from causal4d.latent_contact_v2 import (
+    ContactObservationEvidenceV2,
+    LinearContactObservationGroup,
+    contact_component_log_likelihoods_v2,
+)
+
+
+def _group(
+    *,
+    group_id: str,
+    values_m: np.ndarray,
+    row_indices: np.ndarray,
+    coordinate_indices: np.ndarray,
+    covariance_m2: np.ndarray,
+) -> LinearContactObservationGroup:
+    return LinearContactObservationGroup(
+        group_id=group_id,
+        values_m=values_m,
+        row_indices=row_indices,
+        frame_indices=np.array([0, 1, 0, 1]),
+        node_indices=np.array([0, 0, 1, 1]),
+        coordinate_indices=coordinate_indices,
+        coefficients=np.array([-1.0, 1.0, -1.0, 1.0]),
+        covariance_m2=covariance_m2,
+        contributor_ids=("camera",),
+        prior_nominal_probability=0.999,
+        source_id="invariance-test",
+    )
+
+
+def test_endpoint_contrast_cannot_cancel_across_coordinates() -> None:
+    with pytest.raises(ValueError, match="translation-neutral.*per coordinate"):
+        LinearContactObservationGroup(
+            group_id="mixed-coordinate-endpoint",
+            values_m=np.zeros(1),
+            row_indices=np.array([0, 0]),
+            frame_indices=np.array([0, 1]),
+            node_indices=np.array([0, 0]),
+            coordinate_indices=np.array([0, 1]),
+            coefficients=np.array([1.0, -1.0]),
+            covariance_m2=np.eye(1),
+            contributor_ids=("camera",),
+            source_id="invariance-test",
+        )
+
+
+def test_same_coordinate_multi_node_endpoint_contrast_remains_valid() -> None:
+    group = LinearContactObservationGroup(
+        group_id="multi-node-x-displacement",
+        values_m=np.zeros(1),
+        row_indices=np.zeros(4, dtype=int),
+        frame_indices=np.array([0, 0, 1, 1]),
+        node_indices=np.array([0, 1, 0, 1]),
+        coordinate_indices=np.zeros(4, dtype=int),
+        coefficients=np.array([-0.25, -0.75, 0.4, 0.6]),
+        covariance_m2=np.eye(1),
+        contributor_ids=("camera",),
+        source_id="invariance-test",
+    )
+
+    translated = np.zeros((2, 2, 2), dtype=float)
+    translated[..., 0] = 12.5
+    assert group.apply(translated)[0] == pytest.approx(0.0)
+
+
+def test_valid_endpoint_rows_preserve_row_permutation_and_unit_scaling() -> None:
+    covariance = np.array([[0.04, 0.01], [0.01, 0.09]])
+    group = _group(
+        group_id="metres",
+        values_m=np.array([0.1, -0.2]),
+        row_indices=np.array([0, 0, 1, 1]),
+        coordinate_indices=np.array([0, 0, 1, 1]),
+        covariance_m2=covariance,
+    )
+    permuted = _group(
+        group_id="permuted",
+        values_m=np.array([-0.2, 0.1]),
+        row_indices=np.array([1, 1, 0, 0]),
+        coordinate_indices=np.array([0, 0, 1, 1]),
+        covariance_m2=covariance[np.ix_([1, 0], [1, 0])],
+    )
+    scaled = _group(
+        group_id="millimetres",
+        values_m=1000.0 * group.values_m,
+        row_indices=group.row_indices,
+        coordinate_indices=group.coordinate_indices,
+        covariance_m2=1_000_000.0 * group.covariance_m2,
+    )
+
+    components = np.zeros((3, 2, 2, 2), dtype=float)
+    components[0, 1, 0, 0] = 0.05
+    components[0, 1, 1, 1] = -0.10
+    components[1, 1, 0, 0] = 0.20
+    components[1, 1, 1, 1] = -0.35
+    components[2, 1, 0, 0] = -0.10
+    components[2, 1, 1, 1] = 0.15
+
+    scores, _ = contact_component_log_likelihoods_v2(
+        components,
+        ContactObservationEvidenceV2((group,)),
+        prefix_frame_count=2,
+    )
+    permuted_scores, _ = contact_component_log_likelihoods_v2(
+        components,
+        ContactObservationEvidenceV2((permuted,)),
+        prefix_frame_count=2,
+    )
+    scaled_scores, _ = contact_component_log_likelihoods_v2(
+        1000.0 * components,
+        ContactObservationEvidenceV2((scaled,)),
+        prefix_frame_count=2,
+    )
+
+    assert np.allclose(scores, permuted_scores, atol=1e-12, rtol=1e-12)
+    assert np.allclose(
+        scores - scores[0],
+        scaled_scores - scaled_scores[0],
+        atol=1e-12,
+        rtol=1e-12,
+    )


### PR DESCRIPTION
## Summary

Fix #233 by requiring every endpoint-containing linear observation row to be translation-neutral separately for each Cartesian coordinate.

The previous transport-history PR #238 is superseded by this clean one-commit branch based on current `main@1974fefe17dfd0df717f524117fa5658c6314820`. The diff contains exactly the three reviewable product files and no temporary workflow, encoded patch, or branch-rewriting machinery.

## Changes

- `LinearContactObservationGroup` now rejects global cross-coordinate cancellation such as `+x_0-y_1`;
- valid same-coordinate endpoint-to-response displacement contrasts remain accepted;
- multi-node same-coordinate contrasts are supported when each coordinate's coefficient mass is neutral;
- regression tests cover mixed-coordinate rejection, row permutation, and metre/millimetre likelihood invariance; and
- the latent-contact-v2 documentation now states the coordinate-wise translation-invariance contract explicitly.

## Relationship to full-joint inference

Merged PR #231 already enforces the same per-coordinate invariant for prospective `LinearJointObservationEvidence`. This PR repairs the earlier `LinearContactObservationGroup` contract independently and keeps the two observation paths consistent.

## Exact scope

```text
docs/latent_contact_v2.md
src/causal4d/latent_contact_v2.py
tests/test_linear_contact_observation_invariance.py
```

Exact head:

```text
397b066a33bb6adcf51d0c0ab468eb385e3a1090
```

## Scientific boundary

This is a fail-closed contract-correctness repair. It does not reinterpret valid same-coordinate evidence, alter the frozen v0.3 estimator bytes, change the registered 18-session/36-execution protocol, open target outcomes, or increment the physical evidence count.