### PR TITLE
Add generic external rollout importer and bridge doctor

### DIFF
--- a/docs/external_rollout_import.md
+++ b/docs/external_rollout_import.md
@@ -1,0 +1,126 @@
+# External physical rollout-bank import
+
+Causal4D can ingest a finite bank of complete trajectories from an external MPM,
+IPC, FEM, mass-spring, or other forward simulator without importing that
+simulator or differentiating through it.
+
+The first portable contract intentionally supports a flat rollout axis:
+
+```text
+R complete candidates × T frames × N persistent nodes × C coordinates
+```
+
+Each candidate becomes one discrete `JointRolloutBank` hypothesis. Physical
+parameters can be retained as metadata for every candidate. More structured
+hypothesis-by-parameter support can already be expressed directly with
+`JointRolloutBank`; the flat importer is the low-burden collaborator boundary.
+
+## Producer NPZ
+
+A minimal producer file contains:
+
+```python
+import numpy as np
+
+np.savez_compressed(
+    "producer_rollouts.npz",
+    node_ids=node_ids,                         # integer [N]
+    trajectories_world_m=trajectories_world_m, # float [R,T,N,3]
+    rollout_weights=rollout_weights,           # float [R]
+    frame_times_s=frame_times_s,                # float [T]
+    rollout_ids=rollout_ids,                    # text [R], optional
+    parameter_values=parameter_values,          # float [R,D], optional
+)
+```
+
+Requirements:
+
+- node identities are persistent and unique;
+- frame times are in seconds and strictly increasing;
+- `anchor_time_s` in the manifest matches exactly one frame;
+- candidate weights are finite, nonnegative, and have positive total mass;
+- trajectories are complete and finite; and
+- object arrays and pickle are forbidden.
+
+## Import manifest v1
+
+```json
+{
+  "schema": "causal4d.external_rollout_import",
+  "schema_version": 1,
+  "case_id": "single_lift_cloth",
+  "source": {
+    "simulator": "external-mpm",
+    "revision": "git-or-configuration-revision",
+    "artifact_id": "optional-upstream-run-id"
+  },
+  "arrays": {
+    "node_ids": "node_ids",
+    "trajectories": "trajectories_world_m",
+    "frame_times_s": "frame_times_s",
+    "rollout_weights": "rollout_weights",
+    "rollout_ids": "rollout_ids",
+    "parameter_values": "parameter_values"
+  },
+  "layout": "RTNC",
+  "coordinate_frame": "world",
+  "position_unit": "m",
+  "anchor_time_s": 0.0,
+  "parameter_names": [
+    "young_modulus_pa",
+    "damping",
+    "table_friction",
+    "grasp_stiffness"
+  ],
+  "variance_floor_m2": 1e-6,
+  "confidence_level": 0.9,
+  "metadata": {
+    "action_setting": "known"
+  }
+}
+```
+
+The importer accepts `m`, `cm`, and `mm`. Camera-frame 3-D trajectories are also
+accepted when `arrays.camera_to_world` names a finite rigid `4 x 4` transform;
+its translation is expressed in metres.
+
+## Import and preflight validation
+
+```bash
+python -m causal4d.cli.external_rollout_import \
+  producer_rollouts.npz \
+  external_rollout_manifest.json \
+  canonical_rollout_bank.npz
+```
+
+Then compare the canonical bank with a canonical external forecast:
+
+```bash
+python -m causal4d.cli.external_bridge_doctor \
+  canonical_forecast.npz \
+  canonical_rollout_bank.npz \
+  instruction \
+  bridge_doctor.json
+```
+
+The doctor validates:
+
+- case identity;
+- exact forecast-node membership in the rollout bank;
+- forecast/rollout time overlap;
+- interpolation frame indices;
+- anchor mismatch;
+- forecast-to-rollout motion-scale ratio;
+- validity-mask coverage; and
+- byte-identical physical weights at zero semantic weight.
+
+Use `--strict-warnings` when anchor or motion-scale warnings should return exit
+status `3` while retaining a complete JSON report.
+
+## Scientific boundary
+
+Import success establishes only contract compatibility. It does not establish
+that the rollout support is physically calibrated, that a positive semantic
+weight is beneficial, or that an external forecast is an independent physical
+observation. Positive semantic trust still requires source-only competence and
+held-out confirmation; rejection must preserve the physical weights exactly.

--- a/examples/molmomotion_physics_bridge/README.md
+++ b/examples/molmomotion_physics_bridge/README.md
@@ -95,6 +95,43 @@ underlying generic importer also supports camera coordinates, `m`/`cm`/`mm`,
 `PFC`/`FPC`/`KPFC`/`KFPC` layouts, explicit frame indices, and coordinate-level
 validity; see [`docs/external_forecast_import.md`](../../docs/external_forecast_import.md).
 
+## Import rollouts from an existing simulator
+
+The simulator can remain in its own environment and only needs to export one
+non-pickled NPZ:
+
+```python
+np.savez_compressed(
+    "producer_rollouts.npz",
+    node_ids=node_ids,                         # [N]
+    trajectories_world_m=trajectories_world_m, # [R,T,N,3]
+    rollout_weights=rollout_weights,           # [R]
+    frame_times_s=frame_times_s,                # [T], includes t0
+    rollout_ids=rollout_ids,                    # [R], optional
+    parameter_values=parameter_values,          # [R,D], optional
+)
+```
+
+Copy and edit `external_rollout_manifest_v1.json`, then run:
+
+```bash
+python -m causal4d.cli.external_rollout_import \
+  producer_rollouts.npz \
+  external_rollout_manifest.json \
+  canonical_rollout_bank.npz
+
+python -m causal4d.cli.external_bridge_doctor \
+  canonical_forecast.npz \
+  canonical_rollout_bank.npz \
+  instruction \
+  bridge_doctor.json
+```
+
+The doctor checks node identities, time overlap, anchor alignment, motion scale,
+and the byte-identical zero-semantic-weight fallback before any positive
+reweighting is attempted. See
+[`docs/external_rollout_import.md`](../../docs/external_rollout_import.md).
+
 ## Generate the physical posterior
 
 BayesianPhysTwin supplies uncertain state/parameter particles and PhysTwin/Warp

--- a/examples/molmomotion_physics_bridge/external_rollout_manifest_v1.json
+++ b/examples/molmomotion_physics_bridge/external_rollout_manifest_v1.json
@@ -1,0 +1,33 @@
+{
+  "schema": "causal4d.external_rollout_import",
+  "schema_version": 1,
+  "case_id": "single_lift_cloth",
+  "source": {
+    "simulator": "external-mpm",
+    "revision": "replace-with-simulator-revision",
+    "artifact_id": "replace-with-run-id"
+  },
+  "arrays": {
+    "node_ids": "node_ids",
+    "trajectories": "trajectories_world_m",
+    "frame_times_s": "frame_times_s",
+    "rollout_weights": "rollout_weights",
+    "rollout_ids": "rollout_ids",
+    "parameter_values": "parameter_values"
+  },
+  "layout": "RTNC",
+  "coordinate_frame": "world",
+  "position_unit": "m",
+  "anchor_time_s": 0.0,
+  "parameter_names": [
+    "young_modulus_pa",
+    "damping",
+    "table_friction",
+    "grasp_stiffness"
+  ],
+  "variance_floor_m2": 1e-6,
+  "confidence_level": 0.9,
+  "metadata": {
+    "action_setting": "known"
+  }
+}

--- a/src/causal4d/_external_rollout_schema.py
+++ b/src/causal4d/_external_rollout_schema.py
@@ -1,0 +1,390 @@
+"""Portable import boundary for external finite physical rollout banks."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from causal4d.contracts import array_sha256
+from causal4d.immutable_array import readonly_array, readonly_integer_array
+from causal4d.immutable_json import plain_json, validated_json_mapping
+from causal4d.rollout_bank import JointRolloutBank
+
+EXTERNAL_ROLLOUT_IMPORT_SCHEMA = "causal4d.external_rollout_import"
+EXTERNAL_ROLLOUT_IMPORT_SCHEMA_VERSION = 1
+EXTERNAL_ROLLOUT_BANK_SCHEMA = "causal4d.external_rollout_bank"
+EXTERNAL_ROLLOUT_BANK_SCHEMA_VERSION = 1
+
+_IMPORT_REQUIRED_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "case_id",
+        "source",
+        "arrays",
+        "layout",
+        "coordinate_frame",
+        "position_unit",
+        "anchor_time_s",
+    }
+)
+_IMPORT_OPTIONAL_FIELDS = frozenset(
+    {
+        "parameter_names",
+        "variance_floor_m2",
+        "confidence_level",
+        "metadata",
+    }
+)
+_IMPORT_ARRAY_REQUIRED_FIELDS = frozenset(
+    {"node_ids", "trajectories", "frame_times_s", "rollout_weights"}
+)
+_IMPORT_ARRAY_OPTIONAL_FIELDS = frozenset(
+    {"rollout_ids", "parameter_values", "camera_to_world"}
+)
+_SOURCE_REQUIRED_FIELDS = frozenset({"simulator"})
+_SOURCE_OPTIONAL_FIELDS = frozenset({"revision", "artifact_id"})
+_BANK_DESCRIPTOR_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "artifact_id",
+        "case_id",
+        "source",
+        "node_ids",
+        "frame_times_s",
+        "anchor_time_s",
+        "anchor_frame_index",
+        "parameter_names",
+        "source_npz_sha256",
+        "import_manifest_sha256",
+        "bank_artifact_id",
+        "metadata",
+    }
+)
+_BANK_SOURCE_FIELDS = frozenset({"simulator", "revision", "artifact_id"})
+_UNIT_SCALE_TO_M = {"m": 1.0, "cm": 1e-2, "mm": 1e-3}
+_COORDINATE_FRAMES = frozenset({"world", "camera"})
+_SUPPORTED_LAYOUTS = frozenset({"RTNC"})
+
+
+def _require_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    if any(type(key) is not str for key in value):
+        raise ValueError(f"{name} keys must be strings")
+    return value
+
+
+def _require_fields(
+    value: Any,
+    *,
+    name: str,
+    required: frozenset[str],
+    optional: frozenset[str] = frozenset(),
+) -> Mapping[str, Any]:
+    mapping = _require_mapping(value, name=name)
+    actual = set(mapping)
+    missing = sorted(required - actual)
+    unexpected = sorted(actual - required - optional)
+    if missing or unexpected:
+        raise ValueError(
+            f"{name} fields do not match schema; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    return mapping
+
+
+def _require_nonempty_string(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _require_optional_string(value: Any, *, name: str) -> str | None:
+    if value is None:
+        return None
+    return _require_nonempty_string(value, name=name)
+
+
+def _require_integer(value: Any, *, name: str, minimum: int = 0) -> int:
+    if type(value) is not int or value < minimum:
+        raise ValueError(
+            f"{name} must be an integer greater than or equal to {minimum}"
+        )
+    return value
+
+
+def _require_finite_number(value: Any, *, name: str) -> float:
+    if type(value) not in {int, float} or not np.isfinite(value):
+        raise ValueError(f"{name} must be a finite JSON number")
+    return float(value)
+
+
+def _require_positive_number(value: Any, *, name: str) -> float:
+    result = _require_finite_number(value, name=name)
+    if result <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return result
+
+
+def _validated_string_tuple(
+    values: Any,
+    *,
+    name: str,
+    allow_empty: bool = False,
+) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise ValueError(f"{name} must be a sequence of strings")
+    result = tuple(
+        _require_nonempty_string(value, name=f"{name}[{index}]")
+        for index, value in enumerate(values)
+    )
+    if not result and not allow_empty:
+        raise ValueError(f"{name} must be nonempty")
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must not contain duplicates")
+    return result
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_json_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON constant {value!r} is not allowed")
+
+
+def _load_json_mapping(path: str | Path, *, name: str) -> Mapping[str, Any]:
+    try:
+        parsed = json.loads(
+            Path(path).read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_json_keys,
+            parse_constant=_reject_nonfinite_json_constant,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"{name} is not valid UTF-8 JSON") from error
+    return _require_mapping(parsed, name=name)
+
+
+def _canonical_json(value: Mapping[str, Any]) -> str:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def _file_sha256(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_sha256(value: Any, *, name: str) -> str:
+    if (
+        type(value) is not str
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _source_array(
+    archive: np.lib.npyio.NpzFile,
+    key: Any,
+    *,
+    name: str,
+) -> np.ndarray:
+    key_text = _require_nonempty_string(key, name=f"arrays.{name}")
+    if key_text not in archive.files:
+        raise ValueError(f"source NPZ does not contain array {key_text!r} for {name}")
+    try:
+        return np.asarray(archive[key_text])
+    except ValueError as error:
+        raise ValueError(
+            f"source array {key_text!r} cannot be loaded without pickle"
+        ) from error
+
+
+def _text_vector(values: np.ndarray, *, name: str) -> tuple[str, ...]:
+    array = np.asarray(values)
+    if array.ndim != 1 or array.dtype.kind not in {"U", "S"}:
+        raise ValueError(f"{name} must be a one-dimensional text array")
+    result: list[str] = []
+    for index, raw in enumerate(array):
+        value: Any = raw.item() if isinstance(raw, np.generic) else raw
+        if isinstance(value, bytes):
+            try:
+                value = value.decode("utf-8")
+            except UnicodeDecodeError as error:
+                raise ValueError(f"{name}[{index}] is not valid UTF-8") from error
+        result.append(_require_nonempty_string(value, name=f"{name}[{index}]"))
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must not contain duplicates")
+    return tuple(result)
+
+
+def _camera_to_world(points_m: np.ndarray, transform: np.ndarray) -> np.ndarray:
+    matrix = np.asarray(transform, dtype=np.float64)
+    if matrix.shape != (4, 4) or not np.all(np.isfinite(matrix)):
+        raise ValueError("camera_to_world must have finite shape (4, 4)")
+    if not np.allclose(matrix[3], np.asarray([0.0, 0.0, 0.0, 1.0])):
+        raise ValueError("camera_to_world must be a homogeneous rigid transform")
+    rotation = matrix[:3, :3]
+    if not np.allclose(rotation.T @ rotation, np.eye(3), atol=1e-6, rtol=1e-6):
+        raise ValueError("camera_to_world rotation must be orthonormal")
+    if not np.isclose(np.linalg.det(rotation), 1.0, atol=1e-6, rtol=1e-6):
+        raise ValueError("camera_to_world rotation must have determinant one")
+    flat = points_m.reshape(-1, 3)
+    homogeneous = np.column_stack((flat, np.ones(len(flat))))
+    transformed = homogeneous @ matrix.T
+    return transformed[:, :3].reshape(points_m.shape)
+
+
+@dataclass(frozen=True)
+class ExternalRolloutBundle:
+    """Canonical finite rollout support with explicit node and time identities."""
+
+    bank: JointRolloutBank
+    case_id: str
+    source_simulator: str
+    node_ids: np.ndarray
+    frame_times_s: np.ndarray
+    anchor_time_s: float
+    source_npz_sha256: str
+    import_manifest_sha256: str
+    source_revision: str | None = None
+    source_artifact_id: str | None = None
+    parameter_names: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.bank, JointRolloutBank):
+            raise TypeError("bank must be a JointRolloutBank")
+        case_id = _require_nonempty_string(self.case_id, name="case_id")
+        source_simulator = _require_nonempty_string(
+            self.source_simulator,
+            name="source_simulator",
+        )
+        source_revision = _require_optional_string(
+            self.source_revision,
+            name="source_revision",
+        )
+        source_artifact_id = _require_optional_string(
+            self.source_artifact_id,
+            name="source_artifact_id",
+        )
+        source_npz_sha256 = _validate_sha256(
+            self.source_npz_sha256,
+            name="source_npz_sha256",
+        )
+        import_manifest_sha256 = _validate_sha256(
+            self.import_manifest_sha256,
+            name="import_manifest_sha256",
+        )
+        nodes = readonly_integer_array(self.node_ids, name="node_ids")
+        if nodes.ndim != 1 or len(nodes) != self.bank.node_count:
+            raise ValueError("node_ids must identify every rollout-bank node")
+        if np.any(nodes < 0) or len(np.unique(nodes)) != len(nodes):
+            raise ValueError("node_ids must be unique and nonnegative")
+        times = readonly_array(self.frame_times_s, dtype=np.float64)
+        if times.shape != (self.bank.frame_count,) or not np.all(np.isfinite(times)):
+            raise ValueError("frame_times_s must be finite and match rollout frames")
+        if np.any(np.diff(times) <= 0.0):
+            raise ValueError("frame_times_s must be strictly increasing")
+        anchor_time = _require_finite_number(self.anchor_time_s, name="anchor_time_s")
+        matches = np.flatnonzero(np.isclose(times, anchor_time, atol=1e-12, rtol=0.0))
+        if len(matches) != 1:
+            raise ValueError("anchor_time_s must match exactly one rollout frame")
+        parameter_names = _validated_string_tuple(
+            self.parameter_names,
+            name="parameter_names",
+            allow_empty=True,
+        )
+        metadata = validated_json_mapping(
+            self.metadata,
+            error_message="external rollout metadata must be finite JSON data",
+        )
+        object.__setattr__(self, "case_id", case_id)
+        object.__setattr__(self, "source_simulator", source_simulator)
+        object.__setattr__(self, "source_revision", source_revision)
+        object.__setattr__(self, "source_artifact_id", source_artifact_id)
+        object.__setattr__(self, "source_npz_sha256", source_npz_sha256)
+        object.__setattr__(self, "import_manifest_sha256", import_manifest_sha256)
+        object.__setattr__(self, "node_ids", nodes)
+        object.__setattr__(self, "frame_times_s", times)
+        object.__setattr__(self, "anchor_time_s", anchor_time)
+        object.__setattr__(self, "parameter_names", parameter_names)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def anchor_frame_index(self) -> int:
+        matches = np.flatnonzero(
+            np.isclose(self.frame_times_s, self.anchor_time_s, atol=1e-12, rtol=0.0)
+        )
+        return int(matches[0])
+
+    def _descriptor_without_id(self) -> dict[str, Any]:
+        return {
+            "schema": EXTERNAL_ROLLOUT_BANK_SCHEMA,
+            "schema_version": EXTERNAL_ROLLOUT_BANK_SCHEMA_VERSION,
+            "case_id": self.case_id,
+            "source": {
+                "simulator": self.source_simulator,
+                "revision": self.source_revision,
+                "artifact_id": self.source_artifact_id,
+            },
+            "node_ids": self.node_ids.tolist(),
+            "frame_times_s": self.frame_times_s.tolist(),
+            "anchor_time_s": self.anchor_time_s,
+            "anchor_frame_index": self.anchor_frame_index,
+            "parameter_names": list(self.parameter_names),
+            "source_npz_sha256": self.source_npz_sha256,
+            "import_manifest_sha256": self.import_manifest_sha256,
+            "bank_artifact_id": self.bank.artifact_id,
+            "metadata": plain_json(self.metadata),
+        }
+
+    @property
+    def artifact_id(self) -> str:
+        encoded = _canonical_json(self._descriptor_without_id()).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def descriptor(self) -> dict[str, Any]:
+        descriptor = self._descriptor_without_id()
+        descriptor["artifact_id"] = self.artifact_id
+        return descriptor
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "artifact_id": self.artifact_id,
+            "bank_artifact_id": self.bank.artifact_id,
+            "case_id": self.case_id,
+            "source_simulator": self.source_simulator,
+            "source_revision": self.source_revision,
+            "rollout_count": len(self.bank.hypothesis_ids),
+            "frame_count": self.bank.frame_count,
+            "node_count": self.bank.node_count,
+            "coordinate_count": self.bank.coordinate_count,
+            "anchor_time_s": self.anchor_time_s,
+            "anchor_frame_index": self.anchor_frame_index,
+            "frame_time_start_s": float(self.frame_times_s[0]),
+            "frame_time_stop_s": float(self.frame_times_s[-1]),
+            "parameter_names": list(self.parameter_names),
+        }

--- a/src/causal4d/_external_rollout_schema.py
+++ b/src/causal4d/_external_rollout_schema.py
@@ -11,7 +11,6 @@ from typing import Any
 
 import numpy as np
 
-from causal4d.contracts import array_sha256
 from causal4d.immutable_array import readonly_array, readonly_integer_array
 from causal4d.immutable_json import plain_json, validated_json_mapping
 from causal4d.rollout_bank import JointRolloutBank

--- a/src/causal4d/cli/external_bridge_doctor.py
+++ b/src/causal4d/cli/external_bridge_doctor.py
@@ -1,0 +1,74 @@
+"""Validate a canonical external forecast against an external rollout bank."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+
+def _load_runtime_dependencies() -> None:
+    global build_external_bridge_report
+    global load_external_forecast
+    global load_external_rollout_bank
+    global plain_json
+
+    from causal4d.external_bridge import build_external_bridge_report
+    from causal4d.external_forecast import load_external_forecast
+    from causal4d.external_rollout import load_external_rollout_bank
+    from causal4d.immutable_json import plain_json
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check case identity, node correspondence, time overlap, anchor "
+            "alignment, motion scale, and exact zero-weight fallback."
+        )
+    )
+    parser.add_argument("external_forecast_npz")
+    parser.add_argument("external_rollout_bank_npz")
+    parser.add_argument("forecast_id")
+    parser.add_argument("output_json")
+    parser.add_argument("--anchor-tolerance-m", type=float, default=0.01)
+    parser.add_argument("--motion-ratio-min", type=float, default=0.10)
+    parser.add_argument("--motion-ratio-max", type=float, default=10.0)
+    parser.add_argument("--scale-m", type=float, default=0.05)
+    parser.add_argument("--degrees-of-freedom", type=float, default=3.0)
+    parser.add_argument(
+        "--strict-warnings",
+        action="store_true",
+        help="return exit status 3 when the contract is valid but warnings remain",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    _load_runtime_dependencies()
+    forecast = load_external_forecast(args.external_forecast_npz)
+    rollouts = load_external_rollout_bank(args.external_rollout_bank_npz)
+    report = build_external_bridge_report(
+        forecast,
+        args.forecast_id,
+        rollouts,
+        anchor_tolerance_m=args.anchor_tolerance_m,
+        motion_ratio_min=args.motion_ratio_min,
+        motion_ratio_max=args.motion_ratio_max,
+        scale_m=args.scale_m,
+        degrees_of_freedom=args.degrees_of_freedom,
+    )
+    output = Path(args.output_json)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    payload = plain_json(report)
+    output.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 3 if args.strict_warnings and payload["warnings"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d/cli/external_rollout_import.py
+++ b/src/causal4d/cli/external_rollout_import.py
@@ -1,0 +1,51 @@
+"""Import a portable external physical rollout bank."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+
+def _load_runtime_dependencies() -> None:
+    global import_external_rollouts
+    global save_external_rollout_bank
+
+    from causal4d.external_rollout import (
+        import_external_rollouts,
+        save_external_rollout_bank,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Normalize a flat external simulator rollout support into the "
+            "content-addressed Causal4D JointRolloutBank contract."
+        )
+    )
+    parser.add_argument("source_npz")
+    parser.add_argument("import_manifest_json")
+    parser.add_argument("output_rollout_bank_npz")
+    parser.add_argument("--no-overwrite", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    _load_runtime_dependencies()
+    bundle = import_external_rollouts(args.source_npz, args.import_manifest_json)
+    save_external_rollout_bank(
+        args.output_rollout_bank_npz,
+        bundle,
+        overwrite=not args.no_overwrite,
+    )
+    summary = bundle.summary()
+    summary["output"] = str(Path(args.output_rollout_bank_npz).resolve())
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d/external_bridge.py
+++ b/src/causal4d/external_bridge.py
@@ -1,0 +1,238 @@
+"""Preflight validation for sparse external forecasts and rollout banks."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import numpy as np
+
+from causal4d.external_forecast import ExternalForecastBundle
+from causal4d.external_rollout import ExternalRolloutBundle
+from causal4d.immutable_json import plain_json, validated_json_mapping
+from causal4d.rollout_bank import SparseTrajectoryEvidence
+
+BRIDGE_DOCTOR_SCHEMA = "causal4d.external_forecast_rollout_doctor"
+BRIDGE_DOCTOR_SCHEMA_VERSION = 1
+
+
+def _fractional_frame_indices(
+    frame_times_s: np.ndarray,
+    query_times_s: np.ndarray,
+) -> np.ndarray:
+    times = np.asarray(frame_times_s, dtype=np.float64)
+    query = np.asarray(query_times_s, dtype=np.float64)
+    if times.ndim != 1 or query.ndim != 1 or not len(query):
+        raise ValueError("frame and query times must be nonempty vectors")
+    if not np.all(np.isfinite(times)) or not np.all(np.isfinite(query)):
+        raise ValueError("frame and query times must be finite")
+    if np.any(np.diff(times) <= 0.0) or np.any(np.diff(query) <= 0.0):
+        raise ValueError("frame and query times must be strictly increasing")
+    tolerance = 1e-12
+    if query[0] < times[0] - tolerance or query[-1] > times[-1] + tolerance:
+        raise ValueError("forecast times exceed rollout-bank time support")
+    query = np.clip(query, times[0], times[-1])
+    return np.interp(query, times, np.arange(len(times), dtype=np.float64))
+
+
+def _interpolate_components(
+    trajectories: np.ndarray,
+    frame_indices: np.ndarray,
+    node_indices: np.ndarray,
+) -> np.ndarray:
+    lower = np.floor(frame_indices).astype(np.int64)
+    upper = np.ceil(frame_indices).astype(np.int64)
+    alpha = (frame_indices - lower).reshape(1, 1, -1, 1, 1)
+    selected_lower = trajectories[:, :, lower][:, :, :, node_indices]
+    selected_upper = trajectories[:, :, upper][:, :, :, node_indices]
+    return (1.0 - alpha) * selected_lower + alpha * selected_upper
+
+
+def _weighted_mean(values: np.ndarray, weights: np.ndarray) -> float:
+    flattened = np.asarray(values, dtype=np.float64).reshape(-1)
+    flattened_weights = np.asarray(weights, dtype=np.float64).reshape(-1)
+    return float(np.sum(flattened * flattened_weights))
+
+
+def _coordinate_motion_rms(
+    displacement: np.ndarray,
+    valid: np.ndarray,
+) -> float:
+    values = np.asarray(displacement, dtype=np.float64)
+    mask = np.asarray(valid, dtype=bool)
+    if values.shape != mask.shape or not np.any(mask):
+        raise ValueError("motion RMS requires matching nonempty valid coordinates")
+    return float(np.sqrt(np.mean(np.square(values[mask]))))
+
+
+def build_external_bridge_report(
+    forecast: ExternalForecastBundle,
+    forecast_id: str,
+    rollouts: ExternalRolloutBundle,
+    *,
+    anchor_tolerance_m: float = 0.01,
+    motion_ratio_min: float = 0.10,
+    motion_ratio_max: float = 10.0,
+    scale_m: float = 0.05,
+    degrees_of_freedom: float = 3.0,
+    metadata: Mapping[str, Any] | None = None,
+) -> Mapping[str, Any]:
+    """Validate identity, timing, scale, and exact fallback before reweighting."""
+
+    if not np.isfinite(anchor_tolerance_m) or anchor_tolerance_m <= 0.0:
+        raise ValueError("anchor_tolerance_m must be finite and positive")
+    if (
+        not np.isfinite(motion_ratio_min)
+        or not np.isfinite(motion_ratio_max)
+        or motion_ratio_min <= 0.0
+        or motion_ratio_max <= motion_ratio_min
+    ):
+        raise ValueError("motion-ratio bounds must be finite, positive, and ordered")
+    if forecast.case_id != rollouts.case_id:
+        raise ValueError("external forecast and rollout bank case IDs differ")
+    if forecast.future_times_s is None:
+        raise ValueError(
+            "external forecast must retain future_times_s for rollout-bank bridging"
+        )
+    forecast_index = forecast.forecast_index(forecast_id)
+    if rollouts.bank.coordinate_count != 3:
+        raise ValueError("external forecast bridge currently requires 3-D rollouts")
+
+    node_lookup = {
+        int(node_id): index for index, node_id in enumerate(rollouts.node_ids)
+    }
+    missing_nodes = [
+        int(node_id)
+        for node_id in forecast.node_indices
+        if int(node_id) not in node_lookup
+    ]
+    if missing_nodes:
+        raise ValueError(
+            "forecast node IDs are absent from rollout bank: " + repr(missing_nodes)
+        )
+    internal_nodes = np.asarray(
+        [node_lookup[int(node_id)] for node_id in forecast.node_indices],
+        dtype=np.int64,
+    )
+
+    query_times = rollouts.anchor_time_s + forecast.future_times_s
+    query_frame_indices = _fractional_frame_indices(
+        rollouts.frame_times_s,
+        query_times,
+    )
+    target = forecast.future_positions_m[forecast_index]
+    valid = forecast.coordinate_validity[forecast_index]
+    evidence = SparseTrajectoryEvidence(
+        positions_m=target,
+        node_indices=internal_nodes,
+        rollout_frame_indices=query_frame_indices,
+        scale_m=scale_m,
+        degrees_of_freedom=degrees_of_freedom,
+        likelihood_weight=0.0,
+        compare_displacements=True,
+        anchor_positions_m=forecast.anchor_positions_m,
+        anchor_rollout_frame=rollouts.anchor_frame_index,
+        valid=valid,
+        source=f"ExternalForecast:{forecast.artifact_id}:{forecast_id}",
+    )
+    prior = rollouts.bank.prior_joint_weights
+    fallback = rollouts.bank.update_from_sparse_evidence(evidence)
+    beta_zero_identical = fallback.tobytes() == prior.tobytes()
+    if not beta_zero_identical:
+        raise RuntimeError("zero semantic weight did not preserve rollout weights")
+
+    anchor_components = rollouts.bank.trajectories[
+        :, :, rollouts.anchor_frame_index, internal_nodes
+    ].astype(np.float64)
+    anchor_error = np.linalg.norm(
+        anchor_components - forecast.anchor_positions_m[None, None],
+        axis=-1,
+    )
+    anchor_component_rms = np.sqrt(np.mean(np.square(anchor_error), axis=-1))
+    best_anchor_rms = float(np.min(anchor_component_rms))
+    maximum_anchor_rms = float(np.max(anchor_component_rms))
+    weighted_anchor_rms = _weighted_mean(anchor_component_rms, prior)
+
+    future_components = _interpolate_components(
+        rollouts.bank.trajectories.astype(np.float64),
+        query_frame_indices,
+        internal_nodes,
+    )
+    rollout_displacement = future_components - anchor_components[:, :, None]
+    rollout_component_rms = np.sqrt(
+        np.mean(np.square(rollout_displacement), axis=(2, 3, 4))
+    )
+    weighted_rollout_rms = _weighted_mean(rollout_component_rms, prior)
+    forecast_displacement = target - forecast.anchor_positions_m[None]
+    forecast_motion_rms = _coordinate_motion_rms(forecast_displacement, valid)
+    motion_ratio = (
+        forecast_motion_rms / weighted_rollout_rms
+        if weighted_rollout_rms > 0.0
+        else None
+    )
+
+    warnings: list[str] = []
+    if best_anchor_rms > anchor_tolerance_m:
+        warnings.append(
+            "no rollout component matches the forecast anchor within the configured "
+            "tolerance"
+        )
+    elif maximum_anchor_rms > anchor_tolerance_m:
+        warnings.append(
+            "some rollout components exceed the configured anchor tolerance"
+        )
+    if motion_ratio is None:
+        warnings.append("rollout-bank motion scale is zero")
+    elif not motion_ratio_min <= motion_ratio <= motion_ratio_max:
+        warnings.append(
+            "forecast motion scale lies outside the configured rollout-bank ratio"
+        )
+
+    report = {
+        "schema": BRIDGE_DOCTOR_SCHEMA,
+        "schema_version": BRIDGE_DOCTOR_SCHEMA_VERSION,
+        "valid": True,
+        "case_id": forecast.case_id,
+        "forecast_artifact_id": forecast.artifact_id,
+        "forecast_id": forecast_id,
+        "rollout_artifact_id": rollouts.artifact_id,
+        "rollout_bank_artifact_id": rollouts.bank.artifact_id,
+        "matched_node_ids": forecast.node_indices.tolist(),
+        "matched_node_count": len(forecast.node_indices),
+        "forecast_future_times_s": forecast.future_times_s.tolist(),
+        "rollout_query_times_s": query_times.tolist(),
+        "rollout_fractional_frame_indices": query_frame_indices.tolist(),
+        "valid_coordinate_fraction": float(np.mean(valid)),
+        "anchor": {
+            "configured_tolerance_m": float(anchor_tolerance_m),
+            "best_component_rms_m": best_anchor_rms,
+            "prior_weighted_rms_m": weighted_anchor_rms,
+            "maximum_component_rms_m": maximum_anchor_rms,
+        },
+        "motion": {
+            "forecast_coordinate_rms_m": forecast_motion_rms,
+            "prior_weighted_rollout_coordinate_rms_m": weighted_rollout_rms,
+            "forecast_to_rollout_ratio": motion_ratio,
+            "configured_ratio_min": float(motion_ratio_min),
+            "configured_ratio_max": float(motion_ratio_max),
+        },
+        "beta_zero_weights_bit_identical": beta_zero_identical,
+        "warnings": warnings,
+        "metadata": plain_json(
+            validated_json_mapping(
+                {} if metadata is None else metadata,
+                error_message="bridge report metadata must be finite JSON data",
+            )
+        ),
+    }
+    return validated_json_mapping(
+        report,
+        error_message="bridge doctor report must be finite JSON data",
+    )
+
+
+__all__ = [
+    "BRIDGE_DOCTOR_SCHEMA",
+    "BRIDGE_DOCTOR_SCHEMA_VERSION",
+    "build_external_bridge_report",
+]

--- a/src/causal4d/external_rollout.py
+++ b/src/causal4d/external_rollout.py
@@ -1,0 +1,373 @@
+"""Portable import boundary for external finite physical rollout banks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from causal4d._external_rollout_schema import (
+    EXTERNAL_ROLLOUT_BANK_SCHEMA,
+    EXTERNAL_ROLLOUT_BANK_SCHEMA_VERSION,
+    EXTERNAL_ROLLOUT_IMPORT_SCHEMA,
+    EXTERNAL_ROLLOUT_IMPORT_SCHEMA_VERSION,
+    ExternalRolloutBundle,
+    _BANK_DESCRIPTOR_FIELDS,
+    _BANK_SOURCE_FIELDS,
+    _COORDINATE_FRAMES,
+    _IMPORT_ARRAY_OPTIONAL_FIELDS,
+    _IMPORT_ARRAY_REQUIRED_FIELDS,
+    _IMPORT_OPTIONAL_FIELDS,
+    _IMPORT_REQUIRED_FIELDS,
+    _SOURCE_OPTIONAL_FIELDS,
+    _SOURCE_REQUIRED_FIELDS,
+    _SUPPORTED_LAYOUTS,
+    _UNIT_SCALE_TO_M,
+    _camera_to_world,
+    _file_sha256,
+    _load_json_mapping,
+    _require_fields,
+    _require_finite_number,
+    _require_integer,
+    _require_mapping,
+    _require_nonempty_string,
+    _require_optional_string,
+    _require_positive_number,
+    _source_array,
+    _text_vector,
+    _validate_sha256,
+    _validated_string_tuple,
+)
+from causal4d.contracts import array_sha256
+from causal4d.immutable_array import readonly_integer_array
+from causal4d.immutable_json import plain_json, validated_json_mapping
+from causal4d.rollout_bank import JointRolloutBank
+from causal4d.rollout_bank_io import load_rollout_bank, save_rollout_bank
+
+
+def import_external_rollouts(
+    source_npz: str | Path,
+    import_manifest_json: str | Path,
+) -> ExternalRolloutBundle:
+    """Normalize one flat external rollout support through a strict manifest."""
+
+    manifest_hash = _file_sha256(import_manifest_json)
+    manifest = _require_fields(
+        _load_json_mapping(import_manifest_json, name="external rollout manifest"),
+        name="external rollout manifest",
+        required=_IMPORT_REQUIRED_FIELDS,
+        optional=_IMPORT_OPTIONAL_FIELDS,
+    )
+    if _file_sha256(import_manifest_json) != manifest_hash:
+        raise ValueError("external rollout manifest changed during import")
+    if (
+        _require_nonempty_string(manifest["schema"], name="schema")
+        != EXTERNAL_ROLLOUT_IMPORT_SCHEMA
+    ):
+        raise ValueError("unexpected external rollout import schema")
+    if (
+        _require_integer(manifest["schema_version"], name="schema_version", minimum=1)
+        != EXTERNAL_ROLLOUT_IMPORT_SCHEMA_VERSION
+    ):
+        raise ValueError("unsupported external rollout import schema version")
+
+    case_id = _require_nonempty_string(manifest["case_id"], name="case_id")
+    source = _require_fields(
+        manifest["source"],
+        name="source",
+        required=_SOURCE_REQUIRED_FIELDS,
+        optional=_SOURCE_OPTIONAL_FIELDS,
+    )
+    source_simulator = _require_nonempty_string(
+        source["simulator"],
+        name="source.simulator",
+    )
+    source_revision = _require_optional_string(
+        source.get("revision"),
+        name="source.revision",
+    )
+    source_artifact_id = _require_optional_string(
+        source.get("artifact_id"),
+        name="source.artifact_id",
+    )
+    arrays = _require_fields(
+        manifest["arrays"],
+        name="arrays",
+        required=_IMPORT_ARRAY_REQUIRED_FIELDS,
+        optional=_IMPORT_ARRAY_OPTIONAL_FIELDS,
+    )
+    layout = _require_nonempty_string(manifest["layout"], name="layout")
+    if layout not in _SUPPORTED_LAYOUTS:
+        raise ValueError(f"layout must be one of {sorted(_SUPPORTED_LAYOUTS)}")
+    coordinate_frame = _require_nonempty_string(
+        manifest["coordinate_frame"],
+        name="coordinate_frame",
+    )
+    if coordinate_frame not in _COORDINATE_FRAMES:
+        raise ValueError(
+            f"coordinate_frame must be one of {sorted(_COORDINATE_FRAMES)}"
+        )
+    position_unit = _require_nonempty_string(
+        manifest["position_unit"],
+        name="position_unit",
+    )
+    if position_unit not in _UNIT_SCALE_TO_M:
+        raise ValueError(f"position_unit must be one of {sorted(_UNIT_SCALE_TO_M)}")
+    anchor_time_s = _require_finite_number(
+        manifest["anchor_time_s"],
+        name="anchor_time_s",
+    )
+    parameter_names = _validated_string_tuple(
+        manifest.get("parameter_names", ()),
+        name="parameter_names",
+        allow_empty=True,
+    )
+    variance_floor_m2 = _require_positive_number(
+        manifest.get("variance_floor_m2", 1e-6),
+        name="variance_floor_m2",
+    )
+    confidence_level = _require_finite_number(
+        manifest.get("confidence_level", 0.90),
+        name="confidence_level",
+    )
+    if not 0.0 < confidence_level < 1.0:
+        raise ValueError("confidence_level must lie in (0, 1)")
+    producer_metadata = validated_json_mapping(
+        _require_mapping(manifest.get("metadata", {}), name="metadata"),
+        error_message="manifest metadata must be finite JSON data",
+    )
+
+    source_hash = _file_sha256(source_npz)
+    with np.load(source_npz, allow_pickle=False) as archive:
+        nodes = readonly_integer_array(
+            _source_array(archive, arrays["node_ids"], name="node_ids"),
+            name="node_ids",
+        )
+        trajectories = np.asarray(
+            _source_array(archive, arrays["trajectories"], name="trajectories"),
+            dtype=np.float64,
+        )
+        frame_times = np.asarray(
+            _source_array(archive, arrays["frame_times_s"], name="frame_times_s"),
+            dtype=np.float64,
+        )
+        rollout_weights = np.asarray(
+            _source_array(
+                archive,
+                arrays["rollout_weights"],
+                name="rollout_weights",
+            ),
+            dtype=np.float64,
+        )
+        if "rollout_ids" in arrays:
+            rollout_ids = _text_vector(
+                _source_array(
+                    archive,
+                    arrays["rollout_ids"],
+                    name="rollout_ids",
+                ),
+                name="rollout_ids",
+            )
+        else:
+            rollout_ids = tuple(
+                f"rollout_{index:04d}" for index in range(trajectories.shape[0])
+            )
+        parameter_values = None
+        if "parameter_values" in arrays:
+            parameter_values = np.asarray(
+                _source_array(
+                    archive,
+                    arrays["parameter_values"],
+                    name="parameter_values",
+                ),
+                dtype=np.float64,
+            )
+        transform = None
+        if "camera_to_world" in arrays:
+            transform = np.asarray(
+                _source_array(
+                    archive,
+                    arrays["camera_to_world"],
+                    name="camera_to_world",
+                ),
+                dtype=np.float64,
+            )
+
+    if _file_sha256(source_npz) != source_hash:
+        raise ValueError("source NPZ changed during import")
+    if nodes.ndim != 1 or not len(nodes):
+        raise ValueError("node_ids must be a nonempty vector")
+    if np.any(nodes < 0) or len(np.unique(nodes)) != len(nodes):
+        raise ValueError("node_ids must be unique and nonnegative")
+    if trajectories.ndim != 4 or trajectories.shape[-1] not in {2, 3}:
+        raise ValueError("RTNC trajectories must have shape (R, T, N, 2|3)")
+    rollout_count, frame_count, node_count, coordinate_count = trajectories.shape
+    if rollout_count < 1 or frame_count < 2 or node_count != len(nodes):
+        raise ValueError("rollout trajectories must have nonempty matching dimensions")
+    if not np.all(np.isfinite(trajectories)):
+        raise ValueError("rollout trajectories must be finite")
+    if frame_times.shape != (frame_count,) or not np.all(np.isfinite(frame_times)):
+        raise ValueError("frame_times_s must be a finite vector matching T")
+    if np.any(np.diff(frame_times) <= 0.0):
+        raise ValueError("frame_times_s must be strictly increasing")
+    if len(rollout_ids) != rollout_count:
+        raise ValueError("rollout_ids must identify every rollout")
+    if rollout_weights.shape != (rollout_count,):
+        raise ValueError("rollout_weights must identify every rollout")
+    if not np.all(np.isfinite(rollout_weights)) or np.any(rollout_weights < 0.0):
+        raise ValueError("rollout_weights must be finite and nonnegative")
+    if float(np.sum(rollout_weights)) <= 0.0:
+        raise ValueError("rollout_weights must have positive mass")
+    if parameter_values is None:
+        if parameter_names:
+            raise ValueError("parameter_names require arrays.parameter_values")
+    else:
+        if parameter_values.shape != (rollout_count, len(parameter_names)):
+            raise ValueError("parameter_values must have shape (R, D)")
+        if not np.all(np.isfinite(parameter_values)):
+            raise ValueError("parameter_values must be finite")
+
+    scale = _UNIT_SCALE_TO_M[position_unit]
+    trajectories = trajectories * scale
+    camera_to_world_sha256 = None
+    if coordinate_frame == "camera":
+        if transform is None:
+            raise ValueError("camera-frame rollouts require arrays.camera_to_world")
+        if coordinate_count != 3:
+            raise ValueError("camera-frame transformation requires 3-D trajectories")
+        camera_to_world_sha256 = array_sha256(transform)
+        trajectories = _camera_to_world(trajectories, transform)
+    elif transform is not None:
+        raise ValueError(
+            "arrays.camera_to_world is only valid for coordinate_frame='camera'"
+        )
+
+    hypothesis_metadata: list[dict[str, Any]] = []
+    for index, rollout_id in enumerate(rollout_ids):
+        entry: dict[str, Any] = {
+            "hypothesis_id": rollout_id,
+            "source_rollout_index": index,
+        }
+        if parameter_values is not None:
+            entry["parameters"] = {
+                name: float(parameter_values[index, parameter_index])
+                for parameter_index, name in enumerate(parameter_names)
+            }
+        hypothesis_metadata.append(entry)
+
+    bank = JointRolloutBank(
+        hypothesis_ids=rollout_ids,
+        hypothesis_metadata=tuple(hypothesis_metadata),
+        hypothesis_prior_weights=rollout_weights,
+        parameter_particles=np.zeros((1, 0), dtype=np.float64),
+        parameter_weights=np.ones(1, dtype=np.float64),
+        trajectories=trajectories[:, None].astype(np.float32),
+        variance_floor_m2=variance_floor_m2,
+        confidence_level=confidence_level,
+    )
+    metadata = {
+        "importer": {
+            "schema": EXTERNAL_ROLLOUT_IMPORT_SCHEMA,
+            "schema_version": EXTERNAL_ROLLOUT_IMPORT_SCHEMA_VERSION,
+            "source_layout": layout,
+            "source_coordinate_frame": coordinate_frame,
+            "source_position_unit": position_unit,
+            "camera_to_world_sha256": camera_to_world_sha256,
+        },
+        "producer": plain_json(producer_metadata),
+    }
+    return ExternalRolloutBundle(
+        bank=bank,
+        case_id=case_id,
+        source_simulator=source_simulator,
+        source_revision=source_revision,
+        source_artifact_id=source_artifact_id,
+        node_ids=nodes,
+        frame_times_s=frame_times,
+        anchor_time_s=anchor_time_s,
+        parameter_names=parameter_names,
+        source_npz_sha256=source_hash,
+        import_manifest_sha256=manifest_hash,
+        metadata=metadata,
+    )
+
+
+def save_external_rollout_bank(
+    path: str | Path,
+    bundle: ExternalRolloutBundle,
+    *,
+    overwrite: bool = True,
+) -> None:
+    """Atomically publish a canonical external rollout bank."""
+
+    save_rollout_bank(path, bundle.bank, bundle.descriptor(), overwrite=overwrite)
+    restored = load_external_rollout_bank(path)
+    if restored.artifact_id != bundle.artifact_id:
+        raise ValueError("external rollout bundle changed during serialization")
+
+
+def load_external_rollout_bank(path: str | Path) -> ExternalRolloutBundle:
+    """Load and fully revalidate a canonical external rollout bank."""
+
+    bank, descriptor = load_rollout_bank(path)
+    manifest = _require_fields(
+        descriptor,
+        name="external rollout bank descriptor",
+        required=_BANK_DESCRIPTOR_FIELDS,
+    )
+    if (
+        _require_nonempty_string(manifest["schema"], name="schema")
+        != EXTERNAL_ROLLOUT_BANK_SCHEMA
+    ):
+        raise ValueError("rollout bank is not a canonical external rollout bank")
+    if (
+        _require_integer(manifest["schema_version"], name="schema_version", minimum=1)
+        != EXTERNAL_ROLLOUT_BANK_SCHEMA_VERSION
+    ):
+        raise ValueError("unsupported external rollout bank schema version")
+    source = _require_fields(
+        manifest["source"],
+        name="source",
+        required=_BANK_SOURCE_FIELDS,
+    )
+    bundle = ExternalRolloutBundle(
+        bank=bank,
+        case_id=manifest["case_id"],
+        source_simulator=source["simulator"],
+        source_revision=source["revision"],
+        source_artifact_id=source["artifact_id"],
+        node_ids=np.asarray(manifest["node_ids"]),
+        frame_times_s=np.asarray(manifest["frame_times_s"]),
+        anchor_time_s=manifest["anchor_time_s"],
+        parameter_names=tuple(manifest["parameter_names"]),
+        source_npz_sha256=manifest["source_npz_sha256"],
+        import_manifest_sha256=manifest["import_manifest_sha256"],
+        metadata=manifest["metadata"],
+    )
+    if bundle.anchor_frame_index != _require_integer(
+        manifest["anchor_frame_index"],
+        name="anchor_frame_index",
+    ):
+        raise ValueError("external rollout anchor frame index does not match timebase")
+    if bundle.bank.artifact_id != _validate_sha256(
+        manifest["bank_artifact_id"],
+        name="bank_artifact_id",
+    ):
+        raise ValueError("external rollout bank artifact ID does not match payload")
+    expected_id = _validate_sha256(manifest["artifact_id"], name="artifact_id")
+    if bundle.artifact_id != expected_id:
+        raise ValueError("external rollout artifact ID does not match descriptor")
+    return bundle
+
+
+__all__ = [
+    "EXTERNAL_ROLLOUT_BANK_SCHEMA",
+    "EXTERNAL_ROLLOUT_BANK_SCHEMA_VERSION",
+    "EXTERNAL_ROLLOUT_IMPORT_SCHEMA",
+    "EXTERNAL_ROLLOUT_IMPORT_SCHEMA_VERSION",
+    "ExternalRolloutBundle",
+    "import_external_rollouts",
+    "load_external_rollout_bank",
+    "save_external_rollout_bank",
+]

--- a/tests/test_external_rollout_bridge.py
+++ b/tests/test_external_rollout_bridge.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from causal4d.cli.external_bridge_doctor import main as doctor_main
+from causal4d.cli.external_rollout_import import main as rollout_import_main
+from causal4d.external_bridge import build_external_bridge_report
+from causal4d.external_forecast import (
+    ExternalForecastBundle,
+    save_external_forecast,
+)
+from causal4d.external_rollout import (
+    EXTERNAL_ROLLOUT_IMPORT_SCHEMA,
+    import_external_rollouts,
+    load_external_rollout_bank,
+    save_external_rollout_bank,
+)
+
+
+def _write_rollout_source(path: Path, *, offset_m: float = 0.0) -> None:
+    trajectories = np.zeros((2, 4, 2, 3), dtype=np.float64)
+    trajectories[0, :, 0, 0] = np.asarray([0.0, 0.01, 0.02, 0.03]) + offset_m
+    trajectories[1, :, 0, 0] = np.asarray([0.0, 0.02, 0.04, 0.06]) + offset_m
+    trajectories[:, :, 1, 1] = 0.25
+    np.savez_compressed(
+        path,
+        nodes=np.asarray([10, 20], dtype=np.int64),
+        trajectories=trajectories,
+        times=np.asarray([0.0, 0.5, 1.0, 1.5]),
+        weights=np.asarray([0.6, 0.4]),
+        ids=np.asarray(["slow", "fast"]),
+        parameters=np.asarray([[100.0], [200.0]]),
+    )
+
+
+def _write_manifest(path: Path, **overrides: object) -> None:
+    payload: dict[str, object] = {
+        "schema": EXTERNAL_ROLLOUT_IMPORT_SCHEMA,
+        "schema_version": 1,
+        "case_id": "cloth",
+        "source": {
+            "simulator": "example-mpm",
+            "revision": "abc123",
+            "artifact_id": "run-1",
+        },
+        "arrays": {
+            "node_ids": "nodes",
+            "trajectories": "trajectories",
+            "frame_times_s": "times",
+            "rollout_weights": "weights",
+            "rollout_ids": "ids",
+            "parameter_values": "parameters",
+        },
+        "layout": "RTNC",
+        "coordinate_frame": "world",
+        "position_unit": "m",
+        "anchor_time_s": 0.0,
+        "parameter_names": ["young_modulus_pa"],
+        "metadata": {"producer": "unit-test"},
+    }
+    payload.update(overrides)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _forecast() -> ExternalForecastBundle:
+    future = np.zeros((1, 3, 1, 3), dtype=np.float64)
+    future[0, :, 0, 0] = [0.01, 0.02, 0.03]
+    return ExternalForecastBundle(
+        case_id="cloth",
+        source_model="MolmoMotion",
+        source_revision="checkpoint",
+        forecast_ids=("instruction",),
+        node_indices=np.asarray([10], dtype=np.int64),
+        anchor_positions_m=np.zeros((1, 3)),
+        future_positions_m=future,
+        physical_frame_indices=np.asarray([1.0, 2.0, 3.0]),
+        future_times_s=np.asarray([0.5, 1.0, 1.5]),
+    )
+
+
+def test_external_rollout_import_roundtrip_and_doctor(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "rollouts.npz"
+    manifest = tmp_path / "rollouts.json"
+    canonical = tmp_path / "rollout_bank.npz"
+    forecast_path = tmp_path / "forecast.npz"
+    report_path = tmp_path / "doctor.json"
+    _write_rollout_source(source)
+    _write_manifest(manifest)
+
+    imported = import_external_rollouts(source, manifest)
+    assert imported.bank.trajectories.shape == (2, 1, 4, 2, 3)
+    assert imported.bank.hypothesis_ids == ("slow", "fast")
+    assert imported.parameter_names == ("young_modulus_pa",)
+    assert imported.bank.hypothesis_metadata[1]["parameters"] == {
+        "young_modulus_pa": 200.0
+    }
+    save_external_rollout_bank(canonical, imported)
+    loaded = load_external_rollout_bank(canonical)
+    assert loaded.artifact_id == imported.artifact_id
+    assert loaded.node_ids.tolist() == [10, 20]
+
+    forecast = _forecast()
+    save_external_forecast(forecast_path, forecast)
+    report = build_external_bridge_report(
+        forecast,
+        "instruction",
+        loaded,
+        anchor_tolerance_m=1e-6,
+    )
+    assert report["beta_zero_weights_bit_identical"] is True
+    assert report["matched_node_ids"] == [10]
+    assert report["rollout_fractional_frame_indices"] == [1.0, 2.0, 3.0]
+    assert report["warnings"] == []
+
+    assert (
+        rollout_import_main([str(source), str(manifest), str(canonical)]) == 0
+    )
+    import_summary = json.loads(capsys.readouterr().out)
+    assert import_summary["rollout_count"] == 2
+    assert (
+        doctor_main(
+            [
+                str(forecast_path),
+                str(canonical),
+                "instruction",
+                str(report_path),
+                "--anchor-tolerance-m",
+                "0.000001",
+            ]
+        )
+        == 0
+    )
+    cli_report = json.loads(capsys.readouterr().out)
+    assert cli_report["valid"] is True
+    assert json.loads(report_path.read_text(encoding="utf-8")) == cli_report
+
+
+def test_camera_mm_rollouts_are_converted_to_world_metres(tmp_path: Path) -> None:
+    source = tmp_path / "camera.npz"
+    transform = np.eye(4)
+    transform[:3, 3] = [1.0, 2.0, 3.0]
+    np.savez_compressed(
+        source,
+        nodes=np.asarray([10]),
+        trajectories=np.asarray([[[[1000.0, 0.0, 0.0]], [[2000.0, 0.0, 0.0]]]]),
+        times=np.asarray([0.0, 1.0]),
+        weights=np.asarray([1.0]),
+        c2w=transform,
+    )
+    manifest = tmp_path / "manifest.json"
+    _write_manifest(
+        manifest,
+        arrays={
+            "node_ids": "nodes",
+            "trajectories": "trajectories",
+            "frame_times_s": "times",
+            "rollout_weights": "weights",
+            "camera_to_world": "c2w",
+        },
+        coordinate_frame="camera",
+        position_unit="mm",
+        parameter_names=[],
+    )
+    imported = import_external_rollouts(source, manifest)
+    assert np.allclose(imported.bank.trajectories[0, 0, 0, 0], [2.0, 2.0, 3.0])
+    assert np.allclose(imported.bank.trajectories[0, 0, 1, 0], [3.0, 2.0, 3.0])
+
+
+def test_import_rejects_duplicate_node_ids(tmp_path: Path) -> None:
+    source = tmp_path / "bad.npz"
+    np.savez_compressed(
+        source,
+        nodes=np.asarray([10, 10]),
+        trajectories=np.zeros((1, 2, 2, 3)),
+        times=np.asarray([0.0, 1.0]),
+        weights=np.asarray([1.0]),
+    )
+    manifest = tmp_path / "manifest.json"
+    _write_manifest(
+        manifest,
+        arrays={
+            "node_ids": "nodes",
+            "trajectories": "trajectories",
+            "frame_times_s": "times",
+            "rollout_weights": "weights",
+        },
+        parameter_names=[],
+    )
+    with pytest.raises(ValueError, match="unique"):
+        import_external_rollouts(source, manifest)
+
+
+def test_doctor_rejects_missing_node_and_time_support(tmp_path: Path) -> None:
+    source = tmp_path / "rollouts.npz"
+    manifest = tmp_path / "rollouts.json"
+    _write_rollout_source(source)
+    _write_manifest(manifest)
+    rollouts = import_external_rollouts(source, manifest)
+
+    missing_node = ExternalForecastBundle(
+        case_id="cloth",
+        source_model="model",
+        forecast_ids=("f",),
+        node_indices=np.asarray([999]),
+        anchor_positions_m=np.zeros((1, 3)),
+        future_positions_m=np.zeros((1, 1, 1, 3)),
+        physical_frame_indices=np.asarray([1.0]),
+        future_times_s=np.asarray([0.5]),
+    )
+    with pytest.raises(ValueError, match="absent"):
+        build_external_bridge_report(missing_node, "f", rollouts)
+
+    outside = ExternalForecastBundle(
+        case_id="cloth",
+        source_model="model",
+        forecast_ids=("f",),
+        node_indices=np.asarray([10]),
+        anchor_positions_m=np.zeros((1, 3)),
+        future_positions_m=np.zeros((1, 1, 1, 3)),
+        physical_frame_indices=np.asarray([1.0]),
+        future_times_s=np.asarray([2.0]),
+    )
+    with pytest.raises(ValueError, match="time support"):
+        build_external_bridge_report(outside, "f", rollouts)
+
+
+def test_doctor_reports_anchor_warning_and_strict_exit(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "rollouts.npz"
+    manifest = tmp_path / "rollouts.json"
+    canonical = tmp_path / "rollout_bank.npz"
+    forecast_path = tmp_path / "forecast.npz"
+    report_path = tmp_path / "doctor.json"
+    _write_rollout_source(source, offset_m=0.1)
+    _write_manifest(manifest)
+    rollouts = import_external_rollouts(source, manifest)
+    save_external_rollout_bank(canonical, rollouts)
+    save_external_forecast(forecast_path, _forecast())
+
+    result = doctor_main(
+        [
+            str(forecast_path),
+            str(canonical),
+            "instruction",
+            str(report_path),
+            "--anchor-tolerance-m",
+            "0.01",
+            "--strict-warnings",
+        ]
+    )
+    assert result == 3
+    report = json.loads(capsys.readouterr().out)
+    assert report["warnings"]


### PR DESCRIPTION
## Summary

Complete the low-burden simulator side of the MolmoMotion bridge.

- add a strict external rollout importer for flat `(rollout, time, node, coordinate)` supports from MPM, IPC, FEM, mass-spring, or other forward simulators;
- retain persistent node IDs, exact frame times, an explicit anchor time, rollout priors, optional rollout IDs and physical-parameter metadata;
- normalize `m`/`cm`/`mm` and validated camera-to-world inputs into metric world trajectories;
- convert every external candidate into the existing content-addressed `JointRolloutBank` without importing or differentiating through the producer simulator;
- bind the exact source NPZ and import-manifest bytes, simulator revision, normalized bank, node/time identities, and finite metadata;
- add a forecast/rollout preflight doctor for case identity, exact node correspondence, time support, interpolation, anchor mismatch, motion-scale mismatch, validity coverage, and byte-identical zero-semantic-weight fallback;
- add module runners, a copyable manifest, documentation, and adversarial/integration tests; and
- extend the existing MolmoMotion bridge README with the two-command external-simulator path.

## Usage

```bash
python -m causal4d.cli.external_rollout_import \
  producer_rollouts.npz \
  external_rollout_manifest.json \
  canonical_rollout_bank.npz

python -m causal4d.cli.external_bridge_doctor \
  canonical_forecast.npz \
  canonical_rollout_bank.npz \
  instruction \
  bridge_doctor.json
```

The producer NPZ can be as small as:

```python
np.savez_compressed(
    "producer_rollouts.npz",
    node_ids=node_ids,                         # [N]
    trajectories_world_m=trajectories_world_m, # [R,T,N,3]
    rollout_weights=rollout_weights,           # [R]
    frame_times_s=frame_times_s,                # [T]
)
```

## Validation

Final head: `268ea614928bec43896ad17b46d399c1b9b67080`.

- merge-result quality checks passed;
- complete default repository test suite passed;
- distribution build and validation passed;
- pinned BayesianPhysTwin installed-wheel integration passed;
- declared dependency floors on Python 3.10 passed;
- core suites on Python 3.11 and 3.13 passed;
- security scanning, CodeQL for Python and Actions, and dependency audit passed;
- local new external-rollout/doctor suite: **5 passed**;
- local focused forecast, rollout-bank, Molmo bridge, semantic-posterior, and new bridge suite: **22 passed**;
- the actual prepared eight-point MolmoMotion handoff and its nine-component smoke bank imported successfully;
- its doctor report matched all eight node IDs, covered the complete time support, measured an anchor RMS of approximately `6.6e-9 m`, reported a forecast/rollout motion ratio of approximately `1.54`, and proved byte-identical zero-weight fallback.

Merged as `ff43f44bd4713ecaa883bc76c0ae3828099dce4d`.

## Scientific boundary

This is an integration and preflight contract. Import or doctor success does not establish physical calibration, simulator competence, positive semantic trust, or downstream prediction benefit. A positive semantic weight still requires source-only competence and held-out confirmation; rejection preserves the physical support exactly.