### PR TITLE
Harden report-shell pairing and scientific invariants

### DIFF
--- a/docs/causal4d_registered_real_report_shell.md
+++ b/docs/causal4d_registered_real_report_shell.md
@@ -32,8 +32,10 @@ binds the exact analysis bytes and software revisions, and writes:
 - a Markdown dry rendering with visibly empty result cells.
 
 Both destinations are checked before publication. Existing outputs are rejected
-unless `--overwrite` is supplied, so a stale JSON file cannot be silently paired
-with a newly rendered Markdown file.
+unless `--overwrite` is supplied. The Markdown derivative is published first
+and the validated JSON shell is published last as the completion marker. On the
+default no-overwrite path, an in-process JSON publication failure removes the
+new Markdown draft instead of leaving a misleading half-published pair.
 
 ## Validate the shell against its source
 
@@ -45,18 +47,24 @@ causal4d evidence real-report-shell validate \
   /data/causal4d-sloth-multi-action-v1/operator/real-report-shell.json
 ```
 
-For acquisition use, always bind the shell back to the exact registered analysis:
+For acquisition use, bind the shell back to both the exact registered analysis
+and the separately stored Markdown rendering:
 
 ```bash
 causal4d evidence real-report-shell validate \
   /data/causal4d-sloth-multi-action-v1/operator/real-report-shell.json \
   --analysis-manifest \
-  /data/causal4d-sloth-multi-action-v1/registered-analysis.json
+  /data/causal4d-sloth-multi-action-v1/registered-analysis.json \
+  --markdown \
+  /data/causal4d-sloth-multi-action-v1/operator/real-report-shell.md
 ```
 
-The second form rebuilds the expected shell from the validated source bytes and
-requires exact equality. Readdressing both an embedded contract and its shell ID
-therefore cannot substitute a different analysis manifest.
+This form rebuilds the expected shell from the validated source bytes, requires
+exact shell equality, regenerates the deterministic Markdown, and compares its
+exact UTF-8 bytes. Readdressing an embedded contract and its shell ID therefore
+cannot substitute either a different analysis manifest or a stale/manually
+edited report rendering. The validation summary reports the Markdown SHA-256 and
+byte count for archiving.
 
 ## What is rendered
 

--- a/src/causal4d/atomic_io.py
+++ b/src/causal4d/atomic_io.py
@@ -22,6 +22,36 @@ def _fsync_directory(path: Path) -> None:
         os.close(descriptor)
 
 
+def _publish_temporary(
+    temporary: Path,
+    target: Path,
+    *,
+    overwrite: bool,
+) -> None:
+    """Publish one prepared file and roll back failed no-overwrite durability."""
+
+    linked_without_overwrite = False
+    if overwrite:
+        os.replace(temporary, target)
+    else:
+        os.link(temporary, target)
+        temporary.unlink()
+        linked_without_overwrite = True
+    try:
+        _fsync_directory(target.parent)
+    except BaseException:
+        if linked_without_overwrite:
+            # The caller owns this newly linked destination. A failed durability
+            # step must not report failure while leaving a visible exactly-once
+            # artifact that a higher-level transaction may treat as complete.
+            target.unlink(missing_ok=True)
+            try:
+                _fsync_directory(target.parent)
+            except OSError:
+                pass
+        raise
+
+
 def atomic_write_binary(
     path: str | Path,
     writer: Callable[[BinaryIO], None],
@@ -46,12 +76,11 @@ def atomic_write_binary(
             os.fsync(handle.fileno())
         if validate is not None:
             validate(temporary)
-        if overwrite:
-            os.replace(temporary, target)
-        else:
-            os.link(temporary, target)
-            temporary.unlink()
-        _fsync_directory(target.parent)
+        _publish_temporary(
+            temporary,
+            target,
+            overwrite=overwrite,
+        )
     finally:
         temporary.unlink(missing_ok=True)
 
@@ -82,12 +111,11 @@ def atomic_write_text(
             handle.write(text)
             handle.flush()
             os.fsync(handle.fileno())
-        if overwrite:
-            os.replace(temporary, target)
-        else:
-            os.link(temporary, target)
-            temporary.unlink()
-        _fsync_directory(target.parent)
+        _publish_temporary(
+            temporary,
+            target,
+            overwrite=overwrite,
+        )
     finally:
         temporary.unlink(missing_ok=True)
 

--- a/src/causal4d/registered_real_report_shell.py
+++ b/src/causal4d/registered_real_report_shell.py
@@ -897,6 +897,38 @@ def render_registered_real_report_shell_markdown(
     return "\n".join(lines)
 
 
+def validate_registered_real_report_shell_markdown(
+    payload: Mapping[str, Any],
+    markdown: str | bytes,
+) -> str:
+    """Require Markdown to be the exact deterministic rendering of ``payload``.
+
+    The JSON shell is the authoritative completion marker.  This check binds a
+    separately stored Markdown rendering back to those exact validated bytes so
+    a stale, manually edited, or partially replaced document cannot be paired
+    with a valid shell.
+    """
+
+    shell = validate_registered_real_report_shell(payload)
+    if isinstance(markdown, bytes):
+        try:
+            text = markdown.decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise ValueError(
+                "registered real report shell Markdown must be UTF-8"
+            ) from error
+    elif type(markdown) is str:
+        text = markdown
+    else:
+        raise ValueError("registered real report shell Markdown must be text")
+    expected = render_registered_real_report_shell_markdown(shell)
+    _require(
+        text == expected,
+        "registered real report shell Markdown does not match the shell",
+    )
+    return text
+
+
 def _load_shell(path: str | Path) -> tuple[dict[str, Any], str, int]:
     from causal4d.artifact_io import load_strict_json_object, read_regular_file
 
@@ -955,8 +987,21 @@ def _render_command(arguments: Sequence[str]) -> int:
         analysis_manifest_byte_count=byte_count,
     )
     markdown = render_registered_real_report_shell_markdown(shell)
-    atomic_write_json(json_path, shell, overwrite=parsed.overwrite)
+    validate_registered_real_report_shell_markdown(shell, markdown)
+
+    # Publish the human-readable derivative first and the validated JSON shell
+    # last.  The JSON file is the completion marker: after an interruption there
+    # can be an orphan Markdown draft, but never a new authoritative shell that
+    # points at a missing Markdown rendering.  For the default no-overwrite path,
+    # remove that orphan when the second publication raises in-process.
     atomic_write_text(markdown_path, markdown, overwrite=parsed.overwrite)
+    try:
+        atomic_write_json(json_path, shell, overwrite=parsed.overwrite)
+    except BaseException:
+        if not parsed.overwrite:
+            markdown_path.unlink(missing_ok=True)
+        raise
+    markdown_payload = markdown.encode("utf-8")
     print(
         json.dumps(
             {
@@ -964,6 +1009,8 @@ def _render_command(arguments: Sequence[str]) -> int:
                 "shell_id": shell["shell_id"],
                 "output_json": str(json_path.resolve()),
                 "output_markdown": str(markdown_path.resolve()),
+                "markdown_sha256": hashlib.sha256(markdown_payload).hexdigest(),
+                "markdown_bytes": len(markdown_payload),
                 "target_outcomes_loaded": False,
                 "confirmatory_execution_evidence_count": 0,
             },
@@ -980,8 +1027,24 @@ def _validate_command(arguments: Sequence[str]) -> int:
     )
     parser.add_argument("report_shell")
     parser.add_argument("--analysis-manifest")
+    parser.add_argument("--markdown")
     parsed = parser.parse_args(arguments)
     shell, sha256, byte_count = _load_shell(parsed.report_shell)
+    markdown_sha256 = None
+    markdown_byte_count = None
+    if parsed.markdown:
+        from causal4d.artifact_io import read_regular_file
+
+        markdown_snapshot = read_regular_file(
+            parsed.markdown,
+            name="registered real report shell Markdown",
+        )
+        validate_registered_real_report_shell_markdown(
+            shell,
+            markdown_snapshot.payload,
+        )
+        markdown_sha256 = markdown_snapshot.sha256
+        markdown_byte_count = markdown_snapshot.byte_count
     if parsed.analysis_manifest:
         from causal4d.registered_real_analysis import (
             load_registered_real_analysis_manifest,
@@ -1003,6 +1066,8 @@ def _validate_command(arguments: Sequence[str]) -> int:
                 "shell_id": shell["shell_id"],
                 "sha256": sha256,
                 "bytes": byte_count,
+                "markdown_sha256": markdown_sha256,
+                "markdown_bytes": markdown_byte_count,
                 "target_outcomes_loaded": False,
                 "confirmatory_execution_evidence_count": 0,
             },
@@ -1035,6 +1100,7 @@ __all__ = [
     "report_shell_id_for_payload",
     "validate_registered_real_report_shell",
     "validate_registered_real_report_shell_against_analysis",
+    "validate_registered_real_report_shell_markdown",
 ]
 
 

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -4,7 +4,12 @@ import json
 
 import pytest
 
-from causal4d.atomic_io import atomic_write_binary, atomic_write_json
+import causal4d.atomic_io as atomic_io_module
+from causal4d.atomic_io import (
+    atomic_write_binary,
+    atomic_write_json,
+    atomic_write_text,
+)
 
 
 def test_atomic_write_json_publishes_sorted_finite_json(tmp_path) -> None:
@@ -68,3 +73,53 @@ def test_atomic_write_binary_can_fail_closed_on_existing_destination(tmp_path) -
         )
 
     assert target.read_bytes() == b"first"
+
+
+def test_no_overwrite_publication_rolls_back_failed_directory_durability(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "artifact.txt"
+    calls = 0
+
+    def fail_first_directory_sync(path) -> None:
+        nonlocal calls
+        assert path == tmp_path
+        calls += 1
+        if calls == 1:
+            raise OSError("simulated directory fsync failure")
+
+    monkeypatch.setattr(
+        atomic_io_module,
+        "_fsync_directory",
+        fail_first_directory_sync,
+    )
+    with pytest.raises(OSError, match="simulated directory fsync failure"):
+        atomic_write_text(target, "candidate", overwrite=False)
+
+    assert calls == 2
+    assert not target.exists()
+    assert not list(tmp_path.glob(f".{target.name}.*.tmp"))
+
+
+def test_overwrite_publication_retains_visible_target_on_durability_failure(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "artifact.txt"
+    target.write_text("old", encoding="utf-8")
+
+    def fail_directory_sync(path) -> None:
+        assert path == tmp_path
+        raise OSError("simulated directory fsync failure")
+
+    monkeypatch.setattr(
+        atomic_io_module,
+        "_fsync_directory",
+        fail_directory_sync,
+    )
+    with pytest.raises(OSError, match="simulated directory fsync failure"):
+        atomic_write_text(target, "candidate", overwrite=True)
+
+    assert target.read_text(encoding="utf-8") == "candidate"
+    assert not list(tmp_path.glob(f".{target.name}.*.tmp"))

--- a/tests/test_joint_observation_metamorphic.py
+++ b/tests/test_joint_observation_metamorphic.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import numpy as np
+
+from causal4d.joint_observation import (
+    LinearJointObservationEvidence,
+    joint_component_log_likelihoods,
+    posterior_weights_from_joint_observation,
+)
+
+
+RNG_SEED = 20_260_809
+
+
+def _positive_definite(
+    rng: np.random.Generator,
+    leading_shape: tuple[int, ...],
+    dimension: int,
+) -> np.ndarray:
+    roots = rng.normal(size=(*leading_shape, dimension, dimension))
+    covariance = np.einsum("...ik,...jk->...ij", roots, roots)
+    covariance += np.eye(dimension) * 0.05
+    return covariance
+
+
+def _random_evidence(
+    rng: np.random.Generator,
+    *,
+    observation_count: int,
+    node_count: int,
+    coordinate_count: int,
+) -> LinearJointObservationEvidence:
+    return LinearJointObservationEvidence(
+        evidence_id="metamorphic-joint-observation",
+        values_m=rng.normal(size=observation_count),
+        row_indices=np.arange(observation_count),
+        frame_indices=rng.integers(1, 3, size=observation_count),
+        node_indices=rng.integers(0, node_count, size=observation_count),
+        coordinate_indices=rng.integers(
+            0,
+            coordinate_count,
+            size=observation_count,
+        ),
+        coefficients=rng.choice((-1.0, 1.0), size=observation_count),
+        base_covariance_m2=_positive_definite(rng, (), observation_count),
+        shared_covariance_factor_m=rng.normal(
+            scale=0.05,
+            size=(observation_count, 2),
+        ),
+        source_id="metamorphic-test",
+    )
+
+
+def test_component_permutation_preserves_joint_posterior_with_uncertainty() -> None:
+    rng = np.random.default_rng(RNG_SEED)
+    component_count = 6
+    observation_count = 5
+    components = rng.normal(size=(component_count, 4, 5, 3))
+    evidence = _random_evidence(
+        rng,
+        observation_count=observation_count,
+        node_count=5,
+        coordinate_count=3,
+    )
+    prior = rng.dirichlet(np.ones(component_count))
+    prior[[1, 4]] = 0.0
+    prior /= np.sum(prior)
+    independent_variance = rng.uniform(0.0, 0.1, size=components.shape)
+    joint_covariance = _positive_definite(
+        rng,
+        (component_count,),
+        observation_count,
+    )
+    joint_factor = rng.normal(
+        scale=0.03,
+        size=(component_count, observation_count, 1),
+    )
+
+    posterior, diagnostics = posterior_weights_from_joint_observation(
+        prior,
+        components,
+        evidence,
+        prefix_frame_count=3,
+        component_independent_variance_m2=independent_variance,
+        component_joint_covariance_m2=joint_covariance,
+        component_joint_covariance_factor_m=joint_factor,
+    )
+    permutation = rng.permutation(component_count)
+    inverse = np.argsort(permutation)
+    permuted_posterior, permuted_diagnostics = posterior_weights_from_joint_observation(
+        prior[permutation],
+        components[permutation],
+        evidence,
+        prefix_frame_count=3,
+        component_independent_variance_m2=independent_variance[permutation],
+        component_joint_covariance_m2=joint_covariance[permutation],
+        component_joint_covariance_factor_m=joint_factor[permutation],
+    )
+
+    np.testing.assert_allclose(
+        posterior,
+        permuted_posterior[inverse],
+        rtol=1e-12,
+        atol=1e-12,
+    )
+    assert diagnostics == permuted_diagnostics
+    assert posterior[1] == 0.0
+    assert posterior[4] == 0.0
+
+
+def test_graph_node_relabelling_preserves_joint_scores() -> None:
+    rng = np.random.default_rng(RNG_SEED + 1)
+    node_count = 7
+    components = rng.normal(size=(5, 4, node_count, 3))
+    evidence = _random_evidence(
+        rng,
+        observation_count=8,
+        node_count=node_count,
+        coordinate_count=3,
+    )
+    scores, _ = joint_component_log_likelihoods(
+        components,
+        evidence,
+        prefix_frame_count=3,
+    )
+
+    node_permutation = rng.permutation(node_count)
+    inverse = np.argsort(node_permutation)
+    relabelled_evidence = LinearJointObservationEvidence(
+        evidence_id="metamorphic-node-relabelled",
+        values_m=evidence.values_m,
+        row_indices=evidence.row_indices,
+        frame_indices=evidence.frame_indices,
+        node_indices=inverse[evidence.node_indices],
+        coordinate_indices=evidence.coordinate_indices,
+        coefficients=evidence.coefficients,
+        base_covariance_m2=evidence.base_covariance_m2,
+        shared_covariance_factor_m=evidence.shared_covariance_factor_m,
+        source_id=evidence.source_id,
+        metadata=evidence.metadata,
+    )
+    relabelled_scores, _ = joint_component_log_likelihoods(
+        components[:, :, node_permutation, :],
+        relabelled_evidence,
+        prefix_frame_count=3,
+    )
+
+    np.testing.assert_allclose(scores, relabelled_scores, rtol=1e-12, atol=1e-12)
+
+
+def test_future_suffix_changes_cannot_affect_prefix_only_joint_update() -> None:
+    rng = np.random.default_rng(RNG_SEED + 2)
+    components = rng.normal(size=(4, 7, 3, 2))
+    evidence = _random_evidence(
+        rng,
+        observation_count=5,
+        node_count=3,
+        coordinate_count=2,
+    )
+    prior = rng.dirichlet(np.ones(len(components)))
+    variance = rng.uniform(0.0, 0.1, size=components.shape)
+    posterior, _ = posterior_weights_from_joint_observation(
+        prior,
+        components,
+        evidence,
+        prefix_frame_count=3,
+        component_independent_variance_m2=variance,
+    )
+
+    changed_components = components.copy()
+    changed_variance = variance.copy()
+    changed_components[:, 3:] = rng.normal(
+        loc=10_000.0,
+        scale=100.0,
+        size=changed_components[:, 3:].shape,
+    )
+    changed_variance[:, 3:] = rng.uniform(
+        10_000.0,
+        20_000.0,
+        size=changed_variance[:, 3:].shape,
+    )
+    changed_posterior, _ = posterior_weights_from_joint_observation(
+        prior,
+        changed_components,
+        evidence,
+        prefix_frame_count=3,
+        component_independent_variance_m2=changed_variance,
+    )
+
+    np.testing.assert_array_equal(posterior, changed_posterior)
+
+
+def test_sparse_term_order_preserves_scores_and_variance_propagation() -> None:
+    rng = np.random.default_rng(RNG_SEED + 3)
+    observation_count = 4
+    term_count = 10
+    row_indices = np.asarray((0, 0, 1, 1, 1, 2, 2, 3, 3, 3))
+    frame_indices = rng.integers(1, 3, size=term_count)
+    node_indices = rng.integers(0, 4, size=term_count)
+    coordinate_indices = rng.integers(0, 3, size=term_count)
+    coefficients = rng.normal(size=term_count)
+    components = rng.normal(size=(5, 4, 4, 3))
+    variance = rng.uniform(0.0, 0.1, size=components.shape)
+    covariance = _positive_definite(rng, (), observation_count)
+    evidence = LinearJointObservationEvidence(
+        evidence_id="metamorphic-term-order",
+        values_m=rng.normal(size=observation_count),
+        row_indices=row_indices,
+        frame_indices=frame_indices,
+        node_indices=node_indices,
+        coordinate_indices=coordinate_indices,
+        coefficients=coefficients,
+        base_covariance_m2=covariance,
+    )
+    scores, _ = joint_component_log_likelihoods(
+        components,
+        evidence,
+        prefix_frame_count=3,
+        component_independent_variance_m2=variance,
+    )
+    propagated = evidence.apply_independent_covariance(variance)
+
+    permutation = rng.permutation(term_count)
+    permuted = LinearJointObservationEvidence(
+        evidence_id="metamorphic-term-order-permuted",
+        values_m=evidence.values_m,
+        row_indices=row_indices[permutation],
+        frame_indices=frame_indices[permutation],
+        node_indices=node_indices[permutation],
+        coordinate_indices=coordinate_indices[permutation],
+        coefficients=coefficients[permutation],
+        base_covariance_m2=covariance,
+    )
+    permuted_scores, _ = joint_component_log_likelihoods(
+        components,
+        permuted,
+        prefix_frame_count=3,
+        component_independent_variance_m2=variance,
+    )
+    permuted_propagated = permuted.apply_independent_covariance(variance)
+
+    np.testing.assert_allclose(scores, permuted_scores, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(
+        propagated,
+        permuted_propagated,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+
+def test_endpoint_displacement_rows_are_global_translation_invariant() -> None:
+    evidence = LinearJointObservationEvidence(
+        evidence_id="metamorphic-translation",
+        values_m=np.asarray((0.2, -0.1, 0.05)),
+        row_indices=np.repeat(np.arange(3), 2),
+        frame_indices=np.tile((0, 1), 3),
+        node_indices=np.repeat((0, 1, 2), 2),
+        coordinate_indices=np.repeat(np.arange(3), 2),
+        coefficients=np.tile((-1.0, 1.0), 3),
+        base_covariance_m2=np.eye(3) * 0.1,
+    )
+    rng = np.random.default_rng(RNG_SEED + 4)
+    components = rng.normal(size=(4, 3, 3, 3))
+    scores, _ = joint_component_log_likelihoods(
+        components,
+        evidence,
+        prefix_frame_count=2,
+    )
+    translation = np.asarray((100.0, -250.0, 75.0))
+    translated_scores, _ = joint_component_log_likelihoods(
+        components + translation,
+        evidence,
+        prefix_frame_count=2,
+    )
+
+    np.testing.assert_allclose(scores, translated_scores, rtol=1e-12, atol=1e-12)

--- a/tests/test_registered_real_report_shell.py
+++ b/tests/test_registered_real_report_shell.py
@@ -22,6 +22,7 @@ from causal4d.registered_real_report_shell import (
     report_shell_id_for_payload,
     validate_registered_real_report_shell,
     validate_registered_real_report_shell_against_analysis,
+    validate_registered_real_report_shell_markdown,
 )
 
 
@@ -152,6 +153,20 @@ def test_markdown_renders_every_registered_path_without_results() -> None:
     assert "Diagnostic intervention-oracle gap attribution" in markdown
     assert shell["shell_id"] in markdown
     assert "not populated" in markdown
+    assert validate_registered_real_report_shell_markdown(shell, markdown) == markdown
+
+
+def test_markdown_validation_rejects_stale_edits_and_non_utf8_bytes() -> None:
+    shell = _shell()
+    markdown = render_registered_real_report_shell_markdown(shell)
+
+    with pytest.raises(ValueError, match="does not match"):
+        validate_registered_real_report_shell_markdown(
+            shell,
+            markdown.replace("not populated", "selected result", 1),
+        )
+    with pytest.raises(ValueError, match="must be UTF-8"):
+        validate_registered_real_report_shell_markdown(shell, b"\xff")
 
 
 def test_shell_rejects_target_values_and_selected_result_narratives() -> None:
@@ -236,6 +251,8 @@ def test_cli_renders_validates_and_refuses_partial_overwrite(
                 str(shell_path),
                 "--analysis-manifest",
                 str(analysis_path),
+                "--markdown",
+                str(markdown_path),
             ]
         )
         == 0
@@ -253,3 +270,74 @@ def test_cli_renders_validates_and_refuses_partial_overwrite(
             ]
         )
     assert not (tmp_path / "other.md").exists()
+
+
+def test_cli_rejects_a_stale_markdown_pair(tmp_path: Path) -> None:
+    analysis = _analysis()
+    analysis_path = tmp_path / "registered-analysis.json"
+    analysis_path.write_bytes(_analysis_bytes(analysis))
+    shell_path = tmp_path / "report-shell.json"
+    markdown_path = tmp_path / "report-shell.md"
+    assert (
+        main(
+            [
+                "render",
+                str(analysis_path),
+                "--output-json",
+                str(shell_path),
+                "--output-markdown",
+                str(markdown_path),
+            ]
+        )
+        == 0
+    )
+    markdown_path.write_text(
+        markdown_path.read_text(encoding="utf-8").replace(
+            "not populated",
+            "manually selected",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        main(
+            [
+                "validate",
+                str(shell_path),
+                "--markdown",
+                str(markdown_path),
+            ]
+        )
+
+
+def test_render_removes_orphan_markdown_when_json_publication_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    analysis = _analysis()
+    analysis_path = tmp_path / "registered-analysis.json"
+    analysis_path.write_bytes(_analysis_bytes(analysis))
+    shell_path = tmp_path / "report-shell.json"
+    markdown_path = tmp_path / "report-shell.md"
+
+    def fail_json_publication(*args: object, **kwargs: object) -> None:
+        raise OSError("simulated JSON publication failure")
+
+    monkeypatch.setattr(
+        "causal4d.atomic_io.atomic_write_json",
+        fail_json_publication,
+    )
+    with pytest.raises(OSError, match="simulated JSON publication failure"):
+        main(
+            [
+                "render",
+                str(analysis_path),
+                "--output-json",
+                str(shell_path),
+                "--output-markdown",
+                str(markdown_path),
+            ]
+        )
+    assert not shell_path.exists()
+    assert not markdown_path.exists()

--- a/tests/test_registered_real_report_shell_durability.py
+++ b/tests/test_registered_real_report_shell_durability.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import causal4d.atomic_io as atomic_io_module
+from causal4d.registered_real_report_shell import main
+from tests.test_registered_real_report_shell import _analysis, _analysis_bytes
+
+
+def test_no_overwrite_pair_rolls_back_json_directory_sync_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    analysis = _analysis()
+    analysis_path = tmp_path / "registered-analysis.json"
+    analysis_path.write_bytes(_analysis_bytes(analysis))
+    shell_path = tmp_path / "report-shell.json"
+    markdown_path = tmp_path / "report-shell.md"
+    real_fsync_directory = atomic_io_module._fsync_directory
+    calls = 0
+
+    def fail_json_directory_sync(path: Path) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("simulated JSON directory fsync failure")
+        real_fsync_directory(path)
+
+    monkeypatch.setattr(
+        atomic_io_module,
+        "_fsync_directory",
+        fail_json_directory_sync,
+    )
+    with pytest.raises(OSError, match="simulated JSON directory fsync failure"):
+        main(
+            [
+                "render",
+                str(analysis_path),
+                "--output-json",
+                str(shell_path),
+                "--output-markdown",
+                str(markdown_path),
+            ]
+        )
+
+    assert calls == 3
+    assert not shell_path.exists()
+    assert not markdown_path.exists()
+    assert not tuple(tmp_path.glob(".*.tmp"))


### PR DESCRIPTION
## Summary

Rebuild the report-shell hardening from draft PR #254 as one clean commit on current `main@ca8af60dd150d4aa7b54f71248d2d6143aabff51`, while closing a post-publication durability gap found during review.

- bind separately stored Markdown to the exact validated target-free JSON shell;
- reject stale, manually edited, non-UTF-8, or analysis-mismatched renderings;
- publish Markdown first and JSON last as the completion marker;
- report the exact Markdown SHA-256 and byte count;
- roll back newly linked no-overwrite atomic destinations when directory durability fails;
- ensure a JSON durability failure removes both sides of a newly published report pair rather than leaving an authoritative half-pair; and
- add deterministic full-joint observation metamorphic regressions for component permutation, graph-node relabelling, future-suffix noninterference, sparse-term ordering, exact zero support, and global-translation invariance.

## Additional root cause fixed

The original draft cleaned up Markdown whenever JSON publication raised. `atomic_write_json`, however, could raise after its destination had already become visible if the final directory `fsync` failed. That sequence could delete Markdown while leaving the JSON completion marker.

The clean replacement strengthens the shared no-overwrite atomic-publication primitive: when a newly hard-linked destination fails its directory durability step, the helper removes that destination before propagating the error. The report-shell cleanup then removes the Markdown draft, leaving neither side visible. Existing overwrite semantics remain unchanged because a replaced destination cannot be safely restored generically.

## Exact scope

```text
docs/causal4d_registered_real_report_shell.md
src/causal4d/atomic_io.py
src/causal4d/registered_real_report_shell.py
tests/test_atomic_io.py
tests/test_joint_observation_metamorphic.py
tests/test_registered_real_report_shell.py
tests/test_registered_real_report_shell_durability.py
```

The branch is one commit ahead and zero behind its base.

## Validation

Exact validated head:

```text
c9222af85ef78179999ffca6d210d5348b090c65
```

Authoritative GitHub Actions:

- CI and release run `31273001575`: success, including Ruff, incremental formatting, MyPy, Python 3.10/3.12/3.14 core suites, wheel and sdist builds/installations, all installed CLI help paths, result bundles, frozen-manifest validation, and pinned BayesianPhysTwin installed-wheel integration;
- Extended compatibility run `31273001583`: success, including Python 3.11/3.13 and declared dependency floors;
- Security scanning run `31273001600`: success, including resolved dependency audit and CodeQL for Python and Actions;
- Causal4D merge gate run `31273001582`: success, including repository quality, the complete default suite, rebuilt distributions, and installed BayesianPhysTwin integration on the synthetic merge result; and
- Three-repository installed-wheel compatibility run `31273001577`: success, including exact Prob4D/BayesianPhysTwin/Causal4D wheel identities, stack-lock verification, isolated golden path, strict provider-v2 admission, and cross-repository contract tests.

Focused clean-tree validation:

```text
18 passed
Python compilation with SyntaxWarning treated as error: passed
changed Python lines <= 88 characters
```

## Scientific boundary

This is report reproducibility, artifact-transaction, and metamorphic regression hardening. It changes no estimator, posterior, registered 18-session/36-execution protocol, target-access boundary, threshold, calibration rule, scientific result, or physical evidence count.