### PR TITLE
Support structured covariance in identifiability diagnostics

### DIFF
--- a/docs/covariance_and_query_identifiability.md
+++ b/docs/covariance_and_query_identifiability.md
@@ -61,9 +61,47 @@ A covariance with leading shape `(particle, d, d)` broadcasts over a rollout
 bank with leading shape `(hypothesis, particle)`. This lets one discrepancy
 belief per physical particle be shared across its intervention hypotheses.
 
+## Structured covariance whitening
+
+`assess_intervention_identifiability` accepts either a dense positive-definite
+response covariance or a positive diagonal variance vector. The optional
+`covariance_factor` adds a shared positive-semidefinite term:
+
+```text
+Sigma = B + U U.T
+```
+
+where `B` is the dense or diagonal value supplied through `covariance`, and `U`
+is the response-by-rank `covariance_factor`. For a diagonal base, the diagnostic
+uses storage proportional to the response count times the low rank rather than
+forming a response-by-response covariance.
+
+The implementation whitens by the base covariance and then applies the exact
+inverse square root of the low-rank update through a thin singular-value
+decomposition. Consequently, the conditional information, nuisance projection,
+subspace angles, and query gate agree with an explicitly materialized dense
+`B + U U.T` covariance up to floating-point precision.
+
+```python
+result = assess_intervention_identifiability(
+    intervention_sensitivity,
+    nuisance_sensitivity,
+    covariance=response_variance,
+    covariance_factor=shared_camera_and_gauge_factor,
+    parameter_scales=parameter_scales,
+    query_sensitivity=query_sensitivity,
+)
+```
+
+The factor requires an explicit positive-definite base covariance. Nonpositive
+diagonal entries, nonfinite factors, mismatched response dimensions, and empty
+low-rank factors fail closed. This is an information-geometry diagnostic; richer
+covariance does not by itself establish calibration and should remain source-fit
+or preregistered before confirmatory evaluation.
+
 ## Standardized partial identifiability
 
-`assess_intervention_identifiability` now accepts positive
+`assess_intervention_identifiability` accepts positive
 `parameter_scales`. For physical intervention coordinates `z` and standardized
 coordinates `eta`, use
 

--- a/src/causal4d/identifiability.py
+++ b/src/causal4d/identifiability.py
@@ -212,24 +212,92 @@ def finite_response_sensitivity(
     return matrix
 
 
-def _whiten(matrix: np.ndarray, covariance: np.ndarray | None) -> np.ndarray:
-    values = np.asarray(matrix, dtype=float)
-    if values.ndim != 2 or values.shape[0] == 0 or values.shape[1] == 0:
-        raise ValueError("sensitivity matrices must be nonempty two-dimensional arrays")
-    if not np.all(np.isfinite(values)):
-        raise ValueError("sensitivity matrices must be finite")
+def _whiten_sensitivities(
+    matrices: tuple[np.ndarray, ...],
+    covariance: np.ndarray | None,
+    covariance_factor: np.ndarray | None,
+) -> tuple[np.ndarray, ...]:
+    """Whiten aligned sensitivities under ``B + U U.T`` response covariance."""
+
+    if not matrices:
+        raise ValueError("at least one sensitivity matrix is required")
+    values = tuple(np.asarray(matrix, dtype=float) for matrix in matrices)
+    response_count = values[0].shape[0] if values[0].ndim == 2 else 0
+    for matrix in values:
+        if matrix.ndim != 2 or matrix.shape[0] != response_count:
+            raise ValueError("sensitivity matrices must share a nonempty row dimension")
+        if not np.all(np.isfinite(matrix)):
+            raise ValueError("sensitivity matrices must be finite")
+    if response_count < 1 or values[0].shape[1] < 1:
+        raise ValueError("the primary sensitivity matrix must be nonempty")
+
+    shared_factor: np.ndarray | None = None
+    if covariance_factor is not None:
+        if covariance is None:
+            raise ValueError("covariance_factor requires a base covariance")
+        shared_factor = np.asarray(covariance_factor, dtype=float)
+        if (
+            shared_factor.ndim != 2
+            or shared_factor.shape[0] != response_count
+            or shared_factor.shape[1] < 1
+        ):
+            raise ValueError(
+                "covariance_factor must have shape (response, positive rank)"
+            )
+        if not np.all(np.isfinite(shared_factor)):
+            raise ValueError("covariance_factor must be finite")
+
     if covariance is None:
         return values
+
+    parts = list(values)
+    if shared_factor is not None:
+        parts.append(shared_factor)
+    widths = [part.shape[1] for part in parts]
+    combined = np.column_stack(parts)
     noise = np.asarray(covariance, dtype=float)
-    if noise.shape != (values.shape[0], values.shape[0]):
-        raise ValueError("covariance must match the response dimension")
-    if not np.all(np.isfinite(noise)) or not np.allclose(noise, noise.T, atol=1e-12):
-        raise ValueError("covariance must be finite and symmetric")
-    try:
-        factor = np.linalg.cholesky(noise)
-    except np.linalg.LinAlgError as error:
-        raise ValueError("covariance must be positive definite") from error
-    return np.linalg.solve(factor, values)
+    if noise.ndim == 1:
+        if noise.shape != (response_count,):
+            raise ValueError("diagonal covariance must match the response dimension")
+        if not np.all(np.isfinite(noise)) or np.any(noise <= 0.0):
+            raise ValueError("diagonal covariance must be finite and positive")
+        whitened = combined / np.sqrt(noise)[:, None]
+    elif noise.ndim == 2:
+        if noise.shape != (response_count, response_count):
+            raise ValueError("covariance must match the response dimension")
+        if not np.all(np.isfinite(noise)) or not np.allclose(
+            noise,
+            noise.T,
+            atol=1e-12,
+        ):
+            raise ValueError("covariance must be finite and symmetric")
+        try:
+            base_factor = np.linalg.cholesky(noise)
+        except np.linalg.LinAlgError as error:
+            raise ValueError("covariance must be positive definite") from error
+        whitened = np.linalg.solve(base_factor, combined)
+    else:
+        raise ValueError("covariance must be a diagonal vector or square matrix")
+
+    split_points = np.cumsum(widths[:-1])
+    whitened_parts = tuple(np.split(whitened, split_points, axis=1))
+    whitened_values = whitened_parts[: len(values)]
+    if shared_factor is None:
+        return whitened_values
+
+    whitened_factor = whitened_parts[-1]
+    left, singular_values, _ = np.linalg.svd(
+        whitened_factor,
+        full_matrices=False,
+    )
+    normalizer = np.hypot(1.0, singular_values)
+    shrinkage = (singular_values / normalizer) * (
+        singular_values / (1.0 + normalizer)
+    )
+    return tuple(
+        matrix - left @ (shrinkage[:, None] * (left.T @ matrix))
+        for matrix in whitened_values
+    )
 
 
 def _orthonormal_basis(matrix: np.ndarray, tolerance: float) -> np.ndarray:
@@ -276,6 +344,7 @@ def assess_intervention_identifiability(
     nuisance_sensitivity: np.ndarray | None = None,
     *,
     covariance: np.ndarray | None = None,
+    covariance_factor: np.ndarray | None = None,
     parameter_scales: np.ndarray | None = None,
     query_sensitivity: np.ndarray | None = None,
     config: IdentifiabilityConfig | None = None,
@@ -283,28 +352,38 @@ def assess_intervention_identifiability(
     """Assess intervention information conditional on nuisance response.
 
     Intervention columns are first converted to standardized parameter
-    coordinates using ``parameter_scales`` and whitened by ``covariance``. They
-    are then projected onto the orthogonal complement of nuisance response. If a
-    future ``query_sensitivity`` is supplied, the result also reports how much of
-    that query response lies in the unresolved intervention subspace. Thus a
+    coordinates using ``parameter_scales`` and whitened by ``covariance``. A
+    positive diagonal vector may replace a dense base covariance, and
+    ``covariance_factor`` adds an exact positive-semidefinite ``U U.T`` term
+    without materializing it. Sensitivities are then projected onto the
+    orthogonal complement of nuisance response. If a future
+    ``query_sensitivity`` is supplied, the result also reports how much of that
+    query response lies in the unresolved intervention subspace. Thus a
     parameter vector can be only partially identified while a particular future
     prediction remains locally identifiable.
     """
 
     settings = config or IdentifiabilityConfig()
     raw_intervention = np.asarray(intervention_sensitivity, dtype=float)
-    if raw_intervention.ndim != 2 or raw_intervention.shape[1] == 0:
+    if (
+        raw_intervention.ndim != 2
+        or raw_intervention.shape[0] == 0
+        or raw_intervention.shape[1] == 0
+    ):
         raise ValueError("intervention_sensitivity must be a nonempty matrix")
     scales = _parameter_scales(parameter_scales, raw_intervention.shape[1])
-    intervention = _whiten(raw_intervention * scales[None], covariance)
-    response_count, parameter_count = intervention.shape
     if nuisance_sensitivity is None:
-        nuisance = np.zeros((response_count, 0), dtype=float)
+        nuisance_raw = np.zeros((raw_intervention.shape[0], 0), dtype=float)
     else:
         nuisance_raw = np.asarray(nuisance_sensitivity, dtype=float)
-        if nuisance_raw.ndim != 2 or nuisance_raw.shape[0] != response_count:
+        if nuisance_raw.ndim != 2 or nuisance_raw.shape[0] != len(raw_intervention):
             raise ValueError("nuisance_sensitivity must share the response dimension")
-        nuisance = _whiten(nuisance_raw, covariance)
+    intervention, nuisance = _whiten_sensitivities(
+        (raw_intervention * scales[None], nuisance_raw),
+        covariance,
+        covariance_factor,
+    )
+    parameter_count = intervention.shape[1]
 
     nuisance_basis = _orthonormal_basis(nuisance, settings.relative_rank_tolerance)
     intervention_basis = _orthonormal_basis(

--- a/src/causal4d/identifiability.py
+++ b/src/causal4d/identifiability.py
@@ -291,9 +291,7 @@ def _whiten_sensitivities(
         full_matrices=False,
     )
     normalizer = np.hypot(1.0, singular_values)
-    shrinkage = (singular_values / normalizer) * (
-        singular_values / (1.0 + normalizer)
-    )
+    shrinkage = (singular_values / normalizer) * (singular_values / (1.0 + normalizer))
     return tuple(
         matrix - left @ (shrinkage[:, None] * (left.T @ matrix))
         for matrix in whitened_values

--- a/tests/test_identifiability_structured_covariance.py
+++ b/tests/test_identifiability_structured_covariance.py
@@ -1,0 +1,210 @@
+import numpy as np
+import pytest
+
+from causal4d.identifiability import (
+    IdentifiabilityConfig,
+    InterventionIdentifiabilityResult,
+    assess_intervention_identifiability,
+)
+
+
+def _comparison_config() -> IdentifiabilityConfig:
+    return IdentifiabilityConfig(
+        minimum_information_eigenvalue=1.0e-12,
+        maximum_condition_number=1.0e12,
+        minimum_residualized_response_fraction=0.0,
+        maximum_subspace_cosine=1.0,
+        maximum_query_null_response_fraction=1.0,
+    )
+
+
+def _assert_equivalent(
+    left: InterventionIdentifiabilityResult,
+    right: InterventionIdentifiabilityResult,
+) -> None:
+    assert np.allclose(
+        left.conditional_information,
+        right.conditional_information,
+        atol=1.0e-10,
+        rtol=1.0e-10,
+    )
+    assert np.allclose(left.eigenvalues, right.eigenvalues, atol=1.0e-10, rtol=1.0e-10)
+    assert np.allclose(
+        left.identified_projection,
+        right.identified_projection,
+        atol=1.0e-10,
+        rtol=1.0e-10,
+    )
+    assert left.effective_rank == right.effective_rank
+    assert left.failure_reasons == right.failure_reasons
+    assert left.query_identifiable == right.query_identifiable
+    assert left.query_null_response_fraction == pytest.approx(
+        right.query_null_response_fraction,
+        abs=1.0e-10,
+        rel=1.0e-10,
+    )
+    assert left.residualized_response_fraction == pytest.approx(
+        right.residualized_response_fraction,
+        abs=1.0e-10,
+        rel=1.0e-10,
+    )
+    assert left.maximum_subspace_cosine == pytest.approx(
+        right.maximum_subspace_cosine,
+        abs=1.0e-10,
+        rel=1.0e-10,
+    )
+
+
+def test_diagonal_low_rank_covariance_matches_dense_total() -> None:
+    rng = np.random.default_rng(6114)
+    intervention = rng.normal(size=(12, 3))
+    nuisance = rng.normal(size=(12, 2))
+    query = rng.normal(size=(4, 3))
+    diagonal = np.linspace(0.2, 1.3, len(intervention))
+    factor = rng.normal(scale=0.15, size=(len(intervention), 3))
+
+    structured = assess_intervention_identifiability(
+        intervention,
+        nuisance,
+        covariance=diagonal,
+        covariance_factor=factor,
+        query_sensitivity=query,
+        config=_comparison_config(),
+    )
+    dense = assess_intervention_identifiability(
+        intervention,
+        nuisance,
+        covariance=np.diag(diagonal) + factor @ factor.T,
+        query_sensitivity=query,
+        config=_comparison_config(),
+    )
+
+    _assert_equivalent(structured, dense)
+
+
+def test_diagonal_vector_matches_dense_diagonal_covariance() -> None:
+    rng = np.random.default_rng(7892)
+    intervention = rng.normal(size=(10, 2))
+    nuisance = rng.normal(size=(10, 1))
+    diagonal = np.linspace(0.05, 0.5, len(intervention))
+
+    vector = assess_intervention_identifiability(
+        intervention,
+        nuisance,
+        covariance=diagonal,
+        config=_comparison_config(),
+    )
+    dense = assess_intervention_identifiability(
+        intervention,
+        nuisance,
+        covariance=np.diag(diagonal),
+        config=_comparison_config(),
+    )
+
+    assert np.allclose(vector.conditional_information, dense.conditional_information)
+    assert np.allclose(vector.identified_projection, dense.identified_projection)
+
+
+def test_low_rank_covariance_is_invariant_to_factor_rotation() -> None:
+    rng = np.random.default_rng(8445)
+    intervention = rng.normal(size=(16, 3))
+    nuisance = rng.normal(size=(16, 2))
+    diagonal = np.linspace(0.1, 0.9, len(intervention))
+    factor = rng.normal(scale=0.1, size=(len(intervention), 2))
+    angle = 0.73
+    rotation = np.asarray(
+        [
+            [np.cos(angle), -np.sin(angle)],
+            [np.sin(angle), np.cos(angle)],
+        ]
+    )
+
+    reference = assess_intervention_identifiability(
+        intervention,
+        nuisance,
+        covariance=diagonal,
+        covariance_factor=factor,
+        config=_comparison_config(),
+    )
+    rotated = assess_intervention_identifiability(
+        intervention,
+        nuisance,
+        covariance=diagonal,
+        covariance_factor=factor @ rotation,
+        config=_comparison_config(),
+    )
+
+    assert np.allclose(
+        reference.conditional_information,
+        rotated.conditional_information,
+        atol=1.0e-10,
+        rtol=1.0e-10,
+    )
+    assert np.allclose(
+        reference.identified_projection,
+        rotated.identified_projection,
+        atol=1.0e-10,
+        rtol=1.0e-10,
+    )
+
+
+def test_large_diagonal_low_rank_path_does_not_call_dense_cholesky(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rng = np.random.default_rng(9017)
+    response_count = 2048
+    intervention = rng.normal(size=(response_count, 2))
+    factor = rng.normal(scale=0.02, size=(response_count, 4))
+
+    def forbidden_cholesky(_: np.ndarray) -> np.ndarray:
+        raise AssertionError("diagonal structured whitening formed a dense covariance")
+
+    monkeypatch.setattr(np.linalg, "cholesky", forbidden_cholesky)
+    result = assess_intervention_identifiability(
+        intervention,
+        covariance=np.full(response_count, 0.2),
+        covariance_factor=factor,
+        config=_comparison_config(),
+    )
+
+    assert result.conditional_information.shape == (2, 2)
+    assert np.all(np.isfinite(result.conditional_information))
+
+
+def test_covariance_factor_requires_base_covariance() -> None:
+    with pytest.raises(ValueError, match="requires a base covariance"):
+        assess_intervention_identifiability(
+            np.eye(4, 2),
+            covariance_factor=np.ones((4, 1)),
+        )
+
+
+@pytest.mark.parametrize(
+    "diagonal",
+    [
+        np.asarray([1.0, 1.0, 0.0, 1.0]),
+        np.asarray([1.0, 1.0, -1.0, 1.0]),
+        np.asarray([1.0, 1.0, np.nan, 1.0]),
+    ],
+)
+def test_invalid_diagonal_covariance_fails_closed(diagonal: np.ndarray) -> None:
+    with pytest.raises(ValueError, match="finite and positive"):
+        assess_intervention_identifiability(
+            np.eye(4, 2),
+            covariance=diagonal,
+        )
+
+
+def test_invalid_covariance_factor_fails_closed() -> None:
+    with pytest.raises(ValueError, match="positive rank"):
+        assess_intervention_identifiability(
+            np.eye(4, 2),
+            covariance=np.ones(4),
+            covariance_factor=np.empty((4, 0)),
+        )
+    with pytest.raises(ValueError, match="must be finite"):
+        assess_intervention_identifiability(
+            np.eye(4, 2),
+            covariance=np.ones(4),
+            covariance_factor=np.asarray([[0.0], [0.0], [np.nan], [0.0]]),
+        )


### PR DESCRIPTION
## What changed

- allow `assess_intervention_identifiability` to accept a positive diagonal variance vector as the base response covariance;
- add optional `covariance_factor` support for exact `B + U U.T` response covariance;
- whiten the low-rank update through a thin singular-value decomposition without materializing `U U.T` or a dense response covariance when the base is diagonal;
- apply the same structured whitening jointly to intervention and nuisance sensitivities so their conditional geometry remains consistent;
- fail closed on missing base covariance, nonpositive diagonal entries, nonfinite or empty factors, and response-dimension mismatches;
- preserve the legacy dense-covariance and no-covariance paths when the new argument is omitted; and
- document the scientific boundary and add dense-equivalence, factor-rotation, large-response, compatibility, and validation tests.

## Why

The current identifiability diagnostic requires a dense positive-definite covariance. That is unnecessarily expensive for long trajectory responses and cannot directly consume the diagonal-plus-low-rank camera, gauge, and discrepancy uncertainty already used elsewhere in the stack.

For `Sigma = B + U U.T`, this PR first whitens by `B`, then applies the exact inverse square root of the low-rank update using the thin SVD of `B^{-1/2} U`. The resulting conditional information matrix, nuisance projection, subspace angles, and query-identifiability gate match an explicitly materialized dense covariance up to floating-point precision.

## User and scientific impact

Callers can perform intervention-versus-nuisance and query-identifiability audits on thousands of response coordinates with storage proportional to response count times low rank when the base covariance is diagonal. This supports explicit common camera, timing, gauge, or graph modes without discarding their dependence structure.

This is an opt-in information-geometry diagnostic. It does not alter the frozen `v0.3.0-causal4d-aip` estimator, the locked 36-execution protocol, posterior weights, counterfactual operator, source-panel evidence, Prob4D admission, or BayesianPhysTwin provider contracts. A richer covariance representation is not itself evidence of calibration.

## Validation

Focused local validation from the exact proposed files:

- `16 passed`, covering the new structured-covariance tests, existing identifiability behavior, query-aware gating, parameter-unit invariance, and legacy serialization compatibility;
- Python compilation passed;
- Python 3.10 syntax parsing passed for the changed module and new tests;
- changed Python and Markdown lines are at most 88 characters.

GitHub Actions is authoritative for Ruff, formatting, MyPy, the complete repository suite, multi-Python and dependency-floor compatibility, packaging, security scanning, and pinned BayesianPhysTwin integration.