### PR TITLE
Harden live acquisition snapshot freshness and integrity

### DIFF
--- a/docs/acquisition_health_snapshot_integrity.md
+++ b/docs/acquisition_health_snapshot_integrity.md
@@ -1,0 +1,60 @@
+# Live acquisition snapshot integrity
+
+The live acquisition-health route evaluates operational capture health only. It
+must not read prediction errors, held-out metrics, coverage, oracle outputs, or
+other target outcomes.
+
+## Exact-byte input boundary
+
+Use the grouped CLI route:
+
+```bash
+causal4d protocol acquisition snapshot health.json \
+  --maximum-snapshot-age-s 5 \
+  --maximum-heartbeat-age-s 2 \
+  --maximum-clock-offset-ms 5 \
+  --maximum-dropped-frames 0 \
+  --minimum-free-gib 100 \
+  --minimum-write-mib-s 100 \
+  --output-json health-decision.json \
+  --require-healthy
+```
+
+The command opens `health.json` as one ordinary file without following a final
+symbolic link, reads and hashes the exact bytes through that descriptor, and
+parses strict finite UTF-8 JSON. Duplicate object keys are rejected. The decision
+records `snapshot_sha256`, `snapshot_byte_count`, and its own
+`decision_sha256`.
+
+`--output-json` uses the repository's atomic JSON publication helper. Existing
+outputs are not replaced unless `--overwrite` is supplied. The printed decision
+and the optional stored decision are identical.
+
+## Freshness and heartbeat semantics
+
+The producer reports each stream heartbeat age at `captured_at_utc`. A live
+checker must also account for transport and scheduling delay between capture and
+evaluation. The effective age is therefore
+
+```text
+effective_heartbeat_age_s = heartbeat_age_s + snapshot_age_s.
+```
+
+Required streams are tested against the effective age. A snapshot also fails
+when its own age exceeds `--maximum-snapshot-age-s`, or when its capture time is
+farther in the future than `--maximum-future-skew-s` permits. This prevents an
+old file with apparently recent producer-local heartbeats from passing after the
+capture process has stalled.
+
+The Python mapping API remains useful for deterministic archived diagnostics:
+when `evaluated_at_utc` is omitted from `evaluate_health_snapshot`, evaluation is
+anchored to the snapshot capture time. Live file evaluation uses
+`evaluate_health_snapshot_file`, which defaults to the current UTC time and binds
+the exact source bytes.
+
+## Decision boundary
+
+A healthy decision is operational evidence only. It does not increment the
+registered execution count, validate an execution manifest, determine inclusion,
+or support a physical-prediction claim. The capture supervisor remains
+responsible for a safe stop or abort when the decision fails.

--- a/src/causal4d/acquisition_flight_recorder.py
+++ b/src/causal4d/acquisition_flight_recorder.py
@@ -9,6 +9,7 @@ from causal4d.acquisition_health import (
     HEALTH_SNAPSHOT_KIND,
     HealthThresholds,
     evaluate_health_snapshot,
+    evaluate_health_snapshot_file,
 )
 from causal4d.acquisition_journal import (
     JOURNAL_EVENT_KIND,
@@ -34,6 +35,7 @@ __all__ = [
     "build_acquisition_doctor_report",
     "build_journal_event",
     "evaluate_health_snapshot",
+    "evaluate_health_snapshot_file",
     "journal_seal_path",
     "seal_acquisition_journal",
     "validate_acquisition_journal",

--- a/src/causal4d/acquisition_health.py
+++ b/src/causal4d/acquisition_health.py
@@ -251,10 +251,11 @@ def evaluate_health_snapshot_file(
 
     source = read_regular_file(path, name="health snapshot")
     snapshot = load_strict_json_object(source.payload, name="health snapshot")
+    evaluation_time = _utc_now() if evaluated_at_utc is None else evaluated_at_utc
     result = evaluate_health_snapshot(
         snapshot,
         thresholds=thresholds,
-        evaluated_at_utc=evaluated_at_utc or _utc_now(),
+        evaluated_at_utc=evaluation_time,
     )
     result["snapshot_sha256"] = source.sha256
     result["snapshot_byte_count"] = source.byte_count

--- a/src/causal4d/acquisition_health.py
+++ b/src/causal4d/acquisition_health.py
@@ -5,15 +5,19 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 import math
+from pathlib import Path
 from typing import Any
 
 from causal4d.acquisition_flight_common import (
     HEALTH_SNAPSHOT_KIND,
     _assert_json_value,
+    _canonical_sha256,
     _parse_utc,
     _reject_target_outcomes,
     _require,
+    _utc_now,
 )
+from causal4d.artifact_io import load_strict_json_object, read_regular_file
 
 
 @dataclass(frozen=True)
@@ -25,26 +29,40 @@ class HealthThresholds:
     maximum_dropped_frames: int = 0
     minimum_free_bytes: int = 20 * 1024**3
     minimum_write_mib_s: float = 25.0
+    maximum_snapshot_age_s: float = 5.0
+    maximum_future_skew_s: float = 1.0
 
     def __post_init__(self) -> None:
-        _require(
-            self.maximum_heartbeat_age_s > 0.0,
-            "heartbeat threshold must be positive",
+        numeric_thresholds = (
+            ("maximum_heartbeat_age_s", 0.0, False),
+            ("maximum_clock_offset_ms", 0.0, True),
+            ("minimum_write_mib_s", 0.0, True),
+            ("maximum_snapshot_age_s", 0.0, False),
+            ("maximum_future_skew_s", 0.0, True),
         )
-        _require(
-            self.maximum_clock_offset_ms >= 0.0,
-            "clock threshold must be nonnegative",
-        )
+        for name, minimum, inclusive in numeric_thresholds:
+            raw = getattr(self, name)
+            _require(
+                isinstance(raw, (int, float)) and not isinstance(raw, bool),
+                f"{name} must be numeric",
+            )
+            value = float(raw)
+            _require(math.isfinite(value), f"{name} must be finite")
+            relation = value >= minimum if inclusive else value > minimum
+            qualifier = "nonnegative" if inclusive else "positive"
+            _require(relation, f"{name} must be {qualifier}")
+            object.__setattr__(self, name, value)
         _require(
             isinstance(self.maximum_dropped_frames, int)
             and not isinstance(self.maximum_dropped_frames, bool)
             and self.maximum_dropped_frames >= 0,
-            "dropped-frame threshold must be a nonnegative integer",
+            "maximum_dropped_frames must be a nonnegative integer",
         )
-        _require(self.minimum_free_bytes >= 0, "minimum_free_bytes must be nonnegative")
         _require(
-            self.minimum_write_mib_s >= 0.0,
-            "minimum_write_mib_s must be nonnegative",
+            isinstance(self.minimum_free_bytes, int)
+            and not isinstance(self.minimum_free_bytes, bool)
+            and self.minimum_free_bytes >= 0,
+            "minimum_free_bytes must be a nonnegative integer",
         )
 
 
@@ -60,12 +78,29 @@ def _finite_number(value: Any, *, name: str, minimum: float | None = None) -> fl
     return result
 
 
+def _optional_identity(value: Any, *, name: str) -> str | None:
+    if value is None:
+        return None
+    _require(
+        isinstance(value, str) and bool(value.strip()),
+        f"{name} must be a nonempty string when supplied",
+    )
+    return value
+
+
 def evaluate_health_snapshot(
     snapshot: Mapping[str, Any],
     *,
     thresholds: HealthThresholds | None = None,
+    evaluated_at_utc: str | None = None,
 ) -> dict[str, Any]:
-    """Evaluate a live collection-health snapshot without reading target metrics."""
+    """Evaluate one collection-health snapshot without reading target metrics.
+
+    Direct mapping evaluation is deterministic by default: when
+    ``evaluated_at_utc`` is omitted, the snapshot is evaluated at its own capture
+    time. Live callers should use :func:`evaluate_health_snapshot_file`, which
+    evaluates against the current UTC time and binds the exact input bytes.
+    """
 
     settings = thresholds or HealthThresholds()
     values = dict(snapshot)
@@ -82,16 +117,36 @@ def evaluate_health_snapshot(
             isinstance(values.get(field), str) and bool(values[field].strip()),
             f"snapshot {field} must be nonempty",
         )
-    _parse_utc(values.get("captured_at_utc"), name="captured_at_utc")
+    execution_id = _optional_identity(
+        values.get("execution_id"),
+        name="snapshot execution_id",
+    )
+    captured_at = _parse_utc(values.get("captured_at_utc"), name="captured_at_utc")
+    if evaluated_at_utc is None:
+        evaluated_at = captured_at
+    else:
+        evaluated_at = _parse_utc(evaluated_at_utc, name="evaluated_at_utc")
+    signed_snapshot_age_s = (evaluated_at - captured_at).total_seconds()
+    snapshot_age_s = max(0.0, signed_snapshot_age_s)
+
+    failures: list[str] = []
+    warnings: list[str] = []
+    if signed_snapshot_age_s < -settings.maximum_future_skew_s:
+        failures.append("snapshot:captured_in_future")
+    if snapshot_age_s > settings.maximum_snapshot_age_s:
+        failures.append("snapshot:age_limit_exceeded")
+
     streams = values.get("streams")
     _require(
         isinstance(streams, Mapping) and bool(streams),
         "snapshot streams are missing",
     )
-    failures: list[str] = []
-    warnings: list[str] = []
     stream_results: dict[str, Any] = {}
     for stream_id, raw in sorted(streams.items(), key=lambda item: str(item[0])):
+        _require(
+            isinstance(stream_id, str) and bool(stream_id.strip()),
+            "snapshot stream IDs must be nonempty strings",
+        )
         _require(isinstance(raw, Mapping), f"stream {stream_id} must be an object")
         stream = dict(raw)
         required = stream.get("required", True)
@@ -106,6 +161,7 @@ def evaluate_health_snapshot(
             name=f"stream {stream_id}.heartbeat_age_s",
             minimum=0.0,
         )
+        effective_heartbeat = heartbeat + snapshot_age_s
         dropped = stream.get("dropped_frames", 0)
         _require(
             isinstance(dropped, int) and not isinstance(dropped, bool) and dropped >= 0,
@@ -120,7 +176,7 @@ def evaluate_health_snapshot(
         issues = []
         if required and not alive:
             issues.append("required_stream_not_alive")
-        if required and heartbeat > settings.maximum_heartbeat_age_s:
+        if required and effective_heartbeat > settings.maximum_heartbeat_age_s:
             issues.append("required_stream_heartbeat_stale")
         if required and dropped > settings.maximum_dropped_frames:
             issues.append("dropped_frame_limit_exceeded")
@@ -133,13 +189,14 @@ def evaluate_health_snapshot(
         if issues:
             failures.extend(f"stream:{stream_id}:{issue}" for issue in issues)
         elif not required and (
-            not alive or heartbeat > settings.maximum_heartbeat_age_s
+            not alive or effective_heartbeat > settings.maximum_heartbeat_age_s
         ):
             warnings.append(f"optional_stream:{stream_id}:unhealthy")
-        stream_results[str(stream_id)] = {
+        stream_results[stream_id] = {
             "required": required,
             "alive": alive,
             "heartbeat_age_s": heartbeat,
+            "effective_heartbeat_age_s": effective_heartbeat,
             "dropped_frames": dropped,
             "clock_offset_ms": clock_offset,
             "issues": issues,
@@ -169,8 +226,11 @@ def evaluate_health_snapshot(
         "artifact_kind": "Causal4DAcquisitionHealthDecision",
         "protocol_id": values["protocol_id"],
         "session_id": values["session_id"],
-        "execution_id": values.get("execution_id"),
+        "execution_id": execution_id,
         "captured_at_utc": values["captured_at_utc"],
+        "evaluated_at_utc": evaluated_at.isoformat(),
+        "signed_snapshot_age_s": signed_snapshot_age_s,
+        "snapshot_age_s": snapshot_age_s,
         "thresholds": asdict(settings),
         "streams": stream_results,
         "storage": {"free_bytes": free_bytes, "write_mib_s": write_rate},
@@ -181,8 +241,33 @@ def evaluate_health_snapshot(
     }
 
 
+def evaluate_health_snapshot_file(
+    path: str | Path,
+    *,
+    thresholds: HealthThresholds | None = None,
+    evaluated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Evaluate exact ordinary-file snapshot bytes and content-bind the decision."""
+
+    source = read_regular_file(path, name="health snapshot")
+    snapshot = load_strict_json_object(source.payload, name="health snapshot")
+    result = evaluate_health_snapshot(
+        snapshot,
+        thresholds=thresholds,
+        evaluated_at_utc=evaluated_at_utc or _utc_now(),
+    )
+    result["snapshot_sha256"] = source.sha256
+    result["snapshot_byte_count"] = source.byte_count
+    result["decision_sha256"] = _canonical_sha256(
+        result,
+        omitted="decision_sha256",
+    )
+    return result
+
+
 __all__ = [
     "HEALTH_SNAPSHOT_KIND",
     "HealthThresholds",
     "evaluate_health_snapshot",
+    "evaluate_health_snapshot_file",
 ]

--- a/src/causal4d/cli/acquisition_operations.py
+++ b/src/causal4d/cli/acquisition_operations.py
@@ -12,7 +12,7 @@ from causal4d.acquisition_flight_recorder import (
     HealthThresholds,
     append_journal_event,
     build_acquisition_doctor_report,
-    evaluate_health_snapshot,
+    evaluate_health_snapshot_file,
     seal_acquisition_journal,
     validate_acquisition_journal,
     validate_acquisition_journal_seal,
@@ -93,7 +93,7 @@ def _add_journal(subparsers: Any) -> None:
 def _add_snapshot(subparsers: Any) -> None:
     snapshot = subparsers.add_parser(
         "snapshot",
-        help="evaluate one live collection-health snapshot",
+        help="evaluate one exact-byte live collection-health snapshot",
     )
     snapshot.add_argument("snapshot_json", type=Path)
     snapshot.add_argument("--maximum-heartbeat-age-s", type=float, default=2.0)
@@ -101,6 +101,10 @@ def _add_snapshot(subparsers: Any) -> None:
     snapshot.add_argument("--maximum-dropped-frames", type=int, default=0)
     snapshot.add_argument("--minimum-free-gib", type=_gib, default=_gib(20.0))
     snapshot.add_argument("--minimum-write-mib-s", type=float, default=25.0)
+    snapshot.add_argument("--maximum-snapshot-age-s", type=float, default=5.0)
+    snapshot.add_argument("--maximum-future-skew-s", type=float, default=1.0)
+    snapshot.add_argument("--output-json", type=Path)
+    snapshot.add_argument("--overwrite", action="store_true")
     snapshot.add_argument("--require-healthy", action="store_true")
 
 
@@ -182,17 +186,24 @@ def _journal(arguments: argparse.Namespace) -> int:
 
 
 def _snapshot(arguments: argparse.Namespace) -> int:
-    snapshot = _json_object(arguments.snapshot_json, name="health snapshot")
-    result = evaluate_health_snapshot(
-        snapshot,
+    result = evaluate_health_snapshot_file(
+        arguments.snapshot_json,
         thresholds=HealthThresholds(
             maximum_heartbeat_age_s=arguments.maximum_heartbeat_age_s,
             maximum_clock_offset_ms=arguments.maximum_clock_offset_ms,
             maximum_dropped_frames=arguments.maximum_dropped_frames,
             minimum_free_bytes=arguments.minimum_free_gib,
             minimum_write_mib_s=arguments.minimum_write_mib_s,
+            maximum_snapshot_age_s=arguments.maximum_snapshot_age_s,
+            maximum_future_skew_s=arguments.maximum_future_skew_s,
         ),
     )
+    if arguments.output_json is not None:
+        atomic_write_json(
+            arguments.output_json,
+            result,
+            overwrite=arguments.overwrite,
+        )
     print(json.dumps(result, indent=2, sort_keys=True))
     if arguments.require_healthy and not result["passed"]:
         return 3

--- a/tests/test_acquisition_health_freshness.py
+++ b/tests/test_acquisition_health_freshness.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from causal4d.acquisition_health import (
+    HEALTH_SNAPSHOT_KIND,
+    HealthThresholds,
+    evaluate_health_snapshot,
+    evaluate_health_snapshot_file,
+)
+
+
+CAPTURED = "2026-08-03T08:00:00+00:00"
+
+
+def _snapshot() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "artifact_kind": HEALTH_SNAPSHOT_KIND,
+        "protocol_id": "protocol-v1",
+        "session_id": "session-1",
+        "execution_id": "execution-1",
+        "captured_at_utc": CAPTURED,
+        "target_outcomes_used": False,
+        "streams": {
+            "rgbd": {
+                "required": True,
+                "alive": True,
+                "heartbeat_age_s": 0.2,
+                "dropped_frames": 0,
+                "clock_offset_ms": 1.5,
+            }
+        },
+        "storage": {"free_bytes": 1000, "write_mib_s": 100.0},
+    }
+
+
+def _thresholds(**changes: object) -> HealthThresholds:
+    values: dict[str, object] = {
+        "maximum_heartbeat_age_s": 2.0,
+        "maximum_clock_offset_ms": 5.0,
+        "maximum_dropped_frames": 0,
+        "minimum_free_bytes": 500,
+        "minimum_write_mib_s": 50.0,
+        "maximum_snapshot_age_s": 5.0,
+        "maximum_future_skew_s": 1.0,
+    }
+    values.update(changes)
+    return HealthThresholds(**values)
+
+
+def test_direct_mapping_evaluation_remains_deterministic_offline() -> None:
+    result = evaluate_health_snapshot(_snapshot(), thresholds=_thresholds())
+
+    assert result["passed"] is True
+    assert result["snapshot_age_s"] == 0.0
+    assert result["evaluated_at_utc"] == CAPTURED
+    assert result["streams"]["rgbd"]["effective_heartbeat_age_s"] == 0.2
+
+
+def test_transport_delay_contributes_to_effective_heartbeat_age() -> None:
+    result = evaluate_health_snapshot(
+        _snapshot(),
+        thresholds=_thresholds(maximum_snapshot_age_s=10.0),
+        evaluated_at_utc="2026-08-03T08:00:03+00:00",
+    )
+
+    assert result["snapshot_age_s"] == 3.0
+    assert result["streams"]["rgbd"]["effective_heartbeat_age_s"] == 3.2
+    assert "stream:rgbd:required_stream_heartbeat_stale" in result["failures"]
+
+
+def test_snapshot_age_and_future_skew_fail_closed() -> None:
+    stale = evaluate_health_snapshot(
+        _snapshot(),
+        thresholds=_thresholds(maximum_snapshot_age_s=2.0),
+        evaluated_at_utc="2026-08-03T08:00:03+00:00",
+    )
+    assert "snapshot:age_limit_exceeded" in stale["failures"]
+
+    future = evaluate_health_snapshot(
+        _snapshot(),
+        thresholds=_thresholds(maximum_future_skew_s=0.5),
+        evaluated_at_utc="2026-08-03T07:59:58+00:00",
+    )
+    assert "snapshot:captured_in_future" in future["failures"]
+
+
+def test_file_evaluation_binds_exact_bytes_and_rejects_duplicate_keys(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "health.json"
+    path.write_text(json.dumps(_snapshot()), encoding="utf-8")
+    result = evaluate_health_snapshot_file(
+        path,
+        thresholds=_thresholds(),
+        evaluated_at_utc=CAPTURED,
+    )
+
+    assert len(result["snapshot_sha256"]) == 64
+    assert result["snapshot_byte_count"] == path.stat().st_size
+    assert len(result["decision_sha256"]) == 64
+
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text(
+        '{"schema_version":1,"schema_version":1}',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        evaluate_health_snapshot_file(duplicate, evaluated_at_utc=CAPTURED)
+
+
+def test_file_evaluation_rejects_symbolic_links(tmp_path: Path) -> None:
+    target = tmp_path / "health.json"
+    target.write_text(json.dumps(_snapshot()), encoding="utf-8")
+    link = tmp_path / "health-link.json"
+    try:
+        link.symlink_to(target)
+    except OSError as error:  # pragma: no cover - symlinks unavailable
+        pytest.skip(f"symlinks unavailable: {error}")
+
+    with pytest.raises(ValueError, match="ordinary readable file"):
+        evaluate_health_snapshot_file(link, evaluated_at_utc=CAPTURED)
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    (
+        ("maximum_heartbeat_age_s", float("inf")),
+        ("maximum_clock_offset_ms", float("nan")),
+        ("minimum_free_bytes", True),
+        ("maximum_dropped_frames", False),
+    ),
+)
+def test_thresholds_reject_nonfinite_and_boolean_values(
+    name: str,
+    value: object,
+) -> None:
+    with pytest.raises(ValueError):
+        _thresholds(**{name: value})


### PR DESCRIPTION
## Summary

Harden the method-neutral live acquisition-health path without changing the estimator, protocol, target boundary, scientific thresholds, or physical evidence count.

- account for snapshot transport delay when evaluating stream heartbeat freshness;
- reject snapshots that are too old or implausibly far in the future;
- validate optional execution IDs and stream IDs;
- reject non-finite and Boolean watchdog thresholds;
- evaluate CLI inputs through the exact-byte ordinary-file reader and strict JSON parser, rejecting final symlinks, duplicate keys, and non-finite JSON;
- bind decisions to the source snapshot SHA-256 and byte count and emit a decision SHA-256;
- allow atomic archival of the printed decision with `--output-json` and fail-closed no-overwrite behavior; and
- document the freshness, exact-byte, and scientific boundaries.

## Root cause

The previous checker compared `heartbeat_age_s` exactly as reported at `captured_at_utc`. It did not add the delay between capture and evaluation. A stale snapshot could therefore retain apparently recent producer-local heartbeats and pass after the producer or snapshot publication path had stalled. The CLI also used ordinary `Path.read_text()`/`json.loads()` rather than the repository's exact-byte ordinary-file and strict-JSON boundary.

The effective heartbeat age is now:

```text
effective_heartbeat_age_s = heartbeat_age_s + snapshot_age_s
```

Live file evaluation defaults to the current UTC time. Direct mapping evaluation remains deterministic for archived diagnostics by anchoring to the capture time unless an explicit evaluation time is supplied.

## Validation

Targeted local validation against a minimal package reconstruction:

```text
9 passed
Python compilation: passed
Changed Python lines <= 88 characters
```

The new regressions cover transport-delay heartbeat aging, stale and future snapshots, exact-byte identities, duplicate JSON keys, final symlink rejection, deterministic offline evaluation, and non-finite/Boolean thresholds.

GitHub Actions on the exact PR head remain authoritative for Ruff formatting, MyPy, the complete test matrix, distributions, security scanning, and installed-artifact contracts.

## Scientific boundary

This is operational safety and provenance hardening only. A healthy decision remains non-claim-bearing: it does not increment the registered execution count, validate an execution manifest, determine inclusion, tune a method, inspect target outcomes, or support a physical-prediction claim.