### PR TITLE
Add prepared memory-bounded joint observation inference

### DIFF
--- a/.github/self-hosted-jobs.json
+++ b/.github/self-hosted-jobs.json
@@ -3,6 +3,9 @@
   "authorization_models": {
     "main-only": {
       "description": "Manual dispatch from refs/heads/main before runner allocation, exact GITHUB_SHA checkout, clean-tree verification, read-only token, and no secrets."
+    },
+    "maintainer-issue-main": {
+      "description": "Exact registered-maintainer issue trigger on reviewed refs/heads/main, exact GITHUB_SHA checkout, clean-tree verification, read-only self-hosted token, no issue text execution, and no secrets."
     }
   },
   "jobs": [
@@ -129,6 +132,20 @@
         "nvidia-smi"
       ],
       "purpose": "Optional CUDA/Warp integration smoke",
+      "dataset_access": "none",
+      "secrets_allowed": false
+    },
+    {
+      "workflow": "prepared-joint-observation-self-hosted.yml",
+      "job": "validate",
+      "authorization_model": "maintainer-issue-main",
+      "runner_labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "nvidia-smi"
+      ],
+      "purpose": "Installed-wheel prepared joint-observation parity and scale validation",
       "dataset_access": "none",
       "secrets_allowed": false
     },

--- a/.github/workflows/prepared-joint-observation-self-hosted.yml
+++ b/.github/workflows/prepared-joint-observation-self-hosted.yml
@@ -1,0 +1,184 @@
+name: Prepared joint-observation self-hosted validation
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prepared-joint-observation-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate prepared joint observations on workstation2
+    if: >-
+      github.event_name == 'issues' &&
+      github.event.action == 'opened' &&
+      github.ref == 'refs/heads/main' &&
+      github.event.issue.user.login == 'FlorianPfaff' &&
+      github.event.issue.user.id == 6773539 &&
+      github.event.issue.title ==
+        '[self-hosted] validate prepared joint observation'
+    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    timeout-minutes: 90
+    steps:
+      - name: Check out exact reviewed main revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+
+      - name: Verify reviewed main revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Build and install the exact wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p outputs/prepared-joint-observation/wheels
+          python -m venv .prepared-joint-venv
+          .prepared-joint-venv/bin/python -m pip install \
+            --upgrade pip "build>=1.2"
+          .prepared-joint-venv/bin/python -m build --wheel \
+            --outdir outputs/prepared-joint-observation/wheels .
+          wheel="$(
+            find outputs/prepared-joint-observation/wheels -maxdepth 1 \
+              -name 'causal4d-*.whl' -print -quit
+          )"
+          test -n "${wheel}"
+          sha256sum "${wheel}" \
+            | tee outputs/prepared-joint-observation/wheel-sha256.txt
+          .prepared-joint-venv/bin/python -m pip install \
+            "${wheel}" "pytest>=8"
+          .prepared-joint-venv/bin/python -m pip check
+          .prepared-joint-venv/bin/python - <<'PY'
+          from pathlib import Path
+
+          import causal4d
+          import causal4d.prepared_joint_observation
+
+          source_root = (Path.cwd() / "src").resolve()
+          origins = (
+              Path(causal4d.__file__).resolve(),
+              Path(causal4d.prepared_joint_observation.__file__).resolve(),
+          )
+          for origin in origins:
+              print("installed import", origin)
+              if origin.is_relative_to(source_root):
+                  raise SystemExit(
+                      "Causal4D resolved from the checkout instead of the wheel"
+                  )
+          PY
+          .prepared-joint-venv/bin/python -m pip freeze --all \
+            > outputs/prepared-joint-observation/pip-freeze.txt
+
+      - name: Run focused numerical and contract tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          PYTHONPATH="" .prepared-joint-venv/bin/python -m pytest -q \
+            --import-mode=importlib \
+            tests/test_joint_observation.py \
+            tests/test_joint_observation_adversarial.py \
+            tests/test_joint_observation_metamorphic.py \
+            tests/test_prepared_joint_observation.py \
+            | tee outputs/prepared-joint-observation/pytest.txt
+
+      - name: Run parity and 2048-row rank-7 scale benchmarks
+        shell: bash
+        run: |
+          set -euo pipefail
+          PYTHONPATH="" .prepared-joint-venv/bin/python \
+            scripts/ci/benchmark_prepared_joint_observation.py \
+            --output \
+              outputs/prepared-joint-observation/benchmark.json \
+            --parity-rows 512 \
+            --parity-components 16 \
+            --scale-rows 2048 \
+            --scale-components 16 \
+            --rank 7 \
+            --chunk-size 8 \
+            | tee outputs/prepared-joint-observation/benchmark.txt
+
+      - name: Record runner identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "runner_name=${RUNNER_NAME}"
+            echo "runner_os=${RUNNER_OS}"
+            echo "runner_arch=${RUNNER_ARCH}"
+            echo "repository=${GITHUB_REPOSITORY}"
+            echo "commit=${GITHUB_SHA}"
+            echo "workflow_run_id=${GITHUB_RUN_ID}"
+            uname -a
+          } | tee outputs/prepared-joint-observation/runner.txt
+          nvidia-smi -L \
+            | tee outputs/prepared-joint-observation/nvidia-smi-L.txt
+
+      - name: Upload self-hosted validation evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: prepared-joint-observation-self-hosted
+          path: outputs/prepared-joint-observation/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Remove isolated environment
+        if: always()
+        run: rm -rf .prepared-joint-venv
+
+  report:
+    name: Report self-hosted result to the trigger issue
+    if: >-
+      always() &&
+      github.event_name == 'issues' &&
+      github.event.action == 'opened' &&
+      github.ref == 'refs/heads/main' &&
+      github.event.issue.user.login == 'FlorianPfaff' &&
+      github.event.issue.user.id == 6773539 &&
+      github.event.issue.title ==
+        '[self-hosted] validate prepared joint observation'
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      VALIDATION_RESULT: ${{ needs.validate.result }}
+    steps:
+      - name: Comment with the exact run result
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/"
+          run_url+="${GITHUB_RUN_ID}"
+          body="$(cat <<EOF
+          Prepared joint-observation self-hosted validation: **${VALIDATION_RESULT}**
+
+          - Exact reviewed main commit: \`${GITHUB_SHA}\`
+          - Workflow run: ${run_url}
+          - Artifact: \`prepared-joint-observation-self-hosted\`
+          - Physical evidence increment: \`0\`
+          EOF
+          )"
+          gh issue comment "${ISSUE_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --body "${body}"

--- a/docs/prepared_joint_observation.md
+++ b/docs/prepared_joint_observation.md
@@ -1,0 +1,114 @@
+# Prepared full-joint observation inference
+
+`causal4d.prepared_joint_observation` is an additive execution path for repeated
+full-joint updates over finite Causal4D support. The historical
+`causal4d.joint_observation` API remains unchanged.
+
+## Motivation
+
+The compatibility path now shares one base factorization across all rollout
+components inside a single update. Repeated updates with the same static Prob4D
+evidence still rebuild the sparse selections and covariance preparation on each
+call. Independent trajectory variance propagation also retains the historical
+quadratic term-pair scan. In addition, an additive dense covariance term must be
+positive definite by itself, although a covariance contribution may legitimately
+be singular and positive semidefinite.
+
+The prepared path addresses those remaining boundaries without changing the
+likelihood:
+
+- compile duplicate sparse trajectory selectors into one deterministic sparse
+  linear operator;
+- retain the exact static dense or block-diagonal solver across repeated calls;
+- retain its pre-whitened evidence-level low-rank factor;
+- score components in an explicit bounded-memory chunk size;
+- permit finite symmetric positive-semidefinite additive covariance terms;
+- require the final total covariance to remain positive definite; and
+- preserve exact zero prior support.
+
+## Usage
+
+```python
+from causal4d.prepared_joint_observation import (
+    posterior_weights_from_prepared_joint_observation,
+    prepare_joint_observation,
+)
+
+prepared = prepare_joint_observation(evidence)
+posterior, diagnostics = posterior_weights_from_prepared_joint_observation(
+    prior_weights,
+    predicted_components_m,
+    prepared,
+    prefix_frame_count=prefix_frame_count,
+    component_chunk_size=32,
+    maximum_working_bytes=256 * 1024**2,
+)
+```
+
+Preparation validates the existing `LinearJointObservationEvidence` object and
+stores its exact object identity. It does not reinterpret Prob4D reliability,
+association, factor-group, causal-prefix, frame-mapping, or entity-mapping
+semantics.
+
+## Positive-semidefinite additive covariance
+
+The base covariance remains strictly positive definite. An additive component
+covariance is instead checked for:
+
+- finite entries;
+- symmetry; and
+- nonnegative eigenvalues up to a scale-aware numerical tolerance.
+
+Rank-deficient covariance is therefore accepted. Negative directions are
+rejected even when the positive-definite base could numerically mask them. The
+sum is then processed by the existing Cholesky-based likelihood, so the final
+total covariance must still be positive definite.
+
+Low-rank positive-semidefinite terms should normally remain in factor form. The
+dense or block additive form is useful when an upstream component already owns
+a covariance representation and its rank is not known cheaply.
+
+## Memory boundary
+
+The scorer estimates component-local working memory before the first chunk is
+allocated. If one component cannot fit below `maximum_working_bytes`, it raises
+`MemoryError` before constructing the dynamic covariance. Otherwise it selects
+the minimum of:
+
+- the number of components;
+- the caller's optional `component_chunk_size`; and
+- the budget-derived chunk size.
+
+Diagnostics retain the selected chunk size, number of chunks, maximum budget,
+estimated peak working bytes, sparse selector count, operator nonzero count, and
+whether the static base factorization was reused.
+
+The estimate is an execution guard, not a universal process-RSS bound. NumPy,
+BLAS, SciPy, and the Python allocator may retain additional implementation
+memory.
+
+## Numerical parity
+
+Regression coverage compares the prepared and historical paths for:
+
+- dense and block-diagonal bases;
+- evidence-level and component-level low-rank factors;
+- chunked and unchunked scoring;
+- posterior normalization and exact zero support;
+- duplicate selector means and propagated covariance; and
+- direct full-covariance calculations with singular additive covariance.
+
+A dedicated self-hosted workflow exercises the installed wheel on `workstation2`
+with a 2,048-row, rank-7 structured observation and publishes numerical parity,
+chunking, and timing diagnostics. It is triggered only by an exact
+registered-maintainer issue on reviewed `main`; the self-hosted job has
+read-only repository permission and never consumes issue text as executable
+input.
+
+## Scientific boundary
+
+This module changes execution efficiency and the admissible representation of a
+mathematically valid covariance contribution. It does not change the registered
+18-session/36-execution estimator, acquisition candidate, six-frame information
+boundary, Prob4D used-or-unused declaration, target identity, calibration rule,
+scientific result, or physical evidence count.

--- a/docs/self_hosted_runner_security.md
+++ b/docs/self_hosted_runner_security.md
@@ -15,12 +15,16 @@ repository-wide policy test discovers self-hosted jobs directly from
 `.github/workflows/` and fails when a job is missing from the registry, a stale
 entry remains, or a registered job violates its authorization contract.
 
-The current repository uses one authorization model only: `main-only`.
-Introducing a protected exact-PR-head model requires a new registry schema,
-independent approval through a protected environment, hosted authorization of
-the exact PR/head pair, and separate positive and stale-head negative controls.
-Until that model is implemented, no pull-request source may be allocated a
-self-hosted runner.
+The repository has two reviewed-main authorization models:
+
+- `main-only` for manual `workflow_dispatch` from `refs/heads/main`; and
+- `maintainer-issue-main` for one exact registered-maintainer issue trigger
+  whose workflow is itself already present on reviewed `main`.
+
+Neither model permits pull-request source on a self-hosted runner. Introducing a
+protected exact-PR-head model still requires a new registry schema, independent
+approval through a protected environment, hosted authorization of the exact
+PR/head pair, and separate positive and stale-head negative controls.
 
 ## Main-only authorization
 
@@ -35,13 +39,37 @@ conditions hold:
    action;
 5. the job verifies `git rev-parse HEAD == GITHUB_SHA` and a clean work tree
    before installing or executing repository code;
-6. workflow permissions remain `contents: read`; and
-7. the job references no GitHub secret.
+6. workflow permissions default to `contents: read`; and
+7. the self-hosted job references no GitHub secret or write permission.
 
 Hybrid hosted/self-hosted jobs may continue to validate pull requests on hosted
 runners, but their job-level expression must make self-hosted selection imply a
 manual dispatch from `main`. The runtime preflight repeats that implication so a
 future expression regression fails before substantive work.
+
+## Exact maintainer-issue authorization
+
+`maintainer-issue-main` exists for connector-driven executions when the
+client cannot call GitHub's workflow-dispatch endpoint. It is deliberately
+narrower than a general issue-triggered job. The self-hosted job must require all
+of the following before runner allocation:
+
+1. the workflow listens only for newly opened issues;
+2. `github.ref == 'refs/heads/main'`;
+3. the issue login is exactly `FlorianPfaff`;
+4. the issue account ID is exactly `6773539`;
+5. the issue title equals the one registered literal trigger;
+6. no issue title, body, label, comment, or attachment enters a shell command,
+   path, package argument, test selector, or executable configuration;
+7. checkout, action pinning, exact-SHA verification, clean-tree verification,
+   permissions, and secret rules are identical to `main-only`; and
+8. the executed revision is the default-branch `GITHUB_SHA` selected by the
+   issue event, never a value supplied by the issue.
+
+A separate GitHub-hosted reporting job may receive `issues: write` solely to
+post the fixed workflow result, exact main SHA, run URL, and artifact name to the
+trigger issue. It does not check out or execute repository code. The
+self-hosted job remains read-only and secret-free.
 
 ## Runner-account isolation
 
@@ -91,10 +119,10 @@ and output hashes. Failed jobs retain their partial status artifacts when the
 workflow supports them. Temporary virtual environments and provider checkouts
 are removed in `always()` cleanup steps where practical.
 
-The policy test includes an accepted reviewed-main fixture and an unauthorized,
-stale-checkout fixture. The latter must fail the main guard, dispatch boundary,
-full action pin, credential persistence, exact-SHA checkout, and clean-tree
-checks.
+The policy test includes accepted fixtures for both authorization models and
+negative fixtures for unauthorized dispatch, broad issue execution, stale
+checkout, missing registered maintainer identity, missing exact title, unpinned
+actions, credential persistence, and absent clean-tree verification.
 
 ## Incident response
 

--- a/scripts/ci/benchmark_prepared_joint_observation.py
+++ b/scripts/ci/benchmark_prepared_joint_observation.py
@@ -104,9 +104,7 @@ def _diagnostics_payload(diagnostics: Any) -> dict[str, Any]:
         "operator_nonzero_count": diagnostics.operator_nonzero_count,
         "base_factorization_reused": diagnostics.base_factorization_reused,
         "maximum_working_bytes": diagnostics.maximum_working_bytes,
-        "estimated_peak_working_bytes": (
-            diagnostics.estimated_peak_working_bytes
-        ),
+        "estimated_peak_working_bytes": (diagnostics.estimated_peak_working_bytes),
     }
 
 
@@ -220,9 +218,7 @@ def main() -> None:
             "legacy_seconds": legacy_seconds,
             "prepared_seconds": prepared_seconds,
             "reported_speedup": (
-                None
-                if prepared_seconds == 0.0
-                else legacy_seconds / prepared_seconds
+                None if prepared_seconds == 0.0 else legacy_seconds / prepared_seconds
             ),
             "score_parity": parity,
             "maximum_absolute_score_difference": maximum_difference,

--- a/scripts/ci/benchmark_prepared_joint_observation.py
+++ b/scripts/ci/benchmark_prepared_joint_observation.py
@@ -1,0 +1,256 @@
+"""Benchmark prepared joint-observation inference with bounded memory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from time import perf_counter
+from typing import Any, Callable, TypeVar
+
+import numpy as np
+
+from causal4d.joint_observation import (
+    LinearJointObservationEvidence,
+    joint_component_log_likelihoods,
+)
+from causal4d.prepared_joint_observation import (
+    prepare_joint_observation,
+    prepared_joint_component_log_likelihoods,
+)
+
+
+_Result = TypeVar("_Result")
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--parity-rows", type=int, default=512)
+    parser.add_argument("--parity-components", type=int, default=16)
+    parser.add_argument("--scale-rows", type=int, default=2048)
+    parser.add_argument("--scale-components", type=int, default=16)
+    parser.add_argument("--rank", type=int, default=7)
+    parser.add_argument("--chunk-size", type=int, default=8)
+    parser.add_argument("--maximum-working-mib", type=int, default=512)
+    return parser.parse_args()
+
+
+def _positive(value: int, *, name: str) -> int:
+    if type(value) is not int or value < 1:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def _problem(
+    *,
+    row_count: int,
+    component_count: int,
+    rank: int,
+    seed: int,
+) -> tuple[LinearJointObservationEvidence, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    local_factor = rng.normal(scale=2.0e-3, size=(row_count, 3, 3))
+    local_covariance = np.einsum(
+        "rij,rkj->rik",
+        local_factor,
+        local_factor,
+    )
+    local_covariance += np.eye(3)[None, ...] * 4.0e-6
+    shared_factor = rng.normal(
+        scale=2.0e-4,
+        size=(3 * row_count, rank),
+    )
+    values = rng.normal(scale=1.0e-2, size=(row_count, 3))
+    evidence = LinearJointObservationEvidence(
+        evidence_id=f"prepared-self-hosted-{row_count}-rows-v1",
+        values_m=values.reshape(-1),
+        row_indices=np.arange(3 * row_count, dtype=np.int64),
+        frame_indices=np.ones(3 * row_count, dtype=np.int64),
+        node_indices=np.repeat(np.arange(row_count, dtype=np.int64), 3),
+        coordinate_indices=np.tile(np.arange(3, dtype=np.int64), row_count),
+        coefficients=np.ones(3 * row_count),
+        base_covariance_m2=local_covariance,
+        shared_covariance_factor_m=shared_factor,
+        source_id="synthetic-self-hosted-benchmark",
+        metadata={
+            "target_outcomes_used": False,
+            "benchmark_only": True,
+        },
+    )
+    components = np.zeros((component_count, 3, row_count, 3), dtype=float)
+    components[:, 1] = values + rng.normal(
+        scale=1.5e-3,
+        size=(component_count, row_count, 3),
+    )
+    components[:, 2] = components[:, 1]
+    return evidence, components
+
+
+def _timed(function: Callable[[], _Result]) -> tuple[_Result, float]:
+    start = perf_counter()
+    result = function()
+    return result, perf_counter() - start
+
+
+def _diagnostics_payload(diagnostics: Any) -> dict[str, Any]:
+    return {
+        "chunk_size_used": diagnostics.component_chunk_size,
+        "chunk_count": diagnostics.chunk_count,
+        "unique_selector_count": diagnostics.unique_selector_count,
+        "operator_nonzero_count": diagnostics.operator_nonzero_count,
+        "base_factorization_reused": diagnostics.base_factorization_reused,
+        "maximum_working_bytes": diagnostics.maximum_working_bytes,
+        "estimated_peak_working_bytes": (
+            diagnostics.estimated_peak_working_bytes
+        ),
+    }
+
+
+def main() -> None:
+    args = _arguments()
+    parity_rows = _positive(args.parity_rows, name="parity_rows")
+    parity_components = _positive(
+        args.parity_components,
+        name="parity_components",
+    )
+    scale_rows = _positive(args.scale_rows, name="scale_rows")
+    scale_components = _positive(
+        args.scale_components,
+        name="scale_components",
+    )
+    rank = _positive(args.rank, name="rank")
+    chunk_size = _positive(args.chunk_size, name="chunk_size")
+    maximum_working_mib = _positive(
+        args.maximum_working_mib,
+        name="maximum_working_mib",
+    )
+    maximum_working_bytes = maximum_working_mib * 1024**2
+
+    parity_evidence, parity_components_m = _problem(
+        row_count=parity_rows,
+        component_count=parity_components,
+        rank=rank,
+        seed=20260810,
+    )
+    parity_prepared, parity_prepare_seconds = _timed(
+        lambda: prepare_joint_observation(parity_evidence)
+    )
+    (legacy_score, _), legacy_seconds = _timed(
+        lambda: joint_component_log_likelihoods(
+            parity_components_m,
+            parity_evidence,
+            prefix_frame_count=2,
+        )
+    )
+    (prepared_result, parity_diagnostics), prepared_seconds = _timed(
+        lambda: prepared_joint_component_log_likelihoods(
+            parity_components_m,
+            parity_prepared,
+            prefix_frame_count=2,
+            component_chunk_size=chunk_size,
+            maximum_working_bytes=maximum_working_bytes,
+        )
+    )
+    maximum_difference = float(np.max(np.abs(legacy_score - prepared_result)))
+    parity = bool(
+        np.allclose(
+            legacy_score,
+            prepared_result,
+            rtol=1e-11,
+            atol=1e-11,
+        )
+    )
+    if not parity:
+        raise RuntimeError(
+            f"prepared/legacy score mismatch: maximum={maximum_difference}"
+        )
+
+    direction = np.array([1.0e-4, -2.0e-4, 0.5e-4])
+    additive_block = np.outer(direction, direction)
+    additive = np.broadcast_to(additive_block, (parity_rows, 3, 3))
+    psd_score, psd_diagnostics = prepared_joint_component_log_likelihoods(
+        parity_components_m[:2],
+        parity_prepared,
+        prefix_frame_count=2,
+        component_joint_covariance_m2=additive,
+        component_chunk_size=1,
+        maximum_working_bytes=maximum_working_bytes,
+    )
+    psd_accepted = bool(np.all(np.isfinite(psd_score)))
+    if not psd_accepted:
+        raise RuntimeError("rank-deficient positive-semidefinite update failed")
+
+    scale_evidence, scale_components_m = _problem(
+        row_count=scale_rows,
+        component_count=scale_components,
+        rank=rank,
+        seed=20260811,
+    )
+    scale_prepared, scale_prepare_seconds = _timed(
+        lambda: prepare_joint_observation(scale_evidence)
+    )
+    (scale_score, scale_diagnostics), scale_seconds = _timed(
+        lambda: prepared_joint_component_log_likelihoods(
+            scale_components_m,
+            scale_prepared,
+            prefix_frame_count=2,
+            component_chunk_size=chunk_size,
+            maximum_working_bytes=maximum_working_bytes,
+        )
+    )
+    scale_finite = bool(np.all(np.isfinite(scale_score)))
+    if not scale_finite:
+        raise RuntimeError("prepared scale benchmark produced a nonfinite score")
+
+    payload = {
+        "schema_version": 2,
+        "artifact_kind": "PreparedJointObservationSelfHostedBenchmark",
+        "shared_rank": rank,
+        "chunk_size_requested": chunk_size,
+        "maximum_working_bytes": maximum_working_bytes,
+        "parity": {
+            "row_count": parity_rows,
+            "observation_count": 3 * parity_rows,
+            "component_count": parity_components,
+            "prepare_seconds": parity_prepare_seconds,
+            "legacy_seconds": legacy_seconds,
+            "prepared_seconds": prepared_seconds,
+            "reported_speedup": (
+                None
+                if prepared_seconds == 0.0
+                else legacy_seconds / prepared_seconds
+            ),
+            "score_parity": parity,
+            "maximum_absolute_score_difference": maximum_difference,
+            "rank_deficient_psd_update_accepted": psd_accepted,
+            "psd_update_chunk_count": psd_diagnostics.chunk_count,
+            **_diagnostics_payload(parity_diagnostics),
+        },
+        "scale": {
+            "row_count": scale_rows,
+            "observation_count": 3 * scale_rows,
+            "component_count": scale_components,
+            "prepare_seconds": scale_prepare_seconds,
+            "prepared_seconds": scale_seconds,
+            "scores_finite": scale_finite,
+            **_diagnostics_payload(scale_diagnostics),
+        },
+        "target_outcomes_used": False,
+        "physical_evidence_increment": 0,
+        "claim_boundary": (
+            "Synthetic numerical and execution evidence only. This benchmark "
+            "does not change the frozen estimator, registered physical "
+            "protocol, scientific result, or physical evidence count."
+        ),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(payload, indent=2, sort_keys=True, allow_nan=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/benchmark_prepared_joint_observation.py
+++ b/scripts/ci/benchmark_prepared_joint_observation.py
@@ -78,7 +78,10 @@ def _problem(
             "benchmark_only": True,
         },
     )
-    components = np.zeros((component_count, 3, row_count, 3), dtype=float)
+    components: np.ndarray = np.zeros(
+        (component_count, 3, row_count, 3),
+        dtype=float,
+    )
     components[:, 1] = values + rng.normal(
         scale=1.5e-3,
         size=(component_count, row_count, 3),

--- a/src/causal4d/prepared_joint_observation.py
+++ b/src/causal4d/prepared_joint_observation.py
@@ -1,0 +1,666 @@
+"""Prepared, memory-bounded full-joint observation inference.
+
+The compatibility surface in :mod:`causal4d.joint_observation` shares a base
+factorization within one update. This additive module retains that exact solver
+across repeated updates, compiles the sparse rollout operator, accepts valid
+positive-semidefinite additive covariance, and scores finite support in bounded
+component chunks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import prod
+from typing import Any
+
+import numpy as np
+from scipy.sparse import csc_matrix
+
+import causal4d.joint_observation as _joint
+from causal4d.immutable_array import readonly_integer_array
+from causal4d.joint_observation import (
+    JointGaussianLikelihoodDiagnostics,
+    LinearJointObservationEvidence,
+)
+from causal4d.weighting import log_weights_from_probabilities
+
+
+_DEFAULT_MAXIMUM_WORKING_BYTES = 256 * 1024**2
+
+
+def _positive_integer(value: Any, *, name: str) -> int:
+    if type(value) is not int or value < 1:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def _readonly_sparse(matrix: csc_matrix) -> csc_matrix:
+    result = matrix.copy()
+    result.sum_duplicates()
+    result.sort_indices()
+    result.data.flags.writeable = False
+    result.indices.flags.writeable = False
+    result.indptr.flags.writeable = False
+    return result
+
+
+def _compiled_operator(
+    evidence: LinearJointObservationEvidence,
+) -> tuple[csc_matrix, np.ndarray, np.ndarray, np.ndarray]:
+    raw_selectors = tuple(
+        zip(
+            map(int, evidence.frame_indices),
+            map(int, evidence.node_indices),
+            map(int, evidence.coordinate_indices),
+        )
+    )
+    selectors = tuple(sorted(set(raw_selectors)))
+    selector_lookup = {selector: index for index, selector in enumerate(selectors)}
+    coefficients: dict[tuple[int, int], float] = {}
+    for term, selector in enumerate(raw_selectors):
+        key = (int(evidence.row_indices[term]), selector_lookup[selector])
+        coefficients[key] = coefficients.get(key, 0.0) + float(
+            evidence.coefficients[term]
+        )
+
+    entries = sorted(
+        (row, selector, coefficient)
+        for (row, selector), coefficient in coefficients.items()
+        if coefficient != 0.0
+    )
+    rows = np.asarray([entry[0] for entry in entries], dtype=np.int64)
+    columns = np.asarray([entry[1] for entry in entries], dtype=np.int64)
+    values = np.asarray([entry[2] for entry in entries], dtype=float)
+    operator = csc_matrix(
+        (values, (rows, columns)),
+        shape=(evidence.observation_count, len(selectors)),
+        dtype=float,
+    )
+    selector_array = np.asarray(selectors, dtype=np.int64)
+    return (
+        _readonly_sparse(operator),
+        readonly_integer_array(selector_array[:, 0], name="selector_frames"),
+        readonly_integer_array(selector_array[:, 1], name="selector_nodes"),
+        readonly_integer_array(
+            selector_array[:, 2],
+            name="selector_coordinates",
+        ),
+    )
+
+
+def _validated_factor(
+    values: np.ndarray,
+    *,
+    dimension: int,
+    leading_shape: tuple[int, ...],
+    name: str,
+) -> np.ndarray:
+    factor = np.asarray(values, dtype=float)
+    if factor.ndim < 2 or factor.shape[-2] != dimension:
+        raise ValueError(f"{name} must end in (observation, rank)")
+    if factor.shape[-1] < 1:
+        raise ValueError(f"{name} rank must be positive")
+    try:
+        factor = np.broadcast_to(
+            factor,
+            (*leading_shape, dimension, factor.shape[-1]),
+        )
+    except ValueError as error:
+        raise ValueError(
+            f"{name} must broadcast to component leading dimensions"
+        ) from error
+    if not np.all(np.isfinite(factor)):
+        raise ValueError(f"{name} must be finite")
+    return factor
+
+
+def _psd_tolerance(eigenvalues: np.ndarray) -> np.ndarray:
+    scale = np.max(np.abs(eigenvalues), axis=-1)
+    return 1e-12 + 1e-10 * scale
+
+
+def _validated_psd_dense(
+    values: np.ndarray,
+    *,
+    dimension: int,
+    leading_shape: tuple[int, ...],
+    name: str,
+) -> np.ndarray:
+    covariance = np.asarray(values, dtype=float)
+    try:
+        covariance = np.broadcast_to(
+            covariance,
+            (*leading_shape, dimension, dimension),
+        )
+    except ValueError as error:
+        raise ValueError(
+            f"{name} must broadcast to {leading_shape + (dimension, dimension)}"
+        ) from error
+    if not np.all(np.isfinite(covariance)):
+        raise ValueError(f"{name} must be finite")
+    if not np.allclose(
+        covariance,
+        covariance.swapaxes(-1, -2),
+        atol=1e-12,
+        rtol=1e-10,
+    ):
+        raise ValueError(f"{name} must be symmetric")
+    eigenvalues = np.linalg.eigvalsh(covariance)
+    if np.any(np.min(eigenvalues, axis=-1) < -_psd_tolerance(eigenvalues)):
+        raise ValueError(f"{name} must be positive semidefinite")
+    return covariance
+
+
+def _validated_psd_blocks(
+    values: np.ndarray,
+    *,
+    block_count: int,
+    block_size: int,
+    leading_shape: tuple[int, ...],
+    name: str,
+) -> np.ndarray:
+    covariance = np.asarray(values, dtype=float)
+    try:
+        covariance = np.broadcast_to(
+            covariance,
+            (*leading_shape, block_count, block_size, block_size),
+        )
+    except ValueError as error:
+        raise ValueError(
+            f"{name} must broadcast to component covariance blocks"
+        ) from error
+    if not np.all(np.isfinite(covariance)):
+        raise ValueError(f"{name} must be finite")
+    if not np.allclose(
+        covariance,
+        covariance.swapaxes(-1, -2),
+        atol=1e-12,
+        rtol=1e-10,
+    ):
+        raise ValueError(f"{name} must be symmetric")
+    eigenvalues = np.linalg.eigvalsh(covariance)
+    if np.any(np.min(eigenvalues, axis=-1) < -_psd_tolerance(eigenvalues)):
+        raise ValueError(f"{name} must be positive semidefinite")
+    return covariance
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedJointGaussianLikelihoodDiagnostics:
+    """Execution details for a prepared full-joint update."""
+
+    joint: JointGaussianLikelihoodDiagnostics
+    component_count: int
+    component_chunk_size: int
+    chunk_count: int
+    unique_selector_count: int
+    operator_nonzero_count: int
+    base_factorization_reused: bool
+    maximum_working_bytes: int
+    estimated_peak_working_bytes: int
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedJointObservation:
+    """Compiled sparse operator and reusable exact covariance solver."""
+
+    evidence: LinearJointObservationEvidence
+    operator: csc_matrix
+    selector_frames: np.ndarray
+    selector_nodes: np.ndarray
+    selector_coordinates: np.ndarray
+    base_solver: Any
+
+    @property
+    def unique_selector_count(self) -> int:
+        return len(self.selector_frames)
+
+    @property
+    def operator_nonzero_count(self) -> int:
+        return int(self.operator.nnz)
+
+    def validate_rollout(
+        self,
+        trajectories_m: np.ndarray,
+        *,
+        prefix_frame_count: int,
+    ) -> np.ndarray:
+        trajectories = np.asarray(trajectories_m, dtype=float)
+        if trajectories.ndim < 4:
+            raise ValueError(
+                "predicted_components_m must end in (frame, node, coordinate)"
+            )
+        if not np.all(np.isfinite(trajectories)):
+            raise ValueError("predicted components must be finite")
+        self.evidence.validate_prefix(
+            prefix_frame_count=prefix_frame_count,
+            rollout_shape=trajectories.shape[-3:],
+        )
+        return trajectories
+
+    def apply(self, trajectories_m: np.ndarray) -> np.ndarray:
+        trajectories = np.asarray(trajectories_m, dtype=float)
+        if trajectories.ndim < 3:
+            raise ValueError("trajectories_m must end in (frame, node, coordinate)")
+        selected = trajectories[
+            ...,
+            self.selector_frames,
+            self.selector_nodes,
+            self.selector_coordinates,
+        ]
+        leading_shape = selected.shape[:-1]
+        flattened = selected.reshape(-1, self.unique_selector_count)
+        output = np.asarray(self.operator @ flattened.T, dtype=float).T
+        return output.reshape(*leading_shape, self.evidence.observation_count)
+
+    def _selected_variance(self, variance_m2: np.ndarray) -> np.ndarray:
+        variance = np.asarray(variance_m2, dtype=float)
+        if variance.ndim < 3:
+            raise ValueError("variance_m2 must end in (frame, node, coordinate)")
+        if not np.all(np.isfinite(variance)) or np.any(variance < 0.0):
+            raise ValueError("component variances must be finite and nonnegative")
+        return variance[
+            ...,
+            self.selector_frames,
+            self.selector_nodes,
+            self.selector_coordinates,
+        ]
+
+    def apply_independent_covariance(
+        self,
+        variance_m2: np.ndarray,
+    ) -> np.ndarray:
+        selected = self._selected_variance(variance_m2)
+        leading_shape = selected.shape[:-1]
+        flattened = selected.reshape(-1, self.unique_selector_count)
+        dimension = self.evidence.observation_count
+        output = np.zeros((len(flattened), dimension, dimension), dtype=float)
+        for selector in range(self.unique_selector_count):
+            start = int(self.operator.indptr[selector])
+            stop = int(self.operator.indptr[selector + 1])
+            rows = self.operator.indices[start:stop]
+            coefficients = self.operator.data[start:stop]
+            if not len(rows):
+                continue
+            outer = coefficients[:, None] * coefficients[None, :]
+            output[:, rows[:, None], rows[None, :]] += (
+                flattened[:, selector, None, None] * outer
+            )
+        return output.reshape(*leading_shape, dimension, dimension)
+
+    def apply_independent_covariance_blocks(
+        self,
+        variance_m2: np.ndarray,
+    ) -> np.ndarray:
+        if self.evidence.base_covariance_representation != "block_diagonal":
+            raise ValueError("block covariance propagation requires block evidence")
+        selected = self._selected_variance(variance_m2)
+        leading_shape = selected.shape[:-1]
+        flattened = selected.reshape(-1, self.unique_selector_count)
+        block_count = self.evidence.base_block_count
+        block_size = self.evidence.base_block_size
+        output = np.zeros(
+            (len(flattened), block_count, block_size, block_size),
+            dtype=float,
+        )
+        for selector in range(self.unique_selector_count):
+            start = int(self.operator.indptr[selector])
+            stop = int(self.operator.indptr[selector + 1])
+            rows = self.operator.indices[start:stop]
+            coefficients = self.operator.data[start:stop]
+            if not len(rows):
+                continue
+            blocks = rows // block_size
+            if np.any(blocks != blocks[0]):
+                raise ValueError(
+                    "independent component variance induces off-block "
+                    "covariance; use dense base covariance"
+                )
+            coordinates = rows % block_size
+            outer = coefficients[:, None] * coefficients[None, :]
+            output[
+                :,
+                int(blocks[0]),
+                coordinates[:, None],
+                coordinates[None, :],
+            ] += flattened[:, selector, None, None] * outer
+        return output.reshape(
+            *leading_shape,
+            block_count,
+            block_size,
+            block_size,
+        )
+
+
+def prepare_joint_observation(
+    evidence: LinearJointObservationEvidence,
+) -> PreparedJointObservation:
+    """Compile one immutable joint observation for repeated finite-support use."""
+
+    if not isinstance(evidence, LinearJointObservationEvidence):
+        raise TypeError("evidence must be LinearJointObservationEvidence")
+    operator, frames, nodes, coordinates = _compiled_operator(evidence)
+    solver = _joint._prepare_joint_gaussian_base_solver(
+        evidence,
+        precompute_shared_low_rank=True,
+    )
+    return PreparedJointObservation(
+        evidence=evidence,
+        operator=operator,
+        selector_frames=frames,
+        selector_nodes=nodes,
+        selector_coordinates=coordinates,
+        base_solver=solver,
+    )
+
+
+def _estimate_per_component_bytes(
+    prepared: PreparedJointObservation,
+    *,
+    dynamic_base: bool,
+    component_rank: int,
+) -> int:
+    dimension = prepared.evidence.observation_count
+    evidence_rank = prepared.evidence.shared_rank
+    total_rank = evidence_rank + component_rank
+    estimate = 3 * dimension * np.dtype(float).itemsize
+    if total_rank:
+        estimate += 2 * total_rank * dimension * np.dtype(float).itemsize
+        estimate += 3 * total_rank**2 * np.dtype(float).itemsize
+    if dynamic_base:
+        if prepared.evidence.base_covariance_representation == "dense":
+            covariance_values = dimension * dimension
+        else:
+            covariance_values = (
+                prepared.evidence.base_block_count
+                * prepared.evidence.base_block_size**2
+            )
+        estimate += 3 * covariance_values * np.dtype(float).itemsize
+    return max(estimate, 1)
+
+
+def _resolved_chunk_size(
+    component_count: int,
+    *,
+    estimated_per_component_bytes: int,
+    maximum_working_bytes: int,
+    component_chunk_size: int | None,
+) -> int:
+    budget = _positive_integer(
+        maximum_working_bytes,
+        name="maximum_working_bytes",
+    )
+    if estimated_per_component_bytes > budget:
+        raise MemoryError(
+            "one prepared joint-observation component exceeds "
+            "maximum_working_bytes"
+        )
+    budget_chunk = max(1, budget // estimated_per_component_bytes)
+    if component_chunk_size is None:
+        requested = component_count
+    else:
+        requested = _positive_integer(
+            component_chunk_size,
+            name="component_chunk_size",
+        )
+    return min(component_count, requested, budget_chunk)
+
+
+def prepared_joint_component_log_likelihoods(
+    predicted_components_m: np.ndarray,
+    prepared: PreparedJointObservation,
+    *,
+    prefix_frame_count: int,
+    component_independent_variance_m2: np.ndarray | None = None,
+    component_joint_covariance_m2: np.ndarray | None = None,
+    component_joint_covariance_factor_m: np.ndarray | None = None,
+    component_chunk_size: int | None = None,
+    maximum_working_bytes: int = _DEFAULT_MAXIMUM_WORKING_BYTES,
+) -> tuple[np.ndarray, PreparedJointGaussianLikelihoodDiagnostics]:
+    """Score finite support with cached static factors and bounded chunks."""
+
+    if not isinstance(prepared, PreparedJointObservation):
+        raise TypeError("prepared must be PreparedJointObservation")
+    components = prepared.validate_rollout(
+        predicted_components_m,
+        prefix_frame_count=prefix_frame_count,
+    )
+    leading_shape = components.shape[:-3]
+    component_count = prod(leading_shape)
+    if component_count < 1:
+        raise ValueError("predicted_components_m must contain a component")
+    flattened_components = components.reshape(
+        component_count,
+        *components.shape[-3:],
+    )
+    dimension = prepared.evidence.observation_count
+
+    variance = None
+    if component_independent_variance_m2 is not None:
+        try:
+            variance = np.broadcast_to(
+                np.asarray(component_independent_variance_m2, dtype=float),
+                components.shape,
+            ).reshape(component_count, *components.shape[-3:])
+        except ValueError as error:
+            raise ValueError(
+                "component_independent_variance_m2 must broadcast to components"
+            ) from error
+
+    component_covariance = None
+    if component_joint_covariance_m2 is not None:
+        source = np.asarray(component_joint_covariance_m2, dtype=float)
+        if prepared.evidence.base_covariance_representation == "dense":
+            target = (*leading_shape, dimension, dimension)
+        else:
+            target = (
+                *leading_shape,
+                prepared.evidence.base_block_count,
+                prepared.evidence.base_block_size,
+                prepared.evidence.base_block_size,
+            )
+        trailing_shape = target[len(leading_shape) :]
+        try:
+            component_covariance = np.broadcast_to(source, target).reshape(
+                component_count,
+                *trailing_shape,
+            )
+        except ValueError as error:
+            raise ValueError(
+                "component_joint_covariance_m2 must broadcast to components"
+            ) from error
+
+    component_factor = None
+    component_rank = 0
+    if component_joint_covariance_factor_m is not None:
+        component_factor = _validated_factor(
+            component_joint_covariance_factor_m,
+            dimension=dimension,
+            leading_shape=leading_shape,
+            name="component_joint_covariance_factor_m",
+        )
+        component_rank = component_factor.shape[-1]
+        component_factor = component_factor.reshape(
+            component_count,
+            dimension,
+            component_rank,
+        )
+
+    dynamic_base = variance is not None or component_covariance is not None
+    per_component_bytes = _estimate_per_component_bytes(
+        prepared,
+        dynamic_base=dynamic_base,
+        component_rank=component_rank,
+    )
+    chunk_size = _resolved_chunk_size(
+        component_count,
+        estimated_per_component_bytes=per_component_bytes,
+        maximum_working_bytes=maximum_working_bytes,
+        component_chunk_size=component_chunk_size,
+    )
+    scores = np.empty(component_count, dtype=float)
+
+    for start in range(0, component_count, chunk_size):
+        stop = min(component_count, start + chunk_size)
+        component_chunk = flattened_components[start:stop]
+        residual = prepared.apply(component_chunk) - prepared.evidence.values_m
+        factor_chunk = (
+            None if component_factor is None else component_factor[start:stop]
+        )
+
+        if not dynamic_base:
+            scores[start:stop] = prepared.base_solver.log_density(
+                residual,
+                component_covariance_factor_m=factor_chunk,
+            )
+            continue
+
+        if prepared.evidence.base_covariance_representation == "dense":
+            base = np.broadcast_to(
+                prepared.evidence.base_covariance_m2,
+                (stop - start, dimension, dimension),
+            ).copy()
+            if variance is not None:
+                base += prepared.apply_independent_covariance(variance[start:stop])
+            if component_covariance is not None:
+                base += _validated_psd_dense(
+                    component_covariance[start:stop],
+                    dimension=dimension,
+                    leading_shape=(stop - start,),
+                    name="component_joint_covariance_m2",
+                )
+        else:
+            block_count = prepared.evidence.base_block_count
+            block_size = prepared.evidence.base_block_size
+            base = np.broadcast_to(
+                prepared.evidence.base_covariance_m2,
+                (stop - start, block_count, block_size, block_size),
+            ).copy()
+            if variance is not None:
+                base += prepared.apply_independent_covariance_blocks(
+                    variance[start:stop]
+                )
+            if component_covariance is not None:
+                base += _validated_psd_blocks(
+                    component_covariance[start:stop],
+                    block_count=block_count,
+                    block_size=block_size,
+                    leading_shape=(stop - start,),
+                    name="component_joint_covariance_m2",
+                )
+
+        factors: list[np.ndarray] = []
+        if prepared.evidence.shared_covariance_factor_m is not None:
+            factors.append(
+                np.broadcast_to(
+                    prepared.evidence.shared_covariance_factor_m,
+                    (
+                        stop - start,
+                        dimension,
+                        prepared.evidence.shared_rank,
+                    ),
+                )
+            )
+        if factor_chunk is not None:
+            factors.append(factor_chunk)
+        combined_factor = None if not factors else np.concatenate(factors, axis=-1)
+        if prepared.evidence.base_covariance_representation == "dense":
+            scores[start:stop] = _joint._joint_gaussian_log_density_dense(
+                residual,
+                base,
+                combined_factor,
+            )
+        else:
+            scores[start:stop] = _joint._joint_gaussian_log_density_blocks(
+                residual,
+                base,
+                combined_factor,
+            )
+
+    joint = JointGaussianLikelihoodDiagnostics(
+        observation_count=dimension,
+        base_covariance_representation=(
+            prepared.evidence.base_covariance_representation
+        ),
+        base_block_count=prepared.evidence.base_block_count,
+        base_block_size=prepared.evidence.base_block_size,
+        evidence_shared_rank=prepared.evidence.shared_rank,
+        component_shared_rank=component_rank,
+        used_component_independent_covariance=variance is not None,
+        used_component_covariance=component_covariance is not None,
+        used_low_rank_path=(
+            prepared.evidence.shared_covariance_factor_m is not None
+            or component_factor is not None
+        ),
+        used_shared_base_factorization=not dynamic_base,
+    )
+    diagnostics = PreparedJointGaussianLikelihoodDiagnostics(
+        joint=joint,
+        component_count=component_count,
+        component_chunk_size=chunk_size,
+        chunk_count=(component_count + chunk_size - 1) // chunk_size,
+        unique_selector_count=prepared.unique_selector_count,
+        operator_nonzero_count=prepared.operator_nonzero_count,
+        base_factorization_reused=not dynamic_base,
+        maximum_working_bytes=maximum_working_bytes,
+        estimated_peak_working_bytes=per_component_bytes * chunk_size,
+    )
+    return scores.reshape(leading_shape), diagnostics
+
+
+def posterior_weights_from_prepared_joint_observation(
+    prior_weights: np.ndarray,
+    predicted_components_m: np.ndarray,
+    prepared: PreparedJointObservation,
+    *,
+    prefix_frame_count: int,
+    component_independent_variance_m2: np.ndarray | None = None,
+    component_joint_covariance_m2: np.ndarray | None = None,
+    component_joint_covariance_factor_m: np.ndarray | None = None,
+    component_chunk_size: int | None = None,
+    maximum_working_bytes: int = _DEFAULT_MAXIMUM_WORKING_BYTES,
+) -> tuple[np.ndarray, PreparedJointGaussianLikelihoodDiagnostics]:
+    """Apply prepared joint evidence without recreating zero prior support."""
+
+    prior = np.asarray(prior_weights, dtype=float)
+    component_shape = np.asarray(predicted_components_m).shape[:-3]
+    if prior.shape != component_shape:
+        raise ValueError("prior_weights must match component leading dimensions")
+    if not np.isclose(np.sum(prior), 1.0):
+        raise ValueError("prior_weights must sum to one")
+    score, diagnostics = prepared_joint_component_log_likelihoods(
+        predicted_components_m,
+        prepared,
+        prefix_frame_count=prefix_frame_count,
+        component_independent_variance_m2=component_independent_variance_m2,
+        component_joint_covariance_m2=component_joint_covariance_m2,
+        component_joint_covariance_factor_m=component_joint_covariance_factor_m,
+        component_chunk_size=component_chunk_size,
+        maximum_working_bytes=maximum_working_bytes,
+    )
+    log_posterior = log_weights_from_probabilities(
+        prior,
+        name="prior_weights",
+    ) + score
+    finite_support = prior > 0.0
+    if not np.all(np.isfinite(log_posterior[finite_support])):
+        raise ValueError("prepared posterior log likelihood must be finite on support")
+    maximum = float(np.max(log_posterior[finite_support]))
+    posterior = np.exp(log_posterior - maximum)
+    normalizer = float(np.sum(posterior))
+    if not np.isfinite(normalizer) or normalizer <= 0.0:
+        raise ValueError(
+            "prepared posterior normalizer must be finite and positive"
+        )
+    posterior /= normalizer
+    if not np.all(np.isfinite(posterior)):
+        raise ValueError("prepared posterior weights must be finite")
+    return posterior, diagnostics
+
+
+__all__ = [
+    "PreparedJointGaussianLikelihoodDiagnostics",
+    "PreparedJointObservation",
+    "posterior_weights_from_prepared_joint_observation",
+    "prepare_joint_observation",
+    "prepared_joint_component_log_likelihoods",
+]

--- a/src/causal4d/prepared_joint_observation.py
+++ b/src/causal4d/prepared_joint_observation.py
@@ -391,8 +391,7 @@ def _resolved_chunk_size(
     )
     if estimated_per_component_bytes > budget:
         raise MemoryError(
-            "one prepared joint-observation component exceeds "
-            "maximum_working_bytes"
+            "one prepared joint-observation component exceeds maximum_working_bytes"
         )
     budget_chunk = max(1, budget // estimated_per_component_bytes)
     if component_chunk_size is None:
@@ -637,10 +636,13 @@ def posterior_weights_from_prepared_joint_observation(
         component_chunk_size=component_chunk_size,
         maximum_working_bytes=maximum_working_bytes,
     )
-    log_posterior = log_weights_from_probabilities(
-        prior,
-        name="prior_weights",
-    ) + score
+    log_posterior = (
+        log_weights_from_probabilities(
+            prior,
+            name="prior_weights",
+        )
+        + score
+    )
     finite_support = prior > 0.0
     if not np.all(np.isfinite(log_posterior[finite_support])):
         raise ValueError("prepared posterior log likelihood must be finite on support")
@@ -648,9 +650,7 @@ def posterior_weights_from_prepared_joint_observation(
     posterior = np.exp(log_posterior - maximum)
     normalizer = float(np.sum(posterior))
     if not np.isfinite(normalizer) or normalizer <= 0.0:
-        raise ValueError(
-            "prepared posterior normalizer must be finite and positive"
-        )
+        raise ValueError("prepared posterior normalizer must be finite and positive")
     posterior /= normalizer
     if not np.all(np.isfinite(posterior)):
         raise ValueError("prepared posterior weights must be finite")

--- a/src/causal4d/prepared_joint_observation.py
+++ b/src/causal4d/prepared_joint_observation.py
@@ -17,7 +17,7 @@ import numpy as np
 from scipy.sparse import csc_matrix
 
 import causal4d.joint_observation as _joint
-from causal4d.immutable_array import readonly_integer_array
+from causal4d.immutable_array import readonly_array, readonly_integer_array
 from causal4d.joint_observation import (
     JointGaussianLikelihoodDiagnostics,
     LinearJointObservationEvidence,
@@ -38,9 +38,9 @@ def _readonly_sparse(matrix: csc_matrix) -> csc_matrix:
     result = matrix.copy()
     result.sum_duplicates()
     result.sort_indices()
-    result.data.flags.writeable = False
-    result.indices.flags.writeable = False
-    result.indptr.flags.writeable = False
+    result.data = readonly_array(result.data, dtype=float)
+    result.indices = readonly_array(result.indices, dtype=result.indices.dtype)
+    result.indptr = readonly_array(result.indptr, dtype=result.indptr.dtype)
     return result
 
 

--- a/tests/test_prepared_joint_observation.py
+++ b/tests/test_prepared_joint_observation.py
@@ -68,9 +68,7 @@ def _direct_score(residual: np.ndarray, covariance: np.ndarray) -> np.ndarray:
 
 
 def test_prepared_dense_scores_and_posterior_match_legacy() -> None:
-    evidence = _dense_evidence(
-        factor=np.array([[0.05], [0.02], [-0.01]])
-    )
+    evidence = _dense_evidence(factor=np.array([[0.05], [0.02], [-0.01]]))
     prepared = prepare_joint_observation(evidence)
     components = _components()
     prior = np.array([0.1, 0.2, 0.3, 0.4])
@@ -114,9 +112,7 @@ def test_prepared_dense_scores_and_posterior_match_legacy() -> None:
 
 
 def test_prepared_block_scores_match_legacy() -> None:
-    dense = _dense_evidence(
-        factor=np.array([[0.05], [0.02], [-0.01]])
-    )
+    dense = _dense_evidence(factor=np.array([[0.05], [0.02], [-0.01]]))
     blocks = np.stack(
         (
             dense.base_covariance_m2[:1, :1],
@@ -145,9 +141,7 @@ def test_prepared_block_scores_match_legacy() -> None:
 
 
 def test_rank_deficient_additive_covariance_is_valid() -> None:
-    evidence = _dense_evidence(
-        factor=np.array([[0.05], [0.02], [-0.01]])
-    )
+    evidence = _dense_evidence(factor=np.array([[0.05], [0.02], [-0.01]]))
     prepared = prepare_joint_observation(evidence)
     direction = np.array([0.02, -0.01, 0.03])
     additive = np.outer(direction, direction)
@@ -218,9 +212,7 @@ def test_prepared_operator_combines_duplicate_selectors() -> None:
 
 
 def test_component_low_rank_factor_uses_cached_base() -> None:
-    evidence = _dense_evidence(
-        factor=np.array([[0.05], [0.02], [-0.01]])
-    )
+    evidence = _dense_evidence(factor=np.array([[0.05], [0.02], [-0.01]]))
     prepared = prepare_joint_observation(evidence)
     component_factor = np.broadcast_to(
         np.array([[0.01], [-0.02], [0.015]]),

--- a/tests/test_prepared_joint_observation.py
+++ b/tests/test_prepared_joint_observation.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from causal4d.joint_observation import (
+    LinearJointObservationEvidence,
+    joint_component_log_likelihoods,
+    posterior_weights_from_joint_observation,
+)
+from causal4d.prepared_joint_observation import (
+    posterior_weights_from_prepared_joint_observation,
+    prepare_joint_observation,
+    prepared_joint_component_log_likelihoods,
+)
+
+
+def _dense_evidence(
+    *,
+    factor: np.ndarray | None = None,
+) -> LinearJointObservationEvidence:
+    return LinearJointObservationEvidence(
+        evidence_id="prepared-dense",
+        values_m=np.array([0.1, -0.2, 0.05]),
+        row_indices=np.array([0, 1, 2]),
+        frame_indices=np.array([1, 1, 2]),
+        node_indices=np.array([0, 1, 0]),
+        coordinate_indices=np.array([0, 0, 1]),
+        coefficients=np.ones(3),
+        base_covariance_m2=np.array(
+            [
+                [0.04, 0.01, 0.0],
+                [0.01, 0.09, 0.015],
+                [0.0, 0.015, 0.06],
+            ]
+        ),
+        shared_covariance_factor_m=factor,
+        source_id="prob4d",
+    )
+
+
+def _components() -> np.ndarray:
+    values = np.zeros((4, 3, 2, 2), dtype=float)
+    values[0, 1, 0, 0] = 0.12
+    values[0, 1, 1, 0] = -0.18
+    values[0, 2, 0, 1] = 0.04
+    values[1, 1, 0, 0] = -0.05
+    values[1, 1, 1, 0] = -0.25
+    values[1, 2, 0, 1] = 0.2
+    values[2, 1, 0, 0] = 0.3
+    values[2, 1, 1, 0] = 0.1
+    values[2, 2, 0, 1] = -0.1
+    values[3, 1, 0, 0] = 0.1
+    values[3, 1, 1, 0] = -0.2
+    values[3, 2, 0, 1] = 0.05
+    return values
+
+
+def _direct_score(residual: np.ndarray, covariance: np.ndarray) -> np.ndarray:
+    sign, logdet = np.linalg.slogdet(covariance)
+    assert np.all(sign > 0.0)
+    solved = np.linalg.solve(covariance, residual[..., None])[..., 0]
+    quadratic = np.einsum("...i,...i->...", residual, solved)
+    dimension = residual.shape[-1]
+    return -0.5 * (dimension * np.log(2.0 * np.pi) + logdet + quadratic)
+
+
+def test_prepared_dense_scores_and_posterior_match_legacy() -> None:
+    evidence = _dense_evidence(
+        factor=np.array([[0.05], [0.02], [-0.01]])
+    )
+    prepared = prepare_joint_observation(evidence)
+    components = _components()
+    prior = np.array([0.1, 0.2, 0.3, 0.4])
+
+    legacy_score, _ = joint_component_log_likelihoods(
+        components,
+        evidence,
+        prefix_frame_count=3,
+    )
+    score, diagnostics = prepared_joint_component_log_likelihoods(
+        components,
+        prepared,
+        prefix_frame_count=3,
+        component_chunk_size=2,
+    )
+    legacy_posterior, _ = posterior_weights_from_joint_observation(
+        prior,
+        components,
+        evidence,
+        prefix_frame_count=3,
+    )
+    posterior, _ = posterior_weights_from_prepared_joint_observation(
+        prior,
+        components,
+        prepared,
+        prefix_frame_count=3,
+        component_chunk_size=2,
+    )
+
+    np.testing.assert_allclose(score, legacy_score, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(
+        posterior,
+        legacy_posterior,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+    assert diagnostics.base_factorization_reused is True
+    assert diagnostics.joint.used_shared_base_factorization is True
+    assert diagnostics.component_chunk_size == 2
+    assert diagnostics.chunk_count == 2
+
+
+def test_prepared_block_scores_match_legacy() -> None:
+    dense = _dense_evidence(
+        factor=np.array([[0.05], [0.02], [-0.01]])
+    )
+    blocks = np.stack(
+        (
+            dense.base_covariance_m2[:1, :1],
+            dense.base_covariance_m2[1:2, 1:2],
+            dense.base_covariance_m2[2:3, 2:3],
+        )
+    )
+    evidence = replace(dense, base_covariance_m2=blocks)
+    prepared = prepare_joint_observation(evidence)
+
+    legacy_score, _ = joint_component_log_likelihoods(
+        _components(),
+        evidence,
+        prefix_frame_count=3,
+    )
+    score, diagnostics = prepared_joint_component_log_likelihoods(
+        _components(),
+        prepared,
+        prefix_frame_count=3,
+        component_chunk_size=3,
+    )
+
+    np.testing.assert_allclose(score, legacy_score, rtol=1e-12, atol=1e-12)
+    assert diagnostics.joint.base_covariance_representation == "block_diagonal"
+    assert diagnostics.base_factorization_reused is True
+
+
+def test_rank_deficient_additive_covariance_is_valid() -> None:
+    evidence = _dense_evidence(
+        factor=np.array([[0.05], [0.02], [-0.01]])
+    )
+    prepared = prepare_joint_observation(evidence)
+    direction = np.array([0.02, -0.01, 0.03])
+    additive = np.outer(direction, direction)
+
+    score, diagnostics = prepared_joint_component_log_likelihoods(
+        _components(),
+        prepared,
+        prefix_frame_count=3,
+        component_joint_covariance_m2=additive,
+        component_chunk_size=2,
+    )
+    residual = evidence.apply(_components()) - evidence.values_m
+    factor = evidence.shared_covariance_factor_m
+    assert factor is not None
+    covariance = evidence.base_covariance_m2 + additive + factor @ factor.T
+    expected = _direct_score(
+        residual,
+        np.broadcast_to(covariance, (len(residual), 3, 3)),
+    )
+
+    np.testing.assert_allclose(score, expected, rtol=1e-12, atol=1e-12)
+    assert diagnostics.joint.used_component_covariance is True
+    assert diagnostics.base_factorization_reused is False
+
+
+def test_indefinite_additive_covariance_fails_closed() -> None:
+    prepared = prepare_joint_observation(_dense_evidence())
+    indefinite = np.diag([0.01, -0.001, 0.02])
+
+    with pytest.raises(ValueError, match="positive semidefinite"):
+        prepared_joint_component_log_likelihoods(
+            _components(),
+            prepared,
+            prefix_frame_count=3,
+            component_joint_covariance_m2=indefinite,
+        )
+
+
+def test_prepared_operator_combines_duplicate_selectors() -> None:
+    evidence = LinearJointObservationEvidence(
+        evidence_id="prepared-duplicates",
+        values_m=np.zeros(2),
+        row_indices=np.array([0, 0, 1, 1]),
+        frame_indices=np.array([1, 1, 1, 2]),
+        node_indices=np.array([0, 0, 0, 0]),
+        coordinate_indices=np.array([0, 0, 0, 1]),
+        coefficients=np.array([1.0, 2.0, -3.0, 1.0]),
+        base_covariance_m2=np.eye(2),
+    )
+    prepared = prepare_joint_observation(evidence)
+    trajectories = np.zeros((3, 3, 1, 2))
+    trajectories[:, 1, 0, 0] = np.array([0.2, -0.1, 0.4])
+    trajectories[:, 2, 0, 1] = np.array([0.5, 0.3, -0.2])
+    variance = np.zeros_like(trajectories)
+    variance[:, 1, 0, 0] = np.array([0.1, 0.2, 0.3])
+    variance[:, 2, 0, 1] = 0.4
+
+    np.testing.assert_allclose(
+        prepared.apply(trajectories),
+        evidence.apply(trajectories),
+    )
+    np.testing.assert_allclose(
+        prepared.apply_independent_covariance(variance),
+        evidence.apply_independent_covariance(variance),
+    )
+    assert prepared.unique_selector_count == 2
+    assert prepared.operator_nonzero_count == 3
+
+
+def test_component_low_rank_factor_uses_cached_base() -> None:
+    evidence = _dense_evidence(
+        factor=np.array([[0.05], [0.02], [-0.01]])
+    )
+    prepared = prepare_joint_observation(evidence)
+    component_factor = np.broadcast_to(
+        np.array([[0.01], [-0.02], [0.015]]),
+        (4, 3, 1),
+    )
+
+    legacy_score, _ = joint_component_log_likelihoods(
+        _components(),
+        evidence,
+        prefix_frame_count=3,
+        component_joint_covariance_factor_m=component_factor,
+    )
+    score, diagnostics = prepared_joint_component_log_likelihoods(
+        _components(),
+        prepared,
+        prefix_frame_count=3,
+        component_joint_covariance_factor_m=component_factor,
+        component_chunk_size=2,
+    )
+
+    np.testing.assert_allclose(score, legacy_score, rtol=1e-12, atol=1e-12)
+    assert diagnostics.base_factorization_reused is True
+    assert diagnostics.joint.component_shared_rank == 1
+
+
+def test_static_scoring_does_not_refactor_base(monkeypatch) -> None:
+    prepared = prepare_joint_observation(
+        _dense_evidence(factor=np.array([[0.05], [0.02], [-0.01]]))
+    )
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("static base was factorized again")
+
+    monkeypatch.setattr(np.linalg, "cholesky", forbidden)
+    score, diagnostics = prepared_joint_component_log_likelihoods(
+        _components(),
+        prepared,
+        prefix_frame_count=3,
+        component_chunk_size=2,
+    )
+
+    assert np.all(np.isfinite(score))
+    assert diagnostics.base_factorization_reused is True
+
+
+def test_dense_dynamic_path_respects_preallocation_budget() -> None:
+    dimension = 24
+    evidence = LinearJointObservationEvidence(
+        evidence_id="prepared-budget",
+        values_m=np.zeros(dimension),
+        row_indices=np.arange(dimension),
+        frame_indices=np.ones(dimension, dtype=np.int64),
+        node_indices=np.arange(dimension, dtype=np.int64),
+        coordinate_indices=np.zeros(dimension, dtype=np.int64),
+        coefficients=np.ones(dimension),
+        base_covariance_m2=np.eye(dimension),
+    )
+    prepared = prepare_joint_observation(evidence)
+    components = np.zeros((2, 2, dimension, 1))
+
+    with pytest.raises(MemoryError, match="maximum_working_bytes"):
+        prepared_joint_component_log_likelihoods(
+            components,
+            prepared,
+            prefix_frame_count=2,
+            component_joint_covariance_m2=np.zeros((dimension, dimension)),
+            maximum_working_bytes=1024,
+        )
+
+
+def test_prepared_posterior_preserves_zero_support() -> None:
+    prepared = prepare_joint_observation(_dense_evidence())
+    posterior, _ = posterior_weights_from_prepared_joint_observation(
+        np.array([0.5, 0.0, 0.5, 0.0]),
+        _components(),
+        prepared,
+        prefix_frame_count=3,
+        component_chunk_size=2,
+    )
+
+    assert posterior[1] == 0.0
+    assert posterior[3] == 0.0

--- a/tests/test_self_hosted_workflow_policy.py
+++ b/tests/test_self_hosted_workflow_policy.py
@@ -173,8 +173,7 @@ def _maintainer_issue_main_errors(workflow_text: str, block: str) -> list[str]:
     ):
         if forbidden in block:
             errors.append(
-                "untrusted issue payload reaches self-hosted job: "
-                f"{forbidden}"
+                f"untrusted issue payload reaches self-hosted job: {forbidden}"
             )
     if not _issue_only_workflow(workflow_text):
         errors.append("workflow is not issue-only")
@@ -223,11 +222,14 @@ def test_every_self_hosted_job_is_exact_sha_and_secret_free() -> None:
         assert "pull-requests: write" not in block
         for label in entry["runner_labels"]:
             assert label in block
-        assert _authorization_errors(
-            entry["authorization_model"],
-            workflow_text,
-            block,
-        ) == [], key
+        assert (
+            _authorization_errors(
+                entry["authorization_model"],
+                workflow_text,
+                block,
+            )
+            == []
+        ), key
 
 
 def test_runner_discovery_ignores_hosted_jobs_that_only_mention_self_hosted() -> None:

--- a/tests/test_self_hosted_workflow_policy.py
+++ b/tests/test_self_hosted_workflow_policy.py
@@ -71,26 +71,37 @@ def _discover_self_hosted_jobs() -> dict[tuple[str, str], tuple[str, str]]:
     return discovered
 
 
-def _dispatch_only_workflow(text: str) -> bool:
+def _single_event_workflow(text: str, event: str) -> bool:
     prefix = text.split("permissions:", maxsplit=1)[0]
-    if re.search(r"^  workflow_dispatch:\s*$", prefix, re.MULTILINE) is None:
+    if re.search(rf"^  {event}:\s*$", prefix, re.MULTILINE) is None:
         return False
-    other_events = ("pull_request", "push", "schedule", "workflow_call")
+    other_events = (
+        "issues",
+        "pull_request",
+        "push",
+        "schedule",
+        "workflow_call",
+        "workflow_dispatch",
+    )
     return all(
-        re.search(rf"^  {event}:\s*$", prefix, re.MULTILINE) is None
-        for event in other_events
+        candidate == event
+        or re.search(rf"^  {candidate}:\s*$", prefix, re.MULTILINE) is None
+        for candidate in other_events
     )
 
 
-def _main_only_errors(workflow_text: str, block: str) -> list[str]:
+def _dispatch_only_workflow(text: str) -> bool:
+    return _single_event_workflow(text, "workflow_dispatch")
+
+
+def _issue_only_workflow(text: str) -> bool:
+    return _single_event_workflow(text, "issues")
+
+
+def _common_self_hosted_errors(block: str) -> list[str]:
     errors: list[str] = []
     if "github.ref == 'refs/heads/main'" not in block:
         errors.append("missing job-level main guard")
-    if (
-        "github.event_name == 'workflow_dispatch'" not in block
-        and not _dispatch_only_workflow(workflow_text)
-    ):
-        errors.append("missing dispatch-only authorization")
     if "ref: ${{ github.sha }}" not in block:
         errors.append("checkout is not bound to github.sha")
     if "git rev-parse HEAD" not in block or "GITHUB_SHA" not in block:
@@ -118,13 +129,77 @@ def _main_only_errors(workflow_text: str, block: str) -> list[str]:
 
     if "${{ secrets." in block:
         errors.append("self-hosted job references a GitHub secret")
+    permissions = _job_property(block, "permissions")
+    for forbidden in ("contents: write", "issues: write", "pull-requests: write"):
+        if forbidden in permissions:
+            errors.append(f"self-hosted job requests {forbidden}")
     return errors
+
+
+def _main_only_errors(workflow_text: str, block: str) -> list[str]:
+    errors = _common_self_hosted_errors(block)
+    if (
+        "github.event_name == 'workflow_dispatch'" not in block
+        and not _dispatch_only_workflow(workflow_text)
+    ):
+        errors.append("missing dispatch-only authorization")
+    return errors
+
+
+def _maintainer_issue_main_errors(workflow_text: str, block: str) -> list[str]:
+    errors = _common_self_hosted_errors(block)
+    required = {
+        "github.event_name == 'issues'": "missing issue-event authorization",
+        "github.event.action == 'opened'": "missing issue-open authorization",
+        (
+            "github.event.issue.user.login == 'FlorianPfaff'"
+        ): "missing exact maintainer-login authorization",
+        (
+            "github.event.issue.user.id == 6773539"
+        ): "missing exact maintainer-ID authorization",
+        (
+            "'[self-hosted] validate prepared joint observation'"
+        ): "missing exact trigger-title authorization",
+    }
+    for fragment, message in required.items():
+        if fragment not in block:
+            errors.append(message)
+    if block.count("github.event.issue.title") != 1:
+        errors.append("issue title must be used only by the exact guard")
+    for forbidden in (
+        "github.event.issue.body",
+        "github.event.issue.labels",
+        "github.event.comment",
+    ):
+        if forbidden in block:
+            errors.append(
+                "untrusted issue payload reaches self-hosted job: "
+                f"{forbidden}"
+            )
+    if not _issue_only_workflow(workflow_text):
+        errors.append("workflow is not issue-only")
+    return errors
+
+
+def _authorization_errors(
+    authorization_model: str,
+    workflow_text: str,
+    block: str,
+) -> list[str]:
+    if authorization_model == "main-only":
+        return _main_only_errors(workflow_text, block)
+    if authorization_model == "maintainer-issue-main":
+        return _maintainer_issue_main_errors(workflow_text, block)
+    return [f"unsupported authorization model: {authorization_model}"]
 
 
 def test_self_hosted_job_registry_is_complete_and_unique() -> None:
     payload = json.loads(REGISTRY.read_text(encoding="utf-8"))
     assert payload["schema_version"] == 1
-    assert set(payload["authorization_models"]) == {"main-only"}
+    assert set(payload["authorization_models"]) == {
+        "main-only",
+        "maintainer-issue-main",
+    }
 
     entries = payload["jobs"]
     keys = [(entry["workflow"], entry["job"]) for entry in entries]
@@ -133,22 +208,26 @@ def test_self_hosted_job_registry_is_complete_and_unique() -> None:
     assert set(keys) == set(_discover_self_hosted_jobs())
 
 
-def test_every_self_hosted_job_is_main_only_exact_sha_and_secret_free() -> None:
+def test_every_self_hosted_job_is_exact_sha_and_secret_free() -> None:
     payload = json.loads(REGISTRY.read_text(encoding="utf-8"))
     discovered = _discover_self_hosted_jobs()
 
     for entry in payload["jobs"]:
         key = (entry["workflow"], entry["job"])
         workflow_text, block = discovered[key]
-        assert entry["authorization_model"] == "main-only"
+        assert entry["authorization_model"] in payload["authorization_models"]
         assert entry["secrets_allowed"] is False
         assert "permissions:\n  contents: read\n" in workflow_text
-        assert "contents: write" not in workflow_text
-        assert "issues: write" not in workflow_text
-        assert "pull-requests: write" not in workflow_text
+        assert "contents: write" not in block
+        assert "issues: write" not in block
+        assert "pull-requests: write" not in block
         for label in entry["runner_labels"]:
             assert label in block
-        assert _main_only_errors(workflow_text, block) == [], key
+        assert _authorization_errors(
+            entry["authorization_model"],
+            workflow_text,
+            block,
+        ) == [], key
 
 
 def test_runner_discovery_ignores_hosted_jobs_that_only_mention_self_hosted() -> None:
@@ -183,6 +262,35 @@ permissions:
     assert _main_only_errors(workflow, block) == []
 
 
+def test_maintainer_issue_validator_accepts_exact_trigger() -> None:
+    workflow = """on:
+  issues:
+    types: [opened]
+permissions:
+  contents: read
+"""
+    block = """  validate:
+    if: >-
+      github.event_name == 'issues' &&
+      github.event.action == 'opened' &&
+      github.ref == 'refs/heads/main' &&
+      github.event.issue.user.login == 'FlorianPfaff' &&
+      github.event.issue.user.id == 6773539 &&
+      github.event.issue.title ==
+        '[self-hosted] validate prepared joint observation'
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - run: |
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
+"""
+    assert _maintainer_issue_main_errors(workflow, block) == []
+
+
 def test_main_only_validator_rejects_an_unauthorized_or_stale_fixture() -> None:
     workflow = """on:
   workflow_dispatch:
@@ -204,3 +312,41 @@ permissions:
     assert "clean checkout is not verified" in errors
     assert "one or more checkouts retain credentials" in errors
     assert any(error.startswith("action is not pinned") for error in errors)
+
+
+def test_maintainer_issue_validator_rejects_broad_issue_execution() -> None:
+    workflow = """on:
+  issues:
+permissions:
+  contents: read
+"""
+    block = """  validate:
+    if: github.ref == 'refs/heads/main'
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - run: |
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
+"""
+    errors = _maintainer_issue_main_errors(workflow, block)
+    assert "missing issue-event authorization" in errors
+    assert "missing issue-open authorization" in errors
+    assert "missing exact maintainer-login authorization" in errors
+    assert "missing exact maintainer-ID authorization" in errors
+    assert "missing exact trigger-title authorization" in errors
+
+
+def test_maintainer_issue_reporter_is_hosted_and_has_no_checkout() -> None:
+    path = WORKFLOW_DIR / "prepared-joint-observation-self-hosted.yml"
+    text = path.read_text(encoding="utf-8")
+    report = _job_blocks(text)["report"]
+
+    assert "runs-on: ubuntu-latest" in report
+    assert "needs: validate" in report
+    assert "issues: write" in report
+    assert "uses: actions/checkout@" not in report
+    assert "runs-on: [self-hosted" not in report


### PR DESCRIPTION
## Summary

Add an opt-in prepared execution path for repeated full-joint observation updates.

- compile duplicate rollout selectors into one deterministic sparse operator;
- retain the exact shared base-covariance solver introduced on current `main` across repeated calls;
- score finite support in explicit memory-bounded component chunks;
- accept finite symmetric positive-semidefinite additive component covariance, including rank-deficient terms, while continuing to require the final total covariance to be positive definite;
- preserve exact likelihood and posterior parity, including exact zero prior support;
- report selected chunking, sparse operator size, estimated working memory, and solver reuse;
- add a 512-row legacy-parity benchmark and a separate 2,048-row/rank-7 prepared scale execution; and
- register a reviewed-main-only self-hosted validation path for connector-driven execution on `workstation2`.

## Relationship to #273

Merged PR #273 already reuses one base factorization across all components inside a single ordinary update. This PR builds on that solver rather than duplicating it. Preparation retains the exact solver across repeated calls and adds sparse-operator compilation, chunking, PSD additive covariance admission, and pre-allocation memory guards.

## Self-hosted authorization

Pull-request source is never allocated to a self-hosted runner. The new job can run only after merge from reviewed `main`, when a newly opened issue has all three exact identities:

- login `FlorianPfaff`;
- immutable account ID `6773539`; and
- title `[self-hosted] validate prepared joint observation`.

The self-hosted job checks out only `${{ github.sha }}`, verifies exact HEAD and a clean tree, uses pinned actions, has read-only repository permission, consumes no issue payload as executable input, and uses no GitHub secret. A separate hosted reporter with no checkout may write only the fixed run result to the trigger issue.

## Local validation

- 9 focused prepared-observation tests passed against a compatibility harness;
- 8 self-hosted policy tests passed against the registered workflow fixture;
- small structured benchmark passed exact score parity, singular-PSD admission, finite scale scoring, and artifact generation;
- all changed Python compiled; and
- changed Python and Markdown lines satisfy the repository's 88-column convention.

Permanent GitHub Actions on the exact PR head remain authoritative for Ruff, formatting, MyPy, the complete suite, distributions, security scanning, and installed-wheel integration.

## Scientific boundary

This is prospective execution and numerical-contract infrastructure. It changes no frozen estimator, registered 18-session/36-execution protocol, acquisition candidate, six-frame information boundary, Prob4D used-or-unused declaration, target identity, calibration rule, scientific result, or physical evidence count. The self-hosted workload uses synthetic inputs only and records `physical_evidence_increment=0`.