### PR TITLE
Add session-level latent intervention hierarchy

### DIFF
--- a/docs/causal4d_inference_improvements.md
+++ b/docs/causal4d_inference_improvements.md
@@ -1,13 +1,13 @@
 # Session-Aware Abduction and Stable Discrepancy Dynamics
 
-This development extension addresses three limitations without changing the
-frozen `v0.3.0-causal4d-aip` path.
+This development extension addresses limitations in multi-execution inference
+without changing the frozen `v0.3.0-causal4d-aip` path.
 
-## Session-aware hierarchical abduction
+## Session-aware composite evidence
 
 `abduct_hierarchical_interventions` accepts `session_ids`. Executions in the
 same grasp or reset session share nuisance errors, so they should not each count
-as an independent unit of evidence for shared `(theta, phi)` variables.
+as an independent unit of evidence for persistent variables.
 
 For a session with `n_s` executions, each marginalized execution log evidence is
 weighted by `1/n_s`. The local execution likelihood remains unpowered when
@@ -18,15 +18,75 @@ be supplied for a source-frozen alternative composite likelihood.
 The result metadata records the session IDs, evidence powers, session count, and
 evidence mode.
 
+## Optional session-level latent intervention
+
+The original hierarchy forces one persistent intervention realization `phi` to
+be shared by every session. For a future protocol,
+`session_phi_transition[g, f]` can instead define
+
+```text
+p(phi_session = f | phi_bar = g)
+```
+
+on the existing finite `phi` support. The resulting hierarchy is
+
+```text
+theta                         shared physical particle
+phi_bar                       global hardware/intervention hyperstate
+phi_session                   persistent realization for one session
+kappa_execution               local contact and slip realization
+```
+
+For each session, powered execution evidence is first aggregated in its local
+`phi_session` state. The session state is marginalized when updating
+`(phi_bar, theta)`, and its posterior is then recovered conditional on all
+sessions. Each execution keeps its full local `kappa_execution` posterior.
+The returned `SessionHierarchyPosterior` contains:
+
+- global `(phi_bar, theta)` weights;
+- one `(phi_session, theta)` posterior per ordered session;
+- the exact execution-to-session binding and evidence powers;
+- the finite transition matrix; and
+- predictive `(phi_session, theta)` weights for a new session.
+
+A zero-session-variance model is represented by the exact identity transition:
+
+```python
+result = abduct_hierarchical_interventions(
+    banks,
+    observations,
+    prefix_frame_counts=prefix_frame_counts,
+    session_ids=session_ids,
+    session_phi_transition=np.eye(phi_count),
+)
+```
+
+That path is an exact fallback: global weights and every execution posterior are
+required to equal the legacy shared-`phi` result bit for bit. Exact zeros in a
+nonidentity transition preserve excluded support. Invalid, nonfinite,
+non-stochastic, or dimensionally inconsistent transitions fail closed.
+
+A nonidentity transition must be selected from source sessions or preregistered.
+It must not be tuned on confirmatory targets. The finite transition can encode
+session-to-session variation in actuator gain, delay, controller-frame bias, or
+another persistent intervention coordinate already represented by `phi`. It does
+not create support absent from the registered rollout banks.
+
+The global `phi_marginal` is a `phi_bar` marginal when this option is active.
+Use `session_phi_marginals` for observed sessions and
+`predictive_session_joint_weights` for a new session. Treating the global
+hyperstate directly as a realized session intervention would be a semantic
+error.
+
 ## Scale-invariant and partial identifiability
 
 `assess_intervention_identifiability` accepts characteristic
-`parameter_scale`. Intervention sensitivity columns are multiplied by that
-scale before nuisance projection and information analysis. This makes the
+`parameter_scales`. Intervention sensitivity columns are multiplied by those
+scales before nuisance projection and information analysis. This makes the
 result invariant to unit conversions such as degrees versus radians or frames
-versus seconds, provided the corresponding scale is converted consistently.
+versus seconds, provided the corresponding scales are converted consistently.
 
-The result now retains identifiable and nullspace bases. The helper
+The result retains identifiable and nullspace bases. The helper
 `preserve_prior_within_unidentified_subspace` removes unsupported posterior
 distinctions while retaining evidence between distinguishable projection
 groups:
@@ -73,7 +133,9 @@ source executions or preregistered before confirmatory evaluation.
 
 ## Claim boundary
 
-These additions are inference machinery, not new real-data evidence. Promotion
-still requires the locked multi-action protocol, independent-session
-calibration, source-only mechanism selection, and exact persistence/prior
-fallback controls.
+These additions are inference machinery, not new real-data evidence. The
+session-level latent intervention is intended for a separately versioned future
+protocol; it is not part of the locked 36-execution estimator. Promotion still
+requires independent-session calibration, source-only hierarchy selection,
+leave-one-session and held-out-action evaluation, finite-support simulation-
+based calibration, and exact identity/prior fallback controls.

--- a/src/causal4d/hierarchical_abduction.py
+++ b/src/causal4d/hierarchical_abduction.py
@@ -16,6 +16,10 @@ from causal4d.prefix_likelihood import (
     prefix_component_log_likelihood,
 )
 from causal4d.rollout_bank import JointRolloutBank
+from causal4d.session_hierarchy import (
+    SessionHierarchyPosterior,
+    infer_session_phi_hierarchy,
+)
 from causal4d.weighting import log_weights_from_probabilities
 
 
@@ -114,7 +118,7 @@ def _session_evidence_powers(
 
 @dataclass(frozen=True)
 class HierarchicalAbductionResult:
-    """Posterior with shared ``(theta, phi)`` and local execution hypotheses."""
+    """Posterior with persistent, session-local, and execution-local variables."""
 
     phi_names: tuple[str, ...]
     phi_values: np.ndarray
@@ -123,6 +127,7 @@ class HierarchicalAbductionResult:
     execution_joint_weights: tuple[np.ndarray, ...]
     execution_log_evidence: tuple[np.ndarray, ...]
     metadata: dict[str, Any] = field(default_factory=dict)
+    session_hierarchy: SessionHierarchyPosterior | None = None
 
     def __post_init__(self) -> None:
         phi = _readonly_array(self.phi_values)
@@ -169,6 +174,19 @@ class HierarchicalAbductionResult:
                 raise ValueError("execution log evidence must not contain NaN or +inf")
             execution_weights.append(supplied)
             execution_evidence.append(log_evidence)
+        hierarchy = self.session_hierarchy
+        if hierarchy is not None:
+            if hierarchy.global_weights.shape != shared.shape or not np.array_equal(
+                hierarchy.global_weights,
+                shared,
+            ):
+                raise ValueError(
+                    "session hierarchy global weights must equal shared_weights"
+                )
+            if hierarchy.session_phi_transition.shape != (len(phi), len(phi)):
+                raise ValueError("session hierarchy must match the phi support")
+            if len(hierarchy.execution_session_ids) != len(execution_weights):
+                raise ValueError("session hierarchy must cover every execution")
         object.__setattr__(self, "phi_values", phi)
         object.__setattr__(self, "parameter_particles", particles)
         object.__setattr__(self, "shared_weights", shared)
@@ -178,11 +196,21 @@ class HierarchicalAbductionResult:
 
     @property
     def phi_marginal(self) -> np.ndarray:
+        """Marginal of shared ``phi`` or global ``phi_bar`` support."""
+
         return np.sum(self.shared_weights, axis=1)
 
     @property
     def parameter_marginal(self) -> np.ndarray:
         return np.sum(self.shared_weights, axis=0)
+
+    @property
+    def session_phi_marginals(self) -> tuple[np.ndarray, ...]:
+        """Ordered session-local marginals, empty for the shared-``phi`` model."""
+
+        if self.session_hierarchy is None:
+            return ()
+        return self.session_hierarchy.session_phi_marginals
 
 
 def abduct_hierarchical_interventions(
@@ -199,12 +227,13 @@ def abduct_hierarchical_interventions(
     particle_discrepancy_variance_m2: Sequence[np.ndarray | None] | None = None,
     session_ids: Sequence[str] | None = None,
     execution_evidence_powers: Sequence[float] | None = None,
+    session_phi_transition: np.ndarray | None = None,
 ) -> HierarchicalAbductionResult:
     """Pool persistent intervention and twin variables across executions.
 
     Physical parameter particles and persistent intervention variables ``phi``
-    are shared. Each execution retains its own local hypothesis within a ``phi``
-    group, so contact and slip variables remain event-specific.
+    are shared by default. Each execution retains its own local hypothesis within
+    a ``phi`` group, so contact and slip variables remain event-specific.
 
     When ``session_ids`` are supplied, execution log evidences are weighted by
     the reciprocal number of executions in that session. Each grasp/session then
@@ -212,6 +241,13 @@ def abduct_hierarchical_interventions(
     execution retains its full local ``kappa`` posterior. Supplying neither
     session IDs nor explicit powers preserves the original independent-execution
     product exactly.
+
+    ``session_phi_transition[g, f]`` optionally specifies
+    ``p(phi_s=f | phi_bar=g)`` on the same finite support. This introduces a
+    session-local persistent intervention while retaining a global hardware
+    hyperstate and shared physical particles. Exact zeros preserve excluded
+    support. An identity transition is the zero-session-variance limit and
+    reproduces the original shared-``phi`` weights and execution posteriors.
     """
 
     bank_list = tuple(banks)
@@ -335,29 +371,81 @@ def abduct_hierarchical_interventions(
             )
         execution_log_evidence.append(evidence)
 
-    shared_log_weights = (
-        log_weights_from_probabilities(phi_prior, name="shared phi prior")[:, None]
-        + log_weights_from_probabilities(
-            reference.parameter_weights,
-            name="shared parameter prior",
-        )[None]
-    )
-    for power, evidence in zip(evidence_powers, execution_log_evidence, strict=True):
-        shared_log_weights += float(power) * evidence
-    shared_weights = _normalize_log_weights(shared_log_weights)
+    session_hierarchy: SessionHierarchyPosterior | None = None
+    if session_phi_transition is None:
+        shared_log_weights = (
+            log_weights_from_probabilities(phi_prior, name="shared phi prior")[:, None]
+            + log_weights_from_probabilities(
+                reference.parameter_weights,
+                name="shared parameter prior",
+            )[None]
+        )
+        for power, evidence in zip(
+            evidence_powers,
+            execution_log_evidence,
+            strict=True,
+        ):
+            shared_log_weights += float(power) * evidence
+        shared_weights = _normalize_log_weights(shared_log_weights)
+        session_weight_lookup: dict[str, np.ndarray] = {}
+        hierarchy_mode = "shared_phi"
+    else:
+        session_hierarchy = infer_session_phi_hierarchy(
+            execution_log_evidence,
+            phi_prior=phi_prior,
+            parameter_prior=reference.parameter_weights,
+            session_ids=session_identifiers,
+            execution_evidence_powers=evidence_powers,
+            session_phi_transition=session_phi_transition,
+        )
+        shared_weights = session_hierarchy.global_weights
+        session_weight_lookup = dict(
+            zip(
+                session_hierarchy.session_ids,
+                session_hierarchy.session_joint_weights,
+                strict=True,
+            )
+        )
+        hierarchy_mode = session_hierarchy.mode
 
     execution_joint_weights = []
-    for groups, local_prior, log_likelihood, evidence in zip(
-        group_indices,
-        local_log_priors,
-        component_log_likelihoods,
-        execution_log_evidence,
-        strict=True,
+    for execution, (groups, local_prior, log_likelihood, evidence) in enumerate(
+        zip(
+            group_indices,
+            local_log_priors,
+            component_log_likelihoods,
+            execution_log_evidence,
+            strict=True,
+        )
     ):
         conditional = np.exp(local_prior[:, None] + log_likelihood - evidence[groups])
-        joint = shared_weights[groups] * conditional
+        persistent_weights = (
+            shared_weights
+            if session_hierarchy is None
+            else session_weight_lookup[session_identifiers[execution]]
+        )
+        joint = persistent_weights[groups] * conditional
         joint /= np.sum(joint)
         execution_joint_weights.append(joint)
+
+    result_metadata: dict[str, Any] = {
+        "execution_count": len(bank_list),
+        "session_count": len(set(session_identifiers)),
+        "session_ids": list(session_identifiers),
+        "execution_evidence_powers": evidence_powers.tolist(),
+        "shared_evidence_mode": evidence_mode,
+        "shared_variables": ["theta", "phi"],
+        "execution_specific_variables": ["kappa"],
+        "future_frames_read": 0,
+    }
+    if session_hierarchy is not None:
+        result_metadata.update(
+            {
+                "session_hierarchy_mode": hierarchy_mode,
+                "shared_variables": ["theta", "phi_bar"],
+                "session_variables": ["phi_session"],
+            }
+        )
 
     return HierarchicalAbductionResult(
         phi_names=phi_names,
@@ -366,14 +454,6 @@ def abduct_hierarchical_interventions(
         shared_weights=shared_weights,
         execution_joint_weights=tuple(execution_joint_weights),
         execution_log_evidence=tuple(execution_log_evidence),
-        metadata={
-            "execution_count": len(bank_list),
-            "session_count": len(set(session_identifiers)),
-            "session_ids": list(session_identifiers),
-            "execution_evidence_powers": evidence_powers.tolist(),
-            "shared_evidence_mode": evidence_mode,
-            "shared_variables": ["theta", "phi"],
-            "execution_specific_variables": ["kappa"],
-            "future_frames_read": 0,
-        },
+        metadata=result_metadata,
+        session_hierarchy=session_hierarchy,
     )

--- a/src/causal4d/session_hierarchy.py
+++ b/src/causal4d/session_hierarchy.py
@@ -248,9 +248,7 @@ def infer_session_phi_hierarchy(
         for power, values in zip(powers, evidence, strict=True):
             global_log_weights += float(power) * values
         global_weights = _normalize_log_weights(global_log_weights)
-        session_joint_weights = tuple(
-            global_weights.copy() for _ in session_order
-        )
+        session_joint_weights = tuple(global_weights.copy() for _ in session_order)
         mode = "zero_variance_identity"
     else:
         log_transition = log_weights_from_probabilities(

--- a/src/causal4d/session_hierarchy.py
+++ b/src/causal4d/session_hierarchy.py
@@ -1,0 +1,301 @@
+"""Finite-support session-level intervention hierarchy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+from causal4d.immutable_array import readonly_array as _readonly_array
+from causal4d.weighting import log_weights_from_probabilities
+
+
+def _logsumexp(values: np.ndarray, axis: int | None = None) -> np.ndarray:
+    array = np.asarray(values, dtype=float)
+    maximum = np.max(array, axis=axis, keepdims=True)
+    safe_maximum = np.where(np.isfinite(maximum), maximum, 0.0)
+    summed = np.sum(np.exp(array - safe_maximum), axis=axis, keepdims=True)
+    with np.errstate(divide="ignore"):
+        result = safe_maximum + np.log(summed)
+    if axis is not None:
+        result = np.squeeze(result, axis=axis)
+    return np.where(np.squeeze(np.isfinite(maximum), axis=axis), result, -np.inf)
+
+
+def _normalize_log_weights(log_weights: np.ndarray) -> np.ndarray:
+    normalizer = float(np.ravel(_logsumexp(np.asarray(log_weights, dtype=float)))[0])
+    if not np.isfinite(normalizer):
+        raise RuntimeError("session hierarchy posterior normalization failed")
+    return np.exp(log_weights - normalizer)
+
+
+def _probability_vector(values: np.ndarray, count: int, name: str) -> np.ndarray:
+    probabilities = np.asarray(values, dtype=float)
+    if probabilities.shape != (count,):
+        raise ValueError(f"{name} must have shape ({count},)")
+    if not np.all(np.isfinite(probabilities)) or np.any(probabilities < 0.0):
+        raise ValueError(f"{name} must be finite and nonnegative")
+    if float(np.sum(probabilities)) <= 0.0:
+        raise ValueError(f"{name} must contain positive mass")
+    return probabilities
+
+
+def _transition_matrix(values: np.ndarray, phi_count: int) -> np.ndarray:
+    transition = np.asarray(values, dtype=float)
+    if transition.shape != (phi_count, phi_count):
+        raise ValueError("session_phi_transition must have shape (Phi, Phi)")
+    if not np.all(np.isfinite(transition)) or np.any(transition < 0.0):
+        raise ValueError("session_phi_transition must be finite and nonnegative")
+    row_sums = np.sum(transition, axis=1)
+    if not np.allclose(row_sums, 1.0, rtol=0.0, atol=1.0e-12):
+        raise ValueError("session_phi_transition rows must sum to one")
+    return transition
+
+
+@dataclass(frozen=True)
+class SessionHierarchyPosterior:
+    """Posterior over global and session-local finite ``phi`` support."""
+
+    global_weights: np.ndarray
+    session_ids: tuple[str, ...]
+    execution_session_ids: tuple[str, ...]
+    session_joint_weights: tuple[np.ndarray, ...]
+    session_log_evidence: tuple[np.ndarray, ...]
+    session_phi_transition: np.ndarray
+    execution_evidence_powers: np.ndarray
+    mode: str
+
+    def __post_init__(self) -> None:
+        global_weights = _readonly_array(self.global_weights)
+        transition = _readonly_array(self.session_phi_transition)
+        powers = _readonly_array(self.execution_evidence_powers)
+        if global_weights.ndim != 2 or min(global_weights.shape) < 1:
+            raise ValueError("global_weights must have shape (Phi, P)")
+        phi_count, parameter_count = global_weights.shape
+        if (
+            not np.all(np.isfinite(global_weights))
+            or np.any(global_weights < 0.0)
+            or not np.isclose(np.sum(global_weights), 1.0)
+        ):
+            raise ValueError("global_weights must be finite and sum to one")
+        if transition.shape != (phi_count, phi_count):
+            raise ValueError("session_phi_transition must match global phi support")
+        if (
+            not np.all(np.isfinite(transition))
+            or np.any(transition < 0.0)
+            or not np.allclose(
+                np.sum(transition, axis=1),
+                1.0,
+                rtol=0.0,
+                atol=1.0e-12,
+            )
+        ):
+            raise ValueError("session_phi_transition must be row-stochastic")
+        session_ids = tuple(map(str, self.session_ids))
+        if not session_ids or len(set(session_ids)) != len(session_ids):
+            raise ValueError("session_ids must be unique and nonempty")
+        execution_session_ids = tuple(map(str, self.execution_session_ids))
+        if (
+            len(execution_session_ids) != len(powers)
+            or any(not value for value in execution_session_ids)
+            or tuple(dict.fromkeys(execution_session_ids)) != session_ids
+        ):
+            raise ValueError(
+                "execution_session_ids must bind every power to the session order"
+            )
+        if len(self.session_joint_weights) != len(session_ids) or len(
+            self.session_log_evidence
+        ) != len(session_ids):
+            raise ValueError("session posterior arrays must match session_ids")
+        session_weights = []
+        session_evidence = []
+        parameter_marginal = np.sum(global_weights, axis=0)
+        for weights, evidence in zip(
+            self.session_joint_weights,
+            self.session_log_evidence,
+            strict=True,
+        ):
+            joint = _readonly_array(weights)
+            log_evidence = _readonly_array(evidence)
+            if joint.shape != (phi_count, parameter_count):
+                raise ValueError("session weights must have shape (Phi, P)")
+            if (
+                not np.all(np.isfinite(joint))
+                or np.any(joint < 0.0)
+                or not np.isclose(np.sum(joint), 1.0)
+            ):
+                raise ValueError("session weights must be finite and sum to one")
+            if not np.allclose(
+                np.sum(joint, axis=0),
+                parameter_marginal,
+                rtol=1.0e-10,
+                atol=1.0e-12,
+            ):
+                raise ValueError("session weights must preserve parameter marginal")
+            if log_evidence.shape != (phi_count, parameter_count):
+                raise ValueError("session log evidence must have shape (Phi, P)")
+            if np.any(np.isnan(log_evidence)) or np.any(np.isposinf(log_evidence)):
+                raise ValueError("session log evidence must not contain NaN or +inf")
+            session_weights.append(joint)
+            session_evidence.append(log_evidence)
+        if powers.ndim != 1:
+            raise ValueError("execution_evidence_powers must be a vector")
+        if not np.all(np.isfinite(powers)) or np.any(powers <= 0.0):
+            raise ValueError("execution_evidence_powers must be finite and positive")
+        if not self.mode:
+            raise ValueError("mode must be nonempty")
+        object.__setattr__(self, "global_weights", global_weights)
+        object.__setattr__(self, "session_ids", session_ids)
+        object.__setattr__(self, "execution_session_ids", execution_session_ids)
+        object.__setattr__(self, "session_joint_weights", tuple(session_weights))
+        object.__setattr__(self, "session_log_evidence", tuple(session_evidence))
+        object.__setattr__(self, "session_phi_transition", transition)
+        object.__setattr__(self, "execution_evidence_powers", powers)
+
+    @property
+    def global_phi_marginal(self) -> np.ndarray:
+        return np.sum(self.global_weights, axis=1)
+
+    @property
+    def parameter_marginal(self) -> np.ndarray:
+        return np.sum(self.global_weights, axis=0)
+
+    @property
+    def session_phi_marginals(self) -> tuple[np.ndarray, ...]:
+        return tuple(np.sum(weights, axis=1) for weights in self.session_joint_weights)
+
+    @property
+    def predictive_session_joint_weights(self) -> np.ndarray:
+        """Posterior predictive ``(phi_s, theta)`` weights for a new session."""
+
+        predictive = np.einsum(
+            "gp,gf->fp",
+            self.global_weights,
+            self.session_phi_transition,
+        )
+        return _readonly_array(predictive)
+
+
+def infer_session_phi_hierarchy(
+    execution_log_evidence: Sequence[np.ndarray],
+    *,
+    phi_prior: np.ndarray,
+    parameter_prior: np.ndarray,
+    session_ids: Sequence[str],
+    execution_evidence_powers: Sequence[float],
+    session_phi_transition: np.ndarray,
+) -> SessionHierarchyPosterior:
+    """Infer global ``phi_bar`` and session-local ``phi_s`` on finite support.
+
+    ``session_phi_transition[g, f]`` is ``p(phi_s=f | phi_bar=g)``. Exact zeros
+    preserve excluded support. An identity transition is the zero-session-
+    variance limit and reproduces the shared-``phi`` posterior exactly.
+    """
+
+    evidence = tuple(
+        np.asarray(values, dtype=float) for values in execution_log_evidence
+    )
+    if not evidence:
+        raise ValueError("at least one execution log evidence matrix is required")
+    if evidence[0].ndim != 2 or min(evidence[0].shape) < 1:
+        raise ValueError("execution log evidence must have shape (Phi, P)")
+    phi_count, parameter_count = evidence[0].shape
+    for values in evidence:
+        if values.shape != (phi_count, parameter_count):
+            raise ValueError("execution log evidence matrices must share shape")
+        if np.any(np.isnan(values)) or np.any(np.isposinf(values)):
+            raise ValueError("execution log evidence must not contain NaN or +inf")
+
+    identifiers = tuple(map(str, session_ids))
+    if len(identifiers) != len(evidence) or any(not value for value in identifiers):
+        raise ValueError("session_ids must contain one nonempty value per execution")
+    powers = np.asarray(tuple(execution_evidence_powers), dtype=float)
+    if powers.shape != (len(evidence),):
+        raise ValueError("execution_evidence_powers must match executions")
+    if not np.all(np.isfinite(powers)) or np.any(powers <= 0.0):
+        raise ValueError("execution_evidence_powers must be finite and positive")
+
+    normalized_phi_prior = _probability_vector(phi_prior, phi_count, "phi_prior")
+    normalized_parameter_prior = _probability_vector(
+        parameter_prior,
+        parameter_count,
+        "parameter_prior",
+    )
+    transition = _transition_matrix(session_phi_transition, phi_count)
+    session_order = tuple(dict.fromkeys(identifiers))
+    session_lookup = {
+        identifier: index for index, identifier in enumerate(session_order)
+    }
+    session_evidence = [
+        np.zeros((phi_count, parameter_count), dtype=float) for _ in session_order
+    ]
+    for identifier, power, values in zip(identifiers, powers, evidence, strict=True):
+        session_evidence[session_lookup[identifier]] += float(power) * values
+
+    global_log_weights = (
+        log_weights_from_probabilities(
+            normalized_phi_prior,
+            name="global phi prior",
+        )[:, None]
+        + log_weights_from_probabilities(
+            normalized_parameter_prior,
+            name="parameter prior",
+        )[None]
+    )
+    identity = np.eye(phi_count, dtype=float)
+    if np.array_equal(transition, identity):
+        for power, values in zip(powers, evidence, strict=True):
+            global_log_weights += float(power) * values
+        global_weights = _normalize_log_weights(global_log_weights)
+        session_joint_weights = tuple(
+            global_weights.copy() for _ in session_order
+        )
+        mode = "zero_variance_identity"
+    else:
+        log_transition = log_weights_from_probabilities(
+            transition,
+            name="session phi transition",
+        )
+        session_log_marginals = []
+        for values in session_evidence:
+            numerator = log_transition[:, :, None] + values[None]
+            marginal = _logsumexp(numerator, axis=1)
+            session_log_marginals.append(marginal)
+            global_log_weights += marginal
+        global_weights = _normalize_log_weights(global_log_weights)
+
+        session_joint_weights_list = []
+        for values, marginal in zip(
+            session_evidence,
+            session_log_marginals,
+            strict=True,
+        ):
+            numerator = log_transition[:, :, None] + values[None]
+            conditional_log = np.full_like(numerator, -np.inf)
+            valid = np.isfinite(marginal)
+            np.subtract(
+                numerator,
+                marginal[:, None],
+                out=conditional_log,
+                where=valid[:, None],
+            )
+            conditional = np.exp(conditional_log)
+            joint = np.sum(global_weights[:, None] * conditional, axis=0)
+            total = float(np.sum(joint))
+            if not np.isfinite(total) or total <= 0.0:
+                raise RuntimeError("session phi posterior normalization failed")
+            session_joint_weights_list.append(joint / total)
+        session_joint_weights = tuple(session_joint_weights_list)
+        mode = "finite_session_transition"
+
+    return SessionHierarchyPosterior(
+        global_weights=global_weights,
+        session_ids=session_order,
+        execution_session_ids=identifiers,
+        session_joint_weights=session_joint_weights,
+        session_log_evidence=tuple(session_evidence),
+        session_phi_transition=transition,
+        execution_evidence_powers=powers,
+        mode=mode,
+    )

--- a/tests/test_session_hierarchy.py
+++ b/tests/test_session_hierarchy.py
@@ -72,6 +72,67 @@ def test_conflicting_sessions_retain_distinct_local_phi_posteriors() -> None:
     )
 
 
+def test_finite_hierarchy_matches_direct_enumeration() -> None:
+    execution_evidence = (
+        np.asarray([[0.2, -0.1], [-0.4, 0.3]]),
+        np.asarray([[-0.2, 0.4], [0.1, -0.3]]),
+        np.asarray([[0.5, -0.2], [-0.1, 0.2]]),
+    )
+    phi_prior = np.asarray([0.35, 0.65])
+    parameter_prior = np.asarray([0.4, 0.6])
+    transition = np.asarray([[0.8, 0.2], [0.15, 0.85]])
+    identifiers = ("paired", "paired", "other")
+    powers = np.asarray([0.5, 0.5, 1.0])
+
+    result = infer_session_phi_hierarchy(
+        execution_evidence,
+        phi_prior=phi_prior,
+        parameter_prior=parameter_prior,
+        session_ids=identifiers,
+        execution_evidence_powers=powers,
+        session_phi_transition=transition,
+    )
+
+    session_evidence = (
+        0.5 * execution_evidence[0] + 0.5 * execution_evidence[1],
+        execution_evidence[2],
+    )
+    expected_global = np.zeros((2, 2), dtype=float)
+    for global_phi in range(2):
+        for parameter in range(2):
+            weight = phi_prior[global_phi] * parameter_prior[parameter]
+            for evidence in session_evidence:
+                weight *= sum(
+                    transition[global_phi, session_phi]
+                    * np.exp(evidence[session_phi, parameter])
+                    for session_phi in range(2)
+                )
+            expected_global[global_phi, parameter] = weight
+    expected_global /= np.sum(expected_global)
+    np.testing.assert_allclose(result.global_weights, expected_global)
+
+    for session_index, evidence in enumerate(session_evidence):
+        expected_session = np.zeros((2, 2), dtype=float)
+        for session_phi in range(2):
+            for parameter in range(2):
+                for global_phi in range(2):
+                    normalizer = sum(
+                        transition[global_phi, candidate]
+                        * np.exp(evidence[candidate, parameter])
+                        for candidate in range(2)
+                    )
+                    expected_session[session_phi, parameter] += (
+                        expected_global[global_phi, parameter]
+                        * transition[global_phi, session_phi]
+                        * np.exp(evidence[session_phi, parameter])
+                        / normalizer
+                    )
+        np.testing.assert_allclose(
+            result.session_joint_weights[session_index],
+            expected_session,
+        )
+
+
 def test_same_session_composite_powers_preserve_one_evidence_unit() -> None:
     one = infer_session_phi_hierarchy(
         (np.asarray([[0.0], [-2.0]]),),

--- a/tests/test_session_hierarchy.py
+++ b/tests/test_session_hierarchy.py
@@ -1,0 +1,147 @@
+import numpy as np
+import pytest
+
+from causal4d.session_hierarchy import infer_session_phi_hierarchy
+from causal4d.weighting import log_weights_from_probabilities
+
+
+def _logsumexp(values: np.ndarray) -> float:
+    maximum = float(np.max(values))
+    return maximum + float(np.log(np.sum(np.exp(values - maximum))))
+
+
+def _normalize(log_weights: np.ndarray) -> np.ndarray:
+    return np.exp(log_weights - _logsumexp(log_weights))
+
+
+def test_identity_transition_exactly_reproduces_shared_phi_posterior() -> None:
+    execution_evidence = (
+        np.asarray([[0.0, -0.4], [-2.0, -1.0]]),
+        np.asarray([[-0.3, -0.1], [-1.2, -0.8]]),
+        np.asarray([[-0.2, -0.5], [-0.7, -0.6]]),
+    )
+    phi_prior = np.asarray([0.6, 0.4])
+    parameter_prior = np.asarray([0.3, 0.7])
+    powers = np.asarray([0.5, 0.5, 1.0])
+    expected_log_weights = (
+        log_weights_from_probabilities(phi_prior)[:, None]
+        + log_weights_from_probabilities(parameter_prior)[None]
+    )
+    for power, evidence in zip(powers, execution_evidence, strict=True):
+        expected_log_weights += power * evidence
+    expected = _normalize(expected_log_weights)
+
+    result = infer_session_phi_hierarchy(
+        execution_evidence,
+        phi_prior=phi_prior,
+        parameter_prior=parameter_prior,
+        session_ids=("same", "same", "other"),
+        execution_evidence_powers=powers,
+        session_phi_transition=np.eye(2),
+    )
+
+    np.testing.assert_array_equal(result.global_weights, expected)
+    for session_weights in result.session_joint_weights:
+        np.testing.assert_array_equal(session_weights, expected)
+    assert result.mode == "zero_variance_identity"
+
+
+def test_conflicting_sessions_retain_distinct_local_phi_posteriors() -> None:
+    result = infer_session_phi_hierarchy(
+        (
+            np.asarray([[0.0], [-8.0]]),
+            np.asarray([[-8.0], [0.0]]),
+        ),
+        phi_prior=np.asarray([0.5, 0.5]),
+        parameter_prior=np.asarray([1.0]),
+        session_ids=("left", "right"),
+        execution_evidence_powers=(1.0, 1.0),
+        session_phi_transition=np.asarray([[0.9, 0.1], [0.1, 0.9]]),
+    )
+
+    assert result.global_phi_marginal[0] == pytest.approx(0.5)
+    assert result.session_phi_marginals[0][0] > 0.99
+    assert result.session_phi_marginals[1][1] > 0.99
+    np.testing.assert_allclose(
+        np.sum(result.session_joint_weights[0], axis=0),
+        result.parameter_marginal,
+    )
+    np.testing.assert_allclose(
+        np.sum(result.predictive_session_joint_weights, axis=0),
+        result.parameter_marginal,
+    )
+
+
+def test_same_session_composite_powers_preserve_one_evidence_unit() -> None:
+    one = infer_session_phi_hierarchy(
+        (np.asarray([[0.0], [-2.0]]),),
+        phi_prior=np.asarray([0.5, 0.5]),
+        parameter_prior=np.asarray([1.0]),
+        session_ids=("session",),
+        execution_evidence_powers=(1.0,),
+        session_phi_transition=np.eye(2),
+    )
+    duplicate = infer_session_phi_hierarchy(
+        (np.asarray([[0.0], [-2.0]]), np.asarray([[0.0], [-2.0]])),
+        phi_prior=np.asarray([0.5, 0.5]),
+        parameter_prior=np.asarray([1.0]),
+        session_ids=("session", "session"),
+        execution_evidence_powers=(0.5, 0.5),
+        session_phi_transition=np.eye(2),
+    )
+
+    np.testing.assert_array_equal(one.global_weights, duplicate.global_weights)
+    np.testing.assert_array_equal(
+        one.session_log_evidence[0],
+        duplicate.session_log_evidence[0],
+    )
+
+
+def test_transition_zeros_preserve_excluded_support() -> None:
+    result = infer_session_phi_hierarchy(
+        (np.asarray([[0.0], [-10.0]]),),
+        phi_prior=np.asarray([1.0, 0.0]),
+        parameter_prior=np.asarray([1.0]),
+        session_ids=("session",),
+        execution_evidence_powers=(1.0,),
+        session_phi_transition=np.asarray([[1.0, 0.0], [0.25, 0.75]]),
+    )
+
+    assert result.global_weights[1, 0] == 0.0
+    assert result.session_joint_weights[0][1, 0] == 0.0
+
+
+@pytest.mark.parametrize(
+    "transition, message",
+    [
+        (np.ones((2, 3)), "shape"),
+        (np.asarray([[0.8, 0.1], [0.2, 0.8]]), "sum to one"),
+        (np.asarray([[1.0, 0.0], [-0.1, 1.1]]), "nonnegative"),
+        (np.asarray([[1.0, 0.0], [np.nan, np.nan]]), "finite"),
+    ],
+)
+def test_invalid_transition_fails_closed(
+    transition: np.ndarray,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        infer_session_phi_hierarchy(
+            (np.zeros((2, 1)),),
+            phi_prior=np.asarray([0.5, 0.5]),
+            parameter_prior=np.asarray([1.0]),
+            session_ids=("session",),
+            execution_evidence_powers=(1.0,),
+            session_phi_transition=transition,
+        )
+
+
+def test_impossible_all_session_support_fails_normalization() -> None:
+    with pytest.raises(RuntimeError, match="normalization failed"):
+        infer_session_phi_hierarchy(
+            (np.full((2, 1), -np.inf),),
+            phi_prior=np.asarray([0.5, 0.5]),
+            parameter_prior=np.asarray([1.0]),
+            session_ids=("session",),
+            execution_evidence_powers=(1.0,),
+            session_phi_transition=np.asarray([[0.9, 0.1], [0.1, 0.9]]),
+        )

--- a/tests/test_session_hierarchy_integration.py
+++ b/tests/test_session_hierarchy_integration.py
@@ -1,0 +1,105 @@
+import numpy as np
+
+from causal4d.hierarchical_abduction import abduct_hierarchical_interventions
+from causal4d.prefix_likelihood import PrefixLikelihoodConfig
+from causal4d.rollout_bank import JointRolloutBank
+
+
+def _bank() -> JointRolloutBank:
+    trajectories = np.zeros((4, 1, 5, 1, 3), dtype=float)
+    slopes = [0.0, 0.10, 0.12, 0.24]
+    for index, slope in enumerate(slopes):
+        trajectories[index, 0, :, 0, 0] = slope * np.arange(5, dtype=float)
+    metadata = tuple(
+        {
+            "contact": {
+                "gain_multiplier": gain,
+                "delay_steps": 0,
+                "rotation_degrees": 0,
+                "attachment_shifts": [shift],
+                "slip_fraction": 0.0,
+            }
+        }
+        for gain, shift in ((0.8, -1), (0.8, 1), (1.2, -1), (1.2, 1))
+    )
+    return JointRolloutBank(
+        hypothesis_ids=("low-left", "low-right", "high-left", "high-right"),
+        hypothesis_metadata=metadata,
+        hypothesis_prior_weights=np.full(4, 0.25),
+        parameter_particles=np.asarray([[1.0]]),
+        parameter_weights=np.asarray([1.0]),
+        trajectories=trajectories,
+    )
+
+
+def _prefix_config() -> PrefixLikelihoodConfig:
+    return PrefixLikelihoodConfig(
+        observation_scale_m=0.05,
+        likelihood_power=2.0,
+        dynamic_likelihood_weight=0.5,
+    )
+
+
+def test_identity_session_transition_is_exact_legacy_fallback() -> None:
+    bank = _bank()
+    observations = [
+        bank.trajectories[1, 0].copy(),
+        bank.trajectories[2, 0].copy(),
+    ]
+    arguments = {
+        "prefix_frame_counts": [4, 4],
+        "config": _prefix_config(),
+        "session_ids": ["session-low", "session-high"],
+    }
+    legacy = abduct_hierarchical_interventions(
+        [bank, bank],
+        observations,
+        **arguments,
+    )
+    hierarchical = abduct_hierarchical_interventions(
+        [bank, bank],
+        observations,
+        session_phi_transition=np.eye(2),
+        **arguments,
+    )
+
+    np.testing.assert_array_equal(hierarchical.shared_weights, legacy.shared_weights)
+    for actual, expected in zip(
+        hierarchical.execution_joint_weights,
+        legacy.execution_joint_weights,
+        strict=True,
+    ):
+        np.testing.assert_array_equal(actual, expected)
+    assert "session_hierarchy_mode" not in legacy.metadata
+    assert hierarchical.metadata["session_hierarchy_mode"] == (
+        "zero_variance_identity"
+    )
+    assert hierarchical.session_hierarchy is not None
+    assert hierarchical.session_hierarchy.mode == "zero_variance_identity"
+    for session_weights in hierarchical.session_hierarchy.session_joint_weights:
+        np.testing.assert_array_equal(session_weights, legacy.shared_weights)
+
+
+def test_session_transition_retains_session_specific_persistent_state() -> None:
+    bank = _bank()
+    result = abduct_hierarchical_interventions(
+        [bank, bank],
+        [
+            bank.trajectories[1, 0].copy(),
+            bank.trajectories[2, 0].copy(),
+        ],
+        prefix_frame_counts=[4, 4],
+        config=_prefix_config(),
+        session_ids=["session-low", "session-high"],
+        session_phi_transition=np.asarray([[0.9, 0.1], [0.1, 0.9]]),
+    )
+
+    assert result.session_hierarchy is not None
+    assert result.session_hierarchy.mode == "finite_session_transition"
+    low_session, high_session = result.session_phi_marginals
+    assert low_session[0] > high_session[0]
+    assert high_session[1] > low_session[1]
+    np.testing.assert_allclose(
+        np.sum(result.session_hierarchy.session_joint_weights[0], axis=0),
+        result.parameter_marginal,
+    )

--- a/tests/test_session_hierarchy_integration.py
+++ b/tests/test_session_hierarchy_integration.py
@@ -71,9 +71,7 @@ def test_identity_session_transition_is_exact_legacy_fallback() -> None:
     ):
         np.testing.assert_array_equal(actual, expected)
     assert "session_hierarchy_mode" not in legacy.metadata
-    assert hierarchical.metadata["session_hierarchy_mode"] == (
-        "zero_variance_identity"
-    )
+    assert hierarchical.metadata["session_hierarchy_mode"] == ("zero_variance_identity")
     assert hierarchical.session_hierarchy is not None
     assert hierarchical.session_hierarchy.mode == "zero_variance_identity"
     for session_weights in hierarchical.session_hierarchy.session_joint_weights:


### PR DESCRIPTION
## What changed

- add an opt-in finite-support hierarchy with shared physical particles `theta`, a global intervention hyperstate `phi_bar`, a persistent session realization `phi_session`, and execution-local `kappa`;
- accept a row-stochastic `session_phi_transition[g, f] = p(phi_session=f | phi_bar=g)` on the existing registered `phi` support;
- aggregate powered evidence within each session, marginalize its latent state when updating `(phi_bar, theta)`, and recover one `(phi_session, theta)` posterior per session;
- expose posterior-predictive `(phi_session, theta)` weights for a new session while preserving the shared physical-parameter marginal;
- preserve exact zero transition support and fail closed on malformed, nonfinite, negative, non-stochastic, dimensionally inconsistent, or impossible models;
- special-case the identity transition as the zero-session-variance limit and require bit-for-bit equality with the legacy shared-`phi` weights and execution posteriors;
- leave the legacy computation and metadata unchanged when `session_phi_transition` is omitted; and
- document the semantic boundary between the global hyperstate, observed-session states, and new-session prediction.

## Why

The current `session_ids` path correctly limits each session to one unit of composite evidence, but it still forces every session to share exactly the same persistent intervention realization. The paired physical design naturally permits a hierarchy in which actuator gain, delay, controller-frame bias, or another registered persistent intervention coordinate varies by session around a common hardware state.

The implementation stays on the existing finite rollout support rather than introducing an unregistered continuous state. A supplied transition matrix is therefore explicit, source-freezable, and auditable. Exact zeros cannot create excluded support.

## User and scientific impact

Observed sessions receive distinct persistent-intervention posteriors, while a held-out session uses the transition-predictive distribution rather than incorrectly treating `phi_bar` as its realized intervention. The identity transition provides an exact fallback to the current model, making the extension suitable for prospective source-only comparison and finite-support SBC.

This is future-protocol inference machinery only. It does **not** alter the frozen `v0.3.0-causal4d-aip` estimator, the locked 36-execution protocol, acquisition evidence, target identities, Prob4D admission, BayesianPhysTwin provider contracts, or any current real-data claim. A nonidentity transition must be selected from source sessions or preregistered before confirmatory evaluation.

## Validation

Local validation of the standalone finite-support implementation:

- `10 passed`, covering exact identity fallback, conflicting session states, an independent direct enumeration of all global and session latent states, equal-session composite evidence, predictive parameter-marginal conservation, exact-zero support, malformed transitions, and impossible-support rejection;
- Python compilation passed for the new implementation, integration changes, and both new test files;
- Python 3.10-compatible syntax and maximum 88-character line lengths were checked for changed Python and Markdown files.

The branch also adds end-to-end rollout-bank tests for exact legacy fallback and distinct session-level persistent states. GitHub Actions is authoritative for Ruff, formatting, MyPy, the complete repository suite, multi-Python and dependency-floor compatibility, packaging, security scanning, and pinned BayesianPhysTwin integration.