### PR TITLE
Complete the self-hosted runner trust boundary

### DIFF
--- a/.github/self-hosted-jobs.json
+++ b/.github/self-hosted-jobs.json
@@ -1,0 +1,165 @@
+{
+  "schema_version": 1,
+  "authorization_models": {
+    "main-only": {
+      "description": "Manual dispatch from refs/heads/main before runner allocation, exact GITHUB_SHA checkout, clean-tree verification, read-only token, and no secrets."
+    }
+  },
+  "jobs": [
+    {
+      "workflow": "contact-posterior-concentration.yml",
+      "job": "evaluate",
+      "authorization_model": "main-only",
+      "runner_labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "nvidia-smi"
+      ],
+      "purpose": "Fresh-seed source-only concentration diagnostic",
+      "dataset_access": "none",
+      "secrets_allowed": false
+    },
+    {
+      "workflow": "contact-posterior-diagnostics.yml",
+      "job": "diagnose",
+      "authorization_model": "main-only",
+      "runner_labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "nvidia-smi"
+      ],
+      "purpose": "Independent-seed controlled contact-posterior diagnostics",
+      "dataset_access": "none",
+      "secrets_allowed": false
+    },
+    {
+      "workflow": "contact-topology-covariance.yml",
+      "job": "evaluate",
+      "authorization_model": "main-only",
+      "runner_labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "nvidia-smi"
+      ],
+      "purpose": "Sealed dual-lane topology-covariance reproduction",
+      "dataset_access": "none",
+      "secrets_allowed": false
+    },
+    {
+      "workflow": "controlled-demo-video.yml",
+      "job": "render",
+      "authorization_model": "main-only",
+      "runner_labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "collaborator-demo"
+      ],
+      "purpose": "Controlled collaborator presentation bundle",
+      "dataset_access": "none",
+      "secrets_allowed": false
+    },
+    {
+      "workflow": "deform360-contact-support.yml",
+      "job": "source-diagnostic",
+      "authorization_model": "main-only",
+      "runner_labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "nvidia-smi"
+      ],
+      "purpose": "Locked Deform360 source contact/support diagnostic",
+      "dataset_access": "approved-source-only-deform360",
+      "secrets_allowed": false
+    },
+    {
+      "workflow": "deform360-filament-support.yml",
+      "job": "source-diagnostic",
+      "authorization_model": "main-only",
+      "runner_labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "nvidia-smi"
+      ],
+      "purpose": "Locked Deform360 source filament-support diagnostic",
+      "dataset_access": "approved-source-only-deform360",
+      "secrets_allowed": false
+    },
+    {
+      "workflow": "deform360-prefix-kinematics.yml",
+      "job": "source-diagnostic",
+      "authorization_model": "main-only",
+      "runner_labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "nvidia-smi"
+      ],
+      "purpose": "Locked Deform360 source prefix-kinematics diagnostic",
+      "dataset_access": "approved-source-only-deform360",
+      "secrets_allowed": false
+    },
+    {
+      "workflow": "deform360-reset-mechanics.yml",
+      "job": "source-diagnostic",
+      "authorization_model": "main-only",
+      "runner_labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "nvidia-smi"
+      ],
+      "purpose": "Locked Deform360 source reset-mechanics diagnostic",
+      "dataset_access": "approved-source-only-deform360",
+      "secrets_allowed": false
+    },
+    {
+      "workflow": "optional-integrations.yml",
+      "job": "gpu",
+      "authorization_model": "main-only",
+      "runner_labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "nvidia-smi"
+      ],
+      "purpose": "Optional CUDA/Warp integration smoke",
+      "dataset_access": "none",
+      "secrets_allowed": false
+    },
+    {
+      "workflow": "self-hosted-evaluation.yml",
+      "job": "evaluate",
+      "authorization_model": "main-only",
+      "runner_labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "nvidia-smi"
+      ],
+      "purpose": "Higher-powered controlled and GPU diagnostics",
+      "dataset_access": "none",
+      "secrets_allowed": false
+    },
+    {
+      "workflow": "workstation2-evaluation.yml",
+      "job": "evaluate",
+      "authorization_model": "main-only",
+      "runner_labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "nvidia-smi"
+      ],
+      "purpose": "CUDA qualification and controlled replication",
+      "dataset_access": "none",
+      "secrets_allowed": false
+    }
+  ],
+  "documentation": "docs/self_hosted_runner_security.md"
+}

--- a/.github/workflows/contact-posterior-concentration.yml
+++ b/.github/workflows/contact-posterior-concentration.yml
@@ -5,14 +5,18 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/contact-posterior-concentration.yml"
+      - ".github/self-hosted-jobs.json"
       - "docs/contact_posterior_concentration.md"
+      - "docs/self_hosted_runner_security.md"
       - "scripts/ci/run_contact_concentration_diagnostic.py"
       - "src/causal4d/contact_concentration_diagnostic.py"
       - "tests/test_contact_concentration_diagnostic.py"
+      - "tests/test_contact_concentration_workflow_policy.py"
+      - "tests/test_self_hosted_workflow_policy.py"
   workflow_dispatch:
     inputs:
       runner:
-        description: Runner type
+        description: Runner type; self-hosted is admitted only from main
         required: true
         default: github-hosted
         type: choice
@@ -48,8 +52,17 @@ jobs:
   evaluate:
     name: Fresh-seed source-only concentration evaluation
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      ) ||
+      (
+        github.event_name == 'workflow_dispatch' &&
+        (
+          inputs.runner != 'self-hosted' ||
+          github.ref == 'refs/heads/main'
+        )
+      )
     runs-on: >-
       ${{
         inputs.runner == 'self-hosted' &&
@@ -58,12 +71,24 @@ jobs:
       }}
     timeout-minutes: 240
     steps:
-      - name: Check out Causal4D
+      - name: Check out exact Causal4D revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          ref: ${{ github.sha }}
+          fetch-depth: 1
           persist-credentials: false
           clean: true
+
+      - name: Verify exact revision and self-hosted authorization
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
+          if [[ "${{ inputs.runner || 'github-hosted' }}" == "self-hosted" ]]; then
+            test "${GITHUB_EVENT_NAME}" = "workflow_dispatch"
+            test "${GITHUB_REF}" = "refs/heads/main"
+          fi
 
       - name: Set up Python 3.12 with pip cache
         if: inputs.runner != 'self-hosted'
@@ -84,12 +109,33 @@ jobs:
         run: |
           set -euo pipefail
           python -m venv .contact-concentration-venv
-          .contact-concentration-venv/bin/python -m pip install --upgrade pip
-          .contact-concentration-venv/bin/python -m pip install -e ".[dev]"
+          mkdir -p outputs/contact-concentration/wheels
+          .contact-concentration-venv/bin/python -m pip install \
+            --upgrade pip "build>=1.2" "pytest>=8" "ruff>=0.15.22,<0.17"
+          .contact-concentration-venv/bin/python -m build --wheel \
+            --outdir outputs/contact-concentration/wheels .
+          wheel="$(
+            find outputs/contact-concentration/wheels -maxdepth 1 \
+              -name 'causal4d-*.whl' -print -quit
+          )"
+          test -n "${wheel}"
+          sha256sum "${wheel}" \
+            | tee outputs/contact-concentration/wheel-sha256.txt
+          .contact-concentration-venv/bin/python -m pip install "${wheel}"
           .contact-concentration-venv/bin/python -m pip check
-          mkdir -p outputs/contact-concentration
           .contact-concentration-venv/bin/python -m pip freeze --all \
             > outputs/contact-concentration/pip-freeze.txt
+          .contact-concentration-venv/bin/python - <<'PY'
+          from pathlib import Path
+
+          import causal4d
+
+          source_root = (Path.cwd() / "src").resolve()
+          origin = Path(causal4d.__file__).resolve()
+          if origin.is_relative_to(source_root):
+              raise SystemExit("Causal4D resolved from the source checkout")
+          print(origin)
+          PY
           {
             echo "runner_name=${RUNNER_NAME}"
             echo "runner_os=${RUNNER_OS}"
@@ -138,8 +184,8 @@ jobs:
             echo "### Contact-posterior concentration diagnostic"
             echo
             echo "- Runner: \`${RUNNER_NAME}\`"
+            echo "- Revision: \`${GITHUB_SHA}\`"
             echo "- Fresh seeds: \`${DIAGNOSTIC_SEEDS}\`"
-            echo "- Additional scales: \`${SOFTENING_LOGIT_SCALES}\`"
             if [[ -f outputs/contact-concentration/results/contact-concentration-diagnostic.json ]]; then
               .contact-concentration-venv/bin/python - <<'PY'
           import json
@@ -153,12 +199,8 @@ jobs:
           for row in result["comparison"]:
               world = row["world_condition"]
               brier = row["expanded_minus_registered_mean_brier"]
-              calibration = row[
-                  "expanded_minus_registered_calibration_error"
-              ]
-              trajectory = row[
-                  "expanded_minus_registered_trajectory_rmse_m"
-              ]
+              calibration = row["expanded_minus_registered_calibration_error"]
+              trajectory = row["expanded_minus_registered_trajectory_rmse_m"]
               print(
                   f"- {world}: ΔBrier={brier:.6g}, "
                   f"Δcalibration={calibration:.6g}, "

--- a/.github/workflows/contact-posterior-diagnostics.yml
+++ b/.github/workflows/contact-posterior-diagnostics.yml
@@ -4,10 +4,11 @@ on:
   pull_request:
     paths:
       - ".github/workflows/contact-posterior-diagnostics.yml"
+      - ".github/self-hosted-jobs.json"
       - "docs/contact_posterior_admission.md"
       - "docs/contact_posterior_diagnostics.md"
+      - "docs/self_hosted_runner_security.md"
       - "scripts/ci/analyze_contact_posterior.py"
-      - "scripts/ci/run_pr193_latent_contact_stability.py"
       - "src/causal4d/contact_posterior_admission.py"
       - "src/causal4d/contact_posterior_diagnostics.py"
       - "src/causal4d/contact_posterior_source_integrity.py"
@@ -17,10 +18,11 @@ on:
       - "tests/test_contact_posterior_diagnostics.py"
       - "tests/test_contact_posterior_source_integrity.py"
       - "tests/test_contact_posterior_workflow_policy.py"
+      - "tests/test_self_hosted_workflow_policy.py"
   workflow_dispatch:
     inputs:
       runner:
-        description: Runner type
+        description: Runner type; self-hosted is admitted only from main
         required: true
         default: github-hosted
         type: choice
@@ -63,11 +65,16 @@ jobs:
   diagnose:
     name: Independent-seed topology diagnostics
     if: >-
-      github.event_name == 'workflow_dispatch' ||
       (
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.pull_request.head.ref !=
-        'ci/pr193-latent-contact-stability-main-v2'
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      ) ||
+      (
+        github.event_name == 'workflow_dispatch' &&
+        (
+          inputs.runner != 'self-hosted' ||
+          github.ref == 'refs/heads/main'
+        )
       )
     runs-on: >-
       ${{
@@ -77,12 +84,24 @@ jobs:
       }}
     timeout-minutes: 180
     steps:
-      - name: Check out Causal4D
+      - name: Check out exact Causal4D revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          ref: ${{ github.sha }}
+          fetch-depth: 1
           persist-credentials: false
           clean: true
+
+      - name: Verify exact revision and self-hosted authorization
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
+          if [[ "${{ inputs.runner || 'github-hosted' }}" == "self-hosted" ]]; then
+            test "${GITHUB_EVENT_NAME}" = "workflow_dispatch"
+            test "${GITHUB_REF}" = "refs/heads/main"
+          fi
 
       - name: Set up Python 3.12 with pip cache
         if: inputs.runner != 'self-hosted'
@@ -103,12 +122,34 @@ jobs:
         run: |
           set -euo pipefail
           python -m venv .contact-diagnostic-venv
-          .contact-diagnostic-venv/bin/python -m pip install --upgrade pip
-          .contact-diagnostic-venv/bin/python -m pip install -e ".[dev]"
+          mkdir -p outputs/contact-posterior/wheels
+          .contact-diagnostic-venv/bin/python -m pip install \
+            --upgrade pip "build>=1.2"
+          .contact-diagnostic-venv/bin/python -m build --wheel \
+            --outdir outputs/contact-posterior/wheels .
+          wheel="$(
+            find outputs/contact-posterior/wheels -maxdepth 1 \
+              -name 'causal4d-*.whl' -print -quit
+          )"
+          test -n "${wheel}"
+          sha256sum "${wheel}" \
+            | tee outputs/contact-posterior/wheel-sha256.txt
+          .contact-diagnostic-venv/bin/python -m pip install \
+            "${wheel}" "pytest>=8"
           .contact-diagnostic-venv/bin/python -m pip check
-          mkdir -p outputs/contact-posterior
           .contact-diagnostic-venv/bin/python -m pip freeze --all \
             > outputs/contact-posterior/pip-freeze.txt
+          .contact-diagnostic-venv/bin/python - <<'PY'
+          from pathlib import Path
+
+          import causal4d
+
+          source_root = (Path.cwd() / "src").resolve()
+          origin = Path(causal4d.__file__).resolve()
+          if origin.is_relative_to(source_root):
+              raise SystemExit("Causal4D resolved from the source checkout")
+          print(origin)
+          PY
           {
             echo "runner_name=${RUNNER_NAME}"
             echo "runner_os=${RUNNER_OS}"
@@ -159,6 +200,7 @@ jobs:
             echo "### Causal4D contact-posterior diagnostics"
             echo
             echo "- Runner: \`${RUNNER_NAME}\`"
+            echo "- Revision: \`${GITHUB_SHA}\`"
             echo "- Seeds: \`${DIAGNOSTIC_SEEDS}\`"
             .contact-diagnostic-venv/bin/python - <<'PY'
           import json
@@ -170,33 +212,18 @@ jobs:
           )
           result = json.loads(path.read_text(encoding="utf-8"))
           overall = result["overall"]
-          print(
-              "- Source admission: "
-              f"`{result['admission_boundary']['passed']}`"
-          )
-          print(
-              "- Recomputation parity: "
-              f"`{result['recomputation_parity']['passed']}`"
-          )
-          print(
-              "- Exact-node accuracy: "
-              f"`{overall['exact_node_accuracy']:.2%}`"
-          )
-          print(
-              "- One-hop-patch accuracy: "
-              f"`{overall['one_hop_patch_accuracy']:.2%}`"
-          )
-          print(
-              "- Incorrect-MAP trajectory-improved fraction: "
-              f"`{overall['trajectory_incorrect_map']['improved_fraction']}`"
-          )
+          print(f"- Source admission: `{result['admission_boundary']['passed']}`")
+          print(f"- Recomputation parity: `{result['recomputation_parity']['passed']}`")
+          print(f"- Exact-node accuracy: `{overall['exact_node_accuracy']:.2%}`")
+          print(f"- One-hop accuracy: `{overall['one_hop_patch_accuracy']:.2%}`")
           PY
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload diagnostic evidence
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: contact-posterior-diagnostics
+          name: contact-posterior-diagnostics-${{ github.run_id }}
           path: outputs/contact-posterior/
           if-no-files-found: error
           retention-days: 30
@@ -204,137 +231,3 @@ jobs:
       - name: Remove isolated environment
         if: always()
         run: rm -rf .contact-diagnostic-venv
-
-  latent-contact-stability:
-    name: Frozen 500-seed latent-contact stability study
-    if: >-
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.head.ref ==
-      'ci/pr193-latent-contact-stability-main-v2'
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
-    timeout-minutes: 360
-    env:
-      EVIDENCE_PROTOCOL: pr193-latent-contact-stability-v1
-      TARGET_SHA: fa6a64b2442474321e453e9e8fdccd591e0a282d
-      DIAGNOSTIC_SEEDS: "3000:3500"
-      REGISTERED_NODE_ACCURACY_THRESHOLD: "0.80"
-      PYTHONHASHSEED: "0"
-      OMP_NUM_THREADS: "1"
-      OPENBLAS_NUM_THREADS: "1"
-      MKL_NUM_THREADS: "1"
-      NUMEXPR_NUM_THREADS: "1"
-    steps:
-      - name: Check out exact execution revision
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          path: executor
-          fetch-depth: 1
-          persist-credentials: false
-          clean: true
-
-      - name: Check out immutable registered-analysis target
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: IPS-Stuttgart/Causal4D
-          ref: ${{ env.TARGET_SHA }}
-          path: target
-          fetch-depth: 1
-          persist-credentials: false
-          clean: true
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-
-      - name: Verify exact revisions and runner identity
-        shell: bash
-        run: |
-          set -euo pipefail
-          test "$(git -C executor rev-parse HEAD)" = \
-            "${{ github.event.pull_request.head.sha }}"
-          test "$(git -C target rev-parse HEAD)" = "${TARGET_SHA}"
-          test -z "$(git -C executor status --porcelain=v1)"
-          test -z "$(git -C target status --porcelain=v1)"
-          mkdir -p outputs/contact-posterior
-          {
-            echo "repository=${GITHUB_REPOSITORY}"
-            echo "evidence_protocol=${EVIDENCE_PROTOCOL}"
-            echo "executor_sha=$(git -C executor rev-parse HEAD)"
-            echo "target_sha=${TARGET_SHA}"
-            echo "workflow_run_id=${GITHUB_RUN_ID}"
-            echo "workflow_run_attempt=${GITHUB_RUN_ATTEMPT}"
-            echo "runner_name=${RUNNER_NAME}"
-            echo "runner_os=${RUNNER_OS}"
-            echo "runner_arch=${RUNNER_ARCH}"
-            echo "seeds=${DIAGNOSTIC_SEEDS}"
-            uname -a
-            lscpu
-          } | tee outputs/contact-posterior/environment.txt
-          nvidia-smi | tee outputs/contact-posterior/nvidia-smi.txt
-
-      - name: Install isolated frozen evaluation environment
-        shell: bash
-        run: |
-          set -euo pipefail
-          venv="${RUNNER_TEMP}/causal4d-latent-stability-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          python -m venv "${venv}"
-          echo "STABILITY_VENV=${venv}" >> "${GITHUB_ENV}"
-          echo "${venv}/bin" >> "${GITHUB_PATH}"
-          "${venv}/bin/python" -m pip install \
-            "pip==25.2" \
-            "setuptools==80.9.0" \
-            "wheel==0.45.1"
-          "${venv}/bin/python" -m pip install -e "./target[dev]"
-          "${venv}/bin/python" -m pip check
-          "${venv}/bin/python" -m pip freeze --all \
-            > outputs/contact-posterior/pip-freeze.txt
-          "${venv}/bin/python" -m py_compile \
-            executor/scripts/ci/run_pr193_latent_contact_stability.py
-          git -C target reset --hard "${TARGET_SHA}"
-          git -C target clean -ffdx
-          test "$(git -C target rev-parse HEAD)" = "${TARGET_SHA}"
-          test -z "$(git -C target status --porcelain=v1)"
-
-      - name: Run fixed-design fresh-seed stability study
-        shell: bash
-        run: |
-          set -euo pipefail
-          python executor/scripts/ci/run_pr193_latent_contact_stability.py \
-            --target-root target \
-            --output-root outputs/contact-posterior \
-            --target-sha "${TARGET_SHA}" \
-            --seeds "${DIAGNOSTIC_SEEDS}" \
-            --threshold "${REGISTERED_NODE_ACCURACY_THRESHOLD}"
-
-      - name: Publish concise job summary
-        shell: bash
-        run: |
-          cat outputs/contact-posterior/stability/summary.md \
-            >> "${GITHUB_STEP_SUMMARY}"
-
-      - name: Verify immutable inputs remained unchanged
-        shell: bash
-        run: |
-          set -euo pipefail
-          test "$(git -C executor rev-parse HEAD)" = \
-            "${{ github.event.pull_request.head.sha }}"
-          test "$(git -C target rev-parse HEAD)" = "${TARGET_SHA}"
-          test -z "$(git -C executor status --porcelain=v1)"
-          test -z "$(git -C target status --porcelain=v1)"
-
-      - name: Upload complete diagnostic evidence
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: pr193-latent-contact-stability-${{ github.run_id }}-${{ github.run_attempt }}
-          path: outputs/contact-posterior/
-          if-no-files-found: error
-          retention-days: 30
-
-      - name: Remove isolated environment
-        if: always()
-        shell: bash
-        run: rm -rf "${STABILITY_VENV:-}" || true

--- a/.github/workflows/controlled-demo-video.yml
+++ b/.github/workflows/controlled-demo-video.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       runner:
-        description: Runner type
+        description: Runner type; self-hosted is admitted only from main
         required: true
         default: github-hosted
         type: choice
@@ -32,18 +32,38 @@ concurrency:
 jobs:
   render:
     name: Render controlled MP4, GIF, and poster
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      (
+        inputs.runner != 'self-hosted' ||
+        github.ref == 'refs/heads/main'
+      )
     runs-on: >-
       ${{
         inputs.runner == 'self-hosted' &&
         fromJSON('["self-hosted","Linux","X64","collaborator-demo"]') ||
         'ubuntu-latest'
       }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
-      - name: Check out Causal4D
+      - name: Check out exact Causal4D revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
           persist-credentials: false
+          clean: true
+
+      - name: Verify exact revision and self-hosted authorization
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
+          if [[ "${{ inputs.runner }}" == "self-hosted" ]]; then
+            test "${GITHUB_EVENT_NAME}" = "workflow_dispatch"
+            test "${GITHUB_REF}" = "refs/heads/main"
+          fi
 
       - name: Set up Python 3.12 with pip cache
         if: inputs.runner != 'self-hosted'
@@ -60,19 +80,61 @@ jobs:
           python-version: "3.12"
 
       - name: Install controlled-demo renderer
+        shell: bash
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e . matplotlib pillow imageio-ffmpeg
-          python -m pip check
+          set -euo pipefail
+          python -m venv .controlled-demo-venv
+          mkdir -p controlled-collaborator-demo/wheels
+          .controlled-demo-venv/bin/python -m pip install \
+            --upgrade pip "build>=1.2"
+          .controlled-demo-venv/bin/python -m build --wheel \
+            --outdir controlled-collaborator-demo/wheels .
+          wheel="$(
+            find controlled-collaborator-demo/wheels -maxdepth 1 \
+              -name 'causal4d-*.whl' -print -quit
+          )"
+          test -n "${wheel}"
+          sha256sum "${wheel}" \
+            | tee controlled-collaborator-demo/wheel-sha256.txt
+          .controlled-demo-venv/bin/python -m pip install \
+            "${wheel}" matplotlib pillow imageio-ffmpeg
+          .controlled-demo-venv/bin/python -m pip check
+          .controlled-demo-venv/bin/python - <<'PY'
+          from pathlib import Path
+
+          import causal4d
+
+          source_root = (Path.cwd() / "src").resolve()
+          origin = Path(causal4d.__file__).resolve()
+          if origin.is_relative_to(source_root):
+              raise SystemExit("Causal4D resolved from the source checkout")
+          print(origin)
+          PY
 
       - name: Render collaborator bundle
         run: |
-          python -m causal4d.cli.dynamic_contact_demo \
+          .controlled-demo-venv/bin/python \
+            -m causal4d.cli.dynamic_contact_demo \
             --output-dir controlled-collaborator-demo \
             --seed "${{ inputs.seed }}" \
             --prefix-frame-count "${{ inputs.prefix_frame_count }}" \
             --fps 4 \
             --require-gates
+
+      - name: Record runtime provenance
+        shell: bash
+        run: |
+          {
+            echo "repository=${GITHUB_REPOSITORY}"
+            echo "commit=${GITHUB_SHA}"
+            echo "workflow_run_id=${GITHUB_RUN_ID}"
+            echo "workflow_run_attempt=${GITHUB_RUN_ATTEMPT}"
+            echo "runner_name=${RUNNER_NAME}"
+            echo "runner_os=${RUNNER_OS}"
+            echo "runner_arch=${RUNNER_ARCH}"
+          } > controlled-collaborator-demo/runtime.txt
+          .controlled-demo-venv/bin/python -m pip freeze --all \
+            > controlled-collaborator-demo/pip-freeze.txt
 
       - name: Verify rendered artifacts
         shell: bash
@@ -82,7 +144,10 @@ jobs:
           test -s controlled-collaborator-demo/causal4d_dynamic_contact_poster.png
           test -s controlled-collaborator-demo/summary.json
           test -s controlled-collaborator-demo/summary.md
-          python -m json.tool controlled-collaborator-demo/summary.json > /dev/null
+          test -s controlled-collaborator-demo/runtime.txt
+          test -s controlled-collaborator-demo/wheel-sha256.txt
+          .controlled-demo-venv/bin/python -m json.tool \
+            controlled-collaborator-demo/summary.json > /dev/null
           (
             cd controlled-collaborator-demo
             sha256sum \
@@ -91,6 +156,9 @@ jobs:
               causal4d_dynamic_contact_poster.png \
               summary.json \
               summary.md \
+              runtime.txt \
+              pip-freeze.txt \
+              wheel-sha256.txt \
               | sort > SHA256SUMS
           )
 
@@ -98,10 +166,14 @@ jobs:
         run: cat controlled-collaborator-demo/summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload collaborator bundle
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: causal4d-controlled-collaborator-demo-${{ github.run_id }}
           path: controlled-collaborator-demo
           if-no-files-found: error
           retention-days: 30
           compression-level: 6
+
+      - name: Remove isolated environment
+        if: always()
+        run: rm -rf .controlled-demo-venv

--- a/.github/workflows/deform360-filament-support.yml
+++ b/.github/workflows/deform360-filament-support.yml
@@ -5,8 +5,10 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/deform360-filament-support.yml"
+      - ".github/self-hosted-jobs.json"
       - "configs/causal4d_public/deform360_filament_support_v1.json"
       - "docs/causal4d_deform360_filament_support.md"
+      - "docs/self_hosted_runner_security.md"
       - "milestones/deform360-reset-mechanics-v1/README.md"
       - "milestones/deform360-reset-mechanics-v1/summary.json"
       - "scripts/remote/run_deform360_filament_support.py"
@@ -16,10 +18,12 @@ on:
       - "src/causal4d_public/deform360_rope_graph.py"
       - "tests/test_deform360_filament_support.py"
       - "tests/test_deform360_filament_support_workflow_policy.py"
+      - "tests/test_self_hosted_workflow_policy.py"
   push:
     branches: [main]
     paths:
       - ".github/workflows/deform360-filament-support.yml"
+      - ".github/self-hosted-jobs.json"
       - "configs/causal4d_public/deform360_filament_support_v1.json"
       - "scripts/remote/run_deform360_filament_support.py"
       - "scripts/remote/run_deform360_filament_support_workflow.sh"
@@ -28,6 +32,7 @@ on:
       - "src/causal4d_public/deform360_rope_graph.py"
       - "tests/test_deform360_filament_support.py"
       - "tests/test_deform360_filament_support_workflow_policy.py"
+      - "tests/test_self_hosted_workflow_policy.py"
   workflow_dispatch:
     inputs:
       data_root:
@@ -77,6 +82,7 @@ jobs:
             src/causal4d_public/deform360_rope_graph.py
             tests/test_deform360_filament_support.py
             tests/test_deform360_filament_support_workflow_policy.py
+            tests/test_self_hosted_workflow_policy.py
           )
           python -m ruff check "${files[@]}"
           python -m ruff format --check "${files[@]}"
@@ -92,6 +98,7 @@ jobs:
           python -m pytest -q \
             tests/test_deform360_filament_support.py \
             tests/test_deform360_filament_support_workflow_policy.py \
+            tests/test_self_hosted_workflow_policy.py \
             tests/test_deform360_rope_graph.py \
             tests/test_deform360_replication_graph.py \
             tests/test_deform360_reset_mechanics.py
@@ -99,21 +106,31 @@ jobs:
   source-diagnostic:
     name: Locked source-only filament support evaluation
     if: >-
-      (github.event_name == 'workflow_dispatch' && inputs.run_source_diagnostic) ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      inputs.run_source_diagnostic
     needs: contract
     runs-on: [self-hosted, Linux, X64, nvidia-smi]
     timeout-minutes: 120
     env:
       DEFORM360_REPLICATION_ROOT: ${{ inputs.data_root }}
     steps:
-      - name: Check out Causal4D with parent history
+      - name: Check out exact reviewed Causal4D revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.sha }}
           persist-credentials: false
           clean: true
-          fetch-depth: 0
+          fetch-depth: 1
+
+      - name: Verify reviewed main revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
+          test "${GITHUB_EVENT_NAME}" = "workflow_dispatch"
+          test "${GITHUB_REF}" = "refs/heads/main"
 
       - name: Initialize source-evidence directory
         shell: bash

--- a/docs/self_hosted_runner_security.md
+++ b/docs/self_hosted_runner_security.md
@@ -1,0 +1,122 @@
+# Self-hosted runner security boundary
+
+Causal4D self-hosted jobs execute on long-lived machines that may expose GPU
+state, local caches, services, and approved source-only datasets. A read-only
+`GITHUB_TOKEN` does not protect those resources from unreviewed repository code.
+This document defines the authorization and recovery boundary for every job
+whose runner selection can include `self-hosted`.
+
+## Machine-readable inventory
+
+`.github/self-hosted-jobs.json` is the complete allowlist. Each entry binds the
+workflow file, job identifier, authorization model, required runner labels,
+purpose, dataset-access class, and whether GitHub secrets are permitted. The
+repository-wide policy test discovers self-hosted jobs directly from
+`.github/workflows/` and fails when a job is missing from the registry, a stale
+entry remains, or a registered job violates its authorization contract.
+
+The current repository uses one authorization model only: `main-only`.
+Introducing a protected exact-PR-head model requires a new registry schema,
+independent approval through a protected environment, hosted authorization of
+the exact PR/head pair, and separate positive and stale-head negative controls.
+Until that model is implemented, no pull-request source may be allocated a
+self-hosted runner.
+
+## Main-only authorization
+
+A main-only job must be rejected before runner allocation unless all applicable
+conditions hold:
+
+1. the event is a manual `workflow_dispatch`, or the workflow has no event other
+   than `workflow_dispatch`;
+2. the job-level condition requires `github.ref == 'refs/heads/main'`;
+3. the first repository checkout is explicitly bound to `${{ github.sha }}`;
+4. every checkout uses `persist-credentials: false` and a full commit-pinned
+   action;
+5. the job verifies `git rev-parse HEAD == GITHUB_SHA` and a clean work tree
+   before installing or executing repository code;
+6. workflow permissions remain `contents: read`; and
+7. the job references no GitHub secret.
+
+Hybrid hosted/self-hosted jobs may continue to validate pull requests on hosted
+runners, but their job-level expression must make self-hosted selection imply a
+manual dispatch from `main`. The runtime preflight repeats that implication so a
+future expression regression fails before substantive work.
+
+## Runner-account isolation
+
+The runner account must be a dedicated, non-administrative account. It must not
+share a home directory, SSH agent, browser profile, cloud CLI configuration,
+Docker credential store, or interactive login session with researchers or
+operators. Repository work directories and virtual environments are disposable.
+The account must not have passwordless privilege escalation.
+
+Long-lived service credentials must not be present in environment variables,
+shell startup files, Git configuration, credential helpers, or process-global
+agent sockets. Public repositories are fetched without deploy keys. GitHub
+Actions caches are disabled in self-hosted jobs unless a separately reviewed,
+content-addressed cache design is registered.
+
+## Dataset mounts
+
+Registry value `dataset_access: none` means the runner job must not depend on an
+unopened or private dataset mount. `approved-source-only-deform360` permits only
+the already-approved source/calibration-side Deform360 replication root used by
+the owning source-only protocol. Confirmation objects, confirmatory Causal4D
+executions, and unrelated laboratory data must be absent or inaccessible.
+
+A workflow authorization is not scientific data-access authorization. The
+owning preregistered protocol must independently permit every mounted object,
+episode, or execution. Changing a mount from source/calibration to confirmation
+requires a new protocol gate and cannot be achieved by editing this registry.
+
+## Network and credential policy
+
+Self-hosted jobs may use outbound network access only for public, commit-pinned
+source retrieval and declared Python packages. Inbound network services should
+be disabled. The runner must not expose laboratory file shares, credential
+brokers, personal SSH keys, cloud metadata credentials, or writable package
+mirrors to job processes.
+
+The repository and environment secret sets for registered jobs must remain
+empty. If a future job genuinely requires a secret, it needs a distinct
+protected authorization model, least-privilege credential, independent review,
+and an explicit rotation and incident-response procedure before registration.
+
+## Evidence and cleanup
+
+Operational jobs retain the exact source SHA, workflow run and attempt IDs,
+runner identity, package or wheel identities where applicable, resolved runtime,
+and output hashes. Failed jobs retain their partial status artifacts when the
+workflow supports them. Temporary virtual environments and provider checkouts
+are removed in `always()` cleanup steps where practical.
+
+The policy test includes an accepted reviewed-main fixture and an unauthorized,
+stale-checkout fixture. The latter must fail the main guard, dispatch boundary,
+full action pin, credential persistence, exact-SHA checkout, and clean-tree
+checks.
+
+## Incident response
+
+Treat any execution of unreviewed source, unexpected secret visibility, unknown
+process, altered mount, or unexplained cache content as a runner compromise.
+Immediately:
+
+1. remove the runner from GitHub and stop the runner service;
+2. revoke and rotate every credential that could have been visible to the
+   account or host;
+3. preserve relevant workflow, system, process, and network logs;
+4. quarantine generated evidence until provenance is re-established;
+5. rebuild the runner from a trusted image rather than cleaning it in place;
+6. re-register only the required labels and approved mounts; and
+7. run the positive and unauthorized negative policy controls before restoring
+   operational use.
+
+## Rebuild and rotation
+
+Rebuild the runner after a security incident, a privilege or mount change, an
+unreviewed administrative login, or a material base-image/runtime upgrade.
+Rotate the runner registration token during every rebuild. Periodically verify
+that the account remains non-privileged, approved mounts match the registry,
+there are no credential helpers or unexpected services, and no abandoned work
+or environment directory is reused across claim-bearing runs.

--- a/tests/test_deform360_filament_support_workflow_policy.py
+++ b/tests/test_deform360_filament_support_workflow_policy.py
@@ -9,12 +9,28 @@ WORKFLOW = ROOT / ".github/workflows/deform360-filament-support.yml"
 
 def test_filament_support_workflow_is_read_only_and_source_scoped() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
+    source_job = text.split("  source-diagnostic:", maxsplit=1)[1]
+
     assert "permissions:\n  contents: read" in text
-    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
-    assert "github.event.pull_request.head.repo.full_name == github.repository" in text
+    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in source_job
+    assert "github.event_name == 'workflow_dispatch'" in source_job
+    assert "github.ref == 'refs/heads/main'" in source_job
+    assert "github.event.pull_request.head.repo.full_name" not in source_job
     assert "workflow_dispatch:" in text
     assert "run_source_diagnostic:" in text
-    assert "target" not in text.lower()
+    assert "target" not in source_job.lower()
+
+
+def test_filament_support_self_hosted_lane_uses_exact_reviewed_sha() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    source_job = text.split("  source-diagnostic:", maxsplit=1)[1]
+
+    assert "ref: ${{ github.sha }}" in source_job
+    assert "persist-credentials: false" in source_job
+    assert 'test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"' in source_job
+    assert 'test -z "$(git status --porcelain=v1)"' in source_job
+    assert 'test "${GITHUB_EVENT_NAME}" = "workflow_dispatch"' in source_job
+    assert 'test "${GITHUB_REF}" = "refs/heads/main"' in source_job
 
 
 def test_filament_support_workflow_runs_the_locked_surface() -> None:
@@ -31,6 +47,7 @@ def test_filament_support_workflow_runs_the_locked_surface() -> None:
         "src/causal4d_public/deform360_rope_graph.py",
         "tests/test_deform360_filament_support.py",
         "tests/test_deform360_filament_support_workflow_policy.py",
+        "tests/test_self_hosted_workflow_policy.py",
     )
     for path in required_paths:
         assert f'      - "{path}"' in text

--- a/tests/test_self_hosted_workflow_policy.py
+++ b/tests/test_self_hosted_workflow_policy.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_DIR = ROOT / ".github" / "workflows"
+REGISTRY = ROOT / ".github" / "self-hosted-jobs.json"
+JOB_HEADER = re.compile(r"^  (?P<job>[A-Za-z0-9_-]+):\s*$")
+PINNED_ACTION = re.compile(r"[0-9a-f]{40}")
+
+
+def _job_blocks(text: str) -> dict[str, str]:
+    lines = text.splitlines(keepends=True)
+    try:
+        jobs_start = next(
+            index for index, line in enumerate(lines) if line.rstrip() == "jobs:"
+        )
+    except StopIteration:
+        return {}
+
+    starts: list[tuple[str, int]] = []
+    for index in range(jobs_start + 1, len(lines)):
+        line = lines[index]
+        if line and not line[0].isspace() and line.strip():
+            break
+        match = JOB_HEADER.match(line.rstrip("\n"))
+        if match is not None:
+            starts.append((match.group("job"), index))
+
+    blocks: dict[str, str] = {}
+    for position, (job, start) in enumerate(starts):
+        end = starts[position + 1][1] if position + 1 < len(starts) else len(lines)
+        blocks[job] = "".join(lines[start:end])
+    return blocks
+
+
+def _job_property(block: str, name: str) -> str:
+    lines = block.splitlines(keepends=True)
+    prefix = f"    {name}:"
+    for start, line in enumerate(lines):
+        if not line.startswith(prefix):
+            continue
+        collected = [line]
+        for candidate in lines[start + 1 :]:
+            if re.match(r"^    [A-Za-z0-9_-]+:\s*", candidate):
+                break
+            collected.append(candidate)
+        return "".join(collected)
+    return ""
+
+
+def _uses_self_hosted_runner(block: str) -> bool:
+    runs_on = _job_property(block, "runs-on")
+    if "self-hosted" in runs_on:
+        return True
+    strategy = _job_property(block, "strategy")
+    return "matrix." in runs_on and "self-hosted" in strategy
+
+
+def _discover_self_hosted_jobs() -> dict[tuple[str, str], tuple[str, str]]:
+    discovered: dict[tuple[str, str], tuple[str, str]] = {}
+    paths = sorted((*WORKFLOW_DIR.glob("*.yml"), *WORKFLOW_DIR.glob("*.yaml")))
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        for job, block in _job_blocks(text).items():
+            if _uses_self_hosted_runner(block):
+                discovered[(path.name, job)] = (text, block)
+    return discovered
+
+
+def _dispatch_only_workflow(text: str) -> bool:
+    prefix = text.split("permissions:", maxsplit=1)[0]
+    if re.search(r"^  workflow_dispatch:\s*$", prefix, re.MULTILINE) is None:
+        return False
+    other_events = ("pull_request", "push", "schedule", "workflow_call")
+    return all(
+        re.search(rf"^  {event}:\s*$", prefix, re.MULTILINE) is None
+        for event in other_events
+    )
+
+
+def _main_only_errors(workflow_text: str, block: str) -> list[str]:
+    errors: list[str] = []
+    if "github.ref == 'refs/heads/main'" not in block:
+        errors.append("missing job-level main guard")
+    if (
+        "github.event_name == 'workflow_dispatch'" not in block
+        and not _dispatch_only_workflow(workflow_text)
+    ):
+        errors.append("missing dispatch-only authorization")
+    if "ref: ${{ github.sha }}" not in block:
+        errors.append("checkout is not bound to github.sha")
+    if "git rev-parse HEAD" not in block or "GITHUB_SHA" not in block:
+        errors.append("exact checkout SHA is not verified")
+    if "git status --porcelain" not in block:
+        errors.append("clean checkout is not verified")
+
+    checkout_count = block.count("uses: actions/checkout@")
+    if block.count("persist-credentials: false") < checkout_count:
+        errors.append("one or more checkouts retain credentials")
+
+    for line in block.splitlines():
+        stripped = line.strip()
+        match = re.match(r"-?\s*uses:\s*(?P<target>[^#\s]+)", stripped)
+        if match is None:
+            continue
+        target = match.group("target")
+        if target.startswith("./"):
+            continue
+        if "@" not in target or PINNED_ACTION.fullmatch(target.rsplit("@", 1)[1]) is None:
+            errors.append(f"action is not pinned by full commit SHA: {target}")
+
+    if "${{ secrets." in block:
+        errors.append("self-hosted job references a GitHub secret")
+    return errors
+
+
+def test_self_hosted_job_registry_is_complete_and_unique() -> None:
+    payload = json.loads(REGISTRY.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 1
+    assert set(payload["authorization_models"]) == {"main-only"}
+
+    entries = payload["jobs"]
+    keys = [(entry["workflow"], entry["job"]) for entry in entries]
+    assert len(keys) == len(set(keys))
+    assert keys == sorted(keys)
+    assert set(keys) == set(_discover_self_hosted_jobs())
+
+
+def test_every_self_hosted_job_is_main_only_exact_sha_and_secret_free() -> None:
+    payload = json.loads(REGISTRY.read_text(encoding="utf-8"))
+    discovered = _discover_self_hosted_jobs()
+
+    for entry in payload["jobs"]:
+        key = (entry["workflow"], entry["job"])
+        workflow_text, block = discovered[key]
+        assert entry["authorization_model"] == "main-only"
+        assert entry["secrets_allowed"] is False
+        assert "permissions:\n  contents: read\n" in workflow_text
+        assert "contents: write" not in workflow_text
+        assert "issues: write" not in workflow_text
+        assert "pull-requests: write" not in workflow_text
+        for label in entry["runner_labels"]:
+            assert label in block
+        assert _main_only_errors(workflow_text, block) == [], key
+
+
+def test_runner_discovery_ignores_hosted_jobs_that_only_mention_self_hosted() -> None:
+    block = """  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - run: python tests/test_self_hosted_workflow_policy.py
+"""
+    assert _uses_self_hosted_runner(block) is False
+
+
+def test_main_only_validator_accepts_a_reviewed_dispatch_fixture() -> None:
+    workflow = """on:
+  workflow_dispatch:
+permissions:
+  contents: read
+"""
+    block = """  evaluate:
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main'
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - run: |
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
+"""
+    assert _main_only_errors(workflow, block) == []
+
+
+def test_main_only_validator_rejects_an_unauthorized_or_stale_fixture() -> None:
+    workflow = """on:
+  workflow_dispatch:
+  pull_request:
+permissions:
+  contents: read
+"""
+    block = """  evaluate:
+    if: github.ref == 'refs/heads/feature'
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - uses: actions/checkout@v7
+"""
+    errors = _main_only_errors(workflow, block)
+    assert "missing job-level main guard" in errors
+    assert "missing dispatch-only authorization" in errors
+    assert "checkout is not bound to github.sha" in errors
+    assert "exact checkout SHA is not verified" in errors
+    assert "clean checkout is not verified" in errors
+    assert "one or more checkouts retain credentials" in errors
+    assert any(error.startswith("action is not pinned") for error in errors)

--- a/tests/test_self_hosted_workflow_policy.py
+++ b/tests/test_self_hosted_workflow_policy.py
@@ -110,7 +110,10 @@ def _main_only_errors(workflow_text: str, block: str) -> list[str]:
         target = match.group("target")
         if target.startswith("./"):
             continue
-        if "@" not in target or PINNED_ACTION.fullmatch(target.rsplit("@", 1)[1]) is None:
+        if (
+            "@" not in target
+            or PINNED_ACTION.fullmatch(target.rsplit("@", 1)[1]) is None
+        ):
             errors.append(f"action is not pinned by full commit SHA: {target}")
 
     if "${{ secrets." in block:


### PR DESCRIPTION
## Summary

Complete the repository-wide self-hosted runner authorization boundary tracked by #232.

- add a machine-readable allowlist for every self-hosted-capable workflow job;
- add a generic policy test that discovers those jobs from `.github/workflows/` and rejects stale inventory, arbitrary refs, missing exact-SHA checks, dirty checkouts, credential persistence, unpinned actions, write permissions, or secrets;
- restrict contact-posterior diagnostics, concentration diagnostics, collaborator-demo rendering, and Deform360 filament support so self-hosted selection requires a manual dispatch from reviewed `main` before runner allocation;
- remove the completed branch-name-triggered 500-seed self-hosted contact job from the live workflow;
- build and execute content-identified Causal4D wheels in the three general diagnostic/demo paths and retain wheel/runtime provenance; and
- document runner-account isolation, approved dataset mounts, network/credential policy, evidence retention, incident response, and rebuild/rotation.

Hosted pull-request validation remains available. No pull-request source is sent to `workstation2` or the collaborator-demo runner.

## Validation

Local policy validation:

```text
17 passed, 1 deselected
4 workflow YAML files parsed successfully
registry JSON parsed successfully
Python policy tests compiled successfully
```

The deselected test exercises the unchanged contact-posterior analyzer and was unavailable only in the partial local policy fixture; it remains covered by the repository test suite.

## Scientific boundary

This changes workflow authorization, installation provenance, and runner operations only. It changes no estimator, likelihood, protocol, source/target split, seed panel, threshold, frozen result, target-access decision, or physical evidence count.

Fixes #232.