### PR TITLE
Bind strict sensor updates to the embedded evidence ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ evidence. Source-panel executions remain source-only and cannot increment the
 
 ### Fixed
 
+- Bind every strict independent-sensor update to any consumed-evidence ledger
+  already embedded in its factual posterior, rejecting stale-ledger rollback and
+  duplicate factor multiplication while preserving valid sequential updates.
 - Make independent actuator and contact-wrench evidence publication atomic,
   validate the exact temporary archive before publication, refuse replacement by
   default, and reject symlinked inputs, duplicate members, extra arrays, or

--- a/docs/evidence_ownership.md
+++ b/docs/evidence_ownership.md
@@ -73,6 +73,13 @@ otherwise uninformative, it preserves both the original factual artifact and the
 prior ledger exactly. When an update is informative, the returned factual
 artifact embeds the complete resulting ledger and its content identity.
 
+Every later strict update must supply that exact embedded ledger. Passing an
+older, truncated, or otherwise different ledger is rejected before likelihood
+evaluation, preventing a caller from rolling back ownership history and
+multiplying the same raw factor twice. A genuine sequential update remains
+supported by carrying forward the exact returned ledger and adding a distinct,
+independently owned factor.
+
 ## Cross-repository use
 
 For the intended `Prob4D -> BayesianPhysTwin -> Causal4D` path:

--- a/src/causal4d/evidence_ownership.py
+++ b/src/causal4d/evidence_ownership.py
@@ -483,6 +483,26 @@ def _validate_ledger_binding(
     if ledger.causal_frame_stop != factual.evidence_frame_stop:
         raise ValueError("evidence ledger and factual prefix stops differ")
 
+    embedded = factual.metadata.get("consumed_evidence_ledger")
+    if embedded is None:
+        return
+    if not isinstance(embedded, Mapping):
+        raise ValueError("factual intervention embeds an invalid evidence ledger")
+    try:
+        embedded_payload = plain_json(embedded)
+        if not isinstance(embedded_payload, dict):
+            raise ValueError("embedded ledger is not a JSON object")
+        embedded_ledger = ConsumedEvidenceLedgerV1.from_dict(embedded_payload)
+    except (TypeError, ValueError) as error:
+        raise ValueError(
+            "factual intervention embeds an invalid evidence ledger"
+        ) from error
+    if embedded_ledger.as_dict() != ledger.as_dict():
+        raise ValueError(
+            "supplied prior evidence ledger differs from the ledger embedded "
+            "in the factual intervention"
+        )
+
 
 def _validate_consumption_binding(
     consumption: EvidenceConsumptionV1 | None,

--- a/tests/test_evidence_ownership.py
+++ b/tests/test_evidence_ownership.py
@@ -242,3 +242,90 @@ def test_uninformative_strict_sensor_factor_preserves_artifact_and_ledger() -> N
     assert not result.sensor_update_applied
     assert result.factual_intervention is factual
     assert result.evidence_ledger is prior
+
+
+def test_strict_sensor_update_rejects_ledger_rollback() -> None:
+    factual = _factual()
+    evidence = _actuator_evidence()
+    consumption = evidence_consumption_for_independent_sensor(
+        evidence,
+        source_repository="robot/acquisition",
+        source_revision="session-v1",
+        correlation_group_id="independent-actuator",
+    )
+    predictions = np.stack(
+        (evidence.positions_m, evidence.positions_m + 0.2),
+        axis=0,
+    )
+    first = strict_reweight_factual_intervention_with_independent_sensors(
+        factual,
+        prior_evidence_ledger=_empty_ledger(),
+        actuator_evidence=evidence,
+        actuator_consumption=consumption,
+        predicted_actuator_positions_m=predictions,
+    )
+
+    with pytest.raises(ValueError, match="differs from the ledger embedded"):
+        strict_reweight_factual_intervention_with_independent_sensors(
+            first.factual_intervention,
+            prior_evidence_ledger=_empty_ledger(),
+            actuator_evidence=evidence,
+            actuator_consumption=consumption,
+            predicted_actuator_positions_m=predictions,
+        )
+
+
+def test_strict_sensor_update_accepts_exact_embedded_ledger_chain() -> None:
+    factual = _factual()
+    first_evidence = _actuator_evidence()
+    first_consumption = evidence_consumption_for_independent_sensor(
+        first_evidence,
+        source_repository="robot/acquisition",
+        source_revision="session-v1",
+        correlation_group_id="independent-actuator",
+    )
+    first_predictions = np.stack(
+        (first_evidence.positions_m, first_evidence.positions_m + 0.2),
+        axis=0,
+    )
+    first = strict_reweight_factual_intervention_with_independent_sensors(
+        factual,
+        prior_evidence_ledger=_empty_ledger(),
+        actuator_evidence=first_evidence,
+        actuator_consumption=first_consumption,
+        predicted_actuator_positions_m=first_predictions,
+    )
+
+    second_evidence = replace(
+        first_evidence,
+        stream_id="measured_end_effector_backup",
+        provenance="independent backup robot encoder",
+        positions_m=first_evidence.positions_m + 0.05,
+    )
+    second_consumption = evidence_consumption_for_independent_sensor(
+        second_evidence,
+        source_repository="robot/acquisition",
+        source_revision="session-v1",
+        correlation_group_id="independent-actuator-backup",
+    )
+    second_predictions = np.stack(
+        (second_evidence.positions_m, second_evidence.positions_m + 0.1),
+        axis=0,
+    )
+    second = strict_reweight_factual_intervention_with_independent_sensors(
+        first.factual_intervention,
+        prior_evidence_ledger=first.evidence_ledger,
+        actuator_evidence=second_evidence,
+        actuator_consumption=second_consumption,
+        predicted_actuator_positions_m=second_predictions,
+    )
+
+    assert second.sensor_update_applied
+    assert {
+        entry.consumption_id for entry in second.evidence_ledger.entries
+    } == {
+        first_consumption.consumption_id,
+        second_consumption.consumption_id,
+    }
+    embedded = second.factual_intervention.metadata["consumed_evidence_ledger"]
+    assert embedded["artifact_id"] == second.evidence_ledger.artifact_id

--- a/tests/test_evidence_ownership.py
+++ b/tests/test_evidence_ownership.py
@@ -321,9 +321,7 @@ def test_strict_sensor_update_accepts_exact_embedded_ledger_chain() -> None:
     )
 
     assert second.sensor_update_applied
-    assert {
-        entry.consumption_id for entry in second.evidence_ledger.entries
-    } == {
+    assert {entry.consumption_id for entry in second.evidence_ledger.entries} == {
         first_consumption.consumption_id,
         second_consumption.consumption_id,
     }


### PR DESCRIPTION
## Summary

Close a rollback path in the strict independent-sensor evidence-ownership wrapper.

After an informative sensor update, the returned `FactualIntervention` already embeds the complete `ConsumedEvidenceLedgerV1`. A later strict update now:

- reconstructs and validates that embedded ledger through the strict schema;
- requires the caller-supplied prior ledger to match it exactly;
- rejects stale, truncated, malformed, or otherwise different ownership history before evaluating any likelihood; and
- preserves valid sequential updates when the exact returned ledger is carried forward and a distinct independent factor is added.

## Root cause

`_validate_ledger_binding` previously checked only protocol, case, and causal frame stop. A caller could therefore pass an older empty ledger alongside a posterior that already embedded an informative sensor consumption, then multiply the same sensor factor again. The ledger itself rejected duplicates only within the caller-supplied history, so rolling that history back bypassed the intended strict boundary.

## Exact scope

```text
CHANGELOG.md
docs/evidence_ownership.md
src/causal4d/evidence_ownership.py
tests/test_evidence_ownership.py
```

The branch is two commits ahead and zero behind the tested base, with exactly the four declared files.

## Validation

Exact validated head:

```text
dd7381245bb87f2f28c0605f1be87d5f4272586e
```

Authoritative GitHub Actions:

- CI and release run `31272347152`: success, including Ruff, formatting, MyPy, Python 3.10/3.12/3.14 core suites, wheel/sdist builds and installed help checks, result bundles, frozen-manifest validation, and pinned BayesianPhysTwin installed-wheel integration;
- Extended compatibility run `31272347142`: success, including Python 3.11/3.13 and declared dependency floors;
- Security scanning run `31272347146`: success, including the resolved dependency audit and CodeQL for Python and Actions; and
- Causal4D merge gate run `31272347148`: success, including repository quality, the complete default suite, rebuilt distributions, and pinned-provider integration on the synthetic merge result.

Focused validation on the exact product bytes:

```text
30 passed
Python compilation with SyntaxWarning treated as error: passed
whitespace checks: passed
```

Coverage includes:

- rejection of an empty-ledger rollback after one informative update;
- preservation of the existing duplicate, source-byte, correlation-group, and prefix guards;
- acceptance of a genuine second update when the exact first ledger is supplied; and
- equality between the final returned ledger and the ledger embedded in the resulting factual artifact.

## Compatibility

The public API and ledger schema are unchanged. Initial updates without an embedded ledger behave as before. The only rejected behavior is supplying ownership history that contradicts a ledger already bound into the factual posterior.

## Scientific boundary

This is prospective evidence-accounting hardening only. It changes no likelihood formula, posterior factor, frozen estimator, acquisition candidate, registered protocol, target-access rule, calibration rule, scientific result, or physical evidence count.