### PR TITLE
Superseded by #261: stale agent branch hygiene

### DIFF
--- a/.github/stale-agent-branch-allowlist.json
+++ b/.github/stale-agent-branch-allowlist.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": 1,
+  "branches": [],
+  "prefixes": []
+}

--- a/.github/workflows/stale-agent-branch-hygiene.yml
+++ b/.github/workflows/stale-agent-branch-hygiene.yml
@@ -1,0 +1,79 @@
+name: Stale agent branch report
+
+on:
+  schedule:
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+    inputs:
+      minimum_age_days:
+        description: Minimum age of a branch tip before reporting it.
+        required: true
+        default: "30"
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: stale-agent-branch-report
+  cancel-in-progress: false
+
+env:
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  report:
+    name: Report stale agent branches
+    if: >-
+      ${{
+        github.event_name == 'schedule' ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.ref == 'refs/heads/main'
+        )
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Check out the reviewed revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Verify the scheduled or reviewed-main source
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test -z "$(git status --porcelain)"
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            test "$GITHUB_REF" = "refs/heads/main"
+          fi
+      - name: Inventory manual cleanup candidates
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          MINIMUM_AGE_DAYS: ${{ inputs.minimum_age_days || '30' }}
+        run: |
+          python scripts/ci/stale_agent_branches.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --allowlist .github/stale-agent-branch-allowlist.json \
+            --minimum-age-days "$MINIMUM_AGE_DAYS" \
+            --output-json stale-agent-branches.json \
+            --output-markdown stale-agent-branches.md
+          cat stale-agent-branches.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload the report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: stale-agent-branch-report-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            stale-agent-branches.json
+            stale-agent-branches.md
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/branch_hygiene.md
+++ b/docs/branch_hygiene.md
@@ -1,0 +1,51 @@
+# Stale `agent/*` branch hygiene
+
+Causal4D uses short-lived `agent/*` branches for reviewed pull requests. Merged and
+superseded branches can otherwise accumulate indefinitely, making repository
+navigation and provenance audits harder.
+
+The `Stale agent branch report` workflow is deliberately **read-only**. It creates
+an auditable JSON and Markdown inventory but never updates or deletes a branch.
+
+## Candidate policy
+
+A branch is reported as a manual cleanup candidate only when all of the following
+are true:
+
+- its tip is at least the configured number of days old;
+- it is not protected or allowlisted;
+- it has no open pull request; and
+- either its exact tip is reachable from the default branch or that exact tip was
+  merged through a pull request.
+
+Closed-but-unmerged pull requests, branches with unmerged follow-up commits,
+future-dated commits, malformed API responses, and ambiguous histories are
+excluded. The report fails closed instead of guessing.
+
+## Manual cleanup
+
+Run the workflow from reviewed `main`, download the report, inspect every candidate,
+and remove approved branches manually through GitHub. The workflow has only
+`contents: read` and `pull-requests: read`; it has no write-capable job or deletion
+mode.
+
+## Allowlist
+
+The allowlist has a deliberately small strict schema:
+
+```json
+{
+  "schema_version": 1,
+  "branches": ["agent/exact-long-lived-branch"],
+  "prefixes": ["agent/evidence/"]
+}
+```
+
+Unknown fields, duplicate keys or entries, empty strings, symlinked files, and
+unsupported schema versions are rejected.
+
+## Boundary
+
+This report does not modify the frozen estimator, acquisition protocol,
+target-access boundary, retained evidence, scientific result, branch references,
+or physical execution count.

--- a/scripts/ci/stale_agent_branches.py
+++ b/scripts/ci/stale_agent_branches.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""Produce a fail-closed, read-only report for stale ``agent/*`` branches."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any, Mapping, Protocol, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+
+_API_ROOT = "https://api.github.com"
+
+
+class GitHubApiError(RuntimeError):
+    """Raised when GitHub returns an unexpected or malformed response."""
+
+
+class ApiClient(Protocol):
+    def get_json(
+        self,
+        path: str,
+        *,
+        query: Mapping[str, str | int] | None = None,
+    ) -> Any: ...
+
+    def paginated(
+        self,
+        path: str,
+        *,
+        query: Mapping[str, str | int] | None = None,
+    ) -> list[Any]: ...
+
+
+class GitHubApi:
+    """Small dependency-free, GET-only GitHub REST client."""
+
+    def __init__(self, token: str) -> None:
+        if not token:
+            raise ValueError("GitHub token must be nonempty")
+        self._token = token
+
+    def get_json(
+        self,
+        path: str,
+        *,
+        query: Mapping[str, str | int] | None = None,
+    ) -> Any:
+        suffix = f"?{urlencode(query)}" if query else ""
+        request = Request(
+            f"{_API_ROOT}{path}{suffix}",
+            method="GET",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self._token}",
+                "User-Agent": "causal4d-stale-agent-branch-report",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urlopen(request, timeout=60) as response:
+                payload = response.read()
+        except HTTPError as error:
+            body = error.read().decode("utf-8", errors="replace")
+            raise GitHubApiError(
+                f"GitHub API GET {path} failed with {error.code}: {body}"
+            ) from error
+        except URLError as error:
+            raise GitHubApiError(
+                f"GitHub API GET {path} could not be reached: {error}"
+            ) from error
+        if not payload:
+            return None
+        try:
+            return json.loads(payload)
+        except json.JSONDecodeError as error:
+            raise GitHubApiError(
+                f"GitHub API GET {path} returned invalid JSON"
+            ) from error
+
+    def paginated(
+        self,
+        path: str,
+        *,
+        query: Mapping[str, str | int] | None = None,
+    ) -> list[Any]:
+        result: list[Any] = []
+        page = 1
+        while True:
+            parameters: dict[str, str | int] = dict(query or {})
+            parameters.update({"per_page": 100, "page": page})
+            payload = self.get_json(path, query=parameters)
+            if not isinstance(payload, list):
+                raise GitHubApiError(f"GitHub API GET {path} did not return a list")
+            result.extend(payload)
+            if len(payload) < 100:
+                return result
+            page += 1
+
+
+@dataclass(frozen=True)
+class BranchAllowlist:
+    """Exact branches and prefixes excluded from cleanup candidacy."""
+
+    branches: frozenset[str]
+    prefixes: tuple[str, ...]
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> BranchAllowlist:
+        if set(payload) != {"schema_version", "branches", "prefixes"}:
+            raise ValueError(
+                "branch allowlist must contain schema_version, branches, and prefixes"
+            )
+        if payload["schema_version"] != 1:
+            raise ValueError("unsupported branch allowlist schema")
+        branches = _string_sequence(payload["branches"], name="branches")
+        prefixes = _string_sequence(payload["prefixes"], name="prefixes")
+        if len(set(branches)) != len(branches):
+            raise ValueError("allowlisted branches must be unique")
+        if len(set(prefixes)) != len(prefixes):
+            raise ValueError("allowlisted prefixes must be unique")
+        return cls(frozenset(branches), tuple(prefixes))
+
+    def matches(self, branch: str) -> bool:
+        return branch in self.branches or any(
+            branch.startswith(prefix) for prefix in self.prefixes
+        )
+
+
+@dataclass(frozen=True)
+class BranchInspection:
+    """Evidence used to classify one branch conservatively."""
+
+    name: str
+    sha: str
+    committed_at_utc: str
+    protected: bool
+    allowlisted: bool
+    open_pull_requests: tuple[int, ...]
+    exact_tip_merged_pull_requests: tuple[int, ...]
+    tip_reachable_from_default: bool
+
+    @property
+    def committed_at(self) -> datetime:
+        return _parse_utc(self.committed_at_utc, name="committed_at_utc")
+
+
+@dataclass(frozen=True)
+class BranchDecision:
+    """One report-only cleanup-candidate decision."""
+
+    inspection: BranchInspection
+    cleanup_candidate: bool
+    reason: str
+    age_days: float
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self.inspection),
+            "open_pull_requests": list(self.inspection.open_pull_requests),
+            "exact_tip_merged_pull_requests": list(
+                self.inspection.exact_tip_merged_pull_requests
+            ),
+            "cleanup_candidate": self.cleanup_candidate,
+            "reason": self.reason,
+            "age_days": self.age_days,
+        }
+
+
+def _string_sequence(value: Any, *, name: str) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValueError(f"{name} must be a sequence of strings")
+    result: list[str] = []
+    for index, item in enumerate(value):
+        if type(item) is not str or not item:
+            raise ValueError(f"{name}[{index}] must be a nonempty string")
+        result.append(item)
+    return tuple(result)
+
+
+def _parse_utc(value: Any, *, name: str) -> datetime:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a nonempty ISO-8601 timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(f"{name} must be an ISO-8601 timestamp") from error
+    if parsed.tzinfo is None or parsed.utcoffset() != timedelta(0):
+        raise ValueError(f"{name} must use UTC")
+    return parsed.astimezone(timezone.utc)
+
+
+def _utc_text(value: datetime) -> str:
+    if value.tzinfo is None:
+        raise ValueError("timestamps must be timezone-aware")
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _repository_parts(repository: str) -> tuple[str, str]:
+    parts = repository.split("/")
+    if len(parts) != 2 or any(not part for part in parts):
+        raise ValueError("repository must use owner/name syntax")
+    if any(part in {".", ".."} for part in parts):
+        raise ValueError("repository owner and name must be ordinary path segments")
+    return parts[0], parts[1]
+
+
+def _strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_allowlist(path: str | Path) -> BranchAllowlist:
+    source = Path(path)
+    if source.is_symlink() or not source.is_file():
+        raise ValueError("branch allowlist must be an ordinary file")
+    payload = json.loads(
+        source.read_text(encoding="utf-8"),
+        object_pairs_hook=_strict_object,
+        parse_constant=lambda value: (_ for _ in ()).throw(
+            ValueError(f"non-finite JSON constant: {value}")
+        ),
+    )
+    if not isinstance(payload, Mapping):
+        raise ValueError("branch allowlist must be a JSON object")
+    return BranchAllowlist.from_mapping(payload)
+
+
+def classify_branch(
+    inspection: BranchInspection,
+    *,
+    now: datetime,
+    minimum_age_days: int,
+) -> BranchDecision:
+    if minimum_age_days < 1:
+        raise ValueError("minimum_age_days must be positive")
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    age = now.astimezone(timezone.utc) - inspection.committed_at
+    age_days = age.total_seconds() / 86_400.0
+    if age.total_seconds() < 0.0:
+        return BranchDecision(inspection, False, "future_commit_timestamp", age_days)
+    if inspection.protected:
+        return BranchDecision(inspection, False, "protected_branch", age_days)
+    if inspection.allowlisted:
+        return BranchDecision(inspection, False, "allowlisted_branch", age_days)
+    if inspection.open_pull_requests:
+        return BranchDecision(inspection, False, "open_pull_request", age_days)
+    if age < timedelta(days=minimum_age_days):
+        return BranchDecision(inspection, False, "younger_than_threshold", age_days)
+    if inspection.tip_reachable_from_default:
+        return BranchDecision(inspection, True, "tip_reachable_from_default", age_days)
+    if inspection.exact_tip_merged_pull_requests:
+        return BranchDecision(
+            inspection,
+            True,
+            "exact_tip_merged_in_pull_request",
+            age_days,
+        )
+    return BranchDecision(inspection, False, "unmerged_tip", age_days)
+
+
+def _commit_timestamp(payload: Any) -> str:
+    if not isinstance(payload, Mapping):
+        raise GitHubApiError("commit response must be a JSON object")
+    commit = payload.get("commit")
+    if not isinstance(commit, Mapping):
+        raise GitHubApiError("commit response is missing commit metadata")
+    for actor_name in ("committer", "author"):
+        actor = commit.get(actor_name)
+        if isinstance(actor, Mapping) and actor.get("date") is not None:
+            return _utc_text(
+                _parse_utc(actor["date"], name=f"commit.{actor_name}.date")
+            )
+    raise GitHubApiError("commit response has no usable UTC timestamp")
+
+
+def _pull_request_numbers(
+    pulls: Sequence[Any],
+    *,
+    repository: str,
+    branch: str,
+    sha: str | None = None,
+    require_merged: bool = False,
+) -> tuple[int, ...]:
+    numbers: list[int] = []
+    for pull in pulls:
+        if not isinstance(pull, Mapping):
+            continue
+        head = pull.get("head")
+        if not isinstance(head, Mapping):
+            continue
+        head_repo = head.get("repo")
+        full_name = (
+            head_repo.get("full_name") if isinstance(head_repo, Mapping) else None
+        )
+        if full_name != repository or head.get("ref") != branch:
+            continue
+        if sha is not None and head.get("sha") != sha:
+            continue
+        if require_merged and pull.get("merged_at") is None:
+            continue
+        number = pull.get("number")
+        if type(number) is int:
+            numbers.append(number)
+    return tuple(sorted(set(numbers)))
+
+
+def _tip_reachable_from_default(
+    api: ApiClient,
+    *,
+    repository: str,
+    sha: str,
+    default_branch: str,
+) -> bool:
+    payload = api.get_json(
+        (
+            f"/repos/{repository}/compare/{quote(sha, safe='')}..."
+            f"{quote(default_branch, safe='')}"
+        )
+    )
+    if not isinstance(payload, Mapping):
+        raise GitHubApiError("compare response must be a JSON object")
+    merge_base = payload.get("merge_base_commit")
+    return isinstance(merge_base, Mapping) and merge_base.get("sha") == sha
+
+
+def _exact_tip_merged_pull_requests(
+    api: ApiClient,
+    *,
+    repository: str,
+    branch: str,
+    sha: str,
+) -> tuple[int, ...]:
+    pulls = api.paginated(f"/repos/{repository}/commits/{sha}/pulls")
+    return _pull_request_numbers(
+        pulls,
+        repository=repository,
+        branch=branch,
+        sha=sha,
+        require_merged=True,
+    )
+
+
+def inspect_agent_branches(
+    api: ApiClient,
+    *,
+    repository: str,
+    prefix: str,
+    allowlist: BranchAllowlist,
+    minimum_age_days: int,
+    now: datetime,
+) -> tuple[str, tuple[BranchDecision, ...]]:
+    if minimum_age_days < 1:
+        raise ValueError("minimum_age_days must be positive")
+    _repository_parts(repository)
+    if not prefix or prefix.startswith("/") or prefix.endswith("//"):
+        raise ValueError("prefix must be a nonempty branch-name prefix")
+    repository_payload = api.get_json(f"/repos/{repository}")
+    if not isinstance(repository_payload, Mapping):
+        raise GitHubApiError("repository response must be a JSON object")
+    default_branch = repository_payload.get("default_branch")
+    if type(default_branch) is not str or not default_branch:
+        raise GitHubApiError("repository response has no default branch")
+
+    open_pulls = api.paginated(
+        f"/repos/{repository}/pulls",
+        query={"state": "open"},
+    )
+    branches = api.paginated(f"/repos/{repository}/branches")
+    decisions: list[BranchDecision] = []
+    for branch_payload in sorted(
+        branches,
+        key=lambda item: str(item.get("name")) if isinstance(item, Mapping) else "",
+    ):
+        if not isinstance(branch_payload, Mapping):
+            raise GitHubApiError("branch response contains a non-object entry")
+        name = branch_payload.get("name")
+        if type(name) is not str or not name.startswith(prefix):
+            continue
+        if name == default_branch:
+            continue
+        commit = branch_payload.get("commit")
+        sha = commit.get("sha") if isinstance(commit, Mapping) else None
+        if type(sha) is not str or len(sha) != 40:
+            raise GitHubApiError(f"branch {name} has no valid tip SHA")
+        protected = branch_payload.get("protected") is True
+        commit_payload = api.get_json(f"/repos/{repository}/commits/{sha}")
+        preliminary = BranchInspection(
+            name=name,
+            sha=sha,
+            committed_at_utc=_commit_timestamp(commit_payload),
+            protected=protected,
+            allowlisted=allowlist.matches(name),
+            open_pull_requests=_pull_request_numbers(
+                open_pulls,
+                repository=repository,
+                branch=name,
+            ),
+            exact_tip_merged_pull_requests=(),
+            tip_reachable_from_default=False,
+        )
+        preliminary_decision = classify_branch(
+            preliminary,
+            now=now,
+            minimum_age_days=minimum_age_days,
+        )
+        if preliminary_decision.reason in {
+            "protected_branch",
+            "allowlisted_branch",
+            "open_pull_request",
+            "younger_than_threshold",
+            "future_commit_timestamp",
+        }:
+            decisions.append(preliminary_decision)
+            continue
+        reachable = _tip_reachable_from_default(
+            api,
+            repository=repository,
+            sha=sha,
+            default_branch=default_branch,
+        )
+        merged_numbers = (
+            ()
+            if reachable
+            else _exact_tip_merged_pull_requests(
+                api,
+                repository=repository,
+                branch=name,
+                sha=sha,
+            )
+        )
+        decisions.append(
+            classify_branch(
+                BranchInspection(
+                    name=name,
+                    sha=sha,
+                    committed_at_utc=preliminary.committed_at_utc,
+                    protected=protected,
+                    allowlisted=allowlist.matches(name),
+                    open_pull_requests=preliminary.open_pull_requests,
+                    exact_tip_merged_pull_requests=merged_numbers,
+                    tip_reachable_from_default=reachable,
+                ),
+                now=now,
+                minimum_age_days=minimum_age_days,
+            )
+        )
+    return default_branch, tuple(decisions)
+
+
+def build_report(
+    *,
+    repository: str,
+    default_branch: str,
+    prefix: str,
+    minimum_age_days: int,
+    now: datetime,
+    decisions: Sequence[BranchDecision],
+) -> dict[str, Any]:
+    reason_counts: dict[str, int] = {}
+    for decision in decisions:
+        reason_counts[decision.reason] = reason_counts.get(decision.reason, 0) + 1
+    candidate_count = sum(decision.cleanup_candidate for decision in decisions)
+    return {
+        "schema_version": 1,
+        "artifact_kind": "Causal4DStaleAgentBranchReport",
+        "generated_at_utc": _utc_text(now),
+        "repository": repository,
+        "default_branch": default_branch,
+        "prefix": prefix,
+        "minimum_age_days": minimum_age_days,
+        "report_only": True,
+        "branch_count": len(decisions),
+        "cleanup_candidate_count": candidate_count,
+        "excluded_count": len(decisions) - candidate_count,
+        "reason_counts": dict(sorted(reason_counts.items())),
+        "decisions": [decision.as_dict() for decision in decisions],
+    }
+
+
+def render_markdown(report: Mapping[str, Any]) -> str:
+    lines = [
+        "# Stale agent branch report",
+        "",
+        "This workflow is read-only. It never deletes or updates a branch.",
+        "",
+        f"- Repository: `{report['repository']}`",
+        f"- Default branch: `{report['default_branch']}`",
+        f"- Prefix: `{report['prefix']}`",
+        f"- Minimum age: `{report['minimum_age_days']}` days",
+        f"- Inspected: `{report['branch_count']}`",
+        f"- Manual cleanup candidates: `{report['cleanup_candidate_count']}`",
+        "",
+        "## Manual cleanup candidates",
+        "",
+    ]
+    candidates = [item for item in report["decisions"] if item["cleanup_candidate"]]
+    if candidates:
+        lines.extend(
+            f"- `{item['name']}` at `{item['sha']}`: {item['reason']} "
+            f"({item['age_days']:.1f} days old)"
+            for item in candidates
+        )
+    else:
+        lines.append("No branch is a cleanup candidate under the fail-closed policy.")
+    lines.extend(["", "## Exclusion counts", ""])
+    lines.extend(
+        f"- `{reason}`: {count}"
+        for reason, count in report["reason_counts"].items()
+        if reason
+        not in {
+            "tip_reachable_from_default",
+            "exact_tip_merged_in_pull_request",
+        }
+    )
+    lines.extend(
+        [
+            "",
+            "Review the report before removing any candidate manually through GitHub.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _atomic_write(path: str | Path, content: str) -> None:
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(f".{destination.name}.tmp")
+    temporary.write_text(content, encoding="utf-8")
+    temporary.replace(destination)
+
+
+def _now_from_argument(value: str | None) -> datetime:
+    if value is None:
+        return datetime.now(timezone.utc)
+    return _parse_utc(value, name="--now")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repository",
+        default=os.environ.get("GITHUB_REPOSITORY"),
+        help="Repository in owner/name form; defaults to GITHUB_REPOSITORY.",
+    )
+    parser.add_argument("--prefix", default="agent/")
+    parser.add_argument(
+        "--allowlist",
+        default=".github/stale-agent-branch-allowlist.json",
+    )
+    parser.add_argument("--minimum-age-days", type=int, default=30)
+    parser.add_argument("--token-env", default="GITHUB_TOKEN")
+    parser.add_argument("--now", help=argparse.SUPPRESS)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--output-markdown", required=True)
+    arguments = parser.parse_args(argv)
+
+    if not arguments.repository:
+        parser.error("--repository or GITHUB_REPOSITORY is required")
+    repository = str(arguments.repository)
+    _repository_parts(repository)
+    token = os.environ.get(arguments.token_env, "")
+    if not token:
+        parser.error(f"environment variable {arguments.token_env} is required")
+    now = _now_from_argument(arguments.now)
+    default_branch, decisions = inspect_agent_branches(
+        GitHubApi(token),
+        repository=repository,
+        prefix=arguments.prefix,
+        allowlist=load_allowlist(arguments.allowlist),
+        minimum_age_days=arguments.minimum_age_days,
+        now=now,
+    )
+    report = build_report(
+        repository=repository,
+        default_branch=default_branch,
+        prefix=arguments.prefix,
+        minimum_age_days=arguments.minimum_age_days,
+        now=now,
+        decisions=decisions,
+    )
+    _atomic_write(
+        arguments.output_json,
+        json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n",
+    )
+    _atomic_write(arguments.output_markdown, render_markdown(report))
+    print(json.dumps(report, indent=2, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_stale_agent_branch_workflow_policy.py
+++ b/tests/test_stale_agent_branch_workflow_policy.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "stale-agent-branch-hygiene.yml"
+SCRIPT = ROOT / "scripts" / "ci" / "stale_agent_branches.py"
+ALLOWLIST = ROOT / ".github" / "stale-agent-branch-allowlist.json"
+
+
+def test_workflow_is_manual_or_scheduled_and_never_self_hosted() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "schedule:" in text
+    assert "workflow_dispatch:" in text
+    assert "pull_request:" not in text
+    assert "push:" not in text
+    assert "self-hosted" not in text
+    assert "runs-on: ubuntu-latest" in text
+
+
+def test_workflow_is_strictly_read_only() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    script = SCRIPT.read_text(encoding="utf-8")
+
+    assert "contents: read" in workflow
+    assert "pull-requests: read" in workflow
+    assert "contents: write" not in workflow
+    assert "DELETE_AGENT_BRANCHES" not in workflow
+    assert "maximum_deletions" not in workflow
+    assert 'method="GET"' in script
+    assert '"DELETE"' not in script
+    assert "/git/refs/heads/" not in script
+
+
+def test_every_action_is_pinned_and_checkout_drops_credentials() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    action_lines = [line.strip() for line in text.splitlines() if "uses:" in line]
+
+    assert action_lines
+    assert all(
+        re.search(r"uses: [^@\s]+@[0-9a-f]{40}(?:\s|$)", line) for line in action_lines
+    )
+    assert text.count("persist-credentials: false") == 1
+    assert text.count("ref: ${{ github.sha }}") == 1
+    assert text.count('test "$(git rev-parse HEAD)" = "$GITHUB_SHA"') == 1
+
+
+def test_script_and_allowlist_are_bound_into_workflow() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert SCRIPT.is_file()
+    assert ALLOWLIST.is_file()
+    assert text.count("scripts/ci/stale_agent_branches.py") == 1
+    assert text.count(".github/stale-agent-branch-allowlist.json") == 1

--- a/tests/test_stale_agent_branches.py
+++ b/tests/test_stale_agent_branches.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from typing import Any, Mapping
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "ci" / "stale_agent_branches.py"
+SPEC = importlib.util.spec_from_file_location("stale_agent_branches", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+BranchAllowlist = MODULE.BranchAllowlist
+BranchInspection = MODULE.BranchInspection
+GitHubApiError = MODULE.GitHubApiError
+build_report = MODULE.build_report
+classify_branch = MODULE.classify_branch
+inspect_agent_branches = MODULE.inspect_agent_branches
+load_allowlist = MODULE.load_allowlist
+render_markdown = MODULE.render_markdown
+
+
+NOW = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+OLD = (NOW - timedelta(days=45)).isoformat().replace("+00:00", "Z")
+YOUNG = (NOW - timedelta(days=4)).isoformat().replace("+00:00", "Z")
+SHA = "1" * 40
+OTHER_SHA = "2" * 40
+
+
+def _inspection(**overrides: Any) -> Any:
+    values: dict[str, Any] = {
+        "name": "agent/example",
+        "sha": SHA,
+        "committed_at_utc": OLD,
+        "protected": False,
+        "allowlisted": False,
+        "open_pull_requests": (),
+        "exact_tip_merged_pull_requests": (),
+        "tip_reachable_from_default": False,
+    }
+    values.update(overrides)
+    return BranchInspection(**values)
+
+
+class FakeApi:
+    def __init__(self) -> None:
+        self.responses: dict[str, Any] = {}
+        self.paginated_responses: dict[str, Any] = {}
+        self.calls: list[tuple[str, Mapping[str, str | int] | None]] = []
+        self.paginated_calls: list[tuple[str, Mapping[str, str | int] | None]] = []
+
+    def get_json(
+        self,
+        path: str,
+        *,
+        query: Mapping[str, str | int] | None = None,
+    ) -> Any:
+        self.calls.append((path, query))
+        if path not in self.responses:
+            raise AssertionError(f"unexpected request: {path}, query={query}")
+        response = self.responses[path]
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    def paginated(
+        self,
+        path: str,
+        *,
+        query: Mapping[str, str | int] | None = None,
+    ) -> list[Any]:
+        self.paginated_calls.append((path, query))
+        if path not in self.paginated_responses:
+            raise AssertionError(f"unexpected pagination: {path}, query={query}")
+        response = self.paginated_responses[path]
+        if isinstance(response, dict):
+            key = None if query is None else query.get("state")
+            if key not in response:
+                raise AssertionError(f"unexpected pagination state: {path}, {query}")
+            return response[key]
+        return response
+
+
+def test_allowlist_schema_is_strict_and_supports_exact_and_prefix() -> None:
+    allowlist = BranchAllowlist.from_mapping(
+        {
+            "schema_version": 1,
+            "branches": ["agent/exact"],
+            "prefixes": ["agent/evidence/"],
+        }
+    )
+
+    assert allowlist.matches("agent/exact") is True
+    assert allowlist.matches("agent/evidence/run-1") is True
+    assert allowlist.matches("agent/ordinary") is False
+
+    with pytest.raises(ValueError, match="must contain"):
+        BranchAllowlist.from_mapping(
+            {
+                "schema_version": 1,
+                "branches": [],
+                "prefixes": [],
+                "unknown": True,
+            }
+        )
+    with pytest.raises(ValueError, match="unique"):
+        BranchAllowlist.from_mapping(
+            {
+                "schema_version": 1,
+                "branches": ["agent/a", "agent/a"],
+                "prefixes": [],
+            }
+        )
+
+
+def test_load_allowlist_rejects_duplicate_keys_and_symlink(tmp_path: Path) -> None:
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text(
+        '{"schema_version":1,"branches":[],"branches":[],"prefixes":[]}',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="duplicate JSON key"):
+        load_allowlist(duplicate)
+
+    target = tmp_path / "target.json"
+    target.write_text(
+        json.dumps({"schema_version": 1, "branches": [], "prefixes": []}),
+        encoding="utf-8",
+    )
+    link = tmp_path / "link.json"
+    link.symlink_to(target)
+    with pytest.raises(ValueError, match="ordinary file"):
+        load_allowlist(link)
+
+
+def test_classification_is_fail_closed() -> None:
+    cases = [
+        (_inspection(protected=True), "protected_branch", False),
+        (_inspection(allowlisted=True), "allowlisted_branch", False),
+        (_inspection(open_pull_requests=(17,)), "open_pull_request", False),
+        (_inspection(committed_at_utc=YOUNG), "younger_than_threshold", False),
+        (_inspection(), "unmerged_tip", False),
+        (
+            _inspection(tip_reachable_from_default=True),
+            "tip_reachable_from_default",
+            True,
+        ),
+        (
+            _inspection(exact_tip_merged_pull_requests=(259,)),
+            "exact_tip_merged_in_pull_request",
+            True,
+        ),
+    ]
+
+    for inspection, reason, expected_candidate in cases:
+        decision = classify_branch(inspection, now=NOW, minimum_age_days=30)
+        assert decision.reason == reason
+        assert decision.cleanup_candidate is expected_candidate
+
+
+def test_inspection_rejects_nonpositive_age_before_api_access() -> None:
+    api = FakeApi()
+
+    with pytest.raises(ValueError, match="minimum_age_days must be positive"):
+        inspect_agent_branches(
+            api,
+            repository="IPS-Stuttgart/Causal4D",
+            prefix="agent/",
+            allowlist=BranchAllowlist(frozenset(), ()),
+            minimum_age_days=0,
+            now=NOW,
+        )
+
+    assert api.calls == []
+    assert api.paginated_calls == []
+
+
+def test_inspection_avoids_history_queries_for_preliminary_exclusions() -> None:
+    repository = "IPS-Stuttgart/Causal4D"
+    api = FakeApi()
+    api.responses[f"/repos/{repository}"] = {"default_branch": "main"}
+    api.responses[f"/repos/{repository}/commits/{SHA}"] = {
+        "commit": {"committer": {"date": YOUNG}}
+    }
+    api.paginated_responses[f"/repos/{repository}/pulls"] = []
+    api.paginated_responses[f"/repos/{repository}/branches"] = [
+        {"name": "agent/young", "protected": False, "commit": {"sha": SHA}},
+        {"name": "main", "protected": True, "commit": {"sha": OTHER_SHA}},
+    ]
+
+    default, decisions = inspect_agent_branches(
+        api,
+        repository=repository,
+        prefix="agent/",
+        allowlist=BranchAllowlist(frozenset(), ()),
+        minimum_age_days=30,
+        now=NOW,
+    )
+
+    assert default == "main"
+    assert [decision.reason for decision in decisions] == ["younger_than_threshold"]
+    assert all("/compare/" not in path for path, _ in api.calls)
+
+
+def test_inspection_accepts_only_exact_merged_tip() -> None:
+    repository = "IPS-Stuttgart/Causal4D"
+    branch = "agent/merged"
+    api = FakeApi()
+    api.responses[f"/repos/{repository}"] = {"default_branch": "main"}
+    api.responses[f"/repos/{repository}/commits/{SHA}"] = {
+        "commit": {"committer": {"date": OLD}}
+    }
+    api.responses[f"/repos/{repository}/compare/{SHA}...main"] = {
+        "merge_base_commit": {"sha": OTHER_SHA}
+    }
+    api.paginated_responses[f"/repos/{repository}/pulls"] = []
+    api.paginated_responses[f"/repos/{repository}/branches"] = [
+        {"name": branch, "protected": False, "commit": {"sha": SHA}}
+    ]
+    api.paginated_responses[f"/repos/{repository}/commits/{SHA}/pulls"] = [
+        {
+            "number": 259,
+            "merged_at": "2026-08-08T21:20:12Z",
+            "head": {
+                "ref": branch,
+                "sha": SHA,
+                "repo": {"full_name": repository},
+            },
+        },
+        {
+            "number": 258,
+            "merged_at": "2026-08-08T20:00:00Z",
+            "head": {
+                "ref": branch,
+                "sha": OTHER_SHA,
+                "repo": {"full_name": repository},
+            },
+        },
+    ]
+
+    _, decisions = inspect_agent_branches(
+        api,
+        repository=repository,
+        prefix="agent/",
+        allowlist=BranchAllowlist(frozenset(), ()),
+        minimum_age_days=30,
+        now=NOW,
+    )
+
+    assert len(decisions) == 1
+    assert decisions[0].cleanup_candidate is True
+    assert decisions[0].inspection.exact_tip_merged_pull_requests == (259,)
+
+
+def test_malformed_api_payload_fails_closed() -> None:
+    api = FakeApi()
+    api.responses["/repos/IPS-Stuttgart/Causal4D"] = []
+
+    with pytest.raises(GitHubApiError, match="repository response"):
+        inspect_agent_branches(
+            api,
+            repository="IPS-Stuttgart/Causal4D",
+            prefix="agent/",
+            allowlist=BranchAllowlist(frozenset(), ()),
+            minimum_age_days=30,
+            now=NOW,
+        )
+
+
+def test_report_has_no_mutation_or_deletion_state() -> None:
+    decision = classify_branch(
+        _inspection(tip_reachable_from_default=True),
+        now=NOW,
+        minimum_age_days=30,
+    )
+    report = build_report(
+        repository="IPS-Stuttgart/Causal4D",
+        default_branch="main",
+        prefix="agent/",
+        minimum_age_days=30,
+        now=NOW,
+        decisions=(decision,),
+    )
+
+    assert report["report_only"] is True
+    assert report["cleanup_candidate_count"] == 1
+    assert "deleted" not in report
+    markdown = render_markdown(report)
+    assert "read-only" in markdown
+    assert "never deletes" in markdown
+    assert "agent/example" in markdown


### PR DESCRIPTION
Closed as superseded by merged PR #261, which already added the fail-closed, read-only stale `agent/*` branch inventory and its policy/adversarial coverage.

This duplicate points at the same historical branch head and must not be merged a second time. No repository branch was deleted and no scientific code, protocol, result, or evidence count is changed.