### PR TITLE
Operationalize post-freeze calibration diagnostics

### DIFF
--- a/docs/postfreeze_calibration_diagnostics.md
+++ b/docs/postfreeze_calibration_diagnostics.md
@@ -57,6 +57,31 @@ Approximately uniform randomized ranks are then expected up to Monte Carlo error
 Changing the likelihood power, adding derivative terms, or deliberately mismatching
 noise creates a sensitivity diagnostic rather than an exact SBC null.
 
+### Controlled benchmark command
+
+The leave-one-topology benchmark can run the exact self-consistency diagnostic in
+one invocation without changing the benchmark defaults:
+
+```bash
+causal4d benchmark latent-contact \
+  --seeds 0:5 \
+  --sbc-trials-per-fold 5000 \
+  --sbc-bins 10 \
+  --output-dir runs/causal4d-latent-contact-v1
+```
+
+The normal benchmark artifacts are unchanged. The opt-in SBC result is written to
+`OUTPUT_DIR/sbc.json` unless `--sbc-output-json` is supplied. Each seed contains
+three leave-one-topology-out folds. The target object's physical-parameter posterior
+is fitted from its training/validation interactions, the contact prior is learned
+from the other two topologies exactly as in the controlled latent-contact study, and
+SBC truths are then sampled from that finite bank's own declared joint prior.
+
+`causal4d.controlled_latent_contact_sbc.run_controlled_latent_contact_sbc` exposes the
+same operation as a Python API. The aggregate report sums rank histograms across
+folds and uses trial-count weighting for posterior summaries; it never relabels
+folds, frames, points, or coordinates as independent physical executions.
+
 ### Interpretation boundary
 
 Passing SBC means that the finite inference implementation is self-consistent under
@@ -122,6 +147,36 @@ prefix coefficient and recursively accumulates per-mode innovation variance. The
 existing projection variance remains as an irreducible node-coordinate floor. This
 therefore produces explicit horizon-dependent uncertainty without requiring a dense
 cross-mode covariance transition.
+
+### Real diagnostic comparison
+
+The existing graph-discrepancy command now evaluates all five arms in one evidence
+bundle:
+
+```text
+current_random_walk_readout
+state_only
+graph_persistence
+graph_modewise
+graph_temporal
+```
+
+Use the unchanged diagnostic route:
+
+```bash
+causal4d diagnostic discrepancy graph-temporal \
+  physical.npz final_data.pkl optimal_params.pkl parameter_profile.npz \
+  graph_discrepancy.json \
+  --modewise-persistence-prior-weight 0.25 \
+  --modewise-minimum-retention 0.0 \
+  --modewise-maximum-retention 1.0
+```
+
+The mode-wise fit reads O-minus only. The target contributes only the same declared
+O-plus prefix used by the persistence and dense-AR arms. The saved model NPZ binds
+per-mode retention, per-coordinate innovation variance, and shrinkage settings; the
+moments NPZ adds `graph_modewise_mean_m` and `graph_modewise_variance_m2` without
+storing held-out future labels.
 
 ## Prospective use
 

--- a/src/causal4d/cli/evaluate_graph_temporal_discrepancy.py
+++ b/src/causal4d/cli/evaluate_graph_temporal_discrepancy.py
@@ -23,6 +23,8 @@ def _load_runtime_dependencies() -> None:
     global fit_graph_temporal_discrepancy
     global forecast_graph_temporal_discrepancy
     global graph_laplacian_basis
+    global fit_modewise_graph_discrepancy
+    global forecast_modewise_graph_discrepancy
     global physical_posterior_moments
     global RealCalibrationCase
     global evaluate_real_prediction_case
@@ -33,6 +35,10 @@ def _load_runtime_dependencies() -> None:
     )
     from bayesian_phystwin.causal4d_provider_v1 import target_validity
     from causal4d.contracts import PhysicalPosterior, load_contract
+    from causal4d.graph_modewise_discrepancy import (
+        fit_modewise_graph_discrepancy,
+        forecast_modewise_graph_discrepancy,
+    )
     from causal4d.graph_temporal_discrepancy import (
         fit_graph_temporal_discrepancy,
         forecast_graph_temporal_discrepancy,
@@ -168,6 +174,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--o-plus-prefix-frames", type=int, default=6)
     parser.add_argument("--variance-floor-m2", type=float, default=2.5e-5)
     parser.add_argument("--confidence-level", type=float, default=0.90)
+    parser.add_argument(
+        "--modewise-persistence-prior-weight",
+        type=float,
+        default=0.25,
+        help="source-only shrinkage of per-mode AR retention toward persistence",
+    )
+    parser.add_argument("--modewise-minimum-retention", type=float, default=0.0)
+    parser.add_argument("--modewise-maximum-retention", type=float, default=1.0)
     return parser
 
 
@@ -224,6 +238,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         eigenvalues,
         rank_candidates=args.rank_candidates,
     )
+    modewise = fit_modewise_graph_discrepancy(
+        model,
+        o_minus_residual,
+        o_minus_valid,
+        persistence_prior_weight=args.modewise_persistence_prior_weight,
+        minimum_retention=args.modewise_minimum_retention,
+        maximum_retention=args.modewise_maximum_retention,
+    )
 
     state_mean, state_variance = _state_moments(
         artifact,
@@ -249,10 +271,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         total_frame_count=len(state_mean),
         dynamics="persistence",
     )
+    modewise_mean, modewise_variance = forecast_modewise_graph_discrepancy(
+        model,
+        modewise,
+        prefix_residual,
+        prefix_valid,
+        total_frame_count=len(state_mean),
+    )
     graph_mean = graph_mean[:, : state_mean.shape[1]]
     graph_variance = graph_variance[:, : state_mean.shape[1]]
     persistent_mean = persistent_mean[:, : state_mean.shape[1]]
     persistent_variance = persistent_variance[:, : state_mean.shape[1]]
+    modewise_mean = modewise_mean[:, : state_mean.shape[1]]
+    modewise_variance = modewise_variance[:, : state_mean.shape[1]]
     labels = _graph_region_labels(
         graph.springs,
         object_spring_count=graph.num_object_springs,
@@ -288,6 +319,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             "graph_persistence",
             state_mean + persistent_mean,
             state_variance + persistent_variance,
+            truth,
+            target_valid,
+            case_id=artifact.context.case_id,
+            action_id=artifact.context.u_cf.action_id,
+            start_frame=prefix_frame_count,
+            labels=labels,
+            confidence_level=args.confidence_level,
+        ),
+        _evaluate_variant(
+            "graph_modewise",
+            state_mean + modewise_mean,
+            state_variance + modewise_variance,
             truth,
             target_valid,
             case_id=artifact.context.case_id,
@@ -334,6 +377,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         transition=model.transition,
         innovation_covariance=model.innovation_covariance,
         projection_variance_m2=model.projection_variance_m2,
+        modewise_retention=modewise.retention,
+        modewise_innovation_variance_m2=modewise.innovation_variance_m2,
+        modewise_persistence_prior_weight=np.asarray(
+            modewise.persistence_prior_weight, dtype=float
+        ),
+        modewise_minimum_retention=np.asarray(modewise.minimum_retention, dtype=float),
+        modewise_maximum_retention=np.asarray(modewise.maximum_retention, dtype=float),
     )
     np.savez_compressed(
         moments_path,
@@ -349,6 +399,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         "current_random_walk_readout",
                         "state_only",
                         "graph_persistence",
+                        "graph_modewise",
                         "graph_temporal",
                     ],
                     "future_labels_stored": False,
@@ -362,6 +413,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         state_only_variance_m2=state_variance,
         graph_persistence_mean_m=state_mean + persistent_mean,
         graph_persistence_variance_m2=state_variance + persistent_variance,
+        graph_modewise_mean_m=state_mean + modewise_mean,
+        graph_modewise_variance_m2=state_variance + modewise_variance,
         graph_temporal_mean_m=state_mean + graph_mean,
         graph_temporal_variance_m2=state_variance + graph_variance,
     )
@@ -373,6 +426,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "label_use": {
             "basis_and_dynamics_fit": "O-minus only",
             "rank_selection": "O-minus validation suffix only",
+            "modewise_fit": "O-minus only with source-frozen shrinkage settings",
             "target_initialization": f"first {args.o_plus_prefix_frames} O-plus frames",
             "future": "evaluation only",
         },
@@ -386,6 +440,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             "spectral_radius": model.spectral_radius,
             "projection_variance_m2": model.projection_variance_m2.tolist(),
             "fit_frame_count": model.fit_frame_count,
+            "modewise": modewise.as_dict(),
             "model_npz": str(model_path.resolve()),
             "model_sha256": _sha256(model_path),
             "moments_npz": str(moments_path.resolve()),

--- a/src/causal4d/cli/latent_contact_benchmark.py
+++ b/src/causal4d/cli/latent_contact_benchmark.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 from collections.abc import Sequence
+from pathlib import Path
 
 from causal4d.benchmark import CounterfactualBenchmarkConfig
 from causal4d.contact_evaluation import (
@@ -12,6 +13,7 @@ from causal4d.contact_evaluation import (
     write_latent_contact_artifacts,
 )
 from causal4d.contact_inference import LatentContactConfig
+from causal4d.controlled_latent_contact_sbc import run_controlled_latent_contact_sbc
 
 
 def _parse_seeds(value: str) -> list[int]:
@@ -48,6 +50,25 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--observation-fraction", type=float, default=0.20)
     parser.add_argument("--observation-noise-mm", type=float, default=1.5)
     parser.add_argument(
+        "--sbc-trials-per-fold",
+        type=int,
+        default=0,
+        help=(
+            "also run exact finite-support simulation-based calibration; zero "
+            "disables the diagnostic"
+        ),
+    )
+    parser.add_argument(
+        "--sbc-bins",
+        type=int,
+        default=10,
+        help="rank-histogram bins for the optional SBC diagnostic",
+    )
+    parser.add_argument(
+        "--sbc-output-json",
+        help="optional SBC JSON path; defaults to OUTPUT_DIR/sbc.json",
+    )
+    parser.add_argument(
         "--require-gates",
         action="store_true",
         help="return status 2 when any pre-registered milestone gate fails",
@@ -57,6 +78,8 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    if args.sbc_trials_per_fold < 0:
+        raise ValueError("sbc-trials-per-fold must be nonnegative")
     benchmark_config = CounterfactualBenchmarkConfig(
         frame_count=args.frames,
         training_repeats=args.training_repeats,
@@ -69,23 +92,42 @@ def main(argv: Sequence[str] | None = None) -> int:
         observation_noise_std_m=args.observation_noise_mm / 1000.0,
         confidence_level=benchmark_config.confidence_level,
     )
+    seeds = _parse_seeds(args.seeds)
     result = run_latent_contact_benchmark(
-        seeds=_parse_seeds(args.seeds),
+        seeds=seeds,
         benchmark_config=benchmark_config,
         contact_config=contact_config,
     )
     paths = write_latent_contact_artifacts(result, args.output_dir)
-    print(
-        json.dumps(
-            {
-                "success_gates": result["success_gates"],
-                "aggregate": result["aggregate"],
-                "artifacts": paths,
-            },
-            indent=2,
-            sort_keys=True,
+    summary: dict[str, object] = {
+        "success_gates": result["success_gates"],
+        "aggregate": result["aggregate"],
+        "artifacts": paths,
+    }
+    if args.sbc_trials_per_fold:
+        sbc = run_controlled_latent_contact_sbc(
+            seeds=seeds,
+            trials_per_fold=args.sbc_trials_per_fold,
+            bin_count=args.sbc_bins,
+            benchmark_config=benchmark_config,
+            contact_config=contact_config,
         )
-    )
+        sbc_path = (
+            Path(args.sbc_output_json)
+            if args.sbc_output_json
+            else Path(args.output_dir) / "sbc.json"
+        )
+        sbc_path.parent.mkdir(parents=True, exist_ok=True)
+        sbc_path.write_text(
+            json.dumps(sbc, indent=2, sort_keys=True, allow_nan=False) + "\n",
+            encoding="utf-8",
+        )
+        summary["sbc"] = {
+            "path": str(sbc_path.resolve()),
+            "aggregate": sbc["aggregate"],
+            "interpretation": sbc["interpretation"],
+        }
+    print(json.dumps(summary, indent=2, sort_keys=True))
     if args.require_gates and not result["success_gates"]["overall_passed"]:
         return 2
     return 0

--- a/src/causal4d/controlled_latent_contact_sbc.py
+++ b/src/causal4d/controlled_latent_contact_sbc.py
@@ -1,0 +1,274 @@
+"""Controlled simulation-based calibration for latent contact inference.
+
+This module deliberately reuses the held-out-topology benchmark construction but
+samples truths from each finite rollout bank's own prior. It is therefore an
+inference self-consistency diagnostic, not a real-data calibration result and not
+part of the frozen physical-acquisition method.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+import numpy as np
+
+from causal4d.baselines import FittedBaselines, fit_baselines
+from causal4d.benchmark import (
+    CounterfactualBenchmarkConfig,
+    ObjectProtocol,
+    build_protocol,
+    generate_episodes,
+    make_parameter_grid,
+)
+from causal4d.contact_inference import (
+    GraphContactHypothesisModel,
+    LatentContactConfig,
+    build_rollout_bank,
+    fit_contact_prior,
+)
+from causal4d.simulation_calibration import (
+    SimulationCalibrationResult,
+    run_contact_rollout_sbc,
+)
+
+
+@dataclass(frozen=True)
+class _FittedObject:
+    protocol: ObjectProtocol
+    baselines: FittedBaselines
+
+
+def _histogram_uniformity(counts: np.ndarray) -> dict[str, float]:
+    values = np.asarray(counts, dtype=float)
+    if values.ndim != 1 or len(values) < 2 or np.sum(values) <= 0.0:
+        raise ValueError("rank histogram must contain at least two nonempty bins")
+    frequencies = values / np.sum(values)
+    expected = 1.0 / len(values)
+    return {
+        "max_abs_frequency_error": float(np.max(np.abs(frequencies - expected))),
+        "rms_frequency_error": float(
+            np.sqrt(np.mean(np.square(frequencies - expected)))
+        ),
+    }
+
+
+def _weighted_mean(
+    results: Sequence[SimulationCalibrationResult],
+    attribute: str,
+) -> float:
+    weights = np.asarray([result.trial_count for result in results], dtype=float)
+    values = np.asarray([float(getattr(result, attribute)) for result in results])
+    return float(np.sum(weights * values) / np.sum(weights))
+
+
+def _weighted_vector_mean(
+    results: Sequence[SimulationCalibrationResult],
+    attribute: str,
+) -> list[float]:
+    weights = np.asarray([result.trial_count for result in results], dtype=float)
+    values = np.asarray([getattr(result, attribute) for result in results], dtype=float)
+    return [
+        float(value)
+        for value in np.sum(weights[:, None] * values, axis=0) / np.sum(weights)
+    ]
+
+
+def aggregate_controlled_sbc(
+    results: Sequence[SimulationCalibrationResult],
+) -> dict[str, Any]:
+    """Aggregate independent SBC folds without pretending folds are new trials."""
+
+    selected = tuple(results)
+    if not selected:
+        raise ValueError("at least one SBC fold result is required")
+    bin_counts = {result.bin_count for result in selected}
+    if len(bin_counts) != 1:
+        raise ValueError("all SBC folds must use the same bin count")
+    bin_count = selected[0].bin_count
+    parameter_count = len(selected[0].parameter_rank_histograms)
+    if any(len(result.parameter_rank_histograms) != parameter_count for result in selected):
+        raise ValueError("all SBC folds must expose the same parameter dimensions")
+
+    joint = np.sum(
+        np.asarray([result.joint_rank_histogram for result in selected], dtype=int),
+        axis=0,
+    )
+    contact = np.sum(
+        np.asarray([result.contact_rank_histogram for result in selected], dtype=int),
+        axis=0,
+    )
+    parameters = np.sum(
+        np.asarray([result.parameter_rank_histograms for result in selected], dtype=int),
+        axis=0,
+    )
+    total_trials = int(sum(result.trial_count for result in selected))
+    if int(np.sum(joint)) != total_trials or int(np.sum(contact)) != total_trials:
+        raise ValueError("aggregate rank histograms lost SBC trials")
+
+    return {
+        "fold_count": len(selected),
+        "trial_count": total_trials,
+        "bin_count": bin_count,
+        "rank_histograms": {
+            "joint": joint.tolist(),
+            "contact": contact.tolist(),
+            "parameters": parameters.tolist(),
+        },
+        "uniformity": {
+            "joint": _histogram_uniformity(joint),
+            "contact": _histogram_uniformity(contact),
+            "parameters": [
+                _histogram_uniformity(parameters[index])
+                for index in range(parameter_count)
+            ],
+        },
+        "posterior": {
+            "mean_true_joint_mass": _weighted_mean(
+                selected, "mean_true_joint_posterior_mass"
+            ),
+            "mean_true_contact_mass": _weighted_mean(
+                selected, "mean_true_contact_posterior_mass"
+            ),
+            "mean_joint_entropy": _weighted_mean(
+                selected, "mean_joint_posterior_entropy"
+            ),
+            "mean_prior_joint_entropy": _weighted_mean(
+                selected, "prior_joint_entropy"
+            ),
+            "mean_entropy_reduction": _weighted_mean(
+                selected, "mean_entropy_reduction"
+            ),
+            "mean_joint_effective_sample_size": _weighted_mean(
+                selected, "mean_joint_effective_sample_size"
+            ),
+            "mean_parameter_absolute_error": _weighted_vector_mean(
+                selected, "mean_parameter_absolute_error"
+            ),
+        },
+    }
+
+
+def run_controlled_latent_contact_sbc(
+    *,
+    seeds: Sequence[int],
+    trials_per_fold: int = 1000,
+    bin_count: int = 10,
+    benchmark_config: CounterfactualBenchmarkConfig | None = None,
+    contact_config: LatentContactConfig | None = None,
+) -> dict[str, Any]:
+    """Run exact finite-support SBC on every leave-one-topology-out bank.
+
+    The observation simulator and inference likelihood are intentionally matched:
+    Gaussian noise standard deviation equals the likelihood scale,
+    ``likelihood_power`` is one, and dynamic derivative terms are disabled.
+    Consequently randomized ranks should be uniform up to Monte Carlo error when
+    the finite posterior implementation is internally calibrated.
+    """
+
+    if type(trials_per_fold) is not int or trials_per_fold < 1:
+        raise ValueError("trials_per_fold must be a positive integer")
+    if type(bin_count) is not int or bin_count < 2:
+        raise ValueError("bin_count must be an integer of at least two")
+    normalized_seeds = tuple(int(seed) for seed in seeds)
+    if not normalized_seeds or len(set(normalized_seeds)) != len(normalized_seeds):
+        raise ValueError("seeds must be nonempty and unique")
+
+    cfg = benchmark_config or CounterfactualBenchmarkConfig()
+    latent_cfg = contact_config or LatentContactConfig(
+        confidence_level=cfg.confidence_level,
+        observation_noise_std_m=cfg.observation_noise_std_m,
+    )
+    protocols = build_protocol(cfg)
+    fold_rows: list[dict[str, Any]] = []
+    fold_results: list[SimulationCalibrationResult] = []
+
+    for seed in normalized_seeds:
+        fitted: list[_FittedObject] = []
+        for object_index, protocol in enumerate(protocols):
+            training, validation, _ = generate_episodes(
+                protocol,
+                cfg,
+                seed=seed * 10_000 + object_index * 101,
+            )
+            baselines = fit_baselines(
+                training,
+                validation,
+                make_parameter_grid(protocol.graph_object, cfg),
+                cfg,
+            )
+            fitted.append(_FittedObject(protocol=protocol, baselines=baselines))
+
+        for target_index, target in enumerate(fitted):
+            sources = tuple(
+                item for index, item in enumerate(fitted) if index != target_index
+            )
+            source_protocols = tuple(item.protocol for item in sources)
+            source_names = tuple(item.protocol.graph_object.name for item in sources)
+            prior = fit_contact_prior(
+                source_protocols,
+                latent_cfg,
+                action_split="test",
+            )
+            model = GraphContactHypothesisModel(prior=prior, config=latent_cfg)
+            bank = build_rollout_bank(
+                target.protocol.graph_object,
+                target.protocol.test_action,
+                target.baselines.physics.posterior,
+                model,
+                simulator_config=cfg.simulator,
+                parameter_particle_count=latent_cfg.parameter_particle_count,
+                variance_floor_m2=cfg.predictive_variance_floor_m2,
+                confidence_level=latent_cfg.confidence_level,
+            )
+            prefix = latent_cfg.prefix_frame_count(cfg.frame_count)
+            fold_seed = seed * 1_000_003 + target_index * 10_007 + 701
+            result = run_contact_rollout_sbc(
+                bank,
+                trials=trials_per_fold,
+                prefix_frame_count=prefix,
+                likelihood_scale_m=latent_cfg.observation_noise_std_m,
+                likelihood_power=1.0,
+                dynamic_likelihood_weight=0.0,
+                observation_noise_std_m=latent_cfg.observation_noise_std_m,
+                seed=fold_seed,
+                bin_count=bin_count,
+            )
+            fold_results.append(result)
+            fold_rows.append(
+                {
+                    "seed": seed,
+                    "held_out_object": target.protocol.graph_object.name,
+                    "source_objects": list(source_names),
+                    "source_excludes_target": (
+                        target.protocol.graph_object.name not in source_names
+                    ),
+                    "contact_hypothesis_count": len(bank.contact_states),
+                    "parameter_particle_count": len(bank.parameter_particles),
+                    "prefix_frame_count": prefix,
+                    "sbc_seed": fold_seed,
+                    "result": result.as_dict(),
+                }
+            )
+
+    return {
+        "schema": "causal4d.controlled_latent_contact_sbc",
+        "schema_version": 1,
+        "interpretation": (
+            "controlled finite-support inference self-consistency; not real-data "
+            "calibration, physical evidence, or provider competence"
+        ),
+        "exact_null": {
+            "observation_model": "independent Gaussian coordinates",
+            "observation_noise_std_m": latent_cfg.observation_noise_std_m,
+            "likelihood_scale_m": latent_cfg.observation_noise_std_m,
+            "likelihood_power": 1.0,
+            "dynamic_likelihood_weight": 0.0,
+        },
+        "seeds": list(normalized_seeds),
+        "trials_per_fold": trials_per_fold,
+        "benchmark_config": cfg.as_dict(),
+        "contact_config": latent_cfg.as_dict(),
+        "folds": fold_rows,
+        "aggregate": aggregate_controlled_sbc(fold_results),
+    }

--- a/src/causal4d/controlled_latent_contact_sbc.py
+++ b/src/causal4d/controlled_latent_contact_sbc.py
@@ -87,7 +87,9 @@ def aggregate_controlled_sbc(
         raise ValueError("all SBC folds must use the same bin count")
     bin_count = selected[0].bin_count
     parameter_count = len(selected[0].parameter_rank_histograms)
-    if any(len(result.parameter_rank_histograms) != parameter_count for result in selected):
+    if any(
+        len(result.parameter_rank_histograms) != parameter_count for result in selected
+    ):
         raise ValueError("all SBC folds must expose the same parameter dimensions")
 
     joint = np.sum(
@@ -99,7 +101,9 @@ def aggregate_controlled_sbc(
         axis=0,
     )
     parameters = np.sum(
-        np.asarray([result.parameter_rank_histograms for result in selected], dtype=int),
+        np.asarray(
+            [result.parameter_rank_histograms for result in selected], dtype=int
+        ),
         axis=0,
     )
     total_trials = int(sum(result.trial_count for result in selected))
@@ -133,9 +137,7 @@ def aggregate_controlled_sbc(
             "mean_joint_entropy": _weighted_mean(
                 selected, "mean_joint_posterior_entropy"
             ),
-            "mean_prior_joint_entropy": _weighted_mean(
-                selected, "prior_joint_entropy"
-            ),
+            "mean_prior_joint_entropy": _weighted_mean(selected, "prior_joint_entropy"),
             "mean_entropy_reduction": _weighted_mean(
                 selected, "mean_entropy_reduction"
             ),

--- a/tests/test_controlled_latent_contact_sbc.py
+++ b/tests/test_controlled_latent_contact_sbc.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import numpy as np
+
+from causal4d.benchmark import CounterfactualBenchmarkConfig
+from causal4d.contact_inference import LatentContactConfig
+from causal4d.controlled_latent_contact_sbc import (
+    aggregate_controlled_sbc,
+    run_controlled_latent_contact_sbc,
+)
+from causal4d.simulation_calibration import SimulationCalibrationResult
+
+
+def _result(*, trials: int, seed: int, counts: tuple[int, int]) -> SimulationCalibrationResult:
+    parameter_histograms = (counts, counts, counts)
+    return SimulationCalibrationResult(
+        trial_count=trials,
+        bin_count=2,
+        seed=seed,
+        joint_rank_histogram=counts,
+        contact_rank_histogram=counts,
+        parameter_rank_histograms=parameter_histograms,
+        joint_rank_max_abs_frequency_error=0.1,
+        contact_rank_max_abs_frequency_error=0.1,
+        parameter_rank_max_abs_frequency_error=(0.1, 0.1, 0.1),
+        joint_rank_rms_frequency_error=0.1,
+        contact_rank_rms_frequency_error=0.1,
+        parameter_rank_rms_frequency_error=(0.1, 0.1, 0.1),
+        mean_true_joint_posterior_mass=0.4,
+        mean_true_contact_posterior_mass=0.6,
+        mean_joint_posterior_entropy=0.8,
+        prior_joint_entropy=1.0,
+        mean_entropy_reduction=0.2,
+        mean_joint_effective_sample_size=2.0,
+        mean_parameter_absolute_error=(0.1, 0.2, 0.3),
+    )
+
+
+def test_aggregate_controlled_sbc_sums_trials_and_histograms() -> None:
+    first = _result(trials=10, seed=1, counts=(4, 6))
+    second = _result(trials=20, seed=2, counts=(11, 9))
+    aggregate = aggregate_controlled_sbc((first, second))
+
+    assert aggregate["fold_count"] == 2
+    assert aggregate["trial_count"] == 30
+    assert aggregate["rank_histograms"]["joint"] == [15, 15]
+    assert aggregate["rank_histograms"]["contact"] == [15, 15]
+    assert aggregate["uniformity"]["joint"]["max_abs_frequency_error"] == 0.0
+    assert np.isclose(aggregate["posterior"]["mean_entropy_reduction"], 0.2)
+
+
+def test_controlled_sbc_builds_all_held_out_topology_folds() -> None:
+    benchmark = CounterfactualBenchmarkConfig(
+        frame_count=8,
+        training_repeats=2,
+        parameter_grid_count=3,
+        fit_frame_stride=2,
+        observation_noise_std_m=0.0015,
+        inference_noise_std_m=0.004,
+    )
+    contact = LatentContactConfig(
+        observation_fraction=0.20,
+        observation_noise_std_m=0.0015,
+        parameter_particle_count=2,
+        gain_values=(0.8, 1.0),
+        delay_values=(0, 1),
+        slip_values=(0.0,),
+        rotation_values_deg=(0.0,),
+        confidence_level=benchmark.confidence_level,
+    )
+    result = run_controlled_latent_contact_sbc(
+        seeds=(3,),
+        trials_per_fold=12,
+        bin_count=4,
+        benchmark_config=benchmark,
+        contact_config=contact,
+    )
+
+    assert result["schema"] == "causal4d.controlled_latent_contact_sbc"
+    assert "not real-data calibration" in result["interpretation"]
+    assert result["aggregate"]["fold_count"] == 3
+    assert result["aggregate"]["trial_count"] == 36
+    assert {fold["held_out_object"] for fold in result["folds"]} == {
+        "rope",
+        "cloth",
+        "soft_block",
+    }
+    assert all(fold["source_excludes_target"] for fold in result["folds"])
+    assert all(
+        sum(fold["result"]["rank_histograms"]["joint"]) == 12
+        for fold in result["folds"]
+    )

--- a/tests/test_controlled_latent_contact_sbc.py
+++ b/tests/test_controlled_latent_contact_sbc.py
@@ -11,7 +11,9 @@ from causal4d.controlled_latent_contact_sbc import (
 from causal4d.simulation_calibration import SimulationCalibrationResult
 
 
-def _result(*, trials: int, seed: int, counts: tuple[int, int]) -> SimulationCalibrationResult:
+def _result(
+    *, trials: int, seed: int, counts: tuple[int, int]
+) -> SimulationCalibrationResult:
     parameter_histograms = (counts, counts, counts)
     return SimulationCalibrationResult(
         trial_count=trials,


### PR DESCRIPTION
## What changed

- integrate exact finite-support simulation-based calibration into the existing `causal4d benchmark latent-contact` command behind opt-in flags;
- add a controlled leave-one-topology SBC runner that rebuilds each finite contact/physics bank under the existing benchmark split and samples truths from that bank's own declared prior;
- aggregate randomized-rank histograms and posterior summaries across folds without relabelling folds, frames, points, or coordinates as independent physical executions;
- extend the existing real graph-discrepancy evaluator with a `graph_modewise` arm alongside random-walk, state-only, graph persistence, and dense graph-temporal dynamics;
- bind per-mode retention, innovation variance, and source-only shrinkage settings into the saved model artifact and preserve mode-wise predictive moments in the label-free moments artifact;
- add a small end-to-end held-out-topology SBC test; and
- document the operational commands and their strict non-confirmatory interpretation.

## Why

PR #281 introduced the underlying mode-wise stochastic discrepancy model and finite-support SBC primitives. This follow-up makes those diagnostics directly usable through the existing benchmark/evaluation surfaces, without changing the registered 36-execution estimator or creating another competing command hierarchy.

The controlled SBC path is an exact implementation self-consistency test: simulated observation noise equals the likelihood scale, likelihood power is one, and derivative likelihood terms are disabled. A pass can therefore separate finite-posterior implementation issues from the real model/discrepancy shift already observed in Causal4D, but it is not real-data calibration evidence.

The real discrepancy evaluator now compares mode-wise dynamics on exactly the same O-minus fit and O-plus-prefix boundary as persistence and dense AR. No held-out future is used for fitting the mode-wise parameters.

## Scientific boundary

This PR is additive and diagnostic. It does **not** change the frozen primary real method, physical evidence count, acquisition protocol, target identities, graph-persistence baseline, BayesianPhysTwin/Prob4D admission, or calibration claim boundary.

## Validation

GitHub Actions on this exact follow-up head are authoritative. The added unit/integration coverage checks histogram aggregation and a complete three-topology controlled SBC construction using a reduced benchmark configuration.