### PR TITLE
Validate posterior scoring against real contracts

### DIFF
--- a/src/causal4d/_posterior_scoring_contracts.py
+++ b/src/causal4d/_posterior_scoring_contracts.py
@@ -9,6 +9,8 @@ from typing import Any, Sequence
 
 import numpy as np
 
+from causal4d.immutable_array import readonly_array
+
 
 POSTERIOR_SCORE_SCHEMA_VERSION = 1
 POSTERIOR_SCORE_CLAIM_BOUNDARY = (
@@ -41,9 +43,7 @@ def _array_sha256(values: np.ndarray) -> str:
 
 
 def _readonly_array(values: Any, *, dtype: Any) -> np.ndarray:
-    result = np.asarray(values, dtype=dtype).copy()
-    result.setflags(write=False)
-    return result
+    return readonly_array(values, dtype=dtype)
 
 
 def _require_nonempty_string(value: Any, *, name: str) -> str:
@@ -267,4 +267,3 @@ class TrajectoryScoreSpecificationV1:
     @property
     def specification_id(self) -> str:
         return _canonical_id(self.descriptor())
-

--- a/src/causal4d/_posterior_scoring_contracts.py
+++ b/src/causal4d/_posterior_scoring_contracts.py
@@ -255,9 +255,7 @@ class TrajectoryScoreSpecificationV1:
             "variogram": {
                 "pairs_shape": list(self.variogram_pairs.shape),
                 "pairs_sha256": _array_sha256(self.variogram_pairs),
-                "pair_weights_sha256": _array_sha256(
-                    self.variogram_pair_weights
-                ),
+                "pair_weights_sha256": _array_sha256(self.variogram_pair_weights),
                 "order": self.variogram_order,
                 "score_unit_power_m": 2.0 * self.variogram_order,
             },

--- a/tests/test_posterior_scoring_contract_integration.py
+++ b/tests/test_posterior_scoring_contract_integration.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import hashlib
+
+import numpy as np
+import pytest
+
+from causal4d.contracts import (
+    PhysicalPosterior,
+    TaskPosterior,
+    build_causal_context,
+)
+from causal4d.posterior_scoring import (
+    TrajectoryScoreSpecificationV1,
+    score_physical_posterior,
+    trajectory_coordinate_index,
+)
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _posterior_pair() -> tuple[PhysicalPosterior, TaskPosterior]:
+    observations = np.zeros((8, 1, 3), dtype=np.float64)
+    actions = np.zeros((8, 1, 3), dtype=np.float64)
+    context = build_causal_context(
+        protocol_id="posterior-score-integration-v1",
+        case_id="case-001",
+        observations=observations,
+        observed_actions=actions,
+        counterfactual_actions=actions,
+        intervention_frame=4,
+    )
+    trajectories = np.zeros((2, 4, 1, 3), dtype=np.float64)
+    trajectories[0, :, 0, :2] = -1.0
+    trajectories[1, :, 0, :2] = 1.0
+    physical = PhysicalPosterior(
+        context=context,
+        component_ids=("negative", "positive"),
+        state_trajectories_m=trajectories,
+        readout_trajectories_m=trajectories,
+        readout_variance_m2=np.full((2, 1, 3), 1.0e-6),
+        weights=np.asarray([0.6, 0.4]),
+        phi=np.asarray([[1.0], [0.8]]),
+        kappa_cf=np.asarray([[0.0], [0.1]]),
+        hypothesis_indices=np.asarray([0, 1]),
+        twin_particle_indices=np.asarray([0, 1]),
+        phi_names=("gain",),
+        kappa_names=("slip",),
+        source_twin_belief_id=_digest("belief"),
+        source_factual_intervention_id=_digest("factual"),
+        source_query_id=_digest("query"),
+    )
+    task = TaskPosterior(
+        context=context,
+        physical_posterior_id=physical.artifact_id,
+        component_ids=physical.component_ids,
+        physical_weights=physical.weights,
+        task_weights=np.asarray([0.2, 0.8]),
+        semantic_log_scores=np.asarray([-1.0, 1.0]),
+        beta=1.0,
+        query_node_indices=np.asarray([0]),
+        semantic_source="integration-test",
+    )
+    return physical, task
+
+
+def test_real_contracts_preserve_lineage_and_joint_covariance() -> None:
+    physical, task = _posterior_pair()
+    shape = physical.readout_trajectories_m.shape[1:]
+    first = trajectory_coordinate_index(0, 0, 0, shape)
+    second = trajectory_coordinate_index(1, 0, 0, shape)
+    final_x = trajectory_coordinate_index(3, 0, 0, shape)
+    final_y = trajectory_coordinate_index(3, 0, 1, shape)
+    query = np.zeros((2, int(np.prod(shape))), dtype=float)
+    query[0, final_x] = 1.0
+    query[1, final_y] = 1.0
+    specification = TrajectoryScoreSpecificationV1(
+        name="real-contract-integration-v1",
+        valid_mask=np.ones(shape[:-1], dtype=bool),
+        variogram_pairs=np.asarray([[first, second]], dtype=np.int64),
+        variogram_pair_weights=np.asarray([1.0]),
+        query_matrix=query,
+        query_labels=("final-x", "final-y"),
+        query_units=("m", "m"),
+        query_covariance_floor_m2=1.0e-10,
+    )
+    truth = np.ones(shape, dtype=float)
+
+    physical_score = score_physical_posterior(
+        physical,
+        truth,
+        specification,
+        conditional_draws_per_component=4,
+        random_seed=17,
+    )
+    repeated = score_physical_posterior(
+        physical,
+        truth,
+        specification,
+        conditional_draws_per_component=4,
+        random_seed=17,
+    )
+    task_score = score_physical_posterior(
+        physical,
+        truth,
+        specification,
+        task_posterior=task,
+        conditional_draws_per_component=4,
+        random_seed=17,
+    )
+
+    assert physical_score.score_id == repeated.score_id
+    assert physical_score.source_weight_kind == "physical"
+    assert physical_score.source_weight_id == physical.artifact_id
+    assert task_score.source_weight_kind == "task"
+    assert task_score.source_weight_id == task.artifact_id
+    assert physical_score.score_id != task_score.score_id
+    assert physical_score.query_score is not None
+    assert physical_score.query_score.posterior_covariance[0, 1] > 0.0
+    contribution_sum = sum(
+        value.mean_coordinate_variance_m2
+        for value in physical_score.variance_attribution.contributions
+    )
+    assert contribution_sum == pytest.approx(
+        physical_score.variance_attribution.total_mean_coordinate_variance_m2
+    )


### PR DESCRIPTION
## What changed

- add an integration test that constructs the repository's real `PhysicalPosterior` and `TaskPosterior` contracts;
- score both physical and task-weighted versions with the new dependence-aware API;
- verify deterministic content identities, exact posterior/weight lineage, preserved off-diagonal query covariance, and additive variance closure; and
- route posterior-score arrays through Causal4D's immutable-bytes helper so stored masks, weights, moments, covariance matrices, and truths cannot be made writable again.

## Context

The dependence-aware scoring implementation is already on `main` in commits `d2af986` through `7f14881`. This follow-up validates the implementation through the real contract constructors and fixes the immutable-array policy issue discovered by the first complete CI run.

## Scientific boundary

The test and scoring implementation are analysis-only. They do not change the frozen estimator, registered 18-session/36-execution protocol, six-frame causal boundary, target identity, Prob4D admission, BayesianPhysTwin handoff, evidence ledger, or physical evidence count.

## Validation

All required workflow groups pass on `efe159ca9954d176f908dda5619cdb8e622fe2de`:

- Causal4D merge gate;
- CI and release, including Python 3.10, 3.12, and 3.14, distribution builds, isolated wheel/sdist CLI checks, Ruff/format/types, deterministic result bundles, and pinned BayesianPhysTwin wheel integration;
- Extended compatibility, including declared dependency floors and Python 3.11/3.13; and
- Security scanning, including resolved-dependency audit and CodeQL for Python and Actions.

The focused dependence-aware suite and real-contract integration tests are included in the default test run.