### PR TITLE
Add BayesianPhysTwin dynamic belief provider v3 contract

### DIFF
--- a/.github/workflows/belief-provider-v3-integration.yml
+++ b/.github/workflows/belief-provider-v3-integration.yml
@@ -1,0 +1,120 @@
+name: Belief-provider-v3 installed-wheel integration
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/belief-provider-v3-integration.yml"
+      - "ci/bayesian_phystwin_provider_registry.json"
+      - "docs/bayesian_phystwin_belief_provider_v3.md"
+      - "src/causal4d/belief_provider_v3_contract.py"
+      - "tests/test_belief_provider_v3_contract.py"
+      - "tests/test_belief_provider_v3_workflow_policy.py"
+      - "tests/test_bpt_provider_registry.py"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/belief-provider-v3-integration.yml"
+      - "ci/bayesian_phystwin_provider_registry.json"
+      - "docs/bayesian_phystwin_belief_provider_v3.md"
+      - "src/causal4d/belief_provider_v3_contract.py"
+      - "tests/test_belief_provider_v3_contract.py"
+      - "tests/test_belief_provider_v3_workflow_policy.py"
+      - "tests/test_bpt_provider_registry.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: belief-provider-v3-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  installed-wheel-contract:
+    name: BayesianPhysTwin dynamic endpoint -> Causal4D contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact Causal4D revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          path: causal4d
+          persist-credentials: false
+
+      - name: Verify tested Causal4D revision
+        working-directory: causal4d
+        env:
+          EXPECTED_CAUSAL4D_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          actual_sha="$(git rev-parse HEAD)"
+          test "$actual_sha" = "$EXPECTED_CAUSAL4D_SHA"
+          echo "Tested Causal4D revision: $actual_sha"
+
+      - name: Check out exact Bayesian-PhysTwin belief-provider-v3 revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/BayesianPhysTwin
+          ref: 62dff353903dcad273ffcd96644e3c2b3f9e5fd1
+          path: bayesian-phystwin
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            causal4d/pyproject.toml
+            bayesian-phystwin/pyproject.toml
+
+      - name: Build both wheels
+        run: |
+          python -m pip install --upgrade build pip
+          wheelhouse="$RUNNER_TEMP/belief-provider-v3-wheelhouse"
+          mkdir -p "$wheelhouse"
+          python -m build --wheel --outdir "$wheelhouse" bayesian-phystwin
+          python -m build --wheel --outdir "$wheelhouse" causal4d
+          test "$(find "$wheelhouse" -maxdepth 1 -name '*.whl' | wc -l)" -eq 2
+
+      - name: Install wheels in an isolated environment
+        run: |
+          venv="$RUNNER_TEMP/belief-provider-v3-venv"
+          wheelhouse="$RUNNER_TEMP/belief-provider-v3-wheelhouse"
+          python -m venv "$venv"
+          "$venv/bin/python" -m pip install --upgrade pip
+          mapfile -t wheels < <(find "$wheelhouse" -maxdepth 1 -name '*.whl' -print | sort)
+          "$venv/bin/python" -m pip install "${wheels[@]}" pytest
+          "$venv/bin/python" -m pip check
+
+      - name: Exercise the installed cross-repository contract
+        env:
+          CAUSAL4D_REQUIRE_BPT_BELIEF_PROVIDER_V3: "1"
+        run: |
+          cd "$RUNNER_TEMP"
+          env -u PYTHONPATH \
+            "$RUNNER_TEMP/belief-provider-v3-venv/bin/python" -m pytest -q \
+              --import-mode=importlib \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_belief_provider_v2_contract.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_belief_provider_v3_contract.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_bpt_provider_registry.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_belief_provider_v3_workflow_policy.py"
+
+      - name: Check Causal4D source quality
+        if: always()
+        run: |
+          python -m pip install "ruff>=0.15.22,<0.17" "mypy>=1.11"
+          python -m ruff check \
+            causal4d/src/causal4d/belief_provider_v3_contract.py \
+            causal4d/tests/test_belief_provider_v3_contract.py \
+            causal4d/tests/test_belief_provider_v3_workflow_policy.py \
+            causal4d/tests/test_bpt_provider_registry.py
+          python -m ruff format --check --diff \
+            causal4d/src/causal4d/belief_provider_v3_contract.py \
+            causal4d/tests/test_belief_provider_v3_contract.py \
+            causal4d/tests/test_belief_provider_v3_workflow_policy.py \
+            causal4d/tests/test_bpt_provider_registry.py
+          cd causal4d
+          python -m mypy --python-version 3.12 \
+            src/causal4d/belief_provider_v3_contract.py

--- a/ci/bayesian_phystwin_provider_registry.json
+++ b/ci/bayesian_phystwin_provider_registry.json
@@ -33,6 +33,13 @@
       "local_contract_module": "causal4d.belief_provider_v2_contract"
     },
     {
+      "module": "bayesian_phystwin.causal4d_belief_provider_v3",
+      "api_version": 3,
+      "role": "dynamic_endpoint_model_average",
+      "lifecycle": "additive_development",
+      "local_contract_module": "causal4d.belief_provider_v3_contract"
+    },
+    {
       "module": "bayesian_phystwin.causal4d_tree_block_provider_v1",
       "api_version": 1,
       "role": "claim_bearing_tree_block_query_covariance",

--- a/docs/bayesian_phystwin_belief_provider_v3.md
+++ b/docs/bayesian_phystwin_belief_provider_v3.md
@@ -1,0 +1,48 @@
+# Bayesian-PhysTwin dynamic belief provider v3
+
+Causal4D recognizes the additive public module
+`bayesian_phystwin.causal4d_belief_provider_v3` through
+`causal4d.belief_provider_v3_contract`.
+
+The provider adds a source-frozen dynamic endpoint family while retaining the
+provider-v2 model-averaged endpoint and recursive Prob4D stream surface. It
+exposes:
+
+- an exact last-residual persistence component;
+- robust local-level components;
+- robust damped-trend components with horizon-dependent predictive means;
+- per-track or explicitly selected object-pooled component evidence;
+- fail-closed dynamic covariance; and
+- immutable dynamic configuration, posterior, and prediction artifacts.
+
+Causal4D validates the exact provider API identity, API/schema version 3,
+required capabilities, inherited provider-v2 artifact schemas, dynamic artifact
+schema version 2, package compatibility, and all scientific-boundary metadata.
+A missing capability, schema drift, metadata drift, provider-name mismatch, or
+requested-revision mismatch fails before residual inputs are opened.
+
+## Development check
+
+The contract can be checked against an installed BayesianPhysTwin wheel with:
+
+```bash
+CAUSAL4D_REQUIRE_BPT_BELIEF_PROVIDER_V3=1 python -m pytest -q \
+  tests/test_belief_provider_v3_contract.py
+```
+
+The dedicated installed-wheel workflow builds Causal4D and the exact pinned
+BayesianPhysTwin revision as separate wheels, installs them into an isolated
+virtual environment, and runs the same contract test without editable imports.
+
+## Scientific boundary
+
+Provider compatibility is software evidence only. It does not establish that a
+dynamic endpoint component improves a physical query, that raw predictive
+covariance is calibrated, or that object-pooled evidence transfers. Component
+families, priors, evidence pooling, and horizon choices require source-only
+freezing and independent grouped evaluation.
+
+Provider v3 is a post-freeze diagnostic boundary. It does not alter the frozen
+36-execution estimator, provider-v1 or provider-v2 historical experiments,
+graph-persistence fallback, Prob4D admission decision, physical evidence count,
+or method-freeze rules.

--- a/src/causal4d/belief_provider_v3_contract.py
+++ b/src/causal4d/belief_provider_v3_contract.py
@@ -48,8 +48,7 @@ BAYESIAN_PHYSTWIN_BELIEF_V3_COMPONENT_PRIOR = (
     "probabilities override family balancing"
 )
 BAYESIAN_PHYSTWIN_BELIEF_V3_EVIDENCE_POOLING = (
-    "per-track by default; object-pooled weights are an explicit source-frozen "
-    "option"
+    "per-track by default; object-pooled weights are an explicit source-frozen option"
 )
 BAYESIAN_PHYSTWIN_BELIEF_V3_RAW_COVARIANCE_CLAIM = (
     "model-based predictive covariance including within-component uncertainty "
@@ -76,9 +75,7 @@ def load_bayesian_phystwin_belief_provider_v3_manifest(
         causal4d_belief_provider_v3_manifest,
     )
 
-    values = causal4d_belief_provider_v3_manifest(
-        provider_revision=provider_revision
-    )
+    values = causal4d_belief_provider_v3_manifest(provider_revision=provider_revision)
     manifest = PhysicalBeliefProviderManifest.from_provider_descriptor(values)
     if (
         provider_revision is not None
@@ -100,12 +97,8 @@ def _validate_belief_provider_v3_metadata(
         "compatibility": BAYESIAN_PHYSTWIN_BELIEF_V3_COMPATIBILITY,
         "component_prior": BAYESIAN_PHYSTWIN_BELIEF_V3_COMPONENT_PRIOR,
         "evidence_pooling": BAYESIAN_PHYSTWIN_BELIEF_V3_EVIDENCE_POOLING,
-        "raw_covariance_claim": (
-            BAYESIAN_PHYSTWIN_BELIEF_V3_RAW_COVARIANCE_CLAIM
-        ),
-        "recursive_stream_claim": (
-            BAYESIAN_PHYSTWIN_BELIEF_V3_RECURSIVE_STREAM_CLAIM
-        ),
+        "raw_covariance_claim": (BAYESIAN_PHYSTWIN_BELIEF_V3_RAW_COVARIANCE_CLAIM),
+        "recursive_stream_claim": (BAYESIAN_PHYSTWIN_BELIEF_V3_RECURSIVE_STREAM_CLAIM),
     }
     mismatches = {}
     for name, value in expected.items():

--- a/src/causal4d/belief_provider_v3_contract.py
+++ b/src/causal4d/belief_provider_v3_contract.py
@@ -1,0 +1,181 @@
+"""Compatibility contract for Bayesian-PhysTwin dynamic endpoint provider v3."""
+
+from __future__ import annotations
+
+import json
+
+from causal4d.belief_provider_v2_contract import (
+    BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_CAPABILITIES,
+    BAYESIAN_PHYSTWIN_BELIEF_V2_ARTIFACT_SCHEMA_VERSIONS,
+)
+from causal4d.provider_contract import (
+    BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE,
+    PhysicalBeliefProviderManifest,
+    ProviderCompatibilityResult,
+    validate_provider_compatibility,
+)
+
+BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_API = (
+    "bayesian_phystwin.causal4d_belief_provider_v3"
+)
+BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_API_VERSION = 3
+BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_SCHEMA_VERSIONS = (3,)
+BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_CAPABILITIES = (
+    *BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_CAPABILITIES,
+    "exact_last_residual_component",
+    "robust_local_level_components",
+    "robust_damped_trend_components",
+    "horizon_dependent_predictive_mean",
+    "fail_closed_dynamic_covariance",
+    "per_track_or_object_pooled_component_evidence",
+)
+BAYESIAN_PHYSTWIN_BELIEF_V3_ARTIFACT_SCHEMA_VERSIONS = {
+    **BAYESIAN_PHYSTWIN_BELIEF_V2_ARTIFACT_SCHEMA_VERSIONS,
+    "DynamicEndpointModelAverageConfig": 2,
+    "DynamicEndpointPosterior": 2,
+    "DynamicEndpointPrediction": 2,
+}
+BAYESIAN_PHYSTWIN_BELIEF_V3_INFERENCE_ROLE = (
+    "evidence-weighted persistent, local-level, and damped-trend "
+    "readout-discrepancy endpoint"
+)
+BAYESIAN_PHYSTWIN_BELIEF_V3_COMPATIBILITY = (
+    "additive provider; causal4d_belief_provider_v2 and frozen provider-v1 "
+    "experiments are unchanged"
+)
+BAYESIAN_PHYSTWIN_BELIEF_V3_COMPONENT_PRIOR = (
+    "equal prior mass per dynamics family by default; explicit component "
+    "probabilities override family balancing"
+)
+BAYESIAN_PHYSTWIN_BELIEF_V3_EVIDENCE_POOLING = (
+    "per-track by default; object-pooled weights are an explicit source-frozen "
+    "option"
+)
+BAYESIAN_PHYSTWIN_BELIEF_V3_RAW_COVARIANCE_CLAIM = (
+    "model-based predictive covariance including within-component uncertainty "
+    "and between-component disagreement; frequentist coverage requires "
+    "independent calibration"
+)
+BAYESIAN_PHYSTWIN_BELIEF_V3_RECURSIVE_STREAM_CLAIM = (
+    "the provider-v2 Prob4D recursive stream surface is retained without "
+    "changing its contracts or exact fallback behavior"
+)
+
+
+def load_bayesian_phystwin_belief_provider_v3_manifest(
+    *,
+    provider_revision: str | None = None,
+) -> PhysicalBeliefProviderManifest:
+    """Load BPT's additive dynamic endpoint provider descriptor."""
+
+    if provider_revision is not None and (
+        type(provider_revision) is not str or not provider_revision
+    ):
+        raise ValueError("provider_revision must be a nonempty string")
+    from bayesian_phystwin.causal4d_belief_provider_v3 import (
+        causal4d_belief_provider_v3_manifest,
+    )
+
+    values = causal4d_belief_provider_v3_manifest(
+        provider_revision=provider_revision
+    )
+    manifest = PhysicalBeliefProviderManifest.from_provider_descriptor(values)
+    if (
+        provider_revision is not None
+        and manifest.provider_revision != provider_revision
+    ):
+        raise ValueError(
+            "belief provider v3 descriptor revision does not match requested revision"
+        )
+    return manifest
+
+
+def _validate_belief_provider_v3_metadata(
+    manifest: PhysicalBeliefProviderManifest,
+) -> None:
+    expected = {
+        "provider_api": BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_API,
+        "provider_api_version": BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_API_VERSION,
+        "inference_role": BAYESIAN_PHYSTWIN_BELIEF_V3_INFERENCE_ROLE,
+        "compatibility": BAYESIAN_PHYSTWIN_BELIEF_V3_COMPATIBILITY,
+        "component_prior": BAYESIAN_PHYSTWIN_BELIEF_V3_COMPONENT_PRIOR,
+        "evidence_pooling": BAYESIAN_PHYSTWIN_BELIEF_V3_EVIDENCE_POOLING,
+        "raw_covariance_claim": (
+            BAYESIAN_PHYSTWIN_BELIEF_V3_RAW_COVARIANCE_CLAIM
+        ),
+        "recursive_stream_claim": (
+            BAYESIAN_PHYSTWIN_BELIEF_V3_RECURSIVE_STREAM_CLAIM
+        ),
+    }
+    mismatches = {}
+    for name, value in expected.items():
+        actual = manifest.metadata.get(name)
+        if type(actual) is not type(value) or actual != value:
+            mismatches[name] = (value, actual)
+    if mismatches:
+        raise ValueError(
+            "unexpected Bayesian-PhysTwin belief provider v3 metadata: "
+            + json.dumps(mismatches, sort_keys=True)
+        )
+
+
+def validate_bayesian_phystwin_belief_provider_v3(
+    manifest: PhysicalBeliefProviderManifest | None = None,
+    *,
+    provider_revision: str | None = None,
+) -> ProviderCompatibilityResult:
+    """Validate the additive dynamic endpoint provider contract."""
+
+    candidate = manifest or load_bayesian_phystwin_belief_provider_v3_manifest(
+        provider_revision=provider_revision
+    )
+    if candidate.provider_name != "bayesian-phystwin":
+        raise ValueError("expected the bayesian-phystwin belief provider v3")
+    _validate_belief_provider_v3_metadata(candidate)
+    return validate_provider_compatibility(
+        candidate,
+        required_capabilities=BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_CAPABILITIES,
+        supported_schema_versions=(
+            BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_SCHEMA_VERSIONS
+        ),
+        supported_provider_versions=BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE,
+        required_artifact_versions=(
+            BAYESIAN_PHYSTWIN_BELIEF_V3_ARTIFACT_SCHEMA_VERSIONS
+        ),
+    )
+
+
+def require_bayesian_phystwin_belief_provider_v3(
+    *,
+    provider_revision: str | None = None,
+) -> PhysicalBeliefProviderManifest:
+    """Return the installed v3 manifest or fail before opening residual inputs."""
+
+    manifest = load_bayesian_phystwin_belief_provider_v3_manifest(
+        provider_revision=provider_revision
+    )
+    result = validate_bayesian_phystwin_belief_provider_v3(manifest)
+    if not result.compatible:
+        raise RuntimeError(
+            "incompatible Bayesian-PhysTwin belief provider v3: "
+            + json.dumps(result.as_dict(), sort_keys=True)
+        )
+    return manifest
+
+
+__all__ = [
+    "BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_API",
+    "BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_API_VERSION",
+    "BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_CAPABILITIES",
+    "BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_SCHEMA_VERSIONS",
+    "BAYESIAN_PHYSTWIN_BELIEF_V3_ARTIFACT_SCHEMA_VERSIONS",
+    "BAYESIAN_PHYSTWIN_BELIEF_V3_COMPATIBILITY",
+    "BAYESIAN_PHYSTWIN_BELIEF_V3_COMPONENT_PRIOR",
+    "BAYESIAN_PHYSTWIN_BELIEF_V3_EVIDENCE_POOLING",
+    "BAYESIAN_PHYSTWIN_BELIEF_V3_INFERENCE_ROLE",
+    "BAYESIAN_PHYSTWIN_BELIEF_V3_RAW_COVARIANCE_CLAIM",
+    "BAYESIAN_PHYSTWIN_BELIEF_V3_RECURSIVE_STREAM_CLAIM",
+    "load_bayesian_phystwin_belief_provider_v3_manifest",
+    "require_bayesian_phystwin_belief_provider_v3",
+    "validate_bayesian_phystwin_belief_provider_v3",
+]

--- a/tests/test_belief_provider_v3_contract.py
+++ b/tests/test_belief_provider_v3_contract.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from importlib import import_module
+import os
+
+import pytest
+
+from causal4d.belief_provider_v2_contract import (
+    BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_CAPABILITIES,
+    BAYESIAN_PHYSTWIN_BELIEF_V2_ARTIFACT_SCHEMA_VERSIONS,
+)
+from causal4d.belief_provider_v3_contract import (
+    BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_API,
+    BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_API_VERSION,
+    BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_CAPABILITIES,
+    BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_SCHEMA_VERSIONS,
+    BAYESIAN_PHYSTWIN_BELIEF_V3_ARTIFACT_SCHEMA_VERSIONS,
+    BAYESIAN_PHYSTWIN_BELIEF_V3_COMPATIBILITY,
+    BAYESIAN_PHYSTWIN_BELIEF_V3_COMPONENT_PRIOR,
+    BAYESIAN_PHYSTWIN_BELIEF_V3_EVIDENCE_POOLING,
+    BAYESIAN_PHYSTWIN_BELIEF_V3_INFERENCE_ROLE,
+    BAYESIAN_PHYSTWIN_BELIEF_V3_RAW_COVARIANCE_CLAIM,
+    BAYESIAN_PHYSTWIN_BELIEF_V3_RECURSIVE_STREAM_CLAIM,
+    load_bayesian_phystwin_belief_provider_v3_manifest,
+    require_bayesian_phystwin_belief_provider_v3,
+    validate_bayesian_phystwin_belief_provider_v3,
+)
+from causal4d.provider_contract import PhysicalBeliefProviderManifest
+
+
+def _metadata() -> dict[str, object]:
+    return {
+        "provider_api": BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_API,
+        "provider_api_version": BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_API_VERSION,
+        "inference_role": BAYESIAN_PHYSTWIN_BELIEF_V3_INFERENCE_ROLE,
+        "compatibility": BAYESIAN_PHYSTWIN_BELIEF_V3_COMPATIBILITY,
+        "component_prior": BAYESIAN_PHYSTWIN_BELIEF_V3_COMPONENT_PRIOR,
+        "evidence_pooling": BAYESIAN_PHYSTWIN_BELIEF_V3_EVIDENCE_POOLING,
+        "raw_covariance_claim": (
+            BAYESIAN_PHYSTWIN_BELIEF_V3_RAW_COVARIANCE_CLAIM
+        ),
+        "recursive_stream_claim": (
+            BAYESIAN_PHYSTWIN_BELIEF_V3_RECURSIVE_STREAM_CLAIM
+        ),
+    }
+
+
+def _manifest(
+    *,
+    schema_version: int = 3,
+    capabilities: tuple[str, ...] = (
+        BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_CAPABILITIES
+    ),
+    schemas: dict[str, int] | None = None,
+    metadata: dict[str, object] | None = None,
+) -> PhysicalBeliefProviderManifest:
+    return PhysicalBeliefProviderManifest(
+        provider_name="bayesian-phystwin",
+        provider_version="0.4.0",
+        provider_revision="a" * 40,
+        schema_version=schema_version,
+        capabilities=capabilities,
+        artifact_schema_versions=(
+            BAYESIAN_PHYSTWIN_BELIEF_V3_ARTIFACT_SCHEMA_VERSIONS
+            if schemas is None
+            else schemas
+        ),
+        metadata=_metadata() if metadata is None else metadata,
+    )
+
+
+def _provider_api():
+    try:
+        return import_module(BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_API)
+    except ModuleNotFoundError:
+        if os.environ.get("CAUSAL4D_REQUIRE_BPT_BELIEF_PROVIDER_V3") == "1":
+            raise
+        pytest.skip("Bayesian-PhysTwin belief provider v3 is optional")
+
+
+def test_belief_provider_v3_accepts_complete_dynamic_manifest() -> None:
+    result = validate_bayesian_phystwin_belief_provider_v3(_manifest())
+
+    assert BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_SCHEMA_VERSIONS == (3,)
+    assert result.compatible
+    assert result.unsupported_schema_version is None
+    assert result.missing_capabilities == ()
+    assert result.artifact_version_mismatches == ()
+
+
+def test_belief_provider_v3_extends_v2_without_replacing_it() -> None:
+    assert set(BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_CAPABILITIES).issubset(
+        BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_CAPABILITIES
+    )
+    for name, version in BAYESIAN_PHYSTWIN_BELIEF_V2_ARTIFACT_SCHEMA_VERSIONS.items():
+        assert BAYESIAN_PHYSTWIN_BELIEF_V3_ARTIFACT_SCHEMA_VERSIONS[name] == version
+
+
+@pytest.mark.parametrize("schema_version", [1, 2, 4])
+def test_belief_provider_v3_rejects_other_manifest_schemas(
+    schema_version: int,
+) -> None:
+    result = validate_bayesian_phystwin_belief_provider_v3(
+        _manifest(schema_version=schema_version)
+    )
+
+    assert not result.compatible
+    assert result.unsupported_schema_version == schema_version
+
+
+def test_belief_provider_v3_rejects_missing_dynamic_capability() -> None:
+    capabilities = tuple(
+        value
+        for value in BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_CAPABILITIES
+        if value != "robust_damped_trend_components"
+    )
+
+    result = validate_bayesian_phystwin_belief_provider_v3(
+        _manifest(capabilities=capabilities)
+    )
+
+    assert not result.compatible
+    assert result.missing_capabilities == ("robust_damped_trend_components",)
+
+
+def test_belief_provider_v3_rejects_dynamic_schema_drift() -> None:
+    schemas = dict(BAYESIAN_PHYSTWIN_BELIEF_V3_ARTIFACT_SCHEMA_VERSIONS)
+    schemas["DynamicEndpointPrediction"] = 3
+
+    result = validate_bayesian_phystwin_belief_provider_v3(
+        _manifest(schemas=schemas)
+    )
+
+    assert not result.compatible
+    assert result.artifact_version_mismatches == (
+        "DynamicEndpointPrediction:expected=2:actual=3",
+    )
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("provider_api", "bayesian_phystwin.causal4d_belief_provider_v2"),
+        ("provider_api_version", 2),
+        ("inference_role", "physical state correction"),
+        ("compatibility", "replaces provider v2"),
+        ("component_prior", "target-selected component prior"),
+        ("evidence_pooling", "future-pooled evidence"),
+        ("raw_covariance_claim", "calibrated deployment intervals"),
+        ("recursive_stream_claim", "changed recursive stream semantics"),
+    ],
+)
+def test_belief_provider_v3_rejects_metadata_drift(
+    name: str,
+    value: object,
+) -> None:
+    metadata = _metadata()
+    metadata[name] = value
+
+    with pytest.raises(ValueError, match="unexpected"):
+        validate_bayesian_phystwin_belief_provider_v3(
+            _manifest(metadata=metadata)
+        )
+
+
+def test_belief_provider_v3_rejects_wrong_provider_name() -> None:
+    manifest = _manifest()
+    wrong = PhysicalBeliefProviderManifest(
+        provider_name="other-provider",
+        provider_version=manifest.provider_version,
+        provider_revision=manifest.provider_revision,
+        schema_version=manifest.schema_version,
+        capabilities=manifest.capabilities,
+        artifact_schema_versions=manifest.artifact_schema_versions,
+        metadata=manifest.metadata,
+    )
+
+    with pytest.raises(ValueError, match="bayesian-phystwin"):
+        validate_bayesian_phystwin_belief_provider_v3(wrong)
+
+
+def test_installed_belief_provider_v3_matches_contract() -> None:
+    provider_api = _provider_api()
+    manifest = load_bayesian_phystwin_belief_provider_v3_manifest(
+        provider_revision="cross-repository-belief-v3-test"
+    )
+    result = validate_bayesian_phystwin_belief_provider_v3(manifest)
+
+    assert result.compatible, result.as_dict()
+    assert (
+        require_bayesian_phystwin_belief_provider_v3(
+            provider_revision="cross-repository-belief-v3-test"
+        ).manifest_id
+        == manifest.manifest_id
+    )
+    for name in (
+        "DynamicEndpointModelAverageConfigV2",
+        "DynamicEndpointPosteriorV2",
+        "DynamicEndpointPredictionV2",
+        "infer_dynamic_bayesian_anchor_endpoint",
+        "predict_dynamic_endpoint_model_average",
+    ):
+        assert hasattr(provider_api, name)

--- a/tests/test_belief_provider_v3_contract.py
+++ b/tests/test_belief_provider_v3_contract.py
@@ -36,21 +36,15 @@ def _metadata() -> dict[str, object]:
         "compatibility": BAYESIAN_PHYSTWIN_BELIEF_V3_COMPATIBILITY,
         "component_prior": BAYESIAN_PHYSTWIN_BELIEF_V3_COMPONENT_PRIOR,
         "evidence_pooling": BAYESIAN_PHYSTWIN_BELIEF_V3_EVIDENCE_POOLING,
-        "raw_covariance_claim": (
-            BAYESIAN_PHYSTWIN_BELIEF_V3_RAW_COVARIANCE_CLAIM
-        ),
-        "recursive_stream_claim": (
-            BAYESIAN_PHYSTWIN_BELIEF_V3_RECURSIVE_STREAM_CLAIM
-        ),
+        "raw_covariance_claim": (BAYESIAN_PHYSTWIN_BELIEF_V3_RAW_COVARIANCE_CLAIM),
+        "recursive_stream_claim": (BAYESIAN_PHYSTWIN_BELIEF_V3_RECURSIVE_STREAM_CLAIM),
     }
 
 
 def _manifest(
     *,
     schema_version: int = 3,
-    capabilities: tuple[str, ...] = (
-        BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_CAPABILITIES
-    ),
+    capabilities: tuple[str, ...] = (BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V3_CAPABILITIES),
     schemas: dict[str, int] | None = None,
     metadata: dict[str, object] | None = None,
 ) -> PhysicalBeliefProviderManifest:
@@ -127,9 +121,7 @@ def test_belief_provider_v3_rejects_dynamic_schema_drift() -> None:
     schemas = dict(BAYESIAN_PHYSTWIN_BELIEF_V3_ARTIFACT_SCHEMA_VERSIONS)
     schemas["DynamicEndpointPrediction"] = 3
 
-    result = validate_bayesian_phystwin_belief_provider_v3(
-        _manifest(schemas=schemas)
-    )
+    result = validate_bayesian_phystwin_belief_provider_v3(_manifest(schemas=schemas))
 
     assert not result.compatible
     assert result.artifact_version_mismatches == (
@@ -158,9 +150,7 @@ def test_belief_provider_v3_rejects_metadata_drift(
     metadata[name] = value
 
     with pytest.raises(ValueError, match="unexpected"):
-        validate_bayesian_phystwin_belief_provider_v3(
-            _manifest(metadata=metadata)
-        )
+        validate_bayesian_phystwin_belief_provider_v3(_manifest(metadata=metadata))
 
 
 def test_belief_provider_v3_rejects_wrong_provider_name() -> None:

--- a/tests/test_belief_provider_v3_workflow_policy.py
+++ b/tests/test_belief_provider_v3_workflow_policy.py
@@ -65,13 +65,8 @@ def test_belief_provider_v3_workflow_runs_contract_before_quality() -> None:
 def test_belief_provider_v3_workflow_pins_external_actions() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
 
-    assert text.count(
-        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
-    ) == 2
-    assert (
-        "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97"
-        in text
-    )
+    assert text.count("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1") == 2
+    assert "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97" in text
     for line in text.splitlines():
         stripped = line.strip()
         if stripped.startswith("uses:"):

--- a/tests/test_belief_provider_v3_workflow_policy.py
+++ b/tests/test_belief_provider_v3_workflow_policy.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WORKFLOW = Path(".github/workflows/belief-provider-v3-integration.yml")
+BPT_BELIEF_PROVIDER_V3_REVISION = "62dff353903dcad273ffcd96644e3c2b3f9e5fd1"
+CAUSAL4D_HEAD_REF = "${{ github.event.pull_request.head.sha || github.sha }}"
+
+
+def test_belief_provider_v3_workflow_uses_exact_public_revision() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "repository: IPS-Stuttgart/BayesianPhysTwin" in text
+    assert f"ref: {BPT_BELIEF_PROVIDER_V3_REVISION}" in text
+    assert "persist-credentials: false" in text
+    assert "BPT_READ_SSH_KEY" not in text
+
+
+def test_belief_provider_v3_workflow_records_exact_causal4d_revision() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert f"ref: {CAUSAL4D_HEAD_REF}" in text
+    assert f"EXPECTED_CAUSAL4D_SHA: {CAUSAL4D_HEAD_REF}" in text
+    assert 'actual_sha="$(git rev-parse HEAD)"' in text
+    assert 'test "$actual_sha" = "$EXPECTED_CAUSAL4D_SHA"' in text
+
+
+def test_belief_provider_v3_workflow_exercises_installed_wheels() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "python -m build --wheel" in text
+    assert "belief-provider-v3-wheelhouse" in text
+    assert "belief-provider-v3-venv" in text
+    assert "--import-mode=importlib" in text
+    assert "env -u PYTHONPATH" in text
+    assert 'CAUSAL4D_REQUIRE_BPT_BELIEF_PROVIDER_V3: "1"' in text
+    assert "test_belief_provider_v2_contract.py" in text
+    assert "test_belief_provider_v3_contract.py" in text
+    assert "test_bpt_provider_registry.py" in text
+
+
+def test_belief_provider_v3_workflow_is_hosted_and_read_only() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "pull_request:" in text
+    assert "permissions:\n  contents: read\n" in text
+    assert "runs-on: ubuntu-latest" in text
+    assert "self-hosted" not in text
+
+
+def test_belief_provider_v3_workflow_runs_contract_before_quality() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    contract_index = text.index(
+        "- name: Exercise the installed cross-repository contract"
+    )
+    quality_index = text.index("- name: Check Causal4D source quality")
+
+    assert contract_index < quality_index
+    assert "if: always()" in text[quality_index:]
+    assert "python -m mypy" in text[quality_index:]
+
+
+def test_belief_provider_v3_workflow_pins_external_actions() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert text.count(
+        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+    ) == 2
+    assert (
+        "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97"
+        in text
+    )
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("uses:"):
+            assert "@" in stripped
+            reference = stripped.rsplit("@", 1)[1].split()[0]
+            assert len(reference) == 40
+            assert all(character in "0123456789abcdef" for character in reference)

--- a/tests/test_belief_provider_v3_workflow_policy.py
+++ b/tests/test_belief_provider_v3_workflow_policy.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 
 
-WORKFLOW = Path(".github/workflows/belief-provider-v3-integration.yml")
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = _REPOSITORY_ROOT / ".github" / "workflows" / (
+    "belief-provider-v3-integration.yml"
+)
 BPT_BELIEF_PROVIDER_V3_REVISION = "62dff353903dcad273ffcd96644e3c2b3f9e5fd1"
 CAUSAL4D_HEAD_REF = "${{ github.event.pull_request.head.sha || github.sha }}"
 

--- a/tests/test_belief_provider_v3_workflow_policy.py
+++ b/tests/test_belief_provider_v3_workflow_policy.py
@@ -5,10 +5,7 @@ from pathlib import Path
 
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = (
-    _REPOSITORY_ROOT
-    / ".github"
-    / "workflows"
-    / "belief-provider-v3-integration.yml"
+    _REPOSITORY_ROOT / ".github" / "workflows" / "belief-provider-v3-integration.yml"
 )
 BPT_BELIEF_PROVIDER_V3_REVISION = "62dff353903dcad273ffcd96644e3c2b3f9e5fd1"
 CAUSAL4D_HEAD_REF = "${{ github.event.pull_request.head.sha || github.sha }}"

--- a/tests/test_belief_provider_v3_workflow_policy.py
+++ b/tests/test_belief_provider_v3_workflow_policy.py
@@ -4,8 +4,11 @@ from pathlib import Path
 
 
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
-WORKFLOW = _REPOSITORY_ROOT / ".github" / "workflows" / (
-    "belief-provider-v3-integration.yml"
+WORKFLOW = (
+    _REPOSITORY_ROOT
+    / ".github"
+    / "workflows"
+    / "belief-provider-v3-integration.yml"
 )
 BPT_BELIEF_PROVIDER_V3_REVISION = "62dff353903dcad273ffcd96644e3c2b3f9e5fd1"
 CAUSAL4D_HEAD_REF = "${{ github.event.pull_request.head.sha || github.sha }}"

--- a/tests/test_bpt_provider_registry.py
+++ b/tests/test_bpt_provider_registry.py
@@ -12,7 +12,7 @@ import pytest
 
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 _REGISTRY_PATH = _REPOSITORY_ROOT / "ci" / "bayesian_phystwin_provider_registry.json"
-_DOC_PATH = _REPOSITORY_ROOT / "docs" / "bayesian_phystwin_provider.md"
+_DOCS_ROOT = _REPOSITORY_ROOT / "docs"
 _EXPECTED_ENTRY_FIELDS = frozenset(
     {
         "module",
@@ -52,6 +52,12 @@ def _registry() -> dict[str, Any]:
     )
     assert isinstance(payload, dict)
     return payload
+
+
+def _documentation() -> str:
+    paths = sorted(_DOCS_ROOT.glob("*.md"))
+    assert paths
+    return "\n".join(path.read_text(encoding="utf-8") for path in paths)
 
 
 def test_provider_registry_schema_and_entries_are_exact() -> None:
@@ -99,7 +105,7 @@ def test_provider_registry_schema_and_entries_are_exact() -> None:
 
 def test_registry_contract_modules_and_documentation_exist() -> None:
     registry = _registry()
-    documentation = _DOC_PATH.read_text(encoding="utf-8")
+    documentation = _documentation()
     for entry in registry["modules"]:
         module = entry["module"]
         assert f"`{module}`" in documentation
@@ -114,6 +120,7 @@ def test_registry_contains_current_additive_provider_boundaries() -> None:
     modules = {entry["module"] for entry in _registry()["modules"]}
     assert "bayesian_phystwin.causal4d_artifacts_v2" in modules
     assert "bayesian_phystwin.causal4d_belief_provider_v2" in modules
+    assert "bayesian_phystwin.causal4d_belief_provider_v3" in modules
     assert "bayesian_phystwin.causal4d_tree_block_provider_v1" in modules
 
 


### PR DESCRIPTION
## What changed

- add a strict local contract for `bayesian_phystwin.causal4d_belief_provider_v3`;
- validate the exact API/schema version, inherited provider-v2 capabilities and artifacts, dynamic endpoint artifacts, package range, provider identity, and scientific-boundary metadata;
- register the versioned public module in the machine-readable BayesianPhysTwin provider inventory;
- add synthetic fail-closed tests for capability, schema, metadata, revision, and provider-name drift;
- add a hosted read-only installed-wheel workflow pinned to BayesianPhysTwin revision `62dff353903dcad273ffcd96644e3c2b3f9e5fd1`; and
- document the source-freezing, evaluation, covariance, and method-freeze boundaries.

## Why

Dynamic discrepancy estimation belongs to BayesianPhysTwin. Causal4D should consume it only through a narrow versioned public contract rather than reimplementing the estimator or importing internal modules. The installed-wheel lane verifies the real package boundary and prevents editable-checkout imports from hiding compatibility drift.

## Scientific boundary

This is additive software and diagnostic infrastructure. It does **not** change the registered 36-execution estimator, graph-persistence fallback, physical evidence count, provider-v1/v2 historical experiments, Prob4D admission, method freeze, or any calibration claim. Provider compatibility alone is not evidence that the dynamic candidate improves a physical query or transfers.

## Validation

- Python syntax and line-length checks passed for all added Python modules.
- The registry JSON and workflow YAML parse successfully.
- Focused local contract checks accept the exact complete manifest and reject missing dynamic capability and metadata drift.
- GitHub Actions on the exact pull-request head are authoritative for Ruff, formatting, MyPy, complete repository tests, packaging, security, merge-gate, and the installed-wheel provider-v3 lane.