### PR TITLE
Add a reproducible physical-acquisition environment capsule

### DIFF
--- a/docs/causal4d_acquisition_environment_capsule.md
+++ b/docs/causal4d_acquisition_environment_capsule.md
@@ -1,0 +1,196 @@
+# Physical-acquisition software environment capsule
+
+## Purpose
+
+The registered physical experiment requires a sealed software-environment gate
+after the exact method freeze has been independently attested and before the
+first confirmatory execution. The gate must identify the deployed Causal4D and
+BayesianPhysTwin distributions, observation producer, Python and numerical
+runtime, and resolved dependency set.
+
+`causal4d protocol readiness software-environment-stage` constructs that evidence
+from the actually deployed environment. It does **not** approve or seal the gate.
+The independent approval step remains separate:
+
+```text
+build and install exact wheels
+        ↓
+stage immutable environment evidence
+        ↓
+independently inspect the capsule and deployed environment
+        ↓
+seal software_environment_locked
+        ↓
+rerun hash-verified readiness
+```
+
+This separation prevents the process that creates the environment from also
+claiming that it was independently accepted.
+
+## Preconditions
+
+Run the staging command only when all of the following hold:
+
+- the readiness dataset has already been scaffolded;
+- the source-panel and operational prerequisites required before the method
+  freeze are complete;
+- `method_freeze.json` is valid;
+- `method_freeze_validation.json` is valid and independently attested;
+- the Causal4D and BayesianPhysTwin checkouts are clean and exactly match the
+  commits bound by the method freeze;
+- no confirmatory manifest, acquired execution, or validated execution exists;
+- the software-environment gate is still the pristine scaffold template; and
+- the command is executed from the intended deployment Python environment, with
+  Causal4D and BayesianPhysTwin installed from the exact supplied wheel versions.
+
+The selected physical-acquisition candidate keeps Prob4D unused. The staged
+software declaration copies the registered reason from
+`configs/causal4d/sloth_acquisition_candidate_v1.json`; package compatibility is
+not treated as method admission.
+
+## Recommended operator helper
+
+The helper builds both wheels from clean `git archive` exports, creates a new
+deployment virtual environment, installs only the built wheels and their runtime
+dependencies, runs `pip check`, captures `pip freeze --all`, and invokes the
+staging command from that deployed environment.
+
+```bash
+bash scripts/acquisition/stage_software_environment.sh \
+  /opt/causal4d-frozen \
+  /opt/bayesianphystwin-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  /opt/causal4d-acquisition-venv \
+  registered-rgbd-tracker \
+  1.0 \
+  causal4d.observation-prefix-v1 \
+  cuda
+```
+
+The host Python used to launch this helper must already provide the standard
+`build` package. The destination deployment environment must not exist. On a
+failed run the helper removes that incomplete environment; on success it retains
+the environment for independent inspection and acquisition use.
+
+The optional ninth argument selects Causal4D extras as a comma-separated list.
+Use `-` for no extras. Defaults are:
+
+| Backend | Default Causal4D extras |
+| --- | --- |
+| `numpy_cpu` | none |
+| `warp_cpu` | `warp` |
+| `cuda` | `vision,warp` |
+
+An optional tenth argument records an immutable container identity in the form
+`sha256:<64 lowercase hexadecimal characters>`. Omit it for a non-containerized
+deployment.
+
+## Direct command
+
+When the exact wheels and dependency report already exist, stage them directly:
+
+```bash
+/opt/causal4d-acquisition-venv/bin/causal4d \
+  protocol readiness software-environment-stage \
+  /opt/causal4d-frozen \
+  /opt/bayesianphystwin-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  /artifacts/causal4d-0.5.0-py3-none-any.whl \
+  /artifacts/bayesian_phystwin-0.4.0-py3-none-any.whl \
+  /artifacts/resolved-dependencies.txt \
+  --observation-producer-name registered-rgbd-tracker \
+  --observation-producer-version 1.0 \
+  --observation-artifact-contract causal4d.observation-prefix-v1 \
+  --execution-backend cuda
+```
+
+The command fails closed when an installed project version differs from its
+supplied wheel, either import resolves into a source checkout, a checkout is
+dirty, a revision differs from the freeze, the candidate identity changes, the
+dependency report contains an editable project installation, the backend lacks
+its required runtime, or confirmatory collection has started.
+
+## Published evidence
+
+Staging publishes ordinary files below the dataset root:
+
+```text
+preacquisition/software_environment/
+├── capsule.json
+├── build-provenance.json
+├── runtime.json
+├── resolved-dependencies.txt
+└── distributions/
+    ├── causal4d-<version>-<tags>.whl
+    └── bayesian_phystwin-<version>-<tags>.whl
+```
+
+The capsule records:
+
+- protocol, amendment, method-freeze, attestation, and acquisition-candidate
+  identities;
+- exact wheel SHA-256 values and byte counts;
+- clean source revisions;
+- installed versions and import locations relative to the active Python prefix;
+- Python implementation, version, and platform;
+- NumPy, SciPy, and applicable Torch, Warp, OpenCV, CUDA-runtime, and
+  CUDA-driver versions;
+- selected numerical backend and optional container-image digest;
+- observation-producer identity and contract; and
+- explicit declarations that target outcomes were not used and confirmatory
+  collection had not started.
+
+The command also populates
+`preacquisition/software_environment.json`, but deliberately leaves it as an
+unapproved `status=template` record with `artifact_sha256=null`. Every referenced
+file is hashed and validated before that operator template is replaced.
+
+The command refuses to replace an already staged or sealed operator record. A
+rerun after a complete staging therefore fails rather than silently changing the
+deployed environment. An interrupted run before the gate replacement may be
+rerun only when any already published capsule files have exactly the requested
+bytes.
+
+## Independent approval and sealing
+
+The independent verifier should compare the retained deployment environment,
+wheel files, dependency report, runtime report, build provenance, and capsule.
+After approval, seal the gate through the existing operator-identity boundary:
+
+```bash
+/opt/causal4d-acquisition-venv/bin/causal4d \
+  protocol readiness seal-gate \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  software_environment_locked \
+  --approved-by "<independent-verifier>"
+```
+
+Sealing recomputes every descriptor hash, checks the frozen commits and
+attestation, verifies chronology, binds the approved operator identity, and
+refuses to proceed if confirmatory collection has begun.
+
+Finally, derive the collection decision again:
+
+```bash
+/opt/causal4d-acquisition-venv/bin/causal4d \
+  protocol readiness status \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  --verify-file-hashes \
+  --require-ready \
+  --output-json \
+  /data/causal4d-sloth-multi-action-v1/preacquisition-readiness.json
+```
+
+Only `ready=true` together with
+`first_confirmatory_execution_allowed=true` authorizes execution 1.
+
+## Evidence boundary
+
+This capsule is deployment and reproducibility evidence. It creates no source
+execution, confirmatory execution, physical observation, target outcome, model
+accuracy result, calibration result, or scientific claim. In particular, it
+cannot increment the registered `0/36` physical evidence count or substitute for
+the source panel, contact registration, synchronization, dry run, or physical
+experiment.

--- a/scripts/acquisition/stage_software_environment.sh
+++ b/scripts/acquisition/stage_software_environment.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  stage_software_environment.sh \
+    <causal4d-root> <bayesianphystwin-root> <dataset-root> <deployment-venv> \
+    <observation-producer-name> <observation-producer-version> \
+    <observation-artifact-contract> <numpy_cpu|warp_cpu|cuda> \
+    [causal4d-extras] [container-image-digest]
+
+The optional extras argument is a comma-separated Causal4D extras list. Use '-'
+for no extras. Defaults are empty for numpy_cpu, warp for warp_cpu, and
+vision,warp for cuda.
+
+Run this only after the method freeze and independent attestation exist. The
+script refuses a pre-existing deployment environment, builds wheels from clean
+Git archives, installs them into that environment, captures pip freeze, and
+stages the unapproved software-environment gate. Independent approval and
+`seal-gate software_environment_locked` remain separate steps.
+EOF
+}
+
+if (( $# < 8 || $# > 10 )); then
+  usage
+  exit 2
+fi
+
+causal4d_root="$(cd "$1" && pwd -P)"
+bayesian_phystwin_root="$(cd "$2" && pwd -P)"
+dataset_root="$(cd "$3" && pwd -P)"
+deployment_venv="$4"
+producer_name="$5"
+producer_version="$6"
+producer_contract="$7"
+backend="$8"
+extras="${9:-}"
+container_digest="${10:-}"
+python_bin="${PYTHON:-python3}"
+
+case "$backend" in
+  numpy_cpu)
+    default_extras=""
+    ;;
+  warp_cpu)
+    default_extras="warp"
+    ;;
+  cuda)
+    default_extras="vision,warp"
+    ;;
+  *)
+    echo "Unsupported execution backend: $backend" >&2
+    exit 2
+    ;;
+esac
+
+if [[ -z "$extras" ]]; then
+  extras="$default_extras"
+elif [[ "$extras" == "-" ]]; then
+  extras=""
+fi
+
+if [[ -e "$deployment_venv" ]]; then
+  echo "Deployment environment already exists: $deployment_venv" >&2
+  exit 2
+fi
+
+for checkout in "$causal4d_root" "$bayesian_phystwin_root"; do
+  git -C "$checkout" rev-parse --show-toplevel >/dev/null
+  test -z "$(git -C "$checkout" status --porcelain=v1 --untracked-files=all)"
+done
+
+if ! "$python_bin" -m build --version >/dev/null 2>&1; then
+  echo "The selected Python environment needs the 'build' package." >&2
+  exit 2
+fi
+
+work_root="$(mktemp -d "${TMPDIR:-/tmp}/causal4d-acquisition-capsule.XXXXXX")"
+completed=false
+cleanup() {
+  rm -rf "$work_root"
+  if [[ "$completed" != true ]]; then
+    rm -rf "$deployment_venv"
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "$work_root/causal4d" "$work_root/bayesianphystwin" "$work_root/wheels"
+git -C "$causal4d_root" archive --format=tar HEAD \
+  | tar -xf - -C "$work_root/causal4d"
+git -C "$bayesian_phystwin_root" archive --format=tar HEAD \
+  | tar -xf - -C "$work_root/bayesianphystwin"
+
+"$python_bin" -m build --wheel \
+  --outdir "$work_root/wheels" \
+  "$work_root/causal4d"
+"$python_bin" -m build --wheel \
+  --outdir "$work_root/wheels" \
+  "$work_root/bayesianphystwin"
+
+mapfile -t causal4d_wheels < <(
+  find "$work_root/wheels" -maxdepth 1 -type f -name 'causal4d-*.whl' | sort
+)
+mapfile -t bayesian_phystwin_wheels < <(
+  find "$work_root/wheels" -maxdepth 1 -type f \
+    -name 'bayesian_phystwin-*.whl' | sort
+)
+if (( ${#causal4d_wheels[@]} != 1 || ${#bayesian_phystwin_wheels[@]} != 1 )); then
+  echo "Expected exactly one Causal4D and one BayesianPhysTwin wheel." >&2
+  exit 2
+fi
+causal4d_wheel="${causal4d_wheels[0]}"
+bayesian_phystwin_wheel="${bayesian_phystwin_wheels[0]}"
+
+"$python_bin" -m venv "$deployment_venv"
+"$deployment_venv/bin/python" -m pip install --upgrade pip
+
+causal4d_uri="$(
+  "$python_bin" - "$causal4d_wheel" <<'PY'
+from pathlib import Path
+import sys
+
+print(Path(sys.argv[1]).resolve().as_uri())
+PY
+)"
+bayesian_phystwin_uri="$(
+  "$python_bin" - "$bayesian_phystwin_wheel" <<'PY'
+from pathlib import Path
+import sys
+
+print(Path(sys.argv[1]).resolve().as_uri())
+PY
+)"
+causal4d_requirement="causal4d"
+if [[ -n "$extras" ]]; then
+  causal4d_requirement+="[$extras]"
+fi
+causal4d_requirement+=" @ $causal4d_uri"
+bayesian_phystwin_requirement="bayesian-phystwin @ $bayesian_phystwin_uri"
+
+"$deployment_venv/bin/python" -m pip install \
+  "$causal4d_requirement" \
+  "$bayesian_phystwin_requirement"
+"$deployment_venv/bin/python" -m pip check
+"$deployment_venv/bin/python" -m pip freeze --all \
+  > "$work_root/resolved-dependencies.txt"
+
+command=(
+  "$deployment_venv/bin/causal4d"
+  protocol readiness software-environment-stage
+  "$causal4d_root"
+  "$bayesian_phystwin_root"
+  "$dataset_root"
+  "$causal4d_wheel"
+  "$bayesian_phystwin_wheel"
+  "$work_root/resolved-dependencies.txt"
+  --observation-producer-name "$producer_name"
+  --observation-producer-version "$producer_version"
+  --observation-artifact-contract "$producer_contract"
+  --execution-backend "$backend"
+)
+if [[ -n "$container_digest" ]]; then
+  command+=(--container-image-digest "$container_digest")
+fi
+"${command[@]}"
+
+completed=true
+printf 'Deployment environment: %s\n' "$(cd "$deployment_venv" && pwd -P)"
+printf 'Next independent step:\n'
+printf '  %q protocol readiness seal-gate %q %q software_environment_locked --approved-by %q\n' \
+  "$deployment_venv/bin/causal4d" \
+  "$causal4d_root" \
+  "$dataset_root" \
+  '<independent-verifier>'

--- a/src/causal4d/acquisition_environment.py
+++ b/src/causal4d/acquisition_environment.py
@@ -139,7 +139,9 @@ def _safe_dataset_path(dataset_root: Path, relative: Path) -> Path:
             _require(not cursor.is_symlink(), "capsule parent contains a symlink")
         else:
             cursor.mkdir()
-    _require(cursor.resolve(strict=True).is_relative_to(root), "capsule path escapes root")
+    _require(
+        cursor.resolve(strict=True).is_relative_to(root), "capsule path escapes root"
+    )
     target = cursor / relative.name
     if target.exists() or target.is_symlink():
         _require(not target.is_symlink(), "capsule destination is a symlink")
@@ -229,7 +231,9 @@ def _installed_version(name: str, *, required: bool) -> str | None:
         return metadata.version(name)
     except metadata.PackageNotFoundError as error:
         if required:
-            raise ValueError(f"required distribution is not installed: {name}") from error
+            raise ValueError(
+                f"required distribution is not installed: {name}"
+            ) from error
         return None
 
 
@@ -282,7 +286,9 @@ def _cuda_runtime_version() -> str | None:
     try:
         import torch
     except (ImportError, OSError) as error:
-        raise ValueError("CUDA backend requires an importable PyTorch runtime") from error
+        raise ValueError(
+            "CUDA backend requires an importable PyTorch runtime"
+        ) from error
     value = getattr(torch.version, "cuda", None)
     return str(value).strip() if value is not None and str(value).strip() else None
 
@@ -351,7 +357,9 @@ def _capture_runtime_environment(
     if execution_backend == "cuda":
         cuda_runtime_version = _cuda_runtime_version()
         cuda_driver_version = _cuda_driver_version()
-        _require(cuda_runtime_version is not None, "CUDA runtime version is unavailable")
+        _require(
+            cuda_runtime_version is not None, "CUDA runtime version is unavailable"
+        )
         _require(cuda_driver_version is not None, "CUDA driver version is unavailable")
     runtime = {
         "execution_backend": execution_backend,
@@ -577,13 +585,11 @@ def stage_software_environment_capsule(
         causal4d_version=causal4d_identity.version,
         bayesian_phystwin_version=bpt_identity.version,
     )
-    python_environment, runtime_environment, installed = (
-        _capture_runtime_environment(
-            execution_backend=execution_backend,
-            container_image_digest=container_image_digest,
-            causal4d_root=repository,
-            bayesian_phystwin_root=bpt_repository,
-        )
+    python_environment, runtime_environment, installed = _capture_runtime_environment(
+        execution_backend=execution_backend,
+        container_image_digest=container_image_digest,
+        causal4d_root=repository,
+        bayesian_phystwin_root=bpt_repository,
     )
     _require(
         installed["causal4d"]["version"] == causal4d_identity.version,

--- a/src/causal4d/acquisition_environment.py
+++ b/src/causal4d/acquisition_environment.py
@@ -1,0 +1,795 @@
+"""Stage exact software-environment evidence for physical acquisition."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import platform
+import re
+import subprocess
+import sys
+from collections.abc import Mapping
+from copy import deepcopy
+from datetime import datetime, timezone
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+from causal4d.artifact_io import load_strict_json_object, read_regular_file
+from causal4d.atomic_io import atomic_write_binary
+from causal4d.preacquisition_gate_validation import _validate_software_environment
+from causal4d.preacquisition_readiness_contracts import (
+    GATE_PATHS,
+    _parse_utc_timestamp,
+    _require,
+    _sha256_file,
+    gate_evidence_template,
+    load_registered_preacquisition_chain,
+)
+from causal4d.real_evidence_contract_v2 import build_real_evidence_status
+from causal4d.real_experiment_freeze import ACQUISITION_CANDIDATE_PATH
+from causal4d.stack_lock import WheelIdentity, inspect_wheel
+
+CAPSULE_SCHEMA_NAME = "causal4d.acquisition-environment-capsule"
+CAPSULE_SCHEMA_VERSION = 1
+CAPSULE_ARTIFACT_KIND = "Causal4DAcquisitionEnvironmentCapsule"
+CAPSULE_GENERATOR = "causal4d protocol readiness software-environment-stage"
+CAPSULE_ROOT = Path("preacquisition/software_environment")
+CAPSULE_MANIFEST_PATH = CAPSULE_ROOT / "capsule.json"
+RUNTIME_REPORT_PATH = CAPSULE_ROOT / "runtime.json"
+BUILD_PROVENANCE_PATH = CAPSULE_ROOT / "build-provenance.json"
+DEPENDENCY_REPORT_PATH = CAPSULE_ROOT / "resolved-dependencies.txt"
+DISTRIBUTION_ROOT = CAPSULE_ROOT / "distributions"
+SOFTWARE_GATE_ID = "software_environment_locked"
+
+_HEX40 = re.compile(r"[0-9a-f]{40}")
+_HEX64 = re.compile(r"[0-9a-f]{64}")
+_CONTAINER_DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
+_BACKENDS = frozenset({"numpy_cpu", "warp_cpu", "cuda"})
+
+
+def _canonical_sha256(
+    values: Mapping[str, Any],
+    *,
+    omitted_field: str,
+) -> str:
+    payload = deepcopy(dict(values))
+    payload.pop(omitted_field, None)
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _with_content_id(
+    values: Mapping[str, Any],
+    *,
+    field: str,
+) -> dict[str, Any]:
+    payload = deepcopy(dict(values))
+    payload[field] = _canonical_sha256(payload, omitted_field=field)
+    return payload
+
+
+def _nonempty(value: Any, *, name: str) -> str:
+    _require(isinstance(value, str) and bool(value.strip()), f"{name} is missing")
+    return value.strip()
+
+
+def _run_git(root: Path, *arguments: str) -> str:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(root), *arguments],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError) as error:
+        raise ValueError(f"cannot inspect Git checkout: {root}") from error
+    return completed.stdout.strip()
+
+
+def _inspect_git_checkout(
+    root: str | Path,
+    *,
+    label: str,
+    expected_revision: str,
+) -> dict[str, Any]:
+    checkout = Path(root).resolve(strict=True)
+    _require(checkout.is_dir(), f"{label} checkout is not a directory")
+    top_level = Path(_run_git(checkout, "rev-parse", "--show-toplevel")).resolve()
+    _require(top_level == checkout, f"{label} path is not the checkout root")
+    revision = _run_git(checkout, "rev-parse", "HEAD").lower()
+    _require(
+        _HEX40.fullmatch(revision) is not None,
+        f"{label} checkout revision is invalid",
+    )
+    _require(
+        revision == expected_revision,
+        f"{label} checkout differs from the method freeze",
+    )
+    status = _run_git(checkout, "status", "--porcelain=v1", "--untracked-files=all")
+    _require(not status, f"{label} checkout is dirty")
+    return {
+        "repository": (
+            "IPS-Stuttgart/Causal4D"
+            if label == "Causal4D"
+            else "IPS-Stuttgart/BayesianPhysTwin"
+        ),
+        "revision": revision,
+        "clean": True,
+    }
+
+
+def _safe_dataset_path(dataset_root: Path, relative: Path) -> Path:
+    _require(
+        not relative.is_absolute() and ".." not in relative.parts,
+        "capsule destination is unsafe",
+    )
+    root = dataset_root.resolve(strict=True)
+    cursor = dataset_root
+    for part in relative.parts[:-1]:
+        cursor = cursor / part
+        if cursor.exists():
+            _require(cursor.is_dir(), "capsule parent is not a directory")
+            _require(not cursor.is_symlink(), "capsule parent contains a symlink")
+        else:
+            cursor.mkdir()
+    _require(cursor.resolve(strict=True).is_relative_to(root), "capsule path escapes root")
+    target = cursor / relative.name
+    if target.exists() or target.is_symlink():
+        _require(not target.is_symlink(), "capsule destination is a symlink")
+        _require(target.is_file(), "capsule destination is not an ordinary file")
+    return target
+
+
+def _publish_payload(
+    dataset_root: Path,
+    relative: Path,
+    payload: bytes,
+    *,
+    name: str,
+) -> dict[str, Any]:
+    target = _safe_dataset_path(dataset_root, relative)
+    expected_sha256 = hashlib.sha256(payload).hexdigest()
+    expected_bytes = len(payload)
+    if target.exists():
+        existing = read_regular_file(target, name=name)
+        _require(
+            existing.sha256 == expected_sha256
+            and existing.byte_count == expected_bytes,
+            f"existing {name} differs from the requested capsule",
+        )
+    else:
+        try:
+            atomic_write_binary(
+                target,
+                lambda handle: handle.write(payload),
+                overwrite=False,
+            )
+        except FileExistsError:
+            existing = read_regular_file(target, name=name)
+            _require(
+                existing.sha256 == expected_sha256
+                and existing.byte_count == expected_bytes,
+                f"concurrently published {name} differs",
+            )
+    digest, byte_count = _sha256_file(target)
+    _require(digest == expected_sha256, f"published {name} checksum mismatch")
+    _require(byte_count == expected_bytes, f"published {name} byte count mismatch")
+    return {
+        "path": relative.as_posix(),
+        "sha256": digest,
+        "bytes": byte_count,
+    }
+
+
+def _publish_file(
+    dataset_root: Path,
+    relative: Path,
+    source: str | Path,
+    *,
+    name: str,
+) -> dict[str, Any]:
+    snapshot = read_regular_file(source, name=name)
+    _require(snapshot.byte_count > 0, f"{name} is empty")
+    return _publish_payload(
+        dataset_root,
+        relative,
+        snapshot.payload,
+        name=name,
+    )
+
+
+def _publish_json(
+    dataset_root: Path,
+    relative: Path,
+    values: Mapping[str, Any],
+    *,
+    name: str,
+) -> dict[str, Any]:
+    payload = (
+        json.dumps(
+            dict(values),
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+    return _publish_payload(dataset_root, relative, payload, name=name)
+
+
+def _installed_version(name: str, *, required: bool) -> str | None:
+    try:
+        return metadata.version(name)
+    except metadata.PackageNotFoundError as error:
+        if required:
+            raise ValueError(f"required distribution is not installed: {name}") from error
+        return None
+
+
+def _opencv_version() -> str | None:
+    distributions = (
+        "opencv-python",
+        "opencv-python-headless",
+        "opencv-contrib-python",
+        "opencv-contrib-python-headless",
+    )
+    installed: list[str] = []
+    for name in distributions:
+        version = _installed_version(name, required=False)
+        if version is not None:
+            installed.append(f"{name}=={version}")
+    return ";".join(installed) if installed else None
+
+
+def _module_origin(
+    module_name: str,
+    *,
+    distribution_name: str,
+    source_roots: tuple[Path, ...],
+) -> dict[str, Any]:
+    version = _installed_version(distribution_name, required=True)
+    specification = importlib.util.find_spec(module_name)
+    _require(
+        specification is not None and specification.origin is not None,
+        f"installed module cannot be resolved: {module_name}",
+    )
+    origin = Path(specification.origin).resolve(strict=True)
+    for source_root in source_roots:
+        _require(
+            not origin.is_relative_to(source_root),
+            f"{distribution_name} resolves from a source checkout",
+        )
+    prefix = Path(sys.prefix).resolve(strict=True)
+    _require(
+        origin.is_relative_to(prefix),
+        f"{distribution_name} does not resolve below the active Python prefix",
+    )
+    return {
+        "version": version,
+        "origin_relative_to_python_prefix": origin.relative_to(prefix).as_posix(),
+        "source_checkout_resolved": False,
+    }
+
+
+def _cuda_runtime_version() -> str | None:
+    try:
+        import torch
+    except (ImportError, OSError) as error:
+        raise ValueError("CUDA backend requires an importable PyTorch runtime") from error
+    value = getattr(torch.version, "cuda", None)
+    return str(value).strip() if value is not None and str(value).strip() else None
+
+
+def _cuda_driver_version() -> str | None:
+    try:
+        completed = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=driver_version",
+                "--format=csv,noheader",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+    versions = sorted(
+        {line.strip() for line in completed.stdout.splitlines() if line.strip()}
+    )
+    return ",".join(versions) if versions else None
+
+
+def _capture_runtime_environment(
+    *,
+    execution_backend: str,
+    container_image_digest: str | None,
+    causal4d_root: Path,
+    bayesian_phystwin_root: Path,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    _require(
+        execution_backend in _BACKENDS,
+        "execution_backend must be numpy_cpu, warp_cpu, or cuda",
+    )
+    if container_image_digest is not None:
+        _require(
+            _CONTAINER_DIGEST.fullmatch(container_image_digest) is not None,
+            "container image digest must be sha256:<64 lowercase hex>",
+        )
+    source_roots = (causal4d_root.resolve(), bayesian_phystwin_root.resolve())
+    installed = {
+        "causal4d": _module_origin(
+            "causal4d",
+            distribution_name="causal4d",
+            source_roots=source_roots,
+        ),
+        "bayesian_phystwin": _module_origin(
+            "bayesian_phystwin",
+            distribution_name="bayesian-phystwin",
+            source_roots=source_roots,
+        ),
+    }
+    python = {
+        "version": platform.python_version(),
+        "implementation": platform.python_implementation(),
+        "platform": platform.platform(),
+    }
+    torch_version = _installed_version("torch", required=False)
+    warp_version = _installed_version("warp-lang", required=False)
+    cuda_runtime_version = None
+    cuda_driver_version = None
+    if execution_backend in {"warp_cpu", "cuda"}:
+        _require(torch_version is not None, f"{execution_backend} requires PyTorch")
+        _require(warp_version is not None, f"{execution_backend} requires Warp")
+    if execution_backend == "cuda":
+        cuda_runtime_version = _cuda_runtime_version()
+        cuda_driver_version = _cuda_driver_version()
+        _require(cuda_runtime_version is not None, "CUDA runtime version is unavailable")
+        _require(cuda_driver_version is not None, "CUDA driver version is unavailable")
+    runtime = {
+        "execution_backend": execution_backend,
+        "containerized": container_image_digest is not None,
+        "container_image_digest": container_image_digest,
+        "numpy_version": _installed_version("numpy", required=True),
+        "scipy_version": _installed_version("scipy", required=True),
+        "torch_version": torch_version,
+        "warp_version": warp_version,
+        "opencv_version": _opencv_version(),
+        "cuda_runtime_version": cuda_runtime_version,
+        "cuda_driver_version": cuda_driver_version,
+    }
+    return python, runtime, installed
+
+
+def _load_acquisition_candidate(
+    repository_root: Path,
+    *,
+    expected_sha256: str,
+) -> dict[str, Any]:
+    snapshot = read_regular_file(
+        repository_root / ACQUISITION_CANDIDATE_PATH,
+        name="acquisition candidate",
+    )
+    candidate = load_strict_json_object(snapshot.payload, name="acquisition candidate")
+    candidate_sha256 = candidate.get("candidate_sha256")
+    _require(
+        isinstance(candidate_sha256, str)
+        and _HEX64.fullmatch(candidate_sha256) is not None,
+        "acquisition candidate SHA-256 is invalid",
+    )
+    _require(
+        candidate_sha256
+        == _canonical_sha256(candidate, omitted_field="candidate_sha256"),
+        "acquisition candidate SHA-256 does not match its contents",
+    )
+    _require(
+        candidate_sha256 == expected_sha256,
+        "method freeze binds a different acquisition candidate",
+    )
+    prob4d = candidate.get("observation_path", {}).get("prob4d", {})
+    _require(prob4d.get("used") is False, "acquisition candidate admits Prob4D")
+    _nonempty(prob4d.get("reason"), name="unused Prob4D reason")
+    return candidate
+
+
+def _validate_dependency_report(
+    path: str | Path,
+    *,
+    causal4d_version: str,
+    bayesian_phystwin_version: str,
+) -> None:
+    snapshot = read_regular_file(path, name="resolved dependency report")
+    try:
+        text = snapshot.payload.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ValueError("resolved dependency report is not UTF-8") from error
+    _require(bool(text.strip()), "resolved dependency report is empty")
+    normalized = text.casefold().replace("_", "-")
+    _require("causal4d" in normalized, "dependency report omits Causal4D")
+    _require(
+        "bayesian-phystwin" in normalized,
+        "dependency report omits BayesianPhysTwin",
+    )
+    for line in text.splitlines():
+        normalized_line = line.casefold().replace("_", "-").strip()
+        if normalized_line.startswith("-e ") and (
+            "causal4d" in normalized_line or "bayesian-phystwin" in normalized_line
+        ):
+            raise ValueError("dependency report contains an editable project install")
+    _require(bool(causal4d_version), "Causal4D wheel version is missing")
+    _require(
+        bool(bayesian_phystwin_version),
+        "BayesianPhysTwin wheel version is missing",
+    )
+
+
+def _wheel_descriptor(
+    dataset_root: Path,
+    identity: WheelIdentity,
+    *,
+    name: str,
+) -> dict[str, Any]:
+    relative = DISTRIBUTION_ROOT / identity.filename
+    descriptor = _publish_file(
+        dataset_root,
+        relative,
+        identity.path,
+        name=f"{name} wheel",
+    )
+    _require(descriptor["sha256"] == identity.sha256, f"{name} wheel digest drift")
+    _require(descriptor["bytes"] == identity.size_bytes, f"{name} wheel size drift")
+    return descriptor
+
+
+def stage_software_environment_capsule(
+    repository_root: str | Path,
+    bayesian_phystwin_root: str | Path,
+    dataset_root: str | Path,
+    causal4d_wheel: str | Path,
+    bayesian_phystwin_wheel: str | Path,
+    dependency_report: str | Path,
+    *,
+    observation_producer_name: str,
+    observation_producer_version: str,
+    observation_artifact_contract: str,
+    execution_backend: str,
+    container_image_digest: str | None = None,
+    completed_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Populate the unapproved software gate from exact deployed artifacts."""
+
+    repository = Path(repository_root).resolve(strict=True)
+    bpt_repository = Path(bayesian_phystwin_root).resolve(strict=True)
+    dataset = Path(dataset_root)
+    _require(dataset.is_dir(), "dataset root does not exist")
+    protocol, v2, _, v4 = load_registered_preacquisition_chain(repository)
+    gate_path = dataset / GATE_PATHS[SOFTWARE_GATE_ID]
+    expected_template = gate_evidence_template(SOFTWARE_GATE_ID, protocol, v2, v4)
+    gate_snapshot = read_regular_file(gate_path, name="software environment gate")
+    current_gate = load_strict_json_object(
+        gate_snapshot.payload,
+        name="software environment gate",
+    )
+    _require(
+        current_gate == expected_template,
+        "software environment gate is not the pristine scaffold template",
+    )
+
+    real_status = build_real_evidence_status(
+        protocol,
+        dataset,
+        repository_root=repository,
+        verify_file_hashes=True,
+    )
+    prerequisites = real_status.get("prerequisites")
+    _require(isinstance(prerequisites, Mapping), "readiness prerequisites are missing")
+    freeze = prerequisites.get("method_freeze")
+    attestation = prerequisites.get("method_freeze_validation")
+    _require(isinstance(freeze, Mapping), "method freeze status is missing")
+    _require(isinstance(attestation, Mapping), "freeze attestation status is missing")
+    _require(freeze.get("valid") is True, "method freeze is not valid")
+    _require(attestation.get("valid") is True, "method freeze is not attested")
+    for field in (
+        "manifest_executions",
+        "acquired_executions",
+        "validated_executions",
+    ):
+        _require(real_status.get(field) == 0, "confirmatory collection has started")
+
+    freeze_sha256 = _nonempty(freeze.get("sha256"), name="method freeze SHA-256")
+    attestation_sha256 = _nonempty(
+        attestation.get("sha256"),
+        name="freeze attestation SHA-256",
+    )
+    causal4d_revision = _nonempty(
+        freeze.get("causal4d_commit_sha"),
+        name="frozen Causal4D revision",
+    )
+    bpt_revision = _nonempty(
+        freeze.get("bayesian_phystwin_commit_sha"),
+        name="frozen BayesianPhysTwin revision",
+    )
+    _require(
+        _HEX40.fullmatch(causal4d_revision) is not None,
+        "frozen Causal4D revision is invalid",
+    )
+    _require(
+        _HEX40.fullmatch(bpt_revision) is not None,
+        "frozen BayesianPhysTwin revision is invalid",
+    )
+    candidate_sha256 = _nonempty(
+        freeze.get("acquisition_candidate_sha256"),
+        name="frozen acquisition candidate SHA-256",
+    )
+    _require(
+        _HEX64.fullmatch(candidate_sha256) is not None,
+        "frozen acquisition candidate SHA-256 is invalid",
+    )
+    candidate = _load_acquisition_candidate(
+        repository,
+        expected_sha256=candidate_sha256,
+    )
+
+    completed_at = completed_at_utc or datetime.now(timezone.utc).isoformat()
+    completed = _parse_utc_timestamp(
+        completed_at,
+        name="software environment completed_at_utc",
+    )
+    for prerequisite, field, label in (
+        (freeze, "frozen_at_utc", "method freeze"),
+        (attestation, "verified_at_utc", "freeze attestation"),
+    ):
+        value = prerequisite.get(field)
+        if value is not None:
+            _require(
+                completed >= _parse_utc_timestamp(value, name=f"{label} timestamp"),
+                f"software environment completion predates the {label}",
+            )
+
+    checkouts = {
+        "causal4d": _inspect_git_checkout(
+            repository,
+            label="Causal4D",
+            expected_revision=causal4d_revision,
+        ),
+        "bayesian_phystwin": _inspect_git_checkout(
+            bpt_repository,
+            label="BayesianPhysTwin",
+            expected_revision=bpt_revision,
+        ),
+    }
+    causal4d_identity = inspect_wheel(causal4d_wheel)
+    bpt_identity = inspect_wheel(bayesian_phystwin_wheel)
+    _require(causal4d_identity.name == "causal4d", "wrong Causal4D wheel")
+    _require(
+        bpt_identity.name == "bayesian-phystwin",
+        "wrong BayesianPhysTwin wheel",
+    )
+    _validate_dependency_report(
+        dependency_report,
+        causal4d_version=causal4d_identity.version,
+        bayesian_phystwin_version=bpt_identity.version,
+    )
+    python_environment, runtime_environment, installed = (
+        _capture_runtime_environment(
+            execution_backend=execution_backend,
+            container_image_digest=container_image_digest,
+            causal4d_root=repository,
+            bayesian_phystwin_root=bpt_repository,
+        )
+    )
+    _require(
+        installed["causal4d"]["version"] == causal4d_identity.version,
+        "installed Causal4D version differs from the staged wheel",
+    )
+    _require(
+        installed["bayesian_phystwin"]["version"] == bpt_identity.version,
+        "installed BayesianPhysTwin version differs from the staged wheel",
+    )
+
+    causal4d_descriptor = _wheel_descriptor(
+        dataset,
+        causal4d_identity,
+        name="Causal4D",
+    )
+    bpt_descriptor = _wheel_descriptor(
+        dataset,
+        bpt_identity,
+        name="BayesianPhysTwin",
+    )
+    dependency_descriptor = _publish_file(
+        dataset,
+        DEPENDENCY_REPORT_PATH,
+        dependency_report,
+        name="resolved dependency report",
+    )
+
+    runtime_report = _with_content_id(
+        {
+            "schema_version": 1,
+            "artifact_kind": "Causal4DAcquisitionRuntimeEnvironment",
+            "generated_at_utc": completed_at,
+            "python": python_environment,
+            "runtime_environment": runtime_environment,
+            "installed_distributions": installed,
+            "target_outcomes_used": False,
+        },
+        field="runtime_id",
+    )
+    runtime_descriptor = _publish_json(
+        dataset,
+        RUNTIME_REPORT_PATH,
+        runtime_report,
+        name="runtime environment report",
+    )
+
+    provenance = _with_content_id(
+        {
+            "schema_version": 1,
+            "artifact_kind": "Causal4DAcquisitionBuildProvenance",
+            "generated_at_utc": completed_at,
+            "generator": CAPSULE_GENERATOR,
+            "checkouts": checkouts,
+            "distributions": {
+                "causal4d": {
+                    "version": causal4d_identity.version,
+                    "descriptor": causal4d_descriptor,
+                },
+                "bayesian_phystwin": {
+                    "version": bpt_identity.version,
+                    "descriptor": bpt_descriptor,
+                },
+            },
+            "target_outcomes_used": False,
+        },
+        field="provenance_id",
+    )
+    provenance_descriptor = _publish_json(
+        dataset,
+        BUILD_PROVENANCE_PATH,
+        provenance,
+        name="acquisition build provenance",
+    )
+
+    prob4d = candidate["observation_path"]["prob4d"]
+    observation_producer = {
+        "name": _nonempty(
+            observation_producer_name,
+            name="observation producer name",
+        ),
+        "version": _nonempty(
+            observation_producer_version,
+            name="observation producer version",
+        ),
+        "artifact_contract": _nonempty(
+            observation_artifact_contract,
+            name="observation artifact contract",
+        ),
+    }
+    gate_runtime = {
+        **runtime_environment,
+        "resolved_dependency_report": DEPENDENCY_REPORT_PATH.as_posix(),
+    }
+    checks = {
+        "method_freeze_sha256": freeze_sha256,
+        "method_freeze_validation_sha256": attestation_sha256,
+        "causal4d": {
+            "commit_sha": causal4d_revision,
+            "version": causal4d_identity.version,
+            "distribution": causal4d_descriptor,
+        },
+        "bayesian_phystwin": {
+            "commit_sha": bpt_revision,
+            "version": bpt_identity.version,
+            "distribution": bpt_descriptor,
+        },
+        "prob4d": {
+            "used": False,
+            "reason": prob4d["reason"],
+        },
+        "observation_producer": observation_producer,
+        "python": python_environment,
+        "runtime_environment": gate_runtime,
+    }
+    base_artifacts = [
+        causal4d_descriptor,
+        bpt_descriptor,
+        dependency_descriptor,
+        runtime_descriptor,
+        provenance_descriptor,
+    ]
+    capsule = _with_content_id(
+        {
+            "schema_name": CAPSULE_SCHEMA_NAME,
+            "schema_version": CAPSULE_SCHEMA_VERSION,
+            "artifact_kind": CAPSULE_ARTIFACT_KIND,
+            "generated_by": CAPSULE_GENERATOR,
+            "generated_at_utc": completed_at,
+            "protocol_id": protocol["protocol_id"],
+            "protocol_design_sha256": protocol["design_sha256"],
+            "preacquisition_amendment_sha256": v4["amendment_sha256"],
+            "method_freeze_sha256": freeze_sha256,
+            "method_freeze_validation_sha256": attestation_sha256,
+            "acquisition_candidate_id": candidate["candidate_id"],
+            "acquisition_candidate_sha256": candidate_sha256,
+            "observation_producer": observation_producer,
+            "prob4d": checks["prob4d"],
+            "python": python_environment,
+            "runtime_environment": gate_runtime,
+            "installed_distributions": installed,
+            "artifacts": base_artifacts,
+            "confirmatory_collection_started": False,
+            "target_outcomes_used": False,
+        },
+        field="capsule_id",
+    )
+    capsule_descriptor = _publish_json(
+        dataset,
+        CAPSULE_MANIFEST_PATH,
+        capsule,
+        name="acquisition environment capsule",
+    )
+    evidence = [*base_artifacts, capsule_descriptor]
+    evidence_paths = {str(item["path"]) for item in evidence}
+    _validate_software_environment(
+        checks,
+        evidence_paths,
+        dataset_root=dataset,
+        prerequisites=prerequisites,
+        verify_file_hashes=True,
+    )
+
+    staged_gate = deepcopy(expected_template)
+    staged_gate["completed_at_utc"] = completed_at
+    staged_gate["locked_before_confirmatory_collection"] = False
+    staged_gate["target_outcomes_used"] = False
+    staged_gate["checks"] = checks
+    staged_gate["evidence"] = evidence
+    gate_payload = (
+        json.dumps(
+            staged_gate,
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+    atomic_write_binary(
+        gate_path,
+        lambda handle: handle.write(gate_payload),
+        overwrite=True,
+    )
+    return {
+        "valid": True,
+        "passed": True,
+        "ready_to_seal": True,
+        "gate_id": SOFTWARE_GATE_ID,
+        "gate_path": GATE_PATHS[SOFTWARE_GATE_ID],
+        "capsule_id": capsule["capsule_id"],
+        "capsule": capsule_descriptor,
+        "causal4d_wheel": causal4d_descriptor,
+        "bayesian_phystwin_wheel": bpt_descriptor,
+        "resolved_dependency_report": dependency_descriptor,
+        "runtime_report": runtime_descriptor,
+        "build_provenance": provenance_descriptor,
+        "confirmatory_collection_started": False,
+        "target_outcomes_used": False,
+    }
+
+
+__all__ = [
+    "BUILD_PROVENANCE_PATH",
+    "CAPSULE_MANIFEST_PATH",
+    "CAPSULE_SCHEMA_NAME",
+    "CAPSULE_SCHEMA_VERSION",
+    "DEPENDENCY_REPORT_PATH",
+    "RUNTIME_REPORT_PATH",
+    "stage_software_environment_capsule",
+]

--- a/src/causal4d/acquisition_environment_sealing.py
+++ b/src/causal4d/acquisition_environment_sealing.py
@@ -137,8 +137,12 @@ def _validate_capsule_header(
         field="capsule_id",
         name="acquisition environment capsule",
     )
-    _require(capsule["generated_at_utc"] == completed_at, "capsule time differs from gate")
-    _require(capsule["protocol_id"] == protocol["protocol_id"], "capsule protocol changed")
+    _require(
+        capsule["generated_at_utc"] == completed_at, "capsule time differs from gate"
+    )
+    _require(
+        capsule["protocol_id"] == protocol["protocol_id"], "capsule protocol changed"
+    )
     _require(
         capsule["protocol_design_sha256"] == protocol["design_sha256"],
         "capsule protocol digest changed",
@@ -252,7 +256,9 @@ def validate_staged_software_environment_capsule(
         capsule["prob4d"] == checks.get("prob4d"),
         "capsule Prob4D declaration differs",
     )
-    _require(capsule["python"] == checks.get("python"), "capsule Python runtime differs")
+    _require(
+        capsule["python"] == checks.get("python"), "capsule Python runtime differs"
+    )
     _require(
         capsule["runtime_environment"] == checks.get("runtime_environment"),
         "capsule numerical runtime differs from the gate",
@@ -298,9 +304,15 @@ def validate_staged_software_environment_capsule(
         field="runtime_id",
         name="acquisition runtime report",
     )
-    _require(runtime.get("target_outcomes_used") is False, "runtime report used targets")
-    _require(runtime.get("generated_at_utc") == completed_at, "runtime report time changed")
-    _require(runtime.get("python") == capsule["python"], "runtime Python record changed")
+    _require(
+        runtime.get("target_outcomes_used") is False, "runtime report used targets"
+    )
+    _require(
+        runtime.get("generated_at_utc") == completed_at, "runtime report time changed"
+    )
+    _require(
+        runtime.get("python") == capsule["python"], "runtime Python record changed"
+    )
     expected_runtime = dict(capsule["runtime_environment"])
     expected_runtime.pop("resolved_dependency_report", None)
     _require(

--- a/src/causal4d/acquisition_environment_sealing.py
+++ b/src/causal4d/acquisition_environment_sealing.py
@@ -1,0 +1,399 @@
+"""Independent validation and sealing for an acquisition environment capsule."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+from pathlib import Path
+from typing import Any
+
+from causal4d.acquisition_environment import (
+    BUILD_PROVENANCE_PATH,
+    CAPSULE_ARTIFACT_KIND,
+    CAPSULE_GENERATOR,
+    CAPSULE_MANIFEST_PATH,
+    CAPSULE_SCHEMA_NAME,
+    CAPSULE_SCHEMA_VERSION,
+    DEPENDENCY_REPORT_PATH,
+    RUNTIME_REPORT_PATH,
+    SOFTWARE_GATE_ID,
+    _canonical_sha256,
+    _load_acquisition_candidate,
+)
+from causal4d.artifact_io import load_strict_json_object, read_regular_file_beneath
+from causal4d.operator_identity_integration import (
+    seal_registered_preacquisition_gate,
+)
+from causal4d.preacquisition_readiness_contracts import (
+    GATE_PATHS,
+    _parse_utc_timestamp,
+    _require,
+    _validate_descriptor,
+    load_registered_preacquisition_chain,
+)
+from causal4d.real_evidence_contract_v2 import build_real_evidence_status
+
+
+def _descriptor_map(
+    dataset_root: Path,
+    values: Any,
+) -> dict[str, dict[str, Any]]:
+    _require(isinstance(values, list), "software environment evidence must be a list")
+    result: dict[str, dict[str, Any]] = {}
+    for index, value in enumerate(values):
+        _require(
+            isinstance(value, Mapping),
+            f"software environment evidence[{index}] is invalid",
+        )
+        descriptor = dict(value)
+        path = _validate_descriptor(
+            dataset_root,
+            descriptor,
+            name=f"software environment evidence[{index}]",
+            verify_file_hashes=True,
+        )
+        _require(path not in result, f"duplicate software evidence path: {path}")
+        result[path] = descriptor
+    return result
+
+
+def _load_bound_json(
+    dataset_root: Path,
+    descriptors: Mapping[str, Mapping[str, Any]],
+    relative: Path,
+    *,
+    name: str,
+) -> dict[str, Any]:
+    key = relative.as_posix()
+    _require(key in descriptors, f"{name} is not bound as software evidence")
+    snapshot = read_regular_file_beneath(dataset_root, key, name=name)
+    descriptor = descriptors[key]
+    _require(snapshot.sha256 == descriptor["sha256"], f"{name} checksum mismatch")
+    _require(snapshot.byte_count == descriptor["bytes"], f"{name} byte count mismatch")
+    return load_strict_json_object(snapshot.payload, name=name)
+
+
+def _validate_content_id(
+    value: Mapping[str, Any],
+    *,
+    field: str,
+    name: str,
+) -> str:
+    identity = value.get(field)
+    _require(isinstance(identity, str), f"{name} identity is missing")
+    _require(
+        identity == _canonical_sha256(value, omitted_field=field),
+        f"{name} identity does not match its contents",
+    )
+    return identity
+
+
+def validate_staged_software_environment_capsule(
+    repository_root: str | Path,
+    dataset_root: str | Path,
+) -> dict[str, Any]:
+    """Validate the complete unapproved capsule before an approver may seal it."""
+
+    repository = Path(repository_root).resolve(strict=True)
+    dataset = Path(dataset_root).resolve(strict=True)
+    protocol, _, _, v4 = load_registered_preacquisition_chain(repository)
+    gate_relative = GATE_PATHS[SOFTWARE_GATE_ID]
+    gate_snapshot = read_regular_file_beneath(
+        dataset,
+        gate_relative,
+        name="software environment gate",
+    )
+    gate = load_strict_json_object(
+        gate_snapshot.payload,
+        name="software environment gate",
+    )
+    _require(gate.get("gate_id") == SOFTWARE_GATE_ID, "wrong software gate id")
+    _require(gate.get("status") == "template", "software gate is already sealed")
+    _require(
+        gate.get("locked_before_confirmatory_collection") is False,
+        "staged software gate must remain unlocked",
+    )
+    _require(
+        gate.get("target_outcomes_used") is False,
+        "target outcomes entered the staged software gate",
+    )
+    _require(gate.get("artifact_sha256") is None, "staged gate already has a digest")
+    approval = gate.get("approval")
+    _require(
+        isinstance(approval, Mapping) and approval.get("approved") is False,
+        "staged gate already contains an approval",
+    )
+    completed_at = gate.get("completed_at_utc")
+    _parse_utc_timestamp(completed_at, name="software environment completed_at_utc")
+    checks = gate.get("checks")
+    _require(isinstance(checks, Mapping), "software environment checks are missing")
+    descriptors = _descriptor_map(dataset, gate.get("evidence"))
+
+    real_status = build_real_evidence_status(
+        protocol,
+        dataset,
+        repository_root=repository,
+        verify_file_hashes=True,
+    )
+    for field in (
+        "manifest_executions",
+        "acquired_executions",
+        "validated_executions",
+    ):
+        _require(real_status.get(field) == 0, "confirmatory collection has started")
+    prerequisites = real_status.get("prerequisites")
+    _require(isinstance(prerequisites, Mapping), "readiness prerequisites are missing")
+    freeze = prerequisites.get("method_freeze")
+    attestation = prerequisites.get("method_freeze_validation")
+    _require(isinstance(freeze, Mapping), "method freeze status is missing")
+    _require(isinstance(attestation, Mapping), "freeze attestation status is missing")
+    _require(freeze.get("valid") is True, "method freeze is not valid")
+    _require(attestation.get("valid") is True, "freeze attestation is not valid")
+
+    capsule = _load_bound_json(
+        dataset,
+        descriptors,
+        CAPSULE_MANIFEST_PATH,
+        name="acquisition environment capsule",
+    )
+    _require(
+        set(capsule)
+        == {
+            "schema_name",
+            "schema_version",
+            "artifact_kind",
+            "generated_by",
+            "generated_at_utc",
+            "protocol_id",
+            "protocol_design_sha256",
+            "preacquisition_amendment_sha256",
+            "method_freeze_sha256",
+            "method_freeze_validation_sha256",
+            "acquisition_candidate_id",
+            "acquisition_candidate_sha256",
+            "observation_producer",
+            "prob4d",
+            "python",
+            "runtime_environment",
+            "installed_distributions",
+            "artifacts",
+            "confirmatory_collection_started",
+            "target_outcomes_used",
+            "capsule_id",
+        },
+        "acquisition environment capsule has unexpected fields",
+    )
+    _require(capsule["schema_name"] == CAPSULE_SCHEMA_NAME, "wrong capsule schema")
+    _require(
+        capsule["schema_version"] == CAPSULE_SCHEMA_VERSION,
+        "unsupported capsule schema version",
+    )
+    _require(
+        capsule["artifact_kind"] == CAPSULE_ARTIFACT_KIND,
+        "wrong capsule artifact kind",
+    )
+    _require(capsule["generated_by"] == CAPSULE_GENERATOR, "wrong capsule generator")
+    capsule_id = _validate_content_id(
+        capsule,
+        field="capsule_id",
+        name="acquisition environment capsule",
+    )
+    _require(capsule["generated_at_utc"] == completed_at, "capsule time differs from gate")
+    _require(capsule["protocol_id"] == protocol["protocol_id"], "capsule protocol changed")
+    _require(
+        capsule["protocol_design_sha256"] == protocol["design_sha256"],
+        "capsule protocol digest changed",
+    )
+    _require(
+        capsule["preacquisition_amendment_sha256"] == v4["amendment_sha256"],
+        "capsule amendment changed",
+    )
+    _require(
+        capsule["method_freeze_sha256"]
+        == checks.get("method_freeze_sha256")
+        == freeze.get("sha256"),
+        "capsule binds a different method freeze",
+    )
+    _require(
+        capsule["method_freeze_validation_sha256"]
+        == checks.get("method_freeze_validation_sha256")
+        == attestation.get("sha256"),
+        "capsule binds a different freeze attestation",
+    )
+    _require(
+        capsule["confirmatory_collection_started"] is False,
+        "capsule claims confirmatory collection started",
+    )
+    _require(
+        capsule["target_outcomes_used"] is False,
+        "target outcomes entered the capsule",
+    )
+    _require(
+        capsule["observation_producer"] == checks.get("observation_producer"),
+        "capsule observation producer differs from the gate",
+    )
+    _require(capsule["prob4d"] == checks.get("prob4d"), "capsule Prob4D declaration differs")
+    _require(capsule["python"] == checks.get("python"), "capsule Python runtime differs")
+    _require(
+        capsule["runtime_environment"] == checks.get("runtime_environment"),
+        "capsule numerical runtime differs from the gate",
+    )
+
+    candidate_sha256 = capsule.get("acquisition_candidate_sha256")
+    _require(
+        candidate_sha256 == freeze.get("acquisition_candidate_sha256"),
+        "capsule binds a different acquisition candidate",
+    )
+    candidate = _load_acquisition_candidate(
+        repository,
+        expected_sha256=str(candidate_sha256),
+    )
+    _require(
+        capsule["acquisition_candidate_id"] == candidate["candidate_id"],
+        "capsule acquisition candidate id changed",
+    )
+
+    capsule_descriptor = descriptors[CAPSULE_MANIFEST_PATH.as_posix()]
+    expected_artifacts = [
+        descriptor
+        for path, descriptor in descriptors.items()
+        if path != CAPSULE_MANIFEST_PATH.as_posix()
+    ]
+    _require(
+        capsule["artifacts"] == expected_artifacts,
+        "capsule artifact inventory differs from the gate evidence",
+    )
+    _require(
+        capsule_descriptor not in capsule["artifacts"],
+        "capsule recursively includes its own descriptor",
+    )
+
+    runtime = _load_bound_json(
+        dataset,
+        descriptors,
+        RUNTIME_REPORT_PATH,
+        name="acquisition runtime report",
+    )
+    runtime_id = _validate_content_id(
+        runtime,
+        field="runtime_id",
+        name="acquisition runtime report",
+    )
+    _require(runtime.get("target_outcomes_used") is False, "runtime report used targets")
+    _require(runtime.get("generated_at_utc") == completed_at, "runtime report time changed")
+    _require(runtime.get("python") == capsule["python"], "runtime Python record changed")
+    expected_runtime = dict(capsule["runtime_environment"])
+    expected_runtime.pop("resolved_dependency_report", None)
+    _require(
+        runtime.get("runtime_environment") == expected_runtime,
+        "runtime report differs from the capsule",
+    )
+    _require(
+        runtime.get("installed_distributions") == capsule["installed_distributions"],
+        "installed distribution origins differ from the capsule",
+    )
+
+    provenance = _load_bound_json(
+        dataset,
+        descriptors,
+        BUILD_PROVENANCE_PATH,
+        name="acquisition build provenance",
+    )
+    provenance_id = _validate_content_id(
+        provenance,
+        field="provenance_id",
+        name="acquisition build provenance",
+    )
+    _require(
+        provenance.get("target_outcomes_used") is False,
+        "build provenance used targets",
+    )
+    _require(
+        provenance.get("generated_at_utc") == completed_at,
+        "build provenance time changed",
+    )
+    checkouts = provenance.get("checkouts")
+    _require(isinstance(checkouts, Mapping), "build checkout records are missing")
+    for name, commit_field in (
+        ("causal4d", "causal4d_commit_sha"),
+        ("bayesian_phystwin", "bayesian_phystwin_commit_sha"),
+    ):
+        checkout = checkouts.get(name)
+        _require(isinstance(checkout, Mapping), f"{name} checkout record is missing")
+        _require(checkout.get("clean") is True, f"{name} checkout was not clean")
+        _require(
+            checkout.get("revision") == freeze.get(commit_field),
+            f"{name} checkout differs from the method freeze",
+        )
+    distributions = provenance.get("distributions")
+    _require(isinstance(distributions, Mapping), "build distributions are missing")
+    for name in ("causal4d", "bayesian_phystwin"):
+        package = checks.get(name)
+        distribution = distributions.get(name)
+        installed = capsule["installed_distributions"].get(name)
+        _require(isinstance(package, Mapping), f"{name} gate package is missing")
+        _require(isinstance(distribution, Mapping), f"{name} provenance is missing")
+        _require(isinstance(installed, Mapping), f"{name} installed record is missing")
+        _require(
+            distribution.get("version")
+            == package.get("version")
+            == installed.get("version"),
+            f"{name} version differs across capsule records",
+        )
+        _require(
+            distribution.get("descriptor") == package.get("distribution"),
+            f"{name} wheel descriptor differs across capsule records",
+        )
+
+    _require(
+        DEPENDENCY_REPORT_PATH.as_posix() in descriptors,
+        "resolved dependency report is not bound",
+    )
+    return {
+        "valid": True,
+        "passed": True,
+        "ready_to_seal": True,
+        "gate_id": SOFTWARE_GATE_ID,
+        "gate_sha256": gate_snapshot.sha256,
+        "capsule_id": capsule_id,
+        "runtime_id": runtime_id,
+        "provenance_id": provenance_id,
+        "evidence_count": len(descriptors),
+        "confirmatory_collection_started": False,
+        "target_outcomes_used": False,
+    }
+
+
+def seal_staged_software_environment_capsule(
+    repository_root: str | Path,
+    dataset_root: str | Path,
+    *,
+    approved_by: str,
+    approved_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Validate the capsule, then invoke the registered independent gate seal."""
+
+    validation = validate_staged_software_environment_capsule(
+        repository_root,
+        dataset_root,
+    )
+    result = seal_registered_preacquisition_gate(
+        repository_root,
+        dataset_root,
+        SOFTWARE_GATE_ID,
+        approved_by=approved_by,
+        approved_at_utc=approved_at_utc,
+    )
+    return {
+        **result,
+        "capsule_id": validation["capsule_id"],
+        "runtime_id": validation["runtime_id"],
+        "provenance_id": validation["provenance_id"],
+        "capsule_validated_before_seal": True,
+    }
+
+
+__all__ = [
+    "seal_staged_software_environment_capsule",
+    "validate_staged_software_environment_capsule",
+]

--- a/src/causal4d/acquisition_environment_sealing.py
+++ b/src/causal4d/acquisition_environment_sealing.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-import json
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +31,30 @@ from causal4d.preacquisition_readiness_contracts import (
     load_registered_preacquisition_chain,
 )
 from causal4d.real_evidence_contract_v2 import build_real_evidence_status
+
+_CAPSULE_FIELDS = {
+    "schema_name",
+    "schema_version",
+    "artifact_kind",
+    "generated_by",
+    "generated_at_utc",
+    "protocol_id",
+    "protocol_design_sha256",
+    "preacquisition_amendment_sha256",
+    "method_freeze_sha256",
+    "method_freeze_validation_sha256",
+    "acquisition_candidate_id",
+    "acquisition_candidate_sha256",
+    "observation_producer",
+    "prob4d",
+    "python",
+    "runtime_environment",
+    "installed_distributions",
+    "artifacts",
+    "confirmatory_collection_started",
+    "target_outcomes_used",
+    "capsule_id",
+}
 
 
 def _descriptor_map(
@@ -86,6 +109,53 @@ def _validate_content_id(
         f"{name} identity does not match its contents",
     )
     return identity
+
+
+def _validate_capsule_header(
+    capsule: Mapping[str, Any],
+    *,
+    protocol: Mapping[str, Any],
+    v4: Mapping[str, Any],
+    completed_at: Any,
+) -> str:
+    _require(
+        set(capsule) == _CAPSULE_FIELDS,
+        "acquisition environment capsule has unexpected fields",
+    )
+    _require(capsule["schema_name"] == CAPSULE_SCHEMA_NAME, "wrong capsule schema")
+    _require(
+        capsule["schema_version"] == CAPSULE_SCHEMA_VERSION,
+        "unsupported capsule schema version",
+    )
+    _require(
+        capsule["artifact_kind"] == CAPSULE_ARTIFACT_KIND,
+        "wrong capsule artifact kind",
+    )
+    _require(capsule["generated_by"] == CAPSULE_GENERATOR, "wrong capsule generator")
+    capsule_id = _validate_content_id(
+        capsule,
+        field="capsule_id",
+        name="acquisition environment capsule",
+    )
+    _require(capsule["generated_at_utc"] == completed_at, "capsule time differs from gate")
+    _require(capsule["protocol_id"] == protocol["protocol_id"], "capsule protocol changed")
+    _require(
+        capsule["protocol_design_sha256"] == protocol["design_sha256"],
+        "capsule protocol digest changed",
+    )
+    _require(
+        capsule["preacquisition_amendment_sha256"] == v4["amendment_sha256"],
+        "capsule amendment changed",
+    )
+    _require(
+        capsule["confirmatory_collection_started"] is False,
+        "capsule claims confirmatory collection started",
+    )
+    _require(
+        capsule["target_outcomes_used"] is False,
+        "target outcomes entered the capsule",
+    )
+    return capsule_id
 
 
 def validate_staged_software_environment_capsule(
@@ -156,57 +226,11 @@ def validate_staged_software_environment_capsule(
         CAPSULE_MANIFEST_PATH,
         name="acquisition environment capsule",
     )
-    _require(
-        set(capsule)
-        == {
-            "schema_name",
-            "schema_version",
-            "artifact_kind",
-            "generated_by",
-            "generated_at_utc",
-            "protocol_id",
-            "protocol_design_sha256",
-            "preacquisition_amendment_sha256",
-            "method_freeze_sha256",
-            "method_freeze_validation_sha256",
-            "acquisition_candidate_id",
-            "acquisition_candidate_sha256",
-            "observation_producer",
-            "prob4d",
-            "python",
-            "runtime_environment",
-            "installed_distributions",
-            "artifacts",
-            "confirmatory_collection_started",
-            "target_outcomes_used",
-            "capsule_id",
-        },
-        "acquisition environment capsule has unexpected fields",
-    )
-    _require(capsule["schema_name"] == CAPSULE_SCHEMA_NAME, "wrong capsule schema")
-    _require(
-        capsule["schema_version"] == CAPSULE_SCHEMA_VERSION,
-        "unsupported capsule schema version",
-    )
-    _require(
-        capsule["artifact_kind"] == CAPSULE_ARTIFACT_KIND,
-        "wrong capsule artifact kind",
-    )
-    _require(capsule["generated_by"] == CAPSULE_GENERATOR, "wrong capsule generator")
-    capsule_id = _validate_content_id(
+    capsule_id = _validate_capsule_header(
         capsule,
-        field="capsule_id",
-        name="acquisition environment capsule",
-    )
-    _require(capsule["generated_at_utc"] == completed_at, "capsule time differs from gate")
-    _require(capsule["protocol_id"] == protocol["protocol_id"], "capsule protocol changed")
-    _require(
-        capsule["protocol_design_sha256"] == protocol["design_sha256"],
-        "capsule protocol digest changed",
-    )
-    _require(
-        capsule["preacquisition_amendment_sha256"] == v4["amendment_sha256"],
-        "capsule amendment changed",
+        protocol=protocol,
+        v4=v4,
+        completed_at=completed_at,
     )
     _require(
         capsule["method_freeze_sha256"]
@@ -221,18 +245,13 @@ def validate_staged_software_environment_capsule(
         "capsule binds a different freeze attestation",
     )
     _require(
-        capsule["confirmatory_collection_started"] is False,
-        "capsule claims confirmatory collection started",
-    )
-    _require(
-        capsule["target_outcomes_used"] is False,
-        "target outcomes entered the capsule",
-    )
-    _require(
         capsule["observation_producer"] == checks.get("observation_producer"),
         "capsule observation producer differs from the gate",
     )
-    _require(capsule["prob4d"] == checks.get("prob4d"), "capsule Prob4D declaration differs")
+    _require(
+        capsule["prob4d"] == checks.get("prob4d"),
+        "capsule Prob4D declaration differs",
+    )
     _require(capsule["python"] == checks.get("python"), "capsule Python runtime differs")
     _require(
         capsule["runtime_environment"] == checks.get("runtime_environment"),
@@ -288,8 +307,13 @@ def validate_staged_software_environment_capsule(
         runtime.get("runtime_environment") == expected_runtime,
         "runtime report differs from the capsule",
     )
+    installed_distributions = capsule.get("installed_distributions")
     _require(
-        runtime.get("installed_distributions") == capsule["installed_distributions"],
+        isinstance(installed_distributions, Mapping),
+        "installed distribution records are missing",
+    )
+    _require(
+        runtime.get("installed_distributions") == installed_distributions,
         "installed distribution origins differ from the capsule",
     )
 
@@ -330,7 +354,7 @@ def validate_staged_software_environment_capsule(
     for name in ("causal4d", "bayesian_phystwin"):
         package = checks.get(name)
         distribution = distributions.get(name)
-        installed = capsule["installed_distributions"].get(name)
+        installed = installed_distributions.get(name)
         _require(isinstance(package, Mapping), f"{name} gate package is missing")
         _require(isinstance(distribution, Mapping), f"{name} provenance is missing")
         _require(isinstance(installed, Mapping), f"{name} installed record is missing")

--- a/src/causal4d/cli/preacquisition_readiness.py
+++ b/src/causal4d/cli/preacquisition_readiness.py
@@ -8,6 +8,9 @@ from collections.abc import Sequence
 
 from causal4d import preacquisition_operator_flow as _operator_flow
 from causal4d.acquisition_environment import stage_software_environment_capsule
+from causal4d.acquisition_environment_sealing import (
+    seal_staged_software_environment_capsule,
+)
 from causal4d.operator_registry import (
     scaffold_operator_registry,
     seal_operator_registry,
@@ -233,13 +236,21 @@ def main(argv: Sequence[str] | None = None) -> int:
                 completed_at_utc=args.completed_at_utc,
             )
         elif args.command == "seal-gate":
-            result = seal_preacquisition_gate(
-                args.repository_root,
-                args.dataset_root,
-                args.gate_id,
-                approved_by=args.approved_by,
-                approved_at_utc=args.approved_at_utc,
-            )
+            if args.gate_id == "software_environment_locked":
+                result = seal_staged_software_environment_capsule(
+                    args.repository_root,
+                    args.dataset_root,
+                    approved_by=args.approved_by,
+                    approved_at_utc=args.approved_at_utc,
+                )
+            else:
+                result = seal_preacquisition_gate(
+                    args.repository_root,
+                    args.dataset_root,
+                    args.gate_id,
+                    approved_by=args.approved_by,
+                    approved_at_utc=args.approved_at_utc,
+                )
         elif args.command == "source-panel-status":
             result = build_source_panel_status(
                 args.repository_root,

--- a/src/causal4d/cli/preacquisition_readiness.py
+++ b/src/causal4d/cli/preacquisition_readiness.py
@@ -7,6 +7,7 @@ import json
 from collections.abc import Sequence
 
 from causal4d import preacquisition_operator_flow as _operator_flow
+from causal4d.acquisition_environment import stage_software_environment_capsule
 from causal4d.operator_registry import (
     scaffold_operator_registry,
     seal_operator_registry,
@@ -77,6 +78,29 @@ def build_parser() -> argparse.ArgumentParser:
     registry_seal.add_argument("source_json")
     registry_seal.add_argument("--sealed-by", required=True)
     registry_seal.add_argument("--sealed-at-utc")
+
+    software_environment = subparsers.add_parser(
+        "software-environment-stage",
+        help=(
+            "stage exact wheels and runtime evidence into the unapproved software gate"
+        ),
+    )
+    software_environment.add_argument("repository_root")
+    software_environment.add_argument("bayesian_phystwin_root")
+    software_environment.add_argument("dataset_root")
+    software_environment.add_argument("causal4d_wheel")
+    software_environment.add_argument("bayesian_phystwin_wheel")
+    software_environment.add_argument("dependency_report")
+    software_environment.add_argument("--observation-producer-name", required=True)
+    software_environment.add_argument("--observation-producer-version", required=True)
+    software_environment.add_argument("--observation-artifact-contract", required=True)
+    software_environment.add_argument(
+        "--execution-backend",
+        required=True,
+        choices=("numpy_cpu", "warp_cpu", "cuda"),
+    )
+    software_environment.add_argument("--container-image-digest")
+    software_environment.add_argument("--completed-at-utc")
 
     seal = subparsers.add_parser(
         "seal-gate",
@@ -192,6 +216,21 @@ def main(argv: Sequence[str] | None = None) -> int:
                 args.source_json,
                 sealed_by=args.sealed_by,
                 sealed_at_utc=args.sealed_at_utc,
+            )
+        elif args.command == "software-environment-stage":
+            result = stage_software_environment_capsule(
+                args.repository_root,
+                args.bayesian_phystwin_root,
+                args.dataset_root,
+                args.causal4d_wheel,
+                args.bayesian_phystwin_wheel,
+                args.dependency_report,
+                observation_producer_name=args.observation_producer_name,
+                observation_producer_version=args.observation_producer_version,
+                observation_artifact_contract=args.observation_artifact_contract,
+                execution_backend=args.execution_backend,
+                container_image_digest=args.container_image_digest,
+                completed_at_utc=args.completed_at_utc,
             )
         elif args.command == "seal-gate":
             result = seal_preacquisition_gate(

--- a/tests/test_acquisition_environment.py
+++ b/tests/test_acquisition_environment.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 from pathlib import Path
 import subprocess
+from types import SimpleNamespace
 from zipfile import ZipFile
 
 import pytest
@@ -94,67 +95,45 @@ def _write_candidate(repository: Path) -> str:
     return str(candidate["candidate_sha256"])
 
 
-def _prerequisites(candidate_sha256: str) -> dict[str, dict[str, object]]:
-    return {
-        "method_freeze": {
-            "valid": True,
-            "sha256": "c" * 64,
-            "causal4d_commit_sha": "1" * 40,
-            "bayesian_phystwin_commit_sha": "2" * 40,
-            "acquisition_candidate_sha256": candidate_sha256,
-            "frozen_at_utc": "2026-08-08T01:00:00+00:00",
+def _runtime(causal4d_version: str = "0.5.0") -> tuple[dict, dict, dict]:
+    return (
+        {
+            "version": "3.12.4",
+            "implementation": "CPython",
+            "platform": "Linux-test",
         },
-        "method_freeze_validation": {
-            "valid": True,
-            "sha256": "d" * 64,
-            "verified_at_utc": "2026-08-08T01:05:00+00:00",
+        {
+            "execution_backend": "numpy_cpu",
+            "containerized": False,
+            "container_image_digest": None,
+            "numpy_version": "2.2.0",
+            "scipy_version": "1.15.0",
+            "torch_version": None,
+            "warp_version": None,
+            "opencv_version": None,
+            "cuda_runtime_version": None,
+            "cuda_driver_version": None,
         },
-    }
-
-
-def _fake_runtime(*, causal4d_version: str = "0.5.0"):
-    def capture(**_kwargs):
-        return (
-            {
-                "version": "3.12.4",
-                "implementation": "CPython",
-                "platform": "Linux-test",
+        {
+            "causal4d": {
+                "version": causal4d_version,
+                "origin_relative_to_python_prefix": (
+                    "lib/python3.12/site-packages/causal4d/__init__.py"
+                ),
+                "source_checkout_resolved": False,
             },
-            {
-                "execution_backend": "numpy_cpu",
-                "containerized": False,
-                "container_image_digest": None,
-                "numpy_version": "2.2.0",
-                "scipy_version": "1.15.0",
-                "torch_version": None,
-                "warp_version": None,
-                "opencv_version": None,
-                "cuda_runtime_version": None,
-                "cuda_driver_version": None,
+            "bayesian_phystwin": {
+                "version": "0.4.0",
+                "origin_relative_to_python_prefix": (
+                    "lib/python3.12/site-packages/bayesian_phystwin/__init__.py"
+                ),
+                "source_checkout_resolved": False,
             },
-            {
-                "causal4d": {
-                    "version": causal4d_version,
-                    "origin_relative_to_python_prefix": (
-                        "lib/python3.12/site-packages/causal4d/__init__.py"
-                    ),
-                    "source_checkout_resolved": False,
-                },
-                "bayesian_phystwin": {
-                    "version": "0.4.0",
-                    "origin_relative_to_python_prefix": (
-                        "lib/python3.12/site-packages/"
-                        "bayesian_phystwin/__init__.py"
-                    ),
-                    "source_checkout_resolved": False,
-                },
-            },
-        )
-
-    return capture
+        },
+    )
 
 
-def _prepare_case(tmp_path: Path, monkeypatch) -> dict[str, object]:
+def _prepare_case(tmp_path: Path, monkeypatch) -> SimpleNamespace:
     repository = tmp_path / "causal4d"
     bpt_repository = tmp_path / "bayesianphystwin"
     dataset = tmp_path / "dataset"
@@ -180,7 +159,21 @@ def _prepare_case(tmp_path: Path, monkeypatch) -> dict[str, object]:
         "numpy==2.2.0\nscipy==1.15.0\n",
         encoding="utf-8",
     )
-    prerequisites = _prerequisites(candidate_sha256)
+    prerequisites = {
+        "method_freeze": {
+            "valid": True,
+            "sha256": "c" * 64,
+            "causal4d_commit_sha": "1" * 40,
+            "bayesian_phystwin_commit_sha": "2" * 40,
+            "acquisition_candidate_sha256": candidate_sha256,
+            "frozen_at_utc": "2026-08-08T01:00:00+00:00",
+        },
+        "method_freeze_validation": {
+            "valid": True,
+            "sha256": "d" * 64,
+            "verified_at_utc": "2026-08-08T01:05:00+00:00",
+        },
+    }
     real_status = {
         "manifest_executions": 0,
         "acquired_executions": 0,
@@ -188,8 +181,12 @@ def _prepare_case(tmp_path: Path, monkeypatch) -> dict[str, object]:
         "prerequisites": prerequisites,
     }
 
-    chain = lambda _root: (protocol, v2, v3, v4)
-    status = lambda *_args, **_kwargs: real_status
+    def chain(_root):
+        return protocol, v2, v3, v4
+
+    def status(*_arguments, **_keywords):
+        return real_status
+
     monkeypatch.setattr(environment, "load_registered_preacquisition_chain", chain)
     monkeypatch.setattr(environment, "build_real_evidence_status", status)
     monkeypatch.setattr(sealing, "load_registered_preacquisition_chain", chain)
@@ -203,26 +200,30 @@ def _prepare_case(tmp_path: Path, monkeypatch) -> dict[str, object]:
             "clean": True,
         },
     )
-    monkeypatch.setattr(environment, "_capture_runtime_environment", _fake_runtime())
-    return {
-        "repository": repository,
-        "bpt_repository": bpt_repository,
-        "dataset": dataset,
-        "causal4d_wheel": causal4d_wheel,
-        "bpt_wheel": bpt_wheel,
-        "dependency_report": dependency_report,
-        "gate_path": gate_path,
-    }
+    monkeypatch.setattr(
+        environment,
+        "_capture_runtime_environment",
+        lambda **_keywords: _runtime(),
+    )
+    return SimpleNamespace(
+        repository=repository,
+        bpt_repository=bpt_repository,
+        dataset=dataset,
+        causal4d_wheel=causal4d_wheel,
+        bpt_wheel=bpt_wheel,
+        dependency_report=dependency_report,
+        gate_path=gate_path,
+    )
 
 
-def _stage(case: dict[str, object]) -> dict[str, object]:
+def _stage(case: SimpleNamespace) -> dict[str, object]:
     return environment.stage_software_environment_capsule(
-        case["repository"],
-        case["bpt_repository"],
-        case["dataset"],
-        case["causal4d_wheel"],
-        case["bpt_wheel"],
-        case["dependency_report"],
+        case.repository,
+        case.bpt_repository,
+        case.dataset,
+        case.causal4d_wheel,
+        case.bpt_wheel,
+        case.dependency_report,
         observation_producer_name="registered-rgbd-tracker",
         observation_producer_version="1.0",
         observation_artifact_contract="causal4d.observation-prefix-v1",
@@ -236,13 +237,12 @@ def test_stage_capsule_populates_unapproved_hash_verified_gate(
     monkeypatch,
 ) -> None:
     case = _prepare_case(tmp_path, monkeypatch)
-
     result = _stage(case)
 
     assert result["valid"] is True
     assert result["ready_to_seal"] is True
     assert result["confirmatory_collection_started"] is False
-    gate = json.loads(Path(case["gate_path"]).read_text(encoding="utf-8"))
+    gate = json.loads(case.gate_path.read_text(encoding="utf-8"))
     assert gate["status"] == "template"
     assert gate["approval"]["approved"] is False
     assert gate["artifact_sha256"] is None
@@ -253,14 +253,13 @@ def test_stage_capsule_populates_unapproved_hash_verified_gate(
     assert gate["checks"]["runtime_environment"]["execution_backend"] == "numpy_cpu"
     assert len(gate["evidence"]) == 6
     for descriptor in gate["evidence"]:
-        path = Path(case["dataset"]) / descriptor["path"]
-        assert path.is_file()
+        path = case.dataset / descriptor["path"]
         payload = path.read_bytes()
         assert hashlib.sha256(payload).hexdigest() == descriptor["sha256"]
         assert len(payload) == descriptor["bytes"]
 
     capsule = json.loads(
-        (Path(case["dataset"]) / environment.CAPSULE_MANIFEST_PATH).read_text(
+        (case.dataset / environment.CAPSULE_MANIFEST_PATH).read_text(
             encoding="utf-8"
         )
     )
@@ -269,8 +268,8 @@ def test_stage_capsule_populates_unapproved_hash_verified_gate(
     assert capsule["confirmatory_collection_started"] is False
 
     validation = sealing.validate_staged_software_environment_capsule(
-        case["repository"],
-        case["dataset"],
+        case.repository,
+        case.dataset,
     )
     assert validation["valid"] is True
     assert validation["capsule_id"] == result["capsule_id"]
@@ -296,13 +295,13 @@ def test_stage_capsule_rejects_installed_wheel_version_drift_before_publication(
     monkeypatch.setattr(
         environment,
         "_capture_runtime_environment",
-        _fake_runtime(causal4d_version="0.5.1"),
+        lambda **_keywords: _runtime("0.5.1"),
     )
 
     with pytest.raises(ValueError, match="installed Causal4D version differs"):
         _stage(case)
 
-    assert not (Path(case["dataset"]) / environment.CAPSULE_ROOT).exists()
+    assert not (case.dataset / environment.CAPSULE_ROOT).exists()
 
 
 def test_sealing_rejects_semantically_readdressed_target_use(
@@ -311,8 +310,7 @@ def test_sealing_rejects_semantically_readdressed_target_use(
 ) -> None:
     case = _prepare_case(tmp_path, monkeypatch)
     _stage(case)
-    dataset = Path(case["dataset"])
-    capsule_path = dataset / environment.CAPSULE_MANIFEST_PATH
+    capsule_path = case.dataset / environment.CAPSULE_MANIFEST_PATH
     capsule = json.loads(capsule_path.read_text(encoding="utf-8"))
     capsule["target_outcomes_used"] = True
     capsule["capsule_id"] = _canonical_sha256(capsule, omitted="capsule_id")
@@ -321,8 +319,7 @@ def test_sealing_rejects_semantically_readdressed_target_use(
     ).encode("utf-8")
     capsule_path.write_bytes(payload)
 
-    gate_path = Path(case["gate_path"])
-    gate = json.loads(gate_path.read_text(encoding="utf-8"))
+    gate = json.loads(case.gate_path.read_text(encoding="utf-8"))
     descriptor = next(
         item
         for item in gate["evidence"]
@@ -330,12 +327,12 @@ def test_sealing_rejects_semantically_readdressed_target_use(
     )
     descriptor["sha256"] = hashlib.sha256(payload).hexdigest()
     descriptor["bytes"] = len(payload)
-    gate_path.write_text(json.dumps(gate), encoding="utf-8")
+    case.gate_path.write_text(json.dumps(gate), encoding="utf-8")
 
     with pytest.raises(ValueError, match="target outcomes entered the capsule"):
         sealing.validate_staged_software_environment_capsule(
-            case["repository"],
-            case["dataset"],
+            case.repository,
+            case.dataset,
         )
 
 
@@ -354,15 +351,15 @@ def test_independent_seal_validates_capsule_before_registered_gate_seal(
 
     monkeypatch.setattr(sealing, "seal_registered_preacquisition_gate", seal)
     result = sealing.seal_staged_software_environment_capsule(
-        case["repository"],
-        case["dataset"],
+        case.repository,
+        case.dataset,
         approved_by="independent-verifier",
         approved_at_utc="2026-08-08T01:15:00+00:00",
     )
 
     assert received["arguments"] == (
-        case["repository"],
-        case["dataset"],
+        case.repository,
+        case.dataset,
         environment.SOFTWARE_GATE_ID,
     )
     assert received["keywords"] == {

--- a/tests/test_acquisition_environment.py
+++ b/tests/test_acquisition_environment.py
@@ -155,8 +155,7 @@ def _prepare_case(tmp_path: Path, monkeypatch) -> SimpleNamespace:
     bpt_wheel = _write_wheel(wheelhouse, "bayesian-phystwin", "0.4.0")
     dependency_report = tmp_path / "resolved-dependencies.txt"
     dependency_report.write_text(
-        "causal4d==0.5.0\nbayesian-phystwin==0.4.0\n"
-        "numpy==2.2.0\nscipy==1.15.0\n",
+        "causal4d==0.5.0\nbayesian-phystwin==0.4.0\nnumpy==2.2.0\nscipy==1.15.0\n",
         encoding="utf-8",
     )
     prerequisites = {
@@ -259,9 +258,7 @@ def test_stage_capsule_populates_unapproved_hash_verified_gate(
         assert len(payload) == descriptor["bytes"]
 
     capsule = json.loads(
-        (case.dataset / environment.CAPSULE_MANIFEST_PATH).read_text(
-            encoding="utf-8"
-        )
+        (case.dataset / environment.CAPSULE_MANIFEST_PATH).read_text(encoding="utf-8")
     )
     assert capsule["capsule_id"] == result["capsule_id"]
     assert capsule["target_outcomes_used"] is False
@@ -459,21 +456,21 @@ def test_cli_uses_capsule_aware_software_gate_seal(monkeypatch, capsys) -> None:
         "approved_by": "reviewer",
         "approved_at_utc": "2026-08-08T02:10:00+00:00",
     }
-    assert json.loads(capsys.readouterr().out)[
-        "capsule_validated_before_seal"
-    ] is True
+    assert json.loads(capsys.readouterr().out)["capsule_validated_before_seal"] is True
 
 
-def test_acquisition_staging_script_builds_clean_wheels_and_freezes_environment() -> None:
+def test_acquisition_staging_script_builds_clean_wheels_and_freezes_environment() -> (
+    None
+):
     text = SCRIPT.read_text(encoding="utf-8")
 
     subprocess.run(["bash", "-n", str(SCRIPT)], check=True)
-    assert text.count("git -C \"$checkout\" status --porcelain=v1") == 1
-    assert text.count("git -C \"$causal4d_root\" archive") == 1
-    assert text.count("git -C \"$bayesian_phystwin_root\" archive") == 1
+    assert text.count('git -C "$checkout" status --porcelain=v1') == 1
+    assert text.count('git -C "$causal4d_root" archive') == 1
+    assert text.count('git -C "$bayesian_phystwin_root" archive') == 1
     assert text.count("-m build --wheel") == 2
     assert "python -m pip install -e" not in text
     assert "-m pip freeze --all" in text
     assert "protocol readiness software-environment-stage" in text
     assert "software_environment_locked --approved-by" in text
-    assert "rm -rf \"$deployment_venv\"" in text
+    assert 'rm -rf "$deployment_venv"' in text

--- a/tests/test_acquisition_environment.py
+++ b/tests/test_acquisition_environment.py
@@ -9,6 +9,7 @@ from zipfile import ZipFile
 import pytest
 
 from causal4d import acquisition_environment as environment
+from causal4d import acquisition_environment_sealing as sealing
 from causal4d.cli import preacquisition_readiness as readiness_cli
 from causal4d.preacquisition_readiness_contracts import (
     GATE_PATHS,
@@ -180,22 +181,19 @@ def _prepare_case(tmp_path: Path, monkeypatch) -> dict[str, object]:
         encoding="utf-8",
     )
     prerequisites = _prerequisites(candidate_sha256)
+    real_status = {
+        "manifest_executions": 0,
+        "acquired_executions": 0,
+        "validated_executions": 0,
+        "prerequisites": prerequisites,
+    }
 
-    monkeypatch.setattr(
-        environment,
-        "load_registered_preacquisition_chain",
-        lambda _root: (protocol, v2, v3, v4),
-    )
-    monkeypatch.setattr(
-        environment,
-        "build_real_evidence_status",
-        lambda *_args, **_kwargs: {
-            "manifest_executions": 0,
-            "acquired_executions": 0,
-            "validated_executions": 0,
-            "prerequisites": prerequisites,
-        },
-    )
+    chain = lambda _root: (protocol, v2, v3, v4)
+    status = lambda *_args, **_kwargs: real_status
+    monkeypatch.setattr(environment, "load_registered_preacquisition_chain", chain)
+    monkeypatch.setattr(environment, "build_real_evidence_status", status)
+    monkeypatch.setattr(sealing, "load_registered_preacquisition_chain", chain)
+    monkeypatch.setattr(sealing, "build_real_evidence_status", status)
     monkeypatch.setattr(
         environment,
         "_inspect_git_checkout",
@@ -270,6 +268,14 @@ def test_stage_capsule_populates_unapproved_hash_verified_gate(
     assert capsule["target_outcomes_used"] is False
     assert capsule["confirmatory_collection_started"] is False
 
+    validation = sealing.validate_staged_software_environment_capsule(
+        case["repository"],
+        case["dataset"],
+    )
+    assert validation["valid"] is True
+    assert validation["capsule_id"] == result["capsule_id"]
+    assert validation["evidence_count"] == 6
+
 
 def test_stage_capsule_refuses_to_replace_completed_operator_staging(
     tmp_path: Path,
@@ -297,6 +303,74 @@ def test_stage_capsule_rejects_installed_wheel_version_drift_before_publication(
         _stage(case)
 
     assert not (Path(case["dataset"]) / environment.CAPSULE_ROOT).exists()
+
+
+def test_sealing_rejects_semantically_readdressed_target_use(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    case = _prepare_case(tmp_path, monkeypatch)
+    _stage(case)
+    dataset = Path(case["dataset"])
+    capsule_path = dataset / environment.CAPSULE_MANIFEST_PATH
+    capsule = json.loads(capsule_path.read_text(encoding="utf-8"))
+    capsule["target_outcomes_used"] = True
+    capsule["capsule_id"] = _canonical_sha256(capsule, omitted="capsule_id")
+    payload = (
+        json.dumps(capsule, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    ).encode("utf-8")
+    capsule_path.write_bytes(payload)
+
+    gate_path = Path(case["gate_path"])
+    gate = json.loads(gate_path.read_text(encoding="utf-8"))
+    descriptor = next(
+        item
+        for item in gate["evidence"]
+        if item["path"] == environment.CAPSULE_MANIFEST_PATH.as_posix()
+    )
+    descriptor["sha256"] = hashlib.sha256(payload).hexdigest()
+    descriptor["bytes"] = len(payload)
+    gate_path.write_text(json.dumps(gate), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="target outcomes entered the capsule"):
+        sealing.validate_staged_software_environment_capsule(
+            case["repository"],
+            case["dataset"],
+        )
+
+
+def test_independent_seal_validates_capsule_before_registered_gate_seal(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    case = _prepare_case(tmp_path, monkeypatch)
+    staged = _stage(case)
+    received: dict[str, object] = {}
+
+    def seal(*arguments, **keywords):
+        received["arguments"] = arguments
+        received["keywords"] = keywords
+        return {"valid": True, "passed": True, "artifact_sha256": "e" * 64}
+
+    monkeypatch.setattr(sealing, "seal_registered_preacquisition_gate", seal)
+    result = sealing.seal_staged_software_environment_capsule(
+        case["repository"],
+        case["dataset"],
+        approved_by="independent-verifier",
+        approved_at_utc="2026-08-08T01:15:00+00:00",
+    )
+
+    assert received["arguments"] == (
+        case["repository"],
+        case["dataset"],
+        environment.SOFTWARE_GATE_ID,
+    )
+    assert received["keywords"] == {
+        "approved_by": "independent-verifier",
+        "approved_at_utc": "2026-08-08T01:15:00+00:00",
+    }
+    assert result["capsule_validated_before_seal"] is True
+    assert result["capsule_id"] == staged["capsule_id"]
 
 
 def test_cli_routes_software_environment_stage(monkeypatch, capsys) -> None:
@@ -350,6 +424,47 @@ def test_cli_routes_software_environment_stage(monkeypatch, capsys) -> None:
         "completed_at_utc": "2026-08-08T02:00:00+00:00",
     }
     assert json.loads(capsys.readouterr().out)["ready_to_seal"] is True
+
+
+def test_cli_uses_capsule_aware_software_gate_seal(monkeypatch, capsys) -> None:
+    received: dict[str, object] = {}
+
+    def seal(*arguments, **keywords):
+        received["arguments"] = arguments
+        received["keywords"] = keywords
+        return {
+            "valid": True,
+            "passed": True,
+            "capsule_validated_before_seal": True,
+        }
+
+    monkeypatch.setattr(
+        readiness_cli,
+        "seal_staged_software_environment_capsule",
+        seal,
+    )
+    result = readiness_cli.main(
+        [
+            "seal-gate",
+            "/c4",
+            "/data",
+            environment.SOFTWARE_GATE_ID,
+            "--approved-by",
+            "reviewer",
+            "--approved-at-utc",
+            "2026-08-08T02:10:00+00:00",
+        ]
+    )
+
+    assert result == 0
+    assert received["arguments"] == ("/c4", "/data")
+    assert received["keywords"] == {
+        "approved_by": "reviewer",
+        "approved_at_utc": "2026-08-08T02:10:00+00:00",
+    }
+    assert json.loads(capsys.readouterr().out)[
+        "capsule_validated_before_seal"
+    ] is True
 
 
 def test_acquisition_staging_script_builds_clean_wheels_and_freezes_environment() -> None:

--- a/tests/test_acquisition_environment.py
+++ b/tests/test_acquisition_environment.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+from zipfile import ZipFile
+
+import pytest
+
+from causal4d import acquisition_environment as environment
+from causal4d.cli import preacquisition_readiness as readiness_cli
+from causal4d.preacquisition_readiness_contracts import (
+    GATE_PATHS,
+    gate_evidence_template,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "acquisition" / "stage_software_environment.sh"
+
+
+def _canonical_sha256(values: dict[str, object], *, omitted: str) -> str:
+    payload = dict(values)
+    payload.pop(omitted, None)
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _write_wheel(tmp_path: Path, name: str, version: str) -> Path:
+    token = name.replace("-", "_")
+    path = tmp_path / f"{token}-{version}-py3-none-any.whl"
+    dist_info = f"{token}-{version}.dist-info"
+    with ZipFile(path, "w") as archive:
+        archive.writestr(
+            f"{dist_info}/METADATA",
+            f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n",
+        )
+        archive.writestr(
+            f"{dist_info}/WHEEL",
+            "Wheel-Version: 1.0\nTag: py3-none-any\n",
+        )
+    return path
+
+
+def _registered_chain() -> tuple[dict, dict, dict, dict]:
+    protocol = {
+        "protocol_id": "causal4d-sloth-multi-action-v1",
+        "design_sha256": "a" * 64,
+    }
+    v2 = {
+        "preacquisition_signature_panel": {
+            "executions": [
+                {
+                    "execution_id": f"source-{index:02d}",
+                    "session_id": f"session-{index:02d}",
+                }
+                for index in range(12)
+            ]
+        }
+    }
+    v3: dict[str, object] = {}
+    v4 = {
+        "plan_id": "causal4d-sloth-preacquisition-v4",
+        "amendment_sha256": "b" * 64,
+    }
+    return protocol, v2, v3, v4
+
+
+def _write_candidate(repository: Path) -> str:
+    candidate: dict[str, object] = {
+        "schema_version": 1,
+        "candidate_id": "causal4d-sloth-primary-acquisition-v1",
+        "observation_path": {
+            "prob4d": {
+                "used": False,
+                "reason": "Prob4D was not admitted for this acquisition.",
+            }
+        },
+    }
+    candidate["candidate_sha256"] = _canonical_sha256(
+        candidate,
+        omitted="candidate_sha256",
+    )
+    path = repository / environment.ACQUISITION_CANDIDATE_PATH
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(candidate), encoding="utf-8")
+    return str(candidate["candidate_sha256"])
+
+
+def _prerequisites(candidate_sha256: str) -> dict[str, dict[str, object]]:
+    return {
+        "method_freeze": {
+            "valid": True,
+            "sha256": "c" * 64,
+            "causal4d_commit_sha": "1" * 40,
+            "bayesian_phystwin_commit_sha": "2" * 40,
+            "acquisition_candidate_sha256": candidate_sha256,
+            "frozen_at_utc": "2026-08-08T01:00:00+00:00",
+        },
+        "method_freeze_validation": {
+            "valid": True,
+            "sha256": "d" * 64,
+            "verified_at_utc": "2026-08-08T01:05:00+00:00",
+        },
+    }
+
+
+def _fake_runtime(*, causal4d_version: str = "0.5.0"):
+    def capture(**_kwargs):
+        return (
+            {
+                "version": "3.12.4",
+                "implementation": "CPython",
+                "platform": "Linux-test",
+            },
+            {
+                "execution_backend": "numpy_cpu",
+                "containerized": False,
+                "container_image_digest": None,
+                "numpy_version": "2.2.0",
+                "scipy_version": "1.15.0",
+                "torch_version": None,
+                "warp_version": None,
+                "opencv_version": None,
+                "cuda_runtime_version": None,
+                "cuda_driver_version": None,
+            },
+            {
+                "causal4d": {
+                    "version": causal4d_version,
+                    "origin_relative_to_python_prefix": (
+                        "lib/python3.12/site-packages/causal4d/__init__.py"
+                    ),
+                    "source_checkout_resolved": False,
+                },
+                "bayesian_phystwin": {
+                    "version": "0.4.0",
+                    "origin_relative_to_python_prefix": (
+                        "lib/python3.12/site-packages/"
+                        "bayesian_phystwin/__init__.py"
+                    ),
+                    "source_checkout_resolved": False,
+                },
+            },
+        )
+
+    return capture
+
+
+def _prepare_case(tmp_path: Path, monkeypatch) -> dict[str, object]:
+    repository = tmp_path / "causal4d"
+    bpt_repository = tmp_path / "bayesianphystwin"
+    dataset = tmp_path / "dataset"
+    wheelhouse = tmp_path / "wheelhouse"
+    for path in (repository, bpt_repository, dataset, wheelhouse):
+        path.mkdir()
+
+    protocol, v2, v3, v4 = _registered_chain()
+    candidate_sha256 = _write_candidate(repository)
+    gate_path = dataset / GATE_PATHS[environment.SOFTWARE_GATE_ID]
+    gate_path.parent.mkdir(parents=True)
+    gate_path.write_text(
+        json.dumps(
+            gate_evidence_template(environment.SOFTWARE_GATE_ID, protocol, v2, v4)
+        ),
+        encoding="utf-8",
+    )
+    causal4d_wheel = _write_wheel(wheelhouse, "causal4d", "0.5.0")
+    bpt_wheel = _write_wheel(wheelhouse, "bayesian-phystwin", "0.4.0")
+    dependency_report = tmp_path / "resolved-dependencies.txt"
+    dependency_report.write_text(
+        "causal4d==0.5.0\nbayesian-phystwin==0.4.0\n"
+        "numpy==2.2.0\nscipy==1.15.0\n",
+        encoding="utf-8",
+    )
+    prerequisites = _prerequisites(candidate_sha256)
+
+    monkeypatch.setattr(
+        environment,
+        "load_registered_preacquisition_chain",
+        lambda _root: (protocol, v2, v3, v4),
+    )
+    monkeypatch.setattr(
+        environment,
+        "build_real_evidence_status",
+        lambda *_args, **_kwargs: {
+            "manifest_executions": 0,
+            "acquired_executions": 0,
+            "validated_executions": 0,
+            "prerequisites": prerequisites,
+        },
+    )
+    monkeypatch.setattr(
+        environment,
+        "_inspect_git_checkout",
+        lambda _root, *, label, expected_revision: {
+            "repository": label,
+            "revision": expected_revision,
+            "clean": True,
+        },
+    )
+    monkeypatch.setattr(environment, "_capture_runtime_environment", _fake_runtime())
+    return {
+        "repository": repository,
+        "bpt_repository": bpt_repository,
+        "dataset": dataset,
+        "causal4d_wheel": causal4d_wheel,
+        "bpt_wheel": bpt_wheel,
+        "dependency_report": dependency_report,
+        "gate_path": gate_path,
+    }
+
+
+def _stage(case: dict[str, object]) -> dict[str, object]:
+    return environment.stage_software_environment_capsule(
+        case["repository"],
+        case["bpt_repository"],
+        case["dataset"],
+        case["causal4d_wheel"],
+        case["bpt_wheel"],
+        case["dependency_report"],
+        observation_producer_name="registered-rgbd-tracker",
+        observation_producer_version="1.0",
+        observation_artifact_contract="causal4d.observation-prefix-v1",
+        execution_backend="numpy_cpu",
+        completed_at_utc="2026-08-08T01:10:00+00:00",
+    )
+
+
+def test_stage_capsule_populates_unapproved_hash_verified_gate(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    case = _prepare_case(tmp_path, monkeypatch)
+
+    result = _stage(case)
+
+    assert result["valid"] is True
+    assert result["ready_to_seal"] is True
+    assert result["confirmatory_collection_started"] is False
+    gate = json.loads(Path(case["gate_path"]).read_text(encoding="utf-8"))
+    assert gate["status"] == "template"
+    assert gate["approval"]["approved"] is False
+    assert gate["artifact_sha256"] is None
+    assert gate["completed_at_utc"] == "2026-08-08T01:10:00+00:00"
+    assert gate["locked_before_confirmatory_collection"] is False
+    assert gate["target_outcomes_used"] is False
+    assert gate["checks"]["prob4d"]["used"] is False
+    assert gate["checks"]["runtime_environment"]["execution_backend"] == "numpy_cpu"
+    assert len(gate["evidence"]) == 6
+    for descriptor in gate["evidence"]:
+        path = Path(case["dataset"]) / descriptor["path"]
+        assert path.is_file()
+        payload = path.read_bytes()
+        assert hashlib.sha256(payload).hexdigest() == descriptor["sha256"]
+        assert len(payload) == descriptor["bytes"]
+
+    capsule = json.loads(
+        (Path(case["dataset"]) / environment.CAPSULE_MANIFEST_PATH).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert capsule["capsule_id"] == result["capsule_id"]
+    assert capsule["target_outcomes_used"] is False
+    assert capsule["confirmatory_collection_started"] is False
+
+
+def test_stage_capsule_refuses_to_replace_completed_operator_staging(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    case = _prepare_case(tmp_path, monkeypatch)
+    _stage(case)
+
+    with pytest.raises(ValueError, match="not the pristine scaffold template"):
+        _stage(case)
+
+
+def test_stage_capsule_rejects_installed_wheel_version_drift_before_publication(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    case = _prepare_case(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        environment,
+        "_capture_runtime_environment",
+        _fake_runtime(causal4d_version="0.5.1"),
+    )
+
+    with pytest.raises(ValueError, match="installed Causal4D version differs"):
+        _stage(case)
+
+    assert not (Path(case["dataset"]) / environment.CAPSULE_ROOT).exists()
+
+
+def test_cli_routes_software_environment_stage(monkeypatch, capsys) -> None:
+    received: dict[str, object] = {}
+
+    def stage(*arguments, **keywords):
+        received["arguments"] = arguments
+        received["keywords"] = keywords
+        return {"valid": True, "passed": True, "ready_to_seal": True}
+
+    monkeypatch.setattr(readiness_cli, "stage_software_environment_capsule", stage)
+    result = readiness_cli.main(
+        [
+            "software-environment-stage",
+            "/c4",
+            "/bpt",
+            "/data",
+            "/wheels/c4.whl",
+            "/wheels/bpt.whl",
+            "/reports/freeze.txt",
+            "--observation-producer-name",
+            "tracker",
+            "--observation-producer-version",
+            "1",
+            "--observation-artifact-contract",
+            "prefix-v1",
+            "--execution-backend",
+            "cuda",
+            "--container-image-digest",
+            "sha256:" + "e" * 64,
+            "--completed-at-utc",
+            "2026-08-08T02:00:00+00:00",
+        ]
+    )
+
+    assert result == 0
+    assert received["arguments"] == (
+        "/c4",
+        "/bpt",
+        "/data",
+        "/wheels/c4.whl",
+        "/wheels/bpt.whl",
+        "/reports/freeze.txt",
+    )
+    assert received["keywords"] == {
+        "observation_producer_name": "tracker",
+        "observation_producer_version": "1",
+        "observation_artifact_contract": "prefix-v1",
+        "execution_backend": "cuda",
+        "container_image_digest": "sha256:" + "e" * 64,
+        "completed_at_utc": "2026-08-08T02:00:00+00:00",
+    }
+    assert json.loads(capsys.readouterr().out)["ready_to_seal"] is True
+
+
+def test_acquisition_staging_script_builds_clean_wheels_and_freezes_environment() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    subprocess.run(["bash", "-n", str(SCRIPT)], check=True)
+    assert text.count("git -C \"$checkout\" status --porcelain=v1") == 1
+    assert text.count("git -C \"$causal4d_root\" archive") == 1
+    assert text.count("git -C \"$bayesian_phystwin_root\" archive") == 1
+    assert text.count("-m build --wheel") == 2
+    assert "python -m pip install -e" not in text
+    assert "-m pip freeze --all" in text
+    assert "protocol readiness software-environment-stage" in text
+    assert "software_environment_locked --approved-by" in text
+    assert "rm -rf \"$deployment_venv\"" in text


### PR DESCRIPTION
## Summary

Add a fail-closed software-environment capsule for the registered Causal4D physical acquisition.

The new path:

- builds and stages exact Causal4D and BayesianPhysTwin wheels;
- binds both wheel SHA-256 identities and byte counts;
- verifies clean source checkouts at the exact commits named by the method freeze;
- requires the deployed imports to resolve below the active Python prefix and outside both source checkouts;
- captures Python, NumPy, SciPy, and applicable Torch, Warp, OpenCV, CUDA-runtime, and driver identities;
- retains `pip freeze --all`, build provenance, runtime provenance, and a content-addressed capsule;
- copies the registered Prob4D-unused declaration from the frozen acquisition candidate;
- refuses staging after confirmatory collection has started;
- leaves the software gate unapproved; and
- validates the complete capsule semantically before the existing independent operator-identity seal is allowed to run.

## CLI

The stable grouped route gains:

```bash
causal4d protocol readiness software-environment-stage \
  <causal4d-root> \
  <bayesianphystwin-root> \
  <dataset-root> \
  <causal4d-wheel> \
  <bayesianphystwin-wheel> \
  <resolved-dependencies.txt> \
  --observation-producer-name <name> \
  --observation-producer-version <version> \
  --observation-artifact-contract <contract> \
  --execution-backend <numpy_cpu|warp_cpu|cuda>
```

`causal4d protocol readiness seal-gate ... software_environment_locked` now validates the capsule, runtime report, build provenance, candidate identity, target-use declarations, source revisions, installed versions, and cross-artifact consistency before invoking the registered independent approver boundary.

## Operator helper

`scripts/acquisition/stage_software_environment.sh`:

1. requires clean Causal4D and BayesianPhysTwin checkouts;
2. builds wheels from clean `git archive` exports rather than a mutable working tree;
3. creates a new deployment virtual environment;
4. installs local wheel direct references without editable installs;
5. runs `pip check` and captures `pip freeze --all`; and
6. invokes the capsule staging route from the deployed environment.

The helper removes an incomplete deployment environment on failure and retains it after successful staging for independent review and physical acquisition.

## Evidence layout

```text
preacquisition/software_environment/
├── capsule.json
├── build-provenance.json
├── runtime.json
├── resolved-dependencies.txt
└── distributions/
    ├── causal4d-<version>-<tags>.whl
    └── bayesian_phystwin-<version>-<tags>.whl
```

The existing `preacquisition/software_environment.json` operator record remains `status=template`, unapproved, unlocked, and without an artifact digest until a distinct registered verifier seals it.

## Fail-closed behavior

Staging rejects:

- a dirty or wrong source revision;
- a non-pristine or already sealed operator gate;
- a wheel whose distribution identity is wrong;
- an installed project version that differs from its staged wheel;
- an import resolved from either source checkout or outside the active Python prefix;
- an editable project installation in the dependency report;
- a missing backend runtime;
- a changed acquisition candidate or admitted Prob4D path;
- an invalid container digest;
- target-outcome use; and
- any confirmatory manifest/acquired/validated execution.

The independent seal additionally rejects semantically changed but consistently re-addressed capsule, runtime, or provenance artifacts.

## Tests

The new regression suite covers:

- complete hash-verified staging while preserving the unapproved gate boundary;
- semantic validation of all six evidence artifacts;
- rerun refusal after completed staging;
- installed/wheel version drift;
- content-readdressed target-use tampering;
- capsule validation before registered gate sealing;
- grouped CLI routing for staging and sealing; and
- shell syntax, clean-archive wheel builds, non-editable installation, dependency capture, and failure cleanup.

## Documentation

`docs/causal4d_acquisition_environment_capsule.md` provides the complete operator procedure, direct CLI, helper invocation, artifact inventory, independent review and sealing sequence, and scientific non-claim boundary.

## Scientific boundary

This is acquisition reproducibility and deployment-provenance infrastructure. It does not change the frozen estimator, acquisition candidate, 18-session/36-execution protocol, target split, calibration rule, thresholds, evidence count, or scientific claim. It creates no physical execution and cannot authorize execution 1 without the existing final hash-verified readiness decision.