### PR TITLE
Restrict topology-covariance reproduction to reviewed main

### DIFF
--- a/.github/workflows/contact-topology-covariance.yml
+++ b/.github/workflows/contact-topology-covariance.yml
@@ -1,15 +1,6 @@
 name: Contact topology covariance diagnostic
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - ".github/workflows/contact-topology-covariance.yml"
-      - "docs/contact_topology_covariance.md"
-      - "scripts/ci/run_contact_topology_covariance_diagnostic.py"
-      - "src/causal4d/contact_topology_covariance_diagnostic.py"
-      - "tests/test_contact_topology_covariance_diagnostic.py"
-      - "tests/test_contact_topology_covariance_workflow_policy.py"
   workflow_dispatch:
     inputs:
       development_seeds:
@@ -54,8 +45,8 @@ jobs:
   evaluate:
     name: Fresh target-topology covariance evaluation (${{ matrix.lane }})
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
       matrix:
@@ -69,12 +60,20 @@ jobs:
     env:
       EXECUTION_LANE: ${{ matrix.lane }}
     steps:
-      - name: Check out Causal4D
+      - name: Check out exact reviewed Causal4D revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
           clean: true
+
+      - name: Verify reviewed main revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
 
       - name: Set up pinned Python with hosted pip cache
         if: matrix.lane == 'hosted'
@@ -101,7 +100,7 @@ jobs:
             "pyrecest==2.4.1" \
             "pytest==9.1.1" \
             "ruff==0.16.1"
-          python -m pip install -e ".[dev]"
+          python -m pip install ".[dev]"
           python -m pip check
           mkdir -p outputs/contact-topology-covariance
           python -m pip freeze --all \
@@ -130,7 +129,7 @@ jobs:
           31d9dbcfc794843a5ff45267d47c5cb21f8804437338dcf4f38ba27de4117ccf  src/causal4d/contact_topology_covariance_diagnostic.py
           f640f9f366a770408d1d58e650fbf649acd435263125e04de1da509e056d8540  scripts/ci/run_contact_topology_covariance_diagnostic.py
           c9a11dc160193b0ad397639e2d84fdbf0f09d789f97dfdcacec4270c77b6b5bd  tests/test_contact_topology_covariance_diagnostic.py
-          66cc1443b8f99563f99744c46584df13b1b52b5e0828c3b99cab5c96028f2e66  tests/test_contact_topology_covariance_workflow_policy.py
+          04481f7fd2b2965d3439dad9f1b9ca3068f6b5dea1bc62674383571c73667ae1  tests/test_contact_topology_covariance_workflow_policy.py
           ac491668ab4e43fd3e3f0aa0a580cafab52829604ed47cc25c7cd73ff9a0a979  docs/contact_topology_covariance.md
           EOF
           python -m ruff check \

--- a/tests/test_contact_topology_covariance_workflow_policy.py
+++ b/tests/test_contact_topology_covariance_workflow_policy.py
@@ -7,22 +7,52 @@ ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "contact-topology-covariance.yml"
 
 
-def test_topology_covariance_workflow_is_read_only_and_reproduced() -> None:
+def _evaluate_job(text: str) -> str:
+    return text.split("  evaluate:", maxsplit=1)[1]
+
+
+def test_topology_covariance_workflow_is_read_only_manual_and_dual_lane() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
+    preamble = text.split("\njobs:\n", maxsplit=1)[0]
+    job = _evaluate_job(text)
 
     assert "permissions:\n  contents: read\n" in text
     assert "contents: write" not in text
     assert "git push" not in text
     assert "persist-credentials: false" in text
-    assert "lane: hosted" in text
-    assert "runs_on: '\"ubuntu-latest\"'" in text
-    assert "lane: workstation2" in text
-    assert 'runs_on: \'["self-hosted","Linux","X64","nvidia-smi"]\'' in text
-    assert "cache: pip" in text
-    assert "cache-dependency-path: pyproject.toml" in text
-    assert "github.event.pull_request.head.repo.full_name == github.repository" in text
-    assert "workflow_dispatch:" in text
-    assert "  push:" not in text
+    assert "workflow_dispatch:" in preamble
+    assert "\n  pull_request:" not in preamble
+    assert "\n  push:" not in preamble
+    assert "github.event.pull_request" not in job
+    assert "lane: hosted" in job
+    assert "runs_on: '\"ubuntu-latest\"'" in job
+    assert "lane: workstation2" in job
+    assert 'runs_on: \'["self-hosted","Linux","X64","nvidia-smi"]\'' in job
+    assert "cache: pip" in job
+    assert "cache-dependency-path: pyproject.toml" in job
+
+
+def test_topology_covariance_dual_lane_execution_is_main_only() -> None:
+    job = _evaluate_job(WORKFLOW.read_text(encoding="utf-8"))
+
+    assert "github.event_name == 'workflow_dispatch'" in job
+    assert "github.ref == 'refs/heads/main'" in job
+    guard = job.index("if: >-")
+    strategy = job.index("strategy:")
+    runner = job.index("runs-on: ${{ fromJSON(matrix.runs_on) }}")
+    assert guard < strategy < runner
+
+
+def test_topology_covariance_checks_out_and_verifies_exact_main_revision() -> None:
+    job = _evaluate_job(WORKFLOW.read_text(encoding="utf-8"))
+
+    assert "ref: ${{ github.sha }}" in job
+    assert 'test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"' in job
+    assert 'test -z "$(git status --porcelain=v1)"' in job
+    checkout = job.index("- name: Check out exact reviewed Causal4D revision")
+    verify = job.index("- name: Verify reviewed main revision")
+    install = job.index("- name: Install diagnostic environment")
+    assert checkout < verify < install
 
 
 def test_topology_covariance_workflow_locks_panels_grid_and_runtime() -> None:
@@ -65,3 +95,10 @@ def test_topology_covariance_workflow_verifies_frozen_source_before_target() -> 
     assert text.index("sha256sum -c") < text.index(
         "Run fresh target topology-conditioned comparison"
     )
+
+
+def test_topology_covariance_uses_non_editable_distribution() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'python -m pip install ".[dev]"' in text
+    assert "python -m pip install -e" not in text


### PR DESCRIPTION
## Summary

Replace the permanent pull-request-triggered dual-lane topology-covariance workflow with a reviewed-main-only manual reproduction path.

This clean PR was rebuilt on current `main@0a7f88820745fca0f2e0042d7d058ecb17982687` from the validated source artifact produced by the closed transport PR #242.

## Changes

- remove `pull_request` and `push` triggers from the sealed diagnostic;
- require `workflow_dispatch` from `refs/heads/main` at the job level before either hosted or self-hosted runner allocation;
- check out and verify the exact reviewed dispatch SHA;
- preserve the hosted and `workstation2` reproduction lanes, pinned Python/dependencies, sealed source hashes, seed panels, grids, and result publication;
- use a non-editable package install for diagnostic execution; and
- strengthen the workflow-policy test to enforce read-only permissions, immutable checkout, main-only authorization, exact SHA verification, non-editable installation, and the unchanged frozen source gates.

## Validation provenance

Validated hosted transformer run:

```text
run: 31235455959
job: 93046987395
source head: e0ed6e0e1cb43f6ed04bc1b68c63dc2444c59b9f
artifact: 9015228010
artifact digest: sha256:c83b4d125fd203db962d477ed7966dc99dd1ff7a3eaeab7dc8afc6a1cbc7a2ef
```

The transformer verified its exact digest, applied only the reviewed substitutions, passed 36 focused policy/diagnostic tests, verified the final two-file scope, and published the following exact bytes:

```text
527ccd96541aeb40f13f8c858f565e4129af2dbfe3f3be1f03601aa751488c74  .github/workflows/contact-topology-covariance.yml
04481f7fd2b2965d3439dad9f1b9ca3068f6b5dea1bc62674383571c73667ae1  tests/test_contact_topology_covariance_workflow_policy.py
```

## Incident boundary

Before this hardening landed, the old PR-triggered workflow allocated `workstation2` once on run `31235455880`. It failed during environment installation and produced no topology-covariance result or scientific evidence. This PR removes that branch-controlled execution path.

## Scientific boundary

This changes workflow authorization and installation provenance only. It does not change the diagnostic method, development/evaluation panels, retained result, estimator, registered physical protocol, target identities, or evidence count.