### PR TITLE
Resolve registered acquisition root pairs fail-closed

### DIFF
--- a/.github/workflows/acquisition-readiness-self-hosted.yml
+++ b/.github/workflows/acquisition-readiness-self-hosted.yml
@@ -36,6 +36,8 @@ jobs:
       physical_required: ${{ steps.summary.outputs.physical_required }}
       automatable: ${{ steps.summary.outputs.automatable }}
       dataset_present: ${{ steps.summary.outputs.dataset_present }}
+      root_selection: ${{ steps.summary.outputs.root_selection }}
+      selected_root_candidate: ${{ steps.summary.outputs.selected_root_candidate }}
     steps:
       - name: Check out exact reviewed main revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -96,8 +98,14 @@ jobs:
           set -euo pipefail
           PYTHONPATH="" .acquisition-readiness-venv/bin/python \
             scripts/ci/probe_self_hosted_acquisition.py \
-            --repository-root /opt/causal4d-frozen \
-            --dataset-root /data/causal4d-sloth-multi-action-v1 \
+            --root-candidate \
+              canonical \
+              /opt/causal4d-frozen \
+              /data/causal4d-sloth-multi-action-v1 \
+            --root-candidate \
+              workstation2-persistent \
+              /mnt/lexar4tb/causal4d-physical/causal4d-frozen \
+              /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1 \
             --output outputs/acquisition-readiness/report.json \
             | tee outputs/acquisition-readiness/report.txt
 
@@ -132,6 +140,7 @@ jobs:
           )
           action = report.get("next_action") or {}
           dataset = report["registered_roots"]["dataset"]
+          selection = report["registered_root_selection"]
           print(f"conclusion={report['conclusion']}")
           print(f"action_id={action.get('action_id') or 'unavailable'}")
           print(
@@ -140,6 +149,11 @@ jobs:
           )
           print(f"automatable={str(bool(action.get('automatable'))).lower()}")
           print(f"dataset_present={str(bool(dataset.get('exists'))).lower()}")
+          print(f"root_selection={selection['selection_status']}")
+          print(
+              "selected_root_candidate="
+              f"{selection.get('selected_candidate_id') or 'unavailable'}"
+          )
           PY
 
       - name: Upload sanitized readiness evidence
@@ -185,6 +199,8 @@ jobs:
       PHYSICAL_REQUIRED: ${{ needs.inspect.outputs.physical_required }}
       AUTOMATABLE: ${{ needs.inspect.outputs.automatable }}
       DATASET_PRESENT: ${{ needs.inspect.outputs.dataset_present }}
+      ROOT_SELECTION: ${{ needs.inspect.outputs.root_selection }}
+      SELECTED_ROOT_CANDIDATE: ${{ needs.inspect.outputs.selected_root_candidate }}
     steps:
       - name: Comment with the sanitized readiness result
         shell: bash
@@ -196,6 +212,8 @@ jobs:
           Self-hosted Causal4D acquisition readiness inspection: **${INSPECTION_RESULT}**
 
           - Exact reviewed main commit: \`${GITHUB_SHA}\`
+          - Registered root selection: \`${ROOT_SELECTION:-unavailable}\`
+          - Selected root candidate: \`${SELECTED_ROOT_CANDIDATE:-unavailable}\`
           - Registered dataset present: \`${DATASET_PRESENT:-unknown}\`
           - Derived next action: \`${ACTION_ID:-unavailable}\`
           - Physical acquisition required: \`${PHYSICAL_REQUIRED:-unknown}\`

--- a/docs/self_hosted_acquisition_readiness.md
+++ b/docs/self_hosted_acquisition_readiness.md
@@ -1,9 +1,10 @@
 # Self-hosted acquisition readiness inspection
 
 The physical Causal4D campaign may use a self-hosted GitHub Actions runner as
-the orchestration host, but the runner must expose the registered frozen checkout,
-dataset mount, and local robot/sensor interfaces. GPU qualification alone does
-not establish those capabilities.
+the orchestration host, but the runner must expose one complete registered pair
+consisting of a frozen checkout and its matching dataset root, together with the
+local robot/sensor interfaces. GPU qualification alone does not establish those
+capabilities.
 
 The `Self-hosted acquisition readiness inspection` workflow performs a read-only
 qualification on the exact reviewed `main` revision. It can be dispatched
@@ -20,16 +21,40 @@ numeric account ID, on reviewed `main`, with the exact trigger title. Neither th
 issue body nor its labels reach the runner. The self-hosted job receives a
 read-only repository token and no GitHub secrets.
 
+## Registered root-pair selection
+
+The workflow currently inspects these complete pairs rather than testing or
+combining individual paths independently:
+
+| Candidate | Frozen checkout | Dataset root |
+| --- | --- | --- |
+| `canonical` | `/opt/causal4d-frozen` | `/data/causal4d-sloth-multi-action-v1` |
+| `workstation2-persistent` | `/mnt/lexar4tb/causal4d-physical/causal4d-frozen` | `/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1` |
+
+Selection is fail-closed:
+
+- exactly one complete pair of ordinary directories is selected;
+- repository and dataset roots from different candidates are never mixed;
+- a partial pair is reported but cannot be selected;
+- any symlink component or existing non-directory makes that candidate invalid;
+- no complete pair yields `runner_not_provisioned_with_registered_roots`; and
+- more than one complete pair yields `registered_root_selection_ambiguous` and
+  requires an explicit operator decision before readiness is derived.
+
+The probe also retains the explicit `--repository-root` and `--dataset-root`
+interface for controlled one-pair inspection. Both must be supplied together and
+cannot be combined with repeated `--root-candidate` arguments.
+
 The inspection records only sanitized capability evidence:
 
-- presence, readability, writability, and free space for
-  `/opt/causal4d-frozen` and
-  `/data/causal4d-sloth-multi-action-v1`;
+- candidate-pair state, selected candidate ID, presence, readability,
+  writability, symlink status, and free space for the selected roots;
 - counts and SHA-256 digests of candidate serial, video, HID, and input-device
   identities without publishing raw device names;
 - availability plus hashed output summaries for `ros2 topic list` and `lsusb`;
 - the hash-verified registered next-action category, operator role, physical
-  requirement, and automation flag when the registered roots are available; and
+  requirement, and automation flag when exactly one registered root pair is
+  available; and
 - exact runner, wheel, revision, and GPU identities.
 
 The inspection never opens a device node, sends a robot or sensor command,

--- a/scripts/ci/probe_self_hosted_acquisition.py
+++ b/scripts/ci/probe_self_hosted_acquisition.py
@@ -18,6 +18,14 @@ from causal4d.preacquisition_operator_flow import (
 )
 
 
+RootCandidate = tuple[str, Path, Path]
+_CANONICAL_ROOT_CANDIDATE: RootCandidate = (
+    "canonical",
+    Path("/opt/causal4d-frozen"),
+    Path("/data/causal4d-sloth-multi-action-v1"),
+)
+
+
 def _sha256_lines(values: Iterable[str]) -> str | None:
     normalized = sorted(str(value) for value in values)
     if not normalized:
@@ -26,22 +34,123 @@ def _sha256_lines(values: Iterable[str]) -> str | None:
     return hashlib.sha256(payload).hexdigest()
 
 
+def _contains_symlink_component(path: Path) -> bool:
+    candidate = path.absolute()
+    return any(
+        component.is_symlink()
+        for component in (candidate, *candidate.parents)
+    )
+
+
 def _path_status(path: Path) -> dict[str, Any]:
-    exists = path.exists()
-    is_directory = path.is_dir() if exists else False
+    absolute = path.absolute()
+    contains_symlink_component = _contains_symlink_component(absolute)
+    exists = absolute.exists()
+    is_directory = absolute.is_dir() if exists else False
+    ordinary_directory = (
+        exists and is_directory and not contains_symlink_component
+    )
     result: dict[str, Any] = {
-        "path": str(path),
+        "path": str(absolute),
         "exists": exists,
         "is_directory": is_directory,
-        "readable": os.access(path, os.R_OK) if exists else False,
-        "writable": os.access(path, os.W_OK) if exists else False,
-        "is_mount": os.path.ismount(path) if exists else False,
+        "ordinary_directory": ordinary_directory,
+        "contains_symlink_component": contains_symlink_component,
+        "readable": os.access(absolute, os.R_OK) if exists else False,
+        "writable": os.access(absolute, os.W_OK) if exists else False,
+        "is_mount": os.path.ismount(absolute) if exists else False,
     }
-    if is_directory:
-        usage = shutil.disk_usage(path)
+    if ordinary_directory:
+        usage = shutil.disk_usage(absolute)
         result["free_bytes"] = int(usage.free)
         result["total_bytes"] = int(usage.total)
     return result
+
+
+def _root_candidate_status(
+    candidate_id: str,
+    repository_root: Path,
+    dataset_root: Path,
+) -> dict[str, Any]:
+    if (
+        not candidate_id
+        or candidate_id.strip() != candidate_id
+        or any(character.isspace() for character in candidate_id)
+    ):
+        raise ValueError(
+            "root candidate IDs must be nonempty and contain no whitespace"
+        )
+    repository = _path_status(repository_root)
+    dataset = _path_status(dataset_root)
+    invalid = any(
+        status["contains_symlink_component"]
+        or (status["exists"] and not status["is_directory"])
+        for status in (repository, dataset)
+    )
+    if invalid:
+        pair_state = "invalid"
+    elif repository["ordinary_directory"] and dataset["ordinary_directory"]:
+        pair_state = "complete"
+    elif repository["exists"] or dataset["exists"]:
+        pair_state = "partial"
+    else:
+        pair_state = "absent"
+    return {
+        "candidate_id": candidate_id,
+        "pair_state": pair_state,
+        "repository": repository,
+        "dataset": dataset,
+    }
+
+
+def _select_registered_roots(
+    candidates: Iterable[RootCandidate],
+) -> dict[str, Any]:
+    normalized = tuple(candidates)
+    if not normalized:
+        raise ValueError("at least one registered root candidate is required")
+    identifiers = [candidate_id for candidate_id, _, _ in normalized]
+    if len(set(identifiers)) != len(identifiers):
+        raise ValueError("registered root candidate IDs must be unique")
+
+    inspected = [
+        _root_candidate_status(candidate_id, repository_root, dataset_root)
+        for candidate_id, repository_root, dataset_root in normalized
+    ]
+    complete = [
+        candidate for candidate in inspected if candidate["pair_state"] == "complete"
+    ]
+    selected = complete[0] if len(complete) == 1 else None
+    if selected is not None:
+        selection_status = "selected"
+        reason = "exactly one complete ordinary-directory root pair is available"
+    elif complete:
+        selection_status = "ambiguous"
+        reason = (
+            "multiple complete ordinary-directory root pairs are available; "
+            "selection is fail-closed"
+        )
+    else:
+        selection_status = "unavailable"
+        reason = "no complete ordinary-directory root pair is available"
+
+    return {
+        "schema_version": 1,
+        "selection_status": selection_status,
+        "reason": reason,
+        "candidate_count": len(inspected),
+        "complete_candidate_count": len(complete),
+        "selected_candidate_id": (
+            selected["candidate_id"] if selected is not None else None
+        ),
+        "selected_repository_root": (
+            selected["repository"]["path"] if selected is not None else None
+        ),
+        "selected_dataset_root": (
+            selected["dataset"]["path"] if selected is not None else None
+        ),
+        "candidates": inspected,
+    }
 
 
 def _inventory(paths: Iterable[Path]) -> dict[str, Any]:
@@ -175,24 +284,55 @@ def _next_action_summary(
     )
 
 
+def _unselected_path_status() -> dict[str, Any]:
+    return {
+        "path": None,
+        "exists": False,
+        "is_directory": False,
+        "ordinary_directory": False,
+        "contains_symlink_component": False,
+        "readable": False,
+        "writable": False,
+        "is_mount": False,
+    }
+
+
 def build_report(
     *,
-    repository_root: Path,
-    dataset_root: Path,
+    root_candidates: Iterable[RootCandidate],
     device_root: Path,
 ) -> dict[str, Any]:
-    repository = _path_status(repository_root)
-    dataset = _path_status(dataset_root)
+    root_selection = _select_registered_roots(root_candidates)
+    selected_candidate = None
+    if root_selection["selection_status"] == "selected":
+        selected_candidate = next(
+            candidate
+            for candidate in root_selection["candidates"]
+            if candidate["candidate_id"]
+            == root_selection["selected_candidate_id"]
+        )
+        repository = selected_candidate["repository"]
+        dataset = selected_candidate["dataset"]
+        repository_root = Path(repository["path"])
+        dataset_root = Path(dataset["path"])
+        next_action, next_action_error = _next_action_summary(
+            repository_root,
+            dataset_root,
+        )
+    else:
+        repository = _unselected_path_status()
+        dataset = _unselected_path_status()
+        next_action = None
+        next_action_error = root_selection["reason"]
+
     devices = _glob_inventory(device_root)
     ros_topics = _command_summary("ros2", ["topic", "list"], timeout_seconds=8.0)
     usb = _command_summary("lsusb", [], timeout_seconds=5.0)
-    next_action, next_action_error = _next_action_summary(
-        repository_root,
-        dataset_root,
-    )
 
-    if not repository["exists"] or not dataset["exists"]:
+    if root_selection["selection_status"] == "unavailable":
         conclusion = "runner_not_provisioned_with_registered_roots"
+    elif root_selection["selection_status"] == "ambiguous":
+        conclusion = "registered_root_selection_ambiguous"
     elif next_action is None:
         conclusion = "registered_readiness_could_not_be_derived"
     elif next_action["physical_acquisition_required"]:
@@ -207,7 +347,7 @@ def build_report(
         conclusion = "next_action_requires_registered_human_role"
 
     report: dict[str, Any] = {
-        "schema_version": 1,
+        "schema_version": 2,
         "artifact_kind": "Causal4DSelfHostedAcquisitionReadinessProbe",
         "claim_boundary": (
             "Read-only runner qualification. No device node is opened, no robot "
@@ -224,7 +364,10 @@ def build_report(
             "python": platform.python_version(),
             "kernel": platform.release(),
         },
+        "registered_root_selection": root_selection,
         "registered_roots": {
+            "candidate_id": root_selection["selected_candidate_id"],
+            "selection_status": root_selection["selection_status"],
             "repository": repository,
             "dataset": dataset,
         },
@@ -255,28 +398,59 @@ def build_report(
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository-root", type=Path)
+    parser.add_argument("--dataset-root", type=Path)
     parser.add_argument(
-        "--repository-root",
-        type=Path,
-        default=Path("/opt/causal4d-frozen"),
-    )
-    parser.add_argument(
-        "--dataset-root",
-        type=Path,
-        default=Path("/data/causal4d-sloth-multi-action-v1"),
+        "--root-candidate",
+        action="append",
+        nargs=3,
+        metavar=("ID", "REPOSITORY_ROOT", "DATASET_ROOT"),
+        help=(
+            "candidate root pair; repeat for alternatives. Exactly one complete "
+            "ordinary-directory pair must exist"
+        ),
     )
     parser.add_argument("--device-root", type=Path, default=Path("/dev"))
     parser.add_argument("--output", type=Path, required=True)
     return parser
 
 
+def _root_candidates_from_arguments(
+    arguments: argparse.Namespace,
+) -> tuple[RootCandidate, ...]:
+    explicit_repository = arguments.repository_root
+    explicit_dataset = arguments.dataset_root
+    explicit_supplied = explicit_repository is not None or explicit_dataset is not None
+    candidate_records = arguments.root_candidate or []
+    if (explicit_repository is None) != (explicit_dataset is None):
+        raise ValueError(
+            "--repository-root and --dataset-root must be supplied together"
+        )
+    if explicit_supplied and candidate_records:
+        raise ValueError(
+            "explicit roots cannot be combined with --root-candidate"
+        )
+    if explicit_repository is not None and explicit_dataset is not None:
+        return (("explicit", explicit_repository, explicit_dataset),)
+    if candidate_records:
+        return tuple(
+            (candidate_id, Path(repository_root), Path(dataset_root))
+            for candidate_id, repository_root, dataset_root in candidate_records
+        )
+    return (_CANONICAL_ROOT_CANDIDATE,)
+
+
 def main() -> int:
-    arguments = _parser().parse_args()
-    report = build_report(
-        repository_root=arguments.repository_root,
-        dataset_root=arguments.dataset_root,
-        device_root=arguments.device_root,
-    )
+    parser = _parser()
+    arguments = parser.parse_args()
+    try:
+        root_candidates = _root_candidates_from_arguments(arguments)
+        report = build_report(
+            root_candidates=root_candidates,
+            device_root=arguments.device_root,
+        )
+    except ValueError as error:
+        parser.error(str(error))
     arguments.output.parent.mkdir(parents=True, exist_ok=True)
     arguments.output.write_text(
         json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n",

--- a/scripts/ci/probe_self_hosted_acquisition.py
+++ b/scripts/ci/probe_self_hosted_acquisition.py
@@ -36,10 +36,7 @@ def _sha256_lines(values: Iterable[str]) -> str | None:
 
 def _contains_symlink_component(path: Path) -> bool:
     candidate = path.absolute()
-    return any(
-        component.is_symlink()
-        for component in (candidate, *candidate.parents)
-    )
+    return any(component.is_symlink() for component in (candidate, *candidate.parents))
 
 
 def _path_status(path: Path) -> dict[str, Any]:
@@ -47,9 +44,7 @@ def _path_status(path: Path) -> dict[str, Any]:
     contains_symlink_component = _contains_symlink_component(absolute)
     exists = absolute.exists()
     is_directory = absolute.is_dir() if exists else False
-    ordinary_directory = (
-        exists and is_directory and not contains_symlink_component
-    )
+    ordinary_directory = exists and is_directory and not contains_symlink_component
     result: dict[str, Any] = {
         "path": str(absolute),
         "exists": exists,
@@ -308,8 +303,7 @@ def build_report(
         selected_candidate = next(
             candidate
             for candidate in root_selection["candidates"]
-            if candidate["candidate_id"]
-            == root_selection["selected_candidate_id"]
+            if candidate["candidate_id"] == root_selection["selected_candidate_id"]
         )
         repository = selected_candidate["repository"]
         dataset = selected_candidate["dataset"]
@@ -427,9 +421,7 @@ def _root_candidates_from_arguments(
             "--repository-root and --dataset-root must be supplied together"
         )
     if explicit_supplied and candidate_records:
-        raise ValueError(
-            "explicit roots cannot be combined with --root-candidate"
-        )
+        raise ValueError("explicit roots cannot be combined with --root-candidate")
     if explicit_repository is not None and explicit_dataset is not None:
         return (("explicit", explicit_repository, explicit_dataset),)
     if candidate_records:

--- a/tests/test_self_hosted_acquisition_probe.py
+++ b/tests/test_self_hosted_acquisition_probe.py
@@ -63,12 +63,11 @@ def test_root_selection_uses_the_only_complete_pair(tmp_path: Path) -> None:
     assert selection["selected_repository_root"] == str(
         persistent_repository.absolute()
     )
-    assert selection["selected_dataset_root"] == str(
-        persistent_dataset.absolute()
-    )
-    assert [
-        candidate["pair_state"] for candidate in selection["candidates"]
-    ] == ["absent", "complete"]
+    assert selection["selected_dataset_root"] == str(persistent_dataset.absolute())
+    assert [candidate["pair_state"] for candidate in selection["candidates"]] == [
+        "absent",
+        "complete",
+    ]
 
 
 def test_root_selection_never_mixes_partial_pairs(tmp_path: Path) -> None:
@@ -95,9 +94,10 @@ def test_root_selection_never_mixes_partial_pairs(tmp_path: Path) -> None:
     assert selection["selection_status"] == "unavailable"
     assert selection["complete_candidate_count"] == 0
     assert selection["selected_candidate_id"] is None
-    assert [
-        candidate["pair_state"] for candidate in selection["candidates"]
-    ] == ["partial", "partial"]
+    assert [candidate["pair_state"] for candidate in selection["candidates"]] == [
+        "partial",
+        "partial",
+    ]
 
 
 def test_root_selection_fails_closed_when_multiple_pairs_are_complete(

--- a/tests/test_self_hosted_acquisition_probe.py
+++ b/tests/test_self_hosted_acquisition_probe.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "ci"
+    / "probe_self_hosted_acquisition.py"
+)
+
+
+def _load_probe() -> ModuleType:
+    specification = importlib.util.spec_from_file_location(
+        "causal4d_self_hosted_acquisition_probe",
+        SCRIPT_PATH,
+    )
+    assert specification is not None
+    assert specification.loader is not None
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+probe = _load_probe()
+
+
+def _complete_pair(root: Path, name: str) -> tuple[Path, Path]:
+    repository = root / name / "repository"
+    dataset = root / name / "dataset"
+    repository.mkdir(parents=True)
+    dataset.mkdir(parents=True)
+    return repository, dataset
+
+
+def test_root_selection_uses_the_only_complete_pair(tmp_path: Path) -> None:
+    persistent_repository, persistent_dataset = _complete_pair(
+        tmp_path,
+        "persistent",
+    )
+    selection = probe._select_registered_roots(
+        (
+            (
+                "canonical",
+                tmp_path / "canonical" / "repository",
+                tmp_path / "canonical" / "dataset",
+            ),
+            (
+                "persistent",
+                persistent_repository,
+                persistent_dataset,
+            ),
+        )
+    )
+
+    assert selection["selection_status"] == "selected"
+    assert selection["selected_candidate_id"] == "persistent"
+    assert selection["selected_repository_root"] == str(
+        persistent_repository.absolute()
+    )
+    assert selection["selected_dataset_root"] == str(
+        persistent_dataset.absolute()
+    )
+    assert [
+        candidate["pair_state"] for candidate in selection["candidates"]
+    ] == ["absent", "complete"]
+
+
+def test_root_selection_never_mixes_partial_pairs(tmp_path: Path) -> None:
+    first_repository = tmp_path / "first" / "repository"
+    first_repository.mkdir(parents=True)
+    second_dataset = tmp_path / "second" / "dataset"
+    second_dataset.mkdir(parents=True)
+
+    selection = probe._select_registered_roots(
+        (
+            (
+                "first",
+                first_repository,
+                tmp_path / "first" / "dataset",
+            ),
+            (
+                "second",
+                tmp_path / "second" / "repository",
+                second_dataset,
+            ),
+        )
+    )
+
+    assert selection["selection_status"] == "unavailable"
+    assert selection["complete_candidate_count"] == 0
+    assert selection["selected_candidate_id"] is None
+    assert [
+        candidate["pair_state"] for candidate in selection["candidates"]
+    ] == ["partial", "partial"]
+
+
+def test_root_selection_fails_closed_when_multiple_pairs_are_complete(
+    tmp_path: Path,
+) -> None:
+    first = _complete_pair(tmp_path, "first")
+    second = _complete_pair(tmp_path, "second")
+
+    selection = probe._select_registered_roots(
+        (
+            ("first", *first),
+            ("second", *second),
+        )
+    )
+
+    assert selection["selection_status"] == "ambiguous"
+    assert selection["complete_candidate_count"] == 2
+    assert selection["selected_candidate_id"] is None
+    assert selection["selected_repository_root"] is None
+    assert selection["selected_dataset_root"] is None
+
+
+def test_root_selection_rejects_symlink_components(tmp_path: Path) -> None:
+    real_repository = tmp_path / "real-repository"
+    real_repository.mkdir()
+    linked_repository = tmp_path / "linked-repository"
+    try:
+        linked_repository.symlink_to(real_repository, target_is_directory=True)
+    except OSError as error:  # pragma: no cover - symlinks unavailable
+        pytest.skip(f"symlinks unavailable: {error}")
+    dataset = tmp_path / "dataset"
+    dataset.mkdir()
+
+    selection = probe._select_registered_roots(
+        (("linked", linked_repository, dataset),)
+    )
+
+    candidate = selection["candidates"][0]
+    assert selection["selection_status"] == "unavailable"
+    assert candidate["pair_state"] == "invalid"
+    assert candidate["repository"]["contains_symlink_component"] is True
+    assert candidate["repository"]["ordinary_directory"] is False
+
+
+def test_root_selection_rejects_duplicate_candidate_ids(tmp_path: Path) -> None:
+    first = _complete_pair(tmp_path, "first")
+    second = _complete_pair(tmp_path, "second")
+
+    with pytest.raises(ValueError, match="must be unique"):
+        probe._select_registered_roots(
+            (
+                ("duplicate", *first),
+                ("duplicate", *second),
+            )
+        )
+
+
+def test_build_report_derives_action_from_selected_pair(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository, dataset = _complete_pair(tmp_path, "persistent")
+    device_root = tmp_path / "dev"
+    device_root.mkdir()
+    called: dict[str, Path] = {}
+
+    def next_action(
+        repository_root: Path,
+        dataset_root: Path,
+    ) -> tuple[dict[str, object], None]:
+        called["repository"] = repository_root
+        called["dataset"] = dataset_root
+        return (
+            {
+                "action_id": "review-source-panel",
+                "physical_acquisition_required": False,
+                "automatable": False,
+            },
+            None,
+        )
+
+    monkeypatch.setattr(probe, "_next_action_summary", next_action)
+    monkeypatch.setattr(
+        probe,
+        "_command_summary",
+        lambda *args, **kwargs: {
+            "available": False,
+            "return_code": None,
+            "line_count": 0,
+            "output_sha256": None,
+            "timed_out": False,
+        },
+    )
+
+    report = probe.build_report(
+        root_candidates=(
+            (
+                "canonical",
+                tmp_path / "canonical" / "repository",
+                tmp_path / "canonical" / "dataset",
+            ),
+            ("persistent", repository, dataset),
+        ),
+        device_root=device_root,
+    )
+
+    assert called == {
+        "repository": repository.absolute(),
+        "dataset": dataset.absolute(),
+    }
+    assert report["registered_roots"]["candidate_id"] == "persistent"
+    assert report["next_action"]["action_id"] == "review-source-panel"
+    assert report["conclusion"] == "next_action_requires_registered_human_role"
+    assert report["dataset_modified"] is False
+    assert report["physical_evidence_increment"] == 0
+
+
+def test_build_report_does_not_derive_action_for_ambiguous_roots(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = _complete_pair(tmp_path, "first")
+    second = _complete_pair(tmp_path, "second")
+    device_root = tmp_path / "dev"
+    device_root.mkdir()
+
+    def unexpected(*args, **kwargs):
+        raise AssertionError("next action must not be derived for ambiguous roots")
+
+    monkeypatch.setattr(probe, "_next_action_summary", unexpected)
+    monkeypatch.setattr(
+        probe,
+        "_command_summary",
+        lambda *args, **kwargs: {
+            "available": False,
+            "return_code": None,
+            "line_count": 0,
+            "output_sha256": None,
+            "timed_out": False,
+        },
+    )
+
+    report = probe.build_report(
+        root_candidates=(
+            ("first", *first),
+            ("second", *second),
+        ),
+        device_root=device_root,
+    )
+
+    assert report["registered_root_selection"]["selection_status"] == "ambiguous"
+    assert report["next_action"] is None
+    assert report["conclusion"] == "registered_root_selection_ambiguous"
+    assert report["registered_roots"]["repository"]["path"] is None


### PR DESCRIPTION
## Summary

Correct the read-only workstation2 acquisition-readiness inspection so it can find the registered persistent acquisition scaffold that was provisioned and independently verified in PRs #190 and #191.

The current workflow probes only `/opt/causal4d-frozen` and `/data/causal4d-sloth-multi-action-v1`, while the retained workstation2 provisioning lives under `/mnt/lexar4tb/causal4d-physical`. This produces a false `runner_not_provisioned_with_registered_roots` conclusion even though the persistent root pair is present and its hash-verified scaffold audit passed.

This change:

- accepts named repository/dataset root pairs;
- selects only when exactly one complete ordinary-directory pair exists;
- never combines roots across candidates;
- rejects symlink components and existing non-directories;
- fails closed when multiple complete pairs are present;
- registers both the canonical and workstation2-persistent pairs in the self-hosted workflow;
- reports the selection status and selected candidate ID; and
- documents the selection contract.

## Retained provenance

The independent post-provision artifact from run `31073027559` records:

- frozen checkout: `/mnt/lexar4tb/causal4d-physical/causal4d-frozen`;
- dataset root: `/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1`;
- candidate commit: `0cac23a0a64cb48dd531a2e94b0c022eb394f033`;
- source panel: `0/12`, next `sloth-pre-v2-lift_high-r1`;
- confirmatory registry: `0/36` acquired and validated;
- all 15 audit assertions passed; and
- readiness valid but incomplete.

## Validation

- the three modified base-file blob IDs match current `main`;
- the branch is exactly four intended files ahead of `main` and has no unrelated changes;
- Python compilation, YAML parsing, and seven focused regression tests passed in the prepared patch validation;
- hosted CI on this PR is authoritative.

The focused tests cover unique complete-pair selection, no cross-candidate root mixing, ambiguous-pair fail-closed behavior, symlink rejection, duplicate candidate IDs, selected-pair next-action derivation, and suppression of next-action derivation under ambiguity.

## Safety and scientific boundary

This is a read-only orchestration correction. It does not update the detached acquisition checkout, edit or seal the dataset, publish a source manifest, open a device node, dispatch a robot or sensor command, read target outcomes, change the registered estimator/protocol, or increment physical evidence.

`target_outcomes_used=false`, `dataset_modified=false`, and `physical_evidence_increment=0` remain explicit. Once merged, a new exact-title readiness issue should rerun the inspection on reviewed `main`; any physical or governed operator action remains blocked by the registered next-action and local safety interlock.