### PR TITLE
[Superseded in part by #257; target opening deferred] Add prospective V2 promotion and certification contracts

### DIFF
--- a/docs/decision_trace.md
+++ b/docs/decision_trace.md
@@ -90,24 +90,40 @@ artifact from its inputs.
 
 ## Decisions and exact fallback
 
-Each stage may reference content-addressed decisions. Recommended required
-decision names for the prospective V2 path are:
+Each stage may reference content-addressed decisions. The generic decision-trace
+builder accepts an experiment-specific required inventory. The versioned
+prospective V2 deployment profile is:
+
+```text
+causal4d.prospective-v2-deployment-profile/v1
+```
+
+It requires the following complete inventory:
 
 ```text
 prob4d_provider_acceptance
+joint_covariance_admission
 bayesian_phystwin_acceptance
+functional_support
 intervention_identifiability
 action_support
 contact_v2_support
+conditional_uncertainty_calibration
 query_calibration
 counterfactual_regret
 ```
 
-The required inventory is frozen in `DecisionTraceSelection`. Candidate
-deployment is valid if and only if every named required decision is present and
-accepted.
+The profile also fixes the stage and producer for every decision. Use
+`build_prospective_v2_decision_trace_v1` for that path; it inserts the profile ID,
+uses the generic exact-object builder, and then validates the stricter inventory.
+See `docs/prospective_v2_promotion.md` for the profile and promotion protocol.
 
-At runtime, use `build_unified_decision_trace`. It checks Python object identity:
+For other experiments, the required inventory is frozen directly in
+`DecisionTraceSelection`. Candidate deployment is valid if and only if every
+named required decision is present and accepted.
+
+At runtime, the generic `build_unified_decision_trace` checks Python object
+identity:
 
 ```python
 result = build_unified_decision_trace(
@@ -259,9 +275,14 @@ The trace references existing decision artifacts rather than redefining their
 scientific semantics. For example:
 
 - Prob4D provider/lineage acceptance remains governed by the Prob4D contract;
+- joint-covariance admission remains governed by the admitted covariance
+  contract;
 - BayesianPhysTwin provider acceptance remains governed by the BPT contract;
+- functional support remains governed by the rollout-space and projected
+  functional-support certificates;
 - action support remains governed by `ActionSupportDecision`;
 - contact-patch finite support remains governed by `ContactV2SupportDecision`;
+- conditional uncertainty remains governed by its source-calibration artifact;
 - baseline-relative benefit remains governed by
   `CounterfactualRegretDecision`.
 

--- a/docs/prospective_v2_promotion.md
+++ b/docs/prospective_v2_promotion.md
@@ -1,0 +1,240 @@
+# Prospective V2 promotion and deployment profile
+
+## Scope
+
+The modules described here are **prospective infrastructure**. They do not
+change the frozen estimator, the registered physical-acquisition candidate, the
+18-session/36-execution protocol, an existing prediction seal, or any recorded
+evidence count.
+
+They address three separate failure modes in the experimental V2 path:
+
+1. a support reduction can preserve marginal behavior while changing a
+   task-relevant joint readout;
+2. a generic decision trace can omit a newly required V2 certificate; and
+3. a candidate ladder can be evaluated or selected without one target opening,
+   independent-unit aggregation, or exact baseline fallback.
+
+The implementation is split across:
+
+```text
+causal4d.projected_functional_support_v1
+causal4d.prospective_v2_profile
+causal4d.prospective_v2_promotion
+```
+
+## Task-projected functional support
+
+`functional_support_v1` remains the base rollout-space certificate. The
+projected certificate adds a frozen set of linear task readouts over
+`(frame, node, coordinate)` and checks, for every source action and projection:
+
+- projected predictive variance relative error; and
+- projected Gaussian-mixture interval endpoint error.
+
+The projected variance includes all three contributions available at this
+boundary:
+
+1. coordinatewise conditional variance;
+2. posterior mixture covariance between component trajectories; and
+3. optional component-specific low-rank conditional trajectory modes.
+
+For projection coefficients `a`, component mean `mu`, independent variance
+`d`, and low-rank factors `F`, the conditional projected variance is
+
+```text
+sum(a**2 * d) + sum_r (a^T F_r)**2
+```
+
+The mixture variance then applies the law of total variance across support
+components. This catches, for example, two supports with identical coordinate
+marginals but opposite correlation along an endpoint or graph-mode readout.
+
+A projected certificate is valid only when:
+
+- the base certificate covers the same actions in the same order;
+- the base certificate binds every base action artifact;
+- the projected metrics contain the complete action-by-projection product;
+- the base decision and every projected metric exactly imply the serialized
+  decision; and
+- no target outcome or target-loss field appears in source-only metadata.
+
+Example:
+
+```python
+from causal4d.projected_functional_support_v1 import (
+    FunctionalSupportProjectionV1,
+    ProjectedFunctionalSupportActionV1,
+    ProjectedFunctionalSupportPolicyV1,
+    certify_projected_functional_support_v1,
+)
+
+projected_action = ProjectedFunctionalSupportActionV1(
+    action=source_action,
+    full_component_low_rank_factors_m=full_modes,
+    reduced_component_low_rank_factors_m=reduced_modes,
+)
+projection = FunctionalSupportProjectionV1(
+    projection_id="late-endpoint-displacement",
+    coefficients=late_endpoint_coefficients,
+)
+certificate = certify_projected_functional_support_v1(
+    (projected_action,),
+    (projection,),
+    policy=ProjectedFunctionalSupportPolicyV1(
+        maximum_projected_variance_relative_error=0.10,
+        maximum_projected_interval_endpoint_error_m=0.002,
+    ),
+    base_certificate=base_functional_support_certificate,
+    source_artifact_ids=(source_projection_freeze_id,),
+)
+```
+
+Passing a plain `FunctionalSupportActionV1` remains supported and is equivalent
+to supplying no low-rank factors.
+
+## Versioned prospective V2 decision profile
+
+The generic `UnifiedDecisionTrace` intentionally supports experiment-specific
+decision inventories. The prospective profile freezes the complete inventory
+under:
+
+```text
+causal4d.prospective-v2-deployment-profile/v1
+```
+
+The required decisions are:
+
+```text
+prob4d_provider_acceptance
+joint_covariance_admission
+bayesian_phystwin_acceptance
+functional_support
+intervention_identifiability
+action_support
+contact_v2_support
+conditional_uncertainty_calibration
+query_calibration
+counterfactual_regret
+```
+
+The profile also fixes the stage and producer for every decision. In
+particular, joint-covariance admission and functional support must be recorded
+at Causal4D abduction, while conditional-uncertainty calibration must be
+recorded at counterfactual prediction.
+
+Use `build_prospective_v2_decision_trace_v1` at runtime. It delegates to the
+generic builder, preserves its exact Python-object identity check, inserts the
+profile ID into content-addressed metadata, and then validates the stricter
+profile.
+
+A profile validation can be structurally accepted while a required decision is
+rejected. That means the trace is a valid V2 trace and correctly deploys the
+exact baseline object. It does **not** mean that the V2 candidate was accepted.
+The rejected required-decision names are recorded explicitly.
+
+## Two-phase promotion experiment
+
+`ProspectiveV2PromotionFreezeV1` is written before target outcomes are opened.
+It binds:
+
+- the exact three-repository stack lock;
+- the exact candidate and source-configuration artifact IDs;
+- all independent evaluation units and endpoint assignments;
+- the source-artifact inventory;
+- every promotion threshold; and
+- `target_outcomes_used = false`.
+
+The candidate ladder is fixed and ordered:
+
+```text
+registered_v1
+normalized_diagonal_or_block_covariance
+normalized_full_joint_covariance
+support_certified_contact_patch
+complete_v2_structured_uncertainty
+```
+
+The result requires the complete Cartesian product of registered unit and
+candidate. Every metric row must carry the same content-addressed evaluation
+opening ID and must declare `target_outcomes_used = true`. Missing rows,
+unregistered rows, duplicate rows, mixed openings, or endpoint mismatches fail
+closed.
+
+All gates are evaluated per endpoint at the registered independent-unit level:
+
+- mean log-score gain relative to the registered baseline;
+- mean Brier-score change;
+- mean trajectory regret;
+- mean coverage error;
+- mean interval-width ratio;
+- accepted-update rate;
+- harmful accepted-update rate, defined conditionally on acceptance; and
+- fallback rate.
+
+The minimum accepted-update rate must be positive and the maximum fallback rate
+must be below one, so a candidate cannot pass by abstaining on every unit.
+
+The highest candidate in the frozen ladder that passes every endpoint is
+selected. When no candidate passes, the result preserves the exact registered
+baseline artifact ID. Direct result construction also verifies that the
+serialized selection equals the highest accepted result or that exact baseline.
+
+Example:
+
+```python
+from causal4d.prospective_v2_promotion import (
+    ProspectiveV2PromotionFreezeV1,
+    ProspectiveV2PromotionPolicyV1,
+    evaluate_prospective_v2_promotion_v1,
+    write_prospective_v2_promotion_freeze,
+    write_prospective_v2_promotion_result,
+)
+
+freeze = ProspectiveV2PromotionFreezeV1(
+    experiment_id="rope-v2-untouched-panel-1",
+    stack_lock_id=stack_lock["lock_id"],
+    candidates=candidate_ladder,
+    evaluation_units=independent_units,
+    policy=ProspectiveV2PromotionPolicyV1(
+        minimum_units_per_endpoint=8,
+        minimum_mean_log_score_gain=0.0,
+        maximum_mean_brier_change=0.0,
+        maximum_mean_trajectory_regret_m=0.0,
+        maximum_mean_coverage_error=0.05,
+        maximum_mean_interval_width_ratio=1.20,
+        minimum_accepted_update_rate=0.50,
+        maximum_harmful_accepted_update_rate=0.10,
+        maximum_fallback_rate=0.50,
+    ),
+    source_artifact_ids=source_artifact_ids,
+)
+write_prospective_v2_promotion_freeze("promotion-freeze.json", freeze)
+
+# Only after the freeze is independently sealed and the evaluation panel opens:
+result = evaluate_prospective_v2_promotion_v1(freeze, evaluation_metrics)
+write_prospective_v2_promotion_result("promotion-result.json", result)
+```
+
+## Metric orientation
+
+The promotion API assumes that larger log score is better. Therefore,
+`mean_log_score_gain` is candidate minus baseline. Brier change and trajectory
+regret are also candidate minus baseline, so lower values are better. Coverage
+error is an absolute error supplied per independent unit. Interval width is
+compared as candidate divided by baseline after applying the frozen positive
+width floor.
+
+`harmful_update` is meaningful only when `candidate_accepted` is true.
+`fallback_used` must be the exact Boolean complement of `candidate_accepted`.
+The registered baseline rows must be accepted, nonfallback, and nonharmful.
+
+## Scientific boundary
+
+These contracts make the prospective experiment harder to accidentally change,
+but they do not turn source-only calibration into target evidence and they do
+not promote a method by themselves. The candidate ladder, projections,
+thresholds, independent units, source artifacts, and stack lock must be reviewed
+and sealed before opening the untouched panel. A negative result is complete and
+must retain the registered baseline rather than trigger target-driven method
+revision.

--- a/src/causal4d/_projected_functional_support_common.py
+++ b/src/causal4d/_projected_functional_support_common.py
@@ -1,0 +1,127 @@
+"""Shared validation helpers for projected functional-support contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+from causal4d.immutable_json import plain_json, validated_json_mapping
+
+
+PROJECTED_FUNCTIONAL_SUPPORT_SCHEMA_VERSION = 1
+_FORBIDDEN_SOURCE_METADATA_KEYS = {
+    "evaluation_target",
+    "held_out_target",
+    "target_continuation",
+    "target_future",
+    "target_future_observations",
+    "target_future_outcomes",
+    "target_loss",
+    "target_outcome",
+    "target_outcomes",
+    "target_outcomes_used",
+    "target_value",
+    "target_values",
+}
+
+
+def canonical_sha256(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        plain_json(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def require_nonempty_string(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def require_sha256(value: Any, *, name: str) -> str:
+    digest = require_nonempty_string(value, name=name)
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def validated_string_tuple(
+    values: Any,
+    *,
+    name: str,
+    require_digest: bool = False,
+) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise ValueError(f"{name} must be a sequence of strings")
+    validator = require_sha256 if require_digest else require_nonempty_string
+    result = tuple(
+        validator(value, name=f"{name}[{index}]")
+        for index, value in enumerate(values)
+    )
+    if not result:
+        raise ValueError(f"{name} must be nonempty")
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must be unique")
+    return result
+
+
+def finite_nonnegative_float(value: Any, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(
+        value,
+        (int, float, np.integer, np.floating),
+    ):
+        raise ValueError(f"{name} must be a finite nonnegative number")
+    result = float(value)
+    if not np.isfinite(result) or result < 0.0:
+        raise ValueError(f"{name} must be a finite nonnegative number")
+    return result
+
+
+def finite_positive_float(value: Any, *, name: str) -> float:
+    result = finite_nonnegative_float(value, name=name)
+    if result <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return result
+
+
+def require_no_target_access(value: Any, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a boolean")
+    if value:
+        raise ValueError(f"{name} must be false for source-only certification")
+    return False
+
+
+def _reject_target_outcome_metadata(value: Any, *, path: str) -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            normalized = key.strip().lower().replace("-", "_")
+            if normalized in _FORBIDDEN_SOURCE_METADATA_KEYS:
+                raise ValueError(
+                    f"{path}.{key} is forbidden for source-only certification"
+                )
+            _reject_target_outcome_metadata(item, path=f"{path}.{key}")
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        for index, item in enumerate(value):
+            _reject_target_outcome_metadata(item, path=f"{path}[{index}]")
+
+
+def validated_source_metadata(
+    values: Mapping[str, Any],
+    *,
+    name: str,
+) -> Mapping[str, Any]:
+    metadata = validated_json_mapping(
+        values,
+        error_message=f"{name} must contain finite JSON data",
+    )
+    _reject_target_outcome_metadata(metadata, path=name)
+    return metadata

--- a/src/causal4d/_projected_functional_support_inputs.py
+++ b/src/causal4d/_projected_functional_support_inputs.py
@@ -1,0 +1,206 @@
+"""Input contracts for task-projected functional-support certification."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+import numpy as np
+
+from causal4d._projected_functional_support_common import (
+    PROJECTED_FUNCTIONAL_SUPPORT_SCHEMA_VERSION,
+    canonical_sha256,
+    finite_nonnegative_float,
+    finite_positive_float,
+    require_nonempty_string,
+    validated_source_metadata,
+)
+from causal4d.contracts import array_sha256
+from causal4d.functional_support_v1 import FunctionalSupportActionV1
+from causal4d.immutable_array import readonly_array
+from causal4d.immutable_json import plain_json
+
+
+@dataclass(frozen=True)
+class FunctionalSupportProjectionV1:
+    """One immutable linear task readout over a rollout trajectory."""
+
+    projection_id: str
+    coefficients: np.ndarray
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        projection_id = require_nonempty_string(
+            self.projection_id,
+            name="projection_id",
+        )
+        coefficients = readonly_array(self.coefficients, dtype=float)
+        if coefficients.ndim != 3 or coefficients.size < 1:
+            raise ValueError(
+                "projection coefficients must have shape "
+                "(frame, node, coordinate)"
+            )
+        if not np.all(np.isfinite(coefficients)):
+            raise ValueError("projection coefficients must be finite")
+        if not np.any(coefficients != 0.0):
+            raise ValueError("projection coefficients must contain a nonzero value")
+        metadata = validated_source_metadata(
+            self.metadata,
+            name="projection metadata",
+        )
+        object.__setattr__(self, "projection_id", projection_id)
+        object.__setattr__(self, "coefficients", coefficients)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def projection_artifact_id(self) -> str:
+        return canonical_sha256(
+            {
+                "schema_version": PROJECTED_FUNCTIONAL_SUPPORT_SCHEMA_VERSION,
+                "artifact_kind": "Causal4DFunctionalSupportProjectionV1",
+                "projection_id": self.projection_id,
+                "coefficients_sha256": array_sha256(self.coefficients),
+                "metadata": plain_json(self.metadata),
+            }
+        )
+
+
+@dataclass(frozen=True)
+class ProjectedFunctionalSupportActionV1:
+    """One base action plus optional component-specific low-rank modes."""
+
+    action: FunctionalSupportActionV1
+    full_component_low_rank_factors_m: np.ndarray | None = None
+    reduced_component_low_rank_factors_m: np.ndarray | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if type(self.action) is not FunctionalSupportActionV1:
+            raise ValueError("action must be a FunctionalSupportActionV1")
+        full_factors = self._validated_factors(
+            self.full_component_low_rank_factors_m,
+            self.action.full_trajectories_m.shape,
+            name="full_component_low_rank_factors_m",
+        )
+        reduced_factors = self._validated_factors(
+            self.reduced_component_low_rank_factors_m,
+            self.action.reduced_trajectories_m.shape,
+            name="reduced_component_low_rank_factors_m",
+        )
+        metadata = validated_source_metadata(
+            self.metadata,
+            name="projected action metadata",
+        )
+        object.__setattr__(
+            self,
+            "full_component_low_rank_factors_m",
+            full_factors,
+        )
+        object.__setattr__(
+            self,
+            "reduced_component_low_rank_factors_m",
+            reduced_factors,
+        )
+        object.__setattr__(self, "metadata", metadata)
+
+    @staticmethod
+    def _validated_factors(
+        values: np.ndarray | None,
+        trajectory_shape: tuple[int, ...],
+        *,
+        name: str,
+    ) -> np.ndarray | None:
+        if values is None:
+            return None
+        factors = readonly_array(values, dtype=float)
+        if factors.ndim not in (4, 5) or factors.shape[-4] < 1:
+            raise ValueError(
+                f"{name} must end in "
+                "(positive rank, frame, node, coordinate) with an optional "
+                "leading component axis"
+            )
+        rank = factors.shape[-4]
+        target_shape = (trajectory_shape[0], rank, *trajectory_shape[1:])
+        try:
+            broadcast = np.broadcast_to(factors, target_shape)
+        except ValueError as error:
+            raise ValueError(
+                f"{name} cannot broadcast to component trajectories"
+            ) from error
+        if not np.all(np.isfinite(broadcast)):
+            raise ValueError(f"{name} must be finite")
+        return readonly_array(broadcast, dtype=float)
+
+    @property
+    def action_id(self) -> str:
+        return self.action.action_id
+
+    @property
+    def projected_action_artifact_id(self) -> str:
+        return canonical_sha256(
+            {
+                "schema_version": PROJECTED_FUNCTIONAL_SUPPORT_SCHEMA_VERSION,
+                "artifact_kind": "Causal4DProjectedFunctionalSupportActionV1",
+                "base_action_artifact_id": self.action.action_artifact_id,
+                "full_low_rank_factors_sha256": (
+                    None
+                    if self.full_component_low_rank_factors_m is None
+                    else array_sha256(self.full_component_low_rank_factors_m)
+                ),
+                "reduced_low_rank_factors_sha256": (
+                    None
+                    if self.reduced_component_low_rank_factors_m is None
+                    else array_sha256(self.reduced_component_low_rank_factors_m)
+                ),
+                "metadata": plain_json(self.metadata),
+            }
+        )
+
+
+@dataclass(frozen=True)
+class ProjectedFunctionalSupportPolicyV1:
+    """Source-frozen gates for task-projected predictive dependence."""
+
+    maximum_projected_variance_relative_error: float
+    maximum_projected_interval_endpoint_error_m: float
+    confidence_level: float = 0.90
+    variance_floor_m2: float = 1e-12
+    minimum_projection_count: int = 1
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "maximum_projected_variance_relative_error",
+            finite_nonnegative_float(
+                self.maximum_projected_variance_relative_error,
+                name="maximum_projected_variance_relative_error",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "maximum_projected_interval_endpoint_error_m",
+            finite_nonnegative_float(
+                self.maximum_projected_interval_endpoint_error_m,
+                name="maximum_projected_interval_endpoint_error_m",
+            ),
+        )
+        confidence = finite_positive_float(
+            self.confidence_level,
+            name="confidence_level",
+        )
+        if confidence >= 1.0:
+            raise ValueError("confidence_level must be less than one")
+        object.__setattr__(self, "confidence_level", confidence)
+        object.__setattr__(
+            self,
+            "variance_floor_m2",
+            finite_positive_float(
+                self.variance_floor_m2,
+                name="variance_floor_m2",
+            ),
+        )
+        if (
+            type(self.minimum_projection_count) is not int
+            or self.minimum_projection_count < 1
+        ):
+            raise ValueError("minimum_projection_count must be a positive integer")

--- a/src/causal4d/_projected_functional_support_outputs.py
+++ b/src/causal4d/_projected_functional_support_outputs.py
@@ -1,0 +1,239 @@
+"""Output contracts for task-projected functional-support certification."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Mapping
+
+import numpy as np
+
+from causal4d._projected_functional_support_common import (
+    PROJECTED_FUNCTIONAL_SUPPORT_SCHEMA_VERSION,
+    canonical_sha256,
+    finite_nonnegative_float,
+    require_no_target_access,
+    require_nonempty_string,
+    require_sha256,
+    validated_source_metadata,
+    validated_string_tuple,
+)
+from causal4d._projected_functional_support_inputs import (
+    ProjectedFunctionalSupportPolicyV1,
+)
+from causal4d.immutable_json import plain_json
+
+
+@dataclass(frozen=True)
+class ProjectedFunctionalSupportMetricV1:
+    action_id: str
+    projection_id: str
+    full_mean_m: float
+    reduced_mean_m: float
+    full_variance_m2: float
+    reduced_variance_m2: float
+    projected_variance_relative_error: float
+    maximum_projected_interval_endpoint_error_m: float
+    accepted: bool
+    reasons: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "action_id",
+            require_nonempty_string(self.action_id, name="action_id"),
+        )
+        object.__setattr__(
+            self,
+            "projection_id",
+            require_nonempty_string(self.projection_id, name="projection_id"),
+        )
+        for name in ("full_mean_m", "reduced_mean_m"):
+            value = getattr(self, name)
+            if isinstance(value, (bool, np.bool_)) or not isinstance(
+                value,
+                (int, float, np.integer, np.floating),
+            ):
+                raise ValueError(f"{name} must be finite")
+            result = float(value)
+            if not np.isfinite(result):
+                raise ValueError(f"{name} must be finite")
+            object.__setattr__(self, name, result)
+        for name in (
+            "full_variance_m2",
+            "reduced_variance_m2",
+            "projected_variance_relative_error",
+            "maximum_projected_interval_endpoint_error_m",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                finite_nonnegative_float(getattr(self, name), name=name),
+            )
+        if type(self.accepted) is not bool:
+            raise ValueError("accepted must be a boolean")
+        reasons = tuple(self.reasons)
+        if self.accepted and reasons:
+            raise ValueError("accepted projected metrics cannot contain reasons")
+        if not self.accepted and not reasons:
+            raise ValueError("rejected projected metrics require reasons")
+        if len(set(reasons)) != len(reasons):
+            raise ValueError("projected metric reasons must be unique")
+        object.__setattr__(self, "reasons", reasons)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "action_id": self.action_id,
+            "projection_id": self.projection_id,
+            "full_mean_m": self.full_mean_m,
+            "reduced_mean_m": self.reduced_mean_m,
+            "full_variance_m2": self.full_variance_m2,
+            "reduced_variance_m2": self.reduced_variance_m2,
+            "projected_variance_relative_error": (
+                self.projected_variance_relative_error
+            ),
+            "maximum_projected_interval_endpoint_error_m": (
+                self.maximum_projected_interval_endpoint_error_m
+            ),
+            "accepted": self.accepted,
+            "reasons": list(self.reasons),
+        }
+
+
+@dataclass(frozen=True)
+class ProjectedFunctionalSupportCertificateV1:
+    """Fail-closed projection certificate layered on the base certificate."""
+
+    accepted: bool
+    reasons: tuple[str, ...]
+    metrics: tuple[ProjectedFunctionalSupportMetricV1, ...]
+    policy: ProjectedFunctionalSupportPolicyV1
+    base_certificate_id: str
+    base_certificate_accepted: bool
+    base_certificate_reasons: tuple[str, ...]
+    base_action_artifact_ids: tuple[str, ...]
+    action_artifact_ids: tuple[str, ...]
+    projection_artifact_ids: tuple[str, ...]
+    source_artifact_ids: tuple[str, ...]
+    target_outcomes_used: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        metrics = tuple(self.metrics)
+        if not metrics or any(
+            type(metric) is not ProjectedFunctionalSupportMetricV1
+            for metric in metrics
+        ):
+            raise ValueError(
+                "metrics must contain ProjectedFunctionalSupportMetricV1 values"
+            )
+        metric_keys = tuple(
+            (metric.action_id, metric.projection_id) for metric in metrics
+        )
+        if len(set(metric_keys)) != len(metric_keys):
+            raise ValueError("projected metric pairs must be unique")
+        if type(self.accepted) is not bool:
+            raise ValueError("accepted must be a boolean")
+        reasons = tuple(self.reasons)
+        base_id = require_sha256(
+            self.base_certificate_id,
+            name="base_certificate_id",
+        )
+        if type(self.base_certificate_accepted) is not bool:
+            raise ValueError("base_certificate_accepted must be a boolean")
+        base_reasons = tuple(self.base_certificate_reasons)
+        if self.base_certificate_accepted and base_reasons:
+            raise ValueError("accepted base certificate cannot contain reasons")
+        if not self.base_certificate_accepted and not base_reasons:
+            raise ValueError("rejected base certificate requires reasons")
+        base_action_ids = validated_string_tuple(
+            self.base_action_artifact_ids,
+            name="base_action_artifact_ids",
+            require_digest=True,
+        )
+        action_ids = validated_string_tuple(
+            self.action_artifact_ids,
+            name="action_artifact_ids",
+            require_digest=True,
+        )
+        projection_ids = validated_string_tuple(
+            self.projection_artifact_ids,
+            name="projection_artifact_ids",
+            require_digest=True,
+        )
+        action_names = tuple(dict.fromkeys(metric.action_id for metric in metrics))
+        projection_names = tuple(
+            dict.fromkeys(metric.projection_id for metric in metrics)
+        )
+        if len(base_action_ids) != len(action_ids):
+            raise ValueError("base and projected action counts must match")
+        if len(action_names) != len(action_ids):
+            raise ValueError("metrics must cover every action exactly")
+        if len(projection_names) != len(projection_ids):
+            raise ValueError("metrics must cover every projection exactly")
+        expected_keys = tuple(
+            (action_name, projection_name)
+            for action_name in action_names
+            for projection_name in projection_names
+        )
+        if metric_keys != expected_keys:
+            raise ValueError("metrics must follow the full action/projection product")
+        expected_reasons = tuple(
+            f"base:{reason}" for reason in base_reasons
+        ) + tuple(
+            f"{metric.action_id}:{metric.projection_id}:{reason}"
+            for metric in metrics
+            for reason in metric.reasons
+        )
+        expected_accepted = not expected_reasons
+        if reasons != expected_reasons or self.accepted is not expected_accepted:
+            raise ValueError("certificate decision must exactly match its evidence")
+        if len(set(reasons)) != len(reasons):
+            raise ValueError("certificate reasons must be unique")
+        source_ids = validated_string_tuple(
+            self.source_artifact_ids,
+            name="source_artifact_ids",
+        )
+        target_used = require_no_target_access(
+            self.target_outcomes_used,
+            name="target_outcomes_used",
+        )
+        metadata = validated_source_metadata(
+            self.metadata,
+            name="projected certificate metadata",
+        )
+        object.__setattr__(self, "reasons", reasons)
+        object.__setattr__(self, "metrics", metrics)
+        object.__setattr__(self, "base_certificate_id", base_id)
+        object.__setattr__(self, "base_certificate_reasons", base_reasons)
+        object.__setattr__(self, "base_action_artifact_ids", base_action_ids)
+        object.__setattr__(self, "action_artifact_ids", action_ids)
+        object.__setattr__(self, "projection_artifact_ids", projection_ids)
+        object.__setattr__(self, "source_artifact_ids", source_ids)
+        object.__setattr__(self, "target_outcomes_used", target_used)
+        object.__setattr__(self, "metadata", metadata)
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": PROJECTED_FUNCTIONAL_SUPPORT_SCHEMA_VERSION,
+            "artifact_kind": "Causal4DProjectedFunctionalSupportCertificateV1",
+            "accepted": self.accepted,
+            "reasons": list(self.reasons),
+            "metrics": [metric.as_dict() for metric in self.metrics],
+            "policy": asdict(self.policy),
+            "base_certificate_id": self.base_certificate_id,
+            "base_certificate_accepted": self.base_certificate_accepted,
+            "base_certificate_reasons": list(self.base_certificate_reasons),
+            "base_action_artifact_ids": list(self.base_action_artifact_ids),
+            "action_artifact_ids": list(self.action_artifact_ids),
+            "projection_artifact_ids": list(self.projection_artifact_ids),
+            "source_artifact_ids": list(self.source_artifact_ids),
+            "target_outcomes_used": self.target_outcomes_used,
+            "metadata": plain_json(self.metadata),
+        }
+
+    @property
+    def certificate_id(self) -> str:
+        return canonical_sha256(self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "certificate_id": self.certificate_id}

--- a/src/causal4d/_prospective_v2_promotion_candidate_result.py
+++ b/src/causal4d/_prospective_v2_promotion_candidate_result.py
@@ -1,0 +1,87 @@
+"""Candidate-level aggregate for prospective V2 promotion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from causal4d._prospective_v2_promotion_common import (
+    PROSPECTIVE_V2_CANDIDATE_KINDS,
+    _require_bool,
+    _require_nonempty_string,
+    _require_sha256,
+)
+from causal4d._prospective_v2_promotion_metrics import (
+    ProspectiveV2EndpointMetricsV1,
+)
+from causal4d.decision_trace import DECISION_TRACE_ENDPOINTS
+
+
+@dataclass(frozen=True)
+class ProspectiveV2CandidateResultV1:
+    candidate_id: str
+    candidate_kind: str
+    candidate_artifact_id: str
+    endpoint_metrics: tuple[ProspectiveV2EndpointMetricsV1, ...]
+    accepted: bool
+    reasons: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        candidate_id = _require_nonempty_string(
+            self.candidate_id,
+            name="candidate_id",
+        )
+        candidate_kind = _require_nonempty_string(
+            self.candidate_kind,
+            name="candidate_kind",
+        )
+        if candidate_kind not in PROSPECTIVE_V2_CANDIDATE_KINDS[1:]:
+            raise ValueError("candidate result must describe a non-baseline candidate")
+        artifact_id = _require_sha256(
+            self.candidate_artifact_id,
+            name="candidate_artifact_id",
+        )
+        endpoint_metrics = tuple(self.endpoint_metrics)
+        if any(
+            type(metric) is not ProspectiveV2EndpointMetricsV1
+            for metric in endpoint_metrics
+        ):
+            raise ValueError(
+                "endpoint_metrics must contain ProspectiveV2EndpointMetricsV1 values"
+            )
+        if tuple(metric.endpoint for metric in endpoint_metrics) != (
+            DECISION_TRACE_ENDPOINTS
+        ):
+            raise ValueError("candidate result must cover every endpoint in order")
+        if any(metric.candidate_id != candidate_id for metric in endpoint_metrics):
+            raise ValueError("endpoint metrics must identify their candidate")
+        expected_reasons = tuple(
+            f"{metric.endpoint}:{reason}"
+            for metric in endpoint_metrics
+            for reason in metric.reasons
+        )
+        accepted = _require_bool(self.accepted, name="accepted")
+        reasons = tuple(self.reasons)
+        expected_accepted = not expected_reasons
+        if reasons != expected_reasons or accepted is not expected_accepted:
+            raise ValueError(
+                "candidate result decision must exactly match endpoint metrics"
+            )
+        object.__setattr__(self, "candidate_id", candidate_id)
+        object.__setattr__(self, "candidate_kind", candidate_kind)
+        object.__setattr__(self, "candidate_artifact_id", artifact_id)
+        object.__setattr__(self, "endpoint_metrics", endpoint_metrics)
+        object.__setattr__(self, "accepted", accepted)
+        object.__setattr__(self, "reasons", reasons)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "candidate_id": self.candidate_id,
+            "candidate_kind": self.candidate_kind,
+            "candidate_artifact_id": self.candidate_artifact_id,
+            "endpoint_metrics": [
+                metric.as_dict() for metric in self.endpoint_metrics
+            ],
+            "accepted": self.accepted,
+            "reasons": list(self.reasons),
+        }

--- a/src/causal4d/_prospective_v2_promotion_common.py
+++ b/src/causal4d/_prospective_v2_promotion_common.py
@@ -1,0 +1,154 @@
+"""Shared contracts and validation for prospective V2 promotion."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+from causal4d.immutable_json import plain_json, validated_json_mapping
+
+
+PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION = 1
+_FORBIDDEN_SOURCE_METADATA_KEYS = {
+    "evaluation_target",
+    "held_out_target",
+    "target_continuation",
+    "target_future",
+    "target_future_observations",
+    "target_future_outcomes",
+    "target_loss",
+    "target_outcome",
+    "target_outcomes",
+    "target_outcomes_used",
+    "target_value",
+    "target_values",
+}
+
+PROSPECTIVE_V2_CANDIDATE_KINDS = (
+    "registered_v1",
+    "normalized_diagonal_or_block_covariance",
+    "normalized_full_joint_covariance",
+    "support_certified_contact_patch",
+    "complete_v2_structured_uncertainty",
+)
+
+
+def _canonical_sha256(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        plain_json(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _require_nonempty_string(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _require_sha256(value: Any, *, name: str) -> str:
+    digest = _require_nonempty_string(value, name=name)
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _require_bool(value: Any, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a boolean")
+    return value
+
+
+def _require_no_target_access(value: Any, *, name: str) -> bool:
+    result = _require_bool(value, name=name)
+    if result:
+        raise ValueError(f"{name} must be false before evaluation opens")
+    return False
+
+
+def _require_target_access(value: Any, *, name: str) -> bool:
+    result = _require_bool(value, name=name)
+    if not result:
+        raise ValueError(f"{name} must be true for evaluation result metrics")
+    return True
+
+
+def _validated_string_tuple(
+    values: Any,
+    *,
+    name: str,
+    require_sha256: bool = False,
+) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise ValueError(f"{name} must be a sequence of strings")
+    validator = _require_sha256 if require_sha256 else _require_nonempty_string
+    result = tuple(
+        validator(value, name=f"{name}[{index}]")
+        for index, value in enumerate(values)
+    )
+    if not result:
+        raise ValueError(f"{name} must be nonempty")
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must be unique")
+    return result
+
+
+def _finite_float(value: Any, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(
+        value,
+        (int, float, np.integer, np.floating),
+    ):
+        raise ValueError(f"{name} must be finite")
+    result = float(value)
+    if not np.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _finite_nonnegative_float(value: Any, *, name: str) -> float:
+    result = _finite_float(value, name=name)
+    if result < 0.0:
+        raise ValueError(f"{name} must be nonnegative")
+    return result
+
+
+def _rate(value: Any, *, name: str) -> float:
+    result = _finite_nonnegative_float(value, name=name)
+    if result > 1.0:
+        raise ValueError(f"{name} must be at most one")
+    return result
+
+
+def _reject_target_outcome_metadata(value: Any, *, path: str) -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            normalized = key.strip().lower().replace("-", "_")
+            if normalized in _FORBIDDEN_SOURCE_METADATA_KEYS:
+                raise ValueError(
+                    f"{path}.{key} is forbidden before target evaluation opens"
+                )
+            _reject_target_outcome_metadata(item, path=f"{path}.{key}")
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        for index, item in enumerate(value):
+            _reject_target_outcome_metadata(item, path=f"{path}[{index}]")
+
+
+def _validated_source_metadata(
+    values: Mapping[str, Any],
+    *,
+    name: str,
+) -> Mapping[str, Any]:
+    metadata = validated_json_mapping(
+        values,
+        error_message=f"{name} must contain finite JSON data",
+    )
+    _reject_target_outcome_metadata(metadata, path=name)
+    return metadata

--- a/src/causal4d/_prospective_v2_promotion_freeze.py
+++ b/src/causal4d/_prospective_v2_promotion_freeze.py
@@ -1,0 +1,145 @@
+"""Content-addressed target-free freeze for prospective V2 promotion."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Mapping
+
+from causal4d._prospective_v2_promotion_common import (
+    PROSPECTIVE_V2_CANDIDATE_KINDS,
+    PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION,
+    _canonical_sha256,
+    _require_no_target_access,
+    _require_nonempty_string,
+    _require_sha256,
+    _validated_source_metadata,
+    _validated_string_tuple,
+)
+from causal4d._prospective_v2_promotion_inputs import (
+    ProspectiveV2CandidateV1,
+    ProspectiveV2EvaluationUnitV1,
+    ProspectiveV2PromotionPolicyV1,
+)
+from causal4d.decision_trace import DECISION_TRACE_ENDPOINTS
+from causal4d.immutable_json import plain_json
+
+
+@dataclass(frozen=True)
+class ProspectiveV2PromotionFreezeV1:
+    """Target-free freeze for one untouched V2 promotion panel."""
+
+    experiment_id: str
+    stack_lock_id: str
+    candidates: tuple[ProspectiveV2CandidateV1, ...]
+    evaluation_units: tuple[ProspectiveV2EvaluationUnitV1, ...]
+    policy: ProspectiveV2PromotionPolicyV1
+    source_artifact_ids: tuple[str, ...]
+    target_outcomes_used: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        experiment_id = _require_nonempty_string(
+            self.experiment_id,
+            name="experiment_id",
+        )
+        stack_lock_id = _require_sha256(
+            self.stack_lock_id,
+            name="stack_lock_id",
+        )
+        if type(self.policy) is not ProspectiveV2PromotionPolicyV1:
+            raise ValueError("policy must be a ProspectiveV2PromotionPolicyV1")
+        candidates = tuple(self.candidates)
+        if any(type(value) is not ProspectiveV2CandidateV1 for value in candidates):
+            raise ValueError("candidates must contain ProspectiveV2CandidateV1 values")
+        kinds = tuple(candidate.candidate_kind for candidate in candidates)
+        if kinds != PROSPECTIVE_V2_CANDIDATE_KINDS:
+            raise ValueError(
+                "candidate ladder must exactly match the registered V2 comparison"
+            )
+        candidate_ids = tuple(candidate.candidate_id for candidate in candidates)
+        artifact_ids = tuple(candidate.artifact_id for candidate in candidates)
+        if len(set(candidate_ids)) != len(candidate_ids):
+            raise ValueError("candidate IDs must be unique")
+        if len(set(artifact_ids)) != len(artifact_ids):
+            raise ValueError("candidate artifact IDs must be unique")
+        if any(candidate.target_outcomes_used for candidate in candidates):
+            raise ValueError("promotion candidates must remain target-free")
+
+        units = tuple(self.evaluation_units)
+        if not units or any(
+            type(value) is not ProspectiveV2EvaluationUnitV1 for value in units
+        ):
+            raise ValueError(
+                "evaluation_units must contain ProspectiveV2EvaluationUnitV1 values"
+            )
+        unit_ids = tuple(unit.unit_id for unit in units)
+        if len(set(unit_ids)) != len(unit_ids):
+            raise ValueError("evaluation unit IDs must be unique")
+        independence_keys = tuple(
+            (unit.endpoint, unit.independent_group_id) for unit in units
+        )
+        if len(set(independence_keys)) != len(independence_keys):
+            raise ValueError(
+                "independent_group_id must be unique within each endpoint"
+            )
+        for endpoint in DECISION_TRACE_ENDPOINTS:
+            count = sum(unit.endpoint == endpoint for unit in units)
+            if count < self.policy.minimum_units_per_endpoint:
+                raise ValueError(
+                    f"endpoint {endpoint!r} has fewer registered independent units "
+                    "than required by policy"
+                )
+        source_ids = _validated_string_tuple(
+            self.source_artifact_ids,
+            name="source_artifact_ids",
+            require_sha256=True,
+        )
+        target_outcomes_used = _require_no_target_access(
+            self.target_outcomes_used,
+            name="target_outcomes_used",
+        )
+        metadata = _validated_source_metadata(
+            self.metadata,
+            name="promotion-freeze metadata",
+        )
+        object.__setattr__(self, "experiment_id", experiment_id)
+        object.__setattr__(self, "stack_lock_id", stack_lock_id)
+        object.__setattr__(self, "candidates", candidates)
+        object.__setattr__(self, "evaluation_units", units)
+        object.__setattr__(self, "source_artifact_ids", source_ids)
+        object.__setattr__(self, "target_outcomes_used", target_outcomes_used)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def freeze_id(self) -> str:
+        return _canonical_sha256(
+            {
+                "schema_version": PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION,
+                "artifact_kind": "Causal4DProspectiveV2PromotionFreezeV1",
+                "experiment_id": self.experiment_id,
+                "stack_lock_id": self.stack_lock_id,
+                "candidates": [candidate.as_dict() for candidate in self.candidates],
+                "evaluation_units": [
+                    unit.as_dict() for unit in self.evaluation_units
+                ],
+                "policy": asdict(self.policy),
+                "source_artifact_ids": list(self.source_artifact_ids),
+                "target_outcomes_used": self.target_outcomes_used,
+                "metadata": plain_json(self.metadata),
+            }
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION,
+            "artifact_kind": "Causal4DProspectiveV2PromotionFreezeV1",
+            "freeze_id": self.freeze_id,
+            "experiment_id": self.experiment_id,
+            "stack_lock_id": self.stack_lock_id,
+            "candidates": [candidate.as_dict() for candidate in self.candidates],
+            "evaluation_units": [unit.as_dict() for unit in self.evaluation_units],
+            "policy": asdict(self.policy),
+            "source_artifact_ids": list(self.source_artifact_ids),
+            "target_outcomes_used": self.target_outcomes_used,
+            "metadata": plain_json(self.metadata),
+        }

--- a/src/causal4d/_prospective_v2_promotion_inputs.py
+++ b/src/causal4d/_prospective_v2_promotion_inputs.py
@@ -1,0 +1,207 @@
+"""Target-free inputs for the prospective V2 promotion experiment."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from causal4d._prospective_v2_promotion_common import (
+    PROSPECTIVE_V2_CANDIDATE_KINDS,
+    _finite_float,
+    _finite_nonnegative_float,
+    _rate,
+    _require_no_target_access,
+    _require_nonempty_string,
+    _require_sha256,
+    _validated_source_metadata,
+    _validated_string_tuple,
+)
+from causal4d.decision_trace import DECISION_TRACE_ENDPOINTS
+from causal4d.immutable_json import plain_json
+
+
+@dataclass(frozen=True)
+class ProspectiveV2CandidateV1:
+    """One predeclared member of the fixed V2 candidate ladder."""
+
+    candidate_id: str
+    candidate_kind: str
+    artifact_id: str
+    source_configuration_id: str
+    components: tuple[str, ...]
+    target_outcomes_used: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        candidate_id = _require_nonempty_string(
+            self.candidate_id,
+            name="candidate_id",
+        )
+        candidate_kind = _require_nonempty_string(
+            self.candidate_kind,
+            name="candidate_kind",
+        )
+        if candidate_kind not in PROSPECTIVE_V2_CANDIDATE_KINDS:
+            raise ValueError(
+                "candidate_kind must belong to the prospective V2 ladder"
+            )
+        artifact_id = _require_sha256(self.artifact_id, name="artifact_id")
+        source_configuration_id = _require_sha256(
+            self.source_configuration_id,
+            name="source_configuration_id",
+        )
+        components = _validated_string_tuple(self.components, name="components")
+        target_outcomes_used = _require_no_target_access(
+            self.target_outcomes_used,
+            name="target_outcomes_used",
+        )
+        metadata = _validated_source_metadata(
+            self.metadata,
+            name="candidate metadata",
+        )
+        object.__setattr__(self, "candidate_id", candidate_id)
+        object.__setattr__(self, "candidate_kind", candidate_kind)
+        object.__setattr__(self, "artifact_id", artifact_id)
+        object.__setattr__(
+            self,
+            "source_configuration_id",
+            source_configuration_id,
+        )
+        object.__setattr__(self, "components", components)
+        object.__setattr__(self, "target_outcomes_used", target_outcomes_used)
+        object.__setattr__(self, "metadata", metadata)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "candidate_id": self.candidate_id,
+            "candidate_kind": self.candidate_kind,
+            "artifact_id": self.artifact_id,
+            "source_configuration_id": self.source_configuration_id,
+            "components": list(self.components),
+            "target_outcomes_used": self.target_outcomes_used,
+            "metadata": plain_json(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class ProspectiveV2EvaluationUnitV1:
+    """One registered independent session/seed unit for one endpoint."""
+
+    unit_id: str
+    endpoint: str
+    independent_group_id: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        unit_id = _require_nonempty_string(self.unit_id, name="unit_id")
+        endpoint = _require_nonempty_string(self.endpoint, name="endpoint")
+        if endpoint not in DECISION_TRACE_ENDPOINTS:
+            raise ValueError(
+                f"endpoint must be one of {list(DECISION_TRACE_ENDPOINTS)}"
+            )
+        independent_group_id = _require_nonempty_string(
+            self.independent_group_id,
+            name="independent_group_id",
+        )
+        metadata = _validated_source_metadata(
+            self.metadata,
+            name="evaluation-unit metadata",
+        )
+        object.__setattr__(self, "unit_id", unit_id)
+        object.__setattr__(self, "endpoint", endpoint)
+        object.__setattr__(self, "independent_group_id", independent_group_id)
+        object.__setattr__(self, "metadata", metadata)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "unit_id": self.unit_id,
+            "endpoint": self.endpoint,
+            "independent_group_id": self.independent_group_id,
+            "metadata": plain_json(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class ProspectiveV2PromotionPolicyV1:
+    """Predeclared endpoint-wise promotion thresholds."""
+
+    minimum_units_per_endpoint: int
+    minimum_mean_log_score_gain: float
+    maximum_mean_brier_change: float
+    maximum_mean_trajectory_regret_m: float
+    maximum_mean_coverage_error: float
+    maximum_mean_interval_width_ratio: float
+    minimum_accepted_update_rate: float
+    maximum_harmful_accepted_update_rate: float
+    maximum_fallback_rate: float
+    interval_width_floor_m: float = 1e-9
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.minimum_units_per_endpoint) is not int
+            or self.minimum_units_per_endpoint < 1
+        ):
+            raise ValueError("minimum_units_per_endpoint must be a positive integer")
+        for name in (
+            "minimum_mean_log_score_gain",
+            "maximum_mean_brier_change",
+            "maximum_mean_trajectory_regret_m",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _finite_float(getattr(self, name), name=name),
+            )
+        object.__setattr__(
+            self,
+            "maximum_mean_coverage_error",
+            _rate(
+                self.maximum_mean_coverage_error,
+                name="maximum_mean_coverage_error",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "maximum_mean_interval_width_ratio",
+            _finite_nonnegative_float(
+                self.maximum_mean_interval_width_ratio,
+                name="maximum_mean_interval_width_ratio",
+            ),
+        )
+        minimum_accepted_update_rate = _rate(
+            self.minimum_accepted_update_rate,
+            name="minimum_accepted_update_rate",
+        )
+        if minimum_accepted_update_rate <= 0.0:
+            raise ValueError("minimum_accepted_update_rate must be positive")
+        object.__setattr__(
+            self,
+            "minimum_accepted_update_rate",
+            minimum_accepted_update_rate,
+        )
+        object.__setattr__(
+            self,
+            "maximum_harmful_accepted_update_rate",
+            _rate(
+                self.maximum_harmful_accepted_update_rate,
+                name="maximum_harmful_accepted_update_rate",
+            ),
+        )
+        maximum_fallback_rate = _rate(
+            self.maximum_fallback_rate,
+            name="maximum_fallback_rate",
+        )
+        if maximum_fallback_rate >= 1.0:
+            raise ValueError("maximum_fallback_rate must be less than one")
+        object.__setattr__(
+            self,
+            "maximum_fallback_rate",
+            maximum_fallback_rate,
+        )
+        floor = _finite_nonnegative_float(
+            self.interval_width_floor_m,
+            name="interval_width_floor_m",
+        )
+        if floor <= 0.0:
+            raise ValueError("interval_width_floor_m must be positive")
+        object.__setattr__(self, "interval_width_floor_m", floor)

--- a/src/causal4d/_prospective_v2_promotion_metrics.py
+++ b/src/causal4d/_prospective_v2_promotion_metrics.py
@@ -1,0 +1,215 @@
+"""Independent-unit and endpoint metrics for prospective V2 promotion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from causal4d._prospective_v2_promotion_common import (
+    PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION,
+    _canonical_sha256,
+    _finite_float,
+    _finite_nonnegative_float,
+    _rate,
+    _require_bool,
+    _require_nonempty_string,
+    _require_sha256,
+    _require_target_access,
+)
+from causal4d.decision_trace import DECISION_TRACE_ENDPOINTS
+from causal4d.immutable_json import plain_json, validated_json_mapping
+
+
+@dataclass(frozen=True)
+class ProspectiveV2UnitMetricsV1:
+    """One candidate outcome on one registered independent unit."""
+
+    unit_id: str
+    endpoint: str
+    candidate_id: str
+    evaluation_opening_id: str
+    log_score: float
+    brier_score: float
+    trajectory_error_m: float
+    coverage_error: float
+    interval_width_m: float
+    candidate_accepted: bool
+    harmful_update: bool
+    fallback_used: bool
+    target_outcomes_used: bool = True
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        unit_id = _require_nonempty_string(self.unit_id, name="unit_id")
+        endpoint = _require_nonempty_string(self.endpoint, name="endpoint")
+        if endpoint not in DECISION_TRACE_ENDPOINTS:
+            raise ValueError("unit metric endpoint is invalid")
+        candidate_id = _require_nonempty_string(
+            self.candidate_id,
+            name="candidate_id",
+        )
+        opening_id = _require_sha256(
+            self.evaluation_opening_id,
+            name="evaluation_opening_id",
+        )
+        log_score = _finite_float(self.log_score, name="log_score")
+        brier_score = _finite_nonnegative_float(
+            self.brier_score,
+            name="brier_score",
+        )
+        trajectory_error = _finite_nonnegative_float(
+            self.trajectory_error_m,
+            name="trajectory_error_m",
+        )
+        coverage_error = _rate(self.coverage_error, name="coverage_error")
+        interval_width = _finite_nonnegative_float(
+            self.interval_width_m,
+            name="interval_width_m",
+        )
+        accepted = _require_bool(
+            self.candidate_accepted,
+            name="candidate_accepted",
+        )
+        harmful = _require_bool(self.harmful_update, name="harmful_update")
+        fallback = _require_bool(self.fallback_used, name="fallback_used")
+        if harmful and not accepted:
+            raise ValueError("harmful_update requires an accepted candidate update")
+        if fallback is accepted:
+            raise ValueError(
+                "fallback_used must be the exact complement of candidate_accepted"
+            )
+        target_outcomes_used = _require_target_access(
+            self.target_outcomes_used,
+            name="target_outcomes_used",
+        )
+        metadata = validated_json_mapping(
+            self.metadata,
+            error_message="unit-metric metadata must contain finite JSON data",
+        )
+        object.__setattr__(self, "unit_id", unit_id)
+        object.__setattr__(self, "endpoint", endpoint)
+        object.__setattr__(self, "candidate_id", candidate_id)
+        object.__setattr__(self, "evaluation_opening_id", opening_id)
+        object.__setattr__(self, "log_score", log_score)
+        object.__setattr__(self, "brier_score", brier_score)
+        object.__setattr__(self, "trajectory_error_m", trajectory_error)
+        object.__setattr__(self, "coverage_error", coverage_error)
+        object.__setattr__(self, "interval_width_m", interval_width)
+        object.__setattr__(self, "candidate_accepted", accepted)
+        object.__setattr__(self, "harmful_update", harmful)
+        object.__setattr__(self, "fallback_used", fallback)
+        object.__setattr__(self, "target_outcomes_used", target_outcomes_used)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def metric_id(self) -> str:
+        return _canonical_sha256(
+            {
+                "schema_version": PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION,
+                "artifact_kind": "Causal4DProspectiveV2UnitMetricsV1",
+                **self.as_dict(),
+            }
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "unit_id": self.unit_id,
+            "endpoint": self.endpoint,
+            "candidate_id": self.candidate_id,
+            "evaluation_opening_id": self.evaluation_opening_id,
+            "log_score": self.log_score,
+            "brier_score": self.brier_score,
+            "trajectory_error_m": self.trajectory_error_m,
+            "coverage_error": self.coverage_error,
+            "interval_width_m": self.interval_width_m,
+            "candidate_accepted": self.candidate_accepted,
+            "harmful_update": self.harmful_update,
+            "fallback_used": self.fallback_used,
+            "target_outcomes_used": self.target_outcomes_used,
+            "metadata": plain_json(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class ProspectiveV2EndpointMetricsV1:
+    candidate_id: str
+    endpoint: str
+    unit_count: int
+    mean_log_score_gain: float
+    mean_brier_change: float
+    mean_trajectory_regret_m: float
+    mean_coverage_error: float
+    mean_interval_width_m: float
+    mean_interval_width_ratio: float
+    accepted_update_rate: float
+    harmful_accepted_update_rate: float
+    fallback_rate: float
+    accepted: bool
+    reasons: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "candidate_id",
+            _require_nonempty_string(self.candidate_id, name="candidate_id"),
+        )
+        endpoint = _require_nonempty_string(self.endpoint, name="endpoint")
+        if endpoint not in DECISION_TRACE_ENDPOINTS:
+            raise ValueError("endpoint aggregate has an invalid endpoint")
+        object.__setattr__(self, "endpoint", endpoint)
+        if type(self.unit_count) is not int or self.unit_count < 1:
+            raise ValueError("unit_count must be a positive integer")
+        for name in (
+            "mean_log_score_gain",
+            "mean_brier_change",
+            "mean_trajectory_regret_m",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _finite_float(getattr(self, name), name=name),
+            )
+        for name in (
+            "mean_coverage_error",
+            "mean_interval_width_m",
+            "mean_interval_width_ratio",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _finite_nonnegative_float(getattr(self, name), name=name),
+            )
+        for name in (
+            "accepted_update_rate",
+            "harmful_accepted_update_rate",
+            "fallback_rate",
+        ):
+            object.__setattr__(self, name, _rate(getattr(self, name), name=name))
+        accepted = _require_bool(self.accepted, name="accepted")
+        reasons = tuple(self.reasons)
+        if accepted and reasons:
+            raise ValueError("accepted endpoint metrics cannot contain reasons")
+        if not accepted and not reasons:
+            raise ValueError("rejected endpoint metrics require reasons")
+        if len(set(reasons)) != len(reasons):
+            raise ValueError("endpoint rejection reasons must be unique")
+        object.__setattr__(self, "accepted", accepted)
+        object.__setattr__(self, "reasons", reasons)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "candidate_id": self.candidate_id,
+            "endpoint": self.endpoint,
+            "unit_count": self.unit_count,
+            "mean_log_score_gain": self.mean_log_score_gain,
+            "mean_brier_change": self.mean_brier_change,
+            "mean_trajectory_regret_m": self.mean_trajectory_regret_m,
+            "mean_coverage_error": self.mean_coverage_error,
+            "mean_interval_width_m": self.mean_interval_width_m,
+            "mean_interval_width_ratio": self.mean_interval_width_ratio,
+            "accepted_update_rate": self.accepted_update_rate,
+            "harmful_accepted_update_rate": self.harmful_accepted_update_rate,
+            "fallback_rate": self.fallback_rate,
+            "accepted": self.accepted,
+            "reasons": list(self.reasons),
+        }

--- a/src/causal4d/_prospective_v2_promotion_result.py
+++ b/src/causal4d/_prospective_v2_promotion_result.py
@@ -1,0 +1,186 @@
+"""One-opening selection result for prospective V2 promotion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from causal4d._prospective_v2_promotion_candidate_result import (
+    ProspectiveV2CandidateResultV1,
+)
+from causal4d._prospective_v2_promotion_common import (
+    PROSPECTIVE_V2_CANDIDATE_KINDS,
+    PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION,
+    _canonical_sha256,
+    _require_bool,
+    _require_nonempty_string,
+    _require_sha256,
+    _require_target_access,
+    _validated_string_tuple,
+)
+from causal4d.immutable_json import plain_json, validated_json_mapping
+
+
+@dataclass(frozen=True)
+class ProspectiveV2PromotionResultV1:
+    """Content-addressed one-opening result and exact artifact selection."""
+
+    freeze_id: str
+    evaluation_opening_id: str
+    baseline_candidate_id: str
+    baseline_artifact_id: str
+    selected_candidate_id: str
+    selected_candidate_kind: str
+    selected_artifact_id: str
+    candidate_results: tuple[ProspectiveV2CandidateResultV1, ...]
+    evaluation_metric_ids: tuple[str, ...]
+    exact_artifact_fallback_verified: bool
+    one_target_opening_verified: bool
+    target_outcomes_used: bool = True
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        freeze_id = _require_sha256(self.freeze_id, name="freeze_id")
+        opening_id = _require_sha256(
+            self.evaluation_opening_id,
+            name="evaluation_opening_id",
+        )
+        baseline_candidate_id = _require_nonempty_string(
+            self.baseline_candidate_id,
+            name="baseline_candidate_id",
+        )
+        baseline_artifact_id = _require_sha256(
+            self.baseline_artifact_id,
+            name="baseline_artifact_id",
+        )
+        selected_candidate_id = _require_nonempty_string(
+            self.selected_candidate_id,
+            name="selected_candidate_id",
+        )
+        selected_kind = _require_nonempty_string(
+            self.selected_candidate_kind,
+            name="selected_candidate_kind",
+        )
+        if selected_kind not in PROSPECTIVE_V2_CANDIDATE_KINDS:
+            raise ValueError("selected_candidate_kind is invalid")
+        selected_artifact_id = _require_sha256(
+            self.selected_artifact_id,
+            name="selected_artifact_id",
+        )
+        candidate_results = tuple(self.candidate_results)
+        if any(
+            type(result) is not ProspectiveV2CandidateResultV1
+            for result in candidate_results
+        ):
+            raise ValueError(
+                "candidate_results must contain ProspectiveV2CandidateResultV1 values"
+            )
+        expected_kinds = PROSPECTIVE_V2_CANDIDATE_KINDS[1:]
+        if tuple(result.candidate_kind for result in candidate_results) != (
+            expected_kinds
+        ):
+            raise ValueError("candidate results must follow the frozen ladder")
+        candidate_result_ids = tuple(
+            result.candidate_id for result in candidate_results
+        )
+        candidate_result_artifacts = tuple(
+            result.candidate_artifact_id for result in candidate_results
+        )
+        if len(set(candidate_result_ids)) != len(candidate_result_ids):
+            raise ValueError("candidate result IDs must be unique")
+        if len(set(candidate_result_artifacts)) != len(candidate_result_artifacts):
+            raise ValueError("candidate result artifact IDs must be unique")
+        if baseline_candidate_id in candidate_result_ids:
+            raise ValueError("baseline candidate must not appear in candidate results")
+        if baseline_artifact_id in candidate_result_artifacts:
+            raise ValueError("baseline artifact must differ from candidate artifacts")
+        accepted_results = tuple(
+            result for result in candidate_results if result.accepted
+        )
+        if accepted_results:
+            expected_selected = accepted_results[-1]
+            expected_selected_fields = (
+                expected_selected.candidate_id,
+                expected_selected.candidate_kind,
+                expected_selected.candidate_artifact_id,
+            )
+        else:
+            expected_selected_fields = (
+                baseline_candidate_id,
+                PROSPECTIVE_V2_CANDIDATE_KINDS[0],
+                baseline_artifact_id,
+            )
+        observed_selected_fields = (
+            selected_candidate_id,
+            selected_kind,
+            selected_artifact_id,
+        )
+        if observed_selected_fields != expected_selected_fields:
+            raise ValueError(
+                "selected artifact must equal the highest accepted frozen candidate "
+                "or the exact baseline"
+            )
+        metric_ids = _validated_string_tuple(
+            self.evaluation_metric_ids,
+            name="evaluation_metric_ids",
+            require_sha256=True,
+        )
+        if not _require_bool(
+            self.exact_artifact_fallback_verified,
+            name="exact_artifact_fallback_verified",
+        ):
+            raise ValueError("exact artifact fallback must be verified")
+        if not _require_bool(
+            self.one_target_opening_verified,
+            name="one_target_opening_verified",
+        ):
+            raise ValueError("one target opening must be verified")
+        target_outcomes_used = _require_target_access(
+            self.target_outcomes_used,
+            name="target_outcomes_used",
+        )
+        metadata = validated_json_mapping(
+            self.metadata,
+            error_message="promotion-result metadata must contain finite JSON data",
+        )
+        object.__setattr__(self, "freeze_id", freeze_id)
+        object.__setattr__(self, "evaluation_opening_id", opening_id)
+        object.__setattr__(self, "baseline_candidate_id", baseline_candidate_id)
+        object.__setattr__(self, "baseline_artifact_id", baseline_artifact_id)
+        object.__setattr__(self, "selected_candidate_id", selected_candidate_id)
+        object.__setattr__(self, "selected_candidate_kind", selected_kind)
+        object.__setattr__(self, "selected_artifact_id", selected_artifact_id)
+        object.__setattr__(self, "candidate_results", candidate_results)
+        object.__setattr__(self, "evaluation_metric_ids", metric_ids)
+        object.__setattr__(self, "target_outcomes_used", target_outcomes_used)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def result_id(self) -> str:
+        return _canonical_sha256(self.as_dict(include_result_id=False))
+
+    def as_dict(self, *, include_result_id: bool = True) -> dict[str, Any]:
+        payload = {
+            "schema_version": PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION,
+            "artifact_kind": "Causal4DProspectiveV2PromotionResultV1",
+            "freeze_id": self.freeze_id,
+            "evaluation_opening_id": self.evaluation_opening_id,
+            "baseline_candidate_id": self.baseline_candidate_id,
+            "baseline_artifact_id": self.baseline_artifact_id,
+            "selected_candidate_id": self.selected_candidate_id,
+            "selected_candidate_kind": self.selected_candidate_kind,
+            "selected_artifact_id": self.selected_artifact_id,
+            "candidate_results": [
+                result.as_dict() for result in self.candidate_results
+            ],
+            "evaluation_metric_ids": list(self.evaluation_metric_ids),
+            "exact_artifact_fallback_verified": (
+                self.exact_artifact_fallback_verified
+            ),
+            "one_target_opening_verified": self.one_target_opening_verified,
+            "target_outcomes_used": self.target_outcomes_used,
+            "metadata": plain_json(self.metadata),
+        }
+        if include_result_id:
+            payload["result_id"] = self.result_id
+        return payload

--- a/src/causal4d/projected_functional_support_v1.py
+++ b/src/causal4d/projected_functional_support_v1.py
@@ -1,0 +1,309 @@
+"""Source-only task-projection certification for support reductions.
+
+The additive certificate checks frozen linear task readouts after the existing
+rollout-space functional-support certificate. It preserves the registered and
+frozen estimators and never reads target outcomes.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+from causal4d._projected_functional_support_common import (
+    PROJECTED_FUNCTIONAL_SUPPORT_SCHEMA_VERSION,
+    validated_string_tuple,
+)
+from causal4d._projected_functional_support_inputs import (
+    FunctionalSupportProjectionV1,
+    ProjectedFunctionalSupportActionV1,
+    ProjectedFunctionalSupportPolicyV1,
+)
+from causal4d._projected_functional_support_outputs import (
+    ProjectedFunctionalSupportCertificateV1,
+    ProjectedFunctionalSupportMetricV1,
+)
+from causal4d.functional_support_v1 import (
+    FunctionalSupportActionV1,
+    FunctionalSupportCertificateV1,
+)
+from causal4d.latent_contact_v2 import gaussian_mixture_quantiles
+
+
+def _component_variance(
+    values: np.ndarray | None,
+    trajectories: np.ndarray,
+    *,
+    floor_m2: float,
+) -> np.ndarray:
+    if values is None:
+        return np.full_like(trajectories, floor_m2, dtype=float)
+    return np.broadcast_to(values, trajectories.shape) + floor_m2
+
+
+def _projected_component_moments(
+    trajectories: np.ndarray,
+    component_variance_m2: np.ndarray,
+    low_rank_factors_m: np.ndarray | None,
+    coefficients: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    means = np.einsum(
+        "ifnc,fnc->i",
+        trajectories,
+        coefficients,
+        optimize=True,
+    )
+    variances = np.einsum(
+        "ifnc,fnc->i",
+        component_variance_m2,
+        np.square(coefficients),
+        optimize=True,
+    )
+    if low_rank_factors_m is not None:
+        projected_factors = np.einsum(
+            "irfnc,fnc->ir",
+            low_rank_factors_m,
+            coefficients,
+            optimize=True,
+        )
+        variances = variances + np.sum(np.square(projected_factors), axis=1)
+    if (
+        not np.all(np.isfinite(means))
+        or not np.all(np.isfinite(variances))
+        or np.any(variances < 0.0)
+    ):
+        raise ValueError("projected component moments must be finite and valid")
+    return means, variances
+
+
+def _mixture_moments(
+    means: np.ndarray,
+    variances: np.ndarray,
+    weights: np.ndarray,
+) -> tuple[float, float]:
+    mixture_mean = float(np.sum(weights * means))
+    mixture_variance = float(
+        np.sum(weights * (variances + np.square(means - mixture_mean)))
+    )
+    if not np.isfinite(mixture_mean) or not np.isfinite(mixture_variance):
+        raise ValueError("projected mixture moments must be finite")
+    if mixture_variance < 0.0:
+        raise ValueError("projected mixture variance must be nonnegative")
+    return mixture_mean, mixture_variance
+
+
+def _mixture_interval(
+    means: np.ndarray,
+    variances: np.ndarray,
+    weights: np.ndarray,
+    *,
+    confidence_level: float,
+) -> np.ndarray:
+    tail = 0.5 * (1.0 - confidence_level)
+    interval = gaussian_mixture_quantiles(
+        means[:, None, None, None],
+        variances[:, None, None, None],
+        weights,
+        (tail, 1.0 - tail),
+    )
+    result = np.asarray(interval[:, 0, 0, 0], dtype=float)
+    if result.shape != (2,) or not np.all(np.isfinite(result)):
+        raise ValueError("projected mixture interval must be finite")
+    return result
+
+
+def _evaluate_projection(
+    projected_action: ProjectedFunctionalSupportActionV1,
+    projection: FunctionalSupportProjectionV1,
+    policy: ProjectedFunctionalSupportPolicyV1,
+) -> ProjectedFunctionalSupportMetricV1:
+    action = projected_action.action
+    query_shape = action.full_trajectories_m.shape[1:]
+    if projection.coefficients.shape != query_shape:
+        raise ValueError(
+            f"projection {projection.projection_id!r} has shape "
+            f"{projection.coefficients.shape}, expected {query_shape} for "
+            f"action {action.action_id!r}"
+        )
+    full_diagonal = _component_variance(
+        action.full_component_variance_m2,
+        action.full_trajectories_m,
+        floor_m2=policy.variance_floor_m2,
+    )
+    reduced_diagonal = _component_variance(
+        action.reduced_component_variance_m2,
+        action.reduced_trajectories_m,
+        floor_m2=policy.variance_floor_m2,
+    )
+    full_means, full_variances = _projected_component_moments(
+        action.full_trajectories_m,
+        full_diagonal,
+        projected_action.full_component_low_rank_factors_m,
+        projection.coefficients,
+    )
+    reduced_means, reduced_variances = _projected_component_moments(
+        action.reduced_trajectories_m,
+        reduced_diagonal,
+        projected_action.reduced_component_low_rank_factors_m,
+        projection.coefficients,
+    )
+    full_mean, full_variance = _mixture_moments(
+        full_means,
+        full_variances,
+        action.full_weights,
+    )
+    reduced_mean, reduced_variance = _mixture_moments(
+        reduced_means,
+        reduced_variances,
+        action.reduced_weights,
+    )
+    variance_error = abs(reduced_variance - full_variance) / max(
+        full_variance,
+        np.finfo(float).tiny,
+    )
+    full_interval = _mixture_interval(
+        full_means,
+        full_variances,
+        action.full_weights,
+        confidence_level=policy.confidence_level,
+    )
+    reduced_interval = _mixture_interval(
+        reduced_means,
+        reduced_variances,
+        action.reduced_weights,
+        confidence_level=policy.confidence_level,
+    )
+    interval_error = float(np.max(np.abs(reduced_interval - full_interval)))
+    reasons: list[str] = []
+    if variance_error > policy.maximum_projected_variance_relative_error:
+        reasons.append("projected_variance_relative_error_exceeds_limit")
+    if interval_error > policy.maximum_projected_interval_endpoint_error_m:
+        reasons.append("projected_interval_endpoint_error_exceeds_limit")
+    return ProjectedFunctionalSupportMetricV1(
+        action_id=action.action_id,
+        projection_id=projection.projection_id,
+        full_mean_m=full_mean,
+        reduced_mean_m=reduced_mean,
+        full_variance_m2=full_variance,
+        reduced_variance_m2=reduced_variance,
+        projected_variance_relative_error=variance_error,
+        maximum_projected_interval_endpoint_error_m=interval_error,
+        accepted=not reasons,
+        reasons=tuple(reasons),
+    )
+
+
+def _coerce_action(
+    value: FunctionalSupportActionV1 | ProjectedFunctionalSupportActionV1,
+) -> ProjectedFunctionalSupportActionV1:
+    if type(value) is ProjectedFunctionalSupportActionV1:
+        return value
+    if type(value) is FunctionalSupportActionV1:
+        return ProjectedFunctionalSupportActionV1(action=value)
+    raise ValueError(
+        "actions must contain FunctionalSupportActionV1 or "
+        "ProjectedFunctionalSupportActionV1 values"
+    )
+
+
+def certify_projected_functional_support_v1(
+    actions: Sequence[
+        FunctionalSupportActionV1 | ProjectedFunctionalSupportActionV1
+    ],
+    projections: Sequence[FunctionalSupportProjectionV1],
+    *,
+    policy: ProjectedFunctionalSupportPolicyV1,
+    base_certificate: FunctionalSupportCertificateV1,
+    source_artifact_ids: Sequence[str],
+    metadata: Mapping[str, Any] | None = None,
+) -> ProjectedFunctionalSupportCertificateV1:
+    """Certify task projections after the base rollout-space certificate."""
+
+    action_tuple = tuple(_coerce_action(action) for action in actions)
+    projection_tuple = tuple(projections)
+    if not action_tuple:
+        raise ValueError("actions must be nonempty")
+    if len({action.action_id for action in action_tuple}) != len(action_tuple):
+        raise ValueError("source action IDs must be unique")
+    if any(action.action.target_outcomes_used for action in action_tuple):
+        raise ValueError("source actions must not use target outcomes")
+    if len(projection_tuple) < policy.minimum_projection_count:
+        raise ValueError("insufficient task projections for certification")
+    if any(
+        type(projection) is not FunctionalSupportProjectionV1
+        for projection in projection_tuple
+    ):
+        raise ValueError(
+            "projections must contain FunctionalSupportProjectionV1 values"
+        )
+    if len({projection.projection_id for projection in projection_tuple}) != len(
+        projection_tuple
+    ):
+        raise ValueError("projection IDs must be unique")
+    if type(base_certificate) is not FunctionalSupportCertificateV1:
+        raise ValueError("base_certificate must be a FunctionalSupportCertificateV1")
+    action_ids = tuple(action.action_id for action in action_tuple)
+    base_action_ids = tuple(
+        metric.action_id for metric in base_certificate.action_metrics
+    )
+    if base_action_ids != action_ids:
+        raise ValueError(
+            "base certificate action order must match projected source actions"
+        )
+    base_action_artifact_ids = tuple(
+        action.action.action_artifact_id for action in action_tuple
+    )
+    missing_provenance = tuple(
+        artifact_id
+        for artifact_id in base_action_artifact_ids
+        if artifact_id not in base_certificate.source_artifact_ids
+    )
+    if missing_provenance:
+        raise ValueError("base certificate does not bind every projected action")
+    metrics = tuple(
+        _evaluate_projection(action, projection, policy)
+        for action in action_tuple
+        for projection in projection_tuple
+    )
+    reasons = tuple(
+        f"base:{reason}" for reason in base_certificate.reasons
+    ) + tuple(
+        f"{metric.action_id}:{metric.projection_id}:{reason}"
+        for metric in metrics
+        for reason in metric.reasons
+    )
+    source_ids = validated_string_tuple(
+        source_artifact_ids,
+        name="source_artifact_ids",
+    )
+    return ProjectedFunctionalSupportCertificateV1(
+        accepted=not reasons,
+        reasons=reasons,
+        metrics=metrics,
+        policy=policy,
+        base_certificate_id=base_certificate.certificate_id,
+        base_certificate_accepted=base_certificate.accepted,
+        base_certificate_reasons=base_certificate.reasons,
+        base_action_artifact_ids=base_action_artifact_ids,
+        action_artifact_ids=tuple(
+            action.projected_action_artifact_id for action in action_tuple
+        ),
+        projection_artifact_ids=tuple(
+            projection.projection_artifact_id for projection in projection_tuple
+        ),
+        source_artifact_ids=source_ids,
+        target_outcomes_used=False,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+__all__ = [
+    "PROJECTED_FUNCTIONAL_SUPPORT_SCHEMA_VERSION",
+    "FunctionalSupportProjectionV1",
+    "ProjectedFunctionalSupportActionV1",
+    "ProjectedFunctionalSupportCertificateV1",
+    "ProjectedFunctionalSupportMetricV1",
+    "ProjectedFunctionalSupportPolicyV1",
+    "certify_projected_functional_support_v1",
+]

--- a/src/causal4d/prospective_v2_profile.py
+++ b/src/causal4d/prospective_v2_profile.py
@@ -1,0 +1,317 @@
+"""Versioned deployment-decision profile for the prospective Causal4D V2 path.
+
+The generic decision trace deliberately permits experiment-specific decision
+inventories. This module freezes the stricter inventory needed by the
+prospective V2 stack so a candidate cannot be selected while silently omitting
+joint-covariance, functional-support, or conditional-uncertainty evidence.
+It is additive and does not change the frozen physical-acquisition estimator.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from typing import Any, Mapping, Sequence, TypeVar
+
+from causal4d.decision_trace import (
+    DecisionTraceArtifact,
+    DecisionTraceBuildResult,
+    DecisionTraceDecision,
+    DecisionTraceStage,
+    TraceEndpoint,
+    UnifiedDecisionTrace,
+    build_unified_decision_trace,
+)
+from causal4d.immutable_json import plain_json
+
+
+PROSPECTIVE_V2_PROFILE_SCHEMA_VERSION = 1
+PROSPECTIVE_V2_PROFILE_ID = "causal4d.prospective-v2-deployment-profile/v1"
+PROSPECTIVE_V2_REQUIRED_DECISION_NAMES = (
+    "prob4d_provider_acceptance",
+    "joint_covariance_admission",
+    "bayesian_phystwin_acceptance",
+    "functional_support",
+    "intervention_identifiability",
+    "action_support",
+    "contact_v2_support",
+    "conditional_uncertainty_calibration",
+    "query_calibration",
+    "counterfactual_regret",
+)
+
+_EXPECTED_DECISION_LOCATION = {
+    "prob4d_provider_acceptance": ("prob4d_observation", "prob4d"),
+    "joint_covariance_admission": ("causal4d_abduction", "causal4d"),
+    "bayesian_phystwin_acceptance": (
+        "bayesian_phystwin_belief",
+        "bayesian-phystwin",
+    ),
+    "functional_support": ("causal4d_abduction", "causal4d"),
+    "intervention_identifiability": ("causal4d_abduction", "causal4d"),
+    "action_support": ("causal4d_abduction", "causal4d"),
+    "contact_v2_support": ("causal4d_abduction", "causal4d"),
+    "conditional_uncertainty_calibration": (
+        "causal4d_counterfactual",
+        "causal4d",
+    ),
+    "query_calibration": ("causal4d_counterfactual", "causal4d"),
+    "counterfactual_regret": ("deployment", "causal4d"),
+}
+
+BaselineT = TypeVar("BaselineT")
+CandidateT = TypeVar("CandidateT")
+
+
+def _canonical_sha256(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        plain_json(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _require_nonempty_string(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _require_sha256(value: Any, *, name: str) -> str:
+    digest = _require_nonempty_string(value, name=name)
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _require_bool(value: Any, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a boolean")
+    return value
+
+
+@dataclass(frozen=True)
+class ProspectiveV2ProfileValidationV1:
+    """Content-addressed result of applying the V2 trace profile."""
+
+    trace_id: str
+    accepted: bool
+    reasons: tuple[str, ...]
+    required_decision_names: tuple[str, ...]
+    rejected_required_decision_names: tuple[str, ...]
+    candidate_selected: bool
+
+    def __post_init__(self) -> None:
+        trace_id = _require_sha256(self.trace_id, name="trace_id")
+        accepted = _require_bool(self.accepted, name="accepted")
+        candidate_selected = _require_bool(
+            self.candidate_selected,
+            name="candidate_selected",
+        )
+        reasons = tuple(self.reasons)
+        required = tuple(self.required_decision_names)
+        rejected = tuple(self.rejected_required_decision_names)
+        if required != PROSPECTIVE_V2_REQUIRED_DECISION_NAMES:
+            raise ValueError("required_decision_names must equal the V2 profile")
+        if len(set(reasons)) != len(reasons):
+            raise ValueError("profile validation reasons must be unique")
+        if len(set(rejected)) != len(rejected):
+            raise ValueError("rejected required decisions must be unique")
+        if any(name not in required for name in rejected):
+            raise ValueError("rejected decisions must belong to the V2 profile")
+        expected_accepted = not reasons
+        if accepted is not expected_accepted:
+            raise ValueError("profile validation decision must match its reasons")
+        object.__setattr__(self, "trace_id", trace_id)
+        object.__setattr__(self, "accepted", accepted)
+        object.__setattr__(self, "candidate_selected", candidate_selected)
+        object.__setattr__(self, "reasons", reasons)
+        object.__setattr__(self, "required_decision_names", required)
+        object.__setattr__(self, "rejected_required_decision_names", rejected)
+
+    @property
+    def validation_id(self) -> str:
+        return _canonical_sha256(
+            {
+                "schema_version": PROSPECTIVE_V2_PROFILE_SCHEMA_VERSION,
+                "artifact_kind": "Causal4DProspectiveV2ProfileValidationV1",
+                "profile_id": PROSPECTIVE_V2_PROFILE_ID,
+                "trace_id": self.trace_id,
+                "accepted": self.accepted,
+                "reasons": list(self.reasons),
+                "required_decision_names": list(self.required_decision_names),
+                "rejected_required_decision_names": list(
+                    self.rejected_required_decision_names
+                ),
+                "candidate_selected": self.candidate_selected,
+            }
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": PROSPECTIVE_V2_PROFILE_SCHEMA_VERSION,
+            "artifact_kind": "Causal4DProspectiveV2ProfileValidationV1",
+            "profile_id": PROSPECTIVE_V2_PROFILE_ID,
+            "validation_id": self.validation_id,
+            "trace_id": self.trace_id,
+            "accepted": self.accepted,
+            "reasons": list(self.reasons),
+            "required_decision_names": list(self.required_decision_names),
+            "rejected_required_decision_names": list(
+                self.rejected_required_decision_names
+            ),
+            "candidate_selected": self.candidate_selected,
+        }
+
+
+def _decision_index(
+    stages: Sequence[DecisionTraceStage],
+) -> tuple[
+    dict[str, list[tuple[DecisionTraceStage, DecisionTraceDecision]]],
+    list[str],
+]:
+    index: dict[
+        str, list[tuple[DecisionTraceStage, DecisionTraceDecision]]
+    ] = {}
+    duplicate_names: list[str] = []
+    for stage in stages:
+        for decision in stage.decisions:
+            values = index.setdefault(decision.name, [])
+            values.append((stage, decision))
+            if len(values) == 2:
+                duplicate_names.append(decision.name)
+    return index, duplicate_names
+
+
+def validate_prospective_v2_decision_trace_v1(
+    trace: UnifiedDecisionTrace,
+) -> ProspectiveV2ProfileValidationV1:
+    """Validate that a generic trace satisfies the complete V2 profile."""
+
+    if type(trace) is not UnifiedDecisionTrace:
+        raise ValueError("trace must be a UnifiedDecisionTrace")
+    reasons: list[str] = []
+    profile_id = trace.metadata.get("decision_profile_id")
+    if profile_id != PROSPECTIVE_V2_PROFILE_ID:
+        reasons.append("decision_profile_id_mismatch")
+
+    index, duplicate_names = _decision_index(trace.stages)
+    for name in duplicate_names:
+        reasons.append(f"duplicate_required_decision:{name}")
+    rejected: list[str] = []
+    observed_names: list[str] = []
+    for name in PROSPECTIVE_V2_REQUIRED_DECISION_NAMES:
+        entries = index.get(name, [])
+        if not entries:
+            reasons.append(f"missing_required_decision:{name}")
+            continue
+        if len(entries) != 1:
+            continue
+        stage, decision = entries[0]
+        observed_names.append(name)
+        expected_stage, expected_producer = _EXPECTED_DECISION_LOCATION[name]
+        if stage.stage_kind != expected_stage:
+            reasons.append(
+                f"required_decision_wrong_stage:{name}:{stage.stage_kind}"
+            )
+        if decision.producer != expected_producer:
+            reasons.append(
+                f"required_decision_wrong_producer:{name}:{decision.producer}"
+            )
+        if not decision.accepted:
+            rejected.append(name)
+
+    if trace.selection.required_decision_names != (
+        PROSPECTIVE_V2_REQUIRED_DECISION_NAMES
+    ):
+        reasons.append("selection_required_decision_inventory_mismatch")
+    expected_candidate_selected = not rejected and len(observed_names) == len(
+        PROSPECTIVE_V2_REQUIRED_DECISION_NAMES
+    )
+    if (
+        not reasons
+        and trace.selection.candidate_selected != expected_candidate_selected
+    ):
+        reasons.append("selection_state_disagrees_with_v2_profile")
+
+    return ProspectiveV2ProfileValidationV1(
+        trace_id=trace.trace_id,
+        accepted=not reasons,
+        reasons=tuple(reasons),
+        required_decision_names=PROSPECTIVE_V2_REQUIRED_DECISION_NAMES,
+        rejected_required_decision_names=tuple(rejected),
+        candidate_selected=trace.selection.candidate_selected,
+    )
+
+
+def require_prospective_v2_decision_trace_v1(
+    trace: UnifiedDecisionTrace,
+) -> UnifiedDecisionTrace:
+    """Return a trace only when it satisfies the complete V2 profile."""
+
+    validation = validate_prospective_v2_decision_trace_v1(trace)
+    if not validation.accepted:
+        joined = ", ".join(validation.reasons)
+        raise ValueError(f"decision trace does not satisfy the V2 profile: {joined}")
+    return trace
+
+
+def build_prospective_v2_decision_trace_v1(
+    *,
+    trace_name: str,
+    protocol_id: str,
+    case_id: str,
+    session_id: str,
+    endpoint: TraceEndpoint,
+    stack_lock_id: str,
+    root_artifacts: Sequence[DecisionTraceArtifact],
+    stages: Sequence[DecisionTraceStage],
+    baseline: BaselineT,
+    candidate: CandidateT,
+    deployed: BaselineT | CandidateT,
+    baseline_artifact_id: str,
+    candidate_artifact_id: str,
+    metadata: Mapping[str, Any] | None = None,
+) -> DecisionTraceBuildResult[BaselineT, CandidateT]:
+    """Build a generic trace with the exact prospective V2 inventory."""
+
+    trace_metadata = {} if metadata is None else dict(metadata)
+    declared_profile = trace_metadata.get("decision_profile_id")
+    if declared_profile not in (None, PROSPECTIVE_V2_PROFILE_ID):
+        raise ValueError("metadata declares a different decision profile")
+    trace_metadata["decision_profile_id"] = PROSPECTIVE_V2_PROFILE_ID
+    result = build_unified_decision_trace(
+        trace_name=trace_name,
+        protocol_id=protocol_id,
+        case_id=case_id,
+        session_id=session_id,
+        endpoint=endpoint,
+        stack_lock_id=stack_lock_id,
+        root_artifacts=root_artifacts,
+        stages=stages,
+        required_decision_names=PROSPECTIVE_V2_REQUIRED_DECISION_NAMES,
+        baseline=baseline,
+        candidate=candidate,
+        deployed=deployed,
+        baseline_artifact_id=baseline_artifact_id,
+        candidate_artifact_id=candidate_artifact_id,
+        metadata=trace_metadata,
+    )
+    require_prospective_v2_decision_trace_v1(result.trace)
+    return result
+
+
+__all__ = [
+    "PROSPECTIVE_V2_PROFILE_ID",
+    "PROSPECTIVE_V2_PROFILE_SCHEMA_VERSION",
+    "PROSPECTIVE_V2_REQUIRED_DECISION_NAMES",
+    "ProspectiveV2ProfileValidationV1",
+    "build_prospective_v2_decision_trace_v1",
+    "require_prospective_v2_decision_trace_v1",
+    "validate_prospective_v2_decision_trace_v1",
+]

--- a/src/causal4d/prospective_v2_promotion.py
+++ b/src/causal4d/prospective_v2_promotion.py
@@ -1,0 +1,317 @@
+"""Two-phase promotion experiment for prospective Causal4D V2 candidates.
+
+The freeze artifact locks the candidate ladder, independent evaluation units,
+stack identity, source evidence, and all decision thresholds before target
+outcomes are opened. The result evaluates the complete Cartesian product once,
+at the registered independent-unit level, and retains the exact baseline when
+no predeclared candidate passes every endpoint gate.
+
+This module is prospective infrastructure. It does not modify the frozen
+physical-acquisition estimator or reinterpret an existing target result.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+from causal4d._prospective_v2_promotion_candidate_result import (
+    ProspectiveV2CandidateResultV1,
+)
+from causal4d._prospective_v2_promotion_common import (
+    PROSPECTIVE_V2_CANDIDATE_KINDS,
+    PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION,
+)
+from causal4d._prospective_v2_promotion_freeze import (
+    ProspectiveV2PromotionFreezeV1,
+)
+from causal4d._prospective_v2_promotion_inputs import (
+    ProspectiveV2CandidateV1,
+    ProspectiveV2EvaluationUnitV1,
+    ProspectiveV2PromotionPolicyV1,
+)
+from causal4d._prospective_v2_promotion_metrics import (
+    ProspectiveV2EndpointMetricsV1,
+    ProspectiveV2UnitMetricsV1,
+)
+from causal4d._prospective_v2_promotion_result import (
+    ProspectiveV2PromotionResultV1,
+)
+from causal4d.atomic_io import atomic_write_json
+from causal4d.decision_trace import DECISION_TRACE_ENDPOINTS
+
+
+def _mean(values: Sequence[float]) -> float:
+    result = float(np.mean(np.asarray(values, dtype=float)))
+    if not np.isfinite(result):
+        raise ValueError("aggregate metric mean must be finite")
+    return result
+
+
+def _evaluate_endpoint(
+    *,
+    candidate: ProspectiveV2CandidateV1,
+    endpoint: str,
+    units: Sequence[ProspectiveV2EvaluationUnitV1],
+    baseline_metrics: Sequence[ProspectiveV2UnitMetricsV1],
+    candidate_metrics: Sequence[ProspectiveV2UnitMetricsV1],
+    policy: ProspectiveV2PromotionPolicyV1,
+) -> ProspectiveV2EndpointMetricsV1:
+    if len(units) != len(baseline_metrics) or len(units) != len(candidate_metrics):
+        raise ValueError("endpoint metric alignment is incomplete")
+    log_score_gain = _mean(
+        tuple(
+            candidate_metric.log_score - baseline_metric.log_score
+            for baseline_metric, candidate_metric in zip(
+                baseline_metrics,
+                candidate_metrics,
+                strict=True,
+            )
+        )
+    )
+    brier_change = _mean(
+        tuple(
+            candidate_metric.brier_score - baseline_metric.brier_score
+            for baseline_metric, candidate_metric in zip(
+                baseline_metrics,
+                candidate_metrics,
+                strict=True,
+            )
+        )
+    )
+    trajectory_regret = _mean(
+        tuple(
+            candidate_metric.trajectory_error_m - baseline_metric.trajectory_error_m
+            for baseline_metric, candidate_metric in zip(
+                baseline_metrics,
+                candidate_metrics,
+                strict=True,
+            )
+        )
+    )
+    coverage_error = _mean(
+        tuple(metric.coverage_error for metric in candidate_metrics)
+    )
+    interval_width = _mean(
+        tuple(metric.interval_width_m for metric in candidate_metrics)
+    )
+    baseline_interval_width = _mean(
+        tuple(metric.interval_width_m for metric in baseline_metrics)
+    )
+    interval_width_ratio = interval_width / max(
+        baseline_interval_width,
+        policy.interval_width_floor_m,
+    )
+    accepted_count = sum(metric.candidate_accepted for metric in candidate_metrics)
+    harmful_count = sum(metric.harmful_update for metric in candidate_metrics)
+    unit_count = len(candidate_metrics)
+    accepted_rate = accepted_count / unit_count
+    harmful_accepted_rate = harmful_count / accepted_count if accepted_count else 0.0
+    fallback_rate = sum(metric.fallback_used for metric in candidate_metrics) / (
+        unit_count
+    )
+
+    reasons: list[str] = []
+    if log_score_gain < policy.minimum_mean_log_score_gain:
+        reasons.append("mean_log_score_gain_below_limit")
+    if brier_change > policy.maximum_mean_brier_change:
+        reasons.append("mean_brier_change_exceeds_limit")
+    if trajectory_regret > policy.maximum_mean_trajectory_regret_m:
+        reasons.append("mean_trajectory_regret_exceeds_limit")
+    if coverage_error > policy.maximum_mean_coverage_error:
+        reasons.append("mean_coverage_error_exceeds_limit")
+    if interval_width_ratio > policy.maximum_mean_interval_width_ratio:
+        reasons.append("mean_interval_width_ratio_exceeds_limit")
+    if accepted_rate < policy.minimum_accepted_update_rate:
+        reasons.append("accepted_update_rate_below_limit")
+    if harmful_accepted_rate > policy.maximum_harmful_accepted_update_rate:
+        reasons.append("harmful_accepted_update_rate_exceeds_limit")
+    if fallback_rate > policy.maximum_fallback_rate:
+        reasons.append("fallback_rate_exceeds_limit")
+    return ProspectiveV2EndpointMetricsV1(
+        candidate_id=candidate.candidate_id,
+        endpoint=endpoint,
+        unit_count=unit_count,
+        mean_log_score_gain=log_score_gain,
+        mean_brier_change=brier_change,
+        mean_trajectory_regret_m=trajectory_regret,
+        mean_coverage_error=coverage_error,
+        mean_interval_width_m=interval_width,
+        mean_interval_width_ratio=interval_width_ratio,
+        accepted_update_rate=accepted_rate,
+        harmful_accepted_update_rate=harmful_accepted_rate,
+        fallback_rate=fallback_rate,
+        accepted=not reasons,
+        reasons=tuple(reasons),
+    )
+
+
+def evaluate_prospective_v2_promotion_v1(
+    freeze: ProspectiveV2PromotionFreezeV1,
+    metrics: Sequence[ProspectiveV2UnitMetricsV1],
+    *,
+    metadata: Mapping[str, Any] | None = None,
+) -> ProspectiveV2PromotionResultV1:
+    """Evaluate the frozen ladder once and retain exact baseline fallback."""
+
+    if type(freeze) is not ProspectiveV2PromotionFreezeV1:
+        raise ValueError("freeze must be a ProspectiveV2PromotionFreezeV1")
+    metric_tuple = tuple(metrics)
+    if not metric_tuple or any(
+        type(value) is not ProspectiveV2UnitMetricsV1 for value in metric_tuple
+    ):
+        raise ValueError("metrics must contain ProspectiveV2UnitMetricsV1 values")
+    keys = tuple((metric.unit_id, metric.candidate_id) for metric in metric_tuple)
+    if len(set(keys)) != len(keys):
+        raise ValueError("unit/candidate metric pairs must be unique")
+    expected_keys = {
+        (unit.unit_id, candidate.candidate_id)
+        for unit in freeze.evaluation_units
+        for candidate in freeze.candidates
+    }
+    actual_keys = set(keys)
+    missing = sorted(expected_keys - actual_keys)
+    unexpected = sorted(actual_keys - expected_keys)
+    if missing or unexpected:
+        raise ValueError(
+            "evaluation metrics must cover the frozen unit/candidate product; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    unit_index = {unit.unit_id: unit for unit in freeze.evaluation_units}
+    opening_ids = {metric.evaluation_opening_id for metric in metric_tuple}
+    if len(opening_ids) != 1:
+        raise ValueError("all evaluation metrics must come from one target opening")
+    for metric in metric_tuple:
+        unit = unit_index[metric.unit_id]
+        if metric.endpoint != unit.endpoint:
+            raise ValueError("unit metric endpoint disagrees with the frozen unit")
+        if not metric.target_outcomes_used:
+            raise ValueError("evaluation result metrics must use target outcomes")
+
+    metric_index = {
+        (metric.unit_id, metric.candidate_id): metric for metric in metric_tuple
+    }
+    baseline = freeze.candidates[0]
+    for unit in freeze.evaluation_units:
+        baseline_metric = metric_index[(unit.unit_id, baseline.candidate_id)]
+        if (
+            not baseline_metric.candidate_accepted
+            or baseline_metric.fallback_used
+            or baseline_metric.harmful_update
+        ):
+            raise ValueError(
+                "registered baseline metrics must be accepted, nonfallback, "
+                "and nonharmful"
+            )
+
+    candidate_results: list[ProspectiveV2CandidateResultV1] = []
+    for candidate in freeze.candidates[1:]:
+        endpoint_metrics: list[ProspectiveV2EndpointMetricsV1] = []
+        for endpoint in DECISION_TRACE_ENDPOINTS:
+            units = tuple(
+                unit for unit in freeze.evaluation_units if unit.endpoint == endpoint
+            )
+            baseline_metrics = tuple(
+                metric_index[(unit.unit_id, baseline.candidate_id)] for unit in units
+            )
+            candidate_metrics = tuple(
+                metric_index[(unit.unit_id, candidate.candidate_id)] for unit in units
+            )
+            endpoint_metrics.append(
+                _evaluate_endpoint(
+                    candidate=candidate,
+                    endpoint=endpoint,
+                    units=units,
+                    baseline_metrics=baseline_metrics,
+                    candidate_metrics=candidate_metrics,
+                    policy=freeze.policy,
+                )
+            )
+        reasons = tuple(
+            f"{metric.endpoint}:{reason}"
+            for metric in endpoint_metrics
+            for reason in metric.reasons
+        )
+        candidate_results.append(
+            ProspectiveV2CandidateResultV1(
+                candidate_id=candidate.candidate_id,
+                candidate_kind=candidate.candidate_kind,
+                candidate_artifact_id=candidate.artifact_id,
+                endpoint_metrics=tuple(endpoint_metrics),
+                accepted=not reasons,
+                reasons=reasons,
+            )
+        )
+
+    accepted_ids = {
+        result.candidate_id for result in candidate_results if result.accepted
+    }
+    selected = baseline
+    for candidate in freeze.candidates[1:]:
+        if candidate.candidate_id in accepted_ids:
+            selected = candidate
+    ordered_metric_ids = tuple(
+        metric_index[(unit.unit_id, candidate.candidate_id)].metric_id
+        for unit in freeze.evaluation_units
+        for candidate in freeze.candidates
+    )
+    return ProspectiveV2PromotionResultV1(
+        freeze_id=freeze.freeze_id,
+        evaluation_opening_id=next(iter(opening_ids)),
+        baseline_candidate_id=baseline.candidate_id,
+        baseline_artifact_id=baseline.artifact_id,
+        selected_candidate_id=selected.candidate_id,
+        selected_candidate_kind=selected.candidate_kind,
+        selected_artifact_id=selected.artifact_id,
+        candidate_results=tuple(candidate_results),
+        evaluation_metric_ids=ordered_metric_ids,
+        exact_artifact_fallback_verified=True,
+        one_target_opening_verified=True,
+        target_outcomes_used=True,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def write_prospective_v2_promotion_freeze(
+    path: str | Path,
+    freeze: ProspectiveV2PromotionFreezeV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Atomically publish a validated target-free promotion freeze."""
+
+    if type(freeze) is not ProspectiveV2PromotionFreezeV1:
+        raise ValueError("freeze must be a ProspectiveV2PromotionFreezeV1")
+    atomic_write_json(path, freeze.as_dict(), overwrite=overwrite)
+
+
+def write_prospective_v2_promotion_result(
+    path: str | Path,
+    result: ProspectiveV2PromotionResultV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Atomically publish a validated one-opening promotion result."""
+
+    if type(result) is not ProspectiveV2PromotionResultV1:
+        raise ValueError("result must be a ProspectiveV2PromotionResultV1")
+    atomic_write_json(path, result.as_dict(), overwrite=overwrite)
+
+
+__all__ = [
+    "PROSPECTIVE_V2_CANDIDATE_KINDS",
+    "PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION",
+    "ProspectiveV2CandidateResultV1",
+    "ProspectiveV2CandidateV1",
+    "ProspectiveV2EndpointMetricsV1",
+    "ProspectiveV2EvaluationUnitV1",
+    "ProspectiveV2PromotionFreezeV1",
+    "ProspectiveV2PromotionPolicyV1",
+    "ProspectiveV2PromotionResultV1",
+    "ProspectiveV2UnitMetricsV1",
+    "evaluate_prospective_v2_promotion_v1",
+    "write_prospective_v2_promotion_freeze",
+    "write_prospective_v2_promotion_result",
+]

--- a/tests/test_projected_functional_support_v1.py
+++ b/tests/test_projected_functional_support_v1.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from causal4d.functional_support_v1 import (
+    FunctionalSupportActionV1,
+    FunctionalSupportPolicyV1,
+    certify_functional_support_v1,
+)
+from causal4d.projected_functional_support_v1 import (
+    FunctionalSupportProjectionV1,
+    ProjectedFunctionalSupportActionV1,
+    ProjectedFunctionalSupportPolicyV1,
+    certify_projected_functional_support_v1,
+)
+
+
+def _base_policy(**overrides: float | int) -> FunctionalSupportPolicyV1:
+    values: dict[str, float | int] = {
+        "maximum_normalized_mean_error": 10.0,
+        "maximum_variance_trace_relative_error": 10.0,
+        "maximum_interval_endpoint_error_m": 10.0,
+        "maximum_energy_distance_m": 10.0,
+        "variance_floor_m2": 1e-6,
+    }
+    values.update(overrides)
+    return FunctionalSupportPolicyV1(**values)
+
+
+def _projected_policy(
+    **overrides: float | int,
+) -> ProjectedFunctionalSupportPolicyV1:
+    values: dict[str, float | int] = {
+        "maximum_projected_variance_relative_error": 0.05,
+        "maximum_projected_interval_endpoint_error_m": 0.05,
+        "variance_floor_m2": 1e-6,
+    }
+    values.update(overrides)
+    return ProjectedFunctionalSupportPolicyV1(**values)
+
+
+def _base_certificate(
+    action: FunctionalSupportActionV1,
+    *,
+    policy: FunctionalSupportPolicyV1 | None = None,
+):
+    return certify_functional_support_v1(
+        (action,),
+        policy=_base_policy() if policy is None else policy,
+        source_artifact_ids=("source-freeze",),
+    )
+
+
+def test_identical_support_passes_fixed_task_projections() -> None:
+    trajectories = np.asarray(
+        (
+            (((-1.0, -0.5),),),
+            (((1.0, 0.5),),),
+        )
+    )
+    action = FunctionalSupportActionV1(
+        action_id="source-action",
+        full_trajectories_m=trajectories,
+        full_weights=np.asarray((0.5, 0.5)),
+        reduced_trajectories_m=trajectories.copy(),
+        reduced_weights=np.asarray((0.5, 0.5)),
+    )
+    projection = FunctionalSupportProjectionV1(
+        projection_id="endpoint-sum",
+        coefficients=np.asarray((((1.0, 1.0),),)),
+    )
+    certificate = certify_projected_functional_support_v1(
+        (action,),
+        (projection,),
+        policy=_projected_policy(),
+        base_certificate=_base_certificate(action),
+        source_artifact_ids=("projection-freeze",),
+    )
+
+    assert certificate.accepted
+    assert certificate.reasons == ()
+    assert certificate.metrics[0].projected_variance_relative_error == pytest.approx(
+        0.0
+    )
+    assert certificate.metrics[0].maximum_projected_interval_endpoint_error_m == (
+        pytest.approx(0.0)
+    )
+
+
+def test_projection_detects_dependence_change_hidden_by_marginal_metrics() -> None:
+    full = np.asarray(
+        (
+            (((-1.0, -1.0),),),
+            (((1.0, 1.0),),),
+        )
+    )
+    reduced = np.asarray(
+        (
+            (((-1.0, 1.0),),),
+            (((1.0, -1.0),),),
+        )
+    )
+    action = FunctionalSupportActionV1(
+        action_id="rotated-dependence",
+        full_trajectories_m=full,
+        full_weights=np.asarray((0.5, 0.5)),
+        reduced_trajectories_m=reduced,
+        reduced_weights=np.asarray((0.5, 0.5)),
+    )
+    base = _base_certificate(action)
+    assert base.accepted
+    projection = FunctionalSupportProjectionV1(
+        projection_id="sum-mode",
+        coefficients=np.asarray((((2**-0.5, 2**-0.5),),)),
+    )
+
+    certificate = certify_projected_functional_support_v1(
+        (action,),
+        (projection,),
+        policy=_projected_policy(),
+        base_certificate=base,
+        source_artifact_ids=("projection-freeze",),
+    )
+
+    assert not certificate.accepted
+    metric = certificate.metrics[0]
+    assert metric.full_mean_m == pytest.approx(metric.reduced_mean_m)
+    assert metric.projected_variance_relative_error > 0.9
+    assert (
+        "rotated-dependence:sum-mode:"
+        "projected_variance_relative_error_exceeds_limit"
+    ) in certificate.reasons
+
+
+def test_low_rank_conditional_modes_are_projected_exactly() -> None:
+    trajectories = np.asarray(((((0.0, 0.0),),),))
+    action = FunctionalSupportActionV1(
+        "structured-uncertainty",
+        trajectories,
+        np.asarray((1.0,)),
+        trajectories.copy(),
+        np.asarray((1.0,)),
+    )
+    base = _base_certificate(action)
+    assert base.accepted
+    projected_action = ProjectedFunctionalSupportActionV1(
+        action=action,
+        full_component_low_rank_factors_m=np.asarray(((((1.0, 1.0),),),)),
+        reduced_component_low_rank_factors_m=np.asarray(((((1.0, -1.0),),),)),
+    )
+    projection = FunctionalSupportProjectionV1(
+        "sum-mode",
+        np.asarray((((1.0, 1.0),),)),
+    )
+
+    certificate = certify_projected_functional_support_v1(
+        (projected_action,),
+        (projection,),
+        policy=_projected_policy(),
+        base_certificate=base,
+        source_artifact_ids=("projection-freeze",),
+    )
+
+    assert not certificate.accepted
+    metric = certificate.metrics[0]
+    assert metric.full_variance_m2 > 3.9
+    assert metric.reduced_variance_m2 < 1e-4
+    assert metric.projected_variance_relative_error > 0.99
+
+
+def test_base_rejection_is_preserved_by_projected_certificate() -> None:
+    full = np.asarray(((((0.0, 0.0),),),))
+    reduced = np.asarray(((((1.0, 0.0),),),))
+    action = FunctionalSupportActionV1(
+        "shifted",
+        full,
+        np.asarray((1.0,)),
+        reduced,
+        np.asarray((1.0,)),
+    )
+    base = _base_certificate(
+        action,
+        policy=_base_policy(maximum_normalized_mean_error=0.0),
+    )
+    assert not base.accepted
+    projection = FunctionalSupportProjectionV1(
+        "x-readout",
+        np.asarray((((1.0, 0.0),),)),
+    )
+
+    certificate = certify_projected_functional_support_v1(
+        (action,),
+        (projection,),
+        policy=_projected_policy(
+            maximum_projected_variance_relative_error=10.0,
+            maximum_projected_interval_endpoint_error_m=10.0,
+        ),
+        base_certificate=base,
+        source_artifact_ids=("projection-freeze",),
+    )
+
+    assert not certificate.accepted
+    assert any(reason.startswith("base:") for reason in certificate.reasons)
+
+
+def test_projection_shape_and_base_provenance_fail_closed() -> None:
+    trajectories = np.asarray(((((0.0, 0.0),),),))
+    action = FunctionalSupportActionV1(
+        "source-action",
+        trajectories,
+        np.asarray((1.0,)),
+        trajectories,
+        np.asarray((1.0,)),
+    )
+    base = _base_certificate(action)
+    wrong_shape = FunctionalSupportProjectionV1(
+        "wrong-shape",
+        np.ones((2, 1, 2)),
+    )
+    with pytest.raises(ValueError, match="expected"):
+        certify_projected_functional_support_v1(
+            (action,),
+            (wrong_shape,),
+            policy=_projected_policy(),
+            base_certificate=base,
+            source_artifact_ids=("projection-freeze",),
+        )
+
+    with pytest.raises(ValueError, match="does not bind"):
+        certify_projected_functional_support_v1(
+            (action,),
+            (
+                FunctionalSupportProjectionV1(
+                    "valid",
+                    np.asarray((((1.0, 0.0),),)),
+                ),
+            ),
+            policy=_projected_policy(),
+            base_certificate=replace(
+                base,
+                source_artifact_ids=("different-source",),
+            ),
+            source_artifact_ids=("projection-freeze",),
+        )
+
+
+def test_projection_identity_binds_coefficients() -> None:
+    first = FunctionalSupportProjectionV1(
+        "readout",
+        np.asarray((((1.0, 0.0),),)),
+    )
+    second = FunctionalSupportProjectionV1(
+        "readout",
+        np.asarray((((0.0, 1.0),),)),
+    )
+    assert first.projection_artifact_id != second.projection_artifact_id
+    with pytest.raises(ValueError, match="nonzero"):
+        FunctionalSupportProjectionV1(
+            "zero",
+            np.zeros((1, 1, 2)),
+        )

--- a/tests/test_prospective_v2_profile.py
+++ b/tests/test_prospective_v2_profile.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import hashlib
+
+import pytest
+
+from causal4d.decision_trace import (
+    DecisionTraceArtifact,
+    DecisionTraceDecision,
+    DecisionTraceStage,
+    UnifiedDecisionTrace,
+    build_unified_decision_trace,
+)
+from causal4d.prospective_v2_profile import (
+    PROSPECTIVE_V2_PROFILE_ID,
+    PROSPECTIVE_V2_REQUIRED_DECISION_NAMES,
+    build_prospective_v2_decision_trace_v1,
+    require_prospective_v2_decision_trace_v1,
+    validate_prospective_v2_decision_trace_v1,
+)
+
+
+def _id(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _artifact(role: str, producer: str) -> DecisionTraceArtifact:
+    return DecisionTraceArtifact(
+        artifact_id=_id(role),
+        artifact_kind=f"test.{role}",
+        role=role,
+        producer=producer,  # type: ignore[arg-type]
+    )
+
+
+def _decision(
+    name: str,
+    producer: str,
+    *,
+    accepted: bool = True,
+) -> DecisionTraceDecision:
+    reasons = () if accepted else ("source_gate_rejected",)
+    return DecisionTraceDecision(
+        name=name,
+        decision_id=_id(f"decision:{name}:{accepted}"),
+        decision_kind=f"test.{name}",
+        producer=producer,  # type: ignore[arg-type]
+        accepted=accepted,
+        reasons=reasons,
+    )
+
+
+def _parts(
+    *,
+    rejected: str | None = None,
+    wrong_stage: str | None = None,
+    legacy_inventory: bool = False,
+):
+    factual = _artifact("factual_evidence_context", "causal4d")
+    query = _artifact("counterfactual_query_context", "causal4d")
+    observation = _artifact("prob4d_observation", "prob4d")
+    belief = _artifact("bayesian_phystwin_belief", "bayesian-phystwin")
+    baseline_prediction = _artifact("baseline_prediction", "bayesian-phystwin")
+    factual_posterior = _artifact("causal4d_factual_posterior", "causal4d")
+    candidate_prediction = _artifact("candidate_prediction", "causal4d")
+
+    names = PROSPECTIVE_V2_REQUIRED_DECISION_NAMES
+    if legacy_inventory:
+        names = (
+            "prob4d_provider_acceptance",
+            "bayesian_phystwin_acceptance",
+            "intervention_identifiability",
+            "action_support",
+            "contact_v2_support",
+            "query_calibration",
+            "counterfactual_regret",
+        )
+
+    decision_by_name = {
+        name: _decision(
+            name,
+            (
+                "prob4d"
+                if name == "prob4d_provider_acceptance"
+                else "bayesian-phystwin"
+                if name == "bayesian_phystwin_acceptance"
+                else "causal4d"
+            ),
+            accepted=name != rejected,
+        )
+        for name in names
+    }
+
+    prob4d_decisions = [decision_by_name["prob4d_provider_acceptance"]]
+    bpt_decisions = [decision_by_name["bayesian_phystwin_acceptance"]]
+    abduction_names = [
+        "joint_covariance_admission",
+        "functional_support",
+        "intervention_identifiability",
+        "action_support",
+        "contact_v2_support",
+    ]
+    counterfactual_names = [
+        "conditional_uncertainty_calibration",
+        "query_calibration",
+    ]
+    deployment_names = ["counterfactual_regret"]
+
+    if wrong_stage is not None:
+        for groups in (
+            abduction_names,
+            counterfactual_names,
+            deployment_names,
+        ):
+            if wrong_stage in groups:
+                groups.remove(wrong_stage)
+        counterfactual_names.append(wrong_stage)
+
+    stages = (
+        DecisionTraceStage(
+            stage_name="prob4d observation",
+            stage_kind="prob4d_observation",
+            producer="prob4d",
+            input_artifact_ids=(factual.artifact_id,),
+            output_artifacts=(observation,),
+            decisions=tuple(prob4d_decisions),
+        ),
+        DecisionTraceStage(
+            stage_name="bayesian physical belief",
+            stage_kind="bayesian_phystwin_belief",
+            producer="bayesian-phystwin",
+            input_artifact_ids=(observation.artifact_id,),
+            output_artifacts=(belief, baseline_prediction),
+            decisions=tuple(bpt_decisions),
+        ),
+        DecisionTraceStage(
+            stage_name="causal factual abduction",
+            stage_kind="causal4d_abduction",
+            producer="causal4d",
+            input_artifact_ids=(observation.artifact_id, belief.artifact_id),
+            output_artifacts=(factual_posterior,),
+            decisions=tuple(
+                decision_by_name[name]
+                for name in abduction_names
+                if name in decision_by_name
+            ),
+        ),
+        DecisionTraceStage(
+            stage_name="causal counterfactual",
+            stage_kind="causal4d_counterfactual",
+            producer="causal4d",
+            input_artifact_ids=(factual_posterior.artifact_id, query.artifact_id),
+            output_artifacts=(candidate_prediction,),
+            decisions=tuple(
+                decision_by_name[name]
+                for name in counterfactual_names
+                if name in decision_by_name
+            ),
+        ),
+        DecisionTraceStage(
+            stage_name="deployment",
+            stage_kind="deployment",
+            producer="causal4d",
+            input_artifact_ids=(
+                baseline_prediction.artifact_id,
+                candidate_prediction.artifact_id,
+            ),
+            decisions=tuple(
+                decision_by_name[name]
+                for name in deployment_names
+                if name in decision_by_name
+            ),
+        ),
+    )
+    return (
+        (factual, query),
+        stages,
+        names,
+        baseline_prediction.artifact_id,
+        candidate_prediction.artifact_id,
+    )
+
+
+def test_complete_profile_selects_exact_candidate_object() -> None:
+    roots, stages, _, baseline_id, candidate_id = _parts()
+    baseline = object()
+    candidate = object()
+    result = build_prospective_v2_decision_trace_v1(
+        trace_name="case trace",
+        protocol_id="protocol-v2",
+        case_id="case-001",
+        session_id="session-001",
+        endpoint="same_grasp_transfer",
+        stack_lock_id=_id("stack"),
+        root_artifacts=roots,
+        stages=stages,
+        baseline=baseline,
+        candidate=candidate,
+        deployed=candidate,
+        baseline_artifact_id=baseline_id,
+        candidate_artifact_id=candidate_id,
+    )
+
+    assert result.deployed is candidate
+    assert result.trace.selection.candidate_selected
+    assert result.trace.metadata["decision_profile_id"] == PROSPECTIVE_V2_PROFILE_ID
+    validation = validate_prospective_v2_decision_trace_v1(result.trace)
+    assert validation.accepted
+    assert validation.rejected_required_decision_names == ()
+
+
+def test_rejected_v2_gate_preserves_exact_baseline_object() -> None:
+    roots, stages, _, baseline_id, candidate_id = _parts(
+        rejected="conditional_uncertainty_calibration"
+    )
+    baseline = object()
+    candidate = object()
+    result = build_prospective_v2_decision_trace_v1(
+        trace_name="case trace",
+        protocol_id="protocol-v2",
+        case_id="case-001",
+        session_id="session-001",
+        endpoint="new_contact_transfer",
+        stack_lock_id=_id("stack"),
+        root_artifacts=roots,
+        stages=stages,
+        baseline=baseline,
+        candidate=candidate,
+        deployed=baseline,
+        baseline_artifact_id=baseline_id,
+        candidate_artifact_id=candidate_id,
+    )
+
+    assert result.deployed is baseline
+    assert not result.trace.selection.candidate_selected
+    validation = validate_prospective_v2_decision_trace_v1(result.trace)
+    assert validation.accepted
+    assert validation.rejected_required_decision_names == (
+        "conditional_uncertainty_calibration",
+    )
+
+
+def test_legacy_inventory_is_not_a_v2_deployment_profile() -> None:
+    roots, stages, names, baseline_id, candidate_id = _parts(legacy_inventory=True)
+    baseline = object()
+    candidate = object()
+    generic = build_unified_decision_trace(
+        trace_name="legacy trace",
+        protocol_id="protocol-v2",
+        case_id="case-001",
+        session_id="session-001",
+        endpoint="same_grasp_transfer",
+        stack_lock_id=_id("stack"),
+        root_artifacts=roots,
+        stages=stages,
+        required_decision_names=names,
+        baseline=baseline,
+        candidate=candidate,
+        deployed=candidate,
+        baseline_artifact_id=baseline_id,
+        candidate_artifact_id=candidate_id,
+        metadata={"decision_profile_id": PROSPECTIVE_V2_PROFILE_ID},
+    ).trace
+
+    validation = validate_prospective_v2_decision_trace_v1(generic)
+    assert not validation.accepted
+    assert "missing_required_decision:joint_covariance_admission" in (
+        validation.reasons
+    )
+    assert "missing_required_decision:functional_support" in validation.reasons
+    assert (
+        "missing_required_decision:conditional_uncertainty_calibration"
+        in validation.reasons
+    )
+    assert "selection_required_decision_inventory_mismatch" in validation.reasons
+    with pytest.raises(ValueError, match="does not satisfy"):
+        require_prospective_v2_decision_trace_v1(generic)
+
+
+def test_required_decision_must_appear_at_the_registered_stage() -> None:
+    roots, stages, names, baseline_id, candidate_id = _parts(
+        wrong_stage="functional_support"
+    )
+    baseline = object()
+    candidate = object()
+    generic = build_unified_decision_trace(
+        trace_name="wrong-stage trace",
+        protocol_id="protocol-v2",
+        case_id="case-001",
+        session_id="session-001",
+        endpoint="factual_continuation",
+        stack_lock_id=_id("stack"),
+        root_artifacts=roots,
+        stages=stages,
+        required_decision_names=names,
+        baseline=baseline,
+        candidate=candidate,
+        deployed=candidate,
+        baseline_artifact_id=baseline_id,
+        candidate_artifact_id=candidate_id,
+        metadata={"decision_profile_id": PROSPECTIVE_V2_PROFILE_ID},
+    ).trace
+
+    validation = validate_prospective_v2_decision_trace_v1(generic)
+    assert not validation.accepted
+    assert (
+        "required_decision_wrong_stage:functional_support:"
+        "causal4d_counterfactual"
+    ) in validation.reasons
+
+
+def test_profile_metadata_is_content_bound_and_cannot_be_redeclared() -> None:
+    roots, stages, _, baseline_id, candidate_id = _parts()
+    baseline = object()
+    candidate = object()
+    with pytest.raises(ValueError, match="different decision profile"):
+        build_prospective_v2_decision_trace_v1(
+            trace_name="case trace",
+            protocol_id="protocol-v2",
+            case_id="case-001",
+            session_id="session-001",
+            endpoint="same_grasp_transfer",
+            stack_lock_id=_id("stack"),
+            root_artifacts=roots,
+            stages=stages,
+            baseline=baseline,
+            candidate=candidate,
+            deployed=candidate,
+            baseline_artifact_id=baseline_id,
+            candidate_artifact_id=candidate_id,
+            metadata={"decision_profile_id": "other-profile"},
+        )
+
+    valid = build_prospective_v2_decision_trace_v1(
+        trace_name="case trace",
+        protocol_id="protocol-v2",
+        case_id="case-001",
+        session_id="session-001",
+        endpoint="same_grasp_transfer",
+        stack_lock_id=_id("stack"),
+        root_artifacts=roots,
+        stages=stages,
+        baseline=baseline,
+        candidate=candidate,
+        deployed=candidate,
+        baseline_artifact_id=baseline_id,
+        candidate_artifact_id=candidate_id,
+    ).trace
+    tampered = replace(valid, metadata={"decision_profile_id": "other-profile"})
+    validation = validate_prospective_v2_decision_trace_v1(tampered)
+    assert not validation.accepted
+    assert "decision_profile_id_mismatch" in validation.reasons
+    assert isinstance(tampered, UnifiedDecisionTrace)

--- a/tests/test_prospective_v2_promotion.py
+++ b/tests/test_prospective_v2_promotion.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import hashlib
+
+import pytest
+
+from causal4d.decision_trace import DECISION_TRACE_ENDPOINTS
+from causal4d.prospective_v2_promotion import (
+    PROSPECTIVE_V2_CANDIDATE_KINDS,
+    ProspectiveV2CandidateV1,
+    ProspectiveV2EvaluationUnitV1,
+    ProspectiveV2PromotionFreezeV1,
+    ProspectiveV2PromotionPolicyV1,
+    ProspectiveV2PromotionResultV1,
+    ProspectiveV2UnitMetricsV1,
+    evaluate_prospective_v2_promotion_v1,
+)
+
+
+def _id(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _candidates() -> tuple[ProspectiveV2CandidateV1, ...]:
+    return tuple(
+        ProspectiveV2CandidateV1(
+            candidate_id=f"candidate-{index}",
+            candidate_kind=kind,
+            artifact_id=_id(f"artifact:{kind}"),
+            source_configuration_id=_id(f"configuration:{kind}"),
+            components=(kind,),
+        )
+        for index, kind in enumerate(PROSPECTIVE_V2_CANDIDATE_KINDS)
+    )
+
+
+def _units() -> tuple[ProspectiveV2EvaluationUnitV1, ...]:
+    return tuple(
+        ProspectiveV2EvaluationUnitV1(
+            unit_id=f"{endpoint}-{index}",
+            endpoint=endpoint,
+            independent_group_id=f"{endpoint}-group-{index}",
+        )
+        for endpoint in DECISION_TRACE_ENDPOINTS
+        for index in range(2)
+    )
+
+
+def _policy() -> ProspectiveV2PromotionPolicyV1:
+    return ProspectiveV2PromotionPolicyV1(
+        minimum_units_per_endpoint=2,
+        minimum_mean_log_score_gain=0.01,
+        maximum_mean_brier_change=0.0,
+        maximum_mean_trajectory_regret_m=0.0,
+        maximum_mean_coverage_error=0.15,
+        maximum_mean_interval_width_ratio=1.25,
+        minimum_accepted_update_rate=0.5,
+        maximum_harmful_accepted_update_rate=0.25,
+        maximum_fallback_rate=0.5,
+    )
+
+
+def _freeze() -> ProspectiveV2PromotionFreezeV1:
+    return ProspectiveV2PromotionFreezeV1(
+        experiment_id="prospective-v2-evaluation",
+        stack_lock_id=_id("stack"),
+        candidates=_candidates(),
+        evaluation_units=_units(),
+        policy=_policy(),
+        source_artifact_ids=(_id("source-panel"),),
+    )
+
+
+def _metrics(
+    freeze: ProspectiveV2PromotionFreezeV1,
+    *,
+    failing_candidate_id: str | None = None,
+    all_candidates_fail: bool = False,
+) -> tuple[ProspectiveV2UnitMetricsV1, ...]:
+    opening_id = _id("single-evaluation-opening")
+    metrics: list[ProspectiveV2UnitMetricsV1] = []
+    baseline = freeze.candidates[0]
+    for unit in freeze.evaluation_units:
+        metrics.append(
+            ProspectiveV2UnitMetricsV1(
+                unit_id=unit.unit_id,
+                endpoint=unit.endpoint,
+                candidate_id=baseline.candidate_id,
+                evaluation_opening_id=opening_id,
+                log_score=-1.0,
+                brier_score=0.30,
+                trajectory_error_m=0.10,
+                coverage_error=0.10,
+                interval_width_m=0.20,
+                candidate_accepted=True,
+                harmful_update=False,
+                fallback_used=False,
+            )
+        )
+        for candidate in freeze.candidates[1:]:
+            fails = (
+                all_candidates_fail
+                or candidate.candidate_id == failing_candidate_id
+            )
+            metrics.append(
+                ProspectiveV2UnitMetricsV1(
+                    unit_id=unit.unit_id,
+                    endpoint=unit.endpoint,
+                    candidate_id=candidate.candidate_id,
+                    evaluation_opening_id=opening_id,
+                    log_score=-1.10 if fails else -0.90,
+                    brier_score=0.35 if fails else 0.25,
+                    trajectory_error_m=0.12 if fails else 0.08,
+                    coverage_error=0.20 if fails else 0.08,
+                    interval_width_m=0.30 if fails else 0.18,
+                    candidate_accepted=True,
+                    harmful_update=fails,
+                    fallback_used=False,
+                )
+            )
+    return tuple(metrics)
+
+
+def test_highest_passing_candidate_is_selected() -> None:
+    freeze = _freeze()
+    result = evaluate_prospective_v2_promotion_v1(
+        freeze,
+        _metrics(freeze),
+    )
+
+    expected = freeze.candidates[-1]
+    assert result.selected_candidate_id == expected.candidate_id
+    assert result.selected_candidate_kind == expected.candidate_kind
+    assert result.selected_artifact_id == expected.artifact_id
+    assert all(candidate.accepted for candidate in result.candidate_results)
+    assert result.one_target_opening_verified
+    assert result.exact_artifact_fallback_verified
+
+
+def test_failed_top_candidate_selects_highest_remaining_pass() -> None:
+    freeze = _freeze()
+    result = evaluate_prospective_v2_promotion_v1(
+        freeze,
+        _metrics(freeze, failing_candidate_id=freeze.candidates[-1].candidate_id),
+    )
+
+    expected = freeze.candidates[-2]
+    assert result.selected_candidate_id == expected.candidate_id
+    assert result.selected_artifact_id == expected.artifact_id
+    assert not result.candidate_results[-1].accepted
+    assert any(
+        reason.endswith("harmful_accepted_update_rate_exceeds_limit")
+        for reason in result.candidate_results[-1].reasons
+    )
+
+
+def test_all_failed_candidates_preserve_exact_registered_baseline() -> None:
+    freeze = _freeze()
+    result = evaluate_prospective_v2_promotion_v1(
+        freeze,
+        _metrics(freeze, all_candidates_fail=True),
+    )
+
+    baseline = freeze.candidates[0]
+    assert result.selected_candidate_id == baseline.candidate_id
+    assert result.selected_candidate_kind == "registered_v1"
+    assert result.selected_artifact_id == baseline.artifact_id
+    assert not any(candidate.accepted for candidate in result.candidate_results)
+
+
+def test_incomplete_or_multiple_opening_metrics_fail_closed() -> None:
+    freeze = _freeze()
+    metrics = _metrics(freeze)
+    with pytest.raises(ValueError, match="frozen unit/candidate product"):
+        evaluate_prospective_v2_promotion_v1(freeze, metrics[:-1])
+
+    changed = replace(metrics[-1], evaluation_opening_id=_id("second-opening"))
+    with pytest.raises(ValueError, match="one target opening"):
+        evaluate_prospective_v2_promotion_v1(
+            freeze,
+            (*metrics[:-1], changed),
+        )
+
+
+def test_evaluation_units_must_be_independent_within_endpoint() -> None:
+    candidates = _candidates()
+    duplicate_group_units = list(_units())
+    duplicate_group_units[1] = replace(
+        duplicate_group_units[1],
+        independent_group_id=duplicate_group_units[0].independent_group_id,
+    )
+    with pytest.raises(ValueError, match="unique within each endpoint"):
+        ProspectiveV2PromotionFreezeV1(
+            experiment_id="prospective-v2-evaluation",
+            stack_lock_id=_id("stack"),
+            candidates=candidates,
+            evaluation_units=tuple(duplicate_group_units),
+            policy=_policy(),
+            source_artifact_ids=(_id("source-panel"),),
+        )
+
+
+def test_source_freeze_rejects_target_outcome_metadata() -> None:
+    with pytest.raises(ValueError, match="forbidden"):
+        ProspectiveV2CandidateV1(
+            candidate_id="candidate",
+            candidate_kind="registered_v1",
+            artifact_id=_id("artifact"),
+            source_configuration_id=_id("configuration"),
+            components=("registered",),
+            metadata={"nested": {"target_loss": 1.0}},
+        )
+
+
+def test_unit_metrics_require_target_use_and_consistent_acceptance() -> None:
+    values = {
+        "unit_id": "unit",
+        "endpoint": "factual_continuation",
+        "candidate_id": "candidate",
+        "evaluation_opening_id": _id("opening"),
+        "log_score": -1.0,
+        "brier_score": 0.2,
+        "trajectory_error_m": 0.1,
+        "coverage_error": 0.1,
+        "interval_width_m": 0.2,
+        "candidate_accepted": True,
+        "harmful_update": False,
+        "fallback_used": False,
+    }
+    with pytest.raises(ValueError, match="must be true"):
+        ProspectiveV2UnitMetricsV1(**values, target_outcomes_used=False)
+    inconsistent = {**values, "candidate_accepted": True, "fallback_used": True}
+    with pytest.raises(ValueError, match="complement"):
+        ProspectiveV2UnitMetricsV1(**inconsistent)
+
+
+def test_result_construction_rejects_invented_selection() -> None:
+    freeze = _freeze()
+    result = evaluate_prospective_v2_promotion_v1(freeze, _metrics(freeze))
+    with pytest.raises(ValueError, match="highest accepted"):
+        replace(
+            result,
+            selected_candidate_id=result.baseline_candidate_id,
+            selected_candidate_kind="registered_v1",
+            selected_artifact_id=result.baseline_artifact_id,
+        )
+    assert isinstance(result, ProspectiveV2PromotionResultV1)
+
+
+def test_result_identity_binds_metrics_and_selection() -> None:
+    freeze = _freeze()
+    first = evaluate_prospective_v2_promotion_v1(freeze, _metrics(freeze))
+    changed_metrics = list(_metrics(freeze))
+    changed_metrics[-1] = replace(changed_metrics[-1], log_score=-0.89)
+    second = evaluate_prospective_v2_promotion_v1(freeze, tuple(changed_metrics))
+    assert first.result_id != second.result_id


### PR DESCRIPTION
## Summary

Replace the earlier self-declared prospective-promotion result objects with an evidence-bound candidate-selection protocol.

The rewritten implementation:

- freezes the exact stack lock, target-access seal, candidate ladder, candidate configurations, independent evaluation units, target-artifact inventory, scoring implementation, metric semantics, endpoint thresholds, and source artifact inventory before target access;
- derives the one-opening inventory from the freeze and exact ordered target identities rather than accepting a caller-supplied verification flag;
- binds each non-baseline candidate/unit evaluation to a validated prospective-V2 decision trace, factual context, counterfactual query, target artifact, baseline prediction, candidate prediction, scoring run, and metric contract;
- derives candidate admission, exact fallback, harmful accepted updates, log-score gain, Brier change, trajectory regret, coverage error, and interval-width ratio from the source artifacts instead of accepting caller-supplied booleans;
- requires the complete registered unit × candidate Cartesian product and aggregates factual, same-grasp, and new-contact endpoints at the independent-unit level;
- selects the highest passing member of the frozen candidate ladder or preserves the exact registered baseline when none passes; and
- marks every result as candidate-selection-only, prohibits an unbiased post-selection performance claim, and requires a fresh independent confirmation panel.

## Validation

The branch is being published through a self-removing bounded workflow that verifies the exact compressed patch and decoded patch SHA-256 values, applies Ruff formatting and linting, compiles the new modules, runs the focused decision-trace/projected-support/profile/promotion tests, runs the complete default pytest suite, builds wheel and source distributions outside the checkout, and force-with-lease squashes all transport commits into one reviewable source commit.

GitHub's ordinary pull-request workflows remain authoritative after that source commit is published.

## Scientific boundary

This is prospective candidate-selection infrastructure only. It changes no frozen estimator, six-frame information boundary, registered acquisition candidate, 18-session/36-execution protocol, target identities, calibration rule, physical result, or confirmatory evidence count. A positive selection result is not an unbiased post-selection performance result; independent confirmation remains mandatory.