### PR TITLE
Define API v1 and add local Ruff hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+minimum_pre_commit_version: "3.7.0"
+
+repos:
+  - repo: local
+    hooks:
+      - id: ruff-check
+        name: Ruff lint
+        entry: python -m ruff check --fix
+        language: system
+        types_or: [python, pyi]
+      - id: ruff-format
+        name: Ruff format
+        entry: python -m ruff format
+        language: system
+        types_or: [python, pyi]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,20 @@ Install the project and development tools with:
 python -m pip install -e ".[dev]"
 ```
 
+Enable the repository hooks once per checkout:
+
+```bash
+python -m pre_commit install
+```
+
+The hooks run Ruff lint fixes and Ruff formatting on staged Python files using the
+same tool range as CI. Run them over the complete checkout after changing tooling or
+before opening a pull request:
+
+```bash
+python -m pre_commit run --all-files
+```
+
 Bayesian-PhysTwin integrations require the optional provider environment:
 
 ```bash
@@ -108,6 +122,7 @@ available suite. At minimum, a pull request should include:
 Useful local checks include:
 
 ```bash
+python -m pre_commit run --all-files
 python -m pytest -q
 python -m compileall -q src tests
 python -m ruff check .

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -1,0 +1,56 @@
+# Versioned Python API
+
+Causal4D contains stable contracts, registered evidence machinery, diagnostics, and
+fast-moving research prototypes. Importing every convenient top-level name made it
+unclear which interfaces downstream projects could rely on.
+
+The supported version-1 surface is now explicit:
+
+```python
+from causal4d.api.v1 import (
+    CounterfactualQuery,
+    PhysicalPosterior,
+    PrefixLikelihoodConfig,
+    apply_counterfactual_operator,
+)
+```
+
+Only names listed in `causal4d.api.v1.__all__` are covered by the v1 compatibility
+promise. Existing imports such as `from causal4d import PhysicalPosterior` remain
+compatible, but new downstream code should prefer the versioned path.
+
+## What v1 contains
+
+The initial surface is deliberately conservative:
+
+- causal query and posterior contracts;
+- rollout-bank and prefix-likelihood interfaces;
+- the counterfactual operator;
+- hierarchical intervention abduction;
+- full-joint Gaussian observation contracts and updates; and
+- the versioned BayesianPhysTwin provider boundary.
+
+Registered acquisition internals, CLI implementations, paper-specific report
+builders, prospective promotion machinery, semantic branches, and experimental
+contact models remain in their owning modules. They can evolve without expanding a
+stable compatibility promise accidentally.
+
+## Compatibility policy
+
+Within `causal4d.api.v1`:
+
+- existing names retain their import path and meaning;
+- additive names may be introduced when they are mature;
+- incompatible semantics require a new contract or API version;
+- provider schema changes remain governed by their own versioned contracts; and
+- deprecations should include a documented migration path before removal.
+
+A future `causal4d.api.v2` may coexist with v1. The unversioned top-level package is
+kept for backward compatibility and discovery, not as an automatic promise that
+every re-export is stable.
+
+## Checking the surface
+
+The repository locks the exact v1 inventory and verifies that each versioned symbol
+is the same object as its historical top-level counterpart. This prevents silent
+wrappers, accidental copies, and unreviewed expansion of the stable namespace.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ Citation = "https://github.com/IPS-Stuttgart/Causal4D/blob/main/CITATION.cff"
 dev = [
   "build>=1.2",
   "mypy>=1.11",
+  "pre-commit>=3.7,<5",
   "pytest>=8",
   "ruff>=0.15.22,<0.17",
   "twine>=5",

--- a/src/causal4d/api/__init__.py
+++ b/src/causal4d/api/__init__.py
@@ -1,0 +1,5 @@
+"""Versioned supported Python interfaces for Causal4D."""
+
+from causal4d.api import v1
+
+__all__ = ["v1"]

--- a/src/causal4d/api/v1.py
+++ b/src/causal4d/api/v1.py
@@ -1,0 +1,91 @@
+"""Version 1 of Causal4D's supported Python API.
+
+Only names listed in ``__all__`` are covered by the v1 compatibility promise.
+Research prototypes, registered-protocol internals, and command implementations
+remain available from their owning modules but are not part of this surface.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from causal4d.contracts import (
+    CounterfactualQuery,
+    FactualIntervention,
+    PhysicalPosterior,
+    TaskPosterior,
+    TwinBelief,
+)
+from causal4d.counterfactual import apply_counterfactual_operator
+from causal4d.hierarchical_abduction import (
+    HierarchicalAbductionResult,
+    abduct_hierarchical_interventions,
+)
+from causal4d.joint_observation import (
+    JOINT_OBSERVATION_SCHEMA_VERSION,
+    CovarianceRepresentation,
+    JointGaussianLikelihoodDiagnostics,
+    LinearJointObservationEvidence,
+    block_diagonalize_covariance,
+    joint_component_log_likelihoods,
+    posterior_weights_from_joint_observation,
+)
+from causal4d.prefix_likelihood import (
+    PrefixLikelihoodConfig,
+    prefix_component_log_likelihood,
+    update_joint_weights_from_prefix,
+)
+from causal4d.provider_contract import (
+    BASE_CAUSAL4D_PROVIDER_CAPABILITIES,
+    BAYESIAN_PHYSTWIN_ARTIFACT_SCHEMA_VERSIONS,
+    BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE,
+    BAYESIAN_PHYSTWIN_PROVIDER_CAPABILITIES,
+    PHYSICAL_BELIEF_PROVIDER_SCHEMA_VERSION,
+    PhysicalBeliefProviderManifest,
+    ProviderCompatibilityResult,
+    load_bayesian_phystwin_provider_manifest,
+    require_bayesian_phystwin_provider,
+    validate_bayesian_phystwin_provider,
+    validate_provider_compatibility,
+)
+from causal4d.rollout_bank import JointRolloutBank, SparseTrajectoryEvidence
+
+
+PUBLIC_API_NAME: Final = "causal4d.api.v1"
+PUBLIC_API_VERSION: Final = 1
+
+__all__ = [
+    "BASE_CAUSAL4D_PROVIDER_CAPABILITIES",
+    "BAYESIAN_PHYSTWIN_ARTIFACT_SCHEMA_VERSIONS",
+    "BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE",
+    "BAYESIAN_PHYSTWIN_PROVIDER_CAPABILITIES",
+    "JOINT_OBSERVATION_SCHEMA_VERSION",
+    "PHYSICAL_BELIEF_PROVIDER_SCHEMA_VERSION",
+    "PUBLIC_API_NAME",
+    "PUBLIC_API_VERSION",
+    "CounterfactualQuery",
+    "CovarianceRepresentation",
+    "FactualIntervention",
+    "HierarchicalAbductionResult",
+    "JointGaussianLikelihoodDiagnostics",
+    "JointRolloutBank",
+    "LinearJointObservationEvidence",
+    "PhysicalBeliefProviderManifest",
+    "PhysicalPosterior",
+    "PrefixLikelihoodConfig",
+    "ProviderCompatibilityResult",
+    "SparseTrajectoryEvidence",
+    "TaskPosterior",
+    "TwinBelief",
+    "abduct_hierarchical_interventions",
+    "apply_counterfactual_operator",
+    "block_diagonalize_covariance",
+    "joint_component_log_likelihoods",
+    "load_bayesian_phystwin_provider_manifest",
+    "posterior_weights_from_joint_observation",
+    "prefix_component_log_likelihood",
+    "require_bayesian_phystwin_provider",
+    "update_joint_weights_from_prefix",
+    "validate_bayesian_phystwin_provider",
+    "validate_provider_compatibility",
+]

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import causal4d
+
+from causal4d import api
+from causal4d.api import v1
+
+
+EXPECTED_V1_EXPORTS = (
+    "BASE_CAUSAL4D_PROVIDER_CAPABILITIES",
+    "BAYESIAN_PHYSTWIN_ARTIFACT_SCHEMA_VERSIONS",
+    "BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE",
+    "BAYESIAN_PHYSTWIN_PROVIDER_CAPABILITIES",
+    "JOINT_OBSERVATION_SCHEMA_VERSION",
+    "PHYSICAL_BELIEF_PROVIDER_SCHEMA_VERSION",
+    "PUBLIC_API_NAME",
+    "PUBLIC_API_VERSION",
+    "CounterfactualQuery",
+    "CovarianceRepresentation",
+    "FactualIntervention",
+    "HierarchicalAbductionResult",
+    "JointGaussianLikelihoodDiagnostics",
+    "JointRolloutBank",
+    "LinearJointObservationEvidence",
+    "PhysicalBeliefProviderManifest",
+    "PhysicalPosterior",
+    "PrefixLikelihoodConfig",
+    "ProviderCompatibilityResult",
+    "SparseTrajectoryEvidence",
+    "TaskPosterior",
+    "TwinBelief",
+    "abduct_hierarchical_interventions",
+    "apply_counterfactual_operator",
+    "block_diagonalize_covariance",
+    "joint_component_log_likelihoods",
+    "load_bayesian_phystwin_provider_manifest",
+    "posterior_weights_from_joint_observation",
+    "prefix_component_log_likelihood",
+    "require_bayesian_phystwin_provider",
+    "update_joint_weights_from_prefix",
+    "validate_bayesian_phystwin_provider",
+    "validate_provider_compatibility",
+)
+
+
+def test_api_package_exposes_the_versioned_namespace() -> None:
+    assert api.__all__ == ["v1"]
+    assert api.v1 is v1
+
+
+def test_v1_surface_is_explicit_and_unique() -> None:
+    assert tuple(v1.__all__) == EXPECTED_V1_EXPORTS
+    assert len(v1.__all__) == len(set(v1.__all__))
+    assert v1.PUBLIC_API_NAME == "causal4d.api.v1"
+    assert v1.PUBLIC_API_VERSION == 1
+    for name in v1.__all__:
+        assert hasattr(v1, name)
+
+
+def test_v1_preserves_existing_top_level_symbol_identity() -> None:
+    for name in EXPECTED_V1_EXPORTS:
+        if name.startswith("PUBLIC_API_"):
+            continue
+        assert getattr(v1, name) is getattr(causal4d, name)
+
+
+def test_v1_does_not_admit_experimental_or_protocol_internals() -> None:
+    forbidden = {
+        "ContactPatchStateV2",
+        "ProspectiveV2PromotionFreezeV1",
+        "SemanticTimingMetadata",
+        "build_registered_real_analysis_manifest",
+    }
+    assert forbidden.isdisjoint(v1.__all__)


### PR DESCRIPTION
## Summary

Introduce an explicit supported Python interface and catch formatting/lint failures before push.

### Versioned API

- add `causal4d.api.v1` with a conservative, exact export inventory;
- include mature causal contracts, rollout/prefix inference, hierarchical abduction, full-joint observations, and the BayesianPhysTwin provider boundary;
- keep experimental contact models, semantic branches, registered-protocol internals, CLI implementations, and prospective promotion machinery outside the stability promise;
- verify every versioned symbol is the identical historical top-level object; and
- document compatibility and future-version policy.

### Contributor checks

- add local pre-commit hooks for `ruff check --fix` and `ruff format`;
- install pre-commit through the existing `dev` extra; and
- document installation and full-checkout execution in `CONTRIBUTING.md`.

## Compatibility

Existing `from causal4d import ...` imports remain unchanged. This PR adds a preferred, versioned import path; it removes or renames no public symbol and changes no provider schema.

## Validation

The new tests lock the exact v1 namespace, reject duplicate/accidental expansion, confirm package routing, verify symbol identity with the legacy top-level surface, and ensure experimental/protocol internals are not admitted.

Authoritative GitHub Actions are fully green on exact head:

```text
586c2451aa37a33135a2dfd4cb35c91b750954b8
```

- CI and release run `31297331666`: success;
- Extended compatibility run `31297331633`: success;
- Security scanning run `31297331723`: success;
- Causal4D merge gate run `31297331641`: success; and
- Three-repository installed-wheel compatibility run `31297331654`: success, including the exact Prob4D/BayesianPhysTwin/Causal4D packaged stack.

Together these cover Ruff, formatting, MyPy, all supported Python versions, declared dependency floors, distributions and isolated installations, complete CLI help checks, deterministic result bundles, security policy, pinned BayesianPhysTwin integration, and the three-repository installed-wheel boundary.

## Scientific boundary

Maintenance and API-governance only. This changes no estimator, likelihood, intervention support, registered protocol, target-access rule, calibration, scientific result, or physical evidence count.