### PR TITLE
Fix the prepared Prob4D benchmark anchor frame

### DIFF
--- a/scripts/ci/benchmark_prob4d_prepared_per_view.py
+++ b/scripts/ci/benchmark_prob4d_prepared_per_view.py
@@ -70,11 +70,12 @@ def _prob4d_benchmark(
     component_chunk_size: int,
 ) -> dict[str, Any]:
     descriptor, arrays = _fixture()
+    rollout_frame_ids = (0, 1, 2, 3, 4, 5)
     prepared, preparation_seconds = _timed(
         lambda: prepare_prob4d_joint_observation(
             descriptor,
             arrays,
-            rollout_frame_ids=(1, 2, 3, 4, 5),
+            rollout_frame_ids=rollout_frame_ids,
             entity_to_node={0: 0, 1: 1},
             reliability_policy="record_only",
         )
@@ -82,20 +83,22 @@ def _prob4d_benchmark(
     rng = np.random.default_rng(20260812)
     components = rng.normal(
         scale=0.05,
-        size=(component_count, 5, 2, 3),
+        size=(component_count, len(rollout_frame_ids), 2, 3),
     )
     components[..., 2] += 1.0
+    components[:, 0] = 0.0
+    prefix_frame_count = len(rollout_frame_ids)
     (legacy_score, _), legacy_seconds = _timed(
         lambda: joint_component_log_likelihoods(
             components,
             prepared.evidence,
-            prefix_frame_count=5,
+            prefix_frame_count=prefix_frame_count,
         )
     )
     (prepared_score, diagnostics), prepared_seconds = _timed(
         lambda: prepared.log_likelihoods(
             components,
-            prefix_frame_count=5,
+            prefix_frame_count=prefix_frame_count,
             component_chunk_size=component_chunk_size,
         )
     )
@@ -115,7 +118,7 @@ def _prob4d_benchmark(
     for _ in range(repeat_count):
         score, repeated_diagnostics = prepared.log_likelihoods(
             components,
-            prefix_frame_count=5,
+            prefix_frame_count=prefix_frame_count,
             component_chunk_size=component_chunk_size,
         )
         checksum += float(np.sum(score))
@@ -130,6 +133,10 @@ def _prob4d_benchmark(
         "row_count": prepared.adapter_diagnostics.row_count,
         "observation_count": prepared.adapter_diagnostics.observation_count,
         "shared_rank": prepared.adapter_diagnostics.factor_rank,
+        "rollout_frame_ids": list(rollout_frame_ids),
+        "frame_mapping": [
+            list(item) for item in prepared.adapter_diagnostics.frame_mapping
+        ],
         "component_count": component_count,
         "repeat_count": repeat_count,
         "component_chunk_size": diagnostics.component_chunk_size,

--- a/tests/test_prob4d_prepared_benchmark.py
+++ b/tests/test_prob4d_prepared_benchmark.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from scripts.ci.benchmark_prob4d_prepared_per_view import _prob4d_benchmark
+
+
+def test_prob4d_prepared_benchmark_preserves_unobserved_anchor_frame() -> None:
+    result = _prob4d_benchmark(
+        component_count=4,
+        repeat_count=2,
+        component_chunk_size=2,
+    )
+
+    assert result["rollout_frame_ids"] == [0, 1, 2, 3, 4, 5]
+    assert min(mapping[1] for mapping in result["frame_mapping"]) == 1
+    assert result["exact_score_parity"] is True
+    assert result["maximum_absolute_score_difference"] == 0.0
+    assert result["base_factorization_reused"] is True


### PR DESCRIPTION
## Summary

Fix the reviewed-main self-hosted integrated benchmark exposed by run `31385647698`.

The strict Prob4D fixture contains absolute observations for source frames 1 through 5. The benchmark previously declared rollout frames `(1, 2, 3, 4, 5)`, which mapped source frame 1 to internal rollout index 0. Causal4D correctly reserves internal frame 0 for translation-neutral endpoint contrasts and therefore rejected the absolute point row.

This change:

- prepends the unobserved rollout anchor frame 0;
- scores six-frame rollout components while retaining Prob4D observations on internal frames 1 through 5;
- records both rollout-frame IDs and the resulting frame mapping in the benchmark artifact; and
- adds a hosted regression test that executes the strict fixture and verifies no absolute observation maps to frame 0, exact legacy parity remains zero, and the prepared base solver is reused.

## Failure provenance

- failed reviewed-main self-hosted run: `31385647698`;
- exact executed revision: `a9a6829bf847b4b43aa5cfcaafa10109b4b612df`;
- failing invariant: `endpoint zero-sum contrast must be translation-neutral per coordinate`;
- focused installed-wheel tests and the existing 512/2,048-row benchmarks passed before the integrated benchmark reached this configuration error.

## Scientific boundary

This changes only synthetic benchmark frame indexing. It does not modify the Prob4D adapter, likelihood, prepared solver, frozen estimator, registered physical protocol, target boundary, calibration claim, or physical evidence count. `target_outcomes_used=false` and `physical_evidence_increment=0` remain unchanged.