### PR TITLE
Qualify workstation2 for registered physical acquisition

### DIFF
--- a/.github/self-hosted-jobs.json
+++ b/.github/self-hosted-jobs.json
@@ -10,6 +10,20 @@
   },
   "jobs": [
     {
+      "workflow": "acquisition-readiness-self-hosted.yml",
+      "job": "inspect",
+      "authorization_model": "main-only",
+      "runner_labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "nvidia-smi"
+      ],
+      "purpose": "Read-only registered acquisition readiness and interface qualification",
+      "dataset_access": "registered-local-preacquisition-read-only",
+      "secrets_allowed": false
+    },
+    {
       "workflow": "contact-posterior-concentration.yml",
       "job": "evaluate",
       "authorization_model": "main-only",

--- a/.github/workflows/acquisition-readiness-self-hosted.yml
+++ b/.github/workflows/acquisition-readiness-self-hosted.yml
@@ -1,0 +1,199 @@
+name: Self-hosted acquisition readiness inspection
+
+on:
+  workflow_dispatch:
+    inputs:
+      trigger_issue_number:
+        description: Maintainer issue that authorized this inspection
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: acquisition-readiness-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  inspect:
+    name: Inspect registered acquisition readiness on workstation2
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main'
+    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    timeout-minutes: 45
+    outputs:
+      conclusion: ${{ steps.summary.outputs.conclusion }}
+      action_id: ${{ steps.summary.outputs.action_id }}
+      physical_required: ${{ steps.summary.outputs.physical_required }}
+      automatable: ${{ steps.summary.outputs.automatable }}
+      dataset_present: ${{ steps.summary.outputs.dataset_present }}
+    steps:
+      - name: Check out exact reviewed main revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+
+      - name: Verify reviewed main revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Build and install the exact Causal4D wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p outputs/acquisition-readiness/wheels
+          python -m venv .acquisition-readiness-venv
+          .acquisition-readiness-venv/bin/python -m pip install \
+            --upgrade pip "build>=1.2"
+          .acquisition-readiness-venv/bin/python -m build --wheel \
+            --outdir outputs/acquisition-readiness/wheels .
+          wheel="$(
+            find outputs/acquisition-readiness/wheels -maxdepth 1 \
+              -name 'causal4d-*.whl' -print -quit
+          )"
+          test -n "${wheel}"
+          sha256sum "${wheel}" \
+            | tee outputs/acquisition-readiness/wheel-sha256.txt
+          .acquisition-readiness-venv/bin/python -m pip install "${wheel}"
+          .acquisition-readiness-venv/bin/python -m pip check
+          .acquisition-readiness-venv/bin/python - <<'PY'
+          from pathlib import Path
+
+          import causal4d
+
+          source_root = (Path.cwd() / "src").resolve()
+          origin = Path(causal4d.__file__).resolve()
+          print("installed import", origin)
+          if origin.is_relative_to(source_root):
+              raise SystemExit(
+                  "Causal4D resolved from the checkout instead of the wheel"
+              )
+          PY
+
+      - name: Run read-only acquisition readiness probe
+        shell: bash
+        run: |
+          set -euo pipefail
+          PYTHONPATH="" .acquisition-readiness-venv/bin/python \
+            scripts/ci/probe_self_hosted_acquisition.py \
+            --repository-root /opt/causal4d-frozen \
+            --dataset-root /data/causal4d-sloth-multi-action-v1 \
+            --output outputs/acquisition-readiness/report.json \
+            | tee outputs/acquisition-readiness/report.txt
+
+      - name: Record runner and GPU identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "runner_name=${RUNNER_NAME}"
+            echo "runner_os=${RUNNER_OS}"
+            echo "runner_arch=${RUNNER_ARCH}"
+            echo "repository=${GITHUB_REPOSITORY}"
+            echo "commit=${GITHUB_SHA}"
+            echo "workflow_run_id=${GITHUB_RUN_ID}"
+            uname -a
+          } | tee outputs/acquisition-readiness/runner.txt
+          nvidia-smi -L \
+            | tee outputs/acquisition-readiness/nvidia-smi-L.txt
+
+      - name: Export sanitized result fields
+        id: summary
+        shell: bash
+        run: |
+          .acquisition-readiness-venv/bin/python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          from pathlib import Path
+
+          report = json.loads(
+              Path("outputs/acquisition-readiness/report.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          action = report.get("next_action") or {}
+          dataset = report["registered_roots"]["dataset"]
+          print(f"conclusion={report['conclusion']}")
+          print(f"action_id={action.get('action_id') or 'unavailable'}")
+          print(
+              "physical_required="
+              f"{str(bool(action.get('physical_acquisition_required'))).lower()}"
+          )
+          print(f"automatable={str(bool(action.get('automatable'))).lower()}")
+          print(f"dataset_present={str(bool(dataset.get('exists'))).lower()}")
+          PY
+
+      - name: Upload sanitized readiness evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: causal4d-acquisition-readiness-self-hosted
+          path: |
+            outputs/acquisition-readiness/report.json
+            outputs/acquisition-readiness/report.txt
+            outputs/acquisition-readiness/runner.txt
+            outputs/acquisition-readiness/nvidia-smi-L.txt
+            outputs/acquisition-readiness/wheel-sha256.txt
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Remove isolated environment and wheel
+        if: always()
+        run: rm -rf .acquisition-readiness-venv outputs/acquisition-readiness/wheels
+
+  report:
+    name: Report acquisition readiness to the authorizing issue
+    if: always()
+    needs: inspect
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE_NUMBER: ${{ inputs.trigger_issue_number }}
+      INSPECTION_RESULT: ${{ needs.inspect.result }}
+      CONCLUSION: ${{ needs.inspect.outputs.conclusion }}
+      ACTION_ID: ${{ needs.inspect.outputs.action_id }}
+      PHYSICAL_REQUIRED: ${{ needs.inspect.outputs.physical_required }}
+      AUTOMATABLE: ${{ needs.inspect.outputs.automatable }}
+      DATASET_PRESENT: ${{ needs.inspect.outputs.dataset_present }}
+    steps:
+      - name: Comment with the sanitized readiness result
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${ISSUE_NUMBER}" in
+            ''|*[!0-9]*) exit 2 ;;
+          esac
+          run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/"
+          run_url+="${GITHUB_RUN_ID}"
+          body="$(cat <<EOF
+          Self-hosted Causal4D acquisition readiness inspection: **${INSPECTION_RESULT}**
+
+          - Exact reviewed main commit: \`${GITHUB_SHA}\`
+          - Registered dataset present: \`${DATASET_PRESENT:-unknown}\`
+          - Derived next action: \`${ACTION_ID:-unavailable}\`
+          - Physical acquisition required: \`${PHYSICAL_REQUIRED:-unknown}\`
+          - Mechanically automatable: \`${AUTOMATABLE:-unknown}\`
+          - Conclusion: \`${CONCLUSION:-unavailable}\`
+          - Workflow run: ${run_url}
+          - Artifact: \`causal4d-acquisition-readiness-self-hosted\`
+          - Physical evidence increment: \`0\`
+          EOF
+          )"
+          gh issue comment "${ISSUE_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --body "${body}"

--- a/.github/workflows/trigger-acquisition-readiness.yml
+++ b/.github/workflows/trigger-acquisition-readiness.yml
@@ -1,0 +1,40 @@
+name: Authorize self-hosted acquisition readiness inspection
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: Dispatch reviewed-main self-hosted inspection
+    if: >-
+      github.event_name == 'issues' &&
+      github.event.action == 'opened' &&
+      github.ref == 'refs/heads/main' &&
+      github.event.issue.user.login == 'FlorianPfaff' &&
+      github.event.issue.user.id == 6773539 &&
+      github.event.issue.title ==
+        '[self-hosted] inspect Causal4D acquisition readiness'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+    steps:
+      - name: Dispatch exact-main inspection and acknowledge authorization
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run acquisition-readiness-self-hosted.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref main \
+            -f "trigger_issue_number=${ISSUE_NUMBER}"
+          gh issue comment "${ISSUE_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --body "Authorized the reviewed-main, read-only self-hosted acquisition readiness inspection. The dispatched workflow will report the sanitized result here."

--- a/docs/self_hosted_acquisition_readiness.md
+++ b/docs/self_hosted_acquisition_readiness.md
@@ -1,0 +1,36 @@
+# Self-hosted acquisition readiness inspection
+
+The physical Causal4D campaign may use a self-hosted GitHub Actions runner as
+the orchestration host, but the runner must expose the registered frozen checkout,
+dataset mount, and local robot/sensor interfaces. GPU qualification alone does
+not establish those capabilities.
+
+The `Self-hosted acquisition readiness inspection` workflow performs a read-only
+qualification on the exact reviewed `main` revision. It is dispatched only after
+the registered maintainer opens an issue with the exact title:
+
+```text
+[self-hosted] inspect Causal4D acquisition readiness
+```
+
+A GitHub-hosted authorization job dispatches the reviewed-main workflow. The
+self-hosted job receives a read-only repository token, no GitHub secrets, and no
+issue body or label content.
+
+The inspection records only sanitized capability evidence:
+
+- presence, readability, writability, and free space for
+  `/opt/causal4d-frozen` and
+  `/data/causal4d-sloth-multi-action-v1`;
+- counts and SHA-256 digests of candidate serial, video, HID, and input-device
+  identities without publishing raw device names;
+- availability plus hashed output summaries for `ros2 topic list` and `lsusb`;
+- the hash-verified registered next-action category, operator role, physical
+  requirement, and automation flag when the registered roots are available; and
+- exact runner, wheel, revision, and GPU identities.
+
+The inspection never opens a device node, sends a robot or sensor command,
+modifies the registered dataset, reads target outcomes, publishes a source-panel
+manifest, or increments physical evidence. A physical action remains blocked
+unless the registered next action permits it and a separately reviewed local
+acquisition driver plus operator safety interlock exists.

--- a/scripts/ci/probe_self_hosted_acquisition.py
+++ b/scripts/ci/probe_self_hosted_acquisition.py
@@ -63,7 +63,7 @@ def _inventory(paths: Iterable[Path]) -> dict[str, Any]:
 
 def _glob_inventory(device_root: Path) -> dict[str, Any]:
     serial_by_id = device_root / "serial" / "by-id"
-    inventories = {
+    inventories: dict[str, Any] = {
         "serial_by_id": _inventory(
             serial_by_id.iterdir() if serial_by_id.is_dir() else ()
         ),

--- a/scripts/ci/probe_self_hosted_acquisition.py
+++ b/scripts/ci/probe_self_hosted_acquisition.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Read-only qualification of a self-hosted Causal4D acquisition runner."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import shutil
+import subprocess
+from typing import Any, Iterable
+
+from causal4d.preacquisition_operator_flow import (
+    build_preacquisition_operator_next_action,
+)
+
+
+def _sha256_lines(values: Iterable[str]) -> str | None:
+    normalized = sorted(str(value) for value in values)
+    if not normalized:
+        return None
+    payload = "\n".join(normalized).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _path_status(path: Path) -> dict[str, Any]:
+    exists = path.exists()
+    is_directory = path.is_dir() if exists else False
+    result: dict[str, Any] = {
+        "path": str(path),
+        "exists": exists,
+        "is_directory": is_directory,
+        "readable": os.access(path, os.R_OK) if exists else False,
+        "writable": os.access(path, os.W_OK) if exists else False,
+        "is_mount": os.path.ismount(path) if exists else False,
+    }
+    if is_directory:
+        usage = shutil.disk_usage(path)
+        result["free_bytes"] = int(usage.free)
+        result["total_bytes"] = int(usage.total)
+    return result
+
+
+def _inventory(paths: Iterable[Path]) -> dict[str, Any]:
+    existing = sorted({path for path in paths if path.exists()}, key=str)
+    identities: list[str] = []
+    readable = 0
+    writable = 0
+    for path in existing:
+        identities.append(path.name)
+        readable += int(os.access(path, os.R_OK))
+        writable += int(os.access(path, os.W_OK))
+    return {
+        "count": len(existing),
+        "readable_count": readable,
+        "writable_count": writable,
+        "identity_sha256": _sha256_lines(identities),
+    }
+
+
+def _glob_inventory(device_root: Path) -> dict[str, Any]:
+    serial_by_id = device_root / "serial" / "by-id"
+    inventories = {
+        "serial_by_id": _inventory(
+            serial_by_id.iterdir() if serial_by_id.is_dir() else ()
+        ),
+        "tty_usb": _inventory(device_root.glob("ttyUSB*")),
+        "tty_acm": _inventory(device_root.glob("ttyACM*")),
+        "video": _inventory(device_root.glob("video*")),
+        "hidraw": _inventory(device_root.glob("hidraw*")),
+        "input_events": _inventory((device_root / "input").glob("event*")),
+    }
+    inventories["candidate_device_count"] = sum(
+        int(value["count"])
+        for value in inventories.values()
+        if isinstance(value, dict)
+    )
+    return inventories
+
+
+def _command_summary(
+    executable: str,
+    arguments: list[str],
+    *,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    resolved = shutil.which(executable)
+    if resolved is None:
+        return {
+            "available": False,
+            "return_code": None,
+            "line_count": 0,
+            "output_sha256": None,
+            "timed_out": False,
+        }
+    try:
+        completed = subprocess.run(
+            [resolved, *arguments],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            env={**os.environ, "PYTHONUNBUFFERED": "1"},
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "available": True,
+            "return_code": None,
+            "line_count": 0,
+            "output_sha256": None,
+            "timed_out": True,
+        }
+    lines = [
+        line.strip()
+        for line in (completed.stdout + "\n" + completed.stderr).splitlines()
+        if line.strip()
+    ]
+    return {
+        "available": True,
+        "return_code": int(completed.returncode),
+        "line_count": len(lines),
+        "output_sha256": _sha256_lines(lines),
+        "timed_out": False,
+    }
+
+
+def _next_action_summary(
+    repository_root: Path,
+    dataset_root: Path,
+) -> tuple[dict[str, Any] | None, str | None]:
+    if not repository_root.is_dir() or not dataset_root.is_dir():
+        return None, "registered repository or dataset root is absent"
+    try:
+        decision = build_preacquisition_operator_next_action(
+            repository_root,
+            dataset_root,
+            verify_file_hashes=True,
+        )
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        return None, f"{type(error).__name__}: {error}"
+
+    action = decision.get("action")
+    if not isinstance(action, dict):
+        return None, "next-action decision has no action object"
+    execution = action.get("registered_execution")
+    execution_summary = None
+    if isinstance(execution, dict):
+        execution_summary = {
+            "execution_id": execution.get("execution_id"),
+            "session_id": execution.get("session_id"),
+            "command_profile_id": execution.get("command_profile_id"),
+        }
+    physical = action.get("physical_acquisition_required") is True
+    automatable = action.get("automatable") is True
+    return (
+        {
+            "protocol_id": decision.get("protocol_id"),
+            "valid": decision.get("valid") is True,
+            "ready": decision.get("ready") is True,
+            "verify_file_hashes": decision.get("verify_file_hashes") is True,
+            "action_id": action.get("action_id"),
+            "category": action.get("category"),
+            "operator_role": action.get("operator_role"),
+            "physical_acquisition_required": physical,
+            "automatable": automatable,
+            "target_outcomes_permitted": (
+                action.get("target_outcomes_permitted") is True
+            ),
+            "blocking_item_count": len(action.get("blocking_items", [])),
+            "registered_execution": execution_summary,
+            "can_run_unattended_on_runner": automatable and not physical,
+        },
+        None,
+    )
+
+
+def build_report(
+    *,
+    repository_root: Path,
+    dataset_root: Path,
+    device_root: Path,
+) -> dict[str, Any]:
+    repository = _path_status(repository_root)
+    dataset = _path_status(dataset_root)
+    devices = _glob_inventory(device_root)
+    ros_topics = _command_summary("ros2", ["topic", "list"], timeout_seconds=8.0)
+    usb = _command_summary("lsusb", [], timeout_seconds=5.0)
+    next_action, next_action_error = _next_action_summary(
+        repository_root,
+        dataset_root,
+    )
+
+    if not repository["exists"] or not dataset["exists"]:
+        conclusion = "runner_not_provisioned_with_registered_roots"
+    elif next_action is None:
+        conclusion = "registered_readiness_could_not_be_derived"
+    elif next_action["physical_acquisition_required"]:
+        conclusion = (
+            "physical_execution_dispatchable"
+            if next_action["automatable"]
+            else "physical_execution_requires_local_operator_and_driver"
+        )
+    elif next_action["automatable"]:
+        conclusion = "software_next_action_dispatchable"
+    else:
+        conclusion = "next_action_requires_registered_human_role"
+
+    report: dict[str, Any] = {
+        "schema_version": 1,
+        "artifact_kind": "Causal4DSelfHostedAcquisitionReadinessProbe",
+        "claim_boundary": (
+            "Read-only runner qualification. No device node is opened, no robot "
+            "or sensor command is sent, no dataset file is modified, no target "
+            "outcome is read, and physical evidence is not incremented."
+        ),
+        "runner": {
+            "name": os.environ.get("RUNNER_NAME"),
+            "os": os.environ.get("RUNNER_OS"),
+            "arch": os.environ.get("RUNNER_ARCH"),
+            "hostname_sha256": hashlib.sha256(
+                platform.node().encode("utf-8")
+            ).hexdigest(),
+            "python": platform.python_version(),
+            "kernel": platform.release(),
+        },
+        "registered_roots": {
+            "repository": repository,
+            "dataset": dataset,
+        },
+        "candidate_interfaces": {
+            "devices": devices,
+            "ros2_topics": ros_topics,
+            "usb_inventory": usb,
+            "ros_distro": os.environ.get("ROS_DISTRO"),
+            "ros_domain_id_present": bool(os.environ.get("ROS_DOMAIN_ID")),
+        },
+        "next_action": next_action,
+        "next_action_error": next_action_error,
+        "conclusion": conclusion,
+        "target_outcomes_used": False,
+        "device_nodes_opened": False,
+        "dataset_modified": False,
+        "physical_evidence_increment": 0,
+    }
+    canonical = json.dumps(
+        report,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    report["report_sha256"] = hashlib.sha256(canonical).hexdigest()
+    return report
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repository-root",
+        type=Path,
+        default=Path("/opt/causal4d-frozen"),
+    )
+    parser.add_argument(
+        "--dataset-root",
+        type=Path,
+        default=Path("/data/causal4d-sloth-multi-action-v1"),
+    )
+    parser.add_argument("--device-root", type=Path, default=Path("/dev"))
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main() -> int:
+    arguments = _parser().parse_args()
+    report = build_report(
+        repository_root=arguments.repository_root,
+        dataset_root=arguments.dataset_root,
+        device_root=arguments.device_root,
+    )
+    arguments.output.parent.mkdir(parents=True, exist_ok=True)
+    arguments.output.write_text(
+        json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(report, indent=2, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/probe_self_hosted_acquisition.py
+++ b/scripts/ci/probe_self_hosted_acquisition.py
@@ -74,9 +74,7 @@ def _glob_inventory(device_root: Path) -> dict[str, Any]:
         "input_events": _inventory((device_root / "input").glob("event*")),
     }
     inventories["candidate_device_count"] = sum(
-        int(value["count"])
-        for value in inventories.values()
-        if isinstance(value, dict)
+        int(value["count"]) for value in inventories.values() if isinstance(value, dict)
     )
     return inventories
 


### PR DESCRIPTION
## What changed

- add a reviewed-main, dispatch-only self-hosted workflow that inspects the registered frozen checkout, dataset mount, candidate robot/sensor interfaces, and hash-verified pre-acquisition next action;
- add an exact-maintainer issue authorization bridge so the inspection can be launched without exposing issue text or GitHub secrets to workstation2;
- publish only sanitized device counts and SHA-256 digests rather than raw serial, USB, ROS topic, or host identities;
- register the self-hosted job with read-only access to the registered local pre-acquisition dataset; and
- document the boundary between using workstation2 as the orchestration host and actually issuing a physical motion command.

## Why

The existing workstation2 workflows prove Linux/X64/CUDA execution and controlled numerical reproducibility, but their registry explicitly declares `dataset_access: none`. They do not establish that `/opt/causal4d-frozen`, `/data/causal4d-sloth-multi-action-v1`, or the local robot/sensor interfaces are available. This PR adds the missing read-only qualification step before any physical command is considered.

## Safety and scientific boundary

The probe never opens a device node, sends a robot or sensor command, modifies the registered dataset, reads target outcomes, publishes a source-panel manifest, or increments physical evidence. A physical execution remains blocked unless the registered next action permits it and a separately reviewed local driver plus operator safety interlock exists.

## Trigger after merge

Open an issue with the exact title:

`[self-hosted] inspect Causal4D acquisition readiness`

The hosted authorization workflow dispatches the exact reviewed `main` revision and the self-hosted workflow reports its sanitized result back to the issue.
