### PR TITLE
Harden acquisition inputs and SBC artifact publication

### DIFF
--- a/.github/workflows/acquisition-journal-contract.yml
+++ b/.github/workflows/acquisition-journal-contract.yml
@@ -8,8 +8,11 @@ on:
       - "src/causal4d/acquisition_journal_io.py"
       - "src/causal4d/acquisition_journal_lock.py"
       - "src/causal4d/acquisition_journal_seal.py"
+      - "src/causal4d/artifact_io.py"
+      - "src/causal4d/cli/acquisition_operations.py"
       - "tests/test_acquisition_flight_recorder.py"
       - "tests/test_acquisition_journal_locking.py"
+      - "tests/test_acquisition_operations.py"
       - "docs/causal4d_acquisition_flight_recorder.md"
   push:
     branches: [main]
@@ -18,8 +21,11 @@ on:
       - "src/causal4d/acquisition_journal_io.py"
       - "src/causal4d/acquisition_journal_lock.py"
       - "src/causal4d/acquisition_journal_seal.py"
+      - "src/causal4d/artifact_io.py"
+      - "src/causal4d/cli/acquisition_operations.py"
       - "tests/test_acquisition_flight_recorder.py"
       - "tests/test_acquisition_journal_locking.py"
+      - "tests/test_acquisition_operations.py"
   workflow_dispatch:
 
 permissions:
@@ -48,25 +54,31 @@ jobs:
       - name: Install development environment
         run: python -m pip install -e ".[dev]"
 
-      - name: Check claim-bearing journal code
+      - name: Check claim-bearing acquisition code
         run: |
           python -m ruff check \
             src/causal4d/acquisition_journal_io.py \
             src/causal4d/acquisition_journal_lock.py \
             src/causal4d/acquisition_journal_seal.py \
-            tests/test_acquisition_journal_locking.py
+            src/causal4d/cli/acquisition_operations.py \
+            tests/test_acquisition_journal_locking.py \
+            tests/test_acquisition_operations.py
           python -m ruff format --check \
             src/causal4d/acquisition_journal_io.py \
             src/causal4d/acquisition_journal_lock.py \
             src/causal4d/acquisition_journal_seal.py \
-            tests/test_acquisition_journal_locking.py
+            src/causal4d/cli/acquisition_operations.py \
+            tests/test_acquisition_journal_locking.py \
+            tests/test_acquisition_operations.py
           python -m mypy \
             src/causal4d/acquisition_journal_io.py \
             src/causal4d/acquisition_journal_lock.py \
-            src/causal4d/acquisition_journal_seal.py
+            src/causal4d/acquisition_journal_seal.py \
+            src/causal4d/cli/acquisition_operations.py
 
       - name: Exercise journal invariants and process races
         run: |
           python -m pytest -q \
             tests/test_acquisition_journal_locking.py \
-            tests/test_acquisition_flight_recorder.py
+            tests/test_acquisition_flight_recorder.py \
+            tests/test_acquisition_operations.py

--- a/src/causal4d/cli/acquisition_operations.py
+++ b/src/causal4d/cli/acquisition_operations.py
@@ -17,15 +17,17 @@ from causal4d.acquisition_flight_recorder import (
     validate_acquisition_journal,
     validate_acquisition_journal_seal,
 )
+from causal4d.artifact_io import (
+    load_strict_json_object,
+    read_regular_file_no_symlinks,
+)
 from causal4d.atomic_io import atomic_write_json
 from causal4d.real_protocol import validate_protocol
 
 
 def _json_object(path: Path, *, name: str) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError(f"{name} must contain a JSON object")
-    return payload
+    snapshot = read_regular_file_no_symlinks(path, name=name)
+    return load_strict_json_object(snapshot.payload, name=name)
 
 
 def _gib(value: str | float) -> int:

--- a/src/causal4d/cli/latent_contact_benchmark.py
+++ b/src/causal4d/cli/latent_contact_benchmark.py
@@ -7,6 +7,8 @@ import json
 from collections.abc import Sequence
 from pathlib import Path
 
+from causal4d.artifact_io import read_regular_file
+from causal4d.atomic_io import atomic_write_json
 from causal4d.benchmark import CounterfactualBenchmarkConfig
 from causal4d.contact_evaluation import (
     run_latent_contact_benchmark,
@@ -117,13 +119,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             if args.sbc_output_json
             else Path(args.output_dir) / "sbc.json"
         )
-        sbc_path.parent.mkdir(parents=True, exist_ok=True)
-        sbc_path.write_text(
-            json.dumps(sbc, indent=2, sort_keys=True, allow_nan=False) + "\n",
-            encoding="utf-8",
-        )
+        atomic_write_json(sbc_path, sbc)
+        sbc_snapshot = read_regular_file(sbc_path, name="SBC result")
         summary["sbc"] = {
             "path": str(sbc_path.resolve()),
+            "sha256": sbc_snapshot.sha256,
+            "byte_count": sbc_snapshot.byte_count,
+            "configuration": {
+                "seeds": seeds,
+                "trials_per_fold": args.sbc_trials_per_fold,
+                "bin_count": args.sbc_bins,
+                "benchmark": benchmark_config.as_dict(),
+                "contact": contact_config.as_dict(),
+            },
             "aggregate": sbc["aggregate"],
             "interpretation": sbc["interpretation"],
         }

--- a/tests/test_acquisition_operations.py
+++ b/tests/test_acquisition_operations.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from causal4d.artifact_io import ArtifactValidationError
+from causal4d.cli.acquisition_operations import _json_object, main
+
+
+@pytest.mark.parametrize(
+    ("payload", "error_pattern"),
+    [
+        (b'{"value": 1, "value": 2}\n', "duplicate JSON object key"),
+        (b'{"value": NaN}\n', "non-finite JSON number"),
+        (b'{"value": Infinity}\n', "non-finite JSON number"),
+        (b'{"value": -Infinity}\n', "non-finite JSON number"),
+        (b'{"value": 1e999}\n', "non-finite JSON number"),
+        (b"\xff", "not valid UTF-8 JSON"),
+        (b"[]\n", "must contain one JSON object"),
+    ],
+    ids=[
+        "duplicate-key",
+        "nan",
+        "positive-infinity",
+        "negative-infinity",
+        "overflowing-float",
+        "invalid-utf8",
+        "non-object",
+    ],
+)
+def test_json_object_rejects_ambiguous_or_nonfinite_inputs(
+    tmp_path: Path,
+    payload: bytes,
+    error_pattern: str,
+) -> None:
+    path = tmp_path / "input.json"
+    path.write_bytes(payload)
+
+    with pytest.raises(ArtifactValidationError, match=error_pattern):
+        _json_object(path, name="test input")
+
+
+def test_json_object_accepts_one_finite_utf8_object(tmp_path: Path) -> None:
+    path = tmp_path / "input.json"
+    path.write_bytes(b'{"nested": {"value": 1.25}, "enabled": true}\n')
+
+    assert _json_object(path, name="test input") == {
+        "nested": {"value": 1.25},
+        "enabled": True,
+    }
+
+
+def test_json_object_rejects_a_file_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "target.json"
+    target.write_text('{"value": 1}\n', encoding="utf-8")
+    link = tmp_path / "input.json"
+    try:
+        link.symlink_to(target)
+    except (NotImplementedError, OSError) as error:  # pragma: no cover - platform
+        pytest.skip(f"symlinks unavailable: {error}")
+
+    with pytest.raises(ArtifactValidationError, match="ordinary readable file"):
+        _json_object(link, name="test input")
+
+
+def test_json_object_rejects_a_symlinked_parent_directory(tmp_path: Path) -> None:
+    real_parent = tmp_path / "real"
+    real_parent.mkdir()
+    (real_parent / "input.json").write_text('{"value": 1}\n', encoding="utf-8")
+    linked_parent = tmp_path / "linked"
+    try:
+        linked_parent.symlink_to(real_parent, target_is_directory=True)
+    except (NotImplementedError, OSError) as error:  # pragma: no cover - platform
+        pytest.skip(f"symlinks unavailable: {error}")
+
+    with pytest.raises(ArtifactValidationError, match="ordinary readable file"):
+        _json_object(linked_parent / "input.json", name="test input")
+
+
+def test_invalid_journal_payload_never_appends_bytes(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = tmp_path / "payload.json"
+    payload.write_bytes(b'{"note": "first", "note": "second"}\n')
+    journal = tmp_path / "acquisition.jsonl"
+
+    status = main(
+        [
+            "journal",
+            "append",
+            str(journal),
+            "session_started",
+            "--protocol-id",
+            "protocol-v1",
+            "--session-id",
+            "session-1",
+            "--source",
+            "test",
+            "--payload-json",
+            str(payload),
+            "--recorded-at-utc",
+            "2026-08-10T12:00:00+00:00",
+            "--monotonic-ns",
+            "1",
+        ]
+    )
+
+    assert status == 2
+    assert not journal.exists()
+    assert "duplicate JSON object key" in capsys.readouterr().out

--- a/tests/test_latent_contact_benchmark_cli.py
+++ b/tests/test_latent_contact_benchmark_cli.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from causal4d.cli import latent_contact_benchmark as cli
+
+
+def _install_benchmark_stubs(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    sbc: dict[str, Any],
+) -> None:
+    result = {
+        "success_gates": {"overall_passed": True},
+        "aggregate": {"mean_error_m": 0.01},
+    }
+    monkeypatch.setattr(
+        cli,
+        "run_latent_contact_benchmark",
+        lambda **kwargs: result,
+    )
+    monkeypatch.setattr(
+        cli,
+        "write_latent_contact_artifacts",
+        lambda benchmark_result, output_dir: {
+            "summary": str(Path(output_dir) / "summary.json")
+        },
+    )
+    monkeypatch.setattr(
+        cli,
+        "run_controlled_latent_contact_sbc",
+        lambda **kwargs: sbc,
+    )
+
+
+def test_sbc_summary_binds_exact_artifact_and_configuration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sbc = {
+        "aggregate": {"joint_rank_histogram": [4, 5, 6, 5]},
+        "interpretation": "finite-support self-consistency diagnostic",
+    }
+    _install_benchmark_stubs(monkeypatch, sbc=sbc)
+    atomic_calls: list[tuple[Path, object]] = []
+    real_atomic_write_json = cli.atomic_write_json
+
+    def recording_atomic_write_json(path: str | Path, payload: object) -> None:
+        atomic_calls.append((Path(path), payload))
+        real_atomic_write_json(path, payload)
+
+    monkeypatch.setattr(cli, "atomic_write_json", recording_atomic_write_json)
+    output_dir = tmp_path / "run"
+
+    status = cli.main(
+        [
+            "--output-dir",
+            str(output_dir),
+            "--seeds",
+            "2,5",
+            "--frames",
+            "24",
+            "--sbc-trials-per-fold",
+            "7",
+            "--sbc-bins",
+            "4",
+        ]
+    )
+
+    assert status == 0
+    sbc_path = output_dir / "sbc.json"
+    payload = sbc_path.read_bytes()
+    summary = json.loads(capsys.readouterr().out)
+    assert atomic_calls == [(sbc_path, sbc)]
+    assert payload.endswith(b"\n")
+    assert summary["sbc"]["path"] == str(sbc_path.resolve())
+    assert summary["sbc"]["sha256"] == hashlib.sha256(payload).hexdigest()
+    assert summary["sbc"]["byte_count"] == len(payload)
+    assert summary["sbc"]["configuration"]["seeds"] == [2, 5]
+    assert summary["sbc"]["configuration"]["trials_per_fold"] == 7
+    assert summary["sbc"]["configuration"]["bin_count"] == 4
+    assert summary["sbc"]["configuration"]["benchmark"]["frame_count"] == 24
+    assert (
+        summary["sbc"]["configuration"]["contact"]["parameter_particle_count"]
+        == 12
+    )
+    assert summary["sbc"]["aggregate"] == sbc["aggregate"]
+    assert summary["sbc"]["interpretation"] == sbc["interpretation"]
+
+
+def test_invalid_sbc_json_cannot_partially_replace_existing_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_benchmark_stubs(
+        monkeypatch,
+        sbc={
+            "aggregate": {},
+            "interpretation": "invalid test payload",
+            "nonfinite": float("nan"),
+        },
+    )
+    sbc_path = tmp_path / "sbc.json"
+    sentinel = b'{"previous": true}\n'
+    sbc_path.write_bytes(sentinel)
+
+    with pytest.raises(ValueError, match="Out of range float values"):
+        cli.main(
+            [
+                "--output-dir",
+                str(tmp_path / "run"),
+                "--sbc-output-json",
+                str(sbc_path),
+                "--sbc-trials-per-fold",
+                "1",
+            ]
+        )
+
+    assert sbc_path.read_bytes() == sentinel

--- a/tests/test_latent_contact_benchmark_cli.py
+++ b/tests/test_latent_contact_benchmark_cli.py
@@ -86,10 +86,7 @@ def test_sbc_summary_binds_exact_artifact_and_configuration(
     assert summary["sbc"]["configuration"]["trials_per_fold"] == 7
     assert summary["sbc"]["configuration"]["bin_count"] == 4
     assert summary["sbc"]["configuration"]["benchmark"]["frame_count"] == 24
-    assert (
-        summary["sbc"]["configuration"]["contact"]["parameter_particle_count"]
-        == 12
-    )
+    assert summary["sbc"]["configuration"]["contact"]["parameter_particle_count"] == 12
     assert summary["sbc"]["aggregate"] == sbc["aggregate"]
     assert summary["sbc"]["interpretation"] == sbc["interpretation"]
 


### PR DESCRIPTION
## What changed

- Route acquisition protocol and journal-payload JSON through the existing exact-byte strict reader.
- Reject duplicate keys, non-finite numbers, invalid UTF-8, non-object roots, file symlinks, and symlinked parent components before any acquisition mutation.
- Add CLI-level regression coverage proving an invalid journal payload cannot create or append journal bytes.
- Publish controlled SBC JSON through `atomic_write_json` instead of a direct write.
- Bind the exact SBC artifact SHA-256, byte count, seeds, trial count, bin count, benchmark configuration, and contact configuration into the emitted CLI summary.
- Add a failure-path test proving a non-finite SBC result cannot partially replace an existing artifact.
- Extend the acquisition contract workflow so the new input boundary is linted, formatted, typed, and exercised explicitly.

## Why

The acquisition CLI was the remaining claim-bearing path that decoded protocol and payload files with `json.loads(Path.read_text(...))`. That silently accepted duplicate keys, followed symlinked path components, and did not share the repository's exact-byte JSON boundary. The newly merged SBC CLI also wrote its result directly, leaving a partial-publication window and no exact output identity in the command summary.

These changes harden evidence handling without changing the frozen estimator, registered interventions, target boundary, comparison arms, or physical evidence count.

## Validation

Validated on exact head `eba37f13e71d0d767f1a2a7d8487232c39ed7834`:

- [x] Acquisition journal contract
- [x] Causal4D merge gate, including repository quality checks, complete default test suite, distribution validation, and isolated pinned BayesianPhysTwin wheel integration
- [x] CI and release, including Python 3.10/3.12/3.14 core suites, Ruff/format/type checks, wheel/sdist CLI smoke tests, result-bundle production/consumption, frozen-manifest validation, and pinned-provider integration
- [x] Extended compatibility
- [x] Security scanning

New focused tests cover strict JSON rejection, symlink rejection, mutation ordering, exact SBC digest/configuration binding, and atomic rollback on serialization failure.