### PR TITLE
Respect registered randomization in causal-sufficiency tests

### DIFF
--- a/docs/sensor_factorized_abduction.md
+++ b/docs/sensor_factorized_abduction.md
@@ -135,10 +135,44 @@ residual ~ realized-intervention features
 residual ~ realized-intervention features + command identity
 ```
 
-The comparison is grouped by independent execution or session and uses a
-permutation diagnostic. A significant command-identity gain indicates that the
-chosen realization variables are incomplete. Failure to detect a gain is not a
-proof of conditional independence.
+Cross-fitting is by independent execution or session. The score first averages
+squared errors inside each cross-fit group and then gives every group equal
+weight, so a session with more executions cannot become a larger statistical
+unit merely because it contributes more rows. Ridge regression is solved as an
+augmented least-squares problem rather than through the normal equations.
+
+The randomization distribution must match the experimental design. Pass one
+`permutation_block_ids` value per execution to restrict command reassignment to
+the registered pair, session, or randomization block:
+
+```python
+result = assess_command_residual_sufficiency(
+    future_residual_targets,
+    realized_intervention_features,
+    command_ids,
+    group_ids=session_ids,
+    permutation_block_ids=registered_pair_ids,
+    permutation_count=9999,
+    maximum_exact_assignments=10000,
+)
+```
+
+The command multiset in every block is preserved exactly. If the number of
+distinct allowed assignments is at most `maximum_exact_assignments`, all of them
+are enumerated and an exact tail fraction is reported. Larger designs use the
+conservative plus-one Monte Carlo p-value. A block design that permits no label
+reassignment fails closed because it cannot support this randomization test.
+
+Omitting `permutation_block_ids` retains the historical global-shuffle behavior
+for backward compatibility. That mode is valid only when command labels were
+globally exchangeable under the registered design; it must not be substituted
+for paired or blocked randomization. The result metadata records the scheme,
+exact-versus-Monte-Carlo mode, block sizes, evaluated assignment count, p-value
+estimator, equal-group score unit, and ridge solver.
+
+A significant command-identity gain indicates that the chosen realization
+variables are incomplete. Failure to detect a gain is not proof of conditional
+independence.
 
 ## Integration boundary
 

--- a/src/causal4d/causal_sufficiency.py
+++ b/src/causal4d/causal_sufficiency.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+from collections import Counter
+from collections.abc import Iterator
 from dataclasses import dataclass, field
+from itertools import product
+from math import comb
 from typing import Any, Mapping, Sequence
 
 import numpy as np
@@ -80,6 +84,13 @@ def _identifiers(values: Sequence[str], count: int, name: str) -> tuple[str, ...
     return identifiers
 
 
+def _partition_indices(identifiers: tuple[str, ...]) -> tuple[tuple[int, ...], ...]:
+    positions: dict[str, list[int]] = {}
+    for index, identifier in enumerate(identifiers):
+        positions.setdefault(identifier, []).append(index)
+    return tuple(tuple(indices) for indices in positions.values())
+
+
 def _command_features(
     command_ids: tuple[str, ...],
     categories: tuple[str, ...],
@@ -109,11 +120,25 @@ def _ridge_predict(
     test = (test_features - mean) / scale
     train_design = np.column_stack((np.ones(len(train)), train))
     test_design = np.column_stack((np.ones(len(test)), test))
-    penalty = np.eye(train_design.shape[1], dtype=float) * float(ridge)
-    penalty[0, 0] = 0.0
-    normal = train_design.T @ train_design + penalty
-    right = train_design.T @ train_targets
-    coefficients = np.linalg.lstsq(normal, right, rcond=None)[0]
+
+    if ridge > 0.0:
+        penalty = np.eye(train_design.shape[1], dtype=float) * np.sqrt(ridge)
+        penalty[0, 0] = 0.0
+        solve_design = np.vstack((train_design, penalty))
+        solve_targets = np.vstack(
+            (
+                train_targets,
+                np.zeros(
+                    (train_design.shape[1], train_targets.shape[1]),
+                    dtype=float,
+                ),
+            )
+        )
+    else:
+        solve_design = train_design
+        solve_targets = train_targets
+
+    coefficients = np.linalg.lstsq(solve_design, solve_targets, rcond=None)[0]
     return test_design @ coefficients
 
 
@@ -140,13 +165,35 @@ def _cross_fitted_predictions(
     return predictions
 
 
+def _group_balanced_rmse(
+    targets: np.ndarray,
+    prediction: np.ndarray,
+    group_indices: tuple[tuple[int, ...], ...],
+) -> float:
+    execution_mse = np.mean(np.square(targets - prediction), axis=1)
+    group_mse = np.asarray(
+        [np.mean(execution_mse[list(indices)]) for indices in group_indices],
+        dtype=float,
+    )
+    return float(np.sqrt(np.mean(group_mse)))
+
+
 def _relative_improvement(
     targets: np.ndarray,
     baseline_prediction: np.ndarray,
     augmented_prediction: np.ndarray,
+    group_indices: tuple[tuple[int, ...], ...],
 ) -> tuple[float, float, float]:
-    baseline_rmse = float(np.sqrt(np.mean(np.square(targets - baseline_prediction))))
-    augmented_rmse = float(np.sqrt(np.mean(np.square(targets - augmented_prediction))))
+    baseline_rmse = _group_balanced_rmse(
+        targets,
+        baseline_prediction,
+        group_indices,
+    )
+    augmented_rmse = _group_balanced_rmse(
+        targets,
+        augmented_prediction,
+        group_indices,
+    )
     if baseline_rmse <= np.finfo(float).eps:
         return baseline_rmse, augmented_rmse, 0.0
     return (
@@ -156,14 +203,118 @@ def _relative_improvement(
     )
 
 
+def _bounded_multiset_permutation_count(
+    values: tuple[str, ...],
+    *,
+    limit: int,
+) -> int:
+    total = 1
+    placed = 0
+    for count in Counter(values).values():
+        total *= comb(placed + count, count)
+        if total > limit:
+            return limit + 1
+        placed += count
+    return total
+
+
+def _bounded_assignment_count(
+    commands: tuple[str, ...],
+    blocks: tuple[tuple[int, ...], ...],
+    *,
+    limit: int,
+) -> int:
+    total = 1
+    for indices in blocks:
+        block_commands = tuple(commands[index] for index in indices)
+        total *= _bounded_multiset_permutation_count(
+            block_commands,
+            limit=limit,
+        )
+        if total > limit:
+            return limit + 1
+    return total
+
+
+def _distinct_permutations(values: tuple[str, ...]) -> Iterator[tuple[str, ...]]:
+    counts = Counter(values)
+    categories = tuple(sorted(counts))
+    current: list[str] = []
+
+    def generate() -> Iterator[tuple[str, ...]]:
+        if len(current) == len(values):
+            yield tuple(current)
+            return
+        for category in categories:
+            if counts[category] < 1:
+                continue
+            counts[category] -= 1
+            current.append(category)
+            yield from generate()
+            current.pop()
+            counts[category] += 1
+
+    yield from generate()
+
+
+def _exact_command_assignments(
+    commands: tuple[str, ...],
+    blocks: tuple[tuple[int, ...], ...],
+) -> Iterator[tuple[str, ...]]:
+    block_assignments = tuple(
+        tuple(
+            _distinct_permutations(
+                tuple(commands[index] for index in block_indices)
+            )
+        )
+        for block_indices in blocks
+    )
+    for assignment_by_block in product(*block_assignments):
+        assignment = list(commands)
+        for block_indices, block_values in zip(blocks, assignment_by_block):
+            for index, value in zip(block_indices, block_values):
+                assignment[index] = value
+        yield tuple(assignment)
+
+
+def _random_command_assignment(
+    commands: np.ndarray,
+    blocks: tuple[tuple[int, ...], ...],
+    rng: np.random.Generator,
+) -> tuple[str, ...]:
+    assignment = commands.copy()
+    for block_indices in blocks:
+        indices = np.asarray(block_indices, dtype=int)
+        assignment[indices] = rng.permutation(commands[indices])
+    return tuple(map(str, assignment))
+
+
+def _tail_count(
+    null_improvements: np.ndarray,
+    observed_improvement: float,
+) -> tuple[int, float]:
+    comparison_scale = max(
+        1.0,
+        abs(observed_improvement),
+        float(np.max(np.abs(null_improvements))),
+    )
+    tolerance = 64.0 * np.finfo(float).eps * comparison_scale
+    count = int(
+        np.sum(null_improvements >= observed_improvement - tolerance)
+    )
+    return count, tolerance
+
+
 def assess_command_residual_sufficiency(
     future_residual_targets: np.ndarray,
     realization_features: np.ndarray,
     command_ids: Sequence[str],
     *,
     group_ids: Sequence[str] | None = None,
+    permutation_block_ids: Sequence[str] | None = None,
     ridge: float = 1.0e-6,
     permutation_count: int = 199,
+    maximum_exact_assignments: int = 10_000,
     random_seed: int = 0,
     significance_level: float = 0.05,
     minimum_relative_improvement: float = 0.01,
@@ -172,7 +323,15 @@ def assess_command_residual_sufficiency(
 
     A significant held-out gain from command identity is evidence that the
     supplied realization features are causally incomplete. Cross-fitting is by
-    independent group, normally execution session. The permutation test is a
+    independent group, normally execution session, and every group contributes
+    equal weight to the RMSE statistic.
+
+    ``permutation_block_ids`` restricts command-label reassignment to the
+    registered randomization blocks. The command multiset within every block is
+    preserved exactly. The test enumerates every distinct allowed assignment
+    when their count does not exceed ``maximum_exact_assignments``; otherwise it
+    uses a plus-one Monte Carlo p-value. Omitting the block identifiers retains
+    the historical global-exchangeability assumption. The permutation test is a
     finite-sample diagnostic, not a proof of conditional independence.
     """
 
@@ -186,20 +345,48 @@ def assess_command_residual_sufficiency(
         if group_ids is None
         else _identifiers(group_ids, len(targets), "group_ids")
     )
+    permutation_blocks = (
+        None
+        if permutation_block_ids is None
+        else _identifiers(
+            permutation_block_ids,
+            len(targets),
+            "permutation_block_ids",
+        )
+    )
     categories = tuple(sorted(set(commands)))
     unique_groups = tuple(dict.fromkeys(groups))
+    group_indices = _partition_indices(groups)
+    block_indices = (
+        (tuple(range(len(commands))),)
+        if permutation_blocks is None
+        else _partition_indices(permutation_blocks)
+    )
     if len(categories) < 2:
         raise ValueError("at least two commanded actions are required")
     if len(unique_groups) < 3:
         raise ValueError("at least three independent cross-fit groups are required")
     if not np.isfinite(ridge) or ridge < 0.0:
         raise ValueError("ridge must be finite and nonnegative")
-    if permutation_count < 1:
-        raise ValueError("permutation_count must be positive")
+    if type(permutation_count) is not int or permutation_count < 1:
+        raise ValueError("permutation_count must be a positive integer")
+    if type(maximum_exact_assignments) is not int or maximum_exact_assignments < 1:
+        raise ValueError("maximum_exact_assignments must be a positive integer")
     if not 0.0 < significance_level < 1.0:
         raise ValueError("significance_level must lie in (0, 1)")
     if not np.isfinite(minimum_relative_improvement):
         raise ValueError("minimum_relative_improvement must be finite")
+
+    bounded_assignment_count = _bounded_assignment_count(
+        commands,
+        block_indices,
+        limit=maximum_exact_assignments,
+    )
+    if bounded_assignment_count == 1:
+        raise ValueError(
+            "the permutation design does not permit any command reassignment"
+        )
+    use_exact_permutations = bounded_assignment_count <= maximum_exact_assignments
 
     command_features = _command_features(commands, categories)
     augmented_features = np.column_stack((features, command_features))
@@ -219,13 +406,26 @@ def assess_command_residual_sufficiency(
         targets,
         baseline_prediction,
         augmented_prediction,
+        group_indices,
     )
 
-    rng = np.random.default_rng(random_seed)
-    command_array = np.asarray(commands, dtype=object)
-    null_improvements = np.empty(permutation_count, dtype=float)
-    for index in range(permutation_count):
-        permuted = tuple(map(str, rng.permutation(command_array)))
+    if use_exact_permutations:
+        assignments: Iterator[tuple[str, ...]] = _exact_command_assignments(
+            commands,
+            block_indices,
+        )
+        evaluated_assignment_count = bounded_assignment_count
+    else:
+        rng = np.random.default_rng(random_seed)
+        command_array = np.asarray(commands, dtype=object)
+        assignments = (
+            _random_command_assignment(command_array, block_indices, rng)
+            for _ in range(permutation_count)
+        )
+        evaluated_assignment_count = permutation_count
+
+    null_improvements = np.empty(evaluated_assignment_count, dtype=float)
+    for index, permuted in enumerate(assignments):
         permuted_features = np.column_stack(
             (features, _command_features(permuted, categories))
         )
@@ -239,11 +439,21 @@ def assess_command_residual_sufficiency(
             targets,
             baseline_prediction,
             permuted_prediction,
+            group_indices,
         )
-    p_value = float(
-        (1 + np.sum(null_improvements >= observed_improvement))
-        / (permutation_count + 1)
+
+    extreme_count, comparison_tolerance = _tail_count(
+        null_improvements,
+        observed_improvement,
     )
+    if use_exact_permutations:
+        p_value = float(extreme_count / evaluated_assignment_count)
+        p_value_estimator = "exact_tail_fraction"
+    else:
+        p_value = float(
+            (1 + extreme_count) / (evaluated_assignment_count + 1)
+        )
+        p_value_estimator = "plus_one_monte_carlo"
     detected = bool(
         observed_improvement >= minimum_relative_improvement
         and p_value <= significance_level
@@ -259,8 +469,36 @@ def assess_command_residual_sufficiency(
         command_count=len(categories),
         metadata={
             "cross_fit_unit": "group",
+            "score_unit": "equal_weight_cross_fit_group",
             "ridge": float(ridge),
-            "permutation_count": int(permutation_count),
+            "ridge_solver": "augmented_least_squares",
+            "permutation_scheme": (
+                "global"
+                if permutation_blocks is None
+                else "within_registered_block"
+            ),
+            "permutation_mode": (
+                "exact" if use_exact_permutations else "monte_carlo"
+            ),
+            "permutation_block_count": len(block_indices),
+            "permutation_block_sizes": [len(indices) for indices in block_indices],
+            "fixed_permutation_block_count": sum(
+                len(set(commands[index] for index in indices)) == 1
+                for indices in block_indices
+            ),
+            "maximum_exact_assignments": int(maximum_exact_assignments),
+            "distinct_assignment_count": (
+                int(bounded_assignment_count)
+                if use_exact_permutations
+                else None
+            ),
+            "distinct_assignment_count_exceeds_exact_limit": bool(
+                not use_exact_permutations
+            ),
+            "evaluated_assignment_count": int(evaluated_assignment_count),
+            "requested_monte_carlo_permutation_count": int(permutation_count),
+            "p_value_estimator": p_value_estimator,
+            "tail_comparison_tolerance": float(comparison_tolerance),
             "random_seed": int(random_seed),
             "significance_level": float(significance_level),
             "minimum_relative_improvement": float(minimum_relative_improvement),

--- a/src/causal4d/causal_sufficiency.py
+++ b/src/causal4d/causal_sufficiency.py
@@ -496,6 +496,7 @@ def assess_command_residual_sufficiency(
                 not use_exact_permutations
             ),
             "evaluated_assignment_count": int(evaluated_assignment_count),
+            "permutation_count": int(permutation_count),
             "requested_monte_carlo_permutation_count": int(permutation_count),
             "p_value_estimator": p_value_estimator,
             "tail_comparison_tolerance": float(comparison_tolerance),

--- a/src/causal4d/causal_sufficiency.py
+++ b/src/causal4d/causal_sufficiency.py
@@ -262,11 +262,7 @@ def _exact_command_assignments(
     blocks: tuple[tuple[int, ...], ...],
 ) -> Iterator[tuple[str, ...]]:
     block_assignments = tuple(
-        tuple(
-            _distinct_permutations(
-                tuple(commands[index] for index in block_indices)
-            )
-        )
+        tuple(_distinct_permutations(tuple(commands[index] for index in block_indices)))
         for block_indices in blocks
     )
     for assignment_by_block in product(*block_assignments):
@@ -299,9 +295,7 @@ def _tail_count(
         float(np.max(np.abs(null_improvements))),
     )
     tolerance = 64.0 * np.finfo(float).eps * comparison_scale
-    count = int(
-        np.sum(null_improvements >= observed_improvement - tolerance)
-    )
+    count = int(np.sum(null_improvements >= observed_improvement - tolerance))
     return count, tolerance
 
 
@@ -450,9 +444,7 @@ def assess_command_residual_sufficiency(
         p_value = float(extreme_count / evaluated_assignment_count)
         p_value_estimator = "exact_tail_fraction"
     else:
-        p_value = float(
-            (1 + extreme_count) / (evaluated_assignment_count + 1)
-        )
+        p_value = float((1 + extreme_count) / (evaluated_assignment_count + 1))
         p_value_estimator = "plus_one_monte_carlo"
     detected = bool(
         observed_improvement >= minimum_relative_improvement
@@ -473,13 +465,9 @@ def assess_command_residual_sufficiency(
             "ridge": float(ridge),
             "ridge_solver": "augmented_least_squares",
             "permutation_scheme": (
-                "global"
-                if permutation_blocks is None
-                else "within_registered_block"
+                "global" if permutation_blocks is None else "within_registered_block"
             ),
-            "permutation_mode": (
-                "exact" if use_exact_permutations else "monte_carlo"
-            ),
+            "permutation_mode": ("exact" if use_exact_permutations else "monte_carlo"),
             "permutation_block_count": len(block_indices),
             "permutation_block_sizes": [len(indices) for indices in block_indices],
             "fixed_permutation_block_count": sum(
@@ -488,9 +476,7 @@ def assess_command_residual_sufficiency(
             ),
             "maximum_exact_assignments": int(maximum_exact_assignments),
             "distinct_assignment_count": (
-                int(bounded_assignment_count)
-                if use_exact_permutations
-                else None
+                int(bounded_assignment_count) if use_exact_permutations else None
             ),
             "distinct_assignment_count_exceeds_exact_limit": bool(
                 not use_exact_permutations

--- a/tests/test_causal4d_causal_sufficiency.py
+++ b/tests/test_causal4d_causal_sufficiency.py
@@ -51,9 +51,7 @@ def test_block_randomization_prevents_block_composition_false_positive() -> None
     for index in range(6):
         high_response_block = index < 3
         commands.extend(
-            ["b", "b", "b", "a"]
-            if high_response_block
-            else ["b", "a", "a", "a"]
+            ["b", "b", "b", "a"] if high_response_block else ["b", "a", "a", "a"]
         )
         groups.extend([f"session-{index}"] * 4)
         target_values.extend([3.0 if high_response_block else 0.0] * 4)
@@ -128,9 +126,7 @@ def test_exact_block_result_is_invariant_to_execution_order() -> None:
     assert reordered.relative_rmse_reduction == pytest.approx(
         reference.relative_rmse_reduction
     )
-    assert reordered.permutation_p_value == pytest.approx(
-        reference.permutation_p_value
-    )
+    assert reordered.permutation_p_value == pytest.approx(reference.permutation_p_value)
 
 
 def test_group_balanced_rmse_gives_each_session_equal_weight() -> None:
@@ -148,11 +144,7 @@ def test_ridge_solver_remains_stable_for_nearly_collinear_features() -> None:
     rng = np.random.default_rng(2872)
     base = rng.normal(size=20)
     features = np.column_stack(
-        [base]
-        + [
-            base + index * 1.0e-7 * rng.normal(size=20)
-            for index in range(1, 8)
-        ]
+        [base] + [base + index * 1.0e-7 * rng.normal(size=20) for index in range(1, 8)]
     )
     targets = (2.0 * base + 1.0e-8 * rng.normal(size=20))[:, None]
 
@@ -192,6 +184,4 @@ def test_positive_ridge_is_solved_as_an_augmented_least_squares_problem(
     )
 
     parameter_count = train_features.shape[1] + 1
-    assert observed_shapes == [
-        (len(train_features) + parameter_count, parameter_count)
-    ]
+    assert observed_shapes == [(len(train_features) + parameter_count, parameter_count)]

--- a/tests/test_causal4d_causal_sufficiency.py
+++ b/tests/test_causal4d_causal_sufficiency.py
@@ -1,0 +1,197 @@
+import numpy as np
+import pytest
+
+from causal4d.causal_sufficiency import (
+    _group_balanced_rmse,
+    _ridge_predict,
+    assess_command_residual_sufficiency,
+)
+
+
+def _paired_command_effect() -> tuple[
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    list[str],
+    list[str],
+]:
+    commands = np.asarray(["a", "b"] * 6)
+    blocks = [f"pair-{index}" for index in range(6) for _ in range(2)]
+    realization = np.zeros((len(commands), 1), dtype=float)
+    target = 3.0 * (commands == "b")[:, None]
+    return target, realization, commands, blocks, blocks
+
+
+def test_exact_block_randomization_detects_paired_command_effect() -> None:
+    target, realization, commands, groups, blocks = _paired_command_effect()
+    result = assess_command_residual_sufficiency(
+        target,
+        realization,
+        commands,
+        group_ids=groups,
+        permutation_block_ids=blocks,
+        permutation_count=1,
+        maximum_exact_assignments=64,
+    )
+
+    assert result.command_effect_detected
+    assert result.relative_rmse_reduction > 0.99
+    assert result.permutation_p_value == pytest.approx(2.0 / 64.0)
+    assert result.metadata["permutation_scheme"] == "within_registered_block"
+    assert result.metadata["permutation_mode"] == "exact"
+    assert result.metadata["distinct_assignment_count"] == 64
+    assert result.metadata["evaluated_assignment_count"] == 64
+    assert result.metadata["requested_monte_carlo_permutation_count"] == 1
+
+
+def test_block_randomization_prevents_block_composition_false_positive() -> None:
+    commands: list[str] = []
+    groups: list[str] = []
+    target_values: list[float] = []
+    for index in range(6):
+        high_response_block = index < 3
+        commands.extend(
+            ["b", "b", "b", "a"]
+            if high_response_block
+            else ["b", "a", "a", "a"]
+        )
+        groups.extend([f"session-{index}"] * 4)
+        target_values.extend([3.0 if high_response_block else 0.0] * 4)
+
+    target = np.asarray(target_values, dtype=float)[:, None]
+    realization = np.zeros((len(commands), 1), dtype=float)
+    global_result = assess_command_residual_sufficiency(
+        target,
+        realization,
+        commands,
+        group_ids=groups,
+        permutation_count=199,
+        maximum_exact_assignments=32,
+        random_seed=0,
+    )
+    blocked_result = assess_command_residual_sufficiency(
+        target,
+        realization,
+        commands,
+        group_ids=groups,
+        permutation_block_ids=groups,
+        permutation_count=199,
+        maximum_exact_assignments=32,
+        random_seed=0,
+    )
+
+    assert global_result.command_effect_detected
+    assert global_result.permutation_p_value <= 0.05
+    assert not blocked_result.command_effect_detected
+    assert blocked_result.permutation_p_value == pytest.approx(1.0)
+    assert blocked_result.relative_rmse_reduction == pytest.approx(
+        global_result.relative_rmse_reduction
+    )
+
+
+def test_block_randomization_fails_closed_without_exchangeable_labels() -> None:
+    commands = ["a"] * 4 + ["b"] * 4
+    with pytest.raises(ValueError, match="does not permit any command reassignment"):
+        assess_command_residual_sufficiency(
+            np.zeros((8, 1), dtype=float),
+            np.zeros((8, 1), dtype=float),
+            commands,
+            group_ids=[f"execution-{index}" for index in range(8)],
+            permutation_block_ids=["a-only"] * 4 + ["b-only"] * 4,
+        )
+
+
+def test_exact_block_result_is_invariant_to_execution_order() -> None:
+    target, realization, commands, groups, blocks = _paired_command_effect()
+    reference = assess_command_residual_sufficiency(
+        target,
+        realization,
+        commands,
+        group_ids=groups,
+        permutation_block_ids=blocks,
+        maximum_exact_assignments=64,
+    )
+    order = np.asarray([7, 2, 11, 0, 9, 4, 1, 10, 5, 8, 3, 6])
+    reordered = assess_command_residual_sufficiency(
+        target[order],
+        realization[order],
+        commands[order],
+        group_ids=np.asarray(groups)[order],
+        permutation_block_ids=np.asarray(blocks)[order],
+        maximum_exact_assignments=64,
+    )
+
+    assert reordered.baseline_rmse == pytest.approx(reference.baseline_rmse)
+    assert reordered.command_augmented_rmse == pytest.approx(
+        reference.command_augmented_rmse
+    )
+    assert reordered.relative_rmse_reduction == pytest.approx(
+        reference.relative_rmse_reduction
+    )
+    assert reordered.permutation_p_value == pytest.approx(
+        reference.permutation_p_value
+    )
+
+
+def test_group_balanced_rmse_gives_each_session_equal_weight() -> None:
+    targets = np.zeros((10, 1), dtype=float)
+    prediction = np.zeros_like(targets)
+    prediction[0, 0] = 10.0
+    group_indices = ((0,), tuple(range(1, 10)))
+
+    assert _group_balanced_rmse(targets, prediction, group_indices) == pytest.approx(
+        np.sqrt(50.0)
+    )
+
+
+def test_ridge_solver_remains_stable_for_nearly_collinear_features() -> None:
+    rng = np.random.default_rng(2872)
+    base = rng.normal(size=20)
+    features = np.column_stack(
+        [base]
+        + [
+            base + index * 1.0e-7 * rng.normal(size=20)
+            for index in range(1, 8)
+        ]
+    )
+    targets = (2.0 * base + 1.0e-8 * rng.normal(size=20))[:, None]
+
+    prediction = _ridge_predict(
+        features,
+        targets,
+        features,
+        ridge=0.0,
+    )
+
+    rmse = float(np.sqrt(np.mean(np.square(prediction - targets))))
+    assert rmse < 5.0e-8
+
+
+def test_positive_ridge_is_solved_as_an_augmented_least_squares_problem(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed_shapes: list[tuple[int, int]] = []
+    original_lstsq = np.linalg.lstsq
+
+    def recording_lstsq(
+        design: np.ndarray,
+        targets: np.ndarray,
+        rcond: float | None = None,
+    ) -> tuple[np.ndarray, np.ndarray, int, np.ndarray]:
+        observed_shapes.append(design.shape)
+        return original_lstsq(design, targets, rcond=rcond)
+
+    monkeypatch.setattr(np.linalg, "lstsq", recording_lstsq)
+    train_features = np.arange(12, dtype=float).reshape(6, 2)
+    train_targets = np.arange(6, dtype=float)[:, None]
+    _ridge_predict(
+        train_features,
+        train_targets,
+        train_features[:2],
+        ridge=0.25,
+    )
+
+    parameter_count = train_features.shape[1] + 1
+    assert observed_shapes == [
+        (len(train_features) + parameter_count, parameter_count)
+    ]


### PR DESCRIPTION
## What changed

- add optional `permutation_block_ids` so command labels are reassigned only within registered pairs, sessions, or randomization blocks;
- preserve the exact command multiset in every block and fail closed when the supplied design permits no reassignment;
- enumerate all distinct allowed assignments for small designs and use a conservative plus-one Monte Carlo p-value otherwise;
- give every independent cross-fit group equal weight in the RMSE statistic rather than weighting sessions by row count;
- solve ridge regression through an augmented least-squares system instead of squared-condition-number normal equations;
- record the randomization scheme, block sizes, exact/Monte-Carlo mode, evaluated assignment count, p-value estimator, score unit, and solver in result metadata;
- retain global shuffling when no block IDs are supplied, while documenting that it is valid only under global exchangeability; and
- add focused regression, numerical-stability, fail-closed, and execution-order metamorphic tests.

## Why

The previous permutation test shuffled command labels globally. That can be anti-conservative for paired or blocked physical protocols because it destroys the registered randomization structure. A synthetic regression in this PR demonstrates the failure mode: unequal command composition across sessions produces a significant global-shuffle result, while within-session randomization correctly returns `p = 1` without changing the observed predictive gain.

The previous ridge implementation also formed `X.T @ X` before calling `lstsq`, which unnecessarily squares the condition number. The augmented formulation directly solves the penalized least-squares problem.

## User and scientific impact

Callers can now pass the exact registered randomization block for every execution. Small paired designs receive exact finite-sample p-values; larger designs remain reproducible through seeded Monte Carlo. Sessions are the equal-weight statistical units even when they contain different execution counts.

This remains an opt-in falsification diagnostic. It does not alter the frozen `v0.3.0-causal4d-aip` estimator, the locked 36-execution protocol, intervention definitions, physical evidence count, posterior weights, counterfactual operator, Prob4D admission, or BayesianPhysTwin provider contracts. Non-detection remains explicitly not a proof of causal sufficiency.

## Validation

Focused local validation from the exact proposed module and tests:

- `9 passed` covering the seven new tests plus both pre-existing causal-sufficiency behavior cases;
- Python compilation passed;
- Python 3.10 syntax parsing passed for the changed module and new tests;
- all changed Python and Markdown lines are at most 88 characters.

GitHub Actions is authoritative for Ruff, formatting, MyPy, the complete repository suite, multi-Python and dependency-floor compatibility, packaging, security scanning, and pinned BayesianPhysTwin integration.