### PR TITLE
[Merged as #265] Add independent prospective V2 confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- Add a fixed-candidate independent-confirmation contract for prospective V2
+  selections. It revalidates the selection evidence, rejects unit, target,
+  independence-group, session, seal, trace, metric, and scoring-run reuse, keeps
+  the metric contract and thresholds fixed, prohibits candidate re-selection,
+  and preserves the exact registered baseline when confirmation fails.
 - Add evidence-bound prospective V2 promotion contracts that freeze the
   target inventory and metric semantics, derive acceptance, exact fallback,
   and harmful-update status from validated decision traces and raw scores,

--- a/docs/prospective_v2_confirmation.md
+++ b/docs/prospective_v2_confirmation.md
@@ -1,0 +1,111 @@
+# Independent prospective V2 confirmation
+
+A positive prospective V2 promotion result is a candidate-selection result. The
+selection panel has already been inspected to choose the candidate and therefore
+cannot also provide an unbiased estimate of that candidate's predictive
+performance. `causal4d.prospective_v2_confirmation` implements the required
+independent confirmation boundary.
+
+This path is separate from the frozen 18-session/36-execution physical protocol.
+It does not alter that estimator, its six-frame information boundary, or its
+evidence count.
+
+## Confirmation freeze
+
+`build_prospective_v2_confirmation_freeze_v1` first revalidates the complete
+selection result against its original freeze, target opening, and unit
+evaluations. A confirmation freeze can be created only when the selection panel
+chose a non-baseline candidate.
+
+The confirmation freeze binds:
+
+- the exact selection result, freeze, opening, unit evaluations, decision traces,
+  raw metric values, and scoring runs;
+- the exact registered baseline and the one selected candidate configuration;
+- the original stack lock, metric contract, and promotion policy;
+- a new target-access seal and the complete confirmation-unit inventory; and
+- every target-free factual context, counterfactual query, and implementation
+  artifact required for the confirmation panel.
+
+`validate_prospective_v2_confirmation_freeze_v1` reconstructs this freeze from
+the original selection evidence and requires exact equality, so an archived
+confirmation registration remains independently auditable.
+
+The candidate ladder is not present as an active decision surface. The panel
+records:
+
+```text
+panel_role = independent_confirmation
+candidate_selection_performed = false
+selection_panel_outcomes_used = true
+confirmation_target_outcomes_used = false
+```
+
+## Independence checks
+
+The confirmation freeze rejects overlap with the selection panel in any of the
+following identities:
+
+- unit ID or unit binding;
+- target artifact;
+- endpoint-specific independent group;
+- protocol/session pair; or
+- target-access seal.
+
+Confirmation unit IDs, bindings, target artifacts, and endpoint independence
+groups must also be unique within the confirmation inventory. Each endpoint must
+contain at least the number of independent units required by the unchanged
+promotion policy.
+
+These checks prevent a relabelled selection row, target artifact, or physical
+session from being presented as independent evidence.
+
+## Opening and unit evaluation
+
+`build_prospective_v2_confirmation_opening_v1` opens exactly the ordered target
+inventory registered by the confirmation freeze.
+
+Each confirmation trace must retain the normal prospective V2 trace bindings and
+add:
+
+```text
+confirmation_freeze_id
+confirmation_selection_result_id
+confirmation_panel_role = independent_confirmation
+```
+
+`build_prospective_v2_confirmation_unit_evaluation_v1` evaluates only the fixed
+selected candidate against the exact registered baseline. It rejects reuse of a
+selection-panel decision trace, raw metric-value artifact, or scoring run. The
+ordinary V2 trace still derives candidate admission, exact per-unit fallback,
+and harmful accepted-update status; callers cannot supply those labels.
+
+## Confirmation result
+
+`evaluate_prospective_v2_confirmation_v1` requires exactly one evaluation for
+every frozen confirmation unit. It aggregates factual continuation, same-grasp
+transfer, and new-contact transfer separately using the same metric contract and
+thresholds used for selection.
+
+There is no second candidate search. The result has only two possible deployment
+outcomes:
+
+1. the previously selected configuration when every endpoint passes; or
+2. the exact registered baseline configuration when any endpoint fails.
+
+The result records that candidate selection was not performed on the confirmation
+panel and that selection-panel performance was not reused. A passing result means
+the fixed-candidate confirmation gate passed on the registered independent panel;
+it is not evidence that the candidate was optimal among untested alternatives.
+
+`validate_prospective_v2_confirmation_result_v1` recomputes the complete result
+from its frozen evidence and requires exact equality.
+
+## Scientific boundary
+
+The confirmation contracts create no physical observation or result by
+themselves. A confirmation freeze must be produced before its confirmation target
+outcomes are accessed, and a result may be reported only from the complete bound
+panel. The mechanism cannot admit Prob4D into the frozen acquisition, retune the
+selected candidate, replace the primary 36-execution analysis, or convert a
+selection-panel estimate into independent evidence.

--- a/docs/prospective_v2_promotion.md
+++ b/docs/prospective_v2_promotion.md
@@ -90,7 +90,9 @@ independent_confirmation_required = true
 ```
 
 A fresh independent panel is required before reporting post-selection predictive
-performance for the selected candidate.
+performance for the selected candidate. The executable fixed-candidate protocol,
+panel-disjointness checks, and exact-baseline fallback are documented in
+`docs/prospective_v2_confirmation.md`.
 
 ## Strict persistence and independent replay
 

--- a/src/causal4d/prospective_v2_confirmation.py
+++ b/src/causal4d/prospective_v2_confirmation.py
@@ -1,0 +1,1027 @@
+"""Independent confirmation for a fixed prospective Causal4D V2 candidate.
+
+The candidate-selection panel may choose one non-baseline configuration, but it
+cannot support an unbiased post-selection performance claim. This module freezes
+and evaluates a disjoint confirmation panel for that already selected candidate.
+It never reopens the candidate ladder and falls back to the exact registered
+baseline when the fixed candidate does not pass every confirmation endpoint.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from causal4d._prospective_v2_promotion_evidence import (
+    PROSPECTIVE_V2_CANDIDATE_KINDS,
+    ProspectiveV2CandidateV1,
+    ProspectiveV2EvaluationUnitV1,
+    ProspectiveV2MetricContractV1,
+    ProspectiveV2PromotionFreezeV1,
+    ProspectiveV2PromotionPolicyV1,
+    ProspectiveV2TargetOpeningV1,
+    ProspectiveV2UnitEvaluationV1,
+    ProspectiveV2UnitMetricValuesV1,
+    _canonical_sha256,
+    _finite_float,
+    _finite_nonnegative_float,
+    _rate,
+    _require_bool,
+    _require_nonempty_string,
+    _require_sha256,
+    _validated_source_metadata,
+    _validated_unique_strings,
+)
+from causal4d.atomic_io import atomic_write_json
+from causal4d.decision_trace import DECISION_TRACE_ENDPOINTS, UnifiedDecisionTrace
+from causal4d.immutable_json import plain_json, validated_json_mapping
+from causal4d.prospective_v2_promotion import (
+    ProspectiveV2EndpointMetricsV1,
+    ProspectiveV2PromotionResultV1,
+    validate_prospective_v2_promotion_result_v1,
+)
+
+
+PROSPECTIVE_V2_CONFIRMATION_SCHEMA_VERSION = 1
+PROSPECTIVE_V2_CONFIRMATION_PANEL_ROLE = "independent_confirmation"
+
+_CONFIRMATION_TRACE_METADATA = {
+    "confirmation_freeze_id": "confirmation_freeze_id",
+    "confirmation_selection_result_id": "selection_result_id",
+    "confirmation_panel_role": "confirmation_panel_role",
+}
+
+
+def _mean(values: Sequence[float], *, name: str) -> float:
+    if not values:
+        raise ValueError(f"{name} requires at least one value")
+    result = float(np.mean(np.asarray(values, dtype=float)))
+    if not np.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _ordered_unique(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(values))
+
+
+def _unit_identities(
+    units: Sequence[ProspectiveV2EvaluationUnitV1],
+) -> tuple[
+    set[str],
+    set[str],
+    set[str],
+    set[tuple[str, str]],
+    set[tuple[str, str]],
+]:
+    return (
+        {unit.unit_id for unit in units},
+        {unit.unit_binding_id for unit in units},
+        {unit.target_artifact_id for unit in units},
+        {(unit.endpoint, unit.independent_group_id) for unit in units},
+        {(unit.protocol_id, unit.session_id) for unit in units},
+    )
+
+
+def _require_confirmation_trace_metadata(
+    trace: UnifiedDecisionTrace,
+    freeze: ProspectiveV2ConfirmationFreezeV1,
+) -> None:
+    expected_metadata = {
+        "confirmation_freeze_id": freeze.confirmation_freeze_id,
+        "confirmation_selection_result_id": freeze.selection_result_id,
+        "confirmation_panel_role": PROSPECTIVE_V2_CONFIRMATION_PANEL_ROLE,
+    }
+    for key, expected in expected_metadata.items():
+        if trace.metadata.get(key) != expected:
+            field = _CONFIRMATION_TRACE_METADATA[key]
+            raise ValueError(f"decision trace {field} binding changed")
+
+
+@dataclass(frozen=True)
+class ProspectiveV2ConfirmationFreezeV1:
+    """Target-free freeze for a fixed-candidate independent confirmation panel."""
+
+    experiment_id: str
+    selection_result_id: str
+    selection_freeze_id: str
+    selection_opening_id: str
+    selection_evaluation_ids: tuple[str, ...]
+    selection_trace_ids: tuple[str, ...]
+    selection_metric_values_ids: tuple[str, ...]
+    selection_scoring_run_artifact_ids: tuple[str, ...]
+    stack_lock_id: str
+    target_access_seal_id: str
+    baseline_candidate: ProspectiveV2CandidateV1
+    selected_candidate: ProspectiveV2CandidateV1
+    selection_units: tuple[ProspectiveV2EvaluationUnitV1, ...]
+    evaluation_units: tuple[ProspectiveV2EvaluationUnitV1, ...]
+    metric_contract: ProspectiveV2MetricContractV1
+    policy: ProspectiveV2PromotionPolicyV1
+    bound_artifact_ids: tuple[str, ...]
+    confirmation_target_outcomes_used: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        experiment_id = _require_nonempty_string(
+            self.experiment_id,
+            name="experiment_id",
+        )
+        selection_result_id = _require_sha256(
+            self.selection_result_id,
+            name="selection_result_id",
+        )
+        selection_freeze_id = _require_sha256(
+            self.selection_freeze_id,
+            name="selection_freeze_id",
+        )
+        selection_opening_id = _require_sha256(
+            self.selection_opening_id,
+            name="selection_opening_id",
+        )
+        selection_evaluation_ids = _validated_unique_strings(
+            self.selection_evaluation_ids,
+            name="selection_evaluation_ids",
+            require_sha256=True,
+        )
+        selection_trace_ids = _validated_unique_strings(
+            self.selection_trace_ids,
+            name="selection_trace_ids",
+            require_sha256=True,
+        )
+        selection_metric_values_ids = _validated_unique_strings(
+            self.selection_metric_values_ids,
+            name="selection_metric_values_ids",
+            require_sha256=True,
+        )
+        selection_scoring_run_ids = _validated_unique_strings(
+            self.selection_scoring_run_artifact_ids,
+            name="selection_scoring_run_artifact_ids",
+            require_sha256=True,
+        )
+        stack_lock_id = _require_sha256(self.stack_lock_id, name="stack_lock_id")
+        seal_id = _require_sha256(
+            self.target_access_seal_id,
+            name="target_access_seal_id",
+        )
+        if type(self.baseline_candidate) is not ProspectiveV2CandidateV1:
+            raise ValueError("baseline_candidate has the wrong type")
+        if type(self.selected_candidate) is not ProspectiveV2CandidateV1:
+            raise ValueError("selected_candidate has the wrong type")
+        if self.baseline_candidate.candidate_kind != PROSPECTIVE_V2_CANDIDATE_KINDS[0]:
+            raise ValueError("baseline_candidate must be the registered baseline")
+        if self.selected_candidate.candidate_kind == PROSPECTIVE_V2_CANDIDATE_KINDS[0]:
+            raise ValueError(
+                "independent confirmation requires a non-baseline candidate"
+            )
+        if self.baseline_candidate.candidate_id == self.selected_candidate.candidate_id:
+            raise ValueError("baseline and selected candidate IDs must differ")
+        if (
+            self.baseline_candidate.configuration_artifact_id
+            == self.selected_candidate.configuration_artifact_id
+        ):
+            raise ValueError("baseline and selected configurations must differ")
+
+        selection_units = tuple(self.selection_units)
+        confirmation_units = tuple(self.evaluation_units)
+        for name, units in (
+            ("selection_units", selection_units),
+            ("evaluation_units", confirmation_units),
+        ):
+            if not units or any(
+                type(unit) is not ProspectiveV2EvaluationUnitV1 for unit in units
+            ):
+                raise ValueError(
+                    f"{name} must contain ProspectiveV2EvaluationUnitV1 values"
+                )
+        selection_seals = {unit.target_access_seal_id for unit in selection_units}
+        if len(selection_seals) != 1:
+            raise ValueError("selection units must share one target-access seal")
+        if seal_id in selection_seals:
+            raise ValueError("confirmation must use a new target-access seal")
+        if any(unit.target_access_seal_id != seal_id for unit in confirmation_units):
+            raise ValueError("every confirmation unit must bind the new access seal")
+
+        selection_identity = _unit_identities(selection_units)
+        confirmation_identity = _unit_identities(confirmation_units)
+        identity_names = (
+            "unit IDs",
+            "unit bindings",
+            "target artifacts",
+            "endpoint independence groups",
+            "protocol sessions",
+        )
+        for name, selected_values, confirmation_values in zip(
+            identity_names,
+            selection_identity,
+            confirmation_identity,
+            strict=True,
+        ):
+            overlap = sorted(selected_values & confirmation_values)
+            if overlap:
+                raise ValueError(
+                    f"confirmation panel reuses selection-panel {name}: {overlap}"
+                )
+        for name, values in zip(
+            identity_names[:4],
+            confirmation_identity[:4],
+            strict=True,
+        ):
+            if len(values) != len(confirmation_units):
+                raise ValueError(f"confirmation {name} must be unique")
+
+        if type(self.metric_contract) is not ProspectiveV2MetricContractV1:
+            raise ValueError("metric_contract has the wrong type")
+        if type(self.policy) is not ProspectiveV2PromotionPolicyV1:
+            raise ValueError("policy has the wrong type")
+        for endpoint in DECISION_TRACE_ENDPOINTS:
+            count = sum(unit.endpoint == endpoint for unit in confirmation_units)
+            if count < self.policy.minimum_units_per_endpoint:
+                raise ValueError(
+                    f"confirmation endpoint {endpoint!r} has insufficient units"
+                )
+
+        bound_ids = _validated_unique_strings(
+            self.bound_artifact_ids,
+            name="bound_artifact_ids",
+            require_sha256=True,
+        )
+        required_ids = {
+            selection_result_id,
+            selection_freeze_id,
+            selection_opening_id,
+            *selection_evaluation_ids,
+            *selection_trace_ids,
+            *selection_metric_values_ids,
+            *selection_scoring_run_ids,
+            stack_lock_id,
+            seal_id,
+            self.metric_contract.scoring_implementation_artifact_id,
+            self.baseline_candidate.configuration_artifact_id,
+            self.selected_candidate.configuration_artifact_id,
+            *(unit.factual_context_artifact_id for unit in confirmation_units),
+            *(unit.counterfactual_query_artifact_id for unit in confirmation_units),
+        }
+        missing = sorted(required_ids - set(bound_ids))
+        if missing:
+            raise ValueError(
+                "bound_artifact_ids do not cover the confirmation sources; "
+                f"missing={missing}"
+            )
+        if _require_bool(
+            self.confirmation_target_outcomes_used,
+            name="confirmation_target_outcomes_used",
+        ):
+            raise ValueError(
+                "confirmation freeze must predate confirmation target access"
+            )
+        metadata = _validated_source_metadata(
+            self.metadata,
+            name="confirmation-freeze metadata",
+        )
+        object.__setattr__(self, "experiment_id", experiment_id)
+        object.__setattr__(self, "selection_result_id", selection_result_id)
+        object.__setattr__(self, "selection_freeze_id", selection_freeze_id)
+        object.__setattr__(self, "selection_opening_id", selection_opening_id)
+        object.__setattr__(
+            self,
+            "selection_evaluation_ids",
+            selection_evaluation_ids,
+        )
+        object.__setattr__(self, "selection_trace_ids", selection_trace_ids)
+        object.__setattr__(
+            self,
+            "selection_metric_values_ids",
+            selection_metric_values_ids,
+        )
+        object.__setattr__(
+            self,
+            "selection_scoring_run_artifact_ids",
+            selection_scoring_run_ids,
+        )
+        object.__setattr__(self, "stack_lock_id", stack_lock_id)
+        object.__setattr__(self, "target_access_seal_id", seal_id)
+        object.__setattr__(self, "selection_units", selection_units)
+        object.__setattr__(self, "evaluation_units", confirmation_units)
+        object.__setattr__(self, "bound_artifact_ids", bound_ids)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def unit_by_id(self) -> dict[str, ProspectiveV2EvaluationUnitV1]:
+        return {unit.unit_id: unit for unit in self.evaluation_units}
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": PROSPECTIVE_V2_CONFIRMATION_SCHEMA_VERSION,
+            "artifact_kind": "Causal4DProspectiveV2ConfirmationFreezeV1",
+            "experiment_id": self.experiment_id,
+            "selection_result_id": self.selection_result_id,
+            "selection_freeze_id": self.selection_freeze_id,
+            "selection_opening_id": self.selection_opening_id,
+            "selection_evaluation_ids": list(self.selection_evaluation_ids),
+            "selection_trace_ids": list(self.selection_trace_ids),
+            "selection_metric_values_ids": list(self.selection_metric_values_ids),
+            "selection_scoring_run_artifact_ids": list(
+                self.selection_scoring_run_artifact_ids
+            ),
+            "stack_lock_id": self.stack_lock_id,
+            "target_access_seal_id": self.target_access_seal_id,
+            "baseline_candidate": self.baseline_candidate.as_dict(),
+            "selected_candidate": self.selected_candidate.as_dict(),
+            "selection_units": [unit.as_dict() for unit in self.selection_units],
+            "evaluation_units": [unit.as_dict() for unit in self.evaluation_units],
+            "metric_contract": self.metric_contract.as_dict(),
+            "policy": self.policy.as_dict(),
+            "bound_artifact_ids": list(self.bound_artifact_ids),
+            "panel_role": PROSPECTIVE_V2_CONFIRMATION_PANEL_ROLE,
+            "candidate_selection_performed": False,
+            "selection_panel_outcomes_used": True,
+            "confirmation_target_outcomes_used": False,
+            "metadata": plain_json(self.metadata),
+        }
+
+    @property
+    def confirmation_freeze_id(self) -> str:
+        return _canonical_sha256(self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            **self._payload(),
+            "confirmation_freeze_id": self.confirmation_freeze_id,
+        }
+
+
+@dataclass(frozen=True)
+class ProspectiveV2ConfirmationResultV1:
+    """Independent fixed-candidate confirmation with exact baseline fallback."""
+
+    confirmation_freeze_id: str
+    opening_id: str
+    selection_result_id: str
+    baseline_candidate_id: str
+    baseline_configuration_artifact_id: str
+    candidate_id: str
+    candidate_kind: str
+    candidate_configuration_artifact_id: str
+    deployed_candidate_id: str
+    deployed_configuration_artifact_id: str
+    endpoint_metrics: tuple[ProspectiveV2EndpointMetricsV1, ...]
+    evaluation_ids: tuple[str, ...]
+    confirmation_passed: bool
+    reasons: tuple[str, ...]
+    exact_baseline_fallback_verified: bool = True
+    confirmation_target_outcomes_used: bool = True
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        confirmation_freeze_id = _require_sha256(
+            self.confirmation_freeze_id,
+            name="confirmation_freeze_id",
+        )
+        opening_id = _require_sha256(self.opening_id, name="opening_id")
+        selection_result_id = _require_sha256(
+            self.selection_result_id,
+            name="selection_result_id",
+        )
+        baseline_candidate_id = _require_nonempty_string(
+            self.baseline_candidate_id,
+            name="baseline_candidate_id",
+        )
+        baseline_configuration_id = _require_sha256(
+            self.baseline_configuration_artifact_id,
+            name="baseline_configuration_artifact_id",
+        )
+        candidate_id = _require_nonempty_string(self.candidate_id, name="candidate_id")
+        candidate_kind = _require_nonempty_string(
+            self.candidate_kind,
+            name="candidate_kind",
+        )
+        if candidate_kind not in PROSPECTIVE_V2_CANDIDATE_KINDS[1:]:
+            raise ValueError("confirmation candidate must be non-baseline")
+        candidate_configuration_id = _require_sha256(
+            self.candidate_configuration_artifact_id,
+            name="candidate_configuration_artifact_id",
+        )
+        endpoint_metrics = tuple(self.endpoint_metrics)
+        if tuple(metric.endpoint for metric in endpoint_metrics) != (
+            DECISION_TRACE_ENDPOINTS
+        ):
+            raise ValueError("confirmation result must cover every endpoint in order")
+        if any(metric.candidate_id != candidate_id for metric in endpoint_metrics):
+            raise ValueError("endpoint metrics identify a different candidate")
+        expected_reasons = tuple(
+            f"{metric.endpoint}:{reason}"
+            for metric in endpoint_metrics
+            for reason in metric.reasons
+        )
+        passed = _require_bool(self.confirmation_passed, name="confirmation_passed")
+        reasons = tuple(self.reasons)
+        if reasons != expected_reasons or passed is not (not expected_reasons):
+            raise ValueError(
+                "confirmation decision must exactly match endpoint evidence"
+            )
+        expected_deployed = (
+            (candidate_id, candidate_configuration_id)
+            if passed
+            else (baseline_candidate_id, baseline_configuration_id)
+        )
+        deployed_candidate_id = _require_nonempty_string(
+            self.deployed_candidate_id,
+            name="deployed_candidate_id",
+        )
+        deployed_configuration_id = _require_sha256(
+            self.deployed_configuration_artifact_id,
+            name="deployed_configuration_artifact_id",
+        )
+        if (deployed_candidate_id, deployed_configuration_id) != expected_deployed:
+            raise ValueError(
+                "confirmation deployment must use the fixed candidate or exact baseline"
+            )
+        evaluation_ids = _validated_unique_strings(
+            self.evaluation_ids,
+            name="evaluation_ids",
+            require_sha256=True,
+        )
+        if not _require_bool(
+            self.exact_baseline_fallback_verified,
+            name="exact_baseline_fallback_verified",
+        ):
+            raise ValueError("exact baseline fallback must remain verified")
+        if not _require_bool(
+            self.confirmation_target_outcomes_used,
+            name="confirmation_target_outcomes_used",
+        ):
+            raise ValueError("confirmation result must record target-outcome access")
+        metadata = validated_json_mapping(
+            self.metadata,
+            error_message="confirmation-result metadata must contain finite JSON data",
+        )
+        object.__setattr__(
+            self,
+            "confirmation_freeze_id",
+            confirmation_freeze_id,
+        )
+        object.__setattr__(self, "opening_id", opening_id)
+        object.__setattr__(self, "selection_result_id", selection_result_id)
+        object.__setattr__(self, "baseline_candidate_id", baseline_candidate_id)
+        object.__setattr__(
+            self,
+            "baseline_configuration_artifact_id",
+            baseline_configuration_id,
+        )
+        object.__setattr__(self, "candidate_id", candidate_id)
+        object.__setattr__(self, "candidate_kind", candidate_kind)
+        object.__setattr__(
+            self,
+            "candidate_configuration_artifact_id",
+            candidate_configuration_id,
+        )
+        object.__setattr__(self, "deployed_candidate_id", deployed_candidate_id)
+        object.__setattr__(
+            self,
+            "deployed_configuration_artifact_id",
+            deployed_configuration_id,
+        )
+        object.__setattr__(self, "endpoint_metrics", endpoint_metrics)
+        object.__setattr__(self, "evaluation_ids", evaluation_ids)
+        object.__setattr__(self, "confirmation_passed", passed)
+        object.__setattr__(self, "reasons", reasons)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def fixed_candidate_confirmation_gate_passed(self) -> bool:
+        return self.confirmation_passed
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": PROSPECTIVE_V2_CONFIRMATION_SCHEMA_VERSION,
+            "artifact_kind": "Causal4DProspectiveV2ConfirmationResultV1",
+            "confirmation_freeze_id": self.confirmation_freeze_id,
+            "opening_id": self.opening_id,
+            "selection_result_id": self.selection_result_id,
+            "baseline_candidate_id": self.baseline_candidate_id,
+            "baseline_configuration_artifact_id": (
+                self.baseline_configuration_artifact_id
+            ),
+            "candidate_id": self.candidate_id,
+            "candidate_kind": self.candidate_kind,
+            "candidate_configuration_artifact_id": (
+                self.candidate_configuration_artifact_id
+            ),
+            "deployed_candidate_id": self.deployed_candidate_id,
+            "deployed_configuration_artifact_id": (
+                self.deployed_configuration_artifact_id
+            ),
+            "endpoint_metrics": [metric.as_dict() for metric in self.endpoint_metrics],
+            "evaluation_ids": list(self.evaluation_ids),
+            "confirmation_passed": self.confirmation_passed,
+            "reasons": list(self.reasons),
+            "panel_role": PROSPECTIVE_V2_CONFIRMATION_PANEL_ROLE,
+            "candidate_selection_performed": False,
+            "selection_panel_performance_reused": False,
+            "independent_panel_verified": True,
+            "fixed_candidate_confirmation_gate_passed": (
+                self.fixed_candidate_confirmation_gate_passed
+            ),
+            "exact_baseline_fallback_verified": (self.exact_baseline_fallback_verified),
+            "confirmation_target_outcomes_used": (
+                self.confirmation_target_outcomes_used
+            ),
+            "metadata": plain_json(self.metadata),
+        }
+
+    @property
+    def result_id(self) -> str:
+        return _canonical_sha256(self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "result_id": self.result_id}
+
+
+def build_prospective_v2_confirmation_freeze_v1(
+    selection_result: ProspectiveV2PromotionResultV1,
+    selection_freeze: ProspectiveV2PromotionFreezeV1,
+    selection_opening: ProspectiveV2TargetOpeningV1,
+    selection_evaluations: Sequence[ProspectiveV2UnitEvaluationV1],
+    *,
+    experiment_id: str,
+    target_access_seal_id: str,
+    evaluation_units: Sequence[ProspectiveV2EvaluationUnitV1],
+    additional_bound_artifact_ids: Sequence[str] = (),
+    metadata: Mapping[str, Any] | None = None,
+) -> ProspectiveV2ConfirmationFreezeV1:
+    """Freeze a disjoint panel for the exact candidate selected previously."""
+
+    validate_prospective_v2_promotion_result_v1(
+        selection_result,
+        selection_freeze,
+        selection_opening,
+        selection_evaluations,
+    )
+    selected = selection_freeze.candidate_by_id.get(
+        selection_result.selected_candidate_id
+    )
+    if selected is None:
+        raise ValueError("selection result candidate is absent from its freeze")
+    if selected.candidate_kind == PROSPECTIVE_V2_CANDIDATE_KINDS[0]:
+        raise ValueError("selection panel did not select a candidate to confirm")
+    if (
+        selected.candidate_kind,
+        selected.configuration_artifact_id,
+    ) != (
+        selection_result.selected_candidate_kind,
+        selection_result.selected_configuration_artifact_id,
+    ):
+        raise ValueError("selection result candidate binding changed")
+    selection_values = tuple(selection_evaluations)
+    confirmation_units = tuple(evaluation_units)
+    bound_ids = _ordered_unique(
+        (
+            selection_result.result_id,
+            selection_freeze.freeze_id,
+            selection_opening.opening_id,
+            *selection_result.evaluation_ids,
+            *(value.trace.trace_id for value in selection_values),
+            *(value.metric_values.metric_values_id for value in selection_values),
+            *(
+                value.metric_values.scoring_run_artifact_id
+                for value in selection_values
+            ),
+            selection_freeze.stack_lock_id,
+            target_access_seal_id,
+            selection_freeze.metric_contract.scoring_implementation_artifact_id,
+            selection_freeze.baseline_candidate.configuration_artifact_id,
+            selected.configuration_artifact_id,
+            *(unit.factual_context_artifact_id for unit in confirmation_units),
+            *(unit.counterfactual_query_artifact_id for unit in confirmation_units),
+            *additional_bound_artifact_ids,
+        )
+    )
+    return ProspectiveV2ConfirmationFreezeV1(
+        experiment_id=experiment_id,
+        selection_result_id=selection_result.result_id,
+        selection_freeze_id=selection_freeze.freeze_id,
+        selection_opening_id=selection_opening.opening_id,
+        selection_evaluation_ids=selection_result.evaluation_ids,
+        selection_trace_ids=tuple(value.trace.trace_id for value in selection_values),
+        selection_metric_values_ids=tuple(
+            value.metric_values.metric_values_id for value in selection_values
+        ),
+        selection_scoring_run_artifact_ids=tuple(
+            value.metric_values.scoring_run_artifact_id for value in selection_values
+        ),
+        stack_lock_id=selection_freeze.stack_lock_id,
+        target_access_seal_id=target_access_seal_id,
+        baseline_candidate=selection_freeze.baseline_candidate,
+        selected_candidate=selected,
+        selection_units=selection_freeze.evaluation_units,
+        evaluation_units=confirmation_units,
+        metric_contract=selection_freeze.metric_contract,
+        policy=selection_freeze.policy,
+        bound_artifact_ids=bound_ids,
+        confirmation_target_outcomes_used=False,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def validate_prospective_v2_confirmation_freeze_v1(
+    freeze: ProspectiveV2ConfirmationFreezeV1,
+    selection_result: ProspectiveV2PromotionResultV1,
+    selection_freeze: ProspectiveV2PromotionFreezeV1,
+    selection_opening: ProspectiveV2TargetOpeningV1,
+    selection_evaluations: Sequence[ProspectiveV2UnitEvaluationV1],
+) -> ProspectiveV2ConfirmationFreezeV1:
+    """Recompute and require the exact confirmation freeze from its sources."""
+
+    if type(freeze) is not ProspectiveV2ConfirmationFreezeV1:
+        raise ValueError("freeze has the wrong type")
+    expected = build_prospective_v2_confirmation_freeze_v1(
+        selection_result,
+        selection_freeze,
+        selection_opening,
+        selection_evaluations,
+        experiment_id=freeze.experiment_id,
+        target_access_seal_id=freeze.target_access_seal_id,
+        evaluation_units=freeze.evaluation_units,
+        additional_bound_artifact_ids=freeze.bound_artifact_ids,
+        metadata=freeze.metadata,
+    )
+    if freeze != expected or freeze.confirmation_freeze_id != (
+        expected.confirmation_freeze_id
+    ):
+        raise ValueError("confirmation freeze does not match its selection evidence")
+    return freeze
+
+
+def build_prospective_v2_confirmation_opening_v1(
+    freeze: ProspectiveV2ConfirmationFreezeV1,
+    *,
+    opened_at_utc: str,
+    opened_by: str,
+    metadata: Mapping[str, Any] | None = None,
+) -> ProspectiveV2TargetOpeningV1:
+    """Open exactly the disjoint confirmation inventory registered by ``freeze``."""
+
+    if type(freeze) is not ProspectiveV2ConfirmationFreezeV1:
+        raise ValueError("freeze has the wrong type")
+    return ProspectiveV2TargetOpeningV1(
+        freeze_id=freeze.confirmation_freeze_id,
+        target_access_seal_id=freeze.target_access_seal_id,
+        target_artifact_ids=tuple(
+            unit.target_artifact_id for unit in freeze.evaluation_units
+        ),
+        opened_at_utc=opened_at_utc,
+        opened_by=opened_by,
+        target_outcomes_used=True,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def validate_prospective_v2_confirmation_opening_v1(
+    opening: ProspectiveV2TargetOpeningV1,
+    freeze: ProspectiveV2ConfirmationFreezeV1,
+) -> ProspectiveV2TargetOpeningV1:
+    """Require an opening to equal the complete frozen confirmation inventory."""
+
+    if type(opening) is not ProspectiveV2TargetOpeningV1:
+        raise ValueError("opening has the wrong type")
+    if type(freeze) is not ProspectiveV2ConfirmationFreezeV1:
+        raise ValueError("freeze has the wrong type")
+    expected_target_ids = tuple(
+        unit.target_artifact_id for unit in freeze.evaluation_units
+    )
+    if (
+        opening.freeze_id != freeze.confirmation_freeze_id
+        or opening.target_access_seal_id != freeze.target_access_seal_id
+        or opening.target_artifact_ids != expected_target_ids
+    ):
+        raise ValueError("confirmation opening does not match its frozen inventory")
+    return opening
+
+
+def build_prospective_v2_confirmation_unit_evaluation_v1(
+    freeze: ProspectiveV2ConfirmationFreezeV1,
+    opening: ProspectiveV2TargetOpeningV1,
+    *,
+    unit_id: str,
+    trace: UnifiedDecisionTrace,
+    metric_values: ProspectiveV2UnitMetricValuesV1,
+) -> ProspectiveV2UnitEvaluationV1:
+    """Bind one fixed-candidate evaluation to the independent panel."""
+
+    if type(freeze) is not ProspectiveV2ConfirmationFreezeV1:
+        raise ValueError("freeze has the wrong type")
+    unit = freeze.unit_by_id.get(unit_id)
+    if unit is None:
+        raise ValueError("unit_id is not registered by the confirmation freeze")
+    validate_prospective_v2_confirmation_opening_v1(opening, freeze)
+    if type(trace) is not UnifiedDecisionTrace:
+        raise ValueError("trace has the wrong type")
+    _require_confirmation_trace_metadata(trace, freeze)
+    if trace.trace_id in freeze.selection_trace_ids:
+        raise ValueError("confirmation reuses a selection-panel decision trace")
+    if metric_values.metric_values_id in freeze.selection_metric_values_ids:
+        raise ValueError("confirmation reuses selection-panel metric values")
+    if (
+        metric_values.scoring_run_artifact_id
+        in freeze.selection_scoring_run_artifact_ids
+    ):
+        raise ValueError("confirmation reuses a selection-panel scoring run")
+    return ProspectiveV2UnitEvaluationV1(
+        freeze_id=freeze.confirmation_freeze_id,
+        stack_lock_id=freeze.stack_lock_id,
+        unit=unit,
+        candidate=freeze.selected_candidate,
+        opening=opening,
+        metric_contract=freeze.metric_contract,
+        policy=freeze.policy,
+        trace=trace,
+        metric_values=metric_values,
+    )
+
+
+def _evaluate_confirmation_endpoint(
+    freeze: ProspectiveV2ConfirmationFreezeV1,
+    endpoint: str,
+    evaluations: Sequence[ProspectiveV2UnitEvaluationV1],
+) -> ProspectiveV2EndpointMetricsV1:
+    policy = freeze.policy
+    unit_count = len(evaluations)
+    accepted_count = sum(value.candidate_selected for value in evaluations)
+    harmful_count = sum(value.harmful_accepted_update for value in evaluations)
+    accepted_rate = accepted_count / unit_count
+    harmful_rate = harmful_count / accepted_count if accepted_count else 0.0
+    fallback_rate = sum(value.fallback_used for value in evaluations) / unit_count
+    mean_log_gain = _mean(
+        tuple(value.log_score_gain for value in evaluations),
+        name="mean_log_score_gain",
+    )
+    mean_brier_change = _mean(
+        tuple(value.brier_change for value in evaluations),
+        name="mean_brier_change",
+    )
+    mean_regret = _mean(
+        tuple(value.trajectory_regret_m for value in evaluations),
+        name="mean_trajectory_regret_m",
+    )
+    mean_coverage_error = _mean(
+        tuple(value.candidate_coverage_error for value in evaluations),
+        name="mean_coverage_error",
+    )
+    mean_width = _mean(
+        tuple(value.metric_values.candidate_interval_width_m for value in evaluations),
+        name="mean_interval_width_m",
+    )
+    mean_width_ratio = _mean(
+        tuple(value.interval_width_ratio for value in evaluations),
+        name="mean_interval_width_ratio",
+    )
+    reasons: list[str] = []
+    if unit_count < policy.minimum_units_per_endpoint:
+        reasons.append("insufficient_independent_units")
+    if mean_log_gain < policy.minimum_mean_log_score_gain:
+        reasons.append("mean_log_score_gain_below_limit")
+    if mean_brier_change > policy.maximum_mean_brier_change:
+        reasons.append("mean_brier_change_exceeds_limit")
+    if mean_regret > policy.maximum_mean_trajectory_regret_m:
+        reasons.append("mean_trajectory_regret_exceeds_limit")
+    if mean_coverage_error > policy.maximum_mean_coverage_error:
+        reasons.append("mean_coverage_error_exceeds_limit")
+    if mean_width_ratio > policy.maximum_mean_interval_width_ratio:
+        reasons.append("mean_interval_width_ratio_exceeds_limit")
+    if accepted_rate < policy.minimum_accepted_update_rate:
+        reasons.append("accepted_update_rate_below_limit")
+    if harmful_rate > policy.maximum_harmful_accepted_update_rate:
+        reasons.append("harmful_accepted_update_rate_exceeds_limit")
+    if fallback_rate > policy.maximum_fallback_rate:
+        reasons.append("fallback_rate_exceeds_limit")
+    return ProspectiveV2EndpointMetricsV1(
+        candidate_id=freeze.selected_candidate.candidate_id,
+        endpoint=endpoint,
+        unit_count=unit_count,
+        mean_log_score_gain=_finite_float(
+            mean_log_gain,
+            name="mean_log_score_gain",
+        ),
+        mean_brier_change=_finite_float(
+            mean_brier_change,
+            name="mean_brier_change",
+        ),
+        mean_trajectory_regret_m=_finite_float(
+            mean_regret,
+            name="mean_trajectory_regret_m",
+        ),
+        mean_coverage_error=_finite_nonnegative_float(
+            mean_coverage_error,
+            name="mean_coverage_error",
+        ),
+        mean_interval_width_m=_finite_nonnegative_float(
+            mean_width,
+            name="mean_interval_width_m",
+        ),
+        mean_interval_width_ratio=_finite_nonnegative_float(
+            mean_width_ratio,
+            name="mean_interval_width_ratio",
+        ),
+        accepted_update_rate=_rate(accepted_rate, name="accepted_update_rate"),
+        harmful_accepted_update_rate=_rate(
+            harmful_rate,
+            name="harmful_accepted_update_rate",
+        ),
+        fallback_rate=_rate(fallback_rate, name="fallback_rate"),
+        accepted=not reasons,
+        reasons=tuple(reasons),
+    )
+
+
+def evaluate_prospective_v2_confirmation_v1(
+    freeze: ProspectiveV2ConfirmationFreezeV1,
+    opening: ProspectiveV2TargetOpeningV1,
+    evaluations: Sequence[ProspectiveV2UnitEvaluationV1],
+    *,
+    metadata: Mapping[str, Any] | None = None,
+) -> ProspectiveV2ConfirmationResultV1:
+    """Evaluate the fixed candidate on the complete independent panel."""
+
+    if type(freeze) is not ProspectiveV2ConfirmationFreezeV1:
+        raise ValueError("freeze has the wrong type")
+    validate_prospective_v2_confirmation_opening_v1(opening, freeze)
+    values = tuple(evaluations)
+    if not values or any(
+        type(value) is not ProspectiveV2UnitEvaluationV1 for value in values
+    ):
+        raise ValueError("evaluations must contain bound unit evaluations")
+    expected_unit_ids = tuple(unit.unit_id for unit in freeze.evaluation_units)
+    actual_unit_ids = tuple(value.unit.unit_id for value in values)
+    if len(set(actual_unit_ids)) != len(actual_unit_ids):
+        raise ValueError("confirmation evaluation units must be unique")
+    if set(actual_unit_ids) != set(expected_unit_ids):
+        missing = sorted(set(expected_unit_ids) - set(actual_unit_ids))
+        unexpected = sorted(set(actual_unit_ids) - set(expected_unit_ids))
+        raise ValueError(
+            "evaluations must cover the frozen confirmation units; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    unit_index = freeze.unit_by_id
+    evaluation_index = {value.unit.unit_id: value for value in values}
+    for value in values:
+        if value.freeze_id != freeze.confirmation_freeze_id:
+            raise ValueError(
+                "unit evaluation identifies a different confirmation freeze"
+            )
+        if value.opening.opening_id != opening.opening_id:
+            raise ValueError("confirmation evaluations must share one opening")
+        if value.stack_lock_id != freeze.stack_lock_id:
+            raise ValueError("confirmation evaluation uses a different stack lock")
+        if value.candidate.candidate_binding_id != (
+            freeze.selected_candidate.candidate_binding_id
+        ):
+            raise ValueError("confirmation evaluation changed the fixed candidate")
+        if value.unit.unit_binding_id != (
+            unit_index[value.unit.unit_id].unit_binding_id
+        ):
+            raise ValueError("confirmation evaluation changed a unit binding")
+        if value.metric_contract.metric_contract_id != (
+            freeze.metric_contract.metric_contract_id
+        ):
+            raise ValueError("confirmation evaluation changed the metric contract")
+        if value.policy.policy_id != freeze.policy.policy_id:
+            raise ValueError("confirmation evaluation changed the promotion policy")
+        _require_confirmation_trace_metadata(value.trace, freeze)
+        if value.trace.trace_id in freeze.selection_trace_ids:
+            raise ValueError("confirmation reuses a selection-panel decision trace")
+        if value.metric_values.metric_values_id in freeze.selection_metric_values_ids:
+            raise ValueError("confirmation reuses selection-panel metric values")
+        if (
+            value.metric_values.scoring_run_artifact_id
+            in freeze.selection_scoring_run_artifact_ids
+        ):
+            raise ValueError("confirmation reuses a selection-panel scoring run")
+
+    endpoint_metrics = tuple(
+        _evaluate_confirmation_endpoint(
+            freeze,
+            endpoint,
+            tuple(
+                evaluation_index[unit.unit_id]
+                for unit in freeze.evaluation_units
+                if unit.endpoint == endpoint
+            ),
+        )
+        for endpoint in DECISION_TRACE_ENDPOINTS
+    )
+    reasons = tuple(
+        f"{metric.endpoint}:{reason}"
+        for metric in endpoint_metrics
+        for reason in metric.reasons
+    )
+    passed = not reasons
+    deployed = freeze.selected_candidate if passed else freeze.baseline_candidate
+    ordered_evaluation_ids = tuple(
+        evaluation_index[unit.unit_id].evaluation_id for unit in freeze.evaluation_units
+    )
+    return ProspectiveV2ConfirmationResultV1(
+        confirmation_freeze_id=freeze.confirmation_freeze_id,
+        opening_id=opening.opening_id,
+        selection_result_id=freeze.selection_result_id,
+        baseline_candidate_id=freeze.baseline_candidate.candidate_id,
+        baseline_configuration_artifact_id=(
+            freeze.baseline_candidate.configuration_artifact_id
+        ),
+        candidate_id=freeze.selected_candidate.candidate_id,
+        candidate_kind=freeze.selected_candidate.candidate_kind,
+        candidate_configuration_artifact_id=(
+            freeze.selected_candidate.configuration_artifact_id
+        ),
+        deployed_candidate_id=deployed.candidate_id,
+        deployed_configuration_artifact_id=deployed.configuration_artifact_id,
+        endpoint_metrics=endpoint_metrics,
+        evaluation_ids=ordered_evaluation_ids,
+        confirmation_passed=passed,
+        reasons=reasons,
+        exact_baseline_fallback_verified=True,
+        confirmation_target_outcomes_used=True,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def validate_prospective_v2_confirmation_result_v1(
+    result: ProspectiveV2ConfirmationResultV1,
+    freeze: ProspectiveV2ConfirmationFreezeV1,
+    opening: ProspectiveV2TargetOpeningV1,
+    evaluations: Sequence[ProspectiveV2UnitEvaluationV1],
+) -> ProspectiveV2ConfirmationResultV1:
+    """Recompute and require exact equality with a confirmation result."""
+
+    if type(result) is not ProspectiveV2ConfirmationResultV1:
+        raise ValueError("result has the wrong type")
+    expected = evaluate_prospective_v2_confirmation_v1(
+        freeze,
+        opening,
+        evaluations,
+        metadata=result.metadata,
+    )
+    if result != expected or result.result_id != expected.result_id:
+        raise ValueError("confirmation result does not match its bound evidence")
+    return result
+
+
+def write_prospective_v2_confirmation_opening(
+    path: str | Path,
+    freeze: ProspectiveV2ConfirmationFreezeV1,
+    opening: ProspectiveV2TargetOpeningV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Atomically publish an opening after exact inventory validation."""
+
+    validate_prospective_v2_confirmation_opening_v1(opening, freeze)
+    atomic_write_json(path, opening.as_dict(), overwrite=overwrite)
+
+
+def write_prospective_v2_confirmation_freeze(
+    path: str | Path,
+    freeze: ProspectiveV2ConfirmationFreezeV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Atomically publish a validated confirmation freeze."""
+
+    if type(freeze) is not ProspectiveV2ConfirmationFreezeV1:
+        raise ValueError("freeze has the wrong type")
+    atomic_write_json(path, freeze.as_dict(), overwrite=overwrite)
+
+
+def write_prospective_v2_confirmation_result(
+    path: str | Path,
+    result: ProspectiveV2ConfirmationResultV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Atomically publish a recomputable confirmation result."""
+
+    if type(result) is not ProspectiveV2ConfirmationResultV1:
+        raise ValueError("result has the wrong type")
+    atomic_write_json(path, result.as_dict(), overwrite=overwrite)
+
+
+__all__ = [
+    "PROSPECTIVE_V2_CONFIRMATION_PANEL_ROLE",
+    "PROSPECTIVE_V2_CONFIRMATION_SCHEMA_VERSION",
+    "ProspectiveV2ConfirmationFreezeV1",
+    "ProspectiveV2ConfirmationResultV1",
+    "build_prospective_v2_confirmation_freeze_v1",
+    "build_prospective_v2_confirmation_opening_v1",
+    "build_prospective_v2_confirmation_unit_evaluation_v1",
+    "evaluate_prospective_v2_confirmation_v1",
+    "validate_prospective_v2_confirmation_freeze_v1",
+    "validate_prospective_v2_confirmation_opening_v1",
+    "validate_prospective_v2_confirmation_result_v1",
+    "write_prospective_v2_confirmation_freeze",
+    "write_prospective_v2_confirmation_opening",
+    "write_prospective_v2_confirmation_result",
+]

--- a/tests/test_prospective_v2_confirmation.py
+++ b/tests/test_prospective_v2_confirmation.py
@@ -1,0 +1,569 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import hashlib
+
+import pytest
+
+from causal4d.prospective_v2_confirmation import (
+    PROSPECTIVE_V2_CONFIRMATION_PANEL_ROLE,
+    build_prospective_v2_confirmation_freeze_v1,
+    build_prospective_v2_confirmation_opening_v1,
+    build_prospective_v2_confirmation_unit_evaluation_v1,
+    evaluate_prospective_v2_confirmation_v1,
+    validate_prospective_v2_confirmation_freeze_v1,
+    validate_prospective_v2_confirmation_opening_v1,
+    validate_prospective_v2_confirmation_result_v1,
+)
+from causal4d.prospective_v2_promotion import (
+    ProspectiveV2EvaluationUnitV1,
+    ProspectiveV2UnitEvaluationV1,
+    build_prospective_v2_target_opening_v1,
+    build_prospective_v2_unit_evaluation_v1,
+    evaluate_prospective_v2_promotion_v1,
+)
+from tests.test_prospective_v2_promotion import (
+    _evaluations,
+    _freeze,
+    _metric_values,
+    _trace,
+)
+
+
+def _id(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _selection_evidence():
+    freeze = _freeze()
+    opening = build_prospective_v2_target_opening_v1(
+        freeze,
+        opened_at_utc="2026-08-09T00:00:00+00:00",
+        opened_by="selection-evaluator",
+    )
+    evaluations = _evaluations(freeze, opening)
+    result = evaluate_prospective_v2_promotion_v1(
+        freeze,
+        opening,
+        evaluations,
+    )
+    return freeze, opening, evaluations, result
+
+
+def _confirmation_units(
+    *,
+    seal_id: str | None = None,
+) -> tuple[ProspectiveV2EvaluationUnitV1, ...]:
+    seal = _id("confirmation-target-access-seal") if seal_id is None else seal_id
+    return tuple(
+        ProspectiveV2EvaluationUnitV1(
+            unit_id=f"confirmation-unit-{index}",
+            endpoint=endpoint,
+            protocol_id="protocol-v2-confirmation",
+            case_id=f"confirmation-case-{index}",
+            session_id=f"confirmation-session-{index}",
+            independent_group_id=f"confirmation-group-{index}",
+            target_artifact_id=_id(f"confirmation-target:{index}"),
+            factual_context_artifact_id=_id(f"confirmation-factual:{index}"),
+            counterfactual_query_artifact_id=_id(f"confirmation-query:{index}"),
+            target_access_seal_id=seal,
+        )
+        for index, endpoint in enumerate(
+            (
+                "factual_continuation",
+                "same_grasp_transfer",
+                "new_contact_transfer",
+            )
+        )
+    )
+
+
+def _confirmation_evidence():
+    selection_freeze, selection_opening, selection_evaluations, selection_result = (
+        _selection_evidence()
+    )
+    confirmation_freeze = build_prospective_v2_confirmation_freeze_v1(
+        selection_result,
+        selection_freeze,
+        selection_opening,
+        selection_evaluations,
+        experiment_id="prospective-v2-independent-confirmation",
+        target_access_seal_id=_id("confirmation-target-access-seal"),
+        evaluation_units=_confirmation_units(),
+    )
+    confirmation_opening = build_prospective_v2_confirmation_opening_v1(
+        confirmation_freeze,
+        opened_at_utc="2026-08-10T00:00:00+00:00",
+        opened_by="independent-confirmation-evaluator",
+    )
+    evaluations = []
+    candidate = confirmation_freeze.selected_candidate
+    for unit in confirmation_freeze.evaluation_units:
+        trace = _trace(
+            selection_freeze,
+            unit,
+            candidate,
+            metadata_overrides={
+                "confirmation_freeze_id": (confirmation_freeze.confirmation_freeze_id),
+                "confirmation_selection_result_id": (
+                    confirmation_freeze.selection_result_id
+                ),
+                "confirmation_panel_role": PROSPECTIVE_V2_CONFIRMATION_PANEL_ROLE,
+            },
+        )
+        metrics = _metric_values(
+            selection_freeze,
+            confirmation_opening,
+            unit,
+            candidate,
+            trace,
+        )
+        evaluations.append(
+            build_prospective_v2_confirmation_unit_evaluation_v1(
+                confirmation_freeze,
+                confirmation_opening,
+                unit_id=unit.unit_id,
+                trace=trace,
+                metric_values=metrics,
+            )
+        )
+    return (
+        selection_freeze,
+        selection_opening,
+        selection_evaluations,
+        selection_result,
+        confirmation_freeze,
+        confirmation_opening,
+        tuple(evaluations),
+    )
+
+
+def test_disjoint_confirmation_passes_without_reselecting_candidates() -> None:
+    (
+        _,
+        _,
+        _,
+        selection_result,
+        freeze,
+        opening,
+        evaluations,
+    ) = _confirmation_evidence()
+
+    result = evaluate_prospective_v2_confirmation_v1(
+        freeze,
+        opening,
+        evaluations,
+    )
+
+    assert result.selection_result_id == selection_result.result_id
+    assert result.confirmation_passed
+    assert result.fixed_candidate_confirmation_gate_passed
+    assert result.deployed_candidate_id == freeze.selected_candidate.candidate_id
+    assert result.as_dict()["candidate_selection_performed"] is False
+    assert result.as_dict()["selection_panel_performance_reused"] is False
+    assert (
+        validate_prospective_v2_confirmation_result_v1(
+            result,
+            freeze,
+            opening,
+            evaluations,
+        )
+        is result
+    )
+
+
+def test_confirmation_freeze_revalidates_against_selection_evidence() -> None:
+    (
+        selection_freeze,
+        selection_opening,
+        selection_evaluations,
+        _,
+        freeze,
+        _,
+        _,
+    ) = _confirmation_evidence()
+
+    assert (
+        validate_prospective_v2_confirmation_freeze_v1(
+            freeze,
+            evaluate_prospective_v2_promotion_v1(
+                selection_freeze,
+                selection_opening,
+                selection_evaluations,
+            ),
+            selection_freeze,
+            selection_opening,
+            selection_evaluations,
+        )
+        is freeze
+    )
+    changed = replace(
+        freeze,
+        selection_result_id=_id("different-selection-result"),
+        bound_artifact_ids=(
+            _id("different-selection-result"),
+            *tuple(
+                value
+                for value in freeze.bound_artifact_ids
+                if value != freeze.selection_result_id
+            ),
+        ),
+    )
+    selection_result = evaluate_prospective_v2_promotion_v1(
+        selection_freeze,
+        selection_opening,
+        selection_evaluations,
+    )
+    with pytest.raises(ValueError, match="selection evidence"):
+        validate_prospective_v2_confirmation_freeze_v1(
+            changed,
+            selection_result,
+            selection_freeze,
+            selection_opening,
+            selection_evaluations,
+        )
+
+
+def test_confirmation_freeze_rejects_selection_panel_overlap() -> None:
+    selection_freeze, selection_opening, selection_evaluations, selection_result = (
+        _selection_evidence()
+    )
+    units = list(_confirmation_units())
+    units[0] = replace(
+        units[0],
+        target_artifact_id=selection_freeze.evaluation_units[0].target_artifact_id,
+    )
+
+    with pytest.raises(ValueError, match="target artifacts"):
+        build_prospective_v2_confirmation_freeze_v1(
+            selection_result,
+            selection_freeze,
+            selection_opening,
+            selection_evaluations,
+            experiment_id="overlapping-confirmation",
+            target_access_seal_id=_id("confirmation-target-access-seal"),
+            evaluation_units=tuple(units),
+        )
+
+    with pytest.raises(ValueError, match="new target-access seal"):
+        build_prospective_v2_confirmation_freeze_v1(
+            selection_result,
+            selection_freeze,
+            selection_opening,
+            selection_evaluations,
+            experiment_id="reused-seal-confirmation",
+            target_access_seal_id=selection_freeze.target_access_seal_id,
+            evaluation_units=_confirmation_units(
+                seal_id=selection_freeze.target_access_seal_id
+            ),
+        )
+
+
+def test_confirmation_rejects_relabelled_unit_group_and_session_overlap() -> None:
+    selection_freeze, selection_opening, selection_evaluations, selection_result = (
+        _selection_evidence()
+    )
+    selection_unit = selection_freeze.evaluation_units[0]
+    confirmation_unit = _confirmation_units()[0]
+    changes = (
+        (
+            replace(confirmation_unit, unit_id=selection_unit.unit_id),
+            "unit IDs",
+        ),
+        (
+            replace(
+                confirmation_unit,
+                independent_group_id=selection_unit.independent_group_id,
+            ),
+            "endpoint independence groups",
+        ),
+        (
+            replace(
+                confirmation_unit,
+                protocol_id=selection_unit.protocol_id,
+                session_id=selection_unit.session_id,
+            ),
+            "protocol sessions",
+        ),
+    )
+    for changed, message in changes:
+        units = (changed, *_confirmation_units()[1:])
+        with pytest.raises(ValueError, match=message):
+            build_prospective_v2_confirmation_freeze_v1(
+                selection_result,
+                selection_freeze,
+                selection_opening,
+                selection_evaluations,
+                experiment_id="relabelled-overlap",
+                target_access_seal_id=_id("confirmation-target-access-seal"),
+                evaluation_units=units,
+            )
+
+
+def test_confirmation_requires_a_nonbaseline_selected_candidate() -> None:
+    selection_freeze = _freeze()
+    selection_opening = build_prospective_v2_target_opening_v1(
+        selection_freeze,
+        opened_at_utc="2026-08-09T00:00:00+00:00",
+        opened_by="selection-evaluator",
+    )
+    evaluations = []
+    for unit in selection_freeze.evaluation_units:
+        for candidate in selection_freeze.candidates[1:]:
+            trace = _trace(selection_freeze, unit, candidate, selected=False)
+            metrics = _metric_values(
+                selection_freeze,
+                selection_opening,
+                unit,
+                candidate,
+                trace,
+            )
+            evaluations.append(
+                build_prospective_v2_unit_evaluation_v1(
+                    selection_freeze,
+                    selection_opening,
+                    unit_id=unit.unit_id,
+                    candidate_id=candidate.candidate_id,
+                    trace=trace,
+                    metric_values=metrics,
+                )
+            )
+    selection_result = evaluate_prospective_v2_promotion_v1(
+        selection_freeze,
+        selection_opening,
+        tuple(evaluations),
+    )
+    assert selection_result.selected_candidate_kind == "registered_baseline"
+
+    with pytest.raises(ValueError, match="did not select a candidate"):
+        build_prospective_v2_confirmation_freeze_v1(
+            selection_result,
+            selection_freeze,
+            selection_opening,
+            tuple(evaluations),
+            experiment_id="no-candidate-confirmation",
+            target_access_seal_id=_id("confirmation-target-access-seal"),
+            evaluation_units=_confirmation_units(),
+        )
+
+
+def test_confirmation_opening_is_bound_to_the_complete_inventory() -> None:
+    (
+        _,
+        _,
+        _,
+        _,
+        freeze,
+        opening,
+        _,
+    ) = _confirmation_evidence()
+
+    assert validate_prospective_v2_confirmation_opening_v1(opening, freeze) is opening
+    changed = replace(
+        opening,
+        target_artifact_ids=opening.target_artifact_ids[:-1],
+    )
+    with pytest.raises(ValueError, match="frozen inventory"):
+        validate_prospective_v2_confirmation_opening_v1(changed, freeze)
+
+
+def test_confirmation_trace_requires_explicit_panel_bindings() -> None:
+    (
+        selection_freeze,
+        _,
+        _,
+        _,
+        freeze,
+        opening,
+        _,
+    ) = _confirmation_evidence()
+    unit = freeze.evaluation_units[0]
+    candidate = freeze.selected_candidate
+    trace = _trace(selection_freeze, unit, candidate)
+    metrics = _metric_values(
+        selection_freeze,
+        opening,
+        unit,
+        candidate,
+        trace,
+    )
+
+    with pytest.raises(ValueError, match="confirmation_freeze_id"):
+        build_prospective_v2_confirmation_unit_evaluation_v1(
+            freeze,
+            opening,
+            unit_id=unit.unit_id,
+            trace=trace,
+            metric_values=metrics,
+        )
+
+
+def test_confirmation_evaluator_rejects_direct_trace_metadata_bypass() -> None:
+    (
+        selection_freeze,
+        _,
+        _,
+        _,
+        freeze,
+        opening,
+        evaluations,
+    ) = _confirmation_evidence()
+    unit = freeze.evaluation_units[0]
+    candidate = freeze.selected_candidate
+    trace = _trace(selection_freeze, unit, candidate)
+    metrics = _metric_values(
+        selection_freeze,
+        opening,
+        unit,
+        candidate,
+        trace,
+    )
+    bypass = ProspectiveV2UnitEvaluationV1(
+        freeze_id=freeze.confirmation_freeze_id,
+        stack_lock_id=freeze.stack_lock_id,
+        unit=unit,
+        candidate=candidate,
+        opening=opening,
+        metric_contract=freeze.metric_contract,
+        policy=freeze.policy,
+        trace=trace,
+        metric_values=metrics,
+    )
+
+    with pytest.raises(ValueError, match="confirmation_freeze_id"):
+        evaluate_prospective_v2_confirmation_v1(
+            freeze,
+            opening,
+            (bypass, *evaluations[1:]),
+        )
+
+
+def test_confirmation_rejects_selection_scoring_run_reuse() -> None:
+    (
+        selection_freeze,
+        _,
+        selection_evaluations,
+        _,
+        freeze,
+        opening,
+        _,
+    ) = _confirmation_evidence()
+    unit = freeze.evaluation_units[0]
+    candidate = freeze.selected_candidate
+    trace = _trace(
+        selection_freeze,
+        unit,
+        candidate,
+        metadata_overrides={
+            "confirmation_freeze_id": freeze.confirmation_freeze_id,
+            "confirmation_selection_result_id": freeze.selection_result_id,
+            "confirmation_panel_role": PROSPECTIVE_V2_CONFIRMATION_PANEL_ROLE,
+        },
+    )
+    metrics = _metric_values(
+        selection_freeze,
+        opening,
+        unit,
+        candidate,
+        trace,
+    )
+    metrics = replace(
+        metrics,
+        scoring_run_artifact_id=(
+            selection_evaluations[0].metric_values.scoring_run_artifact_id
+        ),
+    )
+
+    with pytest.raises(ValueError, match="selection-panel scoring run"):
+        build_prospective_v2_confirmation_unit_evaluation_v1(
+            freeze,
+            opening,
+            unit_id=unit.unit_id,
+            trace=trace,
+            metric_values=metrics,
+        )
+
+
+def test_failed_confirmation_preserves_exact_baseline() -> None:
+    (
+        _,
+        _,
+        _,
+        _,
+        freeze,
+        opening,
+        evaluations,
+    ) = _confirmation_evidence()
+    first = evaluations[0]
+    changed_values = replace(
+        first.metric_values,
+        candidate_log_score=0.0,
+        candidate_trajectory_error_m=0.3,
+    )
+    changed_first = replace(first, metric_values=changed_values)
+    changed = (changed_first, *evaluations[1:])
+
+    result = evaluate_prospective_v2_confirmation_v1(
+        freeze,
+        opening,
+        changed,
+    )
+
+    assert not result.confirmation_passed
+    assert result.deployed_candidate_id == freeze.baseline_candidate.candidate_id
+    assert result.deployed_configuration_artifact_id == (
+        freeze.baseline_candidate.configuration_artifact_id
+    )
+    assert result.exact_baseline_fallback_verified
+
+
+def test_confirmation_requires_the_complete_frozen_panel() -> None:
+    (
+        _,
+        _,
+        _,
+        _,
+        freeze,
+        opening,
+        evaluations,
+    ) = _confirmation_evidence()
+
+    with pytest.raises(ValueError, match="frozen confirmation units"):
+        evaluate_prospective_v2_confirmation_v1(
+            freeze,
+            opening,
+            evaluations[:-1],
+        )
+
+
+def test_confirmation_revalidation_rejects_changed_metrics() -> None:
+    (
+        _,
+        _,
+        _,
+        _,
+        freeze,
+        opening,
+        evaluations,
+    ) = _confirmation_evidence()
+    result = evaluate_prospective_v2_confirmation_v1(
+        freeze,
+        opening,
+        evaluations,
+    )
+    first = evaluations[0]
+    changed_first = replace(
+        first,
+        metric_values=replace(
+            first.metric_values,
+            candidate_brier_score=first.metric_values.candidate_brier_score + 0.1,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="bound evidence"):
+        validate_prospective_v2_confirmation_result_v1(
+            result,
+            freeze,
+            opening,
+            (changed_first, *evaluations[1:]),
+        )


### PR DESCRIPTION
Superseded by and fully merged through #265.

The merged implementation is on `main` at `8e9339d3bf6d7b4915b7562b303b71f027bf96b4`. The authoritative CI, extended compatibility, security scanning, and merge-gate workflows all passed on the validated source-only head before merge.