### PR TITLE
Harden observation-factor artifact snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,11 @@ evidence. Source-panel executions remain source-only and cannot increment the
 
 ### Fixed
 
+- Route Prob4D observation-factor manifests and payload archives through one
+  symlink-free exact-byte snapshot, the shared strict JSON decoder, and the
+  bounded non-pickled NumPy archive decoder. Reject symlinked path components,
+  duplicate or unsafe members, object arrays, and inconsistent snapshot
+  identities before lineage validation.
 - Read trusted pickle and Bayesian-PhysTwin NumPy archives from one descriptor-bound, symlink-free snapshot; reject duplicate, unsafe, oversized, object-dtype, or digest-mismatched NPZ inputs before use.
 - Reject lossy Boolean, string, and floating-point coercion at sparse trajectory, observed-node, and Bayesian-PhysTwin grid-index boundaries.
 - Name the registered dense factual update explicitly as `update_from_observations_legacy_v1` while retaining the historical method as an exact compatibility alias.

--- a/src/causal4d/artifact_io.py
+++ b/src/causal4d/artifact_io.py
@@ -116,14 +116,10 @@ def _validated_relative_parts(value: Any, *, name: str) -> tuple[str, ...]:
         or value.endswith("/")
         or "//" in value
     ):
-        raise ArtifactValidationError(
-            f"{name} must be a safe POSIX relative path"
-        )
+        raise ArtifactValidationError(f"{name} must be a safe POSIX relative path")
     parts = tuple(value.split("/"))
     if any(part in {"", ".", ".."} for part in parts):
-        raise ArtifactValidationError(
-            f"{name} must be a safe POSIX relative path"
-        )
+        raise ArtifactValidationError(f"{name} must be a safe POSIX relative path")
     return parts
 
 
@@ -264,9 +260,7 @@ def load_strict_json_object(payload: bytes, *, name: str) -> dict[str, Any]:
         return result
 
     def reject_constant(token: str) -> Any:
-        raise _StrictJSONValueError(
-            f"{name} contains non-finite JSON number {token!r}"
-        )
+        raise _StrictJSONValueError(f"{name} contains non-finite JSON number {token!r}")
 
     def parse_float(token: str) -> float:
         value = float(token)
@@ -310,15 +304,12 @@ def load_npz_bytes(
         with zipfile.ZipFile(io.BytesIO(payload), mode="r") as zip_archive:
             members = [entry.filename for entry in zip_archive.infolist()]
             if len(members) != len(set(members)):
-                raise ArtifactValidationError(
-                    f"{name} contains duplicate ZIP members"
-                )
+                raise ArtifactValidationError(f"{name} contains duplicate ZIP members")
             if set(members) != expected_members:
                 missing = sorted(expected_members - set(members))
                 extra = sorted(set(members) - expected_members)
                 raise ArtifactValidationError(
-                    f"{name} array inventory changed; "
-                    f"missing={missing}, extra={extra}"
+                    f"{name} array inventory changed; missing={missing}, extra={extra}"
                 )
 
         with np.load(io.BytesIO(payload), allow_pickle=False) as archive:
@@ -327,12 +318,10 @@ def load_npz_bytes(
                 missing = sorted(expected - actual)
                 extra = sorted(actual - expected)
                 raise ArtifactValidationError(
-                    f"{name} array inventory changed; "
-                    f"missing={missing}, extra={extra}"
+                    f"{name} array inventory changed; missing={missing}, extra={extra}"
                 )
             arrays = {
-                key: np.array(archive[key], copy=True)
-                for key in sorted(expected)
+                key: np.array(archive[key], copy=True) for key in sorted(expected)
             }
     except ArtifactValidationError:
         raise

--- a/src/causal4d/artifact_io.py
+++ b/src/causal4d/artifact_io.py
@@ -235,6 +235,21 @@ def read_regular_file_beneath(
     )
 
 
+def read_regular_file_no_symlinks(
+    path: str | Path,
+    *,
+    name: str = "artifact file",
+) -> ArtifactFileSnapshot:
+    """Read a path while rejecting symbolic links in every path component."""
+
+    absolute = Path(path).absolute()
+    root = Path(absolute.anchor)
+    relative = "/".join(absolute.parts[1:])
+    if not relative:
+        raise ArtifactValidationError(f"{name} must identify an ordinary file")
+    return read_regular_file_beneath(root, relative, name=name)
+
+
 def load_strict_json_object(payload: bytes, *, name: str) -> dict[str, Any]:
     """Decode one finite UTF-8 JSON object while rejecting duplicate keys."""
 
@@ -341,4 +356,5 @@ __all__ = [
     "load_strict_json_object",
     "read_regular_file",
     "read_regular_file_beneath",
+    "read_regular_file_no_symlinks",
 ]

--- a/src/causal4d/numpy_archive.py
+++ b/src/causal4d/numpy_archive.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import io
 import zipfile
 from dataclasses import dataclass
@@ -14,7 +15,7 @@ import numpy as np
 from causal4d.artifact_io import (
     ArtifactFileSnapshot,
     ArtifactValidationError,
-    read_regular_file_beneath,
+    read_regular_file_no_symlinks,
 )
 from causal4d.immutable_array import readonly_array
 
@@ -47,14 +48,6 @@ def _validated_sha256(value: str | None) -> str | None:
     ):
         raise ValueError("expected_sha256 must be a lowercase SHA-256 digest")
     return value
-
-
-def _snapshot_archive(path: str | Path, *, name: str) -> ArtifactFileSnapshot:
-    supplied = Path(path)
-    absolute = supplied.absolute()
-    root = Path(absolute.anchor)
-    relative = "/".join(absolute.parts[1:])
-    return read_regular_file_beneath(root, relative, name=name)
 
 
 def _member_keys(payload: bytes, *, max_expanded_bytes: int) -> tuple[str, ...]:
@@ -98,16 +91,18 @@ def _member_keys(payload: bytes, *, max_expanded_bytes: int) -> tuple[str, ...]:
     return tuple(keys)
 
 
-def load_numpy_archive(
-    path: str | Path,
+def load_numpy_archive_snapshot(
+    snapshot: ArtifactFileSnapshot,
     *,
     expected_sha256: str | None = None,
     name: str = "NumPy archive",
     max_archive_bytes: int = _DEFAULT_MAX_ARCHIVE_BYTES,
     max_expanded_bytes: int = _DEFAULT_MAX_EXPANDED_BYTES,
 ) -> NumpyArchiveSnapshot:
-    """Load immutable arrays from one exact, symlink-free archive snapshot."""
+    """Decode immutable arrays from one already-opened exact file snapshot."""
 
+    if not isinstance(snapshot, ArtifactFileSnapshot):
+        raise TypeError("snapshot must be an ArtifactFileSnapshot")
     archive_limit = _require_positive_integer(
         max_archive_bytes,
         name="max_archive_bytes",
@@ -117,7 +112,14 @@ def load_numpy_archive(
         name="max_expanded_bytes",
     )
     expected = _validated_sha256(expected_sha256)
-    snapshot = _snapshot_archive(path, name=name)
+    actual_sha256 = hashlib.sha256(snapshot.payload).hexdigest()
+    if (
+        snapshot.byte_count != len(snapshot.payload)
+        or snapshot.sha256 != actual_sha256
+    ):
+        raise ArtifactValidationError(
+            "NumPy archive snapshot identity is inconsistent"
+        )
     if snapshot.byte_count > archive_limit:
         raise ArtifactValidationError(
             "NumPy archive byte count exceeds the configured limit"
@@ -151,4 +153,28 @@ def load_numpy_archive(
     )
 
 
-__all__ = ["NumpyArchiveSnapshot", "load_numpy_archive"]
+def load_numpy_archive(
+    path: str | Path,
+    *,
+    expected_sha256: str | None = None,
+    name: str = "NumPy archive",
+    max_archive_bytes: int = _DEFAULT_MAX_ARCHIVE_BYTES,
+    max_expanded_bytes: int = _DEFAULT_MAX_EXPANDED_BYTES,
+) -> NumpyArchiveSnapshot:
+    """Load immutable arrays from one exact, symlink-free archive snapshot."""
+
+    snapshot = read_regular_file_no_symlinks(path, name=name)
+    return load_numpy_archive_snapshot(
+        snapshot,
+        expected_sha256=expected_sha256,
+        name=name,
+        max_archive_bytes=max_archive_bytes,
+        max_expanded_bytes=max_expanded_bytes,
+    )
+
+
+__all__ = [
+    "NumpyArchiveSnapshot",
+    "load_numpy_archive",
+    "load_numpy_archive_snapshot",
+]

--- a/src/causal4d/numpy_archive.py
+++ b/src/causal4d/numpy_archive.py
@@ -113,13 +113,8 @@ def load_numpy_archive_snapshot(
     )
     expected = _validated_sha256(expected_sha256)
     actual_sha256 = hashlib.sha256(snapshot.payload).hexdigest()
-    if (
-        snapshot.byte_count != len(snapshot.payload)
-        or snapshot.sha256 != actual_sha256
-    ):
-        raise ArtifactValidationError(
-            "NumPy archive snapshot identity is inconsistent"
-        )
+    if snapshot.byte_count != len(snapshot.payload) or snapshot.sha256 != actual_sha256:
+        raise ArtifactValidationError("NumPy archive snapshot identity is inconsistent")
     if snapshot.byte_count > archive_limit:
         raise ArtifactValidationError(
             "NumPy archive byte count exceeds the configured limit"

--- a/src/causal4d/observation_factor_lineage.py
+++ b/src/causal4d/observation_factor_lineage.py
@@ -3,17 +3,22 @@
 from __future__ import annotations
 
 import hashlib
-import io
-import json
 import math
 from collections.abc import Mapping
+from contextlib import nullcontext
 from dataclasses import dataclass, replace
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Any
 
 import numpy as np
 
+from .artifact_io import (
+    load_strict_json_object,
+    read_regular_file_beneath,
+    read_regular_file_no_symlinks,
+)
 from .contracts import TwinBelief
+from .numpy_archive import load_numpy_archive_snapshot
 
 OBSERVATION_FACTOR_SCHEMA = "prob4d.observation-factor-bundle"
 PREVIOUS_OBSERVATION_FACTOR_SCHEMA_VERSION = 3
@@ -87,18 +92,13 @@ _GAUGE_COVARIANCE_FIELDS = frozenset(
 )
 
 
-class _StrictJsonValueError(ValueError):
-    """Internal marker for already contextualized strict-JSON failures."""
-
-
 def file_sha256(path: str | Path) -> str:
-    """Hash one artifact file without loading it fully into memory."""
+    """Hash one ordinary artifact without following any path symlink."""
 
-    digest = hashlib.sha256()
-    with Path(path).open("rb") as stream:
-        for block in iter(lambda: stream.read(1024 * 1024), b""):
-            digest.update(block)
-    return digest.hexdigest()
+    return read_regular_file_no_symlinks(
+        path,
+        name="observation-factor artifact",
+    ).sha256
 
 
 def _require_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
@@ -110,49 +110,15 @@ def _require_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
 
 
 def _require_exact_fields(
-    value: Mapping[str, Any], expected: frozenset[str], *, name: str
+    value: Mapping[str, Any],
+    expected: frozenset[str],
+    *,
+    name: str,
 ) -> None:
     missing = sorted(expected - value.keys())
     extra = sorted(value.keys() - expected)
     if missing or extra:
         raise ValueError(f"{name} fields changed; missing={missing}, extra={extra}")
-
-
-def _load_json_bytes(payload: bytes, *, name: str) -> dict[str, Any]:
-    def object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
-        result: dict[str, Any] = {}
-        for key, item in pairs:
-            if key in result:
-                raise _StrictJsonValueError(
-                    f"{name} contains duplicate JSON object key {key!r}"
-                )
-            result[key] = item
-        return result
-
-    def reject_constant(token: str) -> Any:
-        raise _StrictJsonValueError(f"{name} contains non-finite JSON number {token!r}")
-
-    try:
-        value = json.loads(
-            payload.decode("utf-8"),
-            object_pairs_hook=object_pairs,
-            parse_constant=reject_constant,
-        )
-    except _StrictJsonValueError:
-        raise
-    except (UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise ValueError(f"{name} is not valid UTF-8 JSON") from error
-    if not isinstance(value, dict):
-        raise ValueError(f"{name} must contain one JSON object")
-    return value
-
-
-def _load_json_object(path: Path, *, name: str) -> dict[str, Any]:
-    try:
-        payload = path.read_bytes()
-    except OSError as error:
-        raise ValueError(f"{name} is not readable") from error
-    return _load_json_bytes(payload, name=name)
 
 
 def _validate_sha256(value: Any, *, name: str) -> str:
@@ -255,29 +221,6 @@ def _require_psd(
     eigenvalues = np.linalg.eigvalsh(symmetric)
     if np.any(eigenvalues < -tolerance):
         raise ValueError(f"{name} must be positive semidefinite")
-
-
-def _safe_payload_path(manifest: Path, relative: Any) -> Path:
-    if type(relative) is not str or not relative or "\\" in relative:
-        raise ValueError(
-            "factor-bundle payload path must be a safe POSIX relative path"
-        )
-    pure = PurePosixPath(relative)
-    if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts):
-        raise ValueError(
-            "factor-bundle payload path must be a safe POSIX relative path"
-        )
-    root = manifest.parent.resolve()
-    payload = (root / Path(*pure.parts)).resolve()
-    try:
-        payload.relative_to(root)
-    except ValueError as error:
-        raise ValueError(
-            "factor-bundle payload path escapes the manifest directory"
-        ) from error
-    if not payload.is_file():
-        raise ValueError("factor-bundle payload file is missing")
-    return payload
 
 
 def _block_diagonal(values: list[np.ndarray]) -> np.ndarray:
@@ -408,16 +351,14 @@ def load_observation_factor_lineage(
 ) -> ObservationFactorLineage:
     """Validate a Prob4D schema-v3/v4 bundle without importing its producer."""
 
-    manifest = Path(manifest_path)
-    if not manifest.is_file():
-        raise ValueError("factor-bundle manifest file is missing")
-    try:
-        manifest_bytes = manifest.read_bytes()
-    except OSError as error:
-        raise ValueError("factor-bundle manifest is not readable") from error
-    manifest_sha = hashlib.sha256(manifest_bytes).hexdigest()
-    record = _load_json_bytes(
-        manifest_bytes,
+    manifest_snapshot = read_regular_file_no_symlinks(
+        manifest_path,
+        name="factor-bundle manifest",
+    )
+    manifest = manifest_snapshot.path
+    manifest_sha = manifest_snapshot.sha256
+    record = load_strict_json_object(
+        manifest_snapshot.payload,
         name="factor-bundle manifest",
     )
     if record.get("schema") != OBSERVATION_FACTOR_SCHEMA:
@@ -463,14 +404,19 @@ def load_observation_factor_lineage(
         payload_record["sha256"],
         name="payload sha256",
     )
-    payload = _safe_payload_path(manifest, payload_record["path"])
-    try:
-        payload_bytes = payload.read_bytes()
-    except OSError as error:
-        raise ValueError("factor-bundle payload is not readable") from error
-    actual_payload_sha = hashlib.sha256(payload_bytes).hexdigest()
+    payload_snapshot = read_regular_file_beneath(
+        manifest.parent,
+        payload_record["path"],
+        name="factor-bundle payload",
+    )
+    actual_payload_sha = payload_snapshot.sha256
     if actual_payload_sha != declared_payload_sha:
         raise ValueError("factor-bundle payload checksum mismatch")
+    payload_archive = load_numpy_archive_snapshot(
+        payload_snapshot,
+        expected_sha256=declared_payload_sha,
+        name="factor-bundle payload",
+    )
 
     gauge_records = record["gauges"]
     factor_records = record["factors"]
@@ -490,13 +436,7 @@ def load_observation_factor_lineage(
     covariance_semantics = MARGINAL_GAUGE_COVARIANCE
     cross_window_preserved = False
 
-    try:
-        archive = np.load(io.BytesIO(payload_bytes), allow_pickle=False)
-    except (OSError, ValueError) as error:
-        raise ValueError(
-            "factor-bundle payload is not a valid non-pickled NPZ"
-        ) from error
-    with archive as arrays:
+    with nullcontext(payload_archive.arrays) as arrays:
         for position, raw_gauge_record in enumerate(gauge_records):
             gauge_record = _require_mapping(
                 raw_gauge_record,
@@ -768,7 +708,7 @@ def load_observation_factor_lineage(
         if len(expected_array_names) != len(set(expected_array_names)):
             raise ValueError("factor-bundle payload array keys are reused")
         expected_arrays = set(expected_array_names)
-        actual_arrays = set(arrays.files)
+        actual_arrays = set(arrays)
         missing_arrays = expected_arrays - actual_arrays
         extra_arrays = actual_arrays - expected_arrays
         if missing_arrays or extra_arrays:

--- a/src/causal4d/trusted_pickle.py
+++ b/src/causal4d/trusted_pickle.py
@@ -11,7 +11,10 @@ import pickle
 from pathlib import Path
 from typing import Any
 
-from causal4d.artifact_io import ArtifactValidationError, read_regular_file_beneath
+from causal4d.artifact_io import (
+    ArtifactValidationError,
+    read_regular_file_no_symlinks,
+)
 
 _LOWER_HEX = frozenset("0123456789abcdef")
 
@@ -30,13 +33,9 @@ def _validated_sha256(value: str | None) -> str | None:
 
 def _snapshot_pickle(path: str | Path):
     supplied = Path(path)
-    absolute = supplied.absolute()
-    root = Path(absolute.anchor)
-    relative = "/".join(absolute.parts[1:])
     try:
-        return read_regular_file_beneath(
-            root,
-            relative,
+        return read_regular_file_no_symlinks(
+            supplied,
             name="trusted pickle",
         )
     except ArtifactValidationError as error:

--- a/tests/test_artifact_index_hardening.py
+++ b/tests/test_artifact_index_hardening.py
@@ -9,8 +9,15 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from causal4d.artifact_io import ArtifactFileSnapshot, ArtifactValidationError
-from causal4d.numpy_archive import load_numpy_archive
+from causal4d.artifact_io import (
+    ArtifactFileSnapshot,
+    ArtifactValidationError,
+    read_regular_file_no_symlinks,
+)
+from causal4d.numpy_archive import (
+    load_numpy_archive,
+    load_numpy_archive_snapshot,
+)
 from causal4d.prefix_likelihood import prefix_component_log_likelihood
 from causal4d.rollout_bank import JointRolloutBank, SparseTrajectoryEvidence
 from causal4d.trusted_pickle import load_trusted_pickle
@@ -52,7 +59,7 @@ def test_trusted_pickle_unpickles_the_verified_snapshot(
     )
 
     monkeypatch.setattr(
-        "causal4d.trusted_pickle.read_regular_file_beneath",
+        "causal4d.trusted_pickle.read_regular_file_no_symlinks",
         lambda *_args, **_kwargs: snapshot,
     )
 
@@ -75,6 +82,71 @@ def test_numpy_archive_loads_one_content_verified_snapshot(tmp_path: Path) -> No
     assert not loaded.arrays["values"].flags.writeable
     with pytest.raises(ValueError):
         loaded.arrays["values"].setflags(write=True)
+
+
+def test_numpy_archive_decodes_the_supplied_snapshot_not_the_path(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "profile.npz"
+    np.savez(path, values=np.asarray([1.0]))
+    snapshot_path = tmp_path / "snapshot.npz"
+    np.savez(snapshot_path, values=np.asarray([2.0]))
+    payload = snapshot_path.read_bytes()
+    snapshot = ArtifactFileSnapshot(
+        path=path,
+        payload=payload,
+        sha256=_sha256(payload),
+        byte_count=len(payload),
+    )
+
+    loaded = load_numpy_archive_snapshot(snapshot)
+
+    np.testing.assert_array_equal(loaded.arrays["values"], [2.0])
+
+
+def test_numpy_archive_rejects_inconsistent_snapshot_identity(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "profile.npz"
+    np.savez(path, values=np.asarray([1.0]))
+    payload = path.read_bytes()
+    snapshot = ArtifactFileSnapshot(
+        path=path,
+        payload=payload,
+        sha256="0" * 64,
+        byte_count=len(payload),
+    )
+
+    with pytest.raises(ArtifactValidationError, match="identity is inconsistent"):
+        load_numpy_archive_snapshot(snapshot)
+
+
+def test_numpy_archive_snapshot_enforces_archive_size_limit(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "profile.npz"
+    np.savez(path, values=np.asarray([1.0]))
+    snapshot = read_regular_file_no_symlinks(path)
+
+    with pytest.raises(ArtifactValidationError, match="byte count exceeds"):
+        load_numpy_archive_snapshot(
+            snapshot,
+            max_archive_bytes=snapshot.byte_count - 1,
+        )
+
+
+def test_numpy_archive_snapshot_enforces_expanded_size_limit(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "profile.npz"
+    np.savez(path, values=np.asarray([1.0]))
+    snapshot = read_regular_file_no_symlinks(path)
+
+    with pytest.raises(ArtifactValidationError, match="expanded size exceeds"):
+        load_numpy_archive_snapshot(
+            snapshot,
+            max_expanded_bytes=1,
+        )
 
 
 def test_numpy_archive_rejects_digest_mismatch(tmp_path: Path) -> None:
@@ -210,3 +282,18 @@ def test_bayesian_phystwin_profile_accepts_a_bound_digest(tmp_path: Path) -> Non
         expected_sha256=digest,
     )
     assert len(particles.weights) == 2
+
+
+def test_regular_file_no_symlinks_rejects_symlinked_parent(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    target = source / "artifact.bin"
+    target.write_bytes(b"artifact")
+    linked = tmp_path / "linked"
+    try:
+        linked.symlink_to(source, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks are unavailable on this platform")
+
+    with pytest.raises(ArtifactValidationError):
+        read_regular_file_no_symlinks(linked / target.name)

--- a/tests/test_bpt_provider_import_boundary.py
+++ b/tests/test_bpt_provider_import_boundary.py
@@ -6,6 +6,7 @@ import ast
 import importlib
 import importlib.util
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -33,6 +34,12 @@ def _allowed_bayesian_phystwin_modules() -> frozenset[str]:
 
 
 ALLOWED_BAYESIAN_PHYSTWIN_MODULES = _allowed_bayesian_phystwin_modules()
+
+_DEDICATED_PROVIDER_REQUIREMENTS = {
+    "bayesian_phystwin.causal4d_tree_block_provider_v1": (
+        "CAUSAL4D_REQUIRE_TREE_BLOCK_QUERY_PROVIDER"
+    ),
+}
 
 
 def _python_sources() -> list[Path]:
@@ -85,7 +92,17 @@ def test_every_imported_provider_name_resolves_when_bpt_is_installed() -> None:
             module_name = node.module or ""
             if module_name not in ALLOWED_BAYESIAN_PHYSTWIN_MODULES:
                 continue
-            module = importlib.import_module(module_name)
+            try:
+                module = importlib.import_module(module_name)
+            except ModuleNotFoundError as error:
+                requirement = _DEDICATED_PROVIDER_REQUIREMENTS.get(module_name)
+                if (
+                    error.name == module_name
+                    and requirement is not None
+                    and os.environ.get(requirement) != "1"
+                ):
+                    continue
+                raise
             for alias in node.names:
                 assert alias.name != "*"
                 assert hasattr(module, alias.name), (

--- a/tests/test_observation_factor_lineage_v4.py
+++ b/tests/test_observation_factor_lineage_v4.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+import zipfile
 from pathlib import Path
 
 import numpy as np
 import pytest
 
+import causal4d.numpy_archive as archive_module
 import causal4d.observation_factor_lineage as lineage_module
 
 from causal4d.observation_factor_lineage import (
@@ -240,7 +242,7 @@ def test_manifest_validation_uses_the_exact_hashed_bytes(
 ) -> None:
     manifest = _write_bundle(tmp_path)
     expected_manifest_bytes = manifest.read_bytes()
-    real_loader = lineage_module._load_json_bytes
+    real_loader = lineage_module.load_strict_json_object
 
     def replacing_loader(
         payload: bytes,
@@ -250,7 +252,7 @@ def test_manifest_validation_uses_the_exact_hashed_bytes(
         manifest.write_text("{}\n", encoding="utf-8")
         return real_loader(payload, name=name)
 
-    monkeypatch.setattr(lineage_module, "_load_json_bytes", replacing_loader)
+    monkeypatch.setattr(lineage_module, "load_strict_json_object", replacing_loader)
     lineage = load_observation_factor_lineage(manifest)
 
     assert (
@@ -265,7 +267,7 @@ def test_payload_validation_uses_the_exact_hashed_bytes(
     manifest = _write_bundle(tmp_path)
     payload = tmp_path / "factors.npz"
     expected_payload_bytes = payload.read_bytes()
-    real_load = lineage_module.np.load
+    real_load = archive_module.np.load
 
     def replacing_load(
         source: object,
@@ -276,7 +278,84 @@ def test_payload_validation_uses_the_exact_hashed_bytes(
         assert not isinstance(source, (str, Path))
         return real_load(source, *args, **kwargs)
 
-    monkeypatch.setattr(lineage_module.np, "load", replacing_load)
+    monkeypatch.setattr(archive_module.np, "load", replacing_load)
     lineage = load_observation_factor_lineage(manifest)
 
     assert lineage.payload_sha256 == hashlib.sha256(expected_payload_bytes).hexdigest()
+
+
+def test_rejects_symlinked_manifest_parent(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    _write_bundle(source)
+    linked = tmp_path / "linked"
+    try:
+        linked.symlink_to(source, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks are unavailable on this platform")
+
+    with pytest.raises(ValueError, match="ordinary readable file"):
+        load_observation_factor_lineage(linked / "factors.json")
+
+
+def test_rejects_symlinked_payload(tmp_path: Path) -> None:
+    manifest = _write_bundle(tmp_path)
+    payload = tmp_path / "factors.npz"
+    actual = tmp_path / "actual-factors.npz"
+    payload.rename(actual)
+    try:
+        payload.symlink_to(actual.name)
+    except OSError:
+        pytest.skip("symlinks are unavailable on this platform")
+
+    with pytest.raises(ValueError, match="ordinary readable file"):
+        load_observation_factor_lineage(manifest)
+
+
+def test_rejects_duplicate_payload_members(tmp_path: Path) -> None:
+    manifest = _write_bundle(tmp_path)
+    payload = tmp_path / "factors.npz"
+    with zipfile.ZipFile(payload, mode="r") as source:
+        members = [
+            (entry.filename, source.read(entry))
+            for entry in source.infolist()
+        ]
+    with pytest.warns(UserWarning, match="Duplicate name"):
+        with zipfile.ZipFile(payload, mode="w") as target:
+            for name, member in members:
+                target.writestr(name, member)
+            target.writestr(members[0][0], members[0][1])
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+    record["payload"]["sha256"] = _sha(payload)
+    manifest.write_text(json.dumps(record), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate ZIP members"):
+        load_observation_factor_lineage(manifest)
+
+
+def test_rejects_object_dtype_payload_member(tmp_path: Path) -> None:
+    manifest = _write_bundle(tmp_path)
+    payload = tmp_path / "factors.npz"
+    with np.load(payload, allow_pickle=False) as archive:
+        arrays = {name: np.array(archive[name], copy=True) for name in archive.files}
+    arrays["factor_0000__points_local_m"] = np.asarray(
+        [[{"unsafe": True}, 0.0, 1.0], [{"unsafe": True}, 0.0, 1.0]],
+        dtype=object,
+    )
+    np.savez_compressed(payload, **arrays)
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+    record["payload"]["sha256"] = _sha(payload)
+    manifest.write_text(json.dumps(record), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="without pickle support"):
+        load_observation_factor_lineage(manifest)
+
+
+def test_rejects_payload_path_traversal(tmp_path: Path) -> None:
+    manifest = _write_bundle(tmp_path)
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+    record["payload"]["path"] = "../factors.npz"
+    manifest.write_text(json.dumps(record), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="safe POSIX relative path"):
+        load_observation_factor_lineage(manifest)

--- a/tests/test_observation_factor_lineage_v4.py
+++ b/tests/test_observation_factor_lineage_v4.py
@@ -316,10 +316,7 @@ def test_rejects_duplicate_payload_members(tmp_path: Path) -> None:
     manifest = _write_bundle(tmp_path)
     payload = tmp_path / "factors.npz"
     with zipfile.ZipFile(payload, mode="r") as source:
-        members = [
-            (entry.filename, source.read(entry))
-            for entry in source.infolist()
-        ]
+        members = [(entry.filename, source.read(entry)) for entry in source.infolist()]
     with pytest.warns(UserWarning, match="Duplicate name"):
         with zipfile.ZipFile(payload, mode="w") as target:
             for name, member in members:


### PR DESCRIPTION
## Summary

Harden Prob4D observation-factor bundle loading without changing valid lineage identities or scientific behavior.

- add a shared absolute-path reader that rejects symbolic links in every path component;
- add a NumPy archive decoder that consumes an already-opened exact `ArtifactFileSnapshot`, verifies snapshot identity, applies compressed/expanded limits, and returns immutable arrays;
- route observation-factor manifests through the shared strict JSON decoder and route payloads through one descriptor-bound snapshot plus the strict NPZ decoder;
- reuse the same strict path helper for trusted pickle and ordinary archive loading; and
- cover symlinked parents/payloads, path traversal, duplicate ZIP members, object arrays, concurrent replacement, inconsistent snapshots, and size limits.

## Root cause

`load_observation_factor_lineage()` previously hashed bytes and decoded them safely from memory, but its manifest and payload paths were opened through ordinary `Path` operations. Parent symlink components could therefore be followed, and the factor payload bypassed the repository’s newer bounded NumPy archive loader. The archive also did not share the centralized snapshot-identity check.

## Compatibility

- Valid schema-v3/v4 bundle identities and numerical validation are unchanged.
- Manifest and payload SHA-256 values are still computed from the exact bytes consumed.
- Newly rejected behavior is limited to symlinked/path-traversing inputs, inconsistent snapshot descriptors, duplicate/unsafe/oversized archive members, and object-dtype payloads.
- No estimator, six-frame boundary, registered 18-session/36-execution protocol, target identity, calibration rule, result, or physical evidence count changes.

## Validation

Local validation on source matching `main` at `f6c4a04cef40a12b4482154549e66e1c4ce32f75`:

- complete core suite in four bounded groups: `1649 passed, 13 skipped`;
- focused artifact/lineage regressions: `46 passed, 2 skipped`;
- Python compilation for `src` and `tests`;
- wheel construction with build isolation disabled; and
- `git diff --check`.

The skips are optional BayesianPhysTwin/provider and build-frontend integrations. GitHub Actions remain authoritative for Ruff formatting/lint, MyPy, dependency floors, security scanning, installed-wheel integration, and merge-result validation.