### PR TITLE
Add one-command external forecast–physics bridge workflow

### DIFF
--- a/docs/external_bridge_workflow.md
+++ b/docs/external_bridge_workflow.md
@@ -1,0 +1,180 @@
+# External forecast–physics bridge workflow
+
+This workflow is the collaborator-facing path for combining a sparse learned
+future such as MolmoMotion with a finite bank of complete physical rollouts.
+The motion model and simulator remain in their existing environments. Causal4D
+consumes only non-pickled NumPy artifacts and never requires simulator gradients.
+
+Run the complete command family through one module:
+
+```bash
+python -m causal4d.cli.external_bridge_workflow --help
+```
+
+## Three inputs
+
+### 1. Sparse future forecast
+
+Use the existing external-forecast contract:
+
+```bash
+python -m causal4d.cli.external_bridge_workflow import-forecast \
+  producer_forecast.npz \
+  external_forecast_manifest.json \
+  canonical_forecast.npz
+```
+
+The forecast contains persistent material/node IDs, metric anchors, explicit
+future times, one or more caption/sample trajectories, and validity masks.
+
+### 2. Complete physical candidates
+
+Export the external simulator support as:
+
+```python
+np.savez_compressed(
+    "producer_rollouts.npz",
+    node_ids=node_ids,                         # [N]
+    trajectories_world_m=trajectories_world_m, # [R,T,N,3]
+    rollout_weights=rollout_weights,           # [R]
+    frame_times_s=frame_times_s,                # [T], includes t0
+    rollout_ids=rollout_ids,                    # [R], optional
+    parameter_values=parameter_values,          # [R,D], optional
+)
+```
+
+Then import it:
+
+```bash
+python -m causal4d.cli.external_bridge_workflow import-rollouts \
+  producer_rollouts.npz \
+  external_rollout_manifest.json \
+  canonical_rollout_bank.npz
+```
+
+### 3. Optional evaluation reference
+
+For automatic ADE/FDE, coverage, constant-velocity, and component-oracle
+reporting, provide a closed NPZ:
+
+```python
+np.savez_compressed(
+    "reference.npz",
+    case_id=np.asarray("single_lift_cloth"),
+    node_ids=node_ids,                         # [N]
+    positions_world_m=positions_world_m,       # [T,N,3]
+    frame_times_s=frame_times_s,                # [T]
+    validity_mask=validity_mask,                # [T,N] or [T,N,3], optional
+)
+```
+
+Reference data are evaluation-only. They are not consumed as semantic evidence
+and are never used to alter the physical rollout support.
+
+## Audit material-point correspondence
+
+When the visual query does not already contain exact simulator node IDs, run a
+one-to-one geometric assignment:
+
+```bash
+python -m causal4d.cli.external_bridge_workflow map-nodes \
+  query_anchors.npz \
+  simulator_nodes.npz \
+  query_node_mapping.json \
+  --output-npz query_node_mapping.npz \
+  --output-svg query_node_mapping.svg \
+  --maximum-distance-m 0.005
+```
+
+Default keys are:
+
+```text
+query_anchors.npz:    anchor_positions_world_m
+simulator_nodes.npz:  node_positions_world_m, node_ids
+```
+
+Use key options when producer names differ. The command solves a global
+minimum-total-distance one-to-one assignment and returns exit status `3` when
+any assignment exceeds the frozen tolerance. The report explicitly states that
+geometric proximity is an audited convenience, not proof of material identity;
+folded or self-contacting cloth should use exact material labels whenever
+possible.
+
+## Preflight doctor
+
+Before any positive semantic weighting:
+
+```bash
+python -m causal4d.cli.external_bridge_workflow doctor \
+  canonical_forecast.npz \
+  canonical_rollout_bank.npz \
+  instruction \
+  bridge_doctor.json \
+  --strict-warnings
+```
+
+The doctor checks case identity, exact node membership, timeline overlap,
+interpolation, anchor mismatch, forecast-to-rollout motion scale, validity
+coverage, and byte-identical beta-zero fallback.
+
+## One-command beta sweep and report
+
+```bash
+python -m causal4d.cli.external_bridge_workflow run \
+  canonical_forecast.npz \
+  canonical_rollout_bank.npz \
+  instruction \
+  bridge_results \
+  --reference reference.npz \
+  --beta 0 --beta 1 --beta 3 --beta 6 --beta 12 \
+  --scale-m 0.05
+```
+
+The result directory contains:
+
+```text
+bridge_results/
+├── doctor.json
+├── summary.json
+├── summary.md
+├── metrics.csv
+├── weights.csv
+├── error_vs_horizon.csv
+├── error_vs_horizon.svg
+├── predictions.npz
+└── manifest.json
+```
+
+The manifest is written last and binds the exact hashes and sizes of every
+published companion artifact.
+
+Without a reference trajectory, the command still publishes the preflight,
+physical-versus-semantic weight shift, effective support size, KL divergence,
+posterior means, intervals, and exact beta-zero fallback. With a reference, it
+also reports:
+
+- zero-motion and, when two prefix frames are available, constant-velocity
+  baselines;
+- the external forecast itself;
+- physical-prior and semantic-reweighted ADE, FDE, coordinate RMSE, and
+  empirical coordinate coverage;
+- error versus horizon;
+- a component oracle labelled diagnostic-only; and
+- an `evaluation_only_best_beta` that is explicitly prohibited from serving as
+  deployment calibration.
+
+Use `--require-clean-doctor` to return exit status `3` after publishing the
+complete report when preflight warnings remain.
+
+## Trust and claim boundary
+
+The beta sweep is exploratory. Import compatibility, a clean doctor report, or
+an evaluation-only best beta does not establish semantic competence. Positive
+semantic trust must be selected on disjoint source executions and confirmed on
+an independent panel. If the trust gate rejects, beta must be zero and the
+physical weights remain byte-identical.
+
+Prob4D belongs on the observed prefix when multi-view, overlapping-window,
+gauge, or correlated reconstruction uncertainty is material. A predicted
+MolmoMotion future remains a separate task factor and must not be relabelled as
+an independent physical observation.

--- a/src/causal4d/_external_bridge_analysis.py
+++ b/src/causal4d/_external_bridge_analysis.py
@@ -1,0 +1,367 @@
+"""Finite-support analysis for external forecast/rollout bridges."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
+from causal4d._external_bridge_metrics import (
+    _constant_velocity_prediction,
+    _interpolate_reference,
+    _node_indices,
+    _trajectory_metrics,
+    _weight_diagnostics,
+    _weighted_quantile,
+    _weighted_query_mean,
+)
+from causal4d.external_bridge import (
+    _fractional_frame_indices,
+    _interpolate_components,
+    build_external_bridge_report,
+)
+from causal4d.external_forecast import ExternalForecastBundle
+from causal4d.external_reference import ExternalReferenceTrajectory
+from causal4d.external_rollout import ExternalRolloutBundle
+from causal4d.immutable_json import plain_json, validated_json_mapping
+from causal4d.rollout_bank import SparseTrajectoryEvidence
+
+EXTERNAL_BRIDGE_RUN_SCHEMA = "causal4d.external_forecast_rollout_run"
+EXTERNAL_BRIDGE_RUN_SCHEMA_VERSION = 1
+
+
+def _beta_values(values: Sequence[float]) -> tuple[float, ...]:
+    result = tuple(sorted(set(float(value) for value in values)))
+    if not result or result[0] != 0.0:
+        raise ValueError("beta values must be nonnegative and include zero")
+    if any(not np.isfinite(value) or value < 0.0 for value in result):
+        raise ValueError("beta values must be finite and nonnegative")
+    return result
+
+
+def analyze_external_bridge(
+    forecast: ExternalForecastBundle,
+    forecast_id: str,
+    rollouts: ExternalRolloutBundle,
+    *,
+    beta_values: Sequence[float] = (0.0, 1.0, 3.0, 6.0, 12.0),
+    scale_m: float = 0.05,
+    degrees_of_freedom: float = 3.0,
+    anchor_tolerance_m: float = 0.01,
+    motion_ratio_min: float = 0.10,
+    motion_ratio_max: float = 10.0,
+    reference: ExternalReferenceTrajectory | None = None,
+) -> tuple[Mapping[str, Any], dict[str, np.ndarray]]:
+    """Run a beta sweep while keeping semantic evidence outside physical state."""
+
+    betas = _beta_values(beta_values)
+    if not np.isfinite(scale_m) or scale_m <= 0.0:
+        raise ValueError("scale_m must be finite and positive")
+    if not np.isfinite(degrees_of_freedom) or degrees_of_freedom <= 0.0:
+        raise ValueError("degrees_of_freedom must be finite and positive")
+    doctor = build_external_bridge_report(
+        forecast,
+        forecast_id,
+        rollouts,
+        anchor_tolerance_m=anchor_tolerance_m,
+        motion_ratio_min=motion_ratio_min,
+        motion_ratio_max=motion_ratio_max,
+        scale_m=scale_m,
+        degrees_of_freedom=degrees_of_freedom,
+    )
+    forecast_index = forecast.forecast_index(forecast_id)
+    if forecast.future_times_s is None:
+        raise ValueError("bridge run requires explicit forecast future_times_s")
+    internal_nodes = _node_indices(
+        rollouts.node_ids,
+        forecast.node_indices,
+        name="rollout bank",
+    )
+    query_times = rollouts.anchor_time_s + forecast.future_times_s
+    query_frames = _fractional_frame_indices(rollouts.frame_times_s, query_times)
+    components = _interpolate_components(
+        rollouts.bank.trajectories.astype(np.float64),
+        query_frames,
+        internal_nodes,
+    )
+    target = forecast.future_positions_m[forecast_index]
+    forecast_valid = forecast.coordinate_validity[forecast_index]
+    prior = rollouts.bank.prior_joint_weights
+    evidence_base = dict(
+        positions_m=target,
+        node_indices=internal_nodes,
+        rollout_frame_indices=query_frames,
+        scale_m=float(scale_m),
+        degrees_of_freedom=float(degrees_of_freedom),
+        compare_displacements=True,
+        anchor_positions_m=forecast.anchor_positions_m,
+        anchor_rollout_frame=rollouts.anchor_frame_index,
+        valid=forecast_valid,
+        source=f"ExternalForecast:{forecast.artifact_id}:{forecast_id}",
+    )
+
+    weights_by_beta: list[np.ndarray] = []
+    means_by_beta: list[np.ndarray] = []
+    lower_by_beta: list[np.ndarray] = []
+    upper_by_beta: list[np.ndarray] = []
+    beta_entries: list[dict[str, Any]] = []
+    tail = 0.5 * (1.0 - rollouts.bank.confidence_level)
+    for beta in betas:
+        evidence = SparseTrajectoryEvidence(
+            **evidence_base,
+            likelihood_weight=beta,
+        )
+        posterior = rollouts.bank.update_from_sparse_evidence(evidence)
+        if beta == 0.0 and posterior.tobytes() != prior.tobytes():
+            raise RuntimeError("beta=0 did not preserve physical weights exactly")
+        mean = _weighted_query_mean(components, posterior)
+        lower = _weighted_quantile(components, posterior, tail)
+        upper = _weighted_quantile(components, posterior, 1.0 - tail)
+        weights_by_beta.append(posterior)
+        means_by_beta.append(mean)
+        lower_by_beta.append(lower)
+        upper_by_beta.append(upper)
+        beta_entries.append(
+            {
+                "beta": beta,
+                "weight_diagnostics": _weight_diagnostics(
+                    posterior, prior, rollouts.bank.hypothesis_ids
+                ),
+                "metrics": None,
+            }
+        )
+
+    method_predictions: list[
+        tuple[
+            str,
+            str,
+            float | None,
+            np.ndarray,
+            np.ndarray | None,
+            np.ndarray | None,
+        ]
+    ] = []
+    zero_prediction = np.broadcast_to(
+        forecast.anchor_positions_m[None], target.shape
+    ).copy()
+    method_predictions.append(
+        ("zero_motion", "baseline", None, zero_prediction, None, None)
+    )
+    method_predictions.append(
+        ("external_forecast", "forecast", None, target, None, None)
+    )
+    prior_mean = means_by_beta[betas.index(0.0)]
+    prior_lower = lower_by_beta[betas.index(0.0)]
+    prior_upper = upper_by_beta[betas.index(0.0)]
+    method_predictions.append(
+        ("physical_prior", "physical", 0.0, prior_mean, prior_lower, prior_upper)
+    )
+    for beta, mean, lower, upper in zip(
+        betas, means_by_beta, lower_by_beta, upper_by_beta, strict=True
+    ):
+        if beta == 0.0:
+            continue
+        method_predictions.append(
+            (f"semantic_beta_{beta:g}", "semantic", beta, mean, lower, upper)
+        )
+
+    truth_positions = None
+    truth_valid = None
+    reference_frames = None
+    metrics_rows: list[dict[str, Any]] = []
+    horizon_rows: list[dict[str, Any]] = []
+    oracle: dict[str, Any] | None = None
+    evaluation_best_beta: float | None = None
+    if reference is not None:
+        if reference.case_id != forecast.case_id:
+            raise ValueError("reference and forecast case IDs differ")
+        reference_nodes = _node_indices(
+            reference.node_ids,
+            forecast.node_indices,
+            name="reference trajectory",
+        )
+        truth_positions, truth_valid, reference_frames = _interpolate_reference(
+            reference,
+            query_times,
+            reference_nodes,
+        )
+        constant_velocity = _constant_velocity_prediction(
+            reference,
+            query_times,
+            reference_nodes,
+            rollouts.anchor_time_s,
+        )
+        if constant_velocity is not None:
+            method_predictions.insert(
+                1,
+                (
+                    "constant_velocity",
+                    "baseline",
+                    None,
+                    constant_velocity,
+                    None,
+                    None,
+                ),
+            )
+
+        for method, kind, beta, prediction, lower, upper in method_predictions:
+            metrics = _trajectory_metrics(
+                prediction,
+                truth_positions,
+                truth_valid,
+                lower=lower,
+                upper=upper,
+            )
+            row = {
+                "method": method,
+                "kind": kind,
+                "beta": beta,
+                **{
+                    key: value
+                    for key, value in metrics.items()
+                    if key != "frame_ade_m"
+                },
+            }
+            metrics_rows.append(row)
+            for frame, error in enumerate(metrics["frame_ade_m"]):
+                horizon_rows.append(
+                    {
+                        "method": method,
+                        "kind": kind,
+                        "beta": beta,
+                        "forecast_step": frame + 1,
+                        "future_time_s": float(forecast.future_times_s[frame]),
+                        "absolute_time_s": float(query_times[frame]),
+                        "ade_m": error,
+                    }
+                )
+            if kind == "semantic" and beta is not None:
+                beta_entries[betas.index(beta)]["metrics"] = {
+                    key: value for key, value in metrics.items() if key != "frame_ade_m"
+                }
+            if method == "physical_prior":
+                beta_entries[betas.index(0.0)]["metrics"] = {
+                    key: value for key, value in metrics.items() if key != "frame_ade_m"
+                }
+
+        component_metrics: list[tuple[float, int, int, dict[str, Any]]] = []
+        for hypothesis in range(components.shape[0]):
+            for particle in range(components.shape[1]):
+                metrics = _trajectory_metrics(
+                    components[hypothesis, particle],
+                    truth_positions,
+                    truth_valid,
+                )
+                component_metrics.append(
+                    (float(metrics["ade_m"]), hypothesis, particle, metrics)
+                )
+        _, hypothesis, particle, best_metrics = min(
+            component_metrics,
+            key=lambda row: row[0],
+        )
+        oracle = {
+            "diagnostic_only": True,
+            "hypothesis_id": rollouts.bank.hypothesis_ids[hypothesis],
+            "hypothesis_index": hypothesis,
+            "parameter_particle_index": particle,
+            "metrics": {
+                key: value
+                for key, value in best_metrics.items()
+                if key != "frame_ade_m"
+            },
+        }
+        beta_metric_rows = [
+            row
+            for row in metrics_rows
+            if row["method"] == "physical_prior" or row["kind"] == "semantic"
+        ]
+        best_row = min(
+            beta_metric_rows,
+            key=lambda row: (row["ade_m"], row["beta"] or 0.0),
+        )
+        evaluation_best_beta = float(best_row["beta"] or 0.0)
+
+    report: dict[str, Any] = {
+        "schema": EXTERNAL_BRIDGE_RUN_SCHEMA,
+        "schema_version": EXTERNAL_BRIDGE_RUN_SCHEMA_VERSION,
+        "case_id": forecast.case_id,
+        "forecast_artifact_id": forecast.artifact_id,
+        "forecast_id": forecast_id,
+        "rollout_artifact_id": rollouts.artifact_id,
+        "rollout_bank_artifact_id": rollouts.bank.artifact_id,
+        "reference_artifact_id": (
+            reference.artifact_id if reference is not None else None
+        ),
+        "settings": {
+            "beta_values": list(betas),
+            "scale_m": float(scale_m),
+            "degrees_of_freedom": float(degrees_of_freedom),
+            "anchor_tolerance_m": float(anchor_tolerance_m),
+            "motion_ratio_min": float(motion_ratio_min),
+            "motion_ratio_max": float(motion_ratio_max),
+            "confidence_level": float(rollouts.bank.confidence_level),
+        },
+        "doctor": plain_json(doctor),
+        "beta_results": beta_entries,
+        "metrics": metrics_rows,
+        "component_oracle": oracle,
+        "evaluation_only_best_beta": evaluation_best_beta,
+        "claim_boundary": (
+            "The beta sweep and any evaluation-only best beta are diagnostic. "
+            "Positive semantic trust requires source-only calibration and independent "
+            "confirmation; beta=0 preserves the physical support exactly."
+        ),
+    }
+    report = plain_json(
+        validated_json_mapping(
+            report,
+            error_message="external bridge run report must be finite JSON data",
+        )
+    )
+    prediction_names = [method for method, *_ in method_predictions]
+    prediction_values = np.stack(
+        [prediction for _, _, _, prediction, _, _ in method_predictions], axis=0
+    )
+    arrays = {
+        "query_node_ids": forecast.node_indices,
+        "forecast_future_times_s": forecast.future_times_s,
+        "absolute_query_times_s": query_times,
+        "rollout_fractional_frame_indices": query_frames,
+        "beta_values": np.asarray(betas, dtype=np.float64),
+        "posterior_weights": np.stack(weights_by_beta, axis=0),
+        "posterior_query_means_m": np.stack(means_by_beta, axis=0),
+        "posterior_query_lower_m": np.stack(lower_by_beta, axis=0),
+        "posterior_query_upper_m": np.stack(upper_by_beta, axis=0),
+        "hypothesis_ids": np.asarray(rollouts.bank.hypothesis_ids),
+        "method_names": np.asarray(prediction_names),
+        "method_query_predictions_m": prediction_values,
+        "reference_positions_m": (
+            truth_positions
+            if truth_positions is not None
+            else np.asarray([], dtype=np.float64)
+        ),
+        "reference_validity": (
+            truth_valid if truth_valid is not None else np.asarray([], dtype=bool)
+        ),
+        "reference_fractional_frame_indices": (
+            reference_frames
+            if reference_frames is not None
+            else np.asarray([], dtype=np.float64)
+        ),
+    }
+    arrays["metrics_rows_json"] = np.asarray(
+        json.dumps(metrics_rows, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    )
+    arrays["horizon_rows_json"] = np.asarray(
+        json.dumps(horizon_rows, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    )
+    return report, arrays
+
+
+__all__ = [
+    "EXTERNAL_BRIDGE_RUN_SCHEMA",
+    "EXTERNAL_BRIDGE_RUN_SCHEMA_VERSION",
+    "analyze_external_bridge",
+]

--- a/src/causal4d/_external_bridge_analysis.py
+++ b/src/causal4d/_external_bridge_analysis.py
@@ -219,9 +219,7 @@ def analyze_external_bridge(
                 "kind": kind,
                 "beta": beta,
                 **{
-                    key: value
-                    for key, value in metrics.items()
-                    if key != "frame_ade_m"
+                    key: value for key, value in metrics.items() if key != "frame_ade_m"
                 },
             }
             metrics_rows.append(row)

--- a/src/causal4d/_external_bridge_metrics.py
+++ b/src/causal4d/_external_bridge_metrics.py
@@ -1,0 +1,188 @@
+"""Numerical helpers for the external forecast/rollout bridge."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from causal4d.external_bridge import _fractional_frame_indices
+from causal4d.external_reference import ExternalReferenceTrajectory
+
+
+def _node_indices(
+    node_ids: np.ndarray,
+    requested_ids: np.ndarray,
+    *,
+    name: str,
+) -> np.ndarray:
+    lookup = {int(node_id): index for index, node_id in enumerate(node_ids)}
+    missing = [int(node_id) for node_id in requested_ids if int(node_id) not in lookup]
+    if missing:
+        raise ValueError(f"{name} is missing node IDs: {missing!r}")
+    return np.asarray(
+        [lookup[int(node_id)] for node_id in requested_ids],
+        dtype=np.int64,
+    )
+
+
+def _interpolate_reference(
+    reference: ExternalReferenceTrajectory,
+    query_times_s: np.ndarray,
+    node_indices: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    frame_indices = _fractional_frame_indices(reference.frame_times_s, query_times_s)
+    lower = np.floor(frame_indices).astype(np.int64)
+    upper = np.ceil(frame_indices).astype(np.int64)
+    alpha = (frame_indices - lower).reshape(-1, 1, 1)
+    lower_positions = reference.positions_m[lower][:, node_indices]
+    upper_positions = reference.positions_m[upper][:, node_indices]
+    positions = (1.0 - alpha) * lower_positions + alpha * upper_positions
+    lower_valid = reference.validity[lower][:, node_indices]
+    upper_valid = reference.validity[upper][:, node_indices]
+    valid = lower_valid & upper_valid
+    positions[~valid] = np.nan
+    return positions, valid, frame_indices
+
+
+def _weighted_query_mean(components: np.ndarray, weights: np.ndarray) -> np.ndarray:
+    return np.einsum("hp,hpfqc->fqc", weights, components, optimize=True)
+
+
+def _weighted_quantile(
+    components: np.ndarray,
+    weights: np.ndarray,
+    probability: float,
+) -> np.ndarray:
+    if not 0.0 <= probability <= 1.0:
+        raise ValueError("quantile probability must lie in [0, 1]")
+    values = components.reshape(-1, *components.shape[2:]).astype(np.float64)
+    flat_weights = weights.reshape(-1).astype(np.float64)
+    order = np.argsort(values, axis=0, kind="mergesort")
+    sorted_values = np.take_along_axis(values, order, axis=0)
+    broadcast_weights = np.broadcast_to(
+        flat_weights.reshape(-1, 1, 1, 1), values.shape
+    )
+    sorted_weights = np.take_along_axis(broadcast_weights, order, axis=0)
+    cumulative = np.cumsum(sorted_weights, axis=0)
+    cumulative[-1] = 1.0
+    indices = np.argmax(cumulative >= probability, axis=0)
+    return np.take_along_axis(sorted_values, indices[None], axis=0)[0]
+
+
+def _trajectory_metrics(
+    prediction: np.ndarray,
+    truth: np.ndarray,
+    truth_valid: np.ndarray,
+    *,
+    lower: np.ndarray | None = None,
+    upper: np.ndarray | None = None,
+) -> dict[str, Any]:
+    predicted = np.asarray(prediction, dtype=np.float64)
+    reference = np.asarray(truth, dtype=np.float64)
+    coordinate_valid = np.asarray(truth_valid, dtype=bool) & np.isfinite(predicted)
+    point_valid = np.all(coordinate_valid, axis=2)
+    if not np.any(point_valid):
+        raise ValueError("trajectory metric has no valid point-time pairs")
+    point_error = np.linalg.norm(predicted - reference, axis=2)
+    frame_ade = np.full(len(predicted), np.nan, dtype=np.float64)
+    for frame in range(len(predicted)):
+        if np.any(point_valid[frame]):
+            frame_ade[frame] = float(np.mean(point_error[frame, point_valid[frame]]))
+    final_frame = int(np.flatnonzero(np.any(point_valid, axis=1))[-1])
+    valid_coordinates = coordinate_valid
+    metrics: dict[str, Any] = {
+        "ade_m": float(np.mean(point_error[point_valid])),
+        "fde_m": float(np.mean(point_error[final_frame, point_valid[final_frame]])),
+        "coordinate_rmse_m": float(
+            np.sqrt(np.mean(np.square((predicted - reference)[valid_coordinates])))
+        ),
+        "valid_point_time_count": int(np.sum(point_valid)),
+        "valid_coordinate_count": int(np.sum(valid_coordinates)),
+        "final_valid_frame_index": final_frame,
+        "coordinate_coverage": None,
+        "frame_ade_m": [
+            float(value) if np.isfinite(value) else None for value in frame_ade
+        ],
+    }
+    if lower is not None or upper is not None:
+        if lower is None or upper is None:
+            raise ValueError("both interval bounds must be supplied")
+        lower_values = np.asarray(lower, dtype=np.float64)
+        upper_values = np.asarray(upper, dtype=np.float64)
+        if (
+            lower_values.shape != reference.shape
+            or upper_values.shape != reference.shape
+        ):
+            raise ValueError("interval bounds must match reference shape")
+        covered = (reference >= lower_values) & (reference <= upper_values)
+        metrics["coordinate_coverage"] = float(np.mean(covered[valid_coordinates]))
+    return metrics
+
+
+def _weight_diagnostics(
+    posterior: np.ndarray,
+    prior: np.ndarray,
+    hypothesis_ids: tuple[str, ...],
+) -> dict[str, Any]:
+    flat = posterior.reshape(-1)
+    flat_prior = prior.reshape(-1)
+    positive = flat > 0.0
+    if np.any(positive & (flat_prior <= 0.0)):
+        raise RuntimeError("posterior placed mass outside prior support")
+    kl = float(
+        np.sum(flat[positive] * np.log(flat[positive] / flat_prior[positive]))
+    )
+    best_flat = int(np.argmax(flat))
+    hypothesis_index, particle_index = np.unravel_index(best_flat, posterior.shape)
+    return {
+        "effective_component_count": float(1.0 / np.sum(np.square(flat))),
+        "kl_from_physical_prior": kl,
+        "l1_weight_shift": float(np.sum(np.abs(flat - flat_prior))),
+        "maximum_component_weight": float(flat[best_flat]),
+        "top_hypothesis_id": hypothesis_ids[hypothesis_index],
+        "top_hypothesis_index": int(hypothesis_index),
+        "top_parameter_particle_index": int(particle_index),
+        "weights_bit_identical_to_prior": bool(
+            posterior.tobytes() == prior.tobytes()
+        ),
+    }
+
+
+def _constant_velocity_prediction(
+    reference: ExternalReferenceTrajectory,
+    query_times_s: np.ndarray,
+    reference_node_indices: np.ndarray,
+    anchor_time_s: float,
+) -> np.ndarray | None:
+    available = np.flatnonzero(reference.frame_times_s <= anchor_time_s + 1e-12)
+    if len(available) < 2:
+        return None
+    last = int(available[-1])
+    previous = int(available[-2])
+    delta_t = float(reference.frame_times_s[last] - reference.frame_times_s[previous])
+    if delta_t <= 0.0:
+        return None
+    valid = (
+        reference.validity[last, reference_node_indices]
+        & reference.validity[previous, reference_node_indices]
+    )
+    previous_positions = reference.positions_m[previous, reference_node_indices]
+    last_positions = reference.positions_m[last, reference_node_indices]
+    velocity = (last_positions - previous_positions) / delta_t
+    prediction = last_positions[None] + (
+        query_times_s - reference.frame_times_s[last]
+    )[:, None, None] * velocity[None]
+    prediction[:, ~np.all(valid, axis=1)] = np.nan
+    return prediction
+
+
+__all__ = [
+    "_constant_velocity_prediction",
+    "_interpolate_reference",
+    "_node_indices",
+    "_trajectory_metrics",
+    "_weight_diagnostics",
+    "_weighted_quantile",
+    "_weighted_query_mean",
+]

--- a/src/causal4d/_external_bridge_metrics.py
+++ b/src/causal4d/_external_bridge_metrics.py
@@ -60,9 +60,7 @@ def _weighted_quantile(
     flat_weights = weights.reshape(-1).astype(np.float64)
     order = np.argsort(values, axis=0, kind="mergesort")
     sorted_values = np.take_along_axis(values, order, axis=0)
-    broadcast_weights = np.broadcast_to(
-        flat_weights.reshape(-1, 1, 1, 1), values.shape
-    )
+    broadcast_weights = np.broadcast_to(flat_weights.reshape(-1, 1, 1, 1), values.shape)
     sorted_weights = np.take_along_axis(broadcast_weights, order, axis=0)
     cumulative = np.cumsum(sorted_weights, axis=0)
     cumulative[-1] = 1.0
@@ -130,9 +128,7 @@ def _weight_diagnostics(
     positive = flat > 0.0
     if np.any(positive & (flat_prior <= 0.0)):
         raise RuntimeError("posterior placed mass outside prior support")
-    kl = float(
-        np.sum(flat[positive] * np.log(flat[positive] / flat_prior[positive]))
-    )
+    kl = float(np.sum(flat[positive] * np.log(flat[positive] / flat_prior[positive])))
     best_flat = int(np.argmax(flat))
     hypothesis_index, particle_index = np.unravel_index(best_flat, posterior.shape)
     return {
@@ -143,9 +139,7 @@ def _weight_diagnostics(
         "top_hypothesis_id": hypothesis_ids[hypothesis_index],
         "top_hypothesis_index": int(hypothesis_index),
         "top_parameter_particle_index": int(particle_index),
-        "weights_bit_identical_to_prior": bool(
-            posterior.tobytes() == prior.tobytes()
-        ),
+        "weights_bit_identical_to_prior": bool(posterior.tobytes() == prior.tobytes()),
     }
 
 
@@ -170,9 +164,11 @@ def _constant_velocity_prediction(
     previous_positions = reference.positions_m[previous, reference_node_indices]
     last_positions = reference.positions_m[last, reference_node_indices]
     velocity = (last_positions - previous_positions) / delta_t
-    prediction = last_positions[None] + (
-        query_times_s - reference.frame_times_s[last]
-    )[:, None, None] * velocity[None]
+    prediction = (
+        last_positions[None]
+        + (query_times_s - reference.frame_times_s[last])[:, None, None]
+        * velocity[None]
+    )
     prediction[:, ~np.all(valid, axis=1)] = np.nan
     return prediction
 

--- a/src/causal4d/_external_bridge_publication.py
+++ b/src/causal4d/_external_bridge_publication.py
@@ -1,0 +1,326 @@
+"""Atomic report publication for external forecast/rollout bridges."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import html
+import io
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from causal4d.atomic_io import atomic_write_binary, atomic_write_json, atomic_write_text
+from causal4d.immutable_json import plain_json
+
+_OUTPUT_FILES = (
+    "doctor.json",
+    "summary.json",
+    "summary.md",
+    "metrics.csv",
+    "weights.csv",
+    "error_vs_horizon.csv",
+    "error_vs_horizon.svg",
+    "predictions.npz",
+    "manifest.json",
+)
+
+
+def _file_sha256(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _csv_text(rows: list[dict[str, Any]], fields: list[str]) -> str:
+    stream = io.StringIO(newline="")
+    writer = csv.DictWriter(stream, fieldnames=fields, extrasaction="ignore")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({field: row.get(field) for field in fields})
+    return stream.getvalue()
+
+
+def _summary_markdown(report: Mapping[str, Any]) -> str:
+    lines = [
+        "# External forecast–rollout bridge report",
+        "",
+        f"- Case: `{report['case_id']}`",
+        f"- Forecast: `{report['forecast_id']}`",
+        f"- Forecast artifact: `{report['forecast_artifact_id']}`",
+        f"- Rollout artifact: `{report['rollout_artifact_id']}`",
+        f"- Doctor warnings: {len(report['doctor']['warnings'])}",
+        "- Exact beta=0 fallback: "
+        f"`{str(report['doctor']['beta_zero_weights_bit_identical']).lower()}`",
+        "",
+    ]
+    if report["doctor"]["warnings"]:
+        lines.extend(["## Preflight warnings", ""])
+        lines.extend(f"- {warning}" for warning in report["doctor"]["warnings"])
+        lines.append("")
+    metrics = report["metrics"]
+    if metrics:
+        lines.extend(
+            [
+                "## Evaluation metrics",
+                "",
+                "| Method | Beta | ADE [mm] | FDE [mm] | RMSE [mm] | Coverage |",
+                "|---|---:|---:|---:|---:|---:|",
+            ]
+        )
+        for row in metrics:
+            coverage = row["coordinate_coverage"]
+            coverage_text = "—" if coverage is None else f"{100.0 * coverage:.2f}%"
+            beta_text = "—" if row["beta"] is None else f"{row['beta']:g}"
+            lines.append(
+                f"| `{row['method']}` | {beta_text} | "
+                f"{1000.0 * row['ade_m']:.3f} | {1000.0 * row['fde_m']:.3f} | "
+                f"{1000.0 * row['coordinate_rmse_m']:.3f} | {coverage_text} |"
+            )
+        lines.append("")
+        lines.append(
+            "The reported `evaluation_only_best_beta` uses reference future data and "
+            "must not be used as a deployment trust calibration."
+        )
+        lines.append("")
+    lines.extend(["## Scientific boundary", "", str(report["claim_boundary"]), ""])
+    return "\n".join(lines)
+
+
+def _horizon_svg(
+    rows: list[dict[str, Any]],
+    *,
+    width: int = 960,
+    height: int = 600,
+) -> str:
+    finite_rows = [
+        row
+        for row in rows
+        if row["ade_m"] is not None and np.isfinite(row["ade_m"])
+    ]
+    if not finite_rows:
+        return (
+            f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}">'
+            '<rect width="100%" height="100%" fill="white"/>'
+            '<text x="30" y="50" font-family="sans-serif" font-size="18">'
+            'No reference trajectory supplied.</text></svg>\n'
+        )
+    methods: list[str] = []
+    for row in finite_rows:
+        if row["method"] not in methods:
+            methods.append(row["method"])
+    minimum_x = min(float(row["future_time_s"]) for row in finite_rows)
+    maximum_x = max(float(row["future_time_s"]) for row in finite_rows)
+    maximum_y = max(float(row["ade_m"]) for row in finite_rows)
+    maximum_y = max(maximum_y, 1e-9)
+    margin_left, margin_right, margin_top, margin_bottom = 85, 30, 45, 70
+
+    def transform(x: float, y: float) -> tuple[float, float]:
+        x_span = max(maximum_x - minimum_x, 1e-12)
+        px = margin_left + (x - minimum_x) / x_span * (
+            width - margin_left - margin_right
+        )
+        py = height - margin_bottom - y / maximum_y * (
+            height - margin_top - margin_bottom
+        )
+        return px, py
+
+    palette = ["#111", "#555", "#888", "#1f5f99", "#8a3b12", "#287a3d", "#6f3c8f"]
+    elements = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
+        '<rect width="100%" height="100%" fill="white"/>',
+        f'<line x1="{margin_left}" y1="{height-margin_bottom}" x2="{width-margin_right}" y2="{height-margin_bottom}" stroke="#222"/>',
+        f'<line x1="{margin_left}" y1="{margin_top}" x2="{margin_left}" y2="{height-margin_bottom}" stroke="#222"/>',
+        f'<text x="{width/2:.1f}" y="{height-20}" text-anchor="middle" font-family="sans-serif" font-size="14">Forecast horizon [s]</text>',
+        f'<text x="20" y="{height/2:.1f}" transform="rotate(-90 20 {height/2:.1f})" text-anchor="middle" font-family="sans-serif" font-size="14">Mean point error [m]</text>',
+    ]
+    for tick in range(6):
+        y = maximum_y * tick / 5.0
+        _, py = transform(minimum_x, y)
+        elements.append(
+            f'<text x="{margin_left-10}" y="{py+4:.2f}" text-anchor="end" font-family="sans-serif" font-size="11">{y:.3g}</text>'
+        )
+    legend_y = 24
+    for method_index, method in enumerate(methods):
+        method_rows = sorted(
+            (row for row in finite_rows if row["method"] == method),
+            key=lambda row: row["future_time_s"],
+        )
+        points = [
+            transform(float(row["future_time_s"]), float(row["ade_m"]))
+            for row in method_rows
+        ]
+        color = palette[method_index % len(palette)]
+        path = " ".join(
+            ("M" if index == 0 else "L") + f" {x:.2f} {y:.2f}"
+            for index, (x, y) in enumerate(points)
+        )
+        elements.append(
+            f'<path d="{path}" fill="none" stroke="{color}" stroke-width="2"/>'
+        )
+        legend_x = margin_left + method_index * 135
+        if legend_x > width - 140:
+            legend_y += 20
+            legend_x = margin_left + (method_index % 6) * 135
+        elements.extend(
+            (
+                f'<line x1="{legend_x}" y1="{legend_y}" x2="{legend_x+20}" y2="{legend_y}" stroke="{color}" stroke-width="2"/>',
+                f'<text x="{legend_x+25}" y="{legend_y+4}" font-family="sans-serif" font-size="10">{html.escape(method)}</text>',
+            )
+        )
+    elements.append("</svg>")
+    return "\n".join(elements) + "\n"
+
+
+def publish_external_bridge_run(
+    output_dir: str | Path,
+    report: Mapping[str, Any],
+    arrays: Mapping[str, np.ndarray],
+    *,
+    overwrite: bool = False,
+) -> Mapping[str, Any]:
+    """Publish a reproducible report bundle, writing the manifest last."""
+
+    target = Path(output_dir)
+    if target.is_symlink():
+        raise ValueError("output directory must not be a symlink")
+    target.mkdir(parents=True, exist_ok=True)
+    existing = [name for name in _OUTPUT_FILES if (target / name).exists()]
+    if existing and not overwrite:
+        raise FileExistsError(
+            "external bridge output already contains managed files: " + repr(existing)
+        )
+    payload = plain_json(report)
+    doctor = payload["doctor"]
+    metrics_rows = list(payload["metrics"])
+    horizon_rows = json.loads(str(np.asarray(arrays["horizon_rows_json"]).item()))
+    weights_rows: list[dict[str, Any]] = []
+    posterior_weights = np.asarray(arrays["posterior_weights"])
+    beta_values = np.asarray(arrays["beta_values"])
+    prior = posterior_weights[0]
+    hypothesis_ids = tuple(
+        str(value) for value in np.asarray(arrays["hypothesis_ids"]).tolist()
+    )
+    for beta_index, beta in enumerate(beta_values):
+        for hypothesis in range(posterior_weights.shape[1]):
+            for particle in range(posterior_weights.shape[2]):
+                weights_rows.append(
+                    {
+                        "beta": float(beta),
+                        "hypothesis_id": hypothesis_ids[hypothesis],
+                        "hypothesis_index": hypothesis,
+                        "parameter_particle_index": particle,
+                        "prior_weight": float(prior[hypothesis, particle]),
+                        "posterior_weight": float(
+                            posterior_weights[beta_index, hypothesis, particle]
+                        ),
+                        "weight_delta": float(
+                            posterior_weights[beta_index, hypothesis, particle]
+                            - prior[hypothesis, particle]
+                        ),
+                    }
+                )
+
+    atomic_write_json(target / "doctor.json", doctor, overwrite=overwrite)
+    atomic_write_json(target / "summary.json", payload, overwrite=overwrite)
+    atomic_write_text(
+        target / "summary.md", _summary_markdown(payload), overwrite=overwrite
+    )
+    metric_fields = [
+        "method",
+        "kind",
+        "beta",
+        "ade_m",
+        "fde_m",
+        "coordinate_rmse_m",
+        "coordinate_coverage",
+        "valid_point_time_count",
+        "valid_coordinate_count",
+        "final_valid_frame_index",
+    ]
+    atomic_write_text(
+        target / "metrics.csv",
+        _csv_text(metrics_rows, metric_fields),
+        overwrite=overwrite,
+    )
+    atomic_write_text(
+        target / "weights.csv",
+        _csv_text(
+            weights_rows,
+            [
+                "beta",
+                "hypothesis_id",
+                "hypothesis_index",
+                "parameter_particle_index",
+                "prior_weight",
+                "posterior_weight",
+                "weight_delta",
+            ],
+        ),
+        overwrite=overwrite,
+    )
+    atomic_write_text(
+        target / "error_vs_horizon.csv",
+        _csv_text(
+            horizon_rows,
+            [
+                "method",
+                "kind",
+                "beta",
+                "forecast_step",
+                "future_time_s",
+                "absolute_time_s",
+                "ade_m",
+            ],
+        ),
+        overwrite=overwrite,
+    )
+    atomic_write_text(
+        target / "error_vs_horizon.svg",
+        _horizon_svg(horizon_rows),
+        overwrite=overwrite,
+    )
+
+    def write_predictions(handle) -> None:
+        np.savez_compressed(handle, **arrays)
+
+    atomic_write_binary(
+        target / "predictions.npz", write_predictions, overwrite=overwrite
+    )
+    published_files = [name for name in _OUTPUT_FILES if name != "manifest.json"]
+    file_records = {
+        name: {
+            "sha256": _file_sha256(target / name),
+            "size_bytes": (target / name).stat().st_size,
+        }
+        for name in published_files
+    }
+    manifest_without_id = {
+        "schema": "causal4d.external_bridge_result_bundle",
+        "schema_version": 1,
+        "case_id": payload["case_id"],
+        "forecast_artifact_id": payload["forecast_artifact_id"],
+        "rollout_artifact_id": payload["rollout_artifact_id"],
+        "reference_artifact_id": payload["reference_artifact_id"],
+        "files": file_records,
+        "claim_boundary": payload["claim_boundary"],
+    }
+    manifest_id = hashlib.sha256(
+        json.dumps(
+            manifest_without_id,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()
+    manifest = {**manifest_without_id, "manifest_id": manifest_id}
+    atomic_write_json(target / "manifest.json", manifest, overwrite=overwrite)
+    return manifest
+
+
+__all__ = ["publish_external_bridge_run"]

--- a/src/causal4d/_external_bridge_publication.py
+++ b/src/causal4d/_external_bridge_publication.py
@@ -99,16 +99,14 @@ def _horizon_svg(
     height: int = 600,
 ) -> str:
     finite_rows = [
-        row
-        for row in rows
-        if row["ade_m"] is not None and np.isfinite(row["ade_m"])
+        row for row in rows if row["ade_m"] is not None and np.isfinite(row["ade_m"])
     ]
     if not finite_rows:
         return (
             f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}">'
             '<rect width="100%" height="100%" fill="white"/>'
             '<text x="30" y="50" font-family="sans-serif" font-size="18">'
-            'No reference trajectory supplied.</text></svg>\n'
+            "No reference trajectory supplied.</text></svg>\n"
         )
     methods: list[str] = []
     for row in finite_rows:
@@ -125,8 +123,10 @@ def _horizon_svg(
         px = margin_left + (x - minimum_x) / x_span * (
             width - margin_left - margin_right
         )
-        py = height - margin_bottom - y / maximum_y * (
-            height - margin_top - margin_bottom
+        py = (
+            height
+            - margin_bottom
+            - y / maximum_y * (height - margin_top - margin_bottom)
         )
         return px, py
 
@@ -134,16 +134,16 @@ def _horizon_svg(
     elements = [
         f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
         '<rect width="100%" height="100%" fill="white"/>',
-        f'<line x1="{margin_left}" y1="{height-margin_bottom}" x2="{width-margin_right}" y2="{height-margin_bottom}" stroke="#222"/>',
-        f'<line x1="{margin_left}" y1="{margin_top}" x2="{margin_left}" y2="{height-margin_bottom}" stroke="#222"/>',
-        f'<text x="{width/2:.1f}" y="{height-20}" text-anchor="middle" font-family="sans-serif" font-size="14">Forecast horizon [s]</text>',
-        f'<text x="20" y="{height/2:.1f}" transform="rotate(-90 20 {height/2:.1f})" text-anchor="middle" font-family="sans-serif" font-size="14">Mean point error [m]</text>',
+        f'<line x1="{margin_left}" y1="{height - margin_bottom}" x2="{width - margin_right}" y2="{height - margin_bottom}" stroke="#222"/>',
+        f'<line x1="{margin_left}" y1="{margin_top}" x2="{margin_left}" y2="{height - margin_bottom}" stroke="#222"/>',
+        f'<text x="{width / 2:.1f}" y="{height - 20}" text-anchor="middle" font-family="sans-serif" font-size="14">Forecast horizon [s]</text>',
+        f'<text x="20" y="{height / 2:.1f}" transform="rotate(-90 20 {height / 2:.1f})" text-anchor="middle" font-family="sans-serif" font-size="14">Mean point error [m]</text>',
     ]
     for tick in range(6):
         y = maximum_y * tick / 5.0
         _, py = transform(minimum_x, y)
         elements.append(
-            f'<text x="{margin_left-10}" y="{py+4:.2f}" text-anchor="end" font-family="sans-serif" font-size="11">{y:.3g}</text>'
+            f'<text x="{margin_left - 10}" y="{py + 4:.2f}" text-anchor="end" font-family="sans-serif" font-size="11">{y:.3g}</text>'
         )
     legend_y = 24
     for method_index, method in enumerate(methods):
@@ -169,8 +169,8 @@ def _horizon_svg(
             legend_x = margin_left + (method_index % 6) * 135
         elements.extend(
             (
-                f'<line x1="{legend_x}" y1="{legend_y}" x2="{legend_x+20}" y2="{legend_y}" stroke="{color}" stroke-width="2"/>',
-                f'<text x="{legend_x+25}" y="{legend_y+4}" font-family="sans-serif" font-size="10">{html.escape(method)}</text>',
+                f'<line x1="{legend_x}" y1="{legend_y}" x2="{legend_x + 20}" y2="{legend_y}" stroke="{color}" stroke-width="2"/>',
+                f'<text x="{legend_x + 25}" y="{legend_y + 4}" font-family="sans-serif" font-size="10">{html.escape(method)}</text>',
             )
         )
     elements.append("</svg>")

--- a/src/causal4d/cli/external_bridge_run.py
+++ b/src/causal4d/cli/external_bridge_run.py
@@ -1,0 +1,109 @@
+"""Run and publish one external forecast/rollout bridge analysis."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+
+def _load_runtime_dependencies() -> None:
+    global analyze_external_bridge
+    global load_external_forecast
+    global load_external_reference
+    global load_external_rollout_bank
+    global publish_external_bridge_run
+
+    from causal4d.external_bridge_run import (
+        analyze_external_bridge,
+        publish_external_bridge_run,
+    )
+    from causal4d.external_forecast import load_external_forecast
+    from causal4d.external_reference import load_external_reference
+    from causal4d.external_rollout import load_external_rollout_bank
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a beta sweep over a canonical external forecast and finite "
+            "physical rollout bank, then publish doctor, weight, prediction, "
+            "and optional reference-evaluation artifacts."
+        )
+    )
+    parser.add_argument("external_forecast_npz")
+    parser.add_argument("external_rollout_bank_npz")
+    parser.add_argument("forecast_id")
+    parser.add_argument("output_dir")
+    parser.add_argument(
+        "--reference",
+        help=(
+            "Optional closed NPZ with case_id, node_ids, positions_world_m, "
+            "frame_times_s, and optional validity_mask."
+        ),
+    )
+    parser.add_argument(
+        "--beta",
+        action="append",
+        type=float,
+        help="Repeat to define the beta grid; defaults to 0,1,3,6,12.",
+    )
+    parser.add_argument("--scale-m", type=float, default=0.05)
+    parser.add_argument("--degrees-of-freedom", type=float, default=3.0)
+    parser.add_argument("--anchor-tolerance-m", type=float, default=0.01)
+    parser.add_argument("--motion-ratio-min", type=float, default=0.10)
+    parser.add_argument("--motion-ratio-max", type=float, default=10.0)
+    parser.add_argument(
+        "--require-clean-doctor",
+        action="store_true",
+        help="Publish the complete report but return exit status 3 on warnings.",
+    )
+    parser.add_argument("--overwrite", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    _load_runtime_dependencies()
+    forecast = load_external_forecast(args.external_forecast_npz)
+    rollouts = load_external_rollout_bank(args.external_rollout_bank_npz)
+    reference = load_external_reference(args.reference) if args.reference else None
+    beta_values = args.beta if args.beta is not None else [0.0, 1.0, 3.0, 6.0, 12.0]
+    report, arrays = analyze_external_bridge(
+        forecast,
+        args.forecast_id,
+        rollouts,
+        beta_values=beta_values,
+        scale_m=args.scale_m,
+        degrees_of_freedom=args.degrees_of_freedom,
+        anchor_tolerance_m=args.anchor_tolerance_m,
+        motion_ratio_min=args.motion_ratio_min,
+        motion_ratio_max=args.motion_ratio_max,
+        reference=reference,
+    )
+    manifest = publish_external_bridge_run(
+        args.output_dir,
+        report,
+        arrays,
+        overwrite=args.overwrite,
+    )
+    summary = {
+        "case_id": report["case_id"],
+        "doctor_warning_count": len(report["doctor"]["warnings"]),
+        "evaluation_only_best_beta": report["evaluation_only_best_beta"],
+        "exact_beta_zero_fallback": report["doctor"][
+            "beta_zero_weights_bit_identical"
+        ],
+        "manifest_id": manifest["manifest_id"],
+        "output_dir": str(Path(args.output_dir).resolve()),
+        "reference_evaluated": reference is not None,
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    if args.require_clean_doctor and report["doctor"]["warnings"]:
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d/cli/external_bridge_run.py
+++ b/src/causal4d/cli/external_bridge_run.py
@@ -92,9 +92,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "case_id": report["case_id"],
         "doctor_warning_count": len(report["doctor"]["warnings"]),
         "evaluation_only_best_beta": report["evaluation_only_best_beta"],
-        "exact_beta_zero_fallback": report["doctor"][
-            "beta_zero_weights_bit_identical"
-        ],
+        "exact_beta_zero_fallback": report["doctor"]["beta_zero_weights_bit_identical"],
         "manifest_id": manifest["manifest_id"],
         "output_dir": str(Path(args.output_dir).resolve()),
         "reference_evaluated": reference is not None,

--- a/src/causal4d/cli/external_bridge_workflow.py
+++ b/src/causal4d/cli/external_bridge_workflow.py
@@ -1,0 +1,53 @@
+"""Single module entry point for the external forecast/physics bridge."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from importlib import import_module
+
+_COMMANDS = {
+    "import-forecast": "causal4d.cli.external_forecast_import:main",
+    "import-rollouts": "causal4d.cli.external_rollout_import:main",
+    "doctor": "causal4d.cli.external_bridge_doctor:main",
+    "map-nodes": "causal4d.cli.external_node_mapping:main",
+    "run": "causal4d.cli.external_bridge_run:main",
+}
+
+
+def _help() -> str:
+    return "\n".join(
+        (
+            "usage: python -m causal4d.cli.external_bridge_workflow ",
+            "       {import-forecast,import-rollouts,doctor,map-nodes,run} ...",
+            "",
+            "Portable MolmoMotion/external-simulator bridge commands:",
+            "  import-forecast  Normalize a sparse external forecast.",
+            "  import-rollouts  Normalize a finite external rollout bank.",
+            "  doctor           Validate node, time, anchor, and scale alignment.",
+            "  map-nodes        Audit a one-to-one geometric node assignment.",
+            "  run              Sweep semantic weights and publish a report bundle.",
+            "",
+            "Append --help after a subcommand for its detailed arguments.",
+        )
+    )
+
+
+def _target(specification: str) -> Callable[[Sequence[str] | None], int]:
+    module_name, function_name = specification.split(":", 1)
+    return getattr(import_module(module_name), function_name)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = list(argv or ())
+    if not arguments or arguments[0] in {"-h", "--help"}:
+        print(_help())
+        return 0
+    command = arguments.pop(0)
+    if command not in _COMMANDS:
+        available = ", ".join(sorted(_COMMANDS))
+        raise SystemExit(f"unknown bridge command {command!r}; choose from {available}")
+    return int(_target(_COMMANDS[command])(arguments) or 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d/cli/external_node_mapping.py
+++ b/src/causal4d/cli/external_node_mapping.py
@@ -1,0 +1,106 @@
+"""Map visual query anchors to persistent simulator node identities."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+
+def _load_runtime_dependencies() -> None:
+    global _load_array
+    global _text_ids
+    global build_external_node_mapping
+    global save_external_node_mapping
+
+    from causal4d.external_node_mapping import (
+        _load_array,
+        _text_ids,
+        build_external_node_mapping,
+        save_external_node_mapping,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build an audited one-to-one minimum-distance assignment from query "
+            "anchors to simulator nodes. Geometric proximity is not material proof."
+        )
+    )
+    parser.add_argument("query_npz")
+    parser.add_argument("simulator_nodes_npz")
+    parser.add_argument("output_json")
+    parser.add_argument("--output-npz")
+    parser.add_argument("--output-svg")
+    parser.add_argument("--query-position-key", default="anchor_positions_world_m")
+    parser.add_argument("--query-id-key")
+    parser.add_argument("--node-position-key", default="node_positions_world_m")
+    parser.add_argument("--node-id-key", default="node_ids")
+    parser.add_argument("--maximum-distance-m", type=float, default=0.005)
+    parser.add_argument("--projection", choices=("xy", "xz", "yz"), default="xy")
+    parser.add_argument("--overwrite", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    _load_runtime_dependencies()
+    query_positions, query_hash = _load_array(
+        args.query_npz,
+        args.query_position_key,
+        name="query",
+    )
+    node_positions, node_hash = _load_array(
+        args.simulator_nodes_npz,
+        args.node_position_key,
+        name="simulator nodes",
+    )
+    node_ids, second_node_hash = _load_array(
+        args.simulator_nodes_npz,
+        args.node_id_key,
+        name="simulator nodes",
+    )
+    if node_hash != second_node_hash:
+        raise RuntimeError("simulator node NPZ changed while reading arrays")
+    query_ids = None
+    if args.query_id_key:
+        raw_query_ids, second_query_hash = _load_array(
+            args.query_npz,
+            args.query_id_key,
+            name="query",
+        )
+        if query_hash != second_query_hash:
+            raise RuntimeError("query NPZ changed while reading arrays")
+        query_ids = _text_ids(raw_query_ids, name="query_ids")
+    report = build_external_node_mapping(
+        query_positions,
+        node_positions,
+        node_ids,
+        query_ids=query_ids,
+        maximum_distance_m=args.maximum_distance_m,
+        query_source_sha256=query_hash,
+        node_source_sha256=node_hash,
+    )
+    save_external_node_mapping(
+        report,
+        args.output_json,
+        output_npz=args.output_npz,
+        output_svg=args.output_svg,
+        projection=args.projection,
+        overwrite=args.overwrite,
+    )
+    summary = {
+        "accepted": report["accepted"],
+        "mapping_id": report["mapping_id"],
+        "maximum_assigned_distance_m": report["maximum_assigned_distance_m"],
+        "output_json": str(Path(args.output_json).resolve()),
+        "query_count": report["query_count"],
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if report["accepted"] else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d/external_bridge_run.py
+++ b/src/causal4d/external_bridge_run.py
@@ -1,0 +1,15 @@
+"""One-command analysis and reporting for external forecast/rollout bridges."""
+
+from causal4d._external_bridge_analysis import (
+    EXTERNAL_BRIDGE_RUN_SCHEMA,
+    EXTERNAL_BRIDGE_RUN_SCHEMA_VERSION,
+    analyze_external_bridge,
+)
+from causal4d._external_bridge_publication import publish_external_bridge_run
+
+__all__ = [
+    "EXTERNAL_BRIDGE_RUN_SCHEMA",
+    "EXTERNAL_BRIDGE_RUN_SCHEMA_VERSION",
+    "analyze_external_bridge",
+    "publish_external_bridge_run",
+]

--- a/src/causal4d/external_node_mapping.py
+++ b/src/causal4d/external_node_mapping.py
@@ -1,0 +1,307 @@
+"""Audited one-to-one geometric mapping from query points to simulator nodes."""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from scipy.optimize import linear_sum_assignment
+
+from causal4d.atomic_io import atomic_write_binary, atomic_write_json, atomic_write_text
+from causal4d.contracts import array_sha256
+from causal4d.numpy_archive import load_numpy_archive
+
+EXTERNAL_NODE_MAPPING_SCHEMA = "causal4d.external_query_node_mapping"
+EXTERNAL_NODE_MAPPING_SCHEMA_VERSION = 1
+
+
+def _load_array(
+    path: str | Path,
+    key: str,
+    *,
+    name: str,
+) -> tuple[np.ndarray, str]:
+    snapshot = load_numpy_archive(path, name=f"{name} NPZ")
+    if key not in snapshot.arrays:
+        raise ValueError(f"{name} NPZ is missing array {key!r}")
+    return np.asarray(snapshot.arrays[key]), snapshot.snapshot.sha256
+
+
+def _text_ids(values: np.ndarray, *, name: str) -> tuple[str, ...]:
+    array = np.asarray(values)
+    if array.ndim != 1 or array.dtype.kind not in {"U", "S"}:
+        raise ValueError(f"{name} must be a one-dimensional text array")
+    result: list[str] = []
+    for index, raw in enumerate(array):
+        value: Any = raw.item() if isinstance(raw, np.generic) else raw
+        if isinstance(value, bytes):
+            try:
+                value = value.decode("utf-8")
+            except UnicodeDecodeError as error:
+                raise ValueError(f"{name}[{index}] is not valid UTF-8") from error
+        if type(value) is not str or not value:
+            raise ValueError(f"{name}[{index}] must be a nonempty string")
+        result.append(value)
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must not contain duplicates")
+    return tuple(result)
+
+
+def build_external_node_mapping(
+    query_positions_m: np.ndarray,
+    node_positions_m: np.ndarray,
+    node_ids: np.ndarray,
+    *,
+    query_ids: Sequence[str] | None = None,
+    maximum_distance_m: float = 0.005,
+    query_source_sha256: str | None = None,
+    node_source_sha256: str | None = None,
+) -> dict[str, Any]:
+    """Build a minimum-total-distance one-to-one assignment.
+
+    This is an audited geometric convenience, not proof of material identity.
+    """
+
+    queries = np.asarray(query_positions_m, dtype=np.float64)
+    nodes = np.asarray(node_positions_m, dtype=np.float64)
+    raw_node_ids = np.asarray(node_ids)
+    if queries.ndim != 2 or queries.shape[1] not in {2, 3} or not len(queries):
+        raise ValueError("query_positions_m must have nonempty shape (Q, 2|3)")
+    if nodes.ndim != 2 or nodes.shape[1] != queries.shape[1] or not len(nodes):
+        raise ValueError("node_positions_m must have shape (N, C) matching queries")
+    if len(queries) > len(nodes):
+        raise ValueError(
+            "one-to-one mapping requires at least as many nodes as queries"
+        )
+    if not np.all(np.isfinite(queries)) or not np.all(np.isfinite(nodes)):
+        raise ValueError("query and node positions must be finite")
+    if raw_node_ids.ndim != 1 or len(raw_node_ids) != len(nodes):
+        raise ValueError("node_ids must identify every simulator node")
+    if raw_node_ids.dtype.kind not in {"i", "u"}:
+        raise ValueError("node_ids must use an integer dtype")
+    if raw_node_ids.dtype.kind == "u" and raw_node_ids.size:
+        if int(np.max(raw_node_ids)) > np.iinfo(np.int64).max:
+            raise ValueError("node_ids contain values outside int64 range")
+    normalized_node_ids = raw_node_ids.astype(np.int64, copy=True)
+    if np.any(normalized_node_ids < 0) or len(np.unique(normalized_node_ids)) != len(
+        normalized_node_ids
+    ):
+        raise ValueError("node_ids must be unique and nonnegative")
+    if not np.isfinite(maximum_distance_m) or maximum_distance_m <= 0.0:
+        raise ValueError("maximum_distance_m must be finite and positive")
+    normalized_query_ids = (
+        tuple(f"query_{index:04d}" for index in range(len(queries)))
+        if query_ids is None
+        else tuple(query_ids)
+    )
+    if len(normalized_query_ids) != len(queries) or any(
+        type(value) is not str or not value for value in normalized_query_ids
+    ):
+        raise ValueError("query_ids must identify every query with nonempty strings")
+    if len(set(normalized_query_ids)) != len(normalized_query_ids):
+        raise ValueError("query_ids must not contain duplicates")
+
+    distance_matrix = np.linalg.norm(queries[:, None] - nodes[None], axis=2)
+    query_rows, node_columns = linear_sum_assignment(distance_matrix)
+    if not np.array_equal(query_rows, np.arange(len(queries))):
+        raise RuntimeError("assignment did not preserve every query row")
+    distances = distance_matrix[query_rows, node_columns]
+    assigned_node_ids = normalized_node_ids[node_columns]
+    accepted = bool(np.all(distances <= maximum_distance_m))
+    entries = [
+        {
+            "query_index": int(index),
+            "query_id": normalized_query_ids[index],
+            "node_index": int(node_columns[index]),
+            "node_id": int(assigned_node_ids[index]),
+            "distance_m": float(distances[index]),
+            "query_position_m": queries[index].tolist(),
+            "node_position_m": nodes[node_columns[index]].tolist(),
+            "within_tolerance": bool(distances[index] <= maximum_distance_m),
+        }
+        for index in range(len(queries))
+    ]
+    descriptor: dict[str, Any] = {
+        "schema": EXTERNAL_NODE_MAPPING_SCHEMA,
+        "schema_version": EXTERNAL_NODE_MAPPING_SCHEMA_VERSION,
+        "method": "minimum_total_distance_one_to_one",
+        "accepted": accepted,
+        "maximum_distance_m": float(maximum_distance_m),
+        "maximum_assigned_distance_m": float(np.max(distances)),
+        "mean_assigned_distance_m": float(np.mean(distances)),
+        "query_count": len(queries),
+        "node_count": len(nodes),
+        "coordinate_count": queries.shape[1],
+        "query_source_sha256": query_source_sha256,
+        "node_source_sha256": node_source_sha256,
+        "array_hashes": {
+            "query_positions_m": array_sha256(queries),
+            "node_positions_m": array_sha256(nodes),
+            "node_ids": array_sha256(normalized_node_ids),
+            "assigned_node_indices": array_sha256(node_columns.astype(np.int64)),
+            "assigned_node_ids": array_sha256(assigned_node_ids),
+            "assigned_distances_m": array_sha256(distances),
+        },
+        "entries": entries,
+        "warnings": [
+            "geometric proximity does not prove persistent material correspondence"
+        ],
+    }
+    identity_payload = json.dumps(
+        descriptor,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    descriptor["mapping_id"] = hashlib.sha256(identity_payload).hexdigest()
+    return descriptor
+
+
+def _projection_indices(projection: str, coordinate_count: int) -> tuple[int, int]:
+    choices = {"xy": (0, 1), "xz": (0, 2), "yz": (1, 2)}
+    if projection not in choices:
+        raise ValueError("projection must be one of 'xy', 'xz', or 'yz'")
+    indices = choices[projection]
+    if max(indices) >= coordinate_count:
+        if projection != "xy" or coordinate_count != 2:
+            raise ValueError("requested projection is unavailable for 2-D positions")
+    return indices
+
+
+def render_external_node_mapping_svg(
+    report: dict[str, Any],
+    *,
+    projection: str = "xy",
+    width: int = 900,
+    height: int = 650,
+) -> str:
+    """Render an auditable 2-D projection without plotting dependencies."""
+
+    entries = report.get("entries")
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("mapping report has no entries")
+    coordinate_count = int(report["coordinate_count"])
+    first_axis, second_axis = _projection_indices(projection, coordinate_count)
+    query = np.asarray([entry["query_position_m"] for entry in entries], dtype=float)
+    nodes = np.asarray([entry["node_position_m"] for entry in entries], dtype=float)
+    combined = np.concatenate((query, nodes), axis=0)[:, [first_axis, second_axis]]
+    minimum = np.min(combined, axis=0)
+    maximum = np.max(combined, axis=0)
+    span = np.maximum(maximum - minimum, 1e-9)
+    margin = 60.0
+
+    def transform(position: np.ndarray) -> tuple[float, float]:
+        normalized = (position[[first_axis, second_axis]] - minimum) / span
+        x = margin + normalized[0] * (width - 2.0 * margin)
+        y = height - margin - normalized[1] * (height - 2.0 * margin)
+        return float(x), float(y)
+
+    elements = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" '
+        f'viewBox="0 0 {width} {height}">',
+        '<rect width="100%" height="100%" fill="white"/>',
+        f'<text x="20" y="30" font-family="sans-serif" font-size="18">'
+        f'External query-node mapping ({html.escape(projection)})</text>',
+        f'<text x="20" y="52" font-family="sans-serif" font-size="12">'
+        f'accepted={str(report["accepted"]).lower()}, '
+        f'max distance={report["maximum_assigned_distance_m"]:.6g} m</text>',
+    ]
+    for entry in entries:
+        query_position = np.asarray(entry["query_position_m"], dtype=float)
+        node_position = np.asarray(entry["node_position_m"], dtype=float)
+        qx, qy = transform(query_position)
+        nx, ny = transform(node_position)
+        status = "#333" if entry["within_tolerance"] else "#a00"
+        elements.extend(
+            (
+                f'<line x1="{qx:.3f}" y1="{qy:.3f}" x2="{nx:.3f}" '
+                f'y2="{ny:.3f}" stroke="{status}" stroke-width="1"/>',
+                f'<circle cx="{qx:.3f}" cy="{qy:.3f}" r="5" fill="white" '
+                f'stroke="{status}" stroke-width="2"/>',
+                f'<rect x="{nx - 4:.3f}" y="{ny - 4:.3f}" width="8" height="8" '
+                f'fill="{status}"/>',
+                f'<text x="{qx + 7:.3f}" y="{qy - 7:.3f}" '
+                f'font-family="sans-serif" font-size="10">'
+                f'{html.escape(str(entry["query_id"]))} → {entry["node_id"]}</text>',
+            )
+        )
+    elements.append("</svg>")
+    return "\n".join(elements) + "\n"
+
+
+def save_external_node_mapping(
+    report: dict[str, Any],
+    output_json: str | Path,
+    *,
+    output_npz: str | Path | None = None,
+    output_svg: str | Path | None = None,
+    projection: str = "xy",
+    overwrite: bool = False,
+) -> None:
+    """Publish mapping evidence and optional machine/visual artifacts atomically."""
+
+    targets = [Path(output_json)]
+    if output_npz is not None:
+        targets.append(Path(output_npz))
+    if output_svg is not None:
+        targets.append(Path(output_svg))
+    if not overwrite:
+        existing = [str(target) for target in targets if target.exists()]
+        if existing:
+            raise FileExistsError(
+                "external node-mapping outputs already exist: " + repr(existing)
+            )
+    entries = report["entries"]
+    if output_npz is not None:
+        query_positions = np.asarray(
+            [entry["query_position_m"] for entry in entries], dtype=np.float64
+        )
+        node_positions = np.asarray(
+            [entry["node_position_m"] for entry in entries], dtype=np.float64
+        )
+        node_ids = np.asarray([entry["node_id"] for entry in entries], dtype=np.int64)
+        node_indices = np.asarray(
+            [entry["node_index"] for entry in entries], dtype=np.int64
+        )
+        distances = np.asarray(
+            [entry["distance_m"] for entry in entries], dtype=np.float64
+        )
+
+        def writer(handle) -> None:
+            np.savez_compressed(
+                handle,
+                mapping_id=np.asarray(report["mapping_id"]),
+                accepted=np.asarray(report["accepted"], dtype=bool),
+                query_ids=np.asarray([entry["query_id"] for entry in entries]),
+                query_positions_m=query_positions,
+                assigned_node_indices=node_indices,
+                assigned_node_ids=node_ids,
+                assigned_node_positions_m=node_positions,
+                assigned_distances_m=distances,
+            )
+
+        atomic_write_binary(output_npz, writer, overwrite=overwrite)
+    if output_svg is not None:
+        atomic_write_text(
+            output_svg,
+            render_external_node_mapping_svg(report, projection=projection),
+            overwrite=overwrite,
+        )
+    # JSON is the completion marker for the optional companion artifacts.
+    atomic_write_json(output_json, report, overwrite=overwrite)
+
+
+__all__ = [
+    "EXTERNAL_NODE_MAPPING_SCHEMA",
+    "EXTERNAL_NODE_MAPPING_SCHEMA_VERSION",
+    "build_external_node_mapping",
+    "render_external_node_mapping_svg",
+    "save_external_node_mapping",
+    "_load_array",
+    "_text_ids",
+]

--- a/src/causal4d/external_node_mapping.py
+++ b/src/causal4d/external_node_mapping.py
@@ -206,10 +206,10 @@ def render_external_node_mapping_svg(
         f'viewBox="0 0 {width} {height}">',
         '<rect width="100%" height="100%" fill="white"/>',
         f'<text x="20" y="30" font-family="sans-serif" font-size="18">'
-        f'External query-node mapping ({html.escape(projection)})</text>',
+        f"External query-node mapping ({html.escape(projection)})</text>",
         f'<text x="20" y="52" font-family="sans-serif" font-size="12">'
-        f'accepted={str(report["accepted"]).lower()}, '
-        f'max distance={report["maximum_assigned_distance_m"]:.6g} m</text>',
+        f"accepted={str(report['accepted']).lower()}, "
+        f"max distance={report['maximum_assigned_distance_m']:.6g} m</text>",
     ]
     for entry in entries:
         query_position = np.asarray(entry["query_position_m"], dtype=float)
@@ -227,7 +227,7 @@ def render_external_node_mapping_svg(
                 f'fill="{status}"/>',
                 f'<text x="{qx + 7:.3f}" y="{qy - 7:.3f}" '
                 f'font-family="sans-serif" font-size="10">'
-                f'{html.escape(str(entry["query_id"]))} → {entry["node_id"]}</text>',
+                f"{html.escape(str(entry['query_id']))} → {entry['node_id']}</text>",
             )
         )
     elements.append("</svg>")

--- a/src/causal4d/external_reference.py
+++ b/src/causal4d/external_reference.py
@@ -1,0 +1,157 @@
+"""Strict evaluation-only reference trajectories for external bridge studies."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from causal4d.contracts import array_sha256
+from causal4d.immutable_array import readonly_array, readonly_integer_array
+from causal4d.numpy_archive import load_numpy_archive
+
+EXTERNAL_REFERENCE_SCHEMA = "causal4d.external_reference_trajectory"
+EXTERNAL_REFERENCE_SCHEMA_VERSION = 1
+
+_REQUIRED_MEMBERS = frozenset(
+    {"case_id", "node_ids", "positions_world_m", "frame_times_s"}
+)
+_OPTIONAL_MEMBERS = frozenset({"validity_mask"})
+
+
+def _scalar_text(value: np.ndarray, *, name: str) -> str:
+    array = np.asarray(value)
+    if array.shape != () or array.dtype.kind not in {"U", "S"}:
+        raise ValueError(f"{name} must be a scalar text member")
+    item: Any = array.item()
+    if isinstance(item, bytes):
+        try:
+            item = item.decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise ValueError(f"{name} must be valid UTF-8") from error
+    if type(item) is not str or not item:
+        raise ValueError(f"{name} must be a nonempty string")
+    return item
+
+
+@dataclass(frozen=True)
+class ExternalReferenceTrajectory:
+    """A content-addressed trajectory used only for evaluation and baselines."""
+
+    case_id: str
+    node_ids: np.ndarray
+    positions_m: np.ndarray
+    frame_times_s: np.ndarray
+    validity: np.ndarray
+    source_npz_sha256: str
+
+    def __post_init__(self) -> None:
+        if type(self.case_id) is not str or not self.case_id:
+            raise ValueError("reference case_id must be a nonempty string")
+        nodes = readonly_integer_array(self.node_ids, name="reference node_ids")
+        if nodes.ndim != 1 or not len(nodes):
+            raise ValueError("reference node_ids must be a nonempty vector")
+        if np.any(nodes < 0) or len(np.unique(nodes)) != len(nodes):
+            raise ValueError("reference node_ids must be unique and nonnegative")
+        positions = np.asarray(self.positions_m, dtype=np.float64).copy()
+        if positions.ndim != 3 or positions.shape[1:] != (len(nodes), 3):
+            raise ValueError("reference positions must have shape (T, N, 3)")
+        if positions.shape[0] < 2:
+            raise ValueError("reference trajectory must contain at least two frames")
+        times = readonly_array(self.frame_times_s, dtype=np.float64)
+        if times.shape != (positions.shape[0],) or not np.all(np.isfinite(times)):
+            raise ValueError("reference frame_times_s must be finite and match T")
+        if np.any(np.diff(times) <= 0.0):
+            raise ValueError("reference frame_times_s must be strictly increasing")
+        valid = np.asarray(self.validity, dtype=bool).copy()
+        if valid.shape == positions.shape[:2]:
+            valid = np.repeat(valid[..., None], 3, axis=2)
+        if valid.shape != positions.shape:
+            raise ValueError(
+                "reference validity must have shape (T, N) or (T, N, 3)"
+            )
+        if np.any(valid & ~np.isfinite(positions)):
+            raise ValueError("valid reference coordinates must be finite")
+        if not np.any(valid):
+            raise ValueError("reference trajectory has no valid coordinates")
+        positions[~valid] = np.nan
+        positions = readonly_array(positions, dtype=np.float64)
+        valid = readonly_array(valid, dtype=bool)
+        digest = self.source_npz_sha256
+        if (
+            type(digest) is not str
+            or len(digest) != 64
+            or any(character not in "0123456789abcdef" for character in digest)
+        ):
+            raise ValueError("source_npz_sha256 must be a lowercase SHA-256 digest")
+        object.__setattr__(self, "node_ids", nodes)
+        object.__setattr__(self, "positions_m", positions)
+        object.__setattr__(self, "frame_times_s", times)
+        object.__setattr__(self, "validity", valid)
+
+    @property
+    def artifact_id(self) -> str:
+        descriptor = {
+            "schema": EXTERNAL_REFERENCE_SCHEMA,
+            "schema_version": EXTERNAL_REFERENCE_SCHEMA_VERSION,
+            "case_id": self.case_id,
+            "source_npz_sha256": self.source_npz_sha256,
+            "arrays": {
+                "node_ids": array_sha256(self.node_ids),
+                "positions_m": array_sha256(self.positions_m),
+                "frame_times_s": array_sha256(self.frame_times_s),
+                "validity": array_sha256(self.validity),
+            },
+        }
+        encoded = json.dumps(
+            descriptor,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+
+def load_external_reference(path: str | Path) -> ExternalReferenceTrajectory:
+    """Load a closed, non-pickled evaluation-reference NPZ."""
+
+    snapshot = load_numpy_archive(path, name="external reference trajectory")
+    archive = snapshot.arrays
+    members = frozenset(archive)
+    missing = sorted(_REQUIRED_MEMBERS - members)
+    unexpected = sorted(members - _REQUIRED_MEMBERS - _OPTIONAL_MEMBERS)
+    if missing or unexpected:
+        raise ValueError(
+            "external reference archive members changed; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    case_id = _scalar_text(archive["case_id"], name="case_id")
+    nodes = np.asarray(archive["node_ids"])
+    positions = np.asarray(archive["positions_world_m"], dtype=np.float64)
+    times = np.asarray(archive["frame_times_s"], dtype=np.float64)
+    validity = (
+        np.asarray(archive["validity_mask"], dtype=bool)
+        if "validity_mask" in members
+        else np.isfinite(positions)
+    )
+    source_hash = snapshot.snapshot.sha256
+    return ExternalReferenceTrajectory(
+        case_id=case_id,
+        node_ids=nodes,
+        positions_m=positions,
+        frame_times_s=times,
+        validity=validity,
+        source_npz_sha256=source_hash,
+    )
+
+
+__all__ = [
+    "EXTERNAL_REFERENCE_SCHEMA",
+    "EXTERNAL_REFERENCE_SCHEMA_VERSION",
+    "ExternalReferenceTrajectory",
+    "load_external_reference",
+]

--- a/src/causal4d/external_reference.py
+++ b/src/causal4d/external_reference.py
@@ -71,9 +71,7 @@ class ExternalReferenceTrajectory:
         if valid.shape == positions.shape[:2]:
             valid = np.repeat(valid[..., None], 3, axis=2)
         if valid.shape != positions.shape:
-            raise ValueError(
-                "reference validity must have shape (T, N) or (T, N, 3)"
-            )
+            raise ValueError("reference validity must have shape (T, N) or (T, N, 3)")
         if np.any(valid & ~np.isfinite(positions)):
             raise ValueError("valid reference coordinates must be finite")
         if not np.any(valid):

--- a/tests/test_external_bridge_workflow.py
+++ b/tests/test_external_bridge_workflow.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from causal4d.cli.external_bridge_run import main as bridge_run_main
+from causal4d.cli.external_bridge_workflow import main as workflow_main
+from causal4d.cli.external_node_mapping import main as mapping_main
+from causal4d.external_bridge_run import (
+    analyze_external_bridge,
+    publish_external_bridge_run,
+)
+from causal4d.external_forecast import ExternalForecastBundle, save_external_forecast
+from causal4d.external_node_mapping import build_external_node_mapping
+from causal4d.external_reference import load_external_reference
+from causal4d.external_rollout import (
+    EXTERNAL_ROLLOUT_IMPORT_SCHEMA,
+    import_external_rollouts,
+    save_external_rollout_bank,
+)
+
+
+def _write_rollout_source(path: Path) -> None:
+    trajectories = np.zeros((2, 4, 2, 3), dtype=np.float64)
+    trajectories[0, :, 0, 0] = [0.0, 0.01, 0.02, 0.03]
+    trajectories[1, :, 0, 0] = [0.0, 0.02, 0.04, 0.06]
+    trajectories[:, :, 1, 1] = 0.25
+    np.savez_compressed(
+        path,
+        nodes=np.asarray([10, 20], dtype=np.int64),
+        trajectories=trajectories,
+        times=np.asarray([0.0, 0.5, 1.0, 1.5]),
+        weights=np.asarray([0.5, 0.5]),
+        ids=np.asarray(["slow", "fast"]),
+    )
+
+
+def _write_rollout_manifest(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema": EXTERNAL_ROLLOUT_IMPORT_SCHEMA,
+                "schema_version": 1,
+                "case_id": "cloth",
+                "source": {"simulator": "unit-test", "revision": "abc"},
+                "arrays": {
+                    "node_ids": "nodes",
+                    "trajectories": "trajectories",
+                    "frame_times_s": "times",
+                    "rollout_weights": "weights",
+                    "rollout_ids": "ids",
+                },
+                "layout": "RTNC",
+                "coordinate_frame": "world",
+                "position_unit": "m",
+                "anchor_time_s": 0.0,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _forecast() -> ExternalForecastBundle:
+    future = np.zeros((1, 3, 1, 3), dtype=np.float64)
+    future[0, :, 0, 0] = [0.01, 0.02, 0.03]
+    return ExternalForecastBundle(
+        case_id="cloth",
+        source_model="MolmoMotion",
+        source_revision="checkpoint",
+        forecast_ids=("instruction",),
+        node_indices=np.asarray([10], dtype=np.int64),
+        anchor_positions_m=np.zeros((1, 3)),
+        future_positions_m=future,
+        physical_frame_indices=np.asarray([1.0, 2.0, 3.0]),
+        future_times_s=np.asarray([0.5, 1.0, 1.5]),
+    )
+
+
+def _write_reference(path: Path) -> None:
+    positions = np.zeros((5, 2, 3), dtype=np.float64)
+    positions[:, 0, 0] = [-0.01, 0.0, 0.01, 0.02, 0.03]
+    positions[:, 1, 1] = 0.25
+    np.savez_compressed(
+        path,
+        case_id=np.asarray("cloth"),
+        node_ids=np.asarray([10, 20], dtype=np.int64),
+        positions_world_m=positions,
+        frame_times_s=np.asarray([-0.5, 0.0, 0.5, 1.0, 1.5]),
+        validity_mask=np.ones((5, 2), dtype=bool),
+    )
+
+
+def test_bridge_run_publishes_metrics_and_exact_fallback(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "rollouts.npz"
+    manifest = tmp_path / "rollouts.json"
+    rollout_bank_path = tmp_path / "canonical_rollouts.npz"
+    forecast_path = tmp_path / "forecast.npz"
+    reference_path = tmp_path / "reference.npz"
+    output = tmp_path / "result"
+    _write_rollout_source(source)
+    _write_rollout_manifest(manifest)
+    rollouts = import_external_rollouts(source, manifest)
+    save_external_rollout_bank(rollout_bank_path, rollouts)
+    forecast = _forecast()
+    save_external_forecast(forecast_path, forecast)
+    _write_reference(reference_path)
+    reference = load_external_reference(reference_path)
+
+    report, arrays = analyze_external_bridge(
+        forecast,
+        "instruction",
+        rollouts,
+        beta_values=(0.0, 3.0, 12.0),
+        scale_m=0.005,
+        reference=reference,
+    )
+    assert report["doctor"]["beta_zero_weights_bit_identical"] is True
+    assert arrays["posterior_weights"][0].tobytes() == (
+        rollouts.bank.prior_joint_weights.tobytes()
+    )
+    assert arrays["posterior_weights"][1, 0, 0] > 0.5
+    metrics = {row["method"]: row for row in report["metrics"]}
+    assert metrics["constant_velocity"]["ade_m"] == pytest.approx(0.0)
+    assert metrics["external_forecast"]["ade_m"] == pytest.approx(0.0)
+    assert metrics["semantic_beta_3"]["ade_m"] < metrics["physical_prior"]["ade_m"]
+    assert report["evaluation_only_best_beta"] in {3.0, 12.0}
+
+    published = publish_external_bridge_run(output, report, arrays)
+    assert len(published["manifest_id"]) == 64
+    for name in (
+        "doctor.json",
+        "summary.json",
+        "summary.md",
+        "metrics.csv",
+        "weights.csv",
+        "error_vs_horizon.csv",
+        "error_vs_horizon.svg",
+        "predictions.npz",
+        "manifest.json",
+    ):
+        assert (output / name).is_file()
+    assert "constant_velocity" in (output / "metrics.csv").read_text(encoding="utf-8")
+
+    cli_output = tmp_path / "cli-result"
+    assert (
+        bridge_run_main(
+            [
+                str(forecast_path),
+                str(rollout_bank_path),
+                "instruction",
+                str(cli_output),
+                "--reference",
+                str(reference_path),
+                "--beta",
+                "0",
+                "--beta",
+                "3",
+                "--scale-m",
+                "0.005",
+            ]
+        )
+        == 0
+    )
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["exact_beta_zero_fallback"] is True
+    assert summary["reference_evaluated"] is True
+
+
+def test_reference_loader_rejects_unknown_members(tmp_path: Path) -> None:
+    path = tmp_path / "reference.npz"
+    np.savez_compressed(
+        path,
+        case_id=np.asarray("cloth"),
+        node_ids=np.asarray([10]),
+        positions_world_m=np.zeros((2, 1, 3)),
+        frame_times_s=np.asarray([0.0, 1.0]),
+        unexpected=np.asarray([1]),
+    )
+    with pytest.raises(ValueError, match="unexpected"):
+        load_external_reference(path)
+
+
+def test_geometric_node_mapping_is_unique_and_fail_closed(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    queries = np.asarray([[0.01, 0.0, 0.0], [0.02, 0.0, 0.0]])
+    nodes = np.asarray([[0.0, 0.0, 0.0], [0.10, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    node_ids = np.asarray([100, 200, 300])
+    report = build_external_node_mapping(
+        queries,
+        nodes,
+        node_ids,
+        query_ids=("left", "right"),
+        maximum_distance_m=0.09,
+    )
+    assert report["accepted"] is True
+    assigned = [entry["node_id"] for entry in report["entries"]]
+    assert len(set(assigned)) == 2
+    assert assigned == [100, 200]
+
+    query_path = tmp_path / "query.npz"
+    node_path = tmp_path / "nodes.npz"
+    output_json = tmp_path / "mapping.json"
+    output_npz = tmp_path / "mapping.npz"
+    output_svg = tmp_path / "mapping.svg"
+    np.savez_compressed(
+        query_path,
+        anchors=queries,
+        labels=np.asarray(["left", "right"]),
+    )
+    np.savez_compressed(node_path, positions=nodes, ids=node_ids)
+    result = mapping_main(
+        [
+            str(query_path),
+            str(node_path),
+            str(output_json),
+            "--output-npz",
+            str(output_npz),
+            "--output-svg",
+            str(output_svg),
+            "--query-position-key",
+            "anchors",
+            "--query-id-key",
+            "labels",
+            "--node-position-key",
+            "positions",
+            "--node-id-key",
+            "ids",
+            "--maximum-distance-m",
+            "0.015",
+        ]
+    )
+    assert result == 3
+    cli_summary = json.loads(capsys.readouterr().out)
+    assert cli_summary["accepted"] is False
+    assert output_json.is_file()
+    assert output_npz.is_file()
+    assert output_svg.is_file()
+
+
+def test_single_module_bridge_workflow_dispatches_help() -> None:
+    assert workflow_main(["--help"]) == 0


### PR DESCRIPTION
## Summary

Complete the collaborator-facing workflow around the existing external forecast and rollout contracts.

- add a single module command family for forecast import, rollout import, preflight doctor, geometric node mapping, and report generation;
- add a closed, content-addressed evaluation-reference trajectory contract;
- add a global minimum-distance one-to-one query-to-simulator-node mapper with frozen tolerance, machine-readable mapping, and an SVG audit view;
- add a one-command semantic-weight sweep over complete physical rollouts while preserving byte-identical beta-zero fallback;
- automatically report zero-motion, constant-velocity, external-forecast, physical-prior, semantic-reweighted, and diagnostic component-oracle results when a reference is supplied;
- publish ADE, FDE, coordinate RMSE, empirical interval coverage, error-versus-horizon, physical/semantic weight shifts, KL divergence, effective support size, predictions, and a content manifest;
- explicitly label the reference-selected best beta as evaluation-only and non-deployable; and
- document the complete handoff from two producer NPZs to a validated result directory.

## Usage

```bash
python -m causal4d.cli.external_bridge_workflow import-forecast \
  producer_forecast.npz forecast_manifest.json canonical_forecast.npz

python -m causal4d.cli.external_bridge_workflow import-rollouts \
  producer_rollouts.npz rollout_manifest.json canonical_rollouts.npz

python -m causal4d.cli.external_bridge_workflow doctor \
  canonical_forecast.npz canonical_rollouts.npz instruction doctor.json

python -m causal4d.cli.external_bridge_workflow run \
  canonical_forecast.npz canonical_rollouts.npz instruction results \
  --reference reference.npz \
  --beta 0 --beta 1 --beta 3 --beta 6 --beta 12
```

When exact material IDs are unavailable:

```bash
python -m causal4d.cli.external_bridge_workflow map-nodes \
  query_anchors.npz simulator_nodes.npz mapping.json \
  --output-npz mapping.npz --output-svg mapping.svg
```

## Validation

Final head: `eab0b56f1061ce869c41bfcce75786a259a5098f`.

Authoritative checks passed:

- CI and release, including Ruff, formatting, types, Python 3.10/3.12/3.14, wheel/sdist builds, installed-command help, result bundles, and pinned BayesianPhysTwin integration;
- Causal4D merge gate, including the complete default suite and installed-wheel provider integration;
- Extended compatibility, including dependency floors and additional Python versions;
- security scanning, CodeQL for Python and Actions, and dependency audit.

Additional local validation:

- focused bridge, external-rollout, and packaged MolmoMotion example tests: **11 passed**;
- expanded focused suite including command/import regressions before the module-command refactor: **21 passed**;
- Python compilation passed for all new source and test modules.

## Scientific boundary

This is integration, diagnostics, and reporting infrastructure. The beta sweep and any reference-selected best beta are diagnostic only. Positive semantic trust still requires source-only calibration and independent confirmation. The forecast remains a separate task factor and never overwrites physical state or parameters; rejection preserves the physical weights exactly.