### PR TITLE
Bind prospective V2 promotion to validated evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add evidence-bound prospective V2 promotion contracts that freeze the
   target inventory and metric semantics, derive acceptance, exact fallback,
   and harmful-update status from validated decision traces and raw scores,
-  and require independent confirmation after candidate selection.
+  and require a fresh independent confirmation panel after candidate selection.
 - Add source-only task-projected functional-support certification over frozen
   linear readouts, including posterior-mixture covariance, optional
   component-specific low-rank uncertainty modes, exact Gaussian-mixture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- Add evidence-bound prospective V2 promotion contracts that freeze the
+  target inventory and metric semantics, derive acceptance, exact fallback,
+  and harmful-update status from validated decision traces and raw scores,
+  and require independent confirmation after candidate selection.
 - Add source-only task-projected functional-support certification over frozen
   linear readouts, including posterior-mixture covariance, optional
   component-specific low-rank uncertainty modes, exact Gaussian-mixture

--- a/docs/prospective_v2_promotion.md
+++ b/docs/prospective_v2_promotion.md
@@ -1,19 +1,100 @@
-# Prospective V2 promotion status
+# Evidence-bound prospective V2 promotion
 
-The source-only task-projection certificate and the versioned prospective V2
-decision profile are documented in:
+The prospective V2 promotion path is a separate candidate-selection experiment.
+It does not modify the frozen physical-acquisition estimator or the registered
+18-session/36-execution protocol.
 
-- `docs/projected_functional_support.md`; and
-- `docs/prospective_v2_profile.md`.
+The implementation is split into three boundaries:
 
-The target-opening promotion experiment is intentionally not admitted by this
-change. Before publication it must bind every metric row to the frozen target
-artifact, metric definition, candidate artifact, and validated decision trace;
-derive acceptance, fallback, and harmful-update status from those artifacts;
-and record that a panel used for candidate selection cannot also support an
-unbiased post-selection performance claim.
+1. source-only certification and the fixed V2 decision inventory;
+2. one sealed opening of a preregistered target inventory; and
+3. endpoint-wise candidate selection from artifact-bound evaluations.
 
-This separation prevents source-only integration infrastructure from being
-mistaken for target evidence or method promotion. The registered physical
-acquisition candidate, 18-session/36-execution protocol, target boundary, and
-evidence count remain unchanged.
+## Target-free freeze
+
+`ProspectiveV2PromotionFreezeV1` is created before target access. It binds:
+
+- the exact stack lock;
+- the fixed candidate ladder, from the registered baseline through the sparse
+  contact-patch candidate;
+- every independent evaluation unit and its endpoint, protocol, case, session,
+  factual context, counterfactual query, target artifact, and access seal;
+- the scoring implementation and exact metric semantics;
+- the harmful-regret threshold and all endpoint promotion thresholds; and
+- the source artifact inventory.
+
+The freeze is explicitly a `candidate_selection_only` panel. It always records
+that an unbiased post-selection performance claim is unsupported and that an
+independent confirmation panel is required.
+
+## One target opening
+
+`build_prospective_v2_target_opening_v1` derives the opening inventory from the
+freeze. The opening ID binds the complete ordered target-artifact inventory and
+the preregistered target-access seal. The promotion evaluator rejects a subset,
+extra artifact, reordered inventory, different seal, or different freeze.
+
+No caller-supplied `one_target_opening_verified` Boolean exists. The property is
+established by exact identity and inventory validation.
+
+## Bound unit evaluations
+
+Each non-baseline candidate and registered unit produces:
+
+1. a prospective V2 decision trace;
+2. baseline and candidate prediction artifacts; and
+3. one raw metric-value artifact.
+
+The decision trace must pass the complete V2 profile and content-bind the
+candidate ID, candidate configuration, evaluation unit, and target-access seal.
+The raw metric artifact must bind:
+
+- the target opening;
+- the frozen unit and candidate bindings;
+- the exact target artifact;
+- the baseline and candidate prediction artifacts; and
+- the frozen metric contract.
+
+`build_prospective_v2_unit_evaluation_v1` then derives, rather than accepts from
+the caller:
+
+- candidate acceptance from the validated trace;
+- exact fallback from the deployed prediction identity;
+- baseline-relative log-score, Brier, and trajectory effects;
+- coverage error and interval-width ratio; and
+- harmful accepted-update status from the frozen regret threshold.
+
+Consequently, metric rows cannot self-declare acceptance, fallback, or
+harmfulness.
+
+## Promotion result
+
+`evaluate_prospective_v2_promotion_v1` requires the complete Cartesian product of
+registered units and non-baseline candidates. It aggregates at the independent
+unit level for factual continuation, same-grasp transfer, and new-contact
+transfer separately. A candidate passes only when every endpoint passes every
+frozen threshold.
+
+The selected configuration is the highest passing member of the frozen ladder.
+When none passes, the selected configuration is the exact registered baseline
+configuration. `validate_prospective_v2_promotion_result_v1` recomputes the
+complete result and requires exact equality with its bound source evaluations.
+
+Even a positive result remains a selection result. The result artifact always
+contains:
+
+```text
+selection_panel_role = candidate_selection_only
+unbiased_post_selection_performance_claimed = false
+independent_confirmation_required = true
+```
+
+A fresh independent panel is required before reporting post-selection predictive
+performance for the selected candidate.
+
+## Scientific boundary
+
+This infrastructure creates no physical execution, observation, accuracy result,
+calibration result, or evidence count by itself. It cannot admit Prob4D into the
+frozen acquisition, change the six-frame information boundary, revise the
+registered method, or rescue a failed 36-execution primary result.

--- a/src/causal4d/_prospective_v2_promotion_evidence.py
+++ b/src/causal4d/_prospective_v2_promotion_evidence.py
@@ -1,0 +1,1122 @@
+"""Evidence-bound inputs for prospective Causal4D V2 promotion.
+
+The contracts in this module separate target-free registration from target-side
+scoring.  Candidate selection, exact fallback, and harmful-update labels are
+derived from a validated decision trace and baseline-relative metrics; callers
+do not provide those labels.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import hashlib
+import json
+import math
+from numbers import Real
+from typing import Any
+
+from causal4d.decision_trace import DECISION_TRACE_ENDPOINTS, UnifiedDecisionTrace
+from causal4d.immutable_json import plain_json, validated_json_mapping
+from causal4d.prospective_v2_profile import (
+    validate_prospective_v2_decision_trace_v1,
+)
+
+
+PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION = 1
+PROSPECTIVE_V2_SELECTION_PANEL_ROLE = "candidate_selection_only"
+PROSPECTIVE_V2_CANDIDATE_KINDS = (
+    "registered_baseline",
+    "normalized_diagonal",
+    "normalized_full_covariance",
+    "full_covariance_coreset",
+    "sparse_contact_patch",
+)
+PROSPECTIVE_V2_METRIC_SEMANTICS = {
+    "log_score_gain": "candidate_minus_baseline_higher_is_better",
+    "brier_change": "candidate_minus_baseline_lower_is_better",
+    "trajectory_regret_m": "candidate_minus_baseline_lower_is_better",
+    "coverage_error": "absolute_empirical_minus_nominal_lower_is_better",
+    "interval_width_ratio": "candidate_over_baseline_lower_is_better",
+    "accepted_update": "derived_from_validated_v2_decision_trace",
+    "fallback": "deployed_prediction_is_exact_baseline_prediction",
+    "harmful_accepted_update": (
+        "accepted_and_trajectory_regret_exceeds_frozen_threshold"
+    ),
+}
+
+_FORBIDDEN_SOURCE_METADATA_KEYS = {
+    "candidate_metric",
+    "evaluation_target",
+    "held_out_target",
+    "target_future",
+    "target_loss",
+    "target_metric",
+    "target_outcome",
+    "target_outcomes",
+    "target_value",
+}
+
+_TRACE_METADATA_FIELDS = {
+    "promotion_candidate_id": "candidate_id",
+    "promotion_candidate_configuration_id": "candidate_configuration_id",
+    "promotion_evaluation_unit_id": "evaluation_unit_id",
+    "promotion_target_access_seal_id": "target_access_seal_id",
+}
+
+
+def _canonical_sha256(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        plain_json(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _require_nonempty_string(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _require_sha256(value: Any, *, name: str) -> str:
+    digest = _require_nonempty_string(value, name=name)
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _require_bool(value: Any, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a boolean")
+    return value
+
+
+def _finite_float(value: Any, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be a finite number")
+    return result
+
+
+def _finite_nonnegative_float(value: Any, *, name: str) -> float:
+    result = _finite_float(value, name=name)
+    if result < 0.0:
+        raise ValueError(f"{name} must be nonnegative")
+    return result
+
+
+def _rate(value: Any, *, name: str) -> float:
+    result = _finite_float(value, name=name)
+    if not 0.0 <= result <= 1.0:
+        raise ValueError(f"{name} must lie in [0, 1]")
+    return result
+
+
+def _positive_integer(value: Any, *, name: str) -> int:
+    if type(value) is not int or value < 1:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def _utc_timestamp(value: Any, *, name: str) -> str:
+    text = _require_nonempty_string(value, name=name)
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(f"{name} must be an ISO-8601 timestamp") from error
+    if parsed.tzinfo is None or parsed.utcoffset() != timezone.utc.utcoffset(parsed):
+        raise ValueError(f"{name} must use UTC")
+    return text
+
+
+def _validated_unique_strings(
+    values: Any,
+    *,
+    name: str,
+    require_sha256: bool = False,
+) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise ValueError(f"{name} must be a sequence of strings")
+    validator = _require_sha256 if require_sha256 else _require_nonempty_string
+    result = tuple(
+        validator(value, name=f"{name}[{index}]") for index, value in enumerate(values)
+    )
+    if not result:
+        raise ValueError(f"{name} must be nonempty")
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must contain unique values")
+    return result
+
+
+def _reject_target_metadata(value: Any, *, path: str) -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            normalized = key.strip().lower().replace("-", "_")
+            if normalized in _FORBIDDEN_SOURCE_METADATA_KEYS:
+                raise ValueError(f"{path}.{key} is forbidden before target opening")
+            _reject_target_metadata(item, path=f"{path}.{key}")
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        for index, item in enumerate(value):
+            _reject_target_metadata(item, path=f"{path}[{index}]")
+
+
+def _validated_source_metadata(
+    values: Mapping[str, Any],
+    *,
+    name: str,
+) -> Mapping[str, Any]:
+    metadata = validated_json_mapping(
+        values,
+        error_message=f"{name} must contain finite JSON data",
+    )
+    _reject_target_metadata(metadata, path=name)
+    return metadata
+
+
+def _validated_target_metadata(
+    values: Mapping[str, Any],
+    *,
+    name: str,
+) -> Mapping[str, Any]:
+    return validated_json_mapping(
+        values,
+        error_message=f"{name} must contain finite JSON data",
+    )
+
+
+@dataclass(frozen=True)
+class ProspectiveV2MetricContractV1:
+    """Freeze score semantics and harmful-update interpretation before access."""
+
+    scoring_implementation_artifact_id: str
+    nominal_coverage: float
+    harmful_regret_threshold_m: float
+    target_outcomes_used: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        implementation_id = _require_sha256(
+            self.scoring_implementation_artifact_id,
+            name="scoring_implementation_artifact_id",
+        )
+        nominal_coverage = _rate(self.nominal_coverage, name="nominal_coverage")
+        if nominal_coverage in {0.0, 1.0}:
+            raise ValueError("nominal_coverage must lie strictly between zero and one")
+        threshold = _finite_nonnegative_float(
+            self.harmful_regret_threshold_m,
+            name="harmful_regret_threshold_m",
+        )
+        if _require_bool(self.target_outcomes_used, name="target_outcomes_used"):
+            raise ValueError("metric contract must be frozen before target access")
+        metadata = _validated_source_metadata(
+            self.metadata,
+            name="metric-contract metadata",
+        )
+        object.__setattr__(
+            self,
+            "scoring_implementation_artifact_id",
+            implementation_id,
+        )
+        object.__setattr__(self, "nominal_coverage", nominal_coverage)
+        object.__setattr__(self, "harmful_regret_threshold_m", threshold)
+        object.__setattr__(self, "metadata", metadata)
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION,
+            "artifact_kind": "Causal4DProspectiveV2MetricContractV1",
+            "scoring_implementation_artifact_id": (
+                self.scoring_implementation_artifact_id
+            ),
+            "metric_semantics": dict(PROSPECTIVE_V2_METRIC_SEMANTICS),
+            "nominal_coverage": self.nominal_coverage,
+            "harmful_regret_threshold_m": self.harmful_regret_threshold_m,
+            "selection_panel_role": PROSPECTIVE_V2_SELECTION_PANEL_ROLE,
+            "unbiased_post_selection_performance_claimed": False,
+            "independent_confirmation_required": True,
+            "target_outcomes_used": False,
+            "metadata": plain_json(self.metadata),
+        }
+
+    @property
+    def metric_contract_id(self) -> str:
+        return _canonical_sha256(self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "metric_contract_id": self.metric_contract_id}
+
+
+@dataclass(frozen=True)
+class ProspectiveV2PromotionPolicyV1:
+    """Endpoint-wise promotion thresholds frozen before target access."""
+
+    minimum_units_per_endpoint: int
+    minimum_mean_log_score_gain: float
+    maximum_mean_brier_change: float
+    maximum_mean_trajectory_regret_m: float
+    maximum_mean_coverage_error: float
+    maximum_mean_interval_width_ratio: float
+    minimum_accepted_update_rate: float
+    maximum_harmful_accepted_update_rate: float
+    maximum_fallback_rate: float
+    interval_width_floor_m: float = 1e-9
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "minimum_units_per_endpoint",
+            _positive_integer(
+                self.minimum_units_per_endpoint,
+                name="minimum_units_per_endpoint",
+            ),
+        )
+        for name in (
+            "minimum_mean_log_score_gain",
+            "maximum_mean_brier_change",
+            "maximum_mean_trajectory_regret_m",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _finite_float(getattr(self, name), name=name),
+            )
+        object.__setattr__(
+            self,
+            "maximum_mean_coverage_error",
+            _rate(
+                self.maximum_mean_coverage_error,
+                name="maximum_mean_coverage_error",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "maximum_mean_interval_width_ratio",
+            _finite_nonnegative_float(
+                self.maximum_mean_interval_width_ratio,
+                name="maximum_mean_interval_width_ratio",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "minimum_accepted_update_rate",
+            _rate(
+                self.minimum_accepted_update_rate,
+                name="minimum_accepted_update_rate",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "maximum_harmful_accepted_update_rate",
+            _rate(
+                self.maximum_harmful_accepted_update_rate,
+                name="maximum_harmful_accepted_update_rate",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "maximum_fallback_rate",
+            _rate(self.maximum_fallback_rate, name="maximum_fallback_rate"),
+        )
+        floor = _finite_nonnegative_float(
+            self.interval_width_floor_m,
+            name="interval_width_floor_m",
+        )
+        if floor <= 0.0:
+            raise ValueError("interval_width_floor_m must be positive")
+        object.__setattr__(self, "interval_width_floor_m", floor)
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "minimum_units_per_endpoint": self.minimum_units_per_endpoint,
+            "minimum_mean_log_score_gain": self.minimum_mean_log_score_gain,
+            "maximum_mean_brier_change": self.maximum_mean_brier_change,
+            "maximum_mean_trajectory_regret_m": (self.maximum_mean_trajectory_regret_m),
+            "maximum_mean_coverage_error": self.maximum_mean_coverage_error,
+            "maximum_mean_interval_width_ratio": (
+                self.maximum_mean_interval_width_ratio
+            ),
+            "minimum_accepted_update_rate": self.minimum_accepted_update_rate,
+            "maximum_harmful_accepted_update_rate": (
+                self.maximum_harmful_accepted_update_rate
+            ),
+            "maximum_fallback_rate": self.maximum_fallback_rate,
+            "interval_width_floor_m": self.interval_width_floor_m,
+        }
+
+    @property
+    def policy_id(self) -> str:
+        return _canonical_sha256(
+            {
+                "schema_version": PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION,
+                "artifact_kind": "Causal4DProspectiveV2PromotionPolicyV1",
+                **self._payload(),
+            }
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "policy_id": self.policy_id}
+
+
+@dataclass(frozen=True)
+class ProspectiveV2CandidateV1:
+    """One source-frozen candidate configuration in the fixed V2 ladder."""
+
+    candidate_id: str
+    candidate_kind: str
+    configuration_artifact_id: str
+    target_outcomes_used: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        candidate_id = _require_nonempty_string(self.candidate_id, name="candidate_id")
+        candidate_kind = _require_nonempty_string(
+            self.candidate_kind,
+            name="candidate_kind",
+        )
+        if candidate_kind not in PROSPECTIVE_V2_CANDIDATE_KINDS:
+            raise ValueError("candidate_kind does not belong to the V2 ladder")
+        configuration_id = _require_sha256(
+            self.configuration_artifact_id,
+            name="configuration_artifact_id",
+        )
+        if _require_bool(self.target_outcomes_used, name="target_outcomes_used"):
+            raise ValueError("candidate configuration must remain target-free")
+        metadata = _validated_source_metadata(
+            self.metadata,
+            name="candidate metadata",
+        )
+        object.__setattr__(self, "candidate_id", candidate_id)
+        object.__setattr__(self, "candidate_kind", candidate_kind)
+        object.__setattr__(self, "configuration_artifact_id", configuration_id)
+        object.__setattr__(self, "metadata", metadata)
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "candidate_id": self.candidate_id,
+            "candidate_kind": self.candidate_kind,
+            "configuration_artifact_id": self.configuration_artifact_id,
+            "target_outcomes_used": False,
+            "metadata": plain_json(self.metadata),
+        }
+
+    @property
+    def candidate_binding_id(self) -> str:
+        return _canonical_sha256(
+            {
+                "schema_version": PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION,
+                "artifact_kind": "Causal4DProspectiveV2CandidateV1",
+                **self._payload(),
+            }
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "candidate_binding_id": self.candidate_binding_id}
+
+
+@dataclass(frozen=True)
+class ProspectiveV2EvaluationUnitV1:
+    """One target artifact and independent group registered before opening."""
+
+    unit_id: str
+    endpoint: str
+    protocol_id: str
+    case_id: str
+    session_id: str
+    independent_group_id: str
+    target_artifact_id: str
+    factual_context_artifact_id: str
+    counterfactual_query_artifact_id: str
+    target_access_seal_id: str
+    target_outcomes_used: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        unit_id = _require_nonempty_string(self.unit_id, name="unit_id")
+        endpoint = _require_nonempty_string(self.endpoint, name="endpoint")
+        if endpoint not in DECISION_TRACE_ENDPOINTS:
+            raise ValueError("evaluation unit endpoint is invalid")
+        protocol_id = _require_nonempty_string(self.protocol_id, name="protocol_id")
+        case_id = _require_nonempty_string(self.case_id, name="case_id")
+        session_id = _require_nonempty_string(self.session_id, name="session_id")
+        independent_group_id = _require_nonempty_string(
+            self.independent_group_id,
+            name="independent_group_id",
+        )
+        target_id = _require_sha256(
+            self.target_artifact_id,
+            name="target_artifact_id",
+        )
+        factual_id = _require_sha256(
+            self.factual_context_artifact_id,
+            name="factual_context_artifact_id",
+        )
+        query_id = _require_sha256(
+            self.counterfactual_query_artifact_id,
+            name="counterfactual_query_artifact_id",
+        )
+        seal_id = _require_sha256(
+            self.target_access_seal_id,
+            name="target_access_seal_id",
+        )
+        if _require_bool(self.target_outcomes_used, name="target_outcomes_used"):
+            raise ValueError("evaluation units must be registered before target access")
+        metadata = _validated_source_metadata(
+            self.metadata,
+            name="evaluation-unit metadata",
+        )
+        object.__setattr__(self, "unit_id", unit_id)
+        object.__setattr__(self, "endpoint", endpoint)
+        object.__setattr__(self, "protocol_id", protocol_id)
+        object.__setattr__(self, "case_id", case_id)
+        object.__setattr__(self, "session_id", session_id)
+        object.__setattr__(self, "independent_group_id", independent_group_id)
+        object.__setattr__(self, "target_artifact_id", target_id)
+        object.__setattr__(self, "factual_context_artifact_id", factual_id)
+        object.__setattr__(self, "counterfactual_query_artifact_id", query_id)
+        object.__setattr__(self, "target_access_seal_id", seal_id)
+        object.__setattr__(self, "metadata", metadata)
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "unit_id": self.unit_id,
+            "endpoint": self.endpoint,
+            "protocol_id": self.protocol_id,
+            "case_id": self.case_id,
+            "session_id": self.session_id,
+            "independent_group_id": self.independent_group_id,
+            "target_artifact_id": self.target_artifact_id,
+            "factual_context_artifact_id": self.factual_context_artifact_id,
+            "counterfactual_query_artifact_id": (self.counterfactual_query_artifact_id),
+            "target_access_seal_id": self.target_access_seal_id,
+            "target_outcomes_used": False,
+            "metadata": plain_json(self.metadata),
+        }
+
+    @property
+    def unit_binding_id(self) -> str:
+        return _canonical_sha256(
+            {
+                "schema_version": PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION,
+                "artifact_kind": "Causal4DProspectiveV2EvaluationUnitV1",
+                **self._payload(),
+            }
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "unit_binding_id": self.unit_binding_id}
+
+
+@dataclass(frozen=True)
+class ProspectiveV2PromotionFreezeV1:
+    """Complete target-free registration for one candidate-selection panel."""
+
+    experiment_id: str
+    stack_lock_id: str
+    target_access_seal_id: str
+    candidates: tuple[ProspectiveV2CandidateV1, ...]
+    evaluation_units: tuple[ProspectiveV2EvaluationUnitV1, ...]
+    metric_contract: ProspectiveV2MetricContractV1
+    policy: ProspectiveV2PromotionPolicyV1
+    source_artifact_ids: tuple[str, ...]
+    target_outcomes_used: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        experiment_id = _require_nonempty_string(
+            self.experiment_id,
+            name="experiment_id",
+        )
+        stack_lock_id = _require_sha256(self.stack_lock_id, name="stack_lock_id")
+        seal_id = _require_sha256(
+            self.target_access_seal_id,
+            name="target_access_seal_id",
+        )
+        candidates = tuple(self.candidates)
+        if any(
+            type(candidate) is not ProspectiveV2CandidateV1 for candidate in candidates
+        ):
+            raise ValueError("candidates must contain ProspectiveV2CandidateV1 values")
+        if tuple(candidate.candidate_kind for candidate in candidates) != (
+            PROSPECTIVE_V2_CANDIDATE_KINDS
+        ):
+            raise ValueError("candidate ladder must exactly match the V2 registration")
+        candidate_ids = tuple(candidate.candidate_id for candidate in candidates)
+        candidate_bindings = tuple(
+            candidate.candidate_binding_id for candidate in candidates
+        )
+        if len(set(candidate_ids)) != len(candidate_ids):
+            raise ValueError("candidate IDs must be unique")
+        if len(set(candidate_bindings)) != len(candidate_bindings):
+            raise ValueError("candidate bindings must be unique")
+        units = tuple(self.evaluation_units)
+        if not units or any(
+            type(unit) is not ProspectiveV2EvaluationUnitV1 for unit in units
+        ):
+            raise ValueError(
+                "evaluation_units must contain ProspectiveV2EvaluationUnitV1 values"
+            )
+        if any(unit.target_access_seal_id != seal_id for unit in units):
+            raise ValueError("every evaluation unit must bind the frozen access seal")
+        unit_ids = tuple(unit.unit_id for unit in units)
+        unit_bindings = tuple(unit.unit_binding_id for unit in units)
+        target_ids = tuple(unit.target_artifact_id for unit in units)
+        if len(set(unit_ids)) != len(unit_ids):
+            raise ValueError("evaluation unit IDs must be unique")
+        if len(set(unit_bindings)) != len(unit_bindings):
+            raise ValueError("evaluation unit bindings must be unique")
+        if len(set(target_ids)) != len(target_ids):
+            raise ValueError("registered target artifact IDs must be unique")
+        independence_keys = tuple(
+            (unit.endpoint, unit.independent_group_id) for unit in units
+        )
+        if len(set(independence_keys)) != len(independence_keys):
+            raise ValueError(
+                "independent_group_id must be unique within every endpoint"
+            )
+        if type(self.metric_contract) is not ProspectiveV2MetricContractV1:
+            raise ValueError("metric_contract has the wrong type")
+        if type(self.policy) is not ProspectiveV2PromotionPolicyV1:
+            raise ValueError("policy has the wrong type")
+        for endpoint in DECISION_TRACE_ENDPOINTS:
+            count = sum(unit.endpoint == endpoint for unit in units)
+            if count < self.policy.minimum_units_per_endpoint:
+                raise ValueError(
+                    f"endpoint {endpoint!r} has insufficient independent units"
+                )
+        source_ids = _validated_unique_strings(
+            self.source_artifact_ids,
+            name="source_artifact_ids",
+            require_sha256=True,
+        )
+        required_source_ids = {
+            stack_lock_id,
+            seal_id,
+            self.metric_contract.scoring_implementation_artifact_id,
+            *(candidate.configuration_artifact_id for candidate in candidates),
+            *(unit.factual_context_artifact_id for unit in units),
+            *(unit.counterfactual_query_artifact_id for unit in units),
+        }
+        missing_source_ids = sorted(required_source_ids - set(source_ids))
+        if missing_source_ids:
+            raise ValueError(
+                "source_artifact_ids do not bind every target-free source; "
+                f"missing={missing_source_ids}"
+            )
+        if _require_bool(self.target_outcomes_used, name="target_outcomes_used"):
+            raise ValueError("promotion freeze must predate target access")
+        metadata = _validated_source_metadata(
+            self.metadata,
+            name="promotion-freeze metadata",
+        )
+        object.__setattr__(self, "experiment_id", experiment_id)
+        object.__setattr__(self, "stack_lock_id", stack_lock_id)
+        object.__setattr__(self, "target_access_seal_id", seal_id)
+        object.__setattr__(self, "candidates", candidates)
+        object.__setattr__(self, "evaluation_units", units)
+        object.__setattr__(self, "source_artifact_ids", source_ids)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def baseline_candidate(self) -> ProspectiveV2CandidateV1:
+        return self.candidates[0]
+
+    @property
+    def candidate_by_id(self) -> dict[str, ProspectiveV2CandidateV1]:
+        return {candidate.candidate_id: candidate for candidate in self.candidates}
+
+    @property
+    def unit_by_id(self) -> dict[str, ProspectiveV2EvaluationUnitV1]:
+        return {unit.unit_id: unit for unit in self.evaluation_units}
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION,
+            "artifact_kind": "Causal4DProspectiveV2PromotionFreezeV1",
+            "experiment_id": self.experiment_id,
+            "stack_lock_id": self.stack_lock_id,
+            "target_access_seal_id": self.target_access_seal_id,
+            "candidates": [candidate.as_dict() for candidate in self.candidates],
+            "evaluation_units": [unit.as_dict() for unit in self.evaluation_units],
+            "metric_contract": self.metric_contract.as_dict(),
+            "policy": self.policy.as_dict(),
+            "source_artifact_ids": list(self.source_artifact_ids),
+            "selection_panel_role": PROSPECTIVE_V2_SELECTION_PANEL_ROLE,
+            "unbiased_post_selection_performance_claimed": False,
+            "independent_confirmation_required": True,
+            "target_outcomes_used": False,
+            "metadata": plain_json(self.metadata),
+        }
+
+    @property
+    def freeze_id(self) -> str:
+        return _canonical_sha256(self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "freeze_id": self.freeze_id}
+
+
+@dataclass(frozen=True)
+class ProspectiveV2TargetOpeningV1:
+    """One content-addressed opening of the complete registered target inventory."""
+
+    freeze_id: str
+    target_access_seal_id: str
+    target_artifact_ids: tuple[str, ...]
+    opened_at_utc: str
+    opened_by: str
+    target_outcomes_used: bool = True
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        freeze_id = _require_sha256(self.freeze_id, name="freeze_id")
+        seal_id = _require_sha256(
+            self.target_access_seal_id,
+            name="target_access_seal_id",
+        )
+        target_ids = _validated_unique_strings(
+            self.target_artifact_ids,
+            name="target_artifact_ids",
+            require_sha256=True,
+        )
+        opened_at = _utc_timestamp(self.opened_at_utc, name="opened_at_utc")
+        opened_by = _require_nonempty_string(self.opened_by, name="opened_by")
+        if not _require_bool(
+            self.target_outcomes_used,
+            name="target_outcomes_used",
+        ):
+            raise ValueError("target opening must explicitly record target access")
+        metadata = _validated_target_metadata(
+            self.metadata,
+            name="target-opening metadata",
+        )
+        object.__setattr__(self, "freeze_id", freeze_id)
+        object.__setattr__(self, "target_access_seal_id", seal_id)
+        object.__setattr__(self, "target_artifact_ids", target_ids)
+        object.__setattr__(self, "opened_at_utc", opened_at)
+        object.__setattr__(self, "opened_by", opened_by)
+        object.__setattr__(self, "metadata", metadata)
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION,
+            "artifact_kind": "Causal4DProspectiveV2TargetOpeningV1",
+            "freeze_id": self.freeze_id,
+            "target_access_seal_id": self.target_access_seal_id,
+            "target_artifact_ids": list(self.target_artifact_ids),
+            "opened_at_utc": self.opened_at_utc,
+            "opened_by": self.opened_by,
+            "target_outcomes_used": True,
+            "metadata": plain_json(self.metadata),
+        }
+
+    @property
+    def opening_id(self) -> str:
+        return _canonical_sha256(self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "opening_id": self.opening_id}
+
+
+def build_prospective_v2_target_opening_v1(
+    freeze: ProspectiveV2PromotionFreezeV1,
+    *,
+    opened_at_utc: str,
+    opened_by: str,
+    metadata: Mapping[str, Any] | None = None,
+) -> ProspectiveV2TargetOpeningV1:
+    """Open exactly the target inventory registered by ``freeze`` once."""
+
+    if type(freeze) is not ProspectiveV2PromotionFreezeV1:
+        raise ValueError("freeze has the wrong type")
+    return ProspectiveV2TargetOpeningV1(
+        freeze_id=freeze.freeze_id,
+        target_access_seal_id=freeze.target_access_seal_id,
+        target_artifact_ids=tuple(
+            unit.target_artifact_id for unit in freeze.evaluation_units
+        ),
+        opened_at_utc=opened_at_utc,
+        opened_by=opened_by,
+        target_outcomes_used=True,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+@dataclass(frozen=True)
+class ProspectiveV2UnitMetricValuesV1:
+    """Raw baseline/candidate scores bound to exact target and predictions."""
+
+    opening_id: str
+    unit_binding_id: str
+    candidate_binding_id: str
+    target_artifact_id: str
+    baseline_prediction_artifact_id: str
+    candidate_prediction_artifact_id: str
+    metric_contract_id: str
+    scoring_run_artifact_id: str
+    baseline_log_score: float
+    candidate_log_score: float
+    baseline_brier_score: float
+    candidate_brier_score: float
+    baseline_trajectory_error_m: float
+    candidate_trajectory_error_m: float
+    baseline_coverage: float
+    candidate_coverage: float
+    baseline_interval_width_m: float
+    candidate_interval_width_m: float
+    target_outcomes_used: bool = True
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for name in (
+            "opening_id",
+            "unit_binding_id",
+            "candidate_binding_id",
+            "target_artifact_id",
+            "baseline_prediction_artifact_id",
+            "candidate_prediction_artifact_id",
+            "metric_contract_id",
+            "scoring_run_artifact_id",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _require_sha256(getattr(self, name), name=name),
+            )
+        if self.baseline_prediction_artifact_id == (
+            self.candidate_prediction_artifact_id
+        ):
+            raise ValueError("baseline and candidate predictions must differ")
+        for name in ("baseline_log_score", "candidate_log_score"):
+            object.__setattr__(
+                self,
+                name,
+                _finite_float(getattr(self, name), name=name),
+            )
+        for name in (
+            "baseline_brier_score",
+            "candidate_brier_score",
+            "baseline_trajectory_error_m",
+            "candidate_trajectory_error_m",
+            "baseline_interval_width_m",
+            "candidate_interval_width_m",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _finite_nonnegative_float(getattr(self, name), name=name),
+            )
+        for name in ("baseline_coverage", "candidate_coverage"):
+            object.__setattr__(self, name, _rate(getattr(self, name), name=name))
+        if not _require_bool(
+            self.target_outcomes_used,
+            name="target_outcomes_used",
+        ):
+            raise ValueError("unit metrics must record target-outcome access")
+        metadata = _validated_target_metadata(
+            self.metadata,
+            name="unit-metric metadata",
+        )
+        object.__setattr__(self, "metadata", metadata)
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION,
+            "artifact_kind": "Causal4DProspectiveV2UnitMetricValuesV1",
+            "opening_id": self.opening_id,
+            "unit_binding_id": self.unit_binding_id,
+            "candidate_binding_id": self.candidate_binding_id,
+            "target_artifact_id": self.target_artifact_id,
+            "baseline_prediction_artifact_id": (self.baseline_prediction_artifact_id),
+            "candidate_prediction_artifact_id": (self.candidate_prediction_artifact_id),
+            "metric_contract_id": self.metric_contract_id,
+            "scoring_run_artifact_id": self.scoring_run_artifact_id,
+            "baseline_log_score": self.baseline_log_score,
+            "candidate_log_score": self.candidate_log_score,
+            "baseline_brier_score": self.baseline_brier_score,
+            "candidate_brier_score": self.candidate_brier_score,
+            "baseline_trajectory_error_m": self.baseline_trajectory_error_m,
+            "candidate_trajectory_error_m": self.candidate_trajectory_error_m,
+            "baseline_coverage": self.baseline_coverage,
+            "candidate_coverage": self.candidate_coverage,
+            "baseline_interval_width_m": self.baseline_interval_width_m,
+            "candidate_interval_width_m": self.candidate_interval_width_m,
+            "target_outcomes_used": True,
+            "metadata": plain_json(self.metadata),
+        }
+
+    @property
+    def metric_values_id(self) -> str:
+        return _canonical_sha256(self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "metric_values_id": self.metric_values_id}
+
+
+@dataclass(frozen=True)
+class ProspectiveV2UnitEvaluationV1:
+    """Derived unit decision with no caller-supplied acceptance/fallback flags."""
+
+    freeze_id: str
+    stack_lock_id: str
+    unit: ProspectiveV2EvaluationUnitV1
+    candidate: ProspectiveV2CandidateV1
+    opening: ProspectiveV2TargetOpeningV1
+    metric_contract: ProspectiveV2MetricContractV1
+    policy: ProspectiveV2PromotionPolicyV1
+    trace: UnifiedDecisionTrace
+    metric_values: ProspectiveV2UnitMetricValuesV1
+
+    def __post_init__(self) -> None:
+        freeze_id = _require_sha256(self.freeze_id, name="freeze_id")
+        stack_lock_id = _require_sha256(self.stack_lock_id, name="stack_lock_id")
+        if type(self.unit) is not ProspectiveV2EvaluationUnitV1:
+            raise ValueError("unit has the wrong type")
+        if type(self.candidate) is not ProspectiveV2CandidateV1:
+            raise ValueError("candidate has the wrong type")
+        if self.candidate.candidate_kind == PROSPECTIVE_V2_CANDIDATE_KINDS[0]:
+            raise ValueError("unit evaluation requires a non-baseline candidate")
+        if type(self.opening) is not ProspectiveV2TargetOpeningV1:
+            raise ValueError("opening has the wrong type")
+        if type(self.metric_contract) is not ProspectiveV2MetricContractV1:
+            raise ValueError("metric_contract has the wrong type")
+        if type(self.policy) is not ProspectiveV2PromotionPolicyV1:
+            raise ValueError("policy has the wrong type")
+        if type(self.trace) is not UnifiedDecisionTrace:
+            raise ValueError("trace has the wrong type")
+        if type(self.metric_values) is not ProspectiveV2UnitMetricValuesV1:
+            raise ValueError("metric_values has the wrong type")
+        if self.opening.freeze_id != freeze_id:
+            raise ValueError("target opening does not bind the promotion freeze")
+        if self.opening.target_access_seal_id != self.unit.target_access_seal_id:
+            raise ValueError("target opening and evaluation unit use different seals")
+        if self.unit.target_artifact_id not in self.opening.target_artifact_ids:
+            raise ValueError("target opening does not include the unit target artifact")
+        if self.trace.stack_lock_id != stack_lock_id:
+            raise ValueError("decision trace stack lock does not match the freeze")
+        if (
+            self.trace.protocol_id,
+            self.trace.case_id,
+            self.trace.session_id,
+            self.trace.endpoint,
+        ) != (
+            self.unit.protocol_id,
+            self.unit.case_id,
+            self.unit.session_id,
+            self.unit.endpoint,
+        ):
+            raise ValueError("decision trace does not identify the evaluation unit")
+        root_by_role = {
+            artifact.role: artifact for artifact in self.trace.root_artifacts
+        }
+        if root_by_role["factual_evidence_context"].artifact_id != (
+            self.unit.factual_context_artifact_id
+        ):
+            raise ValueError("decision trace factual-context binding changed")
+        if root_by_role["counterfactual_query_context"].artifact_id != (
+            self.unit.counterfactual_query_artifact_id
+        ):
+            raise ValueError("decision trace counterfactual-query binding changed")
+        validation = validate_prospective_v2_decision_trace_v1(self.trace)
+        if not validation.accepted:
+            joined = ", ".join(validation.reasons)
+            raise ValueError(f"decision trace fails the V2 profile: {joined}")
+        expected_metadata = {
+            "promotion_candidate_id": self.candidate.candidate_id,
+            "promotion_candidate_configuration_id": (
+                self.candidate.configuration_artifact_id
+            ),
+            "promotion_evaluation_unit_id": self.unit.unit_id,
+            "promotion_target_access_seal_id": self.unit.target_access_seal_id,
+        }
+        for key, expected in expected_metadata.items():
+            if self.trace.metadata.get(key) != expected:
+                field = _TRACE_METADATA_FIELDS[key]
+                raise ValueError(f"decision trace {field} binding changed")
+        values = self.metric_values
+        expected_metric_bindings = (
+            self.opening.opening_id,
+            self.unit.unit_binding_id,
+            self.candidate.candidate_binding_id,
+            self.unit.target_artifact_id,
+            self.trace.selection.baseline_artifact_id,
+            self.trace.selection.candidate_artifact_id,
+            self.metric_contract.metric_contract_id,
+        )
+        observed_metric_bindings = (
+            values.opening_id,
+            values.unit_binding_id,
+            values.candidate_binding_id,
+            values.target_artifact_id,
+            values.baseline_prediction_artifact_id,
+            values.candidate_prediction_artifact_id,
+            values.metric_contract_id,
+        )
+        if observed_metric_bindings != expected_metric_bindings:
+            raise ValueError(
+                "unit metrics do not bind the registered evaluation sources"
+            )
+        object.__setattr__(self, "freeze_id", freeze_id)
+        object.__setattr__(self, "stack_lock_id", stack_lock_id)
+
+    @property
+    def trace_validation_id(self) -> str:
+        return validate_prospective_v2_decision_trace_v1(self.trace).validation_id
+
+    @property
+    def candidate_selected(self) -> bool:
+        return self.trace.selection.candidate_selected
+
+    @property
+    def fallback_used(self) -> bool:
+        return not self.candidate_selected
+
+    @property
+    def log_score_gain(self) -> float:
+        return self.metric_values.candidate_log_score - (
+            self.metric_values.baseline_log_score
+        )
+
+    @property
+    def brier_change(self) -> float:
+        return self.metric_values.candidate_brier_score - (
+            self.metric_values.baseline_brier_score
+        )
+
+    @property
+    def trajectory_regret_m(self) -> float:
+        return self.metric_values.candidate_trajectory_error_m - (
+            self.metric_values.baseline_trajectory_error_m
+        )
+
+    @property
+    def candidate_coverage_error(self) -> float:
+        return abs(
+            self.metric_values.candidate_coverage
+            - self.metric_contract.nominal_coverage
+        )
+
+    @property
+    def interval_width_ratio(self) -> float:
+        denominator = max(
+            self.metric_values.baseline_interval_width_m,
+            self.policy.interval_width_floor_m,
+        )
+        return self.metric_values.candidate_interval_width_m / denominator
+
+    @property
+    def candidate_harmful(self) -> bool:
+        return (
+            self.trajectory_regret_m > self.metric_contract.harmful_regret_threshold_m
+        )
+
+    @property
+    def harmful_accepted_update(self) -> bool:
+        return self.candidate_selected and self.candidate_harmful
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION,
+            "artifact_kind": "Causal4DProspectiveV2UnitEvaluationV1",
+            "freeze_id": self.freeze_id,
+            "stack_lock_id": self.stack_lock_id,
+            "opening_id": self.opening.opening_id,
+            "unit_binding_id": self.unit.unit_binding_id,
+            "candidate_binding_id": self.candidate.candidate_binding_id,
+            "metric_contract_id": self.metric_contract.metric_contract_id,
+            "policy_id": self.policy.policy_id,
+            "metric_values_id": self.metric_values.metric_values_id,
+            "trace_id": self.trace.trace_id,
+            "trace_validation_id": self.trace_validation_id,
+            "unit_id": self.unit.unit_id,
+            "endpoint": self.unit.endpoint,
+            "candidate_id": self.candidate.candidate_id,
+            "candidate_kind": self.candidate.candidate_kind,
+            "baseline_prediction_artifact_id": (
+                self.trace.selection.baseline_artifact_id
+            ),
+            "candidate_prediction_artifact_id": (
+                self.trace.selection.candidate_artifact_id
+            ),
+            "deployed_prediction_artifact_id": (
+                self.trace.selection.deployed_artifact_id
+            ),
+            "candidate_selected": self.candidate_selected,
+            "fallback_used": self.fallback_used,
+            "candidate_harmful": self.candidate_harmful,
+            "harmful_accepted_update": self.harmful_accepted_update,
+            "log_score_gain": self.log_score_gain,
+            "brier_change": self.brier_change,
+            "trajectory_regret_m": self.trajectory_regret_m,
+            "candidate_coverage_error": self.candidate_coverage_error,
+            "candidate_interval_width_m": (
+                self.metric_values.candidate_interval_width_m
+            ),
+            "interval_width_ratio": self.interval_width_ratio,
+            "target_outcomes_used": True,
+        }
+
+    @property
+    def evaluation_id(self) -> str:
+        return _canonical_sha256(self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "evaluation_id": self.evaluation_id}
+
+
+def build_prospective_v2_unit_evaluation_v1(
+    freeze: ProspectiveV2PromotionFreezeV1,
+    opening: ProspectiveV2TargetOpeningV1,
+    *,
+    unit_id: str,
+    candidate_id: str,
+    trace: UnifiedDecisionTrace,
+    metric_values: ProspectiveV2UnitMetricValuesV1,
+) -> ProspectiveV2UnitEvaluationV1:
+    """Derive one evaluation from frozen bindings, one trace, and raw scores."""
+
+    if type(freeze) is not ProspectiveV2PromotionFreezeV1:
+        raise ValueError("freeze has the wrong type")
+    unit = freeze.unit_by_id.get(unit_id)
+    if unit is None:
+        raise ValueError("unit_id is not registered by the promotion freeze")
+    candidate = freeze.candidate_by_id.get(candidate_id)
+    if candidate is None:
+        raise ValueError("candidate_id is not registered by the promotion freeze")
+    return ProspectiveV2UnitEvaluationV1(
+        freeze_id=freeze.freeze_id,
+        stack_lock_id=freeze.stack_lock_id,
+        unit=unit,
+        candidate=candidate,
+        opening=opening,
+        metric_contract=freeze.metric_contract,
+        policy=freeze.policy,
+        trace=trace,
+        metric_values=metric_values,
+    )
+
+
+__all__ = [
+    "PROSPECTIVE_V2_CANDIDATE_KINDS",
+    "PROSPECTIVE_V2_METRIC_SEMANTICS",
+    "PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION",
+    "PROSPECTIVE_V2_SELECTION_PANEL_ROLE",
+    "ProspectiveV2CandidateV1",
+    "ProspectiveV2EvaluationUnitV1",
+    "ProspectiveV2MetricContractV1",
+    "ProspectiveV2PromotionFreezeV1",
+    "ProspectiveV2PromotionPolicyV1",
+    "ProspectiveV2TargetOpeningV1",
+    "ProspectiveV2UnitEvaluationV1",
+    "ProspectiveV2UnitMetricValuesV1",
+    "build_prospective_v2_target_opening_v1",
+    "build_prospective_v2_unit_evaluation_v1",
+]

--- a/src/causal4d/prospective_v2_promotion.py
+++ b/src/causal4d/prospective_v2_promotion.py
@@ -1,0 +1,720 @@
+"""Evidence-bound target-opening promotion for prospective Causal4D V2.
+
+This module aggregates unit evaluations that have already been bound to the
+registered target inventory, fixed metric semantics, and validated prospective
+V2 decision traces.  Promotion labels are recomputed from those sources.  The
+selection panel is explicitly not an unbiased post-selection performance panel.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+import hashlib
+import json
+import math
+from numbers import Real
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from causal4d._prospective_v2_promotion_evidence import (
+    PROSPECTIVE_V2_CANDIDATE_KINDS,
+    PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION,
+    PROSPECTIVE_V2_SELECTION_PANEL_ROLE,
+    ProspectiveV2CandidateV1,
+    ProspectiveV2EvaluationUnitV1,
+    ProspectiveV2MetricContractV1,
+    ProspectiveV2PromotionFreezeV1,
+    ProspectiveV2PromotionPolicyV1,
+    ProspectiveV2TargetOpeningV1,
+    ProspectiveV2UnitEvaluationV1,
+    ProspectiveV2UnitMetricValuesV1,
+    build_prospective_v2_target_opening_v1,
+    build_prospective_v2_unit_evaluation_v1,
+)
+from causal4d.atomic_io import atomic_write_json
+from causal4d.decision_trace import DECISION_TRACE_ENDPOINTS
+from causal4d.immutable_json import plain_json, validated_json_mapping
+
+
+def _canonical_sha256(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        plain_json(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _require_nonempty_string(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _require_sha256(value: Any, *, name: str) -> str:
+    digest = _require_nonempty_string(value, name=name)
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _require_bool(value: Any, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a boolean")
+    return value
+
+
+def _finite_float(value: Any, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be finite")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _finite_nonnegative_float(value: Any, *, name: str) -> float:
+    result = _finite_float(value, name=name)
+    if result < 0.0:
+        raise ValueError(f"{name} must be nonnegative")
+    return result
+
+
+def _rate(value: Any, *, name: str) -> float:
+    result = _finite_float(value, name=name)
+    if not 0.0 <= result <= 1.0:
+        raise ValueError(f"{name} must lie in [0, 1]")
+    return result
+
+
+def _mean(values: Sequence[float], *, name: str) -> float:
+    if not values:
+        raise ValueError(f"{name} requires at least one value")
+    result = float(np.mean(np.asarray(values, dtype=float)))
+    if not np.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+@dataclass(frozen=True)
+class ProspectiveV2EndpointMetricsV1:
+    """One endpoint aggregate derived from bound independent-unit evaluations."""
+
+    candidate_id: str
+    endpoint: str
+    unit_count: int
+    mean_log_score_gain: float
+    mean_brier_change: float
+    mean_trajectory_regret_m: float
+    mean_coverage_error: float
+    mean_interval_width_m: float
+    mean_interval_width_ratio: float
+    accepted_update_rate: float
+    harmful_accepted_update_rate: float
+    fallback_rate: float
+    accepted: bool
+    reasons: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        candidate_id = _require_nonempty_string(
+            self.candidate_id,
+            name="candidate_id",
+        )
+        endpoint = _require_nonempty_string(self.endpoint, name="endpoint")
+        if endpoint not in DECISION_TRACE_ENDPOINTS:
+            raise ValueError("endpoint aggregate has an invalid endpoint")
+        if type(self.unit_count) is not int or self.unit_count < 1:
+            raise ValueError("unit_count must be a positive integer")
+        for name in (
+            "mean_log_score_gain",
+            "mean_brier_change",
+            "mean_trajectory_regret_m",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _finite_float(getattr(self, name), name=name),
+            )
+        for name in (
+            "mean_coverage_error",
+            "mean_interval_width_m",
+            "mean_interval_width_ratio",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _finite_nonnegative_float(getattr(self, name), name=name),
+            )
+        for name in (
+            "accepted_update_rate",
+            "harmful_accepted_update_rate",
+            "fallback_rate",
+        ):
+            object.__setattr__(self, name, _rate(getattr(self, name), name=name))
+        accepted = _require_bool(self.accepted, name="accepted")
+        reasons = tuple(self.reasons)
+        if accepted and reasons:
+            raise ValueError("accepted endpoint metrics cannot contain reasons")
+        if not accepted and not reasons:
+            raise ValueError("rejected endpoint metrics require reasons")
+        if len(set(reasons)) != len(reasons):
+            raise ValueError("endpoint rejection reasons must be unique")
+        object.__setattr__(self, "candidate_id", candidate_id)
+        object.__setattr__(self, "endpoint", endpoint)
+        object.__setattr__(self, "accepted", accepted)
+        object.__setattr__(self, "reasons", reasons)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "candidate_id": self.candidate_id,
+            "endpoint": self.endpoint,
+            "unit_count": self.unit_count,
+            "mean_log_score_gain": self.mean_log_score_gain,
+            "mean_brier_change": self.mean_brier_change,
+            "mean_trajectory_regret_m": self.mean_trajectory_regret_m,
+            "mean_coverage_error": self.mean_coverage_error,
+            "mean_interval_width_m": self.mean_interval_width_m,
+            "mean_interval_width_ratio": self.mean_interval_width_ratio,
+            "accepted_update_rate": self.accepted_update_rate,
+            "harmful_accepted_update_rate": self.harmful_accepted_update_rate,
+            "fallback_rate": self.fallback_rate,
+            "accepted": self.accepted,
+            "reasons": list(self.reasons),
+        }
+
+
+@dataclass(frozen=True)
+class ProspectiveV2CandidateResultV1:
+    """All registered endpoint decisions for one non-baseline candidate."""
+
+    candidate_id: str
+    candidate_kind: str
+    candidate_configuration_artifact_id: str
+    endpoint_metrics: tuple[ProspectiveV2EndpointMetricsV1, ...]
+    accepted: bool
+    reasons: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        candidate_id = _require_nonempty_string(
+            self.candidate_id,
+            name="candidate_id",
+        )
+        candidate_kind = _require_nonempty_string(
+            self.candidate_kind,
+            name="candidate_kind",
+        )
+        if candidate_kind not in PROSPECTIVE_V2_CANDIDATE_KINDS[1:]:
+            raise ValueError("candidate result must describe a non-baseline candidate")
+        configuration_id = _require_sha256(
+            self.candidate_configuration_artifact_id,
+            name="candidate_configuration_artifact_id",
+        )
+        endpoint_metrics = tuple(self.endpoint_metrics)
+        if tuple(metric.endpoint for metric in endpoint_metrics) != (
+            DECISION_TRACE_ENDPOINTS
+        ):
+            raise ValueError("candidate result must cover every endpoint in order")
+        if any(metric.candidate_id != candidate_id for metric in endpoint_metrics):
+            raise ValueError("endpoint metrics identify the wrong candidate")
+        expected_reasons = tuple(
+            f"{metric.endpoint}:{reason}"
+            for metric in endpoint_metrics
+            for reason in metric.reasons
+        )
+        accepted = _require_bool(self.accepted, name="accepted")
+        reasons = tuple(self.reasons)
+        if reasons != expected_reasons or accepted is not (not expected_reasons):
+            raise ValueError("candidate decision must exactly match endpoint evidence")
+        object.__setattr__(self, "candidate_id", candidate_id)
+        object.__setattr__(self, "candidate_kind", candidate_kind)
+        object.__setattr__(
+            self,
+            "candidate_configuration_artifact_id",
+            configuration_id,
+        )
+        object.__setattr__(self, "endpoint_metrics", endpoint_metrics)
+        object.__setattr__(self, "accepted", accepted)
+        object.__setattr__(self, "reasons", reasons)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "candidate_id": self.candidate_id,
+            "candidate_kind": self.candidate_kind,
+            "candidate_configuration_artifact_id": (
+                self.candidate_configuration_artifact_id
+            ),
+            "endpoint_metrics": [metric.as_dict() for metric in self.endpoint_metrics],
+            "accepted": self.accepted,
+            "reasons": list(self.reasons),
+        }
+
+
+@dataclass(frozen=True)
+class ProspectiveV2PromotionResultV1:
+    """Selection-panel result with exact baseline configuration fallback."""
+
+    freeze_id: str
+    opening_id: str
+    baseline_candidate_id: str
+    baseline_configuration_artifact_id: str
+    selected_candidate_id: str
+    selected_candidate_kind: str
+    selected_configuration_artifact_id: str
+    candidate_results: tuple[ProspectiveV2CandidateResultV1, ...]
+    evaluation_ids: tuple[str, ...]
+    selection_panel_role: str = PROSPECTIVE_V2_SELECTION_PANEL_ROLE
+    unbiased_post_selection_performance_claimed: bool = False
+    independent_confirmation_required: bool = True
+    target_outcomes_used: bool = True
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        freeze_id = _require_sha256(self.freeze_id, name="freeze_id")
+        opening_id = _require_sha256(self.opening_id, name="opening_id")
+        baseline_candidate_id = _require_nonempty_string(
+            self.baseline_candidate_id,
+            name="baseline_candidate_id",
+        )
+        baseline_configuration_id = _require_sha256(
+            self.baseline_configuration_artifact_id,
+            name="baseline_configuration_artifact_id",
+        )
+        selected_candidate_id = _require_nonempty_string(
+            self.selected_candidate_id,
+            name="selected_candidate_id",
+        )
+        selected_kind = _require_nonempty_string(
+            self.selected_candidate_kind,
+            name="selected_candidate_kind",
+        )
+        if selected_kind not in PROSPECTIVE_V2_CANDIDATE_KINDS:
+            raise ValueError("selected_candidate_kind is invalid")
+        selected_configuration_id = _require_sha256(
+            self.selected_configuration_artifact_id,
+            name="selected_configuration_artifact_id",
+        )
+        candidate_results = tuple(self.candidate_results)
+        if any(
+            type(result) is not ProspectiveV2CandidateResultV1
+            for result in candidate_results
+        ):
+            raise ValueError(
+                "candidate_results must contain ProspectiveV2CandidateResultV1 values"
+            )
+        if (
+            tuple(result.candidate_kind for result in candidate_results)
+            != (PROSPECTIVE_V2_CANDIDATE_KINDS[1:])
+        ):
+            raise ValueError("candidate results must follow the frozen V2 ladder")
+        candidate_ids = tuple(result.candidate_id for result in candidate_results)
+        configuration_ids = tuple(
+            result.candidate_configuration_artifact_id for result in candidate_results
+        )
+        if len(set(candidate_ids)) != len(candidate_ids):
+            raise ValueError("candidate result IDs must be unique")
+        if len(set(configuration_ids)) != len(configuration_ids):
+            raise ValueError("candidate result configurations must be unique")
+        accepted_results = tuple(
+            result for result in candidate_results if result.accepted
+        )
+        if accepted_results:
+            expected_selected = accepted_results[-1]
+            expected_fields = (
+                expected_selected.candidate_id,
+                expected_selected.candidate_kind,
+                expected_selected.candidate_configuration_artifact_id,
+            )
+        else:
+            expected_fields = (
+                baseline_candidate_id,
+                PROSPECTIVE_V2_CANDIDATE_KINDS[0],
+                baseline_configuration_id,
+            )
+        if (
+            selected_candidate_id,
+            selected_kind,
+            selected_configuration_id,
+        ) != expected_fields:
+            raise ValueError(
+                "selection must equal the highest accepted candidate or baseline"
+            )
+        evaluation_ids = tuple(
+            _require_sha256(value, name=f"evaluation_ids[{index}]")
+            for index, value in enumerate(self.evaluation_ids)
+        )
+        if not evaluation_ids or len(set(evaluation_ids)) != len(evaluation_ids):
+            raise ValueError("evaluation_ids must be nonempty and unique")
+        if self.selection_panel_role != PROSPECTIVE_V2_SELECTION_PANEL_ROLE:
+            raise ValueError("selection_panel_role is fixed")
+        if _require_bool(
+            self.unbiased_post_selection_performance_claimed,
+            name="unbiased_post_selection_performance_claimed",
+        ):
+            raise ValueError("the selection panel cannot support an unbiased claim")
+        if not _require_bool(
+            self.independent_confirmation_required,
+            name="independent_confirmation_required",
+        ):
+            raise ValueError("independent confirmation must remain required")
+        if not _require_bool(
+            self.target_outcomes_used,
+            name="target_outcomes_used",
+        ):
+            raise ValueError("promotion result must record target-outcome access")
+        metadata = validated_json_mapping(
+            self.metadata,
+            error_message="promotion-result metadata must contain finite JSON data",
+        )
+        object.__setattr__(self, "freeze_id", freeze_id)
+        object.__setattr__(self, "opening_id", opening_id)
+        object.__setattr__(self, "baseline_candidate_id", baseline_candidate_id)
+        object.__setattr__(
+            self,
+            "baseline_configuration_artifact_id",
+            baseline_configuration_id,
+        )
+        object.__setattr__(self, "selected_candidate_id", selected_candidate_id)
+        object.__setattr__(self, "selected_candidate_kind", selected_kind)
+        object.__setattr__(
+            self,
+            "selected_configuration_artifact_id",
+            selected_configuration_id,
+        )
+        object.__setattr__(self, "candidate_results", candidate_results)
+        object.__setattr__(self, "evaluation_ids", evaluation_ids)
+        object.__setattr__(self, "metadata", metadata)
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION,
+            "artifact_kind": "Causal4DProspectiveV2PromotionResultV1",
+            "freeze_id": self.freeze_id,
+            "opening_id": self.opening_id,
+            "baseline_candidate_id": self.baseline_candidate_id,
+            "baseline_configuration_artifact_id": (
+                self.baseline_configuration_artifact_id
+            ),
+            "selected_candidate_id": self.selected_candidate_id,
+            "selected_candidate_kind": self.selected_candidate_kind,
+            "selected_configuration_artifact_id": (
+                self.selected_configuration_artifact_id
+            ),
+            "candidate_results": [
+                result.as_dict() for result in self.candidate_results
+            ],
+            "evaluation_ids": list(self.evaluation_ids),
+            "selection_panel_role": self.selection_panel_role,
+            "unbiased_post_selection_performance_claimed": (
+                self.unbiased_post_selection_performance_claimed
+            ),
+            "independent_confirmation_required": (
+                self.independent_confirmation_required
+            ),
+            "target_outcomes_used": self.target_outcomes_used,
+            "metadata": plain_json(self.metadata),
+        }
+
+    @property
+    def result_id(self) -> str:
+        return _canonical_sha256(self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "result_id": self.result_id}
+
+
+def _evaluate_endpoint(
+    candidate: ProspectiveV2CandidateV1,
+    endpoint: str,
+    evaluations: Sequence[ProspectiveV2UnitEvaluationV1],
+    policy: ProspectiveV2PromotionPolicyV1,
+) -> ProspectiveV2EndpointMetricsV1:
+    unit_count = len(evaluations)
+    accepted_count = sum(value.candidate_selected for value in evaluations)
+    harmful_count = sum(value.harmful_accepted_update for value in evaluations)
+    accepted_rate = accepted_count / unit_count
+    harmful_accepted_rate = harmful_count / accepted_count if accepted_count else 0.0
+    fallback_rate = sum(value.fallback_used for value in evaluations) / unit_count
+    mean_log_gain = _mean(
+        tuple(value.log_score_gain for value in evaluations),
+        name="mean_log_score_gain",
+    )
+    mean_brier_change = _mean(
+        tuple(value.brier_change for value in evaluations),
+        name="mean_brier_change",
+    )
+    mean_regret = _mean(
+        tuple(value.trajectory_regret_m for value in evaluations),
+        name="mean_trajectory_regret_m",
+    )
+    mean_coverage_error = _mean(
+        tuple(value.candidate_coverage_error for value in evaluations),
+        name="mean_coverage_error",
+    )
+    mean_width = _mean(
+        tuple(value.metric_values.candidate_interval_width_m for value in evaluations),
+        name="mean_interval_width_m",
+    )
+    mean_width_ratio = _mean(
+        tuple(value.interval_width_ratio for value in evaluations),
+        name="mean_interval_width_ratio",
+    )
+    reasons: list[str] = []
+    if unit_count < policy.minimum_units_per_endpoint:
+        reasons.append("insufficient_independent_units")
+    if mean_log_gain < policy.minimum_mean_log_score_gain:
+        reasons.append("mean_log_score_gain_below_limit")
+    if mean_brier_change > policy.maximum_mean_brier_change:
+        reasons.append("mean_brier_change_exceeds_limit")
+    if mean_regret > policy.maximum_mean_trajectory_regret_m:
+        reasons.append("mean_trajectory_regret_exceeds_limit")
+    if mean_coverage_error > policy.maximum_mean_coverage_error:
+        reasons.append("mean_coverage_error_exceeds_limit")
+    if mean_width_ratio > policy.maximum_mean_interval_width_ratio:
+        reasons.append("mean_interval_width_ratio_exceeds_limit")
+    if accepted_rate < policy.minimum_accepted_update_rate:
+        reasons.append("accepted_update_rate_below_limit")
+    if harmful_accepted_rate > policy.maximum_harmful_accepted_update_rate:
+        reasons.append("harmful_accepted_update_rate_exceeds_limit")
+    if fallback_rate > policy.maximum_fallback_rate:
+        reasons.append("fallback_rate_exceeds_limit")
+    return ProspectiveV2EndpointMetricsV1(
+        candidate_id=candidate.candidate_id,
+        endpoint=endpoint,
+        unit_count=unit_count,
+        mean_log_score_gain=mean_log_gain,
+        mean_brier_change=mean_brier_change,
+        mean_trajectory_regret_m=mean_regret,
+        mean_coverage_error=mean_coverage_error,
+        mean_interval_width_m=mean_width,
+        mean_interval_width_ratio=mean_width_ratio,
+        accepted_update_rate=accepted_rate,
+        harmful_accepted_update_rate=harmful_accepted_rate,
+        fallback_rate=fallback_rate,
+        accepted=not reasons,
+        reasons=tuple(reasons),
+    )
+
+
+def evaluate_prospective_v2_promotion_v1(
+    freeze: ProspectiveV2PromotionFreezeV1,
+    opening: ProspectiveV2TargetOpeningV1,
+    evaluations: Sequence[ProspectiveV2UnitEvaluationV1],
+    *,
+    metadata: Mapping[str, Any] | None = None,
+) -> ProspectiveV2PromotionResultV1:
+    """Evaluate the complete frozen candidate/unit product exactly once."""
+
+    if type(freeze) is not ProspectiveV2PromotionFreezeV1:
+        raise ValueError("freeze has the wrong type")
+    if type(opening) is not ProspectiveV2TargetOpeningV1:
+        raise ValueError("opening has the wrong type")
+    expected_target_ids = tuple(
+        unit.target_artifact_id for unit in freeze.evaluation_units
+    )
+    if (
+        opening.freeze_id != freeze.freeze_id
+        or opening.target_access_seal_id != freeze.target_access_seal_id
+        or opening.target_artifact_ids != expected_target_ids
+    ):
+        raise ValueError("target opening does not exactly match the frozen inventory")
+    values = tuple(evaluations)
+    if not values or any(
+        type(value) is not ProspectiveV2UnitEvaluationV1 for value in values
+    ):
+        raise ValueError("evaluations must contain bound unit evaluations")
+    expected_keys = {
+        (unit.unit_id, candidate.candidate_id)
+        for unit in freeze.evaluation_units
+        for candidate in freeze.candidates[1:]
+    }
+    actual_keys = {
+        (value.unit.unit_id, value.candidate.candidate_id) for value in values
+    }
+    if len(actual_keys) != len(values):
+        raise ValueError("unit/candidate evaluation pairs must be unique")
+    if actual_keys != expected_keys:
+        missing = sorted(expected_keys - actual_keys)
+        unexpected = sorted(actual_keys - expected_keys)
+        raise ValueError(
+            "evaluations must cover the frozen unit/candidate product; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    candidate_index = freeze.candidate_by_id
+    unit_index = freeze.unit_by_id
+    for value in values:
+        if value.freeze_id != freeze.freeze_id:
+            raise ValueError("unit evaluation identifies a different freeze")
+        if value.opening.opening_id != opening.opening_id:
+            raise ValueError("unit evaluations must share the frozen target opening")
+        if value.metric_contract.metric_contract_id != (
+            freeze.metric_contract.metric_contract_id
+        ):
+            raise ValueError("unit evaluation uses a different metric contract")
+        if value.policy.policy_id != freeze.policy.policy_id:
+            raise ValueError("unit evaluation uses a different promotion policy")
+        if value.unit.unit_binding_id != (
+            unit_index[value.unit.unit_id].unit_binding_id
+        ):
+            raise ValueError("unit evaluation binding differs from the freeze")
+        if value.candidate.candidate_binding_id != (
+            candidate_index[value.candidate.candidate_id].candidate_binding_id
+        ):
+            raise ValueError("candidate evaluation binding differs from the freeze")
+
+    evaluation_index = {
+        (value.unit.unit_id, value.candidate.candidate_id): value for value in values
+    }
+    candidate_results: list[ProspectiveV2CandidateResultV1] = []
+    for candidate in freeze.candidates[1:]:
+        endpoint_metrics = tuple(
+            _evaluate_endpoint(
+                candidate,
+                endpoint,
+                tuple(
+                    evaluation_index[(unit.unit_id, candidate.candidate_id)]
+                    for unit in freeze.evaluation_units
+                    if unit.endpoint == endpoint
+                ),
+                freeze.policy,
+            )
+            for endpoint in DECISION_TRACE_ENDPOINTS
+        )
+        reasons = tuple(
+            f"{metric.endpoint}:{reason}"
+            for metric in endpoint_metrics
+            for reason in metric.reasons
+        )
+        candidate_results.append(
+            ProspectiveV2CandidateResultV1(
+                candidate_id=candidate.candidate_id,
+                candidate_kind=candidate.candidate_kind,
+                candidate_configuration_artifact_id=(
+                    candidate.configuration_artifact_id
+                ),
+                endpoint_metrics=endpoint_metrics,
+                accepted=not reasons,
+                reasons=reasons,
+            )
+        )
+    accepted_ids = {
+        result.candidate_id for result in candidate_results if result.accepted
+    }
+    selected = freeze.baseline_candidate
+    for candidate in freeze.candidates[1:]:
+        if candidate.candidate_id in accepted_ids:
+            selected = candidate
+    ordered_evaluation_ids = tuple(
+        evaluation_index[(unit.unit_id, candidate.candidate_id)].evaluation_id
+        for unit in freeze.evaluation_units
+        for candidate in freeze.candidates[1:]
+    )
+    return ProspectiveV2PromotionResultV1(
+        freeze_id=freeze.freeze_id,
+        opening_id=opening.opening_id,
+        baseline_candidate_id=freeze.baseline_candidate.candidate_id,
+        baseline_configuration_artifact_id=(
+            freeze.baseline_candidate.configuration_artifact_id
+        ),
+        selected_candidate_id=selected.candidate_id,
+        selected_candidate_kind=selected.candidate_kind,
+        selected_configuration_artifact_id=selected.configuration_artifact_id,
+        candidate_results=tuple(candidate_results),
+        evaluation_ids=ordered_evaluation_ids,
+        selection_panel_role=PROSPECTIVE_V2_SELECTION_PANEL_ROLE,
+        unbiased_post_selection_performance_claimed=False,
+        independent_confirmation_required=True,
+        target_outcomes_used=True,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def validate_prospective_v2_promotion_result_v1(
+    result: ProspectiveV2PromotionResultV1,
+    freeze: ProspectiveV2PromotionFreezeV1,
+    opening: ProspectiveV2TargetOpeningV1,
+    evaluations: Sequence[ProspectiveV2UnitEvaluationV1],
+) -> ProspectiveV2PromotionResultV1:
+    """Recompute and require exact equality with a published selection result."""
+
+    if type(result) is not ProspectiveV2PromotionResultV1:
+        raise ValueError("result has the wrong type")
+    expected = evaluate_prospective_v2_promotion_v1(
+        freeze,
+        opening,
+        evaluations,
+        metadata=result.metadata,
+    )
+    if result != expected or result.result_id != expected.result_id:
+        raise ValueError("promotion result does not match its bound source evidence")
+    return result
+
+
+def write_prospective_v2_promotion_freeze(
+    path: str | Path,
+    freeze: ProspectiveV2PromotionFreezeV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Atomically publish a target-free promotion freeze."""
+
+    if type(freeze) is not ProspectiveV2PromotionFreezeV1:
+        raise ValueError("freeze has the wrong type")
+    atomic_write_json(path, freeze.as_dict(), overwrite=overwrite)
+
+
+def write_prospective_v2_target_opening(
+    path: str | Path,
+    opening: ProspectiveV2TargetOpeningV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Atomically publish the one target-opening inventory record."""
+
+    if type(opening) is not ProspectiveV2TargetOpeningV1:
+        raise ValueError("opening has the wrong type")
+    atomic_write_json(path, opening.as_dict(), overwrite=overwrite)
+
+
+def write_prospective_v2_promotion_result(
+    path: str | Path,
+    result: ProspectiveV2PromotionResultV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Atomically publish a recomputable candidate-selection result."""
+
+    if type(result) is not ProspectiveV2PromotionResultV1:
+        raise ValueError("result has the wrong type")
+    atomic_write_json(path, result.as_dict(), overwrite=overwrite)
+
+
+__all__ = [
+    "PROSPECTIVE_V2_CANDIDATE_KINDS",
+    "PROSPECTIVE_V2_PROMOTION_SCHEMA_VERSION",
+    "PROSPECTIVE_V2_SELECTION_PANEL_ROLE",
+    "ProspectiveV2CandidateResultV1",
+    "ProspectiveV2CandidateV1",
+    "ProspectiveV2EndpointMetricsV1",
+    "ProspectiveV2EvaluationUnitV1",
+    "ProspectiveV2MetricContractV1",
+    "ProspectiveV2PromotionFreezeV1",
+    "ProspectiveV2PromotionPolicyV1",
+    "ProspectiveV2PromotionResultV1",
+    "ProspectiveV2TargetOpeningV1",
+    "ProspectiveV2UnitEvaluationV1",
+    "ProspectiveV2UnitMetricValuesV1",
+    "build_prospective_v2_target_opening_v1",
+    "build_prospective_v2_unit_evaluation_v1",
+    "evaluate_prospective_v2_promotion_v1",
+    "validate_prospective_v2_promotion_result_v1",
+    "write_prospective_v2_promotion_freeze",
+    "write_prospective_v2_promotion_result",
+    "write_prospective_v2_target_opening",
+]

--- a/tests/test_prospective_v2_promotion.py
+++ b/tests/test_prospective_v2_promotion.py
@@ -1,0 +1,679 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import hashlib
+
+import pytest
+
+from causal4d.decision_trace import (
+    DecisionTraceArtifact,
+    DecisionTraceDecision,
+    DecisionTraceStage,
+)
+from causal4d.prospective_v2_profile import (
+    PROSPECTIVE_V2_REQUIRED_DECISION_NAMES,
+    build_prospective_v2_decision_trace_v1,
+)
+from causal4d.prospective_v2_promotion import (
+    PROSPECTIVE_V2_CANDIDATE_KINDS,
+    ProspectiveV2CandidateV1,
+    ProspectiveV2EvaluationUnitV1,
+    ProspectiveV2MetricContractV1,
+    ProspectiveV2PromotionFreezeV1,
+    ProspectiveV2PromotionPolicyV1,
+    ProspectiveV2TargetOpeningV1,
+    ProspectiveV2UnitMetricValuesV1,
+    build_prospective_v2_target_opening_v1,
+    build_prospective_v2_unit_evaluation_v1,
+    evaluate_prospective_v2_promotion_v1,
+    validate_prospective_v2_promotion_result_v1,
+)
+
+
+def _id(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _artifact(
+    artifact_id: str,
+    role: str,
+    producer: str,
+) -> DecisionTraceArtifact:
+    return DecisionTraceArtifact(
+        artifact_id=artifact_id,
+        artifact_kind=f"test.{role}",
+        role=role,
+        producer=producer,  # type: ignore[arg-type]
+    )
+
+
+def _decision(
+    name: str,
+    producer: str,
+    *,
+    accepted: bool,
+    label: str,
+) -> DecisionTraceDecision:
+    return DecisionTraceDecision(
+        name=name,
+        decision_id=_id(f"decision:{label}:{name}:{accepted}"),
+        decision_kind=f"test.{name}",
+        producer=producer,  # type: ignore[arg-type]
+        accepted=accepted,
+        reasons=() if accepted else ("source_gate_rejected",),
+    )
+
+
+def _candidate_ladder() -> tuple[ProspectiveV2CandidateV1, ...]:
+    return tuple(
+        ProspectiveV2CandidateV1(
+            candidate_id=f"candidate-{index}",
+            candidate_kind=kind,
+            configuration_artifact_id=_id(f"configuration:{kind}"),
+        )
+        for index, kind in enumerate(PROSPECTIVE_V2_CANDIDATE_KINDS)
+    )
+
+
+def _units() -> tuple[ProspectiveV2EvaluationUnitV1, ...]:
+    endpoints = (
+        "factual_continuation",
+        "same_grasp_transfer",
+        "new_contact_transfer",
+    )
+    return tuple(
+        ProspectiveV2EvaluationUnitV1(
+            unit_id=f"unit-{index}",
+            endpoint=endpoint,
+            protocol_id="protocol-v2",
+            case_id=f"case-{index}",
+            session_id=f"session-{index}",
+            independent_group_id=f"group-{index}",
+            target_artifact_id=_id(f"target:{index}"),
+            factual_context_artifact_id=_id(f"factual:{index}"),
+            counterfactual_query_artifact_id=_id(f"query:{index}"),
+            target_access_seal_id=_id("target-access-seal"),
+        )
+        for index, endpoint in enumerate(endpoints)
+    )
+
+
+def _freeze() -> ProspectiveV2PromotionFreezeV1:
+    return ProspectiveV2PromotionFreezeV1(
+        experiment_id="prospective-v2-selection-panel",
+        stack_lock_id=_id("stack-lock"),
+        target_access_seal_id=_id("target-access-seal"),
+        candidates=_candidate_ladder(),
+        evaluation_units=_units(),
+        metric_contract=ProspectiveV2MetricContractV1(
+            scoring_implementation_artifact_id=_id("scoring-implementation"),
+            nominal_coverage=0.9,
+            harmful_regret_threshold_m=0.001,
+        ),
+        policy=ProspectiveV2PromotionPolicyV1(
+            minimum_units_per_endpoint=1,
+            minimum_mean_log_score_gain=0.05,
+            maximum_mean_brier_change=0.0,
+            maximum_mean_trajectory_regret_m=0.0,
+            maximum_mean_coverage_error=0.05,
+            maximum_mean_interval_width_ratio=1.1,
+            minimum_accepted_update_rate=1.0,
+            maximum_harmful_accepted_update_rate=0.0,
+            maximum_fallback_rate=0.0,
+        ),
+        source_artifact_ids=(
+            _id("stack-lock"),
+            _id("target-access-seal"),
+            _id("scoring-implementation"),
+            *tuple(
+                _id(f"configuration:{kind}") for kind in PROSPECTIVE_V2_CANDIDATE_KINDS
+            ),
+            *tuple(_id(f"factual:{index}") for index in range(3)),
+            *tuple(_id(f"query:{index}") for index in range(3)),
+        ),
+    )
+
+
+def _trace(
+    freeze: ProspectiveV2PromotionFreezeV1,
+    unit: ProspectiveV2EvaluationUnitV1,
+    candidate: ProspectiveV2CandidateV1,
+    *,
+    selected: bool = True,
+    metadata_overrides: dict[str, str] | None = None,
+    wrong_factual_context: bool = False,
+):
+    label = f"{unit.unit_id}:{candidate.candidate_id}"
+    factual = _artifact(
+        (
+            _id(f"wrong-factual:{unit.unit_id}")
+            if wrong_factual_context
+            else unit.factual_context_artifact_id
+        ),
+        "factual_evidence_context",
+        "causal4d",
+    )
+    query = _artifact(
+        unit.counterfactual_query_artifact_id,
+        "counterfactual_query_context",
+        "causal4d",
+    )
+    observation = _artifact(
+        _id(f"observation:{label}"),
+        "prob4d_observation",
+        "prob4d",
+    )
+    belief = _artifact(
+        _id(f"belief:{label}"),
+        "bayesian_phystwin_belief",
+        "bayesian-phystwin",
+    )
+    baseline_prediction = _artifact(
+        _id(f"baseline-prediction:{unit.unit_id}"),
+        "baseline_prediction",
+        "bayesian-phystwin",
+    )
+    factual_posterior = _artifact(
+        _id(f"factual-posterior:{label}"),
+        "causal4d_factual_posterior",
+        "causal4d",
+    )
+    candidate_prediction = _artifact(
+        _id(f"candidate-prediction:{label}"),
+        "candidate_prediction",
+        "causal4d",
+    )
+    decisions = {
+        name: _decision(
+            name,
+            (
+                "prob4d"
+                if name == "prob4d_provider_acceptance"
+                else "bayesian-phystwin"
+                if name == "bayesian_phystwin_acceptance"
+                else "causal4d"
+            ),
+            accepted=selected,
+            label=label,
+        )
+        for name in PROSPECTIVE_V2_REQUIRED_DECISION_NAMES
+    }
+    stages = (
+        DecisionTraceStage(
+            stage_name=f"prob4d:{label}",
+            stage_kind="prob4d_observation",
+            producer="prob4d",
+            input_artifact_ids=(factual.artifact_id,),
+            output_artifacts=(observation,),
+            decisions=(decisions["prob4d_provider_acceptance"],),
+        ),
+        DecisionTraceStage(
+            stage_name=f"bpt:{label}",
+            stage_kind="bayesian_phystwin_belief",
+            producer="bayesian-phystwin",
+            input_artifact_ids=(observation.artifact_id,),
+            output_artifacts=(belief, baseline_prediction),
+            decisions=(decisions["bayesian_phystwin_acceptance"],),
+        ),
+        DecisionTraceStage(
+            stage_name=f"abduction:{label}",
+            stage_kind="causal4d_abduction",
+            producer="causal4d",
+            input_artifact_ids=(observation.artifact_id, belief.artifact_id),
+            output_artifacts=(factual_posterior,),
+            decisions=tuple(
+                decisions[name]
+                for name in (
+                    "joint_covariance_admission",
+                    "functional_support",
+                    "intervention_identifiability",
+                    "action_support",
+                    "contact_v2_support",
+                )
+            ),
+        ),
+        DecisionTraceStage(
+            stage_name=f"counterfactual:{label}",
+            stage_kind="causal4d_counterfactual",
+            producer="causal4d",
+            input_artifact_ids=(factual_posterior.artifact_id, query.artifact_id),
+            output_artifacts=(candidate_prediction,),
+            decisions=tuple(
+                decisions[name]
+                for name in (
+                    "conditional_uncertainty_calibration",
+                    "query_calibration",
+                )
+            ),
+        ),
+        DecisionTraceStage(
+            stage_name=f"deployment:{label}",
+            stage_kind="deployment",
+            producer="causal4d",
+            input_artifact_ids=(
+                baseline_prediction.artifact_id,
+                candidate_prediction.artifact_id,
+            ),
+            decisions=(decisions["counterfactual_regret"],),
+        ),
+    )
+    metadata = {
+        "promotion_candidate_id": candidate.candidate_id,
+        "promotion_candidate_configuration_id": (candidate.configuration_artifact_id),
+        "promotion_evaluation_unit_id": unit.unit_id,
+        "promotion_target_access_seal_id": unit.target_access_seal_id,
+    }
+    if metadata_overrides:
+        metadata.update(metadata_overrides)
+    baseline = object()
+    candidate_object = object()
+    result = build_prospective_v2_decision_trace_v1(
+        trace_name=f"promotion trace {label}",
+        protocol_id=unit.protocol_id,
+        case_id=unit.case_id,
+        session_id=unit.session_id,
+        endpoint=unit.endpoint,  # type: ignore[arg-type]
+        stack_lock_id=freeze.stack_lock_id,
+        root_artifacts=(factual, query),
+        stages=stages,
+        baseline=baseline,
+        candidate=candidate_object,
+        deployed=candidate_object if selected else baseline,
+        baseline_artifact_id=baseline_prediction.artifact_id,
+        candidate_artifact_id=candidate_prediction.artifact_id,
+        metadata=metadata,
+    )
+    return result.trace
+
+
+def _metric_values(
+    freeze: ProspectiveV2PromotionFreezeV1,
+    opening,
+    unit: ProspectiveV2EvaluationUnitV1,
+    candidate: ProspectiveV2CandidateV1,
+    trace,
+    *,
+    candidate_log_score: float = 1.2,
+    candidate_brier_score: float = 0.15,
+    candidate_trajectory_error_m: float = 0.09,
+    candidate_coverage: float = 0.9,
+    baseline_interval_width_m: float = 1.0,
+    candidate_interval_width_m: float = 0.95,
+) -> ProspectiveV2UnitMetricValuesV1:
+    return ProspectiveV2UnitMetricValuesV1(
+        opening_id=opening.opening_id,
+        unit_binding_id=unit.unit_binding_id,
+        candidate_binding_id=candidate.candidate_binding_id,
+        target_artifact_id=unit.target_artifact_id,
+        baseline_prediction_artifact_id=(trace.selection.baseline_artifact_id),
+        candidate_prediction_artifact_id=(trace.selection.candidate_artifact_id),
+        metric_contract_id=freeze.metric_contract.metric_contract_id,
+        scoring_run_artifact_id=_id(
+            f"scoring-run:{unit.unit_id}:{candidate.candidate_id}"
+        ),
+        baseline_log_score=1.0,
+        candidate_log_score=candidate_log_score,
+        baseline_brier_score=0.2,
+        candidate_brier_score=candidate_brier_score,
+        baseline_trajectory_error_m=0.1,
+        candidate_trajectory_error_m=candidate_trajectory_error_m,
+        baseline_coverage=0.85,
+        candidate_coverage=candidate_coverage,
+        baseline_interval_width_m=baseline_interval_width_m,
+        candidate_interval_width_m=candidate_interval_width_m,
+    )
+
+
+def _evaluations(
+    freeze: ProspectiveV2PromotionFreezeV1,
+    opening,
+):
+    values = []
+    for unit in freeze.evaluation_units:
+        for candidate in freeze.candidates[1:]:
+            trace = _trace(freeze, unit, candidate)
+            metrics = _metric_values(
+                freeze,
+                opening,
+                unit,
+                candidate,
+                trace,
+            )
+            values.append(
+                build_prospective_v2_unit_evaluation_v1(
+                    freeze,
+                    opening,
+                    unit_id=unit.unit_id,
+                    candidate_id=candidate.candidate_id,
+                    trace=trace,
+                    metric_values=metrics,
+                )
+            )
+    return tuple(values)
+
+
+def test_complete_bound_panel_selects_highest_passing_candidate() -> None:
+    freeze = _freeze()
+    opening = build_prospective_v2_target_opening_v1(
+        freeze,
+        opened_at_utc="2026-08-09T00:00:00+00:00",
+        opened_by="independent-evaluator",
+    )
+    evaluations = _evaluations(freeze, opening)
+
+    result = evaluate_prospective_v2_promotion_v1(
+        freeze,
+        opening,
+        evaluations,
+    )
+
+    assert result.selected_candidate_kind == "sparse_contact_patch"
+    assert result.selected_candidate_id == freeze.candidates[-1].candidate_id
+    assert result.selection_panel_role == "candidate_selection_only"
+    assert result.unbiased_post_selection_performance_claimed is False
+    assert result.independent_confirmation_required is True
+    assert (
+        validate_prospective_v2_promotion_result_v1(
+            result,
+            freeze,
+            opening,
+            evaluations,
+        )
+        is result
+    )
+
+
+def test_acceptance_fallback_and_harm_are_derived_from_bound_sources() -> None:
+    freeze = _freeze()
+    opening = build_prospective_v2_target_opening_v1(
+        freeze,
+        opened_at_utc="2026-08-09T00:00:00+00:00",
+        opened_by="independent-evaluator",
+    )
+    unit = freeze.evaluation_units[0]
+    candidate = freeze.candidates[1]
+    rejected_trace = _trace(freeze, unit, candidate, selected=False)
+    rejected_metrics = _metric_values(
+        freeze,
+        opening,
+        unit,
+        candidate,
+        rejected_trace,
+        candidate_trajectory_error_m=0.2,
+    )
+    rejected = build_prospective_v2_unit_evaluation_v1(
+        freeze,
+        opening,
+        unit_id=unit.unit_id,
+        candidate_id=candidate.candidate_id,
+        trace=rejected_trace,
+        metric_values=rejected_metrics,
+    )
+
+    assert rejected.candidate_selected is False
+    assert rejected.fallback_used is True
+    assert rejected.candidate_harmful is True
+    assert rejected.harmful_accepted_update is False
+    assert "candidate_accepted" not in rejected_metrics.as_dict()
+    assert "fallback_used" not in rejected_metrics.as_dict()
+    assert "harmful_update" not in rejected_metrics.as_dict()
+
+    selected_trace = _trace(freeze, unit, candidate, selected=True)
+    selected_metrics = _metric_values(
+        freeze,
+        opening,
+        unit,
+        candidate,
+        selected_trace,
+        candidate_trajectory_error_m=0.2,
+    )
+    selected = build_prospective_v2_unit_evaluation_v1(
+        freeze,
+        opening,
+        unit_id=unit.unit_id,
+        candidate_id=candidate.candidate_id,
+        trace=selected_trace,
+        metric_values=selected_metrics,
+    )
+    assert selected.harmful_accepted_update is True
+
+
+def test_trace_candidate_and_unit_bindings_fail_closed() -> None:
+    freeze = _freeze()
+    opening = build_prospective_v2_target_opening_v1(
+        freeze,
+        opened_at_utc="2026-08-09T00:00:00+00:00",
+        opened_by="independent-evaluator",
+    )
+    unit = freeze.evaluation_units[0]
+    candidate = freeze.candidates[1]
+    trace = _trace(
+        freeze,
+        unit,
+        candidate,
+        metadata_overrides={
+            "promotion_candidate_configuration_id": _id("other-configuration")
+        },
+    )
+    metrics = _metric_values(freeze, opening, unit, candidate, trace)
+
+    with pytest.raises(ValueError, match="candidate_configuration_id"):
+        build_prospective_v2_unit_evaluation_v1(
+            freeze,
+            opening,
+            unit_id=unit.unit_id,
+            candidate_id=candidate.candidate_id,
+            trace=trace,
+            metric_values=metrics,
+        )
+
+
+def test_metric_target_prediction_and_contract_bindings_fail_closed() -> None:
+    freeze = _freeze()
+    opening = build_prospective_v2_target_opening_v1(
+        freeze,
+        opened_at_utc="2026-08-09T00:00:00+00:00",
+        opened_by="independent-evaluator",
+    )
+    unit = freeze.evaluation_units[0]
+    candidate = freeze.candidates[1]
+    trace = _trace(freeze, unit, candidate)
+    metrics = _metric_values(freeze, opening, unit, candidate, trace)
+
+    for changed, message in (
+        (
+            replace(metrics, target_artifact_id=_id("different-target")),
+            "registered evaluation sources",
+        ),
+        (
+            replace(
+                metrics,
+                candidate_prediction_artifact_id=_id("different-prediction"),
+            ),
+            "registered evaluation sources",
+        ),
+        (
+            replace(metrics, metric_contract_id=_id("different-contract")),
+            "registered evaluation sources",
+        ),
+    ):
+        with pytest.raises(ValueError, match=message):
+            build_prospective_v2_unit_evaluation_v1(
+                freeze,
+                opening,
+                unit_id=unit.unit_id,
+                candidate_id=candidate.candidate_id,
+                trace=trace,
+                metric_values=changed,
+            )
+
+
+def test_target_opening_must_equal_the_complete_frozen_inventory() -> None:
+    freeze = _freeze()
+    opening = ProspectiveV2TargetOpeningV1(
+        freeze_id=freeze.freeze_id,
+        target_access_seal_id=freeze.target_access_seal_id,
+        target_artifact_ids=(freeze.evaluation_units[0].target_artifact_id,),
+        opened_at_utc="2026-08-09T00:00:00+00:00",
+        opened_by="independent-evaluator",
+    )
+
+    with pytest.raises(ValueError, match="frozen inventory"):
+        evaluate_prospective_v2_promotion_v1(
+            freeze,
+            opening,
+            (),
+        )
+
+
+def test_promotion_requires_complete_unit_candidate_product() -> None:
+    freeze = _freeze()
+    opening = build_prospective_v2_target_opening_v1(
+        freeze,
+        opened_at_utc="2026-08-09T00:00:00+00:00",
+        opened_by="independent-evaluator",
+    )
+    evaluations = _evaluations(freeze, opening)
+
+    with pytest.raises(ValueError, match="unit/candidate product"):
+        evaluate_prospective_v2_promotion_v1(
+            freeze,
+            opening,
+            evaluations[:-1],
+        )
+
+
+def test_revalidation_rejects_result_against_changed_source_metrics() -> None:
+    freeze = _freeze()
+    opening = build_prospective_v2_target_opening_v1(
+        freeze,
+        opened_at_utc="2026-08-09T00:00:00+00:00",
+        opened_by="independent-evaluator",
+    )
+    evaluations = _evaluations(freeze, opening)
+    result = evaluate_prospective_v2_promotion_v1(
+        freeze,
+        opening,
+        evaluations,
+    )
+    first = evaluations[0]
+    changed_values = replace(
+        first.metric_values,
+        candidate_log_score=first.metric_values.candidate_log_score + 0.5,
+    )
+    changed_first = replace(first, metric_values=changed_values)
+    changed_evaluations = (changed_first, *evaluations[1:])
+
+    with pytest.raises(ValueError, match="bound source evidence"):
+        validate_prospective_v2_promotion_result_v1(
+            result,
+            freeze,
+            opening,
+            changed_evaluations,
+        )
+
+
+def test_freeze_rejects_duplicate_independent_groups_and_target_metadata() -> None:
+    freeze = _freeze()
+    duplicate = replace(
+        freeze.evaluation_units[1],
+        endpoint=freeze.evaluation_units[0].endpoint,
+        independent_group_id=freeze.evaluation_units[0].independent_group_id,
+    )
+    with pytest.raises(ValueError, match="independent_group_id"):
+        replace(
+            freeze,
+            evaluation_units=(
+                freeze.evaluation_units[0],
+                duplicate,
+                freeze.evaluation_units[2],
+            ),
+        )
+    with pytest.raises(ValueError, match="forbidden before target opening"):
+        replace(
+            freeze.candidates[1],
+            metadata={"target_metric": 0.1},
+        )
+
+
+def test_trace_root_artifacts_must_match_registered_contexts() -> None:
+    freeze = _freeze()
+    opening = build_prospective_v2_target_opening_v1(
+        freeze,
+        opened_at_utc="2026-08-09T00:00:00+00:00",
+        opened_by="independent-evaluator",
+    )
+    unit = freeze.evaluation_units[0]
+    candidate = freeze.candidates[1]
+    trace = _trace(
+        freeze,
+        unit,
+        candidate,
+        wrong_factual_context=True,
+    )
+    metrics = _metric_values(freeze, opening, unit, candidate, trace)
+
+    with pytest.raises(ValueError, match="factual-context binding"):
+        build_prospective_v2_unit_evaluation_v1(
+            freeze,
+            opening,
+            unit_id=unit.unit_id,
+            candidate_id=candidate.candidate_id,
+            trace=trace,
+            metric_values=metrics,
+        )
+
+
+def test_interval_width_ratio_uses_the_frozen_policy_floor() -> None:
+    freeze = _freeze()
+    opening = build_prospective_v2_target_opening_v1(
+        freeze,
+        opened_at_utc="2026-08-09T00:00:00+00:00",
+        opened_by="independent-evaluator",
+    )
+    unit = freeze.evaluation_units[0]
+    candidate = freeze.candidates[1]
+    trace = _trace(freeze, unit, candidate)
+    metrics = _metric_values(
+        freeze,
+        opening,
+        unit,
+        candidate,
+        trace,
+        baseline_interval_width_m=0.0,
+        candidate_interval_width_m=1e-10,
+    )
+    evaluation = build_prospective_v2_unit_evaluation_v1(
+        freeze,
+        opening,
+        unit_id=unit.unit_id,
+        candidate_id=candidate.candidate_id,
+        trace=trace,
+        metric_values=metrics,
+    )
+
+    assert evaluation.interval_width_ratio == pytest.approx(0.1)
+    assert evaluation.as_dict()["policy_id"] == freeze.policy.policy_id
+
+
+def test_freeze_requires_complete_target_free_source_inventory() -> None:
+    freeze = _freeze()
+    with pytest.raises(ValueError, match="target-free source"):
+        replace(
+            freeze,
+            source_artifact_ids=tuple(
+                value
+                for value in freeze.source_artifact_ids
+                if value != freeze.stack_lock_id
+            ),
+        )
+
+
+def test_target_opening_timestamp_must_use_utc() -> None:
+    freeze = _freeze()
+    with pytest.raises(ValueError, match="must use UTC"):
+        build_prospective_v2_target_opening_v1(
+            freeze,
+            opened_at_utc="2026-08-09T02:00:00+02:00",
+            opened_by="independent-evaluator",
+        )


### PR DESCRIPTION
## Summary

Replace the earlier self-declared prospective-promotion result objects with an evidence-bound candidate-selection protocol.

The rewritten implementation:

- freezes the exact stack lock, target-access seal, candidate ladder, candidate configurations, independent evaluation units, target-artifact inventory, scoring implementation, metric semantics, endpoint thresholds, and source artifact inventory before target access;
- derives the one-opening inventory from the freeze and exact ordered target identities rather than accepting a caller-supplied verification flag;
- binds each non-baseline candidate/unit evaluation to a validated prospective-V2 decision trace, factual context, counterfactual query, target artifact, baseline prediction, candidate prediction, scoring run, and metric contract;
- derives candidate admission, exact fallback, harmful accepted updates, log-score gain, Brier change, trajectory regret, coverage error, and interval-width ratio from the source artifacts instead of accepting caller-supplied booleans;
- requires the complete registered unit × candidate Cartesian product and aggregates factual, same-grasp, and new-contact endpoints at the independent-unit level;
- selects the highest passing member of the frozen candidate ladder or preserves the exact registered baseline when none passes; and
- marks every result as candidate-selection-only, prohibits an unbiased post-selection performance claim, and requires a fresh independent confirmation panel.

## Validation

The bounded publisher verified the exact compressed and decoded patch SHA-256 values, applied repository formatting and deterministic Ruff repair, passed focused decision-trace/projected-support/profile/promotion tests, passed the complete default pytest suite, built wheel and source distributions outside the checkout, and force-with-lease squashed the staging history into one reviewable source commit before the final documentation clarification.

All authoritative checks pass on exact head `c6d9e756aa7ca87c8b90eda85a1af8ecdb0e1e56`:

- CI and release run `31278953939`, including Ruff, incremental formatting, MyPy, Python 3.10/3.12/3.14 core suites, wheel/sdist installation and complete CLI help checks, deterministic result bundles, frozen-manifest validation, and pinned BayesianPhysTwin installed-wheel integration;
- Extended compatibility run `31278953941`, including Python 3.11/3.13 and exact declared dependency floors;
- Security scanning run `31278953956`, including resolved dependency audit and CodeQL for Python and Actions; and
- Causal4D merge gate run `31278953940`, including repository quality, the complete default suite, distribution validation, and isolated pinned-provider integration on the synthetic merge result.

## Scientific boundary

This is prospective candidate-selection infrastructure only. It changes no frozen estimator, six-frame information boundary, registered acquisition candidate, 18-session/36-execution protocol, target identities, calibration rule, physical result, or confirmatory evidence count. A positive selection result is not an unbiased post-selection performance result; independent confirmation remains mandatory.