### PR TITLE
Add target-free registered real-analysis report shell

### DIFF
--- a/docs/causal4d_registered_real_report_shell.md
+++ b/docs/causal4d_registered_real_report_shell.md
@@ -1,0 +1,113 @@
+# Target-free registered real-analysis report shell
+
+The physical Causal4D study has a sealed analysis manifest, but a sealed manifest
+alone does not prove that the final paper tables, figures, failure accounting,
+and interpretation paths can be rendered without ad hoc target-side work.
+
+`causal4d.registered_real_report_shell` creates a deterministic report shell from
+one validated registered-analysis manifest **before confirmatory outcomes are
+opened**. The shell is a derived operator artifact. It is not evidence, it does
+not increment the 36-execution registry, and it cannot approve or interpret a
+scientific result.
+
+## Render the shell
+
+```bash
+python -m causal4d.registered_real_report_shell render \
+  /data/causal4d-sloth-multi-action-v1/registered-analysis.json \
+  --output-json \
+  /data/causal4d-sloth-multi-action-v1/operator/real-report-shell.json \
+  --output-markdown \
+  /data/causal4d-sloth-multi-action-v1/operator/real-report-shell.md
+```
+
+The command validates the registered analysis with the existing closed schema,
+binds the exact analysis bytes and software revisions, and writes:
+
+- a content-addressed JSON contract for the report layout; and
+- a Markdown dry rendering with visibly empty result cells.
+
+Both destinations are checked before publication. Existing outputs are rejected
+unless `--overwrite` is supplied, so a stale JSON file cannot be silently paired
+with a newly rendered Markdown file.
+
+## Validate the shell against its source
+
+Standalone validation checks the schema, content identity, safety boundary, and
+that every table, figure, and result narrative remains empty or unselected:
+
+```bash
+python -m causal4d.registered_real_report_shell validate \
+  /data/causal4d-sloth-multi-action-v1/operator/real-report-shell.json
+```
+
+For acquisition use, always bind the shell back to the exact registered analysis:
+
+```bash
+python -m causal4d.registered_real_report_shell validate \
+  /data/causal4d-sloth-multi-action-v1/operator/real-report-shell.json \
+  --analysis-manifest \
+  /data/causal4d-sloth-multi-action-v1/registered-analysis.json
+```
+
+The second form rebuilds the expected shell from the validated source bytes and
+requires exact equality. Readdressing both an embedded contract and its shell ID
+therefore cannot substitute a different analysis manifest.
+
+## What is rendered
+
+The shell proves that the registered analysis can produce a complete result
+without manual panel selection. It includes empty layouts for:
+
+- all 36 execution records and every preregistered exclusion or technical failure;
+- factual-continuation effects;
+- same-grasp transfer effects;
+- new-contact transfer effects;
+- independent execution-block calibration, coverage, interval width, normalized
+  NEES, and finite-calibration sensitivity;
+- replay/reset variance;
+- diagnostic intervention-oracle gap attribution;
+- paired endpoint-effect figures;
+- coverage and interval-width figures;
+- execution accounting; and
+- oracle-gap decomposition.
+
+It also renders both predeclared interpretation paths:
+
+1. registered success across factual prediction, both transfer endpoints, and
+   independent-execution calibration; and
+2. a bounded negative result that reports each failed gate separately and does
+   not use calibration or an optional branch to rescue failed prediction.
+
+Neither path is selected by the shell. Selection remains the responsibility of
+the source-verified real-result interpretation after blind analysis.
+
+## Fail-closed safety boundary
+
+A valid shell contains exactly:
+
+```json
+{
+  "target_outcomes_loaded": false,
+  "target_metric_values_loaded": false,
+  "confirmatory_execution_evidence_count": 0,
+  "may_select_method_or_hyperparameters": false,
+  "manual_table_or_figure_selection_allowed": false,
+  "derived_artifact_is_claim_bearing": false,
+  "report_shell_is_a_scientific_result": false
+}
+```
+
+Every table has `rows=[]`, every figure has `values=[]`, and both result
+narratives have `selected=false`. Adding a target value, selecting a narrative,
+changing the layout, or altering the registered safety boundary invalidates the
+artifact even when its `shell_id` is recomputed.
+
+## Scientific boundary
+
+This helper changes no estimator, intervention posterior, six-frame information
+boundary, split, threshold, exclusion rule, calibration method, acquisition
+order, or evidence count. The physical status remains `0/36` until genuine
+registered executions are acquired and validated. A successful report-shell dry
+run demonstrates analysis-operational completeness only; it is not empirical
+support for Causal4D.

--- a/src/causal4d/registered_real_report_shell.py
+++ b/src/causal4d/registered_real_report_shell.py
@@ -1,0 +1,1046 @@
+"""Deterministic, target-free shell for the registered real-analysis report."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final, cast
+
+REPORT_SHELL_SCHEMA_VERSION: Final = 1
+REPORT_SHELL_ARTIFACT_KIND: Final = "Causal4DRegisteredRealReportShell"
+REPORT_SHELL_STATUS: Final = "target-free-template"
+
+_TOP_LEVEL_FIELDS = frozenset(
+    {
+        "schema_version",
+        "artifact_kind",
+        "shell_id",
+        "status",
+        "source",
+        "safety_boundary",
+        "analysis_contract",
+        "table_plan",
+        "figure_plan",
+        "narrative_plan",
+        "completion_checks",
+    }
+)
+_SOURCE_FIELDS = frozenset(
+    {
+        "analysis_id",
+        "analysis_manifest_sha256",
+        "analysis_manifest_bytes",
+        "method_freeze_sha256",
+        "protocol_id",
+        "protocol_design_sha256",
+        "preacquisition_amendment_sha256",
+        "software",
+    }
+)
+_CONTRACT_FIELDS = frozenset(
+    {
+        "comparison_arms",
+        "effect_reporting",
+        "confirmatory_calibration",
+        "failure_and_exclusion_policy",
+        "reporting_contract",
+        "claim_boundary",
+    }
+)
+_SAFETY_BOUNDARY = {
+    "target_outcomes_loaded": False,
+    "target_metric_values_loaded": False,
+    "confirmatory_execution_evidence_count": 0,
+    "may_select_method_or_hyperparameters": False,
+    "manual_table_or_figure_selection_allowed": False,
+    "derived_artifact_is_claim_bearing": False,
+    "report_shell_is_a_scientific_result": False,
+}
+_ENDPOINT_COLUMNS = (
+    "arm_id",
+    "registered_units",
+    "valid_units",
+    "excluded_units",
+    "equal_target_session_mean",
+    "candidate_minus_baseline",
+    "confidence_interval_lower",
+    "confidence_interval_upper",
+    "interval_method",
+    "replay_reset_variance",
+)
+_COMPLETION_CHECKS = (
+    "all_registered_units_or_preregistered_exclusions_are_accounted_for",
+    "factual_same_grasp_new_contact_and_calibration_are_reported_separately",
+    "candidate_effects_use_equal_target_session_weighting",
+    "effect_intervals_use_the_registered_resampling_unit_and_seed",
+    "technical_failures_and_exclusion_reasons_are_retained",
+    "coverage_interval_width_and_finite_calibration_sensitivity_are_reported",
+    "intervention_oracle_remains_diagnostic_only",
+    "positive_and_bounded_negative_narratives_are_both_renderable",
+    "optional_branches_cannot_rescue_a_primary_failure",
+    "claim_language_remains_inside_the_registered_boundary",
+)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    _require(isinstance(value, Mapping), f"{name} must be a JSON object")
+    _require(all(type(key) is str for key in value), f"{name} keys must be strings")
+    return cast(Mapping[str, Any], value)
+
+
+def _sequence(value: Any, *, name: str) -> Sequence[Any]:
+    _require(
+        isinstance(value, Sequence) and not isinstance(value, (str, bytes)),
+        f"{name} must be a JSON array",
+    )
+    return cast(Sequence[Any], value)
+
+
+def _nonempty_string(value: Any, *, name: str) -> str:
+    _require(type(value) is str and bool(value.strip()), f"{name} is missing")
+    return value.strip()
+
+
+def _hex_digest(value: Any, *, name: str, length: int) -> str:
+    text = _nonempty_string(value, name=name)
+    _require(
+        len(text) == length
+        and all(character in "0123456789abcdef" for character in text),
+        f"{name} must be a lowercase {length}-hex digest",
+    )
+    return text
+
+
+def _positive_int(value: Any, *, name: str) -> int:
+    _require(type(value) is int and value > 0, f"{name} must be a positive integer")
+    return value
+
+
+def _nonnegative_int(value: Any, *, name: str) -> int:
+    _require(
+        type(value) is int and value >= 0,
+        f"{name} must be a nonnegative integer",
+    )
+    return value
+
+
+def _json_copy(value: Any, *, name: str) -> Any:
+    try:
+        encoded = json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+        return json.loads(encoded)
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{name} must be finite JSON") from error
+
+
+def _canonical_sha256(payload: Mapping[str, Any], *, omitted: str) -> str:
+    values = dict(payload)
+    values.pop(omitted, None)
+    encoded = json.dumps(
+        values,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def report_shell_id_for_payload(payload: Mapping[str, Any]) -> str:
+    """Return the canonical content identity of a report shell."""
+
+    return _canonical_sha256(payload, omitted="shell_id")
+
+
+def _normalize_software(value: Any) -> dict[str, Any]:
+    software = _mapping(value, name="analysis software")
+    required = {
+        "causal4d_commit_sha",
+        "bayesian_phystwin_commit_sha",
+        "observation_provider_bound_by_software_environment_gate",
+        "prob4d_may_change_primary_analysis",
+    }
+    _require(set(software) == required, "analysis software fields changed")
+    _require(
+        software["observation_provider_bound_by_software_environment_gate"] is True,
+        "observation provider must be bound by the software-environment gate",
+    )
+    _require(
+        software["prob4d_may_change_primary_analysis"] is False,
+        "Prob4D may not change the registered primary analysis",
+    )
+    return {
+        "causal4d_commit_sha": _hex_digest(
+            software["causal4d_commit_sha"],
+            name="Causal4D commit",
+            length=40,
+        ),
+        "bayesian_phystwin_commit_sha": _hex_digest(
+            software["bayesian_phystwin_commit_sha"],
+            name="BayesianPhysTwin commit",
+            length=40,
+        ),
+        "observation_provider_bound_by_software_environment_gate": True,
+        "prob4d_may_change_primary_analysis": False,
+    }
+
+
+def _normalize_comparison_arms(value: Any) -> list[dict[str, Any]]:
+    raw_arms = _sequence(value, name="comparison arms")
+    _require(len(raw_arms) >= 3, "comparison arms are incomplete")
+    arms: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    primary_candidates = 0
+    diagnostic_arms = 0
+    for index, raw in enumerate(raw_arms):
+        arm = _mapping(raw, name=f"comparison arm {index}")
+        arm_id = _nonempty_string(arm.get("arm_id"), name=f"arm {index} id")
+        _require(arm_id not in seen, "comparison arm IDs must be unique")
+        seen.add(arm_id)
+        role = _nonempty_string(arm.get("role"), name=f"arm {arm_id} role")
+        _require(
+            role in {"baseline", "primary_candidate", "diagnostic_only"},
+            f"arm {arm_id} has an unsupported role",
+        )
+        primary_candidates += int(role == "primary_candidate")
+        diagnostic_arms += int(role == "diagnostic_only")
+        normalized = _json_copy(dict(arm), name=f"comparison arm {arm_id}")
+        normalized["arm_id"] = arm_id
+        normalized["role"] = role
+        arms.append(normalized)
+    _require(primary_candidates == 1, "exactly one primary candidate is required")
+    _require(diagnostic_arms >= 1, "a diagnostic-only arm is required")
+    return arms
+
+
+def _normalize_effect_reporting(value: Any) -> dict[str, Any]:
+    reporting = _mapping(value, name="effect reporting")
+    inventory = _sequence(
+        reporting.get("endpoint_inventory"),
+        name="endpoint inventory",
+    )
+    endpoints: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, raw in enumerate(inventory):
+        endpoint = _mapping(raw, name=f"endpoint {index}")
+        endpoint_id = _nonempty_string(
+            endpoint.get("endpoint_id"),
+            name=f"endpoint {index} id",
+        )
+        _require(endpoint_id not in seen, "endpoint IDs must be unique")
+        seen.add(endpoint_id)
+        registered_units = _positive_int(
+            endpoint.get("registered_units"),
+            name=f"endpoint {endpoint_id} registered units",
+        )
+        target_sessions = _positive_int(
+            endpoint.get("target_sessions"),
+            name=f"endpoint {endpoint_id} target sessions",
+        )
+        _require(
+            target_sessions <= registered_units,
+            f"endpoint {endpoint_id} has more sessions than units",
+        )
+        endpoints.append(
+            {
+                "endpoint_id": endpoint_id,
+                "split_key": _nonempty_string(
+                    endpoint.get("split_key"),
+                    name=f"endpoint {endpoint_id} split key",
+                ),
+                "registered_units": registered_units,
+                "target_sessions": target_sessions,
+                "primary_estimate": _nonempty_string(
+                    endpoint.get("primary_estimate"),
+                    name=f"endpoint {endpoint_id} primary estimate",
+                ),
+                "interval_method": _nonempty_string(
+                    endpoint.get("interval_method"),
+                    name=f"endpoint {endpoint_id} interval method",
+                ),
+            }
+        )
+    _require(endpoints, "endpoint inventory must not be empty")
+    normalized = _json_copy(dict(reporting), name="effect reporting")
+    normalized["endpoint_inventory"] = endpoints
+    _require(
+        normalized.get("equal_session_weighting") is True,
+        "equal target-session weighting is required",
+    )
+    _positive_int(
+        normalized.get("bootstrap_replicates"),
+        name="bootstrap replicate count",
+    )
+    _nonnegative_int(normalized.get("bootstrap_seed"), name="bootstrap seed")
+    confidence = normalized.get("confidence_level")
+    _require(
+        type(confidence) in {int, float} and 0.0 < float(confidence) < 1.0,
+        "bootstrap confidence level must be in (0, 1)",
+    )
+    return normalized
+
+
+def _normalize_contract(analysis: Mapping[str, Any]) -> dict[str, Any]:
+    for name, expected in (
+        ("primary_analysis_locked", True),
+        ("locked_before_target_access", True),
+        ("target_outcomes_observed_at_registration", False),
+        ("target_outcomes_may_select_method_or_hyperparameters", False),
+        ("optional_branches_may_change_primary_analysis", False),
+    ):
+        _require(analysis.get(name) is expected, f"registered analysis {name} changed")
+
+    contract = {
+        "comparison_arms": _normalize_comparison_arms(analysis.get("comparison_arms")),
+        "effect_reporting": _normalize_effect_reporting(
+            analysis.get("effect_reporting")
+        ),
+        "confirmatory_calibration": _json_copy(
+            dict(
+                _mapping(
+                    analysis.get("confirmatory_calibration"),
+                    name="confirmatory calibration",
+                )
+            ),
+            name="confirmatory calibration",
+        ),
+        "failure_and_exclusion_policy": _json_copy(
+            dict(
+                _mapping(
+                    analysis.get("failure_and_exclusion_policy"),
+                    name="failure and exclusion policy",
+                )
+            ),
+            name="failure and exclusion policy",
+        ),
+        "reporting_contract": _json_copy(
+            dict(
+                _mapping(
+                    analysis.get("reporting_contract"),
+                    name="reporting contract",
+                )
+            ),
+            name="reporting contract",
+        ),
+        "claim_boundary": _json_copy(
+            dict(_mapping(analysis.get("claim_boundary"), name="claim boundary")),
+            name="claim boundary",
+        ),
+    }
+    exclusion = cast(dict[str, Any], contract["failure_and_exclusion_policy"])
+    reporting = cast(dict[str, Any], contract["reporting_contract"])
+    _require(
+        exclusion.get("all_registered_units_accounted_for") is True,
+        "all registered units must be accounted for",
+    )
+    _require(
+        exclusion.get("technical_failures_retained") is True,
+        "technical failures must be retained",
+    )
+    _require(
+        reporting.get("report_success_or_well_powered_negative_result") is True,
+        "both positive and bounded-negative reporting paths are required",
+    )
+    _require(
+        reporting.get(
+            "optional_semantic_or_public_data_results_cannot_rescue_primary_failure"
+        )
+        is True,
+        "optional results may not rescue a primary failure",
+    )
+    return contract
+
+
+def _source_from_analysis(
+    analysis: Mapping[str, Any],
+    *,
+    analysis_manifest_sha256: str,
+    analysis_manifest_byte_count: int,
+) -> dict[str, Any]:
+    return {
+        "analysis_id": _hex_digest(
+            analysis.get("analysis_id"),
+            name="analysis ID",
+            length=64,
+        ),
+        "analysis_manifest_sha256": _hex_digest(
+            analysis_manifest_sha256,
+            name="analysis manifest SHA-256",
+            length=64,
+        ),
+        "analysis_manifest_bytes": _positive_int(
+            analysis_manifest_byte_count,
+            name="analysis manifest byte count",
+        ),
+        "method_freeze_sha256": _hex_digest(
+            analysis.get("method_freeze_sha256"),
+            name="method freeze SHA-256",
+            length=64,
+        ),
+        "protocol_id": _nonempty_string(
+            analysis.get("protocol_id"),
+            name="protocol ID",
+        ),
+        "protocol_design_sha256": _hex_digest(
+            analysis.get("protocol_design_sha256"),
+            name="protocol design SHA-256",
+            length=64,
+        ),
+        "preacquisition_amendment_sha256": _hex_digest(
+            analysis.get("preacquisition_amendment_sha256"),
+            name="pre-acquisition amendment SHA-256",
+            length=64,
+        ),
+        "software": _normalize_software(analysis.get("software")),
+    }
+
+
+def _table_plan(contract: Mapping[str, Any]) -> list[dict[str, Any]]:
+    effect_reporting = _mapping(contract["effect_reporting"], name="effect reporting")
+    endpoints = _sequence(
+        effect_reporting["endpoint_inventory"],
+        name="endpoint inventory",
+    )
+    tables: list[dict[str, Any]] = [
+        {
+            "table_id": "execution-accounting",
+            "title": "Registered execution and exclusion accounting",
+            "required_columns": [
+                "execution_id",
+                "session_id",
+                "registered_condition",
+                "completion_state",
+                "included",
+                "preregistered_exclusion_reason",
+                "technical_failure_reason",
+            ],
+            "rows": [],
+            "row_source": "validated confirmatory evidence registry",
+        }
+    ]
+    for raw in endpoints:
+        endpoint = _mapping(raw, name="endpoint")
+        endpoint_id = cast(str, endpoint["endpoint_id"])
+        tables.append(
+            {
+                "table_id": f"endpoint-{endpoint_id}-effects",
+                "title": f"Registered {endpoint_id.replace('_', ' ')} effects",
+                "endpoint_id": endpoint_id,
+                "registered_units": endpoint["registered_units"],
+                "target_sessions": endpoint["target_sessions"],
+                "primary_estimate": endpoint["primary_estimate"],
+                "required_columns": list(_ENDPOINT_COLUMNS),
+                "rows": [],
+                "row_source": "registered blind analysis output",
+            }
+        )
+    tables.extend(
+        (
+            {
+                "table_id": "execution-block-calibration",
+                "title": "Independent-execution calibration",
+                "required_columns": [
+                    "outer_fold",
+                    "held_out_session",
+                    "calibration_unit_count",
+                    "order_statistic_rank",
+                    "nominal_coverage",
+                    "observed_coverage",
+                    "interval_width",
+                    "normalized_nees",
+                    "finite_calibration_sensitivity",
+                ],
+                "rows": [],
+                "row_source": "registered execution-block calibration output",
+            },
+            {
+                "table_id": "failure-and-exclusion-accounting",
+                "title": "Technical failures and preregistered exclusions",
+                "required_columns": [
+                    "execution_id",
+                    "failure_or_exclusion_class",
+                    "registered_reason",
+                    "target_metrics_redacted_when_excluded",
+                    "replacement_performed",
+                ],
+                "rows": [],
+                "row_source": "validated evidence registry",
+            },
+            {
+                "table_id": "oracle-gap-attribution",
+                "title": "Diagnostic intervention-oracle gap attribution",
+                "required_columns": [
+                    "endpoint_id",
+                    "candidate_error",
+                    "current_bank_oracle_error",
+                    "full_state_oracle_error",
+                    "inference_share",
+                    "proposal_coverage_share",
+                    "model_discrepancy_share",
+                ],
+                "rows": [],
+                "row_source": "diagnostic-only oracle analysis",
+            },
+        )
+    )
+    return tables
+
+
+def _figure_plan(contract: Mapping[str, Any]) -> list[dict[str, Any]]:
+    endpoints = _sequence(
+        _mapping(contract["effect_reporting"], name="effect reporting")[
+            "endpoint_inventory"
+        ],
+        name="endpoint inventory",
+    )
+    figures: list[dict[str, Any]] = []
+    for raw in endpoints:
+        endpoint = _mapping(raw, name="endpoint")
+        endpoint_id = cast(str, endpoint["endpoint_id"])
+        figures.append(
+            {
+                "figure_id": f"endpoint-{endpoint_id}-paired-effects",
+                "title": f"{endpoint_id.replace('_', ' ').title()} paired effects",
+                "endpoint_id": endpoint_id,
+                "required_series": [
+                    "target_session",
+                    "candidate_minus_baseline",
+                    "confidence_interval",
+                ],
+                "values": [],
+                "data_source": "registered blind analysis output",
+            }
+        )
+    figures.extend(
+        (
+            {
+                "figure_id": "coverage-and-width",
+                "title": "Coverage and interval width by endpoint and horizon",
+                "required_series": [
+                    "endpoint_id",
+                    "horizon",
+                    "nominal_coverage",
+                    "observed_coverage",
+                    "interval_width",
+                ],
+                "values": [],
+                "data_source": "registered calibration output",
+            },
+            {
+                "figure_id": "execution-accounting-flow",
+                "title": "Registered, completed, excluded, and failed executions",
+                "required_series": [
+                    "registered",
+                    "completed",
+                    "included",
+                    "excluded",
+                    "technical_failures",
+                ],
+                "values": [],
+                "data_source": "validated evidence registry",
+            },
+            {
+                "figure_id": "oracle-gap-decomposition",
+                "title": "Diagnostic oracle-gap decomposition",
+                "required_series": [
+                    "inference",
+                    "proposal_coverage",
+                    "model_discrepancy",
+                ],
+                "values": [],
+                "data_source": "diagnostic-only oracle analysis",
+            },
+        )
+    )
+    return figures
+
+
+def _narrative_plan() -> list[dict[str, Any]]:
+    return [
+        {
+            "outcome_id": "registered_success",
+            "selected": False,
+            "selection_source": "source-verified real-result interpretation",
+            "required_statements": [
+                "factual prediction gate passed",
+                "same-grasp transfer gate passed",
+                "new-contact transfer gate passed",
+                "independent-execution calibration gate passed",
+                "all failures and exclusions remain reported",
+            ],
+            "forbidden_claims": [
+                "object-class generalization",
+                "raw covariance calibration",
+                "general robot safety",
+                "individual real counterfactual ground truth",
+            ],
+        },
+        {
+            "outcome_id": "registered_bounded_negative",
+            "selected": False,
+            "selection_source": "source-verified real-result interpretation",
+            "required_statements": [
+                "failed prediction or transfer gates are identified separately",
+                "calibration does not rescue a failed prediction gate",
+                "all failures and exclusions remain reported",
+                "the measured transfer or calibration boundary is quantified",
+                "no target-informed retuning is performed",
+            ],
+            "forbidden_claims": [
+                "optional branch rescue of the primary result",
+                "silent replacement of failed executions",
+                "generalization beyond the registered claim boundary",
+            ],
+        },
+    ]
+
+
+def _build_shell_payload(
+    source: Mapping[str, Any],
+    contract: Mapping[str, Any],
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": REPORT_SHELL_SCHEMA_VERSION,
+        "artifact_kind": REPORT_SHELL_ARTIFACT_KIND,
+        "shell_id": "",
+        "status": REPORT_SHELL_STATUS,
+        "source": dict(source),
+        "safety_boundary": dict(_SAFETY_BOUNDARY),
+        "analysis_contract": dict(contract),
+        "table_plan": _table_plan(contract),
+        "figure_plan": _figure_plan(contract),
+        "narrative_plan": _narrative_plan(),
+        "completion_checks": list(_COMPLETION_CHECKS),
+    }
+    payload["shell_id"] = report_shell_id_for_payload(payload)
+    return payload
+
+
+def build_registered_real_report_shell(
+    analysis_manifest: Mapping[str, Any],
+    *,
+    analysis_manifest_sha256: str,
+    analysis_manifest_byte_count: int,
+) -> dict[str, Any]:
+    """Build a complete report plan without reading target outcomes."""
+
+    analysis = _mapping(analysis_manifest, name="registered analysis manifest")
+    source = _source_from_analysis(
+        analysis,
+        analysis_manifest_sha256=analysis_manifest_sha256,
+        analysis_manifest_byte_count=analysis_manifest_byte_count,
+    )
+    contract = _normalize_contract(analysis)
+    return validate_registered_real_report_shell(_build_shell_payload(source, contract))
+
+
+def _validate_empty_result_slots(payload: Mapping[str, Any]) -> None:
+    for raw in _sequence(payload["table_plan"], name="table plan"):
+        table = _mapping(raw, name="table specification")
+        _require(table.get("rows") == [], "report-shell table rows must be empty")
+    for raw in _sequence(payload["figure_plan"], name="figure plan"):
+        figure = _mapping(raw, name="figure specification")
+        _require(
+            figure.get("values") == [],
+            "report-shell figure values must be empty",
+        )
+    for raw in _sequence(payload["narrative_plan"], name="narrative plan"):
+        narrative = _mapping(raw, name="narrative specification")
+        _require(
+            narrative.get("selected") is False,
+            "result narratives must remain unselected before target access",
+        )
+
+
+def validate_registered_real_report_shell(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate a deterministic report shell with empty result slots."""
+
+    values = _mapping(payload, name="registered real report shell")
+    _require(set(values) == _TOP_LEVEL_FIELDS, "report-shell top-level fields changed")
+    _require(
+        values.get("schema_version") == REPORT_SHELL_SCHEMA_VERSION,
+        "report-shell schema version changed",
+    )
+    _require(
+        values.get("artifact_kind") == REPORT_SHELL_ARTIFACT_KIND,
+        "report-shell artifact kind changed",
+    )
+    _require(values.get("status") == REPORT_SHELL_STATUS, "report-shell status changed")
+
+    source = _mapping(values.get("source"), name="report-shell source")
+    _require(set(source) == _SOURCE_FIELDS, "report-shell source fields changed")
+    normalized_source = {
+        "analysis_id": _hex_digest(
+            source["analysis_id"],
+            name="analysis ID",
+            length=64,
+        ),
+        "analysis_manifest_sha256": _hex_digest(
+            source["analysis_manifest_sha256"],
+            name="analysis manifest SHA-256",
+            length=64,
+        ),
+        "analysis_manifest_bytes": _positive_int(
+            source["analysis_manifest_bytes"],
+            name="analysis manifest byte count",
+        ),
+        "method_freeze_sha256": _hex_digest(
+            source["method_freeze_sha256"],
+            name="method freeze SHA-256",
+            length=64,
+        ),
+        "protocol_id": _nonempty_string(source["protocol_id"], name="protocol ID"),
+        "protocol_design_sha256": _hex_digest(
+            source["protocol_design_sha256"],
+            name="protocol design SHA-256",
+            length=64,
+        ),
+        "preacquisition_amendment_sha256": _hex_digest(
+            source["preacquisition_amendment_sha256"],
+            name="pre-acquisition amendment SHA-256",
+            length=64,
+        ),
+        "software": _normalize_software(source["software"]),
+    }
+
+    safety = _mapping(values.get("safety_boundary"), name="safety boundary")
+    _require(dict(safety) == _SAFETY_BOUNDARY, "report-shell safety boundary changed")
+    raw_contract = _mapping(values.get("analysis_contract"), name="analysis contract")
+    _require(set(raw_contract) == _CONTRACT_FIELDS, "analysis-contract fields changed")
+    synthetic_analysis = {
+        "primary_analysis_locked": True,
+        "locked_before_target_access": True,
+        "target_outcomes_observed_at_registration": False,
+        "target_outcomes_may_select_method_or_hyperparameters": False,
+        "optional_branches_may_change_primary_analysis": False,
+        **dict(raw_contract),
+    }
+    normalized_contract = _normalize_contract(synthetic_analysis)
+    expected = _build_shell_payload(normalized_source, normalized_contract)
+    _require(
+        dict(values) == expected,
+        "report-shell plan changed from the embedded analysis contract",
+    )
+    _validate_empty_result_slots(values)
+    _require(
+        values["shell_id"] == report_shell_id_for_payload(values),
+        "report-shell content identity changed",
+    )
+    return dict(values)
+
+
+def validate_registered_real_report_shell_against_analysis(
+    payload: Mapping[str, Any],
+    analysis_manifest: Mapping[str, Any],
+    *,
+    analysis_manifest_sha256: str,
+    analysis_manifest_byte_count: int,
+) -> dict[str, Any]:
+    """Require an exact shell match to one validated registered analysis."""
+
+    shell = validate_registered_real_report_shell(payload)
+    expected = build_registered_real_report_shell(
+        analysis_manifest,
+        analysis_manifest_sha256=analysis_manifest_sha256,
+        analysis_manifest_byte_count=analysis_manifest_byte_count,
+    )
+    _require(shell == expected, "report shell does not match the analysis manifest")
+    return shell
+
+
+def _markdown_claim_boundary(contract: Mapping[str, Any]) -> list[str]:
+    boundary = _mapping(contract["claim_boundary"], name="claim boundary")
+    lines = [
+        "## Registered claim boundary",
+        "",
+        f"- Physical object count: {boundary.get('physical_object_count')}",
+        (
+            "- Registered contact-region count: "
+            f"{boundary.get('registered_contact_region_count')}"
+        ),
+        (
+            "- Registered action-profile count: "
+            f"{boundary.get('registered_action_profile_count')}"
+        ),
+    ]
+    for key, value in sorted(boundary.items()):
+        if key.endswith("_claimed") and value is False:
+            label = key.removesuffix("_claimed").replace("_", " ")
+            lines.append(f"- Not claimed: {label}")
+    lines.append("")
+    return lines
+
+
+def render_registered_real_report_shell_markdown(
+    payload: Mapping[str, Any],
+) -> str:
+    """Render the validated shell as a deterministic, result-free report."""
+
+    shell = validate_registered_real_report_shell(payload)
+    source = _mapping(shell["source"], name="source")
+    contract = _mapping(shell["analysis_contract"], name="analysis contract")
+    software = _mapping(source["software"], name="software")
+    arms = _sequence(contract["comparison_arms"], name="comparison arms")
+    endpoints = _sequence(
+        _mapping(contract["effect_reporting"], name="effect reporting")[
+            "endpoint_inventory"
+        ],
+        name="endpoint inventory",
+    )
+
+    lines = [
+        "# Registered Causal4D real-analysis report shell",
+        "",
+        "> **TARGET-FREE TEMPLATE — NOT A SCIENTIFIC RESULT.**",
+        "> No confirmatory outcomes or target metric values are loaded.",
+        "",
+        "## Bound sources",
+        "",
+        f"- Analysis ID: `{source['analysis_id']}`",
+        f"- Analysis manifest SHA-256: `{source['analysis_manifest_sha256']}`",
+        f"- Method-freeze SHA-256: `{source['method_freeze_sha256']}`",
+        f"- Protocol: `{source['protocol_id']}`",
+        f"- Causal4D commit: `{software['causal4d_commit_sha']}`",
+        f"- BayesianPhysTwin commit: `{software['bayesian_phystwin_commit_sha']}`",
+        "",
+        "## Comparison arms",
+        "",
+        "| Arm | Role | Twin uncertainty | Realized intervention inference |",
+        "|---|---|---:|---:|",
+    ]
+    for raw in arms:
+        arm = _mapping(raw, name="comparison arm")
+        lines.append(
+            "| "
+            f"`{arm['arm_id']}` | {arm['role']} | "
+            f"{arm.get('twin_uncertainty')} | "
+            f"{arm.get('realized_intervention_inference')} |"
+        )
+    lines.extend(
+        (
+            "",
+            "## Registered endpoints",
+            "",
+            "| Endpoint | Registered units | Target sessions | Primary estimate |",
+            "|---|---:|---:|---|",
+        )
+    )
+    for raw in endpoints:
+        endpoint = _mapping(raw, name="endpoint")
+        lines.append(
+            "| "
+            f"`{endpoint['endpoint_id']}` | {endpoint['registered_units']} | "
+            f"{endpoint['target_sessions']} | `{endpoint['primary_estimate']}` |"
+        )
+
+    for raw in _sequence(shell["table_plan"], name="table plan"):
+        table = _mapping(raw, name="table")
+        columns = [str(column) for column in table["required_columns"]]
+        lines.extend(
+            (
+                "",
+                f"## Table: {table['title']}",
+                "",
+                "| " + " | ".join(columns) + " |",
+                "|" + "|".join("---" for _ in columns) + "|",
+                "| " + " | ".join("not populated" for _ in columns) + " |",
+                "",
+                f"Source after blind analysis: {table['row_source']}.",
+            )
+        )
+
+    lines.extend(("", "## Figure plan", ""))
+    for raw in _sequence(shell["figure_plan"], name="figure plan"):
+        figure = _mapping(raw, name="figure")
+        series = ", ".join(f"`{item}`" for item in figure["required_series"])
+        lines.append(f"- **{figure['title']}**: {series}")
+
+    lines.extend(("", "## Predeclared interpretation paths", ""))
+    for raw in _sequence(shell["narrative_plan"], name="narrative plan"):
+        narrative = _mapping(raw, name="narrative")
+        title = str(narrative["outcome_id"]).replace("_", " ").title()
+        lines.extend((f"### {title}", ""))
+        lines.append(f"Selection source: {narrative['selection_source']}.")
+        lines.extend(("", "Required statements:"))
+        for statement in narrative["required_statements"]:
+            lines.append(f"- {statement}")
+        lines.extend(("", "Forbidden claims:"))
+        for statement in narrative["forbidden_claims"]:
+            lines.append(f"- {statement}")
+        lines.append("")
+
+    lines.extend(_markdown_claim_boundary(contract))
+    lines.extend(
+        (
+            "## Completion checklist",
+            "",
+            *[f"- [ ] {item}" for item in shell["completion_checks"]],
+            "",
+            f"Shell ID: `{shell['shell_id']}`",
+            "",
+        )
+    )
+    return "\n".join(lines)
+
+
+def _load_shell(path: str | Path) -> tuple[dict[str, Any], str, int]:
+    from causal4d.artifact_io import load_strict_json_object, read_regular_file
+
+    snapshot = read_regular_file(path, name="registered real report shell")
+    payload = load_strict_json_object(
+        snapshot.payload,
+        name="registered real report shell",
+    )
+    shell = validate_registered_real_report_shell(payload)
+    return shell, snapshot.sha256, snapshot.byte_count
+
+
+def _preflight_output_paths(
+    json_path: Path,
+    markdown_path: Path,
+    *,
+    overwrite: bool,
+) -> None:
+    _require(
+        json_path.resolve() != markdown_path.resolve(),
+        "JSON and Markdown outputs must differ",
+    )
+    if overwrite:
+        return
+    for path in (json_path, markdown_path):
+        if os.path.lexists(path):
+            raise FileExistsError(f"refusing to overwrite existing output: {path}")
+
+
+def _render_command(arguments: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m causal4d.registered_real_report_shell render"
+    )
+    parser.add_argument("analysis_manifest")
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--output-markdown", required=True)
+    parser.add_argument("--overwrite", action="store_true")
+    parsed = parser.parse_args(arguments)
+    json_path = Path(parsed.output_json)
+    markdown_path = Path(parsed.output_markdown)
+    _preflight_output_paths(
+        json_path,
+        markdown_path,
+        overwrite=parsed.overwrite,
+    )
+
+    from causal4d.atomic_io import atomic_write_json, atomic_write_text
+    from causal4d.registered_real_analysis import (
+        load_registered_real_analysis_manifest,
+    )
+
+    analysis, sha256, byte_count = load_registered_real_analysis_manifest(
+        parsed.analysis_manifest
+    )
+    shell = build_registered_real_report_shell(
+        analysis,
+        analysis_manifest_sha256=sha256,
+        analysis_manifest_byte_count=byte_count,
+    )
+    markdown = render_registered_real_report_shell_markdown(shell)
+    atomic_write_json(json_path, shell, overwrite=parsed.overwrite)
+    atomic_write_text(markdown_path, markdown, overwrite=parsed.overwrite)
+    print(
+        json.dumps(
+            {
+                "passed": True,
+                "shell_id": shell["shell_id"],
+                "output_json": str(json_path.resolve()),
+                "output_markdown": str(markdown_path.resolve()),
+                "target_outcomes_loaded": False,
+                "confirmatory_execution_evidence_count": 0,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def _validate_command(arguments: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m causal4d.registered_real_report_shell validate"
+    )
+    parser.add_argument("report_shell")
+    parser.add_argument("--analysis-manifest")
+    parsed = parser.parse_args(arguments)
+    shell, sha256, byte_count = _load_shell(parsed.report_shell)
+    if parsed.analysis_manifest:
+        from causal4d.registered_real_analysis import (
+            load_registered_real_analysis_manifest,
+        )
+
+        analysis, analysis_sha256, analysis_bytes = (
+            load_registered_real_analysis_manifest(parsed.analysis_manifest)
+        )
+        validate_registered_real_report_shell_against_analysis(
+            shell,
+            analysis,
+            analysis_manifest_sha256=analysis_sha256,
+            analysis_manifest_byte_count=analysis_bytes,
+        )
+    print(
+        json.dumps(
+            {
+                "passed": True,
+                "shell_id": shell["shell_id"],
+                "sha256": sha256,
+                "bytes": byte_count,
+                "target_outcomes_loaded": False,
+                "confirmatory_execution_evidence_count": 0,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Render or validate the target-free report shell."""
+
+    arguments = list(argv) if argv is not None else None
+    parser = argparse.ArgumentParser(
+        prog="python -m causal4d.registered_real_report_shell"
+    )
+    parser.add_argument("operation", choices=("render", "validate"))
+    parsed, remaining = parser.parse_known_args(arguments)
+    if parsed.operation == "render":
+        return _render_command(remaining)
+    return _validate_command(remaining)
+
+
+__all__ = [
+    "REPORT_SHELL_ARTIFACT_KIND",
+    "REPORT_SHELL_SCHEMA_VERSION",
+    "REPORT_SHELL_STATUS",
+    "build_registered_real_report_shell",
+    "main",
+    "render_registered_real_report_shell_markdown",
+    "report_shell_id_for_payload",
+    "validate_registered_real_report_shell",
+    "validate_registered_real_report_shell_against_analysis",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_registered_real_report_shell.py
+++ b/tests/test_registered_real_report_shell.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from causal4d.real_experiment_freeze import MILESTONE_ID, SCHEMA_VERSION
+from causal4d.real_protocol import load_protocol
+from causal4d.registered_real_analysis import (
+    EXPECTED_PREACQUISITION_SHA256,
+    EXPECTED_PROTOCOL_DESIGN_SHA256,
+    build_registered_real_analysis_manifest,
+)
+from causal4d.registered_real_report_shell import (
+    build_registered_real_report_shell,
+    main,
+    render_registered_real_report_shell_markdown,
+    report_shell_id_for_payload,
+    validate_registered_real_report_shell,
+    validate_registered_real_report_shell_against_analysis,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL = ROOT / "configs/causal4d/sloth_multi_action_v1.json"
+
+
+def _method_freeze() -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "milestone_id": MILESTONE_ID,
+        "status": "sealed",
+        "locked_before_confirmatory_collection": True,
+        "target_outcomes_observed_at_freeze": False,
+        "causal4d": {"commit_sha": "a" * 40},
+        "bayesian_phystwin": {"commit_sha": "b" * 40},
+        "protocol": {"design_sha256": EXPECTED_PROTOCOL_DESIGN_SHA256},
+        "preacquisition": {
+            "amendment_sha256": EXPECTED_PREACQUISITION_SHA256,
+        },
+        "analysis_contract": {
+            "entrypoints": [
+                "causal4d protocol real",
+                "causal4d calibration execution-block",
+                "causal4d evidence physical-counterfactual evaluate",
+            ],
+            "diagnostic_only_entrypoints": ["causal4d calibration real"],
+            "allowed_observation_prefix_frames": 6,
+            "confirmatory_calibration": {
+                "entrypoint": "causal4d calibration execution-block",
+                "confidence_level": 0.90,
+                "outer_fold_count": 12,
+                "expected_calibration_units_per_outer_fold": 9,
+                "order_statistic_rank_one_based": 9,
+                "calibration_unit": (
+                    "one preregistered execution per independent session"
+                ),
+                "score_kind": "max_abs_standardized_coordinate_v1",
+                "target_threshold_reselection_allowed": False,
+                "pooled_coordinate_conformal_claimed": False,
+                "worst_group_coverage_guarantee_claimed": False,
+            },
+            "target_outcomes_may_select_method_or_hyperparameters": False,
+            "optional_branches_may_change_primary_analysis": False,
+        },
+        "reporting_contract": {
+            "report_success_or_well_powered_negative_result": True,
+            "report_all_36_executions_or_preregistered_exclusions": True,
+            "report_independent_execution_calibration": True,
+            "report_effect_intervals_and_replay_reset_variance": True,
+            (
+                "optional_semantic_or_public_data_results_cannot_rescue_primary_failure"
+            ): True,
+        },
+    }
+
+
+def _analysis() -> dict[str, object]:
+    return build_registered_real_analysis_manifest(
+        load_protocol(PROTOCOL),
+        _method_freeze(),
+        method_freeze_sha256="c" * 64,
+        registered_by="independent-registrar",
+        registered_at_utc="2026-08-08T00:00:00+00:00",
+    )
+
+
+def _analysis_bytes(analysis: dict[str, object]) -> bytes:
+    return (
+        json.dumps(analysis, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    ).encode("utf-8")
+
+
+def _shell(analysis: dict[str, object] | None = None) -> dict[str, object]:
+    values = _analysis() if analysis is None else analysis
+    payload = _analysis_bytes(values)
+    return build_registered_real_report_shell(
+        values,
+        analysis_manifest_sha256=hashlib.sha256(payload).hexdigest(),
+        analysis_manifest_byte_count=len(payload),
+    )
+
+
+def test_shell_is_deterministic_content_addressed_and_result_free() -> None:
+    first = _shell()
+    second = _shell()
+
+    assert first == second
+    assert first["shell_id"] == report_shell_id_for_payload(first)
+    assert first["status"] == "target-free-template"
+    assert first["safety_boundary"] == {
+        "target_outcomes_loaded": False,
+        "target_metric_values_loaded": False,
+        "confirmatory_execution_evidence_count": 0,
+        "may_select_method_or_hyperparameters": False,
+        "manual_table_or_figure_selection_allowed": False,
+        "derived_artifact_is_claim_bearing": False,
+        "report_shell_is_a_scientific_result": False,
+    }
+    assert all(table["rows"] == [] for table in first["table_plan"])
+    assert all(figure["values"] == [] for figure in first["figure_plan"])
+    assert all(not item["selected"] for item in first["narrative_plan"])
+    endpoint_tables = [
+        table["endpoint_id"]
+        for table in first["table_plan"]
+        if table["table_id"].startswith("endpoint-")
+    ]
+    assert endpoint_tables == [
+        "factual_continuation",
+        "same_grasp_transfer",
+        "new_contact_transfer",
+    ]
+
+
+def test_markdown_renders_every_registered_path_without_results() -> None:
+    shell = _shell()
+    markdown = render_registered_real_report_shell_markdown(shell)
+
+    assert "TARGET-FREE TEMPLATE — NOT A SCIENTIFIC RESULT" in markdown
+    assert "No confirmatory outcomes or target metric values are loaded" in markdown
+    assert "Factual Continuation" in markdown
+    assert "Same Grasp Transfer" in markdown
+    assert "New Contact Transfer" in markdown
+    assert "Registered Success" in markdown
+    assert "Registered Bounded Negative" in markdown
+    assert "Independent-execution calibration" in markdown
+    assert "Technical failures and preregistered exclusions" in markdown
+    assert "Diagnostic intervention-oracle gap attribution" in markdown
+    assert shell["shell_id"] in markdown
+    assert "not populated" in markdown
+
+
+def test_shell_rejects_target_values_and_selected_result_narratives() -> None:
+    shell = _shell()
+
+    tampered = copy.deepcopy(shell)
+    tampered["safety_boundary"]["target_outcomes_loaded"] = True
+    tampered["shell_id"] = report_shell_id_for_payload(tampered)
+    with pytest.raises(ValueError, match="safety boundary changed"):
+        validate_registered_real_report_shell(tampered)
+
+    tampered = copy.deepcopy(shell)
+    tampered["table_plan"][1]["rows"] = [{"candidate_minus_baseline": -1.0}]
+    tampered["shell_id"] = report_shell_id_for_payload(tampered)
+    with pytest.raises(ValueError, match="plan changed|rows must be empty"):
+        validate_registered_real_report_shell(tampered)
+
+    tampered = copy.deepcopy(shell)
+    tampered["narrative_plan"][0]["selected"] = True
+    tampered["shell_id"] = report_shell_id_for_payload(tampered)
+    with pytest.raises(ValueError, match="plan changed|remain unselected"):
+        validate_registered_real_report_shell(tampered)
+
+
+def test_shell_is_bound_to_the_exact_registered_analysis() -> None:
+    analysis = _analysis()
+    payload = _analysis_bytes(analysis)
+    shell = build_registered_real_report_shell(
+        analysis,
+        analysis_manifest_sha256=hashlib.sha256(payload).hexdigest(),
+        analysis_manifest_byte_count=len(payload),
+    )
+
+    changed = copy.deepcopy(analysis)
+    changed["software"]["causal4d_commit_sha"] = "d" * 40
+    with pytest.raises(ValueError, match="does not match"):
+        validate_registered_real_report_shell_against_analysis(
+            shell,
+            changed,
+            analysis_manifest_sha256=hashlib.sha256(payload).hexdigest(),
+            analysis_manifest_byte_count=len(payload),
+        )
+
+
+def test_cli_renders_validates_and_refuses_partial_overwrite(
+    tmp_path: Path,
+) -> None:
+    analysis = _analysis()
+    analysis_path = tmp_path / "registered-analysis.json"
+    analysis_path.write_bytes(_analysis_bytes(analysis))
+    shell_path = tmp_path / "report-shell.json"
+    markdown_path = tmp_path / "report-shell.md"
+
+    assert (
+        main(
+            [
+                "render",
+                str(analysis_path),
+                "--output-json",
+                str(shell_path),
+                "--output-markdown",
+                str(markdown_path),
+            ]
+        )
+        == 0
+    )
+    assert shell_path.is_file()
+    assert markdown_path.is_file()
+    assert (
+        main(
+            [
+                "validate",
+                str(shell_path),
+                "--analysis-manifest",
+                str(analysis_path),
+            ]
+        )
+        == 0
+    )
+
+    with pytest.raises(FileExistsError, match="refusing to overwrite"):
+        main(
+            [
+                "render",
+                str(analysis_path),
+                "--output-json",
+                str(shell_path),
+                "--output-markdown",
+                str(tmp_path / "other.md"),
+            ]
+        )
+    assert not (tmp_path / "other.md").exists()


### PR DESCRIPTION
## Summary

Add a deterministic, content-addressed dry rendering for the sealed real-analysis manifest before confirmatory outcomes are opened.

The new report shell:

- binds the exact registered-analysis bytes, method freeze, protocol, and software revisions;
- renders all registered endpoint, calibration, failure/exclusion, replay-variance, and diagnostic oracle-gap table and figure layouts with empty result slots;
- renders both the registered-success and bounded-negative interpretation paths without selecting either one;
- rejects target values, populated result rows, selected result narratives, altered layouts, changed safety boundaries, and mismatches to the bound analysis manifest;
- preflights both output paths before publication to avoid a stale JSON/new Markdown pair; and
- remains explicitly non-claim-bearing with confirmatory evidence count `0`.

## Validation

- `python -m py_compile src/causal4d/registered_real_report_shell.py`
- synthetic target-free build/render/tamper smoke completed locally
- full repository tests and formatting are delegated to the normal PR CI because the execution container cannot resolve GitHub for a full checkout and its package mirror does not provide the repository's pinned Ruff version

## Scientific boundary

This changes no estimator, intervention posterior, six-frame information boundary, split, threshold, exclusion rule, calibration method, acquisition order, target access, result, or evidence count. The physical confirmatory status remains `0/36`.