### PR TITLE
Add prepared Prob4D reuse and per-view residual localization

### DIFF
--- a/.github/workflows/prepared-joint-observation-self-hosted.yml
+++ b/.github/workflows/prepared-joint-observation-self-hosted.yml
@@ -69,12 +69,18 @@ jobs:
           from pathlib import Path
 
           import causal4d
+          import causal4d.per_view_residual_localization
           import causal4d.prepared_joint_observation
+          import causal4d.prob4d_prepared_observation
+          import causal4d.simulation_calibration
 
           source_root = (Path.cwd() / "src").resolve()
           origins = (
               Path(causal4d.__file__).resolve(),
+              Path(causal4d.per_view_residual_localization.__file__).resolve(),
               Path(causal4d.prepared_joint_observation.__file__).resolve(),
+              Path(causal4d.prob4d_prepared_observation.__file__).resolve(),
+              Path(causal4d.simulation_calibration.__file__).resolve(),
           )
           for origin in origins:
               print("installed import", origin)
@@ -96,6 +102,11 @@ jobs:
             tests/test_joint_observation_adversarial.py \
             tests/test_joint_observation_metamorphic.py \
             tests/test_prepared_joint_observation.py \
+            tests/test_prob4d_joint_observation.py \
+            tests/test_prob4d_prepared_observation.py \
+            tests/test_per_view_residual_localization.py \
+            tests/test_graph_modewise_discrepancy.py \
+            tests/test_simulation_calibration.py \
             | tee outputs/prepared-joint-observation/pytest.txt
 
       - name: Run parity and 2048-row rank-7 scale benchmarks
@@ -113,6 +124,22 @@ jobs:
             --rank 7 \
             --chunk-size 8 \
             | tee outputs/prepared-joint-observation/benchmark.txt
+
+      - name: Run prepared Prob4D, per-view, and SBC benchmark
+        shell: bash
+        run: |
+          set -euo pipefail
+          PYTHONPATH="" .prepared-joint-venv/bin/python \
+            scripts/ci/benchmark_prob4d_prepared_per_view.py \
+            --output \
+              outputs/prepared-joint-observation/prob4d-per-view-sbc.json \
+            --component-count 256 \
+            --repeat-count 100 \
+            --component-chunk-size 32 \
+            --per-view-node-count 4096 \
+            --sbc-trials 5000 \
+            | tee \
+              outputs/prepared-joint-observation/prob4d-per-view-sbc.txt
 
       - name: Record runner identity
         shell: bash
@@ -174,6 +201,7 @@ jobs:
           Prepared joint-observation self-hosted validation: **${VALIDATION_RESULT}**
 
           - Exact reviewed main commit: \`${GITHUB_SHA}\`
+          - Prepared Prob4D, per-view localization, and SBC executed: \`true\`
           - Workflow run: ${run_url}
           - Artifact: \`prepared-joint-observation-self-hosted\`
           - Physical evidence increment: \`0\`

--- a/docs/per_view_residual_localization.md
+++ b/docs/per_view_residual_localization.md
@@ -1,0 +1,69 @@
+# Per-view residual localization
+
+`causal4d.per_view_residual_localization` provides a prefix-only diagnostic for
+the per-camera evidence retained by the physical acquisition contract. Its
+purpose is to avoid interpreting camera-specific reconstruction error as a
+physical or state discrepancy.
+
+For view `v`, prefix frame `t`, material node `n`, and coordinate `c`, the
+diagnostic fits
+
+```text
+observed[v,t,n,c] - predicted[t,n,c]
+  = view_contrast[v,c]
+  + shared_frame_offset[t,c]
+  + graph_field[t,n,c]
+  + residual[v,t,n,c].
+```
+
+The graph field is represented in a supplied node basis. Every basis mode is
+centered across nodes and RMS-normalized before fitting, which prevents a global
+translation from being assigned simultaneously to the graph and shared-frame
+terms. One highest-support view is selected as the reference, so view terms are
+contrasts rather than absolute camera biases.
+
+## Inputs and causal boundary
+
+- observed material points: `(view, frame, node, 3)`;
+- predicted material points: `(frame, node, 3)`;
+- Boolean validity: `(view, frame, node)`;
+- optional continuous confidence in `[0, 1]`;
+- optional graph basis: `(node, mode)`;
+- an exact evidence artifact ID; and
+- an optional exclusive causal-prefix stop.
+
+Only the selected prefix is hashed and fitted. Future observations can remain
+retained for blind evaluation without affecting the result. Every view and
+every selected prefix frame must contribute positive weighted support.
+
+## Reported diagnostics
+
+The content-addressed result contains immutable arrays for the fitted
+reference-view contrasts, shared frame offsets, graph coefficients and graph
+field. It also reports per-view RMS residuals before and after fitting, support
+counts, weighted sums of squared errors for nested ablations, and the unique
+explained fraction attributable to each diagnostic family.
+
+The dominant-source label is conservative:
+
+- `view_specific`: relative camera/view effects dominate;
+- `shared_frame`: a common frame/gauge translation dominates;
+- `object_coherent`: a centered graph field dominates;
+- `mixed`: the leading diagnostic families are too close to separate; or
+- `unresolved`: the fitted decomposition explains too little energy.
+
+A pre-allocation design-memory guard fails before constructing an oversized
+dense regression matrix.
+
+## Interpretation
+
+This decomposition is a localization aid, not a causal conclusion. A strong
+object-coherent fraction supports investigation of a readout/rest-geometry
+correction, but it does not by itself prove simulator-state discrepancy.
+Likewise, a view-specific fraction may reflect calibration, occlusion,
+association, confidence calibration, or reconstruction bias.
+
+The result explicitly records `target_outcomes_used=false` and
+`physical_evidence_increment=0`. It does not change the frozen estimator, the
+registered 36-execution protocol, exclusion rules, covariance calibration, or
+the paper's physical evidence count.

--- a/docs/prob4d_prepared_observation.md
+++ b/docs/prob4d_prepared_observation.md
@@ -1,0 +1,66 @@
+# Prepared Prob4D joint observations
+
+`causal4d.prob4d_prepared_observation` is the reusable execution layer for
+validated Prob4D full-joint observation evidence.
+
+The existing `joint_observation_from_prob4d` adapter remains the semantic and
+provenance boundary. Preparation performs that validation once, constructs the
+same `LinearJointObservationEvidence`, and compiles its sparse rollout operator
+and structured Gaussian base solver:
+
+```python
+from causal4d.prob4d_prepared_observation import (
+    prepare_prob4d_joint_observation,
+)
+
+prepared = prepare_prob4d_joint_observation(
+    descriptor,
+    arrays,
+    rollout_frame_ids=rollout_frame_ids,
+    entity_to_node=entity_to_node,
+)
+
+log_likelihood, diagnostics = prepared.log_likelihoods(
+    rollout_components_m,
+    prefix_frame_count=prefix_frame_count,
+    component_chunk_size=32,
+)
+```
+
+## Guarantees
+
+Preparation does not alter the Prob4D covariance model. Local `3 x 3`
+covariance blocks, the shared low-rank gauge factor, row ordering, frame/entity
+mapping, reliability policy, and source provenance are inherited from the
+validated adapter without reinterpretation.
+
+Repeated calls reuse the exact base covariance factorization, use the compiled
+sparse selector operator, and respect the prepared path's explicit working-memory
+budget. Component-specific covariance and low-rank factors retain their existing
+semantics. Posterior updates preserve exact zero prior support.
+
+Portable strict descriptors and historical adapter fixtures place source
+identity in slightly different locations. The prepared adapter accepts
+`source_revision` and `source_artifact_sha256` either at descriptor level or in
+descriptor metadata, while rejecting any disagreement between the two.
+
+## Relationship to the tree-block handoff
+
+This path accelerates finite-rollout likelihood evaluation for validated
+Prob4D observation beliefs. It is complementary to the strict
+BayesianPhysTwin tree-block query provider and belief handoff:
+
+- the tree-block path transfers an admitted BayesianPhysTwin posterior and
+  registered query covariance without dense posterior materialization;
+- the prepared path evaluates Causal4D rollout support repeatedly against one
+  validated full-joint Prob4D observation artifact.
+
+Neither path permits Causal4D to consume the same observation factors twice.
+The existing evidence-ownership ledger remains authoritative at the
+BayesianPhysTwin handoff.
+
+## Scientific boundary
+
+This is numerical execution infrastructure. It does not establish observation
+competence, empirical covariance calibration, physical benefit, intervention
+benefit, deployment safety, or a new physical evidence count.

--- a/scripts/ci/benchmark_prob4d_prepared_per_view.py
+++ b/scripts/ci/benchmark_prob4d_prepared_per_view.py
@@ -1,0 +1,367 @@
+"""Benchmark prepared Prob4D reuse and per-view residual localization."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from copy import deepcopy
+from pathlib import Path
+from time import perf_counter
+from typing import Any, Callable, TypeVar
+
+import numpy as np
+
+from causal4d.contact_inference import ContactRolloutBank, ContactState
+from causal4d.joint_observation import joint_component_log_likelihoods
+from causal4d.per_view_residual_localization import localize_per_view_residuals
+from causal4d.prob4d_prepared_observation import (
+    prepare_prob4d_joint_observation,
+)
+from causal4d.simulation_calibration import run_contact_rollout_sbc
+from causal4d.simulator import Action, GraphObject, PhysicalParameters
+
+
+_Result = TypeVar("_Result")
+FIXTURE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "fixtures"
+    / "prob4d_joint_observation_v1.json"
+)
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--component-count", type=int, default=256)
+    parser.add_argument("--repeat-count", type=int, default=100)
+    parser.add_argument("--component-chunk-size", type=int, default=32)
+    parser.add_argument("--per-view-node-count", type=int, default=4096)
+    parser.add_argument("--sbc-trials", type=int, default=5000)
+    return parser.parse_args()
+
+
+def _positive(value: int, *, name: str) -> int:
+    if type(value) is not int or value < 1:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def _timed(function: Callable[[], _Result]) -> tuple[_Result, float]:
+    start = perf_counter()
+    result = function()
+    return result, perf_counter() - start
+
+
+def _fixture() -> tuple[dict[str, Any], dict[str, np.ndarray]]:
+    payload = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    descriptor = deepcopy(payload["descriptor"])
+    arrays = {
+        name: np.asarray(record["values"], dtype=np.dtype(record["dtype"]))
+        for name, record in payload["arrays"].items()
+    }
+    return descriptor, arrays
+
+
+def _prob4d_benchmark(
+    *,
+    component_count: int,
+    repeat_count: int,
+    component_chunk_size: int,
+) -> dict[str, Any]:
+    descriptor, arrays = _fixture()
+    prepared, preparation_seconds = _timed(
+        lambda: prepare_prob4d_joint_observation(
+            descriptor,
+            arrays,
+            rollout_frame_ids=(1, 2, 3, 4, 5),
+            entity_to_node={0: 0, 1: 1},
+            reliability_policy="record_only",
+        )
+    )
+    rng = np.random.default_rng(20260812)
+    components = rng.normal(
+        scale=0.05,
+        size=(component_count, 5, 2, 3),
+    )
+    components[..., 2] += 1.0
+    (legacy_score, _), legacy_seconds = _timed(
+        lambda: joint_component_log_likelihoods(
+            components,
+            prepared.evidence,
+            prefix_frame_count=5,
+        )
+    )
+    (prepared_score, diagnostics), prepared_seconds = _timed(
+        lambda: prepared.log_likelihoods(
+            components,
+            prefix_frame_count=5,
+            component_chunk_size=component_chunk_size,
+        )
+    )
+    maximum_difference = float(np.max(np.abs(legacy_score - prepared_score)))
+    if not np.allclose(
+        legacy_score,
+        prepared_score,
+        rtol=1e-11,
+        atol=1e-11,
+    ):
+        raise RuntimeError(
+            "prepared Prob4D score differs from the validated legacy path"
+        )
+
+    start = perf_counter()
+    checksum = 0.0
+    for _ in range(repeat_count):
+        score, repeated_diagnostics = prepared.log_likelihoods(
+            components,
+            prefix_frame_count=5,
+            component_chunk_size=component_chunk_size,
+        )
+        checksum += float(np.sum(score))
+    repeated_seconds = perf_counter() - start
+    if not np.isfinite(checksum):
+        raise RuntimeError("repeated prepared Prob4D scoring was nonfinite")
+    if not repeated_diagnostics.base_factorization_reused:
+        raise RuntimeError("prepared Prob4D scoring did not reuse its base solver")
+
+    return {
+        "evidence_artifact_id": prepared.artifact_id,
+        "row_count": prepared.adapter_diagnostics.row_count,
+        "observation_count": prepared.adapter_diagnostics.observation_count,
+        "shared_rank": prepared.adapter_diagnostics.factor_rank,
+        "component_count": component_count,
+        "repeat_count": repeat_count,
+        "component_chunk_size": diagnostics.component_chunk_size,
+        "chunk_count": diagnostics.chunk_count,
+        "preparation_seconds": preparation_seconds,
+        "legacy_seconds": legacy_seconds,
+        "prepared_seconds": prepared_seconds,
+        "reported_single_call_speedup": (
+            None if prepared_seconds == 0.0 else legacy_seconds / prepared_seconds
+        ),
+        "repeated_prepared_seconds": repeated_seconds,
+        "maximum_absolute_score_difference": maximum_difference,
+        "exact_score_parity": True,
+        "base_factorization_reused": diagnostics.base_factorization_reused,
+        "repeated_score_checksum": checksum,
+    }
+
+
+def _centered_basis(
+    rng: np.random.Generator,
+    *,
+    node_count: int,
+    rank: int,
+) -> np.ndarray:
+    basis = rng.normal(size=(node_count, rank))
+    basis -= np.mean(basis, axis=0, keepdims=True)
+    basis /= np.sqrt(np.mean(np.square(basis), axis=0, keepdims=True))
+    return basis
+
+
+def _per_view_benchmark(*, node_count: int) -> dict[str, Any]:
+    rng = np.random.default_rng(20260813)
+    view_count = 4
+    frame_count = 6
+    graph_rank = 8
+    predicted = rng.normal(
+        scale=0.02,
+        size=(frame_count, node_count, 3),
+    )
+    basis = _centered_basis(
+        rng,
+        node_count=node_count,
+        rank=graph_rank,
+    )
+    view_bias = rng.normal(scale=0.008, size=(view_count, 3))
+    view_bias[0] = 0.0
+    frame_offset = rng.normal(scale=0.003, size=(frame_count, 3))
+    graph_coefficients = rng.normal(
+        scale=0.002,
+        size=(frame_count, graph_rank, 3),
+    )
+    graph_field = np.einsum(
+        "nr,trc->tnc",
+        basis,
+        graph_coefficients,
+    )
+    observed = (
+        predicted[None]
+        + view_bias[:, None, None]
+        + frame_offset[None, :, None]
+        + graph_field[None]
+        + rng.normal(
+            scale=0.0005,
+            size=(view_count, frame_count, node_count, 3),
+        )
+    )
+    validity = rng.random((view_count, frame_count, node_count)) > 0.03
+    confidence = rng.uniform(
+        0.5,
+        1.0,
+        size=(view_count, frame_count, node_count),
+    )
+    result, elapsed_seconds = _timed(
+        lambda: localize_per_view_residuals(
+            observed,
+            predicted,
+            validity,
+            evidence_artifact_id="e" * 64,
+            confidence=confidence,
+            graph_basis=basis,
+            causal_prefix_frame_stop=frame_count,
+            maximum_design_bytes=512 * 1024**2,
+        )
+    )
+    if result.full_explained_fraction < 0.95:
+        raise RuntimeError(
+            "synthetic per-view localization explained too little residual energy"
+        )
+    if not np.all(result.per_view_rms_after_m < result.per_view_rms_before_m):
+        raise RuntimeError("per-view localization failed to reduce every view residual")
+    payload = result.as_dict()
+    payload.update(
+        {
+            "elapsed_seconds": elapsed_seconds,
+            "operator_row_count": int(np.sum(validity)),
+            "known_view_bias_rms_m": float(np.sqrt(np.mean(np.square(view_bias)))),
+            "known_frame_offset_rms_m": float(
+                np.sqrt(np.mean(np.square(frame_offset)))
+            ),
+            "known_graph_field_rms_m": float(np.sqrt(np.mean(np.square(graph_field)))),
+        }
+    )
+    return payload
+
+
+def _sbc_bank() -> ContactRolloutBank:
+    graph_object = GraphObject(
+        name="prepared-self-hosted-sbc",
+        rest_positions=np.asarray([[0.0, 0.0], [0.1, 0.0]]),
+        edges=((0, 1),),
+        mass=1.0,
+        support_stiffness=0.2,
+        true_parameters=PhysicalParameters(1.0, 1.0, 1.0),
+        sensor_nodes=(0, 1),
+    )
+    action = Action(
+        action_id="prepared-self-hosted-probe",
+        split="test",
+        contact_nodes=(0,),
+        commanded_forces=np.zeros((4, 1, 2), dtype=float),
+    )
+    states = (
+        ContactState((0,), 0.8, 0, 0.0, 0.0),
+        ContactState((1,), 1.2, 1, 0.0, 0.0),
+    )
+    particles: np.ndarray = np.asarray(
+        [
+            [0.8, 0.9, 0.85],
+            [1.2, 1.1, 1.15],
+        ],
+        dtype=float,
+    )
+    trajectories: np.ndarray = np.zeros((2, 2, 5, 2, 2), dtype=float)
+    time: np.ndarray = np.arange(5, dtype=float)
+    for contact_index in range(2):
+        for parameter_index in range(2):
+            component = 2 * contact_index + parameter_index
+            slope = 0.018 * (component + 1)
+            trajectories[contact_index, parameter_index, :, :, 0] = (
+                slope * time[:, None]
+            )
+            trajectories[contact_index, parameter_index, :, 0, 1] = 0.35 * slope * time
+            trajectories[contact_index, parameter_index, :, 1, 1] = -0.20 * slope * time
+    return ContactRolloutBank(
+        graph_object=graph_object,
+        action=action,
+        contact_states=states,
+        contact_prior_weights=np.asarray([0.5, 0.5]),
+        parameter_particles=particles,
+        parameter_weights=np.asarray([0.5, 0.5]),
+        trajectories=trajectories,
+        variance_floor_m2=1e-8,
+        confidence_level=0.9,
+    )
+
+
+def _sbc_benchmark(*, trials: int) -> dict[str, Any]:
+    result, elapsed_seconds = _timed(
+        lambda: run_contact_rollout_sbc(
+            _sbc_bank(),
+            trials=trials,
+            prefix_frame_count=4,
+            likelihood_scale_m=0.006,
+            likelihood_power=1.0,
+            dynamic_likelihood_weight=0.0,
+            observation_noise_std_m=0.006,
+            seed=321,
+            bin_count=10,
+        )
+    )
+    if result.joint_rank_max_abs_frequency_error >= 0.05:
+        raise RuntimeError("controlled joint SBC rank histogram is not near-uniform")
+    if result.contact_rank_max_abs_frequency_error >= 0.05:
+        raise RuntimeError("controlled contact SBC rank histogram is not near-uniform")
+    if max(result.parameter_rank_max_abs_frequency_error) >= 0.05:
+        raise RuntimeError(
+            "controlled parameter SBC rank histograms are not near-uniform"
+        )
+    if result.mean_entropy_reduction <= 0.2:
+        raise RuntimeError("controlled SBC posterior did not contract")
+    payload = result.as_dict()
+    payload["elapsed_seconds"] = elapsed_seconds
+    return payload
+
+
+def main() -> None:
+    args = _arguments()
+    component_count = _positive(
+        args.component_count,
+        name="component_count",
+    )
+    repeat_count = _positive(args.repeat_count, name="repeat_count")
+    component_chunk_size = _positive(
+        args.component_chunk_size,
+        name="component_chunk_size",
+    )
+    per_view_node_count = _positive(
+        args.per_view_node_count,
+        name="per_view_node_count",
+    )
+    sbc_trials = _positive(args.sbc_trials, name="sbc_trials")
+
+    payload = {
+        "schema_version": 1,
+        "artifact_kind": "Prob4DPreparedPerViewSelfHostedBenchmark",
+        "prob4d_prepared": _prob4d_benchmark(
+            component_count=component_count,
+            repeat_count=repeat_count,
+            component_chunk_size=component_chunk_size,
+        ),
+        "per_view_residual_localization": _per_view_benchmark(
+            node_count=per_view_node_count,
+        ),
+        "simulation_based_calibration": _sbc_benchmark(trials=sbc_trials),
+        "target_outcomes_used": False,
+        "physical_evidence_increment": 0,
+        "claim_boundary": (
+            "Synthetic numerical execution only. This benchmark does not alter "
+            "the frozen estimator, registered physical protocol, calibration "
+            "claim, target boundary, or physical evidence count."
+        ),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(
+        payload,
+        indent=2,
+        sort_keys=True,
+        allow_nan=False,
+    )
+    args.output.write_text(encoded + "\n", encoding="utf-8")
+    print(encoded)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/causal4d/per_view_residual_localization.py
+++ b/src/causal4d/per_view_residual_localization.py
@@ -1,0 +1,557 @@
+"""Prefix-only localization of view, frame, and object-coherent residuals.
+
+The decomposition is diagnostic and non-claim-bearing. It never changes the
+registered estimator, causal boundary, or physical evidence count.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Literal, cast
+
+import numpy as np
+
+from causal4d.contracts import array_sha256
+from causal4d.immutable_array import readonly_array, readonly_integer_array
+
+
+PER_VIEW_RESIDUAL_LOCALIZATION_SCHEMA_VERSION = 1
+DominantResidualSource = Literal[
+    "view_specific",
+    "shared_frame",
+    "object_coherent",
+    "mixed",
+    "unresolved",
+]
+
+
+def _finite_nonnegative(value: float, *, name: str) -> float:
+    result = float(value)
+    if not np.isfinite(result) or result < 0.0:
+        raise ValueError(f"{name} must be finite and nonnegative")
+    return result
+
+
+def _fraction(value: float, *, name: str) -> float:
+    result = float(value)
+    if not np.isfinite(result) or not 0.0 <= result <= 1.0:
+        raise ValueError(f"{name} must lie in [0, 1]")
+    return result
+
+
+def _sha256(value: str, *, name: str) -> str:
+    if (
+        type(value) is not str
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _graph_basis(values: np.ndarray | None, *, node_count: int) -> np.ndarray:
+    if values is None:
+        return np.empty((node_count, 0), dtype=float)
+    basis = np.asarray(values, dtype=float)
+    if basis.ndim != 2 or basis.shape[0] != node_count:
+        raise ValueError("graph_basis must have shape (node, mode)")
+    if not np.all(np.isfinite(basis)):
+        raise ValueError("graph_basis must be finite")
+    if basis.shape[1] == 0:
+        return np.empty((node_count, 0), dtype=float)
+    basis = basis - np.mean(basis, axis=0, keepdims=True)
+    scale = np.sqrt(np.mean(np.square(basis), axis=0))
+    if np.any(scale <= 1e-12):
+        raise ValueError(
+            "every graph_basis mode must retain nonzero centered node variation"
+        )
+    return basis / scale
+
+
+def _fit(
+    design: np.ndarray,
+    observations: np.ndarray,
+    weights: np.ndarray,
+    ridge: np.ndarray,
+    columns: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, float]:
+    if not len(columns):
+        prediction = np.zeros_like(observations)
+        sse = float(np.sum(weights[:, None] * np.square(observations)))
+        return np.empty((0, 3), dtype=float), prediction, sse
+
+    selected = design[:, columns]
+    root_weight = np.sqrt(weights)
+    weighted_design = selected * root_weight[:, None]
+    weighted_observations = observations * root_weight[:, None]
+    normal = weighted_design.T @ weighted_design
+    normal += np.diag(ridge[columns])
+    rhs = weighted_design.T @ weighted_observations
+    try:
+        coefficients = np.linalg.solve(normal, rhs)
+    except np.linalg.LinAlgError:
+        coefficients = np.linalg.lstsq(normal, rhs, rcond=None)[0]
+    prediction = selected @ coefficients
+    residual = observations - prediction
+    sse = float(np.sum(weights[:, None] * np.square(residual)))
+    if not np.all(np.isfinite(coefficients)) or not np.isfinite(sse):
+        raise ValueError("per-view residual fit produced nonfinite values")
+    return coefficients, prediction, sse
+
+
+def _explained(improvement: float, total: float) -> float:
+    if total <= np.finfo(float).tiny:
+        return 0.0
+    return float(np.clip(improvement / total, 0.0, 1.0))
+
+
+@dataclass(frozen=True, slots=True)
+class PerViewResidualLocalizationResult:
+    """Content-addressed prefix-only residual decomposition."""
+
+    evidence_artifact_id: str
+    causal_prefix_frame_stop: int
+    reference_view_index: int
+    view_count: int
+    frame_count: int
+    node_count: int
+    graph_rank: int
+    observed_points_sha256: str
+    predicted_points_sha256: str
+    validity_mask_sha256: str
+    confidence_sha256: str
+    graph_basis_sha256: str | None
+    view_ridge: float
+    frame_ridge: float
+    graph_ridge: float
+    maximum_design_bytes: int
+    view_bias_m: np.ndarray
+    shared_frame_offset_m: np.ndarray
+    graph_coefficients_m: np.ndarray
+    graph_field_m: np.ndarray
+    per_view_rms_before_m: np.ndarray
+    per_view_rms_after_m: np.ndarray
+    valid_observation_counts: np.ndarray
+    total_weighted_sse_m2: float
+    full_weighted_sse_m2: float
+    frame_only_weighted_sse_m2: float
+    no_view_weighted_sse_m2: float
+    no_frame_weighted_sse_m2: float
+    no_graph_weighted_sse_m2: float
+    full_explained_fraction: float
+    view_unique_fraction: float
+    frame_unique_fraction: float
+    graph_unique_fraction: float
+    dominant_source: DominantResidualSource
+    artifact_id: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        _sha256(self.evidence_artifact_id, name="evidence_artifact_id")
+        dimensions = (
+            self.causal_prefix_frame_stop,
+            self.view_count,
+            self.frame_count,
+            self.node_count,
+        )
+        if any(type(value) is not int or value < 1 for value in dimensions):
+            raise ValueError("localization dimensions must be positive integers")
+        if self.frame_count != self.causal_prefix_frame_stop:
+            raise ValueError("frame_count must equal the causal prefix length")
+        if not 0 <= self.reference_view_index < self.view_count:
+            raise ValueError("reference_view_index lies outside the view inventory")
+        if type(self.graph_rank) is not int or self.graph_rank < 0:
+            raise ValueError("graph_rank must be a nonnegative integer")
+        if type(self.maximum_design_bytes) is not int or self.maximum_design_bytes < 1:
+            raise ValueError("maximum_design_bytes must be a positive integer")
+
+        for name in (
+            "observed_points_sha256",
+            "predicted_points_sha256",
+            "validity_mask_sha256",
+            "confidence_sha256",
+        ):
+            _sha256(getattr(self, name), name=name)
+        if self.graph_basis_sha256 is not None:
+            _sha256(self.graph_basis_sha256, name="graph_basis_sha256")
+        for name in ("view_ridge", "frame_ridge", "graph_ridge"):
+            _finite_nonnegative(getattr(self, name), name=name)
+        for name in (
+            "total_weighted_sse_m2",
+            "full_weighted_sse_m2",
+            "frame_only_weighted_sse_m2",
+            "no_view_weighted_sse_m2",
+            "no_frame_weighted_sse_m2",
+            "no_graph_weighted_sse_m2",
+        ):
+            _finite_nonnegative(getattr(self, name), name=name)
+        for name in (
+            "full_explained_fraction",
+            "view_unique_fraction",
+            "frame_unique_fraction",
+            "graph_unique_fraction",
+        ):
+            _fraction(getattr(self, name), name=name)
+        if self.dominant_source not in {
+            "view_specific",
+            "shared_frame",
+            "object_coherent",
+            "mixed",
+            "unresolved",
+        }:
+            raise ValueError("unsupported dominant_source")
+
+        array_shapes = {
+            "view_bias_m": (self.view_count, 3),
+            "shared_frame_offset_m": (self.frame_count, 3),
+            "graph_coefficients_m": (self.frame_count, self.graph_rank, 3),
+            "graph_field_m": (self.frame_count, self.node_count, 3),
+            "per_view_rms_before_m": (self.view_count,),
+            "per_view_rms_after_m": (self.view_count,),
+        }
+        for name, shape in array_shapes.items():
+            values = np.asarray(getattr(self, name), dtype=float)
+            if values.shape != shape or not np.all(np.isfinite(values)):
+                raise ValueError(f"{name} must be finite with shape {shape}")
+            object.__setattr__(self, name, readonly_array(values, dtype=float))
+
+        counts = np.asarray(self.valid_observation_counts)
+        if counts.shape != (self.view_count,) or counts.dtype.kind not in "iu":
+            raise ValueError("valid_observation_counts must be an integer per view")
+        if np.any(counts < 1):
+            raise ValueError("every view must contribute at least one observation")
+        object.__setattr__(
+            self,
+            "valid_observation_counts",
+            readonly_integer_array(counts, name="valid_observation_counts"),
+        )
+
+        payload = self.as_dict(include_artifact_id=False)
+        encoded = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        object.__setattr__(self, "artifact_id", hashlib.sha256(encoded).hexdigest())
+
+    def as_dict(self, *, include_artifact_id: bool = True) -> dict[str, object]:
+        """Return a finite JSON summary without residual-array materialization."""
+
+        result: dict[str, object] = {
+            "schema": "causal4d.per_view_residual_localization",
+            "schema_version": PER_VIEW_RESIDUAL_LOCALIZATION_SCHEMA_VERSION,
+            "evidence_artifact_id": self.evidence_artifact_id,
+            "causal_prefix_frame_stop": self.causal_prefix_frame_stop,
+            "reference_view_index": self.reference_view_index,
+            "dimensions": {
+                "view_count": self.view_count,
+                "frame_count": self.frame_count,
+                "node_count": self.node_count,
+                "graph_rank": self.graph_rank,
+            },
+            "input_sha256": {
+                "observed_points": self.observed_points_sha256,
+                "predicted_points": self.predicted_points_sha256,
+                "validity_mask": self.validity_mask_sha256,
+                "confidence": self.confidence_sha256,
+                "graph_basis": self.graph_basis_sha256,
+            },
+            "output_sha256": {
+                "view_bias": array_sha256(self.view_bias_m),
+                "shared_frame_offset": array_sha256(self.shared_frame_offset_m),
+                "graph_coefficients": array_sha256(self.graph_coefficients_m),
+                "graph_field": array_sha256(self.graph_field_m),
+            },
+            "fit": {
+                "total_weighted_sse_m2": self.total_weighted_sse_m2,
+                "full_weighted_sse_m2": self.full_weighted_sse_m2,
+                "frame_only_weighted_sse_m2": self.frame_only_weighted_sse_m2,
+                "no_view_weighted_sse_m2": self.no_view_weighted_sse_m2,
+                "no_frame_weighted_sse_m2": self.no_frame_weighted_sse_m2,
+                "no_graph_weighted_sse_m2": self.no_graph_weighted_sse_m2,
+                "full_explained_fraction": self.full_explained_fraction,
+                "view_unique_fraction": self.view_unique_fraction,
+                "frame_unique_fraction": self.frame_unique_fraction,
+                "graph_unique_fraction": self.graph_unique_fraction,
+                "dominant_source": self.dominant_source,
+            },
+            "per_view": {
+                "valid_observation_counts": self.valid_observation_counts.tolist(),
+                "rms_before_m": self.per_view_rms_before_m.tolist(),
+                "rms_after_m": self.per_view_rms_after_m.tolist(),
+                "bias_norm_m": np.linalg.norm(self.view_bias_m, axis=1).tolist(),
+            },
+            "regularization": {
+                "view_ridge": self.view_ridge,
+                "frame_ridge": self.frame_ridge,
+                "graph_ridge": self.graph_ridge,
+                "maximum_design_bytes": self.maximum_design_bytes,
+            },
+            "target_outcomes_used": False,
+            "physical_evidence_increment": 0,
+            "claim_boundary": (
+                "Prefix-only diagnostic decomposition; not a physical discrepancy "
+                "claim, estimator update, calibration result, or acquisition count."
+            ),
+        }
+        if include_artifact_id:
+            result["artifact_id"] = self.artifact_id
+        return result
+
+
+def localize_per_view_residuals(
+    observed_points_m: np.ndarray,
+    predicted_points_m: np.ndarray,
+    validity_mask: np.ndarray,
+    *,
+    evidence_artifact_id: str,
+    confidence: np.ndarray | None = None,
+    graph_basis: np.ndarray | None = None,
+    causal_prefix_frame_stop: int | None = None,
+    view_ridge: float = 1e-8,
+    frame_ridge: float = 1e-8,
+    graph_ridge: float = 1e-6,
+    minimum_explained_fraction: float = 0.05,
+    dominance_margin: float = 0.02,
+    maximum_design_bytes: int = 512 * 1024**2,
+) -> PerViewResidualLocalizationResult:
+    """Separate relative view, shared-frame, and graph-coherent prefix residuals."""
+
+    observed = np.asarray(observed_points_m, dtype=float)
+    predicted = np.asarray(predicted_points_m, dtype=float)
+    validity = np.asarray(validity_mask)
+    if observed.ndim != 4 or observed.shape[-1] != 3:
+        raise ValueError("observed_points_m must have shape (view, frame, node, 3)")
+    view_count, available_frames, node_count, _ = observed.shape
+    if predicted.shape != (available_frames, node_count, 3) or not np.all(
+        np.isfinite(predicted)
+    ):
+        raise ValueError(
+            "predicted_points_m must be finite with shape (frame, node, 3)"
+        )
+    if validity.dtype.kind != "b" or validity.shape != observed.shape[:-1]:
+        raise ValueError("validity_mask must be boolean with shape (view, frame, node)")
+    if view_count < 2 or node_count < 1:
+        raise ValueError("residual localization requires two views and one node")
+    if causal_prefix_frame_stop is None:
+        frame_count = available_frames
+    elif (
+        type(causal_prefix_frame_stop) is not int
+        or not 1 <= causal_prefix_frame_stop <= available_frames
+    ):
+        raise ValueError(
+            "causal_prefix_frame_stop must select a nonempty available prefix"
+        )
+    else:
+        frame_count = causal_prefix_frame_stop
+    if type(maximum_design_bytes) is not int or maximum_design_bytes < 1:
+        raise ValueError("maximum_design_bytes must be a positive integer")
+
+    used_observed = observed[:, :frame_count]
+    used_predicted = predicted[:frame_count]
+    used_validity = validity[:, :frame_count]
+    if confidence is None:
+        used_confidence = np.ones(used_validity.shape, dtype=float)
+    else:
+        confidence_values = np.asarray(confidence, dtype=float)
+        if confidence_values.shape != observed.shape[:-1]:
+            raise ValueError("confidence must have shape (view, frame, node)")
+        used_confidence = confidence_values[:, :frame_count]
+        if (
+            not np.all(np.isfinite(used_confidence))
+            or np.any(used_confidence < 0.0)
+            or np.any(used_confidence > 1.0)
+        ):
+            raise ValueError("confidence must contain finite probabilities")
+
+    weights_full = used_confidence * used_validity
+    positive = weights_full > 0.0
+    if np.any(~np.isfinite(used_observed[positive])):
+        raise ValueError("valid observed points must be finite")
+    view_support = np.sum(weights_full, axis=(1, 2))
+    frame_support = np.sum(weights_full, axis=(0, 2))
+    if np.any(view_support <= 0.0):
+        raise ValueError("every view must contribute positive weighted support")
+    if np.any(frame_support <= 0.0):
+        raise ValueError("every prefix frame must contribute positive weighted support")
+    reference_view = int(np.argmax(view_support))
+
+    basis = _graph_basis(graph_basis, node_count=node_count)
+    graph_rank = basis.shape[1]
+    view_indices, frame_indices, node_indices = np.nonzero(positive)
+    weights = weights_full[view_indices, frame_indices, node_indices]
+    observations = (
+        used_observed[view_indices, frame_indices, node_indices]
+        - used_predicted[frame_indices, node_indices]
+    )
+    observation_count = len(weights)
+
+    view_count_parameters = view_count - 1
+    frame_start = view_count_parameters
+    graph_start = frame_start + frame_count
+    parameter_count = graph_start + frame_count * graph_rank
+    itemsize = np.dtype(float).itemsize
+    estimated_bytes = itemsize * (
+        observation_count * (parameter_count + 10) + parameter_count * parameter_count
+    )
+    if estimated_bytes > maximum_design_bytes:
+        raise MemoryError(
+            "per-view residual design exceeds maximum_design_bytes before allocation"
+        )
+
+    design = np.zeros((observation_count, parameter_count), dtype=float)
+    view_columns: dict[int, int] = {}
+    for view in range(view_count):
+        if view != reference_view:
+            view_columns[view] = len(view_columns)
+    nonreference = view_indices != reference_view
+    if np.any(nonreference):
+        rows = np.flatnonzero(nonreference)
+        columns = np.asarray(
+            [view_columns[int(view)] for view in view_indices[nonreference]],
+            dtype=np.int64,
+        )
+        design[rows, columns] = 1.0
+    design[
+        np.arange(observation_count),
+        frame_start + frame_indices,
+    ] = 1.0
+    if graph_rank:
+        rows = np.arange(observation_count)[:, None]
+        columns = (
+            graph_start
+            + frame_indices[:, None] * graph_rank
+            + np.arange(graph_rank)[None, :]
+        )
+        design[rows, columns] = basis[node_indices]
+
+    ridge = np.empty(parameter_count, dtype=float)
+    ridge[:frame_start] = _finite_nonnegative(view_ridge, name="view_ridge")
+    ridge[frame_start:graph_start] = _finite_nonnegative(
+        frame_ridge,
+        name="frame_ridge",
+    )
+    ridge[graph_start:] = _finite_nonnegative(graph_ridge, name="graph_ridge")
+    minimum = _fraction(
+        minimum_explained_fraction,
+        name="minimum_explained_fraction",
+    )
+    margin = _fraction(dominance_margin, name="dominance_margin")
+
+    view_columns_array = np.arange(frame_start, dtype=np.int64)
+    frame_columns = np.arange(frame_start, graph_start, dtype=np.int64)
+    graph_columns = np.arange(graph_start, parameter_count, dtype=np.int64)
+    all_columns = np.arange(parameter_count, dtype=np.int64)
+    no_view = np.concatenate((frame_columns, graph_columns))
+    no_frame = np.concatenate((view_columns_array, graph_columns))
+    no_graph = np.concatenate((view_columns_array, frame_columns))
+
+    coefficients, prediction, full_sse = _fit(
+        design,
+        observations,
+        weights,
+        ridge,
+        all_columns,
+    )
+    _, _, frame_only_sse = _fit(
+        design,
+        observations,
+        weights,
+        ridge,
+        frame_columns,
+    )
+    _, _, no_view_sse = _fit(design, observations, weights, ridge, no_view)
+    _, _, no_frame_sse = _fit(design, observations, weights, ridge, no_frame)
+    _, _, no_graph_sse = _fit(design, observations, weights, ridge, no_graph)
+    total_sse = float(np.sum(weights[:, None] * np.square(observations)))
+    full_explained = _explained(total_sse - full_sse, total_sse)
+    unique = {
+        "view_specific": _explained(no_view_sse - full_sse, total_sse),
+        "shared_frame": _explained(no_frame_sse - full_sse, total_sse),
+        "object_coherent": _explained(no_graph_sse - full_sse, total_sse),
+    }
+    ordered = sorted(unique.items(), key=lambda item: item[1], reverse=True)
+    if full_explained < minimum or ordered[0][1] < minimum:
+        dominant: DominantResidualSource = "unresolved"
+    elif ordered[0][1] - ordered[1][1] <= margin:
+        dominant = "mixed"
+    else:
+        dominant = cast(DominantResidualSource, ordered[0][0])
+
+    view_bias = np.zeros((view_count, 3), dtype=float)
+    for view, column in view_columns.items():
+        view_bias[view] = coefficients[column]
+    shared_frame = coefficients[frame_start:graph_start]
+    if graph_rank:
+        graph_coefficients = coefficients[graph_start:].reshape(
+            frame_count,
+            graph_rank,
+            3,
+        )
+        graph_field = np.einsum("nr,trc->tnc", basis, graph_coefficients)
+    else:
+        graph_coefficients = np.empty((frame_count, 0, 3), dtype=float)
+        graph_field = np.zeros((frame_count, node_count, 3), dtype=float)
+
+    residual_after = observations - prediction
+    rms_before = np.empty(view_count, dtype=float)
+    rms_after = np.empty(view_count, dtype=float)
+    valid_counts = np.bincount(view_indices, minlength=view_count)
+    for view in range(view_count):
+        selected = view_indices == view
+        denominator = 3.0 * float(np.sum(weights[selected]))
+        rms_before[view] = np.sqrt(
+            np.sum(weights[selected, None] * np.square(observations[selected]))
+            / denominator
+        )
+        rms_after[view] = np.sqrt(
+            np.sum(weights[selected, None] * np.square(residual_after[selected]))
+            / denominator
+        )
+
+    return PerViewResidualLocalizationResult(
+        evidence_artifact_id=evidence_artifact_id,
+        causal_prefix_frame_stop=frame_count,
+        reference_view_index=reference_view,
+        view_count=view_count,
+        frame_count=frame_count,
+        node_count=node_count,
+        graph_rank=graph_rank,
+        observed_points_sha256=array_sha256(used_observed),
+        predicted_points_sha256=array_sha256(used_predicted),
+        validity_mask_sha256=array_sha256(used_validity),
+        confidence_sha256=array_sha256(used_confidence),
+        graph_basis_sha256=None if not graph_rank else array_sha256(basis),
+        view_ridge=float(view_ridge),
+        frame_ridge=float(frame_ridge),
+        graph_ridge=float(graph_ridge),
+        maximum_design_bytes=maximum_design_bytes,
+        view_bias_m=view_bias,
+        shared_frame_offset_m=shared_frame,
+        graph_coefficients_m=graph_coefficients,
+        graph_field_m=graph_field,
+        per_view_rms_before_m=rms_before,
+        per_view_rms_after_m=rms_after,
+        valid_observation_counts=valid_counts,
+        total_weighted_sse_m2=total_sse,
+        full_weighted_sse_m2=full_sse,
+        frame_only_weighted_sse_m2=frame_only_sse,
+        no_view_weighted_sse_m2=no_view_sse,
+        no_frame_weighted_sse_m2=no_frame_sse,
+        no_graph_weighted_sse_m2=no_graph_sse,
+        full_explained_fraction=full_explained,
+        view_unique_fraction=unique["view_specific"],
+        frame_unique_fraction=unique["shared_frame"],
+        graph_unique_fraction=unique["object_coherent"],
+        dominant_source=dominant,
+    )
+
+
+__all__ = [
+    "DominantResidualSource",
+    "PER_VIEW_RESIDUAL_LOCALIZATION_SCHEMA_VERSION",
+    "PerViewResidualLocalizationResult",
+    "localize_per_view_residuals",
+]

--- a/src/causal4d/prob4d_prepared_observation.py
+++ b/src/causal4d/prob4d_prepared_observation.py
@@ -1,0 +1,170 @@
+"""Prepared, reusable full-joint inference for validated Prob4D evidence."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from causal4d.joint_observation import LinearJointObservationEvidence
+from causal4d.prepared_joint_observation import (
+    PreparedJointGaussianLikelihoodDiagnostics,
+    PreparedJointObservation,
+    posterior_weights_from_prepared_joint_observation,
+    prepare_joint_observation,
+    prepared_joint_component_log_likelihoods,
+)
+from causal4d.prob4d_joint_observation import (
+    Prob4DJointObservationDiagnostics,
+    Prob4DReliabilityPolicy,
+    joint_observation_from_prob4d,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedProb4DJointObservation:
+    """One validated Prob4D artifact with a reusable exact inference plan."""
+
+    evidence: LinearJointObservationEvidence
+    adapter_diagnostics: Prob4DJointObservationDiagnostics
+    prepared: PreparedJointObservation
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.evidence, LinearJointObservationEvidence):
+            raise TypeError("evidence must be LinearJointObservationEvidence")
+        if not isinstance(self.adapter_diagnostics, Prob4DJointObservationDiagnostics):
+            raise TypeError(
+                "adapter_diagnostics must be Prob4DJointObservationDiagnostics"
+            )
+        if not isinstance(self.prepared, PreparedJointObservation):
+            raise TypeError("prepared must be PreparedJointObservation")
+        if self.prepared.evidence.artifact_id != self.evidence.artifact_id:
+            raise ValueError(
+                "prepared inference plan must bind the same Prob4D evidence artifact"
+            )
+        if (
+            self.adapter_diagnostics.observation_count
+            != self.evidence.observation_count
+        ):
+            raise ValueError(
+                "Prob4D adapter diagnostics and prepared evidence dimensions differ"
+            )
+
+    @property
+    def artifact_id(self) -> str:
+        """Return the content identity of the consumed Prob4D evidence."""
+
+        return self.evidence.artifact_id
+
+    def log_likelihoods(
+        self,
+        predicted_components_m: np.ndarray,
+        *,
+        prefix_frame_count: int,
+        component_independent_variance_m2: np.ndarray | None = None,
+        component_joint_covariance_m2: np.ndarray | None = None,
+        component_joint_covariance_factor_m: np.ndarray | None = None,
+        component_chunk_size: int | None = None,
+        maximum_working_bytes: int = 256 * 1024**2,
+    ) -> tuple[np.ndarray, PreparedJointGaussianLikelihoodDiagnostics]:
+        """Score finite rollout support with the cached Prob4D plan."""
+
+        return prepared_joint_component_log_likelihoods(
+            predicted_components_m,
+            self.prepared,
+            prefix_frame_count=prefix_frame_count,
+            component_independent_variance_m2=component_independent_variance_m2,
+            component_joint_covariance_m2=component_joint_covariance_m2,
+            component_joint_covariance_factor_m=component_joint_covariance_factor_m,
+            component_chunk_size=component_chunk_size,
+            maximum_working_bytes=maximum_working_bytes,
+        )
+
+    def posterior_weights(
+        self,
+        prior_weights: np.ndarray,
+        predicted_components_m: np.ndarray,
+        *,
+        prefix_frame_count: int,
+        component_independent_variance_m2: np.ndarray | None = None,
+        component_joint_covariance_m2: np.ndarray | None = None,
+        component_joint_covariance_factor_m: np.ndarray | None = None,
+        component_chunk_size: int | None = None,
+        maximum_working_bytes: int = 256 * 1024**2,
+    ) -> tuple[np.ndarray, PreparedJointGaussianLikelihoodDiagnostics]:
+        """Update finite support while preserving exact zero prior mass."""
+
+        return posterior_weights_from_prepared_joint_observation(
+            prior_weights,
+            predicted_components_m,
+            self.prepared,
+            prefix_frame_count=prefix_frame_count,
+            component_independent_variance_m2=component_independent_variance_m2,
+            component_joint_covariance_m2=component_joint_covariance_m2,
+            component_joint_covariance_factor_m=component_joint_covariance_factor_m,
+            component_chunk_size=component_chunk_size,
+            maximum_working_bytes=maximum_working_bytes,
+        )
+
+
+def _descriptor_with_source_identity(
+    descriptor: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Resolve producer identity from the portable descriptor metadata.
+
+    Historical adapter fixtures place ``source_revision`` and
+    ``source_artifact_sha256`` at the top level, whereas portable strict Prob4D
+    artifacts bind the same fields in ``metadata``. Accept both representations,
+    reject disagreement, and pass one canonical mapping to the existing adapter.
+    """
+
+    normalized = dict(descriptor)
+    metadata = descriptor.get("metadata")
+    if metadata is None:
+        return normalized
+    if not isinstance(metadata, Mapping):
+        return normalized
+
+    for name in ("source_revision", "source_artifact_sha256"):
+        direct = descriptor.get(name)
+        nested = metadata.get(name)
+        if direct is not None and nested is not None and direct != nested:
+            raise ValueError(f"Prob4D {name} differs between descriptor and metadata")
+        if direct is None and nested is not None:
+            normalized[name] = nested
+    return normalized
+
+
+def prepare_prob4d_joint_observation(
+    descriptor: Mapping[str, Any],
+    arrays: Mapping[str, np.ndarray],
+    *,
+    rollout_frame_ids: Sequence[int],
+    entity_to_node: Mapping[int, int],
+    reliability_policy: Prob4DReliabilityPolicy = "require_neutral",
+    evidence_id: str | None = None,
+) -> PreparedProb4DJointObservation:
+    """Validate, adapt, and compile one Prob4D observation exactly once."""
+
+    normalized_descriptor = _descriptor_with_source_identity(descriptor)
+    evidence, diagnostics = joint_observation_from_prob4d(
+        normalized_descriptor,
+        arrays,
+        rollout_frame_ids=rollout_frame_ids,
+        entity_to_node=entity_to_node,
+        reliability_policy=reliability_policy,
+        evidence_id=evidence_id,
+    )
+    return PreparedProb4DJointObservation(
+        evidence=evidence,
+        adapter_diagnostics=diagnostics,
+        prepared=prepare_joint_observation(evidence),
+    )
+
+
+__all__ = [
+    "PreparedProb4DJointObservation",
+    "prepare_prob4d_joint_observation",
+]

--- a/tests/test_per_view_residual_localization.py
+++ b/tests/test_per_view_residual_localization.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from causal4d.per_view_residual_localization import (
+    localize_per_view_residuals,
+)
+
+
+def _basis(node_count: int, rank: int, *, seed: int = 7) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    values = rng.normal(size=(node_count, rank))
+    values -= np.mean(values, axis=0, keepdims=True)
+    values /= np.sqrt(np.mean(np.square(values), axis=0, keepdims=True))
+    return values
+
+
+def test_per_view_localization_recovers_view_frame_and_graph_terms() -> None:
+    rng = np.random.default_rng(11)
+    view_count, frame_count, node_count, rank = 3, 5, 9, 2
+    predicted = rng.normal(scale=0.01, size=(frame_count, node_count, 3))
+    basis = _basis(node_count, rank)
+    view_bias = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.02, -0.01, 0.005],
+            [-0.015, 0.004, 0.01],
+        ]
+    )
+    frame_offset = rng.normal(scale=0.003, size=(frame_count, 3))
+    graph_coefficients = rng.normal(
+        scale=0.002,
+        size=(frame_count, rank, 3),
+    )
+    graph_field = np.einsum("nr,trc->tnc", basis, graph_coefficients)
+    observed = (
+        predicted[None]
+        + view_bias[:, None, None]
+        + frame_offset[None, :, None]
+        + graph_field[None]
+    )
+    validity = np.ones((view_count, frame_count, node_count), dtype=bool)
+
+    result = localize_per_view_residuals(
+        observed,
+        predicted,
+        validity,
+        evidence_artifact_id="a" * 64,
+        graph_basis=basis,
+        view_ridge=0.0,
+        frame_ridge=0.0,
+        graph_ridge=0.0,
+        minimum_explained_fraction=0.01,
+        dominance_margin=0.001,
+    )
+
+    np.testing.assert_allclose(result.view_bias_m, view_bias, atol=1e-12)
+    np.testing.assert_allclose(
+        result.shared_frame_offset_m,
+        frame_offset,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(result.graph_field_m, graph_field, atol=1e-12)
+    assert result.full_explained_fraction == pytest.approx(1.0)
+    assert result.full_weighted_sse_m2 < 1e-24
+    assert result.reference_view_index == 0
+    assert result.as_dict()["target_outcomes_used"] is False
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("view", "view_specific"),
+        ("frame", "shared_frame"),
+        ("graph", "object_coherent"),
+    ],
+)
+def test_per_view_localization_identifies_pure_residual_families(
+    source: str,
+    expected: str,
+) -> None:
+    view_count, frame_count, node_count = 3, 4, 12
+    predicted = np.zeros((frame_count, node_count, 3))
+    observed = np.zeros((view_count, frame_count, node_count, 3))
+    basis = _basis(node_count, 1)
+    if source == "view":
+        observed[1, ..., 0] = 0.03
+        observed[2, ..., 1] = -0.02
+    elif source == "frame":
+        observed[:, :, :, 0] = np.linspace(0.0, 0.03, frame_count)[None, :, None]
+    else:
+        coefficients = np.linspace(-0.01, 0.02, frame_count)
+        observed[..., 2] = coefficients[None, :, None] * basis[None, None, :, 0]
+    validity = np.ones((view_count, frame_count, node_count), dtype=bool)
+
+    result = localize_per_view_residuals(
+        observed,
+        predicted,
+        validity,
+        evidence_artifact_id="b" * 64,
+        graph_basis=basis,
+        view_ridge=0.0,
+        frame_ridge=0.0,
+        graph_ridge=0.0,
+        minimum_explained_fraction=0.01,
+        dominance_margin=0.01,
+    )
+
+    assert result.dominant_source == expected
+    assert result.full_explained_fraction > 0.999999
+
+
+def test_per_view_localization_uses_only_the_declared_prefix() -> None:
+    view_count, frame_count, node_count = 2, 6, 5
+    predicted = np.zeros((frame_count, node_count, 3))
+    observed = np.zeros((view_count, frame_count, node_count, 3))
+    observed[1, :3, :, 0] = 0.01
+    observed[1, 3:, :, 0] = 10.0
+    validity = np.ones((view_count, frame_count, node_count), dtype=bool)
+
+    prefix = localize_per_view_residuals(
+        observed,
+        predicted,
+        validity,
+        evidence_artifact_id="c" * 64,
+        causal_prefix_frame_stop=3,
+        view_ridge=0.0,
+        frame_ridge=0.0,
+    )
+    sliced = localize_per_view_residuals(
+        observed[:, :3],
+        predicted[:3],
+        validity[:, :3],
+        evidence_artifact_id="c" * 64,
+        view_ridge=0.0,
+        frame_ridge=0.0,
+    )
+
+    assert prefix.artifact_id == sliced.artifact_id
+    np.testing.assert_allclose(prefix.view_bias_m, sliced.view_bias_m)
+    assert prefix.view_bias_m[1, 0] == pytest.approx(0.01)
+
+
+def test_per_view_localization_respects_preallocation_guard() -> None:
+    observed = np.zeros((3, 4, 20, 3))
+    predicted = np.zeros((4, 20, 3))
+    validity = np.ones((3, 4, 20), dtype=bool)
+
+    with pytest.raises(MemoryError, match="maximum_design_bytes"):
+        localize_per_view_residuals(
+            observed,
+            predicted,
+            validity,
+            evidence_artifact_id="d" * 64,
+            graph_basis=_basis(20, 3),
+            maximum_design_bytes=128,
+        )
+
+
+def test_per_view_localization_result_arrays_are_irreversibly_read_only() -> None:
+    observed = np.zeros((2, 2, 3, 3))
+    observed[1, ..., 0] = 0.01
+    predicted = np.zeros((2, 3, 3))
+    validity = np.ones((2, 2, 3), dtype=bool)
+
+    result = localize_per_view_residuals(
+        observed,
+        predicted,
+        validity,
+        evidence_artifact_id="e" * 64,
+    )
+
+    with pytest.raises(ValueError):
+        result.view_bias_m.setflags(write=True)
+    with pytest.raises(ValueError):
+        result.valid_observation_counts.setflags(write=True)

--- a/tests/test_prob4d_prepared_observation.py
+++ b/tests/test_prob4d_prepared_observation.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from causal4d.joint_observation import joint_component_log_likelihoods
+from causal4d.prob4d_prepared_observation import (
+    prepare_prob4d_joint_observation,
+)
+
+
+def _descriptor() -> dict[str, object]:
+    return {
+        "case_id": "case-prepared",
+        "source_revision": "a" * 40,
+        "source_artifact_sha256": "b" * 64,
+    }
+
+
+def _arrays() -> dict[str, np.ndarray]:
+    return {
+        "mean_xyz_m": np.array(
+            [
+                [0.1, 0.2, 0.3],
+                [-0.1, 0.0, 0.4],
+            ]
+        ),
+        "local_covariance_m2": np.array(
+            [
+                np.eye(3) * 0.04,
+                np.array(
+                    [
+                        [0.09, 0.01, 0.0],
+                        [0.01, 0.07, 0.005],
+                        [0.0, 0.005, 0.08],
+                    ]
+                ),
+            ]
+        ),
+        "low_rank_factor_m": np.array(
+            [
+                [[0.02], [0.01], [0.0]],
+                [[-0.01], [0.015], [0.005]],
+            ]
+        ),
+        "frame_ids": np.array([10, 11], dtype=np.int64),
+        "entity_ids": np.array([7, 8], dtype=np.int64),
+        "factor_group_ids": np.zeros(2, dtype=np.int64),
+        "association_probability": np.ones(2),
+        "prior_reliability": np.ones(2),
+        "group_prior_nominal_probability": np.ones(2),
+        "group_composite_weight": np.ones(2),
+    }
+
+
+def _components() -> np.ndarray:
+    components = np.zeros((4, 3, 2, 3))
+    components[0, 1, 1] = [0.12, 0.18, 0.31]
+    components[0, 2, 0] = [-0.12, 0.01, 0.38]
+    components[1, 1, 1] = [0.4, -0.2, 0.1]
+    components[1, 2, 0] = [0.0, 0.2, 0.7]
+    components[2, 1, 1] = [0.1, 0.2, 0.3]
+    components[2, 2, 0] = [-0.1, 0.0, 0.4]
+    components[3, 1, 1] = [0.08, 0.23, 0.29]
+    components[3, 2, 0] = [-0.08, -0.02, 0.43]
+    return components
+
+
+@pytest.fixture
+def prepared(monkeypatch):
+    monkeypatch.setattr(
+        "causal4d.prob4d_joint_observation.validate_prob4d_causal_observation_metadata",
+        lambda descriptor, arrays: {"validated": True},
+    )
+    return prepare_prob4d_joint_observation(
+        _descriptor(),
+        _arrays(),
+        rollout_frame_ids=(9, 10, 11),
+        entity_to_node={7: 1, 8: 0},
+    )
+
+
+def test_prepared_prob4d_scores_match_legacy_and_reuse_solver(
+    prepared,
+    monkeypatch,
+) -> None:
+    components = _components()
+    expected, _ = joint_component_log_likelihoods(
+        components,
+        prepared.evidence,
+        prefix_frame_count=3,
+    )
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("prepared Prob4D base was factorized again")
+
+    monkeypatch.setattr(np.linalg, "cholesky", forbidden)
+    first, first_diagnostics = prepared.log_likelihoods(
+        components,
+        prefix_frame_count=3,
+        component_chunk_size=2,
+    )
+    second, second_diagnostics = prepared.log_likelihoods(
+        components,
+        prefix_frame_count=3,
+        component_chunk_size=1,
+    )
+
+    np.testing.assert_allclose(first, expected, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(second, expected, rtol=1e-12, atol=1e-12)
+    assert first_diagnostics.base_factorization_reused is True
+    assert second_diagnostics.base_factorization_reused is True
+    assert prepared.adapter_diagnostics.factor_rank == 1
+    assert prepared.artifact_id == prepared.evidence.artifact_id
+
+
+def test_prepared_prob4d_posterior_preserves_zero_support(prepared) -> None:
+    posterior, diagnostics = prepared.posterior_weights(
+        np.array([0.5, 0.0, 0.5, 0.0]),
+        _components(),
+        prefix_frame_count=3,
+        component_chunk_size=2,
+    )
+
+    assert posterior[1] == 0.0
+    assert posterior[3] == 0.0
+    assert np.isclose(np.sum(posterior), 1.0)
+    assert diagnostics.base_factorization_reused is True
+
+
+def test_prepared_prob4d_accepts_portable_metadata_source_identity(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "causal4d.prob4d_joint_observation.validate_prob4d_causal_observation_metadata",
+        lambda descriptor, arrays: {"validated": True},
+    )
+    descriptor = {
+        "case_id": "case-prepared",
+        "metadata": {
+            "source_revision": "a" * 40,
+            "source_artifact_sha256": "b" * 64,
+        },
+    }
+
+    result = prepare_prob4d_joint_observation(
+        descriptor,
+        _arrays(),
+        rollout_frame_ids=(9, 10, 11),
+        entity_to_node={7: 1, 8: 0},
+    )
+
+    assert result.evidence.metadata["source_revision"] == "a" * 40
+    assert result.evidence.metadata["source_artifact_sha256"] == "b" * 64
+
+
+def test_prepared_prob4d_rejects_conflicting_source_identity(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "causal4d.prob4d_joint_observation.validate_prob4d_causal_observation_metadata",
+        lambda descriptor, arrays: {"validated": True},
+    )
+    descriptor = _descriptor()
+    descriptor["metadata"] = {
+        "source_revision": "c" * 40,
+        "source_artifact_sha256": "b" * 64,
+    }
+
+    with pytest.raises(ValueError, match="source_revision differs"):
+        prepare_prob4d_joint_observation(
+            descriptor,
+            _arrays(),
+            rollout_frame_ids=(9, 10, 11),
+            entity_to_node={7: 1, 8: 0},
+        )
+
+
+def test_prepared_prob4d_rejects_a_mismatched_plan(
+    prepared,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "causal4d.prob4d_joint_observation.validate_prob4d_causal_observation_metadata",
+        lambda descriptor, arrays: {"validated": True},
+    )
+    other = prepare_prob4d_joint_observation(
+        _descriptor(),
+        _arrays(),
+        rollout_frame_ids=(9, 10, 11),
+        entity_to_node={7: 1, 8: 0},
+        evidence_id="other-prob4d-evidence",
+    )
+
+    with pytest.raises(ValueError, match="same Prob4D evidence artifact"):
+        replace(prepared, prepared=other.prepared)


### PR DESCRIPTION
## Summary

Add the next executable layer on top of the merged prepared joint-observation, strict tree-block provider, BayesianPhysTwin handoff, and post-freeze calibration diagnostics.

- validate and prepare one Prob4D full-joint observation artifact once, then reuse its compiled sparse rollout operator and exact structured Gaussian solver across repeated finite-support updates;
- preserve the existing Prob4D adapter, covariance semantics, reliability policy, provenance, component covariance support, and exact zero prior support;
- add a content-addressed prefix-only residual decomposition into relative view effects, shared frame/gauge translation, and centered graph-coherent object fields;
- report nested-ablation explained fractions, conservative source labels, immutable fitted arrays, per-view RMS reduction, and an explicit memory guard;
- add focused parity, solver-reuse, source-identity, causal-prefix, classification, immutability, and memory tests;
- extend the reviewed-main-only workstation2 workflow to execute the new modules together with graph-mode discrepancy and finite-support SBC diagnostics; and
- add one integrated synthetic benchmark over the strict Prob4D fixture, 4-view/4,096-node residual localization, and 5,000-trial exact-model SBC.

## Relationship to existing work

The strict tree-block posterior-query provider and BayesianPhysTwin handoff are already on `main`. This PR does not duplicate or weaken them. The prepared Prob4D path is for repeated rollout likelihood evaluation against one validated full-joint observation artifact; the tree-block handoff remains the strict posterior/query-covariance route with evidence-ownership enforcement.

PR #281 has also landed. Its simulation-based calibration and conservative mode-wise discrepancy diagnostics are executed by the extended self-hosted workflow, but this PR does not change their statistical definitions.

## Self-hosted boundary

Pull-request source is never allocated to workstation2. After hosted CI and merge, the existing exact-maintainer issue trigger checks out only the reviewed `main` event SHA, verifies exact HEAD and a clean tree, builds and installs the exact wheel, runs the focused tests and benchmarks, and retains the evidence artifact. The self-hosted job has read-only repository permission and no GitHub secret.

## Physical acquisition boundary

The current workstation2 readiness inspection concluded `runner_not_provisioned_with_registered_roots`: the registered frozen checkout and dataset mount are absent. This PR does not bypass that gate, command a robot, open device nodes, read target outcomes, or increment physical evidence. The registered 36-execution campaign remains blocked until the declared roots and separately reviewed local driver/operator interlock are provisioned.

## Scientific boundary

All new execution is synthetic and prefix-only. `target_outcomes_used=false` and `physical_evidence_increment=0`. No frozen estimator, registered protocol, target identity, covariance-calibration claim, acquisition readiness decision, or paper result is changed.