### PR TITLE
Harden independent sensor evidence publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ evidence. Source-panel executions remain source-only and cannot increment the
 
 ### Fixed
 
+- Make independent actuator and contact-wrench evidence publication atomic,
+  validate the exact temporary archive before publication, refuse replacement by
+  default, and reject symlinked inputs, duplicate members, extra arrays, or
+  non-strict descriptor JSON during loading.
 - Include the runnable MolmoMotion bridge helpers in source distributions and
   execute their end-to-end regression from the extracted archive, preventing a
   published sdist from retaining tests and documentation for files it omits.

--- a/docs/sensor_factorized_abduction.md
+++ b/docs/sensor_factorized_abduction.md
@@ -47,7 +47,12 @@ clock. Evidence from another protocol, case, or observed action is rejected
 before any likelihood is evaluated.
 
 Use `save_independent_sensor_evidence` and
-`load_independent_sensor_evidence` for checksummed round trips.
+`load_independent_sensor_evidence` for checksummed round trips. Publication is
+atomic, validates the exact temporary bytes before they become visible, and is
+exactly once by default. Replacing an existing evidence file requires the explicit
+`overwrite=True` opt-in. Loading snapshots one ordinary non-symlink file, rejects
+duplicate or unexpected NPZ members, and parses the embedded descriptor with the
+strict finite-JSON contract.
 
 ## Robust independent-sensor factors
 

--- a/src/causal4d/sensor_evidence.py
+++ b/src/causal4d/sensor_evidence.py
@@ -6,17 +6,42 @@ import hashlib
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, BinaryIO, Mapping
 
 import numpy as np
 
+from causal4d.artifact_io import (
+    ArtifactValidationError,
+    load_npz_bytes,
+    load_strict_json_object,
+    read_regular_file,
+)
+from causal4d.atomic_io import atomic_write_binary
+from causal4d.contracts import array_sha256
 from causal4d.immutable_array import readonly_array
 from causal4d.immutable_json import plain_json, validated_json_mapping
 
-from causal4d.contracts import array_sha256
-
 
 INDEPENDENT_SENSOR_SCHEMA_VERSION = 1
+
+_ACTUATOR_ARCHIVE_ARRAYS = frozenset(
+    {
+        "descriptor_json",
+        "sample_times_s",
+        "positions_m",
+        "variance_m2",
+        "valid_mask",
+    }
+)
+_CONTACT_WRENCH_ARCHIVE_ARRAYS = frozenset(
+    {
+        "descriptor_json",
+        "sample_times_s",
+        "wrench",
+        "variance",
+        "valid_mask",
+    }
+)
 
 
 def _readonly(values: np.ndarray, *, dtype: type | None = float) -> np.ndarray:
@@ -268,12 +293,9 @@ class ContactWrenchEvidence:
         )
 
 
-def save_independent_sensor_evidence(
-    path: str | Path,
+def _sensor_archive_payload(
     evidence: ActuatorEvidence | ContactWrenchEvidence,
-) -> None:
-    """Serialize one evidence artifact as a non-pickled checksummed NPZ."""
-
+) -> tuple[dict[str, Any], dict[str, np.ndarray]]:
     if isinstance(evidence, ActuatorEvidence):
         descriptor = {
             "schema_version": INDEPENDENT_SENSOR_SCHEMA_VERSION,
@@ -307,89 +329,159 @@ def save_independent_sensor_evidence(
         }
     else:
         raise TypeError("unsupported independent-sensor evidence type")
+    return descriptor, arrays
+
+
+def save_independent_sensor_evidence(
+    path: str | Path,
+    evidence: ActuatorEvidence | ContactWrenchEvidence,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Publish one checksummed NPZ atomically and exactly once by default."""
+
+    if type(overwrite) is not bool:
+        raise TypeError("overwrite must be an exact boolean")
+    descriptor, arrays = _sensor_archive_payload(evidence)
     encoded = json.dumps(
         descriptor,
         sort_keys=True,
         separators=(",", ":"),
         allow_nan=False,
     ).encode("utf-8")
-    output = Path(path)
-    output.parent.mkdir(parents=True, exist_ok=True)
-    with output.open("wb") as handle:
+
+    def write_archive(handle: BinaryIO) -> None:
         np.savez_compressed(
             handle,
             descriptor_json=np.frombuffer(encoded, dtype=np.uint8),
             **arrays,
         )
 
+    def validate_archive(candidate: Path) -> None:
+        restored = load_independent_sensor_evidence(candidate)
+        if type(restored) is not type(evidence):
+            raise ArtifactValidationError(
+                "published independent-sensor evidence kind changed"
+            )
+        if restored.artifact_id != evidence.artifact_id:
+            raise ArtifactValidationError(
+                "published independent-sensor evidence identity changed"
+            )
+
+    atomic_write_binary(
+        path,
+        write_archive,
+        overwrite=overwrite,
+        validate=validate_archive,
+    )
+
 
 def _descriptor_identity(descriptor: Mapping[str, Any]) -> dict[str, str]:
-    return {
-        "protocol_id": str(descriptor["protocol_id"]),
-        "case_id": str(descriptor["case_id"]),
-        "observed_action_id": str(descriptor["observed_action_id"]),
-        "stream_id": str(descriptor["stream_id"]),
-        "clock_id": str(descriptor["clock_id"]),
-        "provenance": str(descriptor["provenance"]),
-    }
+    identity: dict[str, str] = {}
+    for field_name in (
+        "protocol_id",
+        "case_id",
+        "observed_action_id",
+        "stream_id",
+        "clock_id",
+        "provenance",
+    ):
+        value = descriptor.get(field_name)
+        if type(value) is not str or not value:
+            raise ArtifactValidationError(
+                f"independent-sensor {field_name} must be a nonempty string"
+            )
+        identity[field_name] = value
+    return identity
+
+
+def _load_sensor_archive_arrays(
+    payload: bytes,
+) -> tuple[dict[str, np.ndarray], str]:
+    failures: list[ArtifactValidationError] = []
+    for kind, expected_arrays in (
+        ("ActuatorEvidence", _ACTUATOR_ARCHIVE_ARRAYS),
+        ("ContactWrenchEvidence", _CONTACT_WRENCH_ARCHIVE_ARRAYS),
+    ):
+        try:
+            return (
+                load_npz_bytes(
+                    payload,
+                    name="independent-sensor evidence",
+                    expected_arrays=expected_arrays,
+                ),
+                kind,
+            )
+        except ArtifactValidationError as error:
+            failures.append(error)
+    raise ArtifactValidationError(
+        "independent-sensor evidence does not match a supported closed array inventory"
+    ) from failures[-1]
 
 
 def load_independent_sensor_evidence(
     path: str | Path,
 ) -> ActuatorEvidence | ContactWrenchEvidence:
-    """Load and verify a serialized independent-sensor evidence artifact."""
+    """Load exact ordinary-file bytes and verify the closed NPZ contract."""
 
-    with np.load(Path(path), allow_pickle=False) as archive:
-        if "descriptor_json" not in archive.files:
-            raise ValueError("sensor evidence archive is missing descriptor_json")
-        descriptor = json.loads(
-            np.asarray(archive["descriptor_json"], dtype=np.uint8)
-            .tobytes()
-            .decode("utf-8")
+    snapshot = read_regular_file(path, name="independent-sensor evidence")
+    arrays, inventory_kind = _load_sensor_archive_arrays(snapshot.payload)
+    descriptor_array = arrays["descriptor_json"]
+    if descriptor_array.dtype != np.dtype(np.uint8) or descriptor_array.ndim != 1:
+        raise ArtifactValidationError(
+            "independent-sensor descriptor_json must be a uint8 vector"
         )
-        if descriptor.get("schema_version") != INDEPENDENT_SENSOR_SCHEMA_VERSION:
-            raise ValueError("unsupported independent-sensor schema version")
-        kind = descriptor.get("artifact_kind")
-        identity = _descriptor_identity(descriptor)
-        if kind == "ActuatorEvidence":
-            required = {
-                "sample_times_s",
-                "positions_m",
-                "variance_m2",
-                "valid_mask",
-            }
-            if not required.issubset(archive.files):
-                raise ValueError("actuator evidence archive is incomplete")
-            evidence: ActuatorEvidence | ContactWrenchEvidence = ActuatorEvidence(
-                **identity,
-                sample_times_s=archive["sample_times_s"],
-                positions_m=archive["positions_m"],
-                variance_m2=archive["variance_m2"],
-                evidence_frame_stop=int(descriptor["evidence_frame_stop"]),
-                valid_mask=archive["valid_mask"],
-                metadata=descriptor.get("metadata", {}),
+    descriptor = load_strict_json_object(
+        descriptor_array.tobytes(),
+        name="independent-sensor descriptor",
+    )
+    schema_version = descriptor.get("schema_version")
+    if (
+        type(schema_version) is not int
+        or schema_version != INDEPENDENT_SENSOR_SCHEMA_VERSION
+    ):
+        raise ValueError("unsupported independent-sensor schema version")
+    kind = descriptor.get("artifact_kind")
+    if kind != inventory_kind:
+        raise ArtifactValidationError(
+            "independent-sensor descriptor kind disagrees with its array inventory"
+        )
+    identity = _descriptor_identity(descriptor)
+    evidence_frame_stop = descriptor.get("evidence_frame_stop")
+    if type(evidence_frame_stop) is not int:
+        raise ArtifactValidationError(
+            "independent-sensor evidence_frame_stop must be an integer"
+        )
+    if kind == "ActuatorEvidence":
+        evidence: ActuatorEvidence | ContactWrenchEvidence = ActuatorEvidence(
+            **identity,
+            sample_times_s=arrays["sample_times_s"],
+            positions_m=arrays["positions_m"],
+            variance_m2=arrays["variance_m2"],
+            evidence_frame_stop=evidence_frame_stop,
+            valid_mask=arrays["valid_mask"],
+            metadata=descriptor.get("metadata", {}),
+        )
+    else:
+        quantity_names = descriptor.get("quantity_names")
+        if (
+            type(quantity_names) is not list
+            or not quantity_names
+            or any(type(name) is not str or not name for name in quantity_names)
+        ):
+            raise ArtifactValidationError(
+                "independent-sensor quantity_names must be nonempty strings"
             )
-        elif kind == "ContactWrenchEvidence":
-            required = {
-                "sample_times_s",
-                "wrench",
-                "variance",
-                "valid_mask",
-            }
-            if not required.issubset(archive.files):
-                raise ValueError("contact-wrench evidence archive is incomplete")
-            evidence = ContactWrenchEvidence(
-                **identity,
-                sample_times_s=archive["sample_times_s"],
-                wrench=archive["wrench"],
-                variance=archive["variance"],
-                quantity_names=tuple(map(str, descriptor["quantity_names"])),
-                evidence_frame_stop=int(descriptor["evidence_frame_stop"]),
-                valid_mask=archive["valid_mask"],
-                metadata=descriptor.get("metadata", {}),
-            )
-        else:
-            raise ValueError(f"unsupported sensor evidence kind: {kind!r}")
+        evidence = ContactWrenchEvidence(
+            **identity,
+            sample_times_s=arrays["sample_times_s"],
+            wrench=arrays["wrench"],
+            variance=arrays["variance"],
+            quantity_names=tuple(quantity_names),
+            evidence_frame_stop=evidence_frame_stop,
+            valid_mask=arrays["valid_mask"],
+            metadata=descriptor.get("metadata", {}),
+        )
     if evidence.artifact_id != descriptor.get("artifact_id"):
         raise ValueError("independent-sensor evidence checksum mismatch")
     return evidence

--- a/tests/test_sensor_evidence_io_hardening.py
+++ b/tests/test_sensor_evidence_io_hardening.py
@@ -60,9 +60,7 @@ def _read_archive(path: Path) -> dict[str, np.ndarray]:
 
 def _descriptor(arrays: dict[str, np.ndarray]) -> dict[str, object]:
     return json.loads(
-        np.asarray(arrays["descriptor_json"], dtype=np.uint8)
-        .tobytes()
-        .decode("utf-8")
+        np.asarray(arrays["descriptor_json"], dtype=np.uint8).tobytes().decode("utf-8")
     )
 
 

--- a/tests/test_sensor_evidence_io_hardening.py
+++ b/tests/test_sensor_evidence_io_hardening.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import causal4d.sensor_evidence as sensor_evidence_module
+from causal4d.artifact_io import ArtifactValidationError
+from causal4d.sensor_evidence import (
+    ActuatorEvidence,
+    ContactWrenchEvidence,
+    load_independent_sensor_evidence,
+    save_independent_sensor_evidence,
+)
+
+
+def _identity() -> dict[str, str]:
+    return {
+        "protocol_id": "sensor_evidence_io_unit",
+        "case_id": "unit_case",
+        "observed_action_id": "u_obs",
+    }
+
+
+def _actuator_evidence() -> ActuatorEvidence:
+    positions = np.zeros((2, 1, 3), dtype=float)
+    return ActuatorEvidence(
+        **_identity(),
+        stream_id="measured_end_effector",
+        clock_id="robot_monotonic",
+        provenance="robot encoder independent of object reconstruction",
+        sample_times_s=np.asarray([0.0, 1.0 / 30.0]),
+        positions_m=positions,
+        variance_m2=np.full_like(positions, 1.0e-4),
+        evidence_frame_stop=6,
+    )
+
+
+def _wrench_evidence() -> ContactWrenchEvidence:
+    wrench = np.asarray([[1.0, 0.0, 0.0]])
+    return ContactWrenchEvidence(
+        **_identity(),
+        stream_id="wrist_force",
+        clock_id="robot_monotonic",
+        provenance="wrist force sensor independent of object reconstruction",
+        sample_times_s=np.asarray([0.0]),
+        wrench=wrench,
+        variance=np.full_like(wrench, 1.0e-3),
+        quantity_names=("force_x_n", "force_y_n", "force_z_n"),
+        evidence_frame_stop=6,
+    )
+
+
+def _read_archive(path: Path) -> dict[str, np.ndarray]:
+    with np.load(path, allow_pickle=False) as archive:
+        return {name: np.array(archive[name], copy=True) for name in archive.files}
+
+
+def _descriptor(arrays: dict[str, np.ndarray]) -> dict[str, object]:
+    return json.loads(
+        np.asarray(arrays["descriptor_json"], dtype=np.uint8)
+        .tobytes()
+        .decode("utf-8")
+    )
+
+
+def _rewrite_descriptor(
+    path: Path,
+    arrays: dict[str, np.ndarray],
+    descriptor: dict[str, object],
+) -> None:
+    encoded = json.dumps(
+        descriptor,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    arrays["descriptor_json"] = np.frombuffer(encoded, dtype=np.uint8)
+    with path.open("wb") as handle:
+        np.savez_compressed(handle, **arrays)
+
+
+def test_publication_is_exactly_once_by_default(tmp_path: Path) -> None:
+    path = tmp_path / "sensor_evidence.npz"
+    actuator = _actuator_evidence()
+    save_independent_sensor_evidence(path, actuator)
+    original = path.read_bytes()
+
+    with pytest.raises(FileExistsError):
+        save_independent_sensor_evidence(path, _wrench_evidence())
+
+    assert path.read_bytes() == original
+    restored = load_independent_sensor_evidence(path)
+    assert type(restored) is ActuatorEvidence
+    assert restored.artifact_id == actuator.artifact_id
+
+
+def test_overwrite_requires_explicit_opt_in(tmp_path: Path) -> None:
+    path = tmp_path / "sensor_evidence.npz"
+    save_independent_sensor_evidence(path, _actuator_evidence())
+    wrench = _wrench_evidence()
+
+    save_independent_sensor_evidence(path, wrench, overwrite=True)
+
+    restored = load_independent_sensor_evidence(path)
+    assert type(restored) is ContactWrenchEvidence
+    assert restored.artifact_id == wrench.artifact_id
+
+
+def test_unbound_extra_archive_members_are_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "sensor_evidence.npz"
+    save_independent_sensor_evidence(path, _actuator_evidence())
+    arrays = _read_archive(path)
+    arrays["unbound_payload"] = np.asarray([1], dtype=np.int64)
+    with path.open("wb") as handle:
+        np.savez_compressed(handle, **arrays)
+
+    with pytest.raises(ArtifactValidationError, match="closed array inventory"):
+        load_independent_sensor_evidence(path)
+
+
+def test_coercible_descriptor_schema_drift_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "sensor_evidence.npz"
+    save_independent_sensor_evidence(path, _actuator_evidence())
+    arrays = _read_archive(path)
+    descriptor = _descriptor(arrays)
+
+    descriptor["schema_version"] = 1.0
+    _rewrite_descriptor(path, arrays, descriptor)
+    with pytest.raises(ValueError, match="schema version"):
+        load_independent_sensor_evidence(path)
+
+    descriptor["schema_version"] = 1
+    descriptor["case_id"] = 17
+    _rewrite_descriptor(path, arrays, descriptor)
+    with pytest.raises(ArtifactValidationError, match="case_id"):
+        load_independent_sensor_evidence(path)
+
+
+def test_symlinked_input_is_rejected(tmp_path: Path) -> None:
+    source = tmp_path / "source.npz"
+    save_independent_sensor_evidence(source, _actuator_evidence())
+    link = tmp_path / "link.npz"
+    try:
+        link.symlink_to(source)
+    except OSError:
+        pytest.skip("symlinks are unavailable on this platform")
+
+    with pytest.raises(ArtifactValidationError, match="ordinary readable file"):
+        load_independent_sensor_evidence(link)
+
+
+def test_failed_write_leaves_no_partial_destination(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "sensor_evidence.npz"
+
+    def fail_after_partial_write(handle, **arrays) -> None:
+        del arrays
+        handle.write(b"partial")
+        raise RuntimeError("injected write failure")
+
+    monkeypatch.setattr(
+        sensor_evidence_module.np,
+        "savez_compressed",
+        fail_after_partial_write,
+    )
+    with pytest.raises(RuntimeError, match="injected write failure"):
+        save_independent_sensor_evidence(path, _actuator_evidence())
+
+    assert not path.exists()
+    assert not tuple(tmp_path.glob(".sensor_evidence.npz.*.tmp"))
+
+
+def test_overwrite_flag_requires_exact_boolean(tmp_path: Path) -> None:
+    with pytest.raises(TypeError, match="exact boolean"):
+        save_independent_sensor_evidence(
+            tmp_path / "sensor_evidence.npz",
+            _actuator_evidence(),
+            overwrite=1,
+        )


### PR DESCRIPTION
## Summary

Make independent actuator and contact-wrench evidence publication fail closed and content-complete.

- snapshot one ordinary non-symlink file before loading;
- parse the exact snapshotted bytes rather than reopening a mutable path;
- require one of two closed NPZ array inventories and reject duplicate or extra ZIP members;
- parse the embedded descriptor with strict finite JSON and reject coercible schema drift;
- publish through a validated temporary archive and atomic rename/link;
- refuse to replace an existing evidence artifact by default;
- require explicit `overwrite=True` for replacement; and
- add adversarial coverage for replacement, partial writes, symlinks, unbound members, and descriptor type drift.

## Root cause

`save_independent_sensor_evidence` previously opened the destination directly with `wb`, so an interrupted write could leave a partial artifact and an existing evidence file was silently replaced. A destination symlink was followed.

`load_independent_sensor_evidence` opened the path through NumPy, accepted any superset of the required arrays, used permissive `json.loads`, and coerced descriptor identities and frame indices before recomputing the semantic artifact ID. Consequently, unbound extra NPZ members and some coercible wire-schema changes were not rejected.

## Exact scope

```text
CHANGELOG.md
docs/sensor_factorized_abduction.md
src/causal4d/sensor_evidence.py
tests/test_sensor_evidence_io_hardening.py
```

## Validation

Exact validated head:

```text
2f8c925a38c8b7c02e858d40e0accc9486fff5d2
```

Authoritative GitHub Actions:

- CI and release run `31271173208`: success, including Ruff, formatting, MyPy, Python 3.10/3.12/3.14 core suites, wheel/sdist builds and installed help checks, result bundles, frozen-manifest validation, and pinned BayesianPhysTwin installed-wheel integration;
- Extended compatibility run `31271173204`: success;
- Security scanning run `31271173234`: success, including the resolved dependency audit and CodeQL for Python and Actions; and
- Causal4D merge gate run `31271173246`: success, including repository quality, the complete default suite, rebuilt distributions, and pinned-provider integration on the synthetic merge result.

Focused pre-publication validation:

```text
25 passed
Python byte compilation with SyntaxWarning treated as error: passed
whitespace checks: passed
```

An equivalent in-place regression set was also exercised with the complete source-tree suite before the tests were split into the dedicated module:

```text
1462 passed, 16 skipped
```

## Compatibility

The artifact schema version and semantic `artifact_id` are unchanged. Existing valid files continue to load. The only behavioral change for writers is that replacement is now opt-in rather than implicit.

## Scientific boundary

This is artifact-integrity and publication hardening only. It changes no likelihood, posterior update, sensor factor, estimator, acquisition candidate, registered protocol, calibration rule, target boundary, scientific result, or physical evidence count.