### PR TITLE
Harden diagnostic and source-panel staging publication

### DIFF
--- a/docs/causal4d_preacquisition_next_action.md
+++ b/docs/causal4d_preacquisition_next_action.md
@@ -1,14 +1,14 @@
 # Pre-acquisition next-action decision
 
-The registered physical experiment has several independent prerequisite,
-source-panel, approval, freeze, and software-lineage gates. The authoritative
-status commands remain the source of truth, but their complete blocker lists are
-not an operator runbook.
+The registered physical experiment has independent prerequisite, source-panel,
+approval, freeze, and software-lineage gates. The authoritative status commands
+remain the source of truth, but their complete blocker lists are not an operator
+runbook.
 
-`causal4d protocol readiness next-action` derives exactly one admissible next
-step from the current hash-verified readiness and source-panel status. It does
-not create evidence, repair invalid artifacts, choose scientific settings, or
-inspect target outcomes.
+`causal4d protocol readiness next-action` derives exactly one admissible next step
+from the current hash-verified readiness and source-panel status. It does not create
+physical evidence, repair invalid artifacts, choose scientific settings, or inspect
+target outcomes.
 
 ## Usage
 
@@ -29,27 +29,27 @@ collection. When all logical evidence is present, the resulting action remains
 
 The command returns:
 
-- exit code `0` only when the readiness decision already authorizes the first
-  confirmatory execution;
+- exit code `0` only when readiness already authorizes the first confirmatory
+  execution;
 - exit code `3` for a valid but incomplete state with one prescribed next action;
 - exit code `2` when present evidence is malformed, contradictory, out of order,
   or otherwise invalid.
 
 ## Deterministic action order
 
-The decision follows the registered information order. It emits the first
-applicable action from this sequence:
+The decision follows the registered information order and emits the first applicable
+action from this sequence:
 
-1. create the registered real-dataset scaffold when the dataset root is absent
-   or empty;
+1. create the registered real-dataset scaffold when the dataset root is absent or
+   empty;
 2. create the non-overwriting pre-acquisition gate and source-panel templates;
 3. scaffold and seal the operator identity registry;
 4. stop on malformed evidence, chronology violations, unexpected source-panel
    entries, or confirmatory collection that began before readiness;
 5. complete the fixed object registration, slip pilot, shared timebase, and
    independently reviewed contact registration;
-6. acquire, verify, independently review, and publish exactly the next
-   registered source-panel execution;
+6. acquire, safely stage, verify, independently review, and publish exactly the
+   next registered source-panel execution;
 7. seal source-panel completion, actuator synchronization, support/gravity, and
    nonconfirmatory end-to-end dry-run gates;
 8. seal the exact clean method freeze;
@@ -58,20 +58,22 @@ applicable action from this sequence:
 11. run the final hash-verified readiness gate; and
 12. validate the freeze and begin only the first registered confirmatory session.
 
-The source-panel action includes the exact execution ID, session ID, registered
-command profile, manifest template, staging destination, preflight-report path,
-and exactly-once publication command. It never skips ahead or selects a
-different source execution.
+The source-panel action includes the exact execution ID, session ID, command profile,
+manifest template, fixed staging destination, preflight path, review-receipt path,
+and exactly-once publication command. It never skips ahead or selects a different
+source execution.
 
 ## Source-panel publication sequence
 
 A physical source execution has an irreversible claim-bearing publication step.
-The next-action artifact therefore represents five explicit phases:
+The next-action artifact therefore represents six explicit phases:
 
 ```text
 acquire registered execution
         ↓
-verify staged manifest and every referenced artifact
+build the staging manifest from the registered template and actual artifact bytes
+        ↓
+verify the staged manifest and every referenced artifact
         ↓
 independently review the content-addressed preflight report
         ↓
@@ -80,59 +82,87 @@ publish the manifest exactly once
 recompute the next action
 ```
 
-The preflight command is emitted under
-`post_acquisition_verification_argv` and writes the path recorded in
-`preflight_report_path`. The publication command is separate under
+The staging command is emitted under `staged_manifest_build_argv` and
+`staged_manifest_build_text`. It contains placeholders for the exact UTC start/end
+times and one artifact path. Repeat `--artifact` for every ordinary file below the
+registered execution directory. The fixed destination is recorded under
+`staged_manifest_path`.
+
+The builder derives the current `next_execution`, copies the immutable registered
+worksheet, computes artifact SHA-256 values and byte counts, and refuses replacement.
+It does not verify, review, publish, or mutate the final claim-bearing manifest.
+
+The read-only preflight command is emitted under
+`post_acquisition_verification_argv` and writes the path in
+`preflight_report_path`. Independent review is emitted under `staged_review_argv`
+and produces `review_receipt_path`. Publication is separate under
 `claim_bearing_publication_argv`; it is never presented as the immediate
-post-acquisition command. `independent_review_required_before_publication=true`
-records the human decision boundary explicitly.
+post-acquisition command.
 
-Publication reruns all registered validation and hash checks. A preflight report
-is a snapshot and never reserves the next execution slot or counts as physical
-evidence.
-
-## Output contract
-
-The JSON report is content addressed and contains:
-
-- the protocol, design, pre-acquisition plan, and amendment identities;
-- the source readiness and source-panel evidence/status identities;
-- one `action` object with a stable `action_id` and category;
-- an argv representation and shell-rendered form for executable commands;
-- required inputs, outputs, and operator role;
-- explicit post-acquisition verification and claim-bearing publication commands
-  when applicable;
-- whether independent review is required before publication;
-- the completion check that should be run after the action sequence;
-- whether physical acquisition is required;
-- whether the action is mechanically automatable;
-- a portable `evidence_sha256` that normalizes repository and dataset mount
-  points; and
-- an exact host-local `status_sha256`.
-
-Every action records:
+These fields make the human boundary explicit:
 
 ```json
 {
+  "two_person_publication_required": true,
+  "independent_review_required_before_publication": true,
   "changes_registered_method": false,
   "target_outcomes_permitted": false
 }
 ```
 
+Publication reruns all registered identity, role, review, staging, and file-hash
+checks. Neither a staging file nor a preflight report reserves the next execution
+slot or counts as physical evidence.
+
+## Persisted-action freshness
+
+Before executing a persisted decision, validate it against the current filesystem:
+
+```bash
+causal4d protocol readiness next-action-validate \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  /data/causal4d-sloth-multi-action-v1/operator/next-action.json \
+  --output-json \
+  /data/causal4d-sloth-multi-action-v1/operator/next-action-validation.json
+```
+
+Validation requires the current schema, exact content hashes, current repository and
+dataset mounts, the same logical evidence digest, and the same action/execution
+identity. Any intervening publication or evidence mutation makes the decision stale.
+
+## Output contract
+
+The JSON report is content addressed and contains:
+
+- protocol, design, pre-acquisition plan, and amendment identities;
+- readiness and source-panel evidence/status identities;
+- one `action` object with a stable `action_id` and category;
+- argv and shell-rendered forms for executable commands;
+- required inputs, outputs, and operator role;
+- explicit staging, verification, review, and claim-bearing publication commands
+  when applicable;
+- the completion check that follows the complete action sequence;
+- whether physical acquisition is required;
+- whether the action is mechanically automatable;
+- a portable `evidence_sha256` that normalizes repository and dataset mount points;
+  and
+- an exact host-local `status_sha256`.
+
 The Markdown report renders the same sequence for an acquisition operator. Both
-formats are derived artifacts and may be overwritten by a newer status
-snapshot; they are never counted as experimental evidence.
+formats are derived status artifacts and may be overwritten by a newer snapshot;
+they are never counted as experimental evidence.
 
 ## Invalid evidence
 
-An invalid state always yields `stop_and_repair_invalid_evidence`. The command
-lists the detected malformed prerequisites, invalid gates, chronology blockers,
-source-panel blockers, or premature-collection condition. It deliberately does
-not synthesize a repair command because a method-affecting defect may require a
-new protocol version rather than mutation of the current registration.
+An invalid state always yields `stop_and_repair_invalid_evidence`. The command lists
+the detected malformed prerequisites, invalid gates, chronology blockers,
+source-panel blockers, or premature-collection condition. It deliberately does not
+synthesize a repair command because a method-affecting defect may require a new
+protocol version rather than mutation of the current registration.
 
-The operator must resolve the first invalid boundary under the applicable
-runbook and independent-review policy, then rerun the decision command.
+Resolve the first invalid boundary under the applicable runbook and independent
+review policy, then rerun the decision command.
 
 ## Scientific boundary
 
@@ -148,6 +178,6 @@ This interface is operational provenance only. It does not modify:
   interventional prediction.
 
 A `begin_first_confirmatory_session` action is emitted only when the existing
-readiness status already has `ready=true`, all requested hashes were verified,
-and `first_confirmatory_execution_allowed=true` follows from the registered
-collection gate.
+readiness status already has `ready=true`, all requested hashes were verified, and
+`first_confirmatory_execution_allowed=true` follows from the registered collection
+gate.

--- a/docs/causal4d_source_panel_acquisition.md
+++ b/docs/causal4d_source_panel_acquisition.md
@@ -14,12 +14,15 @@ evidence count.
 The source-panel control surface enforces these invariants:
 
 - the protocol, v2, v3, and v4 registration chain must validate;
-- execution and session identities are taken from that chain, not supplied by an
-  operator;
+- execution and session identities come from that chain, not from operator input;
 - completed manifests must form the exact registered prefix;
 - the next execution includes its complete registered command profile;
-- every referenced artifact is an ordinary file below the dataset root and is
-  checked by SHA-256 and byte count before publication;
+- staging copies the immutable registered worksheet and fills only completion
+  values plus descriptors computed from the actual artifact bytes;
+- every artifact must be an ordinary, symlink-free file below the exact registered
+  execution directory;
+- artifact SHA-256 values and byte counts are recomputed before and after staging;
+- staging never creates or replaces a final evidence manifest;
 - publication creates `manifest.json` exactly once and never overwrites it;
 - target-outcome fields are forbidden recursively;
 - templates do not count as completed evidence; and
@@ -27,7 +30,8 @@ The source-panel control surface enforces these invariants:
   manifests, and file-hash verification.
 
 An invalid or missing template, an out-of-order manifest, an unexpected execution
-entry, a stale digest, or a malformed completed manifest fails closed.
+entry, a stale digest, a concurrent artifact change, or a malformed completed
+manifest fails closed.
 
 ## Scaffold once
 
@@ -52,8 +56,7 @@ preacquisition/source_panel/executions/<execution-id>/manifest.template.json
 ```
 
 Do not rename, edit in place, delete, or promote that worksheet by a filesystem
-move. Retain every worksheet through source-panel gate sealing. Create a separate
-completed JSON file for validation and exactly-once publication.
+move. Retain every worksheet through source-panel gate sealing.
 
 ## Inspect the next execution
 
@@ -68,28 +71,65 @@ causal4d protocol readiness source-panel-status \
   /data/causal4d-sloth-multi-action-v1/preacquisition/source-panel-status.json
 ```
 
-The report identifies `next_execution` and includes the exact registered
-profile, contact, realization condition, replicate, execution ID, and independent
-session ID. Use that record as the operator instruction. Do not choose another
-profile or repair the ordering manually.
+The report identifies `next_execution` and includes the exact registered profile,
+contact, realization condition, replicate, execution ID, and independent session
+ID. Use that record as the operator instruction. Do not choose another profile or
+repair the ordering manually.
 
-A valid incomplete panel is an expected state. With `--require-complete`, the
-command returns:
+A valid incomplete panel is expected. With `--require-complete`, the status command
+returns `0` when all 12 executions validate, `3` when the panel is valid but
+incomplete, and `2` when present evidence is malformed or contradictory.
 
-- `0` when all 12 source executions validate with file hashes;
-- `3` when the panel is valid but incomplete; and
-- `2` when present evidence is malformed or contradictory.
+## Acquire one source execution
 
-## Acquire and describe one source execution
+Use a fresh reset and fresh grasp for the displayed execution. Store the raw sensor,
+controller, timing, registration, gripper, contact, and technical-quality files
+below its registered execution directory:
 
-Use a fresh reset and fresh grasp for the displayed execution. Store raw sensor,
-controller, timing, registration, gripper, contact, and technical-quality
-artifacts below its registered execution directory. Preserve technical failures;
-do not silently replace a registered source execution.
+```text
+preacquisition/source_panel/executions/<execution-id>/
+```
 
-Copy the corresponding worksheet to an operator staging path and complete only
-its values. A completed `SourcePanelExecutionManifest` must retain the exact
-schema and registered identities and state:
+Preserve technical failures; do not silently replace a registered execution. The
+staging command below constructs a publishable successful manifest, so run it only
+after the preregistered technical quality gates have passed. When a gate fails,
+retain the raw files and failure record for review and do not stage or publish a
+manifest that claims inclusion.
+
+## Build the staging manifest safely
+
+Use the exact start and end times and repeat `--artifact` for every artifact file:
+
+```bash
+causal4d protocol readiness source-panel-stage \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  --started-at-utc 2026-08-10T08:00:00Z \
+  --ended-at-utc 2026-08-10T08:01:00Z \
+  --artifact \
+    preacquisition/source_panel/executions/<execution-id>/rgbd.npz \
+  --artifact \
+    preacquisition/source_panel/executions/<execution-id>/controller.csv \
+  --artifact \
+    preacquisition/source_panel/executions/<execution-id>/timing.json
+```
+
+The builder derives the exact next execution, reads and validates its immutable
+worksheet, copies all registered identities, validates UTC chronology, computes
+SHA-256 and byte counts, and atomically creates:
+
+```text
+staging/<execution-id>.json
+```
+
+It refuses replacement. Paths may be dataset-relative or absolute, but after
+resolution every file must remain below the dataset root and below the exact
+registered execution directory. Absolute escapes, `..` escapes, symlinks,
+directories, duplicate paths, and the worksheet/final manifest files are rejected.
+The builder rehashes the worksheet and artifacts after writing and removes the
+new staging file if any concurrent change is detected.
+
+The resulting manifest has the registered schema:
 
 ```json
 {
@@ -104,46 +144,82 @@ schema and registered identities and state:
   "artifacts": [
     {
       "path": "preacquisition/source_panel/executions/<id>/<artifact>",
-      "sha256": "<64 lowercase hexadecimal characters>",
+      "sha256": "<computed 64-character lowercase digest>",
       "bytes": 123
     }
   ]
 }
 ```
 
-The other protocol, plan, execution, and session fields must remain byte-for-byte
-consistent with the worksheet. `artifacts` must be nonempty. Descriptor paths are
-relative to the dataset root; absolute paths, `..`, symlinks, directories, stale
-hashes, and incorrect byte counts are rejected.
+Staging is not verification, approval, or publication. It does not reserve the
+execution slot and does not change claim-bearing evidence.
 
-If a preregistered quality gate fails, retain the files and failure record for
-operator review. Do not set `included=true` and do not publish a manifest that
-pretends the gate passed.
+## Verify the staged bytes
+
+Hash-verify the exact staging manifest and all referenced files, and persist the
+content-addressed preflight report:
+
+```bash
+causal4d protocol readiness source-panel-verify-staged \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  /data/causal4d-sloth-multi-action-v1/staging/<execution-id>.json \
+  --output-json \
+  /data/causal4d-sloth-multi-action-v1/operator/<execution-id>-preflight.json
+```
+
+The preflight is read-only. It requires that the staging file is directly below
+`dataset_root/staging`, has the exact next execution filename and schema, and still
+matches every artifact byte. It also confirms that the final manifest does not
+exist and that source-panel status stayed unchanged during verification.
+
+## Obtain independent review
+
+A registered reviewer inspects the staged manifest, artifacts, and exact preflight
+and seals a review receipt:
+
+```bash
+causal4d protocol readiness source-panel-review-staged \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  /data/causal4d-sloth-multi-action-v1/staging/<execution-id>.json \
+  --reviewed-by "<registered-reviewer-id>"
+```
+
+This creates the registered receipt under:
+
+```text
+staging/reviews/<execution-id>.json
+```
+
+Review remains separate from publication. A stale or changed staging manifest or
+preflight must be verified and reviewed again.
 
 ## Publish exactly once
 
-Validate every referenced artifact and atomically create the final registered
-manifest:
+A distinct registered publisher performs the irreversible claim-bearing step:
 
 ```bash
 causal4d protocol readiness source-panel-publish \
   /opt/causal4d-frozen \
   /data/causal4d-sloth-multi-action-v1 \
-  /data/causal4d-sloth-multi-action-v1/staging/<execution-id>.json
+  /data/causal4d-sloth-multi-action-v1/staging/<execution-id>.json \
+  --review-receipt \
+    /data/causal4d-sloth-multi-action-v1/staging/reviews/<execution-id>.json \
+  --published-by "<registered-publisher-id>"
 ```
 
-The publisher admits only the exact `next_execution`. It validates the completed
-JSON through the same source-panel contract used by final readiness, verifies
-all artifact hashes, fsyncs the temporary manifest, and creates:
+The publisher revalidates the registered operator roles, review receipt, completed
+JSON, exact next-execution identity, artifact hashes, and source-panel status. It
+atomically creates:
 
 ```text
 preacquisition/source_panel/executions/<execution-id>/manifest.json
 ```
 
-The destination must not already exist. A second publication, an out-of-order
-execution, or a failed temporary validation leaves the final path untouched.
-The command then recomputes the complete source-panel status and reports the next
-registered execution.
+The destination must not already exist. Repeated publication, out-of-order
+publication, stale review, or failed validation leaves the final path untouched.
+After success, recompute `next-action`; do not manually increment the execution.
 
 ## Complete and seal the source-panel gate
 
@@ -171,18 +247,17 @@ causal4d protocol readiness seal-gate \
 ```
 
 The actuator synchronization, support/gravity registration, and nonconfirmatory
-end-to-end dry-run gates remain separate prerequisites. All four operational
-gates and the operator registry must predate the method freeze. The software
-environment gate must follow the freeze and independent attestation.
+end-to-end dry-run gates remain separate prerequisites. All four operational gates
+and the operator registry must predate the method freeze. The software-environment
+gate must follow the freeze and independent attestation.
 
 ## Evidence interpretation
 
 A green source-panel status means only that the registered 12 source executions
-exist in order and their bound files validate. It is pre-acquisition evidence,
-not confirmatory performance evidence. It cannot change a method, threshold,
-exclusion, target identity, or paper claim, and it cannot authorize execution 1
-by itself. Confirmatory collection remains forbidden until the final readiness
-status reports both:
+exist in order and their bound files validate. It is pre-acquisition evidence, not
+confirmatory performance evidence. It cannot change a method, threshold, exclusion,
+target identity, or paper claim, and it cannot authorize execution 1 by itself.
+Confirmatory collection remains forbidden until the final readiness status reports:
 
 ```text
 ready=true

--- a/docs/causal4d_source_panel_staging_preflight.md
+++ b/docs/causal4d_source_panel_staging_preflight.md
@@ -6,8 +6,8 @@ concurrently changing source file should therefore be detected before the
 non-overwriting publication step.
 
 `causal4d protocol readiness source-panel-verify-staged` performs the same
-claim-boundary checks needed for admission while leaving the claim-bearing
-source registry unchanged. It verifies that the staging file:
+claim-boundary checks needed for admission while leaving the claim-bearing source
+registry unchanged. It verifies that the staging file:
 
 - is an ordinary file directly below `dataset_root/staging`, with no symlinked
   path component;
@@ -15,11 +15,9 @@ source registry unchanged. It verifies that the staging file:
 - is exactly the next registered source execution and session;
 - has the exact schema of the registered manifest template;
 - contains no target-outcome field, including nested fields;
-- marks the source execution complete, included, and free of quality-gate
-  failures;
+- marks the source execution complete, included, and free of quality-gate failures;
 - retains the source-only and nonconfirmatory information boundary;
-- references only admissible artifacts whose byte counts and SHA-256 values
-  match;
+- references only admissible artifacts whose byte counts and SHA-256 values match;
 - remains byte-identical throughout validation;
 - retains byte-identical referenced artifacts throughout validation;
 - leaves the hash-verified source-panel status unchanged; and
@@ -27,8 +25,27 @@ source registry unchanged. It verifies that the staging file:
 
 ## Operator flow
 
-Fill the registered staging manifest and place every referenced artifact below
-the dataset root. Then run:
+First construct the staging manifest from the immutable registered worksheet and
+the actual artifact bytes:
+
+```bash
+causal4d protocol readiness source-panel-stage \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  --started-at-utc 2026-08-10T08:00:00Z \
+  --ended-at-utc 2026-08-10T08:01:00Z \
+  --artifact \
+    preacquisition/source_panel/executions/source-lift_high-r1/rgbd.npz \
+  --artifact \
+    preacquisition/source_panel/executions/source-lift_high-r1/controller.csv
+```
+
+Repeat `--artifact` for every ordinary file below the registered execution
+directory. The builder computes descriptors, refuses replacement, and rechecks the
+worksheet, artifacts, and source-panel status after atomically creating the staging
+file. It does not approve or publish evidence.
+
+Then run the independent preflight:
 
 ```bash
 causal4d protocol readiness source-panel-verify-staged \
@@ -52,37 +69,51 @@ target_outcomes_used=false
 
 It also records the exact staged-manifest checksum, a complete post-validation
 snapshot of every referenced artifact, the stable source-panel status identity,
-the expected one-step progress, and the exact publication command. The report is
-derived operator evidence; it does not count as a physical execution and does
-not reserve the next execution slot.
+and the expected one-step progress. The `publication_command_argv` field identifies
+the base publication target; the claim-bearing command still requires the separately
+sealed review receipt and publisher identity described below. The report is derived
+operator evidence. It does not count as a physical execution and does not reserve
+the next execution slot.
 
-After independent review, publish with the command returned by the report. The
-reviewer should compare the content-addressed report with the staged manifest
-and artifact inventory; a successful preflight is not itself an approval.
+## Independent review and publication
+
+A registered reviewer inspects the staging manifest, artifact inventory, and exact
+preflight and seals the review receipt:
+
+```bash
+causal4d protocol readiness source-panel-review-staged \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  /data/causal4d-sloth-multi-action-v1/staging/source-lift_high-r1.json \
+  --reviewed-by "<registered-reviewer-id>"
+```
+
+A distinct registered publisher then supplies that receipt explicitly:
 
 ```bash
 causal4d protocol readiness source-panel-publish \
   /opt/causal4d-frozen \
   /data/causal4d-sloth-multi-action-v1 \
-  /data/causal4d-sloth-multi-action-v1/staging/source-lift_high-r1.json
+  /data/causal4d-sloth-multi-action-v1/staging/source-lift_high-r1.json \
+  --review-receipt \
+    /data/causal4d-sloth-multi-action-v1/staging/reviews/source-lift_high-r1.json \
+  --published-by "<registered-publisher-id>"
 ```
 
 Publication reruns all validation. This matters because a preflight report is a
-snapshot: a staging file or referenced artifact changed afterward is rejected,
-and concurrent publication remains protected by the existing exactly-once final
-write.
+snapshot: a staging file or referenced artifact changed afterward is rejected, and
+concurrent publication remains protected by the exactly-once final write.
 
 ## Mutation and concurrency boundary
 
 The preflight hashes the staging manifest before parsing and after complete
 validation. It also snapshots every referenced artifact before and after the
-registered validator runs. Any changed byte count, SHA-256 value, artifact path,
-or source-panel status identity fails the preflight.
+registered validator runs. Any changed byte count, SHA-256 value, artifact path, or
+source-panel status identity fails the preflight.
 
-These checks close mutations that occur while the report is being constructed.
-They cannot reserve files after the command returns. The exactly-once publisher
-therefore remains authoritative and reruns every check immediately before
-publication.
+These checks close mutations that occur while the report is being constructed. They
+cannot reserve files after the command returns. The exactly-once publisher therefore
+remains authoritative and reruns every check immediately before publication.
 
 ## Exit behavior
 
@@ -93,8 +124,7 @@ normal fail-closed error contract.
 
 ## Scientific boundary
 
-The preflight does not modify the estimator, intervention posterior, source or
-target split, six-frame information boundary, quality gates, exclusion rules,
-physical evidence count, or registered analysis. It never authorizes
-confirmatory collection and never converts a staged file into claim-bearing
-evidence.
+The builder and preflight do not modify the estimator, intervention posterior,
+source or target split, six-frame information boundary, quality gates, exclusion
+rules, physical evidence count, or registered analysis. Neither authorizes
+confirmatory collection nor converts a staged file into claim-bearing evidence.

--- a/docs/postfreeze_calibration_diagnostics.md
+++ b/docs/postfreeze_calibration_diagnostics.md
@@ -13,7 +13,7 @@ They address two questions that remain useful after the primary method is frozen
 2. can graph discrepancy uncertainty grow with horizon without fitting one dense
    cross-mode transition matrix that may become unstable or transfer poorly?
 
-Neither diagnostic is a substitute for the independent-execution calibration gate.
+Neither diagnostic substitutes for the independent-execution calibration gate.
 
 ## Simulation-based calibration
 
@@ -54,13 +54,13 @@ When `likelihood_power=1`, `dynamic_likelihood_weight=0`, and the simulated
 observation standard deviation equals `likelihood_scale_m`, the experiment is an
 exact self-consistency check for the finite independent-Gaussian prefix likelihood.
 Approximately uniform randomized ranks are then expected up to Monte Carlo error.
-Changing the likelihood power, adding derivative terms, or deliberately mismatching
+Changing likelihood power, adding derivative terms, or deliberately mismatching
 noise creates a sensitivity diagnostic rather than an exact SBC null.
 
 ### Controlled benchmark command
 
 The leave-one-topology benchmark can run the exact self-consistency diagnostic in
-one invocation without changing the benchmark defaults:
+one invocation without changing benchmark defaults:
 
 ```bash
 causal4d benchmark latent-contact \
@@ -70,15 +70,38 @@ causal4d benchmark latent-contact \
   --output-dir runs/causal4d-latent-contact-v1
 ```
 
-The normal benchmark artifacts are unchanged. The opt-in SBC result is written to
-`OUTPUT_DIR/sbc.json` unless `--sbc-output-json` is supplied. Each seed contains
-three leave-one-topology-out folds. The target object's physical-parameter posterior
-is fitted from its training/validation interactions, the contact prior is learned
-from the other two topologies exactly as in the controlled latent-contact study, and
-SBC truths are then sampled from that finite bank's own declared joint prior.
+The normal benchmark artifacts are unchanged. The opt-in SBC result is published
+atomically to `OUTPUT_DIR/sbc.json` unless `--sbc-output-json` is supplied. The
+command refuses to replace an existing SBC artifact by default and performs that
+check before running the expensive benchmark. Replacement requires the explicit
+flag:
 
-`causal4d.controlled_latent_contact_sbc.run_controlled_latent_contact_sbc` exposes the
-same operation as a Python API. The aggregate report sums rank histograms across
+```bash
+causal4d benchmark latent-contact \
+  --seeds 0:5 \
+  --sbc-trials-per-fold 5000 \
+  --sbc-output-json runs/controlled-sbc.json \
+  --overwrite-sbc-output
+```
+
+The no-overwrite publication is race-safe: a destination created after the initial
+check still causes a clean failure rather than replacement. JSON serialization
+forbids non-finite values and the atomic writer does not leave a partial destination
+on process or machine failure.
+
+Every saved result contains a `producer` object with the Causal4D distribution and
+version, the runtime diagnostic module name, and the SHA-256 of the exact loaded
+module bytes. This supplements the benchmark configuration and seed inventory with
+a direct implementation identity.
+
+Each seed contains three leave-one-topology-out folds. The target object's
+physical-parameter posterior is fitted from its training/validation interactions,
+the contact prior is learned from the other two topologies exactly as in the
+controlled latent-contact study, and SBC truths are sampled from that finite bank's
+own declared joint prior.
+
+`causal4d.controlled_latent_contact_sbc.run_controlled_latent_contact_sbc` exposes
+the same operation as a Python API. The aggregate report sums rank histograms across
 folds and uses trial-count weighting for posterior summaries; it never relabels
 folds, frames, points, or coordinates as independent physical executions.
 
@@ -93,8 +116,8 @@ its own controlled model. It does **not** establish:
 - calibrated physical deployment uncertainty; or
 - Prob4D/BayesianPhysTwin provider competence.
 
-This distinction is useful for the current Causal4D failure attribution: if SBC is
-well behaved while real coverage remains poor, the remaining evidence points toward
+This distinction is useful for current Causal4D failure attribution: if SBC is well
+behaved while real coverage remains poor, the remaining evidence points toward
 model/discrepancy shift rather than a basic finite-posterior implementation error.
 
 ## Mode-wise graph discrepancy dynamics
@@ -145,12 +168,12 @@ mean, variance = forecast_modewise_graph_discrepancy(
 The forecast starts with zero latent-coefficient uncertainty at the last observed
 prefix coefficient and recursively accumulates per-mode innovation variance. The
 existing projection variance remains as an irreducible node-coordinate floor. This
-therefore produces explicit horizon-dependent uncertainty without requiring a dense
-cross-mode covariance transition.
+produces explicit horizon-dependent uncertainty without requiring a dense cross-mode
+covariance transition.
 
 ### Real diagnostic comparison
 
-The existing graph-discrepancy command now evaluates all five arms in one evidence
+The existing graph-discrepancy command evaluates all five arms in one evidence
 bundle:
 
 ```text
@@ -186,7 +209,7 @@ For any future post-freeze study, compare at least:
 - the existing dense learned graph transition; and
 - mode-wise stochastic dynamics with a source-frozen persistence prior.
 
-Select the prior weight and any retention bounds using controlled/source data only.
+Select the prior weight and retention bounds using controlled/source data only.
 Report held-out trajectory accuracy, proper scores, horizon coverage, interval width,
 worst-group coverage, and the full negative result when persistence still wins.
 

--- a/src/causal4d/cli/latent_contact_benchmark.py
+++ b/src/causal4d/cli/latent_contact_benchmark.py
@@ -110,8 +110,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--overwrite-sbc-output",
         action="store_true",
         help=(
-            "replace an existing SBC JSON explicitly; default publication "
-            "is once-only"
+            "replace an existing SBC JSON explicitly; default publication is once-only"
         ),
     )
     parser.add_argument(

--- a/src/causal4d/cli/latent_contact_benchmark.py
+++ b/src/causal4d/cli/latent_contact_benchmark.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import os
+import sys
 from collections.abc import Sequence
+from importlib import metadata
 from pathlib import Path
 
+from causal4d.atomic_io import atomic_write_json
 from causal4d.benchmark import CounterfactualBenchmarkConfig
 from causal4d.contact_evaluation import (
     run_latent_contact_benchmark,
@@ -32,6 +37,39 @@ def _parse_seeds(value: str) -> list[int]:
     if not seeds:
         raise argparse.ArgumentTypeError("at least one seed is required")
     return seeds
+
+
+def _sbc_producer_identity() -> dict[str, str]:
+    try:
+        package_version = metadata.version("causal4d")
+    except metadata.PackageNotFoundError:
+        package_version = "unknown"
+    source_path = Path(run_controlled_latent_contact_sbc.__code__.co_filename).resolve()
+    source_digest = hashlib.sha256(source_path.read_bytes()).hexdigest()
+    return {
+        "distribution": "causal4d",
+        "version": package_version,
+        "module": "causal4d.controlled_latent_contact_sbc",
+        "module_sha256": source_digest,
+    }
+
+
+def _report_existing_sbc_output(path: Path) -> int:
+    print(
+        json.dumps(
+            {
+                "error": (
+                    "SBC output already exists; pass --overwrite-sbc-output "
+                    "to replace it explicitly"
+                ),
+                "path": str(path.absolute()),
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        file=sys.stderr,
+    )
+    return 2
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -69,6 +107,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="optional SBC JSON path; defaults to OUTPUT_DIR/sbc.json",
     )
     parser.add_argument(
+        "--overwrite-sbc-output",
+        action="store_true",
+        help=(
+            "replace an existing SBC JSON explicitly; default publication "
+            "is once-only"
+        ),
+    )
+    parser.add_argument(
         "--require-gates",
         action="store_true",
         help="return status 2 when any pre-registered milestone gate fails",
@@ -80,6 +126,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     if args.sbc_trials_per_fold < 0:
         raise ValueError("sbc-trials-per-fold must be nonnegative")
+    sbc_path: Path | None = None
+    if args.sbc_trials_per_fold:
+        sbc_path = (
+            Path(args.sbc_output_json)
+            if args.sbc_output_json
+            else Path(args.output_dir) / "sbc.json"
+        )
+        if os.path.lexists(sbc_path) and not args.overwrite_sbc_output:
+            return _report_existing_sbc_output(sbc_path)
+
     benchmark_config = CounterfactualBenchmarkConfig(
         frame_count=args.frames,
         training_repeats=args.training_repeats,
@@ -105,6 +161,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "artifacts": paths,
     }
     if args.sbc_trials_per_fold:
+        assert sbc_path is not None
         sbc = run_controlled_latent_contact_sbc(
             seeds=seeds,
             trials_per_fold=args.sbc_trials_per_fold,
@@ -112,20 +169,20 @@ def main(argv: Sequence[str] | None = None) -> int:
             benchmark_config=benchmark_config,
             contact_config=contact_config,
         )
-        sbc_path = (
-            Path(args.sbc_output_json)
-            if args.sbc_output_json
-            else Path(args.output_dir) / "sbc.json"
-        )
-        sbc_path.parent.mkdir(parents=True, exist_ok=True)
-        sbc_path.write_text(
-            json.dumps(sbc, indent=2, sort_keys=True, allow_nan=False) + "\n",
-            encoding="utf-8",
-        )
+        sbc["producer"] = _sbc_producer_identity()
+        try:
+            atomic_write_json(
+                sbc_path,
+                sbc,
+                overwrite=args.overwrite_sbc_output,
+            )
+        except FileExistsError:
+            return _report_existing_sbc_output(sbc_path)
         summary["sbc"] = {
             "path": str(sbc_path.resolve()),
             "aggregate": sbc["aggregate"],
             "interpretation": sbc["interpretation"],
+            "producer": sbc["producer"],
         }
     print(json.dumps(summary, indent=2, sort_keys=True))
     if args.require_gates and not result["success_gates"]["overall_passed"]:

--- a/src/causal4d/cli/preacquisition_readiness.py
+++ b/src/causal4d/cli/preacquisition_readiness.py
@@ -26,6 +26,9 @@ from causal4d.preacquisition_readiness import (
     seal_preacquisition_gate,
     write_preacquisition_readiness,
 )
+from causal4d.preacquisition_source_panel_builder import (
+    stage_source_panel_manifest,
+)
 from causal4d.preacquisition_source_panel_control import (
     build_source_panel_status,
     write_source_panel_status,
@@ -127,6 +130,27 @@ def build_parser() -> argparse.ArgumentParser:
         "--require-complete",
         action="store_true",
         help="return exit code 3 while the valid source panel is incomplete",
+    )
+
+    source_stage = subparsers.add_parser(
+        "source-panel-stage",
+        help=(
+            "construct the exact next completed source manifest from registered "
+            "identities and local artifact bytes"
+        ),
+    )
+    source_stage.add_argument("repository_root")
+    source_stage.add_argument("dataset_root")
+    source_stage.add_argument("--started-at-utc", required=True)
+    source_stage.add_argument("--ended-at-utc", required=True)
+    source_stage.add_argument(
+        "--artifact",
+        action="append",
+        required=True,
+        help=(
+            "artifact path below the registered execution directory; repeat for "
+            "every file"
+        ),
     )
 
     source_verify = subparsers.add_parser(
@@ -259,6 +283,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             if args.output_json:
                 write_source_panel_status(args.output_json, result)
+        elif args.command == "source-panel-stage":
+            result = stage_source_panel_manifest(
+                args.repository_root,
+                args.dataset_root,
+                started_at_utc=args.started_at_utc,
+                ended_at_utc=args.ended_at_utc,
+                artifacts=args.artifact,
+            )
         elif args.command == "source-panel-verify-staged":
             result = verify_source_panel_manifest_staging(
                 args.repository_root,

--- a/src/causal4d/preacquisition_operator_flow.py
+++ b/src/causal4d/preacquisition_operator_flow.py
@@ -16,8 +16,8 @@ from causal4d.preacquisition_next_action import (
     next_action_status_sha256,
 )
 
-OPERATOR_FLOW_SCHEMA_VERSION = 1
-NEXT_ACTION_SCHEMA_VERSION = 2
+OPERATOR_FLOW_SCHEMA_VERSION = 2
+NEXT_ACTION_SCHEMA_VERSION = 3
 
 
 def _command_pair(argv: list[str]) -> tuple[list[str], str]:
@@ -43,7 +43,7 @@ def _expected_publication_command(
 def enrich_preacquisition_next_action(
     decision: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Insert staged verification and two-person review before publication."""
+    """Insert safe staging, verification, and two-person publication."""
 
     result = deepcopy(dict(decision))
     action_value = result.get("action")
@@ -82,6 +82,22 @@ def enrich_preacquisition_next_action(
                 "source action publication command differs from the registered path"
             )
 
+        staging_argv, staging_text = _command_pair(
+            [
+                "causal4d",
+                "protocol",
+                "readiness",
+                "source-panel-stage",
+                repository,
+                dataset,
+                "--started-at-utc",
+                "<execution-started-at-utc>",
+                "--ended-at-utc",
+                "<execution-ended-at-utc>",
+                "--artifact",
+                "<dataset-relative-artifact-path>",
+            ]
+        )
         verification_argv, verification_text = _command_pair(
             [
                 "causal4d",
@@ -119,6 +135,13 @@ def enrich_preacquisition_next_action(
         )
         action["after_completion_argv"] = None
         action["after_completion_text"] = None
+        action["staged_manifest_build_argv"] = staging_argv
+        action["staged_manifest_build_text"] = staging_text
+        action["staged_manifest_path"] = staging
+        action["staged_manifest_build_note"] = (
+            "Repeat --artifact once for every ordinary artifact file below the "
+            "registered execution directory."
+        )
         action["post_acquisition_verification_argv"] = verification_argv
         action["post_acquisition_verification_text"] = verification_text
         action["preflight_report_path"] = preflight
@@ -133,17 +156,23 @@ def enrich_preacquisition_next_action(
         action["claim_bearing_publication_text"] = publication_text
         action["operator_sequence"] = [
             "acquire_registered_source_execution",
+            "build_staged_manifest_from_registered_template_and_artifact_bytes",
             "verify_staged_manifest_and_artifacts",
             "independent_review_of_preflight_report",
             "publish_exactly_once",
             "recompute_next_action",
         ]
         outputs = list(action.get("output_paths", []))
-        for index, path in enumerate((preflight, receipt), start=1):
-            if path not in outputs:
-                outputs.insert(min(index, len(outputs)), path)
-        action["output_paths"] = outputs
+        staged_outputs = (staging, preflight, receipt)
+        action["output_paths"] = [
+            *staged_outputs,
+            *(path for path in outputs if path not in staged_outputs),
+        ]
     else:
+        action.setdefault("staged_manifest_build_argv", None)
+        action.setdefault("staged_manifest_build_text", None)
+        action.setdefault("staged_manifest_path", None)
+        action.setdefault("staged_manifest_build_note", None)
         action.setdefault("post_acquisition_verification_argv", None)
         action.setdefault("post_acquisition_verification_text", None)
         action.setdefault("preflight_report_path", None)
@@ -172,7 +201,7 @@ def build_preacquisition_operator_next_action(
     *,
     verify_file_hashes: bool = True,
 ) -> dict[str, Any]:
-    """Build one decision with explicit verification and publication stages."""
+    """Build one decision with explicit staging and publication boundaries."""
 
     return enrich_preacquisition_next_action(
         _build_next_action(
@@ -226,19 +255,27 @@ def render_preacquisition_operator_next_action_markdown(
         f"`{str(action['physical_acquisition_required']).lower()}`",
     ]
     sections = (
-        ("Command", "command_text"),
-        ("Verify staged evidence", "post_acquisition_verification_text"),
-        ("Review and seal receipt", "staged_review_text"),
+        ("Command", "command_text", None),
+        (
+            "Build staged manifest",
+            "staged_manifest_build_text",
+            "staged_manifest_build_note",
+        ),
+        ("Verify staged evidence", "post_acquisition_verification_text", None),
+        ("Review and seal receipt", "staged_review_text", None),
         (
             "Publish after independent review",
             "claim_bearing_publication_text",
+            None,
         ),
-        ("Completion check", "completion_check_text"),
+        ("Completion check", "completion_check_text", None),
     )
-    for heading, field in sections:
+    for heading, field, note_field in sections:
         value = action.get(field)
         if value:
             lines += ["", f"### {heading}", "", "```bash", str(value), "```"]
+            if note_field and action.get(note_field):
+                lines += ["", str(action[note_field])]
     if action.get("independent_review_required_before_publication") is True:
         lines += [
             "",

--- a/src/causal4d/preacquisition_source_panel_builder.py
+++ b/src/causal4d/preacquisition_source_panel_builder.py
@@ -1,0 +1,335 @@
+"""Safe construction of the next source-panel staging manifest."""
+
+from __future__ import annotations
+
+import shlex
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from causal4d.acquisition_flight_common import (
+    _assert_no_symlink_components,
+    _assert_ordinary_file_or_missing,
+    _fsync_directory,
+    _reject_target_outcomes,
+    _require,
+)
+from causal4d.atomic_io import atomic_write_json
+from causal4d.preacquisition_readiness_contracts import (
+    SOURCE_PANEL_MANIFEST_PATH,
+    SOURCE_PANEL_MANIFEST_TEMPLATE_PATH,
+    _parse_utc_timestamp,
+    _read_json_mapping,
+    _sha256_file,
+    load_registered_preacquisition_chain,
+    source_panel_execution_manifest_template,
+)
+from causal4d.preacquisition_source_panel_control import build_source_panel_status
+from causal4d.preacquisition_source_validation import (
+    _validate_source_execution_manifest,
+)
+
+SOURCE_PANEL_STAGING_RESULT_SCHEMA_VERSION = 1
+SOURCE_PANEL_STAGING_RESULT_ARTIFACT_KIND = "Causal4DSourcePanelStagingResult"
+
+
+def _resolved_dataset_root(dataset_root: str | Path) -> Path:
+    candidate = Path(dataset_root)
+    _assert_no_symlink_components(candidate, name="dataset root")
+    _require(candidate.is_dir(), "dataset root must exist")
+    return candidate.resolve()
+
+
+def _resolved_artifact(
+    dataset_root: Path,
+    value: str | Path,
+    *,
+    execution_id: str,
+    index: int,
+) -> tuple[str, Path]:
+    raw = Path(value)
+    candidate = raw if raw.is_absolute() else dataset_root / raw
+    name = f"source execution artifact {index}"
+    _assert_no_symlink_components(candidate, name=name)
+    _require(candidate.is_file(), f"{name} file is missing")
+    resolved = candidate.resolve(strict=True)
+    _require(
+        resolved.is_relative_to(dataset_root),
+        f"{name} path escapes the dataset root",
+    )
+    relative = resolved.relative_to(dataset_root)
+    execution_root = (
+        Path("preacquisition") / "source_panel" / "executions" / execution_id
+    )
+    _require(
+        relative.is_relative_to(execution_root),
+        f"{name} must be below {execution_root.as_posix()}",
+    )
+    _require(
+        relative
+        not in {
+            execution_root / "manifest.json",
+            execution_root / "manifest.template.json",
+        },
+        f"{name} cannot be a source-panel manifest",
+    )
+    return relative.as_posix(), resolved
+
+
+def _artifact_descriptors(
+    dataset_root: Path,
+    artifacts: Sequence[str | Path],
+    *,
+    execution_id: str,
+) -> list[dict[str, Any]]:
+    _require(
+        not isinstance(artifacts, (str, bytes))
+        and isinstance(artifacts, Sequence)
+        and bool(artifacts),
+        "source execution artifacts must be a nonempty sequence",
+    )
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, value in enumerate(artifacts):
+        _require(
+            isinstance(value, (str, Path)),
+            f"source execution artifact {index} path is invalid",
+        )
+        relative, path = _resolved_artifact(
+            dataset_root,
+            value,
+            execution_id=execution_id,
+            index=index,
+        )
+        _require(
+            relative not in seen,
+            f"source execution artifacts contain a duplicate path: {relative}",
+        )
+        digest, byte_count = _sha256_file(path)
+        rows.append(
+            {
+                "path": relative,
+                "sha256": digest,
+                "bytes": byte_count,
+            }
+        )
+        seen.add(relative)
+    return sorted(rows, key=lambda row: str(row["path"]))
+
+
+def _rollback_owned_staging_file(path: Path) -> None:
+    path.unlink(missing_ok=True)
+    try:
+        _fsync_directory(path.parent)
+    except OSError:
+        pass
+
+
+def stage_source_panel_manifest(
+    repository_root: str | Path,
+    dataset_root: str | Path,
+    *,
+    started_at_utc: str,
+    ended_at_utc: str,
+    artifacts: Sequence[str | Path],
+) -> dict[str, Any]:
+    """Build the exact next completed manifest without verifying or publishing it."""
+
+    protocol, _, _, v4 = load_registered_preacquisition_chain(repository_root)
+    root = _resolved_dataset_root(dataset_root)
+    status_before = build_source_panel_status(
+        repository_root,
+        root,
+        verify_file_hashes=True,
+    )
+    _require(status_before["valid"] is True, "source-panel status is invalid")
+    _require(status_before["complete"] is False, "source panel is already complete")
+    next_execution = status_before.get("next_execution")
+    _require(isinstance(next_execution, Mapping), "source panel has no next execution")
+    _require(
+        next_execution.get("template_present") is True
+        and next_execution.get("template_valid") is True,
+        "next source-panel manifest template is missing or invalid",
+    )
+
+    execution_id = str(next_execution["execution_id"])
+    session_id = str(next_execution["session_id"])
+    expected_template = source_panel_execution_manifest_template(
+        next_execution,
+        protocol,
+        v4,
+    )
+    template_relative = SOURCE_PANEL_MANIFEST_TEMPLATE_PATH.format(
+        execution_id=execution_id
+    )
+    template_path = root / template_relative
+    _assert_no_symlink_components(template_path, name="source-panel worksheet template")
+    _require(template_path.is_file(), "source-panel worksheet template is missing")
+    template_digest_before, template_bytes_before = _sha256_file(template_path)
+    template = _read_json_mapping(
+        template_path,
+        name="source-panel worksheet template",
+    )
+    _require(
+        template == expected_template,
+        "source-panel worksheet template differs from the registered template",
+    )
+
+    started = _parse_utc_timestamp(
+        started_at_utc,
+        name="source execution started_at_utc",
+    )
+    ended = _parse_utc_timestamp(
+        ended_at_utc,
+        name="source execution ended_at_utc",
+    )
+    _require(ended >= started, "source execution ends before it starts")
+    descriptors_before = _artifact_descriptors(
+        root,
+        artifacts,
+        execution_id=execution_id,
+    )
+
+    manifest = deepcopy(template)
+    manifest.update(
+        {
+            "status": "complete",
+            "included": True,
+            "quality_gate_failures": [],
+            "started_at_utc": started_at_utc,
+            "ended_at_utc": ended_at_utc,
+            "artifacts": descriptors_before,
+        }
+    )
+    _reject_target_outcomes(manifest)
+
+    final_relative = SOURCE_PANEL_MANIFEST_PATH.format(execution_id=execution_id)
+    final_path = root / final_relative
+    _assert_ordinary_file_or_missing(final_path, name="source-panel manifest")
+    _require(not final_path.exists(), "source-panel manifest already exists")
+
+    staging_root = root / "staging"
+    _assert_no_symlink_components(staging_root, name="source-panel staging directory")
+    staging_root.mkdir(parents=True, exist_ok=True)
+    _assert_no_symlink_components(staging_root, name="source-panel staging directory")
+    staging_relative = (Path("staging") / f"{execution_id}.json").as_posix()
+    target = root / staging_relative
+    _assert_ordinary_file_or_missing(target, name="source-panel staging manifest")
+    _require(not target.exists(), "source-panel staging manifest already exists")
+
+    created = False
+    try:
+        atomic_write_json(target, manifest, overwrite=False)
+        created = True
+        staged = _read_json_mapping(target, name="source-panel staging manifest")
+        _require(staged == manifest, "staged source-panel manifest changed on write")
+        _validate_source_execution_manifest(
+            root,
+            staging_relative,
+            protocol=protocol,
+            v4=v4,
+            execution_id=execution_id,
+            session_id=session_id,
+            verify_file_hashes=True,
+        )
+        staged_digest, staged_bytes = _sha256_file(target)
+
+        template_digest_after, template_bytes_after = _sha256_file(template_path)
+        _require(
+            (template_digest_after, template_bytes_after)
+            == (template_digest_before, template_bytes_before),
+            "source-panel worksheet template changed while staging",
+        )
+        descriptors_after = _artifact_descriptors(
+            root,
+            [str(row["path"]) for row in descriptors_before],
+            execution_id=execution_id,
+        )
+        _require(
+            descriptors_after == descriptors_before,
+            "source-panel artifacts changed while staging",
+        )
+
+        status_after = build_source_panel_status(
+            repository_root,
+            root,
+            verify_file_hashes=True,
+        )
+        _require(
+            status_after["status_sha256"] == status_before["status_sha256"],
+            "source-panel status changed while staging",
+        )
+        next_after = status_after.get("next_execution")
+        _require(
+            isinstance(next_after, Mapping)
+            and next_after.get("execution_id") == execution_id,
+            "next source-panel execution changed while staging",
+        )
+        _require(
+            not final_path.exists(),
+            "staging unexpectedly created the final source-panel manifest",
+        )
+    except BaseException:
+        if created:
+            _rollback_owned_staging_file(target)
+        raise
+
+    repository = str(Path(repository_root).resolve())
+    verification_command = [
+        "causal4d",
+        "protocol",
+        "readiness",
+        "source-panel-verify-staged",
+        repository,
+        str(root),
+        str(target.resolve(strict=True)),
+    ]
+    return {
+        "schema_version": SOURCE_PANEL_STAGING_RESULT_SCHEMA_VERSION,
+        "artifact_kind": SOURCE_PANEL_STAGING_RESULT_ARTIFACT_KIND,
+        "protocol_id": protocol["protocol_id"],
+        "protocol_design_sha256": protocol["design_sha256"],
+        "preacquisition_plan_id": v4["plan_id"],
+        "preacquisition_amendment_sha256": v4["amendment_sha256"],
+        "repository_root": repository,
+        "dataset_root": str(root),
+        "execution_id": execution_id,
+        "session_id": session_id,
+        "source_panel_execution_index": next_execution["source_panel_execution_index"],
+        "command_profile_id": next_execution["command_profile_id"],
+        "template_relative_path": template_relative,
+        "template_sha256": template_digest_before,
+        "template_bytes": template_bytes_before,
+        "source_json": str(target.resolve(strict=True)),
+        "source_manifest_relative_path": staging_relative,
+        "source_manifest_sha256": staged_digest,
+        "source_manifest_bytes": staged_bytes,
+        "started_at_utc": started_at_utc,
+        "ended_at_utc": ended_at_utc,
+        "artifact_count": len(descriptors_before),
+        "artifacts": descriptors_before,
+        "final_manifest_path": final_relative,
+        "final_manifest_present": False,
+        "source_panel_evidence_sha256_before": status_before["evidence_sha256"],
+        "source_panel_status_sha256_before": status_before["status_sha256"],
+        "source_panel_status_sha256_after": status_after["status_sha256"],
+        "source_panel_status_stable": True,
+        "staged_verification_command_argv": verification_command,
+        "staged_verification_command_text": shlex.join(verification_command),
+        "ready_for_staged_verification": True,
+        "published": False,
+        "claim_bearing_evidence_mutated": False,
+        "changes_registered_method": False,
+        "target_outcomes_used": False,
+        "valid": True,
+        "complete": True,
+        "passed": True,
+    }
+
+
+__all__ = [
+    "SOURCE_PANEL_STAGING_RESULT_ARTIFACT_KIND",
+    "SOURCE_PANEL_STAGING_RESULT_SCHEMA_VERSION",
+    "stage_source_panel_manifest",
+]

--- a/tests/test_latent_contact_benchmark_cli.py
+++ b/tests/test_latent_contact_benchmark_cli.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import causal4d.cli.latent_contact_benchmark as cli
+
+
+def _benchmark_result() -> dict:
+    return {
+        "success_gates": {"overall_passed": True},
+        "aggregate": {"mean_error": 0.0},
+    }
+
+
+def _sbc_result() -> dict:
+    return {
+        "schema": "causal4d.controlled_latent_contact_sbc",
+        "schema_version": 1,
+        "aggregate": {"trial_count": 3},
+        "interpretation": "controlled diagnostic only",
+    }
+
+
+def _patch_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        cli,
+        "run_latent_contact_benchmark",
+        lambda **kwargs: _benchmark_result(),
+    )
+    monkeypatch.setattr(
+        cli,
+        "write_latent_contact_artifacts",
+        lambda result, output_dir: {"summary": str(Path(output_dir) / "summary.json")},
+    )
+    monkeypatch.setattr(
+        cli,
+        "run_controlled_latent_contact_sbc",
+        lambda **kwargs: _sbc_result(),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_sbc_producer_identity",
+        lambda: {
+            "distribution": "causal4d",
+            "version": "test",
+            "module": "causal4d.controlled_latent_contact_sbc",
+            "module_sha256": "a" * 64,
+        },
+    )
+
+
+def _arguments(output: Path, *, overwrite: bool = False) -> list[str]:
+    values = [
+        "--seeds",
+        "1",
+        "--sbc-trials-per-fold",
+        "1",
+        "--sbc-output-json",
+        str(output),
+    ]
+    if overwrite:
+        values.append("--overwrite-sbc-output")
+    return values
+
+
+def test_sbc_cli_publishes_atomically_with_producer_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _patch_runtime(monkeypatch)
+    output = tmp_path / "diagnostics" / "sbc.json"
+
+    code = cli.main(_arguments(output))
+
+    assert code == 0
+    artifact = json.loads(output.read_text(encoding="utf-8"))
+    assert artifact["aggregate"]["trial_count"] == 3
+    assert artifact["producer"] == {
+        "distribution": "causal4d",
+        "version": "test",
+        "module": "causal4d.controlled_latent_contact_sbc",
+        "module_sha256": "a" * 64,
+    }
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["sbc"]["path"] == str(output.resolve())
+    assert summary["sbc"]["producer"] == artifact["producer"]
+
+
+def test_sbc_cli_refuses_existing_output_before_running_benchmark(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output = tmp_path / "sbc.json"
+    output.write_text('{"old": true}\n', encoding="utf-8")
+
+    def unexpected(**kwargs):
+        del kwargs
+        raise AssertionError("benchmark must not run when output already exists")
+
+    monkeypatch.setattr(cli, "run_latent_contact_benchmark", unexpected)
+
+    code = cli.main(_arguments(output))
+
+    assert code == 2
+    assert json.loads(output.read_text(encoding="utf-8")) == {"old": True}
+    error = json.loads(capsys.readouterr().err)
+    assert "already exists" in error["error"]
+    assert error["path"] == str(output.absolute())
+
+
+def test_sbc_cli_requires_explicit_overwrite(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _patch_runtime(monkeypatch)
+    output = tmp_path / "sbc.json"
+    output.write_text('{"old": true}\n', encoding="utf-8")
+
+    code = cli.main(_arguments(output, overwrite=True))
+
+    assert code == 0
+    artifact = json.loads(output.read_text(encoding="utf-8"))
+    assert "old" not in artifact
+    assert artifact["producer"]["module_sha256"] == "a" * 64
+
+
+def test_sbc_cli_handles_no_overwrite_race(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _patch_runtime(monkeypatch)
+    output = tmp_path / "sbc.json"
+
+    def raced(*args, **kwargs) -> None:
+        del args, kwargs
+        raise FileExistsError(output)
+
+    monkeypatch.setattr(cli, "atomic_write_json", raced)
+
+    code = cli.main(_arguments(output))
+
+    assert code == 2
+    assert "already exists" in json.loads(capsys.readouterr().err)["error"]
+
+
+def test_sbc_producer_identity_binds_runtime_module_bytes() -> None:
+    identity = cli._sbc_producer_identity()
+
+    assert identity["distribution"] == "causal4d"
+    assert identity["module"] == "causal4d.controlled_latent_contact_sbc"
+    assert identity["version"]
+    assert len(identity["module_sha256"]) == 64
+    assert set(identity["module_sha256"]) <= set("0123456789abcdef")

--- a/tests/test_preacquisition_operator_flow.py
+++ b/tests/test_preacquisition_operator_flow.py
@@ -96,14 +96,20 @@ def _source_decision() -> dict:
     return decision
 
 
-def test_source_action_inserts_preflight_and_independent_review() -> None:
+def test_source_action_inserts_staging_preflight_and_independent_review() -> None:
     result = operator_flow.enrich_preacquisition_next_action(_source_decision())
 
     action = result["action"]
-    assert result["schema_version"] == 2
-    assert result["operator_flow_schema_version"] == 1
+    assert result["schema_version"] == 3
+    assert result["operator_flow_schema_version"] == 2
     assert action["after_completion_argv"] is None
     assert action["after_completion_text"] is None
+    assert action["staged_manifest_build_argv"][3] == "source-panel-stage"
+    assert action["staged_manifest_build_argv"].count("--artifact") == 1
+    assert action["staged_manifest_path"].endswith(
+        "staging/source-lift_high-r1.json"
+    )
+    assert "Repeat --artifact" in action["staged_manifest_build_note"]
     assert action["post_acquisition_verification_argv"][3] == (
         "source-panel-verify-staged"
     )
@@ -115,11 +121,13 @@ def test_source_action_inserts_preflight_and_independent_review() -> None:
     assert action["claim_bearing_publication_argv"][3] == "source-panel-publish"
     assert action["operator_sequence"] == [
         "acquire_registered_source_execution",
+        "build_staged_manifest_from_registered_template_and_artifact_bytes",
         "verify_staged_manifest_and_artifacts",
         "independent_review_of_preflight_report",
         "publish_exactly_once",
         "recompute_next_action",
     ]
+    assert action["staged_manifest_path"] in action["output_paths"]
     assert action["preflight_report_path"] in action["output_paths"]
     assert result["evidence_sha256"] == next_action_evidence_sha256(result)
     assert result["status_sha256"] == next_action_status_sha256(result)
@@ -139,6 +147,8 @@ def test_non_source_action_gets_explicit_empty_publication_boundary() -> None:
     result = operator_flow.enrich_preacquisition_next_action(decision)
 
     action = result["action"]
+    assert action["staged_manifest_build_argv"] is None
+    assert action["staged_manifest_path"] is None
     assert action["post_acquisition_verification_argv"] is None
     assert action["claim_bearing_publication_argv"] is None
     assert action["independent_review_required_before_publication"] is False
@@ -161,15 +171,17 @@ def test_source_action_requires_registered_execution_identity() -> None:
         operator_flow.enrich_preacquisition_next_action(decision)
 
 
-def test_markdown_orders_verification_before_publication() -> None:
+def test_markdown_orders_staging_verification_and_publication() -> None:
     result = operator_flow.enrich_preacquisition_next_action(_source_decision())
 
     markdown = operator_flow.render_preacquisition_operator_next_action_markdown(result)
 
+    staging = markdown.index("### Build staged manifest")
     verification = markdown.index("### Verify staged evidence")
     publication = markdown.index("### Publish after independent review")
     completion = markdown.index("### Completion check")
-    assert verification < publication < completion
+    assert staging < verification < publication < completion
+    assert "Repeat --artifact" in markdown
     assert "requires independent review" in markdown
     assert result["evidence_sha256"] in markdown
 
@@ -214,6 +226,7 @@ def test_build_wrapper_enriches_underlying_decision(
         "/data",
     )
 
+    assert result["action"]["staged_manifest_build_argv"] is not None
     assert result["action"]["post_acquisition_verification_argv"] is not None
 
 
@@ -238,4 +251,6 @@ def test_json_and_markdown_writers_are_atomic(tmp_path: Path) -> None:
     )
     assert json_path.is_file()
     assert markdown_path.is_file()
-    assert "Verify staged evidence" in markdown_path.read_text(encoding="utf-8")
+    markdown = markdown_path.read_text(encoding="utf-8")
+    assert "Build staged manifest" in markdown
+    assert "Verify staged evidence" in markdown

--- a/tests/test_preacquisition_operator_flow.py
+++ b/tests/test_preacquisition_operator_flow.py
@@ -106,9 +106,7 @@ def test_source_action_inserts_staging_preflight_and_independent_review() -> Non
     assert action["after_completion_text"] is None
     assert action["staged_manifest_build_argv"][3] == "source-panel-stage"
     assert action["staged_manifest_build_argv"].count("--artifact") == 1
-    assert action["staged_manifest_path"].endswith(
-        "staging/source-lift_high-r1.json"
-    )
+    assert action["staged_manifest_path"].endswith("staging/source-lift_high-r1.json")
     assert "Repeat --artifact" in action["staged_manifest_build_note"]
     assert action["post_acquisition_verification_argv"][3] == (
         "source-panel-verify-staged"

--- a/tests/test_preacquisition_source_panel_builder.py
+++ b/tests/test_preacquisition_source_panel_builder.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+import causal4d.preacquisition_source_panel_builder as builder
+from causal4d.cli import preacquisition_readiness as readiness_cli
+from causal4d.preacquisition_readiness_contracts import (
+    SOURCE_PANEL_MANIFEST_PATH,
+    SOURCE_PANEL_MANIFEST_TEMPLATE_PATH,
+    source_panel_execution_manifest_template,
+)
+
+
+def _registered_values() -> tuple[dict, dict, dict]:
+    protocol = {
+        "protocol_id": "test-protocol",
+        "design_sha256": "a" * 64,
+    }
+    execution = {
+        "execution_id": "source-lift-high-r1",
+        "session_id": "session-lift-high-r1",
+        "source_panel_execution_index": 0,
+        "command_profile_id": "lift_high",
+        "template_present": True,
+        "template_valid": True,
+    }
+    v4 = {
+        "plan_id": "test-preacquisition-v4",
+        "amendment_sha256": "b" * 64,
+    }
+    return protocol, execution, v4
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _setup(
+    monkeypatch: pytest.MonkeyPatch,
+    root: Path,
+) -> tuple[dict, dict, dict, Path]:
+    protocol, execution, v4 = _registered_values()
+    root.mkdir(parents=True, exist_ok=True)
+    template = source_panel_execution_manifest_template(execution, protocol, v4)
+    template_path = root / SOURCE_PANEL_MANIFEST_TEMPLATE_PATH.format(
+        execution_id=execution["execution_id"]
+    )
+    _write_json(template_path, template)
+    artifact_root = (
+        root
+        / "preacquisition"
+        / "source_panel"
+        / "executions"
+        / execution["execution_id"]
+    )
+    artifact_root.mkdir(parents=True, exist_ok=True)
+
+    status = {
+        "valid": True,
+        "complete": False,
+        "evidence_sha256": "c" * 64,
+        "status_sha256": "d" * 64,
+        "next_execution": execution,
+    }
+    monkeypatch.setattr(
+        builder,
+        "load_registered_preacquisition_chain",
+        lambda repository_root: (protocol, {}, {}, v4),
+    )
+    monkeypatch.setattr(
+        builder,
+        "build_source_panel_status",
+        lambda *args, **kwargs: deepcopy(status),
+    )
+    return protocol, execution, v4, artifact_root
+
+
+def test_stage_builds_exact_next_manifest_without_publication(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    protocol, execution, v4, artifact_root = _setup(monkeypatch, tmp_path)
+    first = artifact_root / "rgbd.npz"
+    second = artifact_root / "controller.csv"
+    first.write_bytes(b"rgbd")
+    second.write_bytes(b"controller")
+
+    result = builder.stage_source_panel_manifest(
+        tmp_path,
+        tmp_path,
+        started_at_utc="2026-08-10T08:00:00Z",
+        ended_at_utc="2026-08-10T08:01:00Z",
+        artifacts=(first, second.relative_to(tmp_path)),
+    )
+
+    staged_path = Path(result["source_json"])
+    staged = json.loads(staged_path.read_text(encoding="utf-8"))
+    expected = source_panel_execution_manifest_template(execution, protocol, v4)
+    expected.update(
+        {
+            "status": "complete",
+            "included": True,
+            "quality_gate_failures": [],
+            "started_at_utc": "2026-08-10T08:00:00Z",
+            "ended_at_utc": "2026-08-10T08:01:00Z",
+            "artifacts": result["artifacts"],
+        }
+    )
+
+    assert staged == expected
+    assert result["execution_id"] == execution["execution_id"]
+    assert result["session_id"] == execution["session_id"]
+    assert result["artifact_count"] == 2
+    assert [row["path"] for row in result["artifacts"]] == sorted(
+        row["path"] for row in result["artifacts"]
+    )
+    assert result["source_panel_status_stable"] is True
+    assert result["ready_for_staged_verification"] is True
+    assert result["published"] is False
+    assert result["claim_bearing_evidence_mutated"] is False
+    assert result["changes_registered_method"] is False
+    assert result["target_outcomes_used"] is False
+    assert result["staged_verification_command_argv"][3] == (
+        "source-panel-verify-staged"
+    )
+    final = tmp_path / SOURCE_PANEL_MANIFEST_PATH.format(
+        execution_id=execution["execution_id"]
+    )
+    assert not final.exists()
+
+
+def test_stage_refuses_to_replace_existing_staging_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, execution, _, artifact_root = _setup(monkeypatch, tmp_path)
+    artifact = artifact_root / "raw.bin"
+    artifact.write_bytes(b"raw")
+    target = tmp_path / "staging" / f"{execution['execution_id']}.json"
+    target.parent.mkdir(parents=True)
+    target.write_text("existing\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="staging manifest already exists"):
+        builder.stage_source_panel_manifest(
+            tmp_path,
+            tmp_path,
+            started_at_utc="2026-08-10T08:00:00Z",
+            ended_at_utc="2026-08-10T08:01:00Z",
+            artifacts=(artifact,),
+        )
+
+    assert target.read_text(encoding="utf-8") == "existing\n"
+
+
+def test_stage_rejects_artifact_outside_registered_execution_directory(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _setup(monkeypatch, tmp_path)
+    artifact = tmp_path / "other" / "raw.bin"
+    artifact.parent.mkdir()
+    artifact.write_bytes(b"raw")
+
+    with pytest.raises(ValueError, match="must be below"):
+        builder.stage_source_panel_manifest(
+            tmp_path,
+            tmp_path,
+            started_at_utc="2026-08-10T08:00:00Z",
+            ended_at_utc="2026-08-10T08:01:00Z",
+            artifacts=(artifact,),
+        )
+
+
+def test_stage_rejects_duplicate_artifact_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, _, _, artifact_root = _setup(monkeypatch, tmp_path)
+    artifact = artifact_root / "raw.bin"
+    artifact.write_bytes(b"raw")
+
+    with pytest.raises(ValueError, match="duplicate path"):
+        builder.stage_source_panel_manifest(
+            tmp_path,
+            tmp_path,
+            started_at_utc="2026-08-10T08:00:00Z",
+            ended_at_utc="2026-08-10T08:01:00Z",
+            artifacts=(artifact, artifact.relative_to(tmp_path)),
+        )
+
+
+def test_stage_rolls_back_when_status_changes_during_construction(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, execution, _, artifact_root = _setup(monkeypatch, tmp_path)
+    artifact = artifact_root / "raw.bin"
+    artifact.write_bytes(b"raw")
+    calls = 0
+
+    def changing_status(*args, **kwargs):
+        nonlocal calls
+        del args, kwargs
+        calls += 1
+        return {
+            "valid": True,
+            "complete": False,
+            "evidence_sha256": "c" * 64,
+            "status_sha256": ("d" if calls == 1 else "e") * 64,
+            "next_execution": _registered_values()[1],
+        }
+
+    monkeypatch.setattr(builder, "build_source_panel_status", changing_status)
+
+    with pytest.raises(ValueError, match="status changed while staging"):
+        builder.stage_source_panel_manifest(
+            tmp_path,
+            tmp_path,
+            started_at_utc="2026-08-10T08:00:00Z",
+            ended_at_utc="2026-08-10T08:01:00Z",
+            artifacts=(artifact,),
+        )
+
+    target = tmp_path / "staging" / f"{execution['execution_id']}.json"
+    assert not target.exists()
+
+
+def test_stage_rolls_back_when_artifact_changes_during_construction(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, execution, _, artifact_root = _setup(monkeypatch, tmp_path)
+    artifact = artifact_root / "raw.bin"
+    artifact.write_bytes(b"raw")
+    validate = builder._validate_source_execution_manifest
+
+    def validate_then_mutate(*args, **kwargs) -> None:
+        validate(*args, **kwargs)
+        artifact.write_bytes(b"changed")
+
+    monkeypatch.setattr(
+        builder,
+        "_validate_source_execution_manifest",
+        validate_then_mutate,
+    )
+
+    with pytest.raises(ValueError, match="artifacts changed while staging"):
+        builder.stage_source_panel_manifest(
+            tmp_path,
+            tmp_path,
+            started_at_utc="2026-08-10T08:00:00Z",
+            ended_at_utc="2026-08-10T08:01:00Z",
+            artifacts=(artifact,),
+        )
+
+    target = tmp_path / "staging" / f"{execution['execution_id']}.json"
+    assert not target.exists()
+
+
+def test_stage_cli_dispatches_artifacts_and_timestamps(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    captured: dict[str, object] = {}
+
+    def stage(repository_root, dataset_root, **kwargs):
+        captured.update(
+            repository_root=repository_root,
+            dataset_root=dataset_root,
+            **kwargs,
+        )
+        return {
+            "valid": True,
+            "complete": True,
+            "passed": True,
+            "published": False,
+        }
+
+    monkeypatch.setattr(readiness_cli, "stage_source_panel_manifest", stage)
+    code = readiness_cli.main(
+        [
+            "source-panel-stage",
+            "/repo",
+            "/dataset",
+            "--started-at-utc",
+            "2026-08-10T08:00:00Z",
+            "--ended-at-utc",
+            "2026-08-10T08:01:00Z",
+            "--artifact",
+            "first.bin",
+            "--artifact",
+            "second.bin",
+        ]
+    )
+
+    assert code == 0
+    assert captured == {
+        "repository_root": "/repo",
+        "dataset_root": "/dataset",
+        "started_at_utc": "2026-08-10T08:00:00Z",
+        "ended_at_utc": "2026-08-10T08:01:00Z",
+        "artifacts": ["first.bin", "second.bin"],
+    }
+    assert json.loads(capsys.readouterr().out)["published"] is False


### PR DESCRIPTION
## Summary

- Publish controlled latent-contact SBC JSON atomically, refuse replacement by default, handle publication races, and bind the exact runtime diagnostic module bytes through a producer SHA-256.
- Add `causal4d protocol readiness source-panel-stage`, which derives the exact next execution from the registered chain, copies the immutable worksheet, computes artifact SHA-256 values and byte counts, validates paths and chronology, refuses overwrite, and rolls back its own staging file when concurrent mutation is detected.
- Insert the staging builder into the generated operator sequence before staged verification, independent review, and exactly-once publication.
- Update the acquisition and post-freeze runbooks and add focused regression tests.

## Scientific boundary

These are acquisition-only and post-freeze diagnostic changes. They do not alter the frozen estimator, intervention posterior, target identities, causal information boundary, signals, quality gates, exclusion rules, registered analysis outputs, or physical evidence count. The staging builder never publishes claim-bearing evidence.

## Validation

All current-head GitHub Actions workflows pass:

- Causal4D merge gate: repository quality checks, complete default test suite, distribution validation, and pinned BayesianPhysTwin installed-wheel integration.
- CI and release: Ruff, formatting, types, Python 3.10/3.12/3.14 core suites, frozen milestone manifest, result-bundle round trip, distributions, installed wheel/sdist CLI help, and pinned provider integration.
- Extended compatibility: Python 3.11/3.13 and exact declared dependency floors on Python 3.10.
- Security scanning: dependency audit and CodeQL for Python and Actions.

Focused regression coverage includes SBC no-overwrite/explicit-overwrite/race behavior and producer identity; exact source-manifest construction, path confinement, duplicate rejection, non-overwrite behavior, mutation rollback, and CLI dispatch; and the explicit build → verify → review → publish operator sequence.