### PR TITLE
Execute one allowlisted nonphysical pre-acquisition action

### DIFF
--- a/.github/self-hosted-jobs.json
+++ b/.github/self-hosted-jobs.json
@@ -24,6 +24,20 @@
       "secrets_allowed": false
     },
     {
+      "workflow": "automatable-preacquisition-self-hosted.yml",
+      "job": "execute",
+      "authorization_model": "main-only",
+      "runner_labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "nvidia-smi"
+      ],
+      "purpose": "Execute one exact allowlisted nonphysical registered next action",
+      "dataset_access": "registered-local-preacquisition-single-template-write",
+      "secrets_allowed": false
+    },
+    {
       "workflow": "contact-posterior-concentration.yml",
       "job": "evaluate",
       "authorization_model": "main-only",

--- a/.github/workflows/automatable-preacquisition-self-hosted.yml
+++ b/.github/workflows/automatable-preacquisition-self-hosted.yml
@@ -1,0 +1,299 @@
+name: Self-hosted automatable pre-acquisition action
+
+on:
+  workflow_dispatch:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: automatable-preacquisition-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  execute:
+    name: Execute one registered nonphysical action on workstation2
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'issues' &&
+          github.event.action == 'opened' &&
+          github.event.issue.user.login == 'FlorianPfaff' &&
+          github.event.issue.user.id == 6773539 &&
+          github.event.issue.title ==
+            '[self-hosted] execute Causal4D automatable next action'
+        )
+      )
+    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    timeout-minutes: 45
+    outputs:
+      selected_root_candidate: ${{ steps.summary.outputs.selected_root_candidate }}
+      executed_action: ${{ steps.summary.outputs.executed_action }}
+      created_path: ${{ steps.summary.outputs.created_path }}
+      next_action: ${{ steps.summary.outputs.next_action }}
+      next_automatable: ${{ steps.summary.outputs.next_automatable }}
+      next_physical: ${{ steps.summary.outputs.next_physical }}
+      physical_evidence_increment: ${{ steps.summary.outputs.physical_evidence_increment }}
+    steps:
+      - name: Check out exact reviewed main revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+
+      - name: Verify reviewed main revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Build and install the exact Causal4D wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p outputs/automatable-preacquisition/wheels
+          python -m venv .automatable-preacquisition-venv
+          .automatable-preacquisition-venv/bin/python -m pip install \
+            --upgrade pip "build>=1.2"
+          .automatable-preacquisition-venv/bin/python -m build --wheel \
+            --outdir outputs/automatable-preacquisition/wheels .
+          wheel="$(
+            find outputs/automatable-preacquisition/wheels -maxdepth 1 \
+              -name 'causal4d-*.whl' -print -quit
+          )"
+          test -n "${wheel}"
+          sha256sum "${wheel}" \
+            | tee outputs/automatable-preacquisition/wheel-sha256.txt
+          .automatable-preacquisition-venv/bin/python -m pip install "${wheel}"
+          .automatable-preacquisition-venv/bin/python -m pip check
+          .automatable-preacquisition-venv/bin/python - <<'PY'
+          from pathlib import Path
+
+          import causal4d
+
+          source_root = (Path.cwd() / "src").resolve()
+          origin = Path(causal4d.__file__).resolve()
+          print("installed import", origin)
+          if origin.is_relative_to(source_root):
+              raise SystemExit(
+                  "Causal4D resolved from the checkout instead of the wheel"
+              )
+          PY
+
+      - name: Derive the exact registered pre-action state
+        shell: bash
+        run: |
+          set -euo pipefail
+          PYTHONPATH="" .automatable-preacquisition-venv/bin/python \
+            scripts/ci/probe_self_hosted_acquisition.py \
+            --root-candidate \
+              canonical \
+              /opt/causal4d-frozen \
+              /data/causal4d-sloth-multi-action-v1 \
+            --root-candidate \
+              workstation2-persistent \
+              /mnt/lexar4tb/causal4d-physical/causal4d-frozen \
+              /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1 \
+            --output \
+              outputs/automatable-preacquisition/before-readiness.json \
+            | tee outputs/automatable-preacquisition/before-readiness.txt
+
+      - name: Require the allowlisted nonphysical action
+        shell: bash
+        run: |
+          set -euo pipefail
+          .automatable-preacquisition-venv/bin/python - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(
+              Path(
+                  "outputs/automatable-preacquisition/before-readiness.json"
+              ).read_text(encoding="utf-8")
+          )
+          selection = report["registered_root_selection"]
+          action = report.get("next_action") or {}
+          assert selection["selection_status"] == "selected"
+          assert selection["selected_candidate_id"] == "workstation2-persistent"
+          assert report["conclusion"] == "software_next_action_dispatchable"
+          assert action.get("action_id") == "scaffold_operator_registry"
+          assert action.get("automatable") is True
+          assert action.get("can_run_unattended_on_runner") is True
+          assert action.get("physical_acquisition_required") is False
+          assert action.get("target_outcomes_permitted") is False
+          assert report.get("target_outcomes_used") is False
+          assert report.get("dataset_modified") is False
+          assert report.get("physical_evidence_increment") == 0
+          PY
+
+      - name: Execute the exact allowlisted action
+        shell: bash
+        run: |
+          set -euo pipefail
+          PYTHONPATH="" .automatable-preacquisition-venv/bin/python \
+            scripts/ci/execute_self_hosted_preacquisition_action.py \
+            --repository-root \
+              /mnt/lexar4tb/causal4d-physical/causal4d-frozen \
+            --dataset-root \
+              /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1 \
+            --expected-action-id scaffold_operator_registry \
+            --output outputs/automatable-preacquisition/execution.json \
+            | tee outputs/automatable-preacquisition/execution.txt
+
+      - name: Derive the exact registered post-action state
+        shell: bash
+        run: |
+          set -euo pipefail
+          PYTHONPATH="" .automatable-preacquisition-venv/bin/python \
+            scripts/ci/probe_self_hosted_acquisition.py \
+            --root-candidate \
+              canonical \
+              /opt/causal4d-frozen \
+              /data/causal4d-sloth-multi-action-v1 \
+            --root-candidate \
+              workstation2-persistent \
+              /mnt/lexar4tb/causal4d-physical/causal4d-frozen \
+              /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1 \
+            --output outputs/automatable-preacquisition/after-readiness.json \
+            | tee outputs/automatable-preacquisition/after-readiness.txt
+
+      - name: Require the human-governed sealing boundary
+        id: summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          .automatable-preacquisition-venv/bin/python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          from pathlib import Path
+
+          execution = json.loads(
+              Path(
+                  "outputs/automatable-preacquisition/execution.json"
+              ).read_text(encoding="utf-8")
+          )
+          after = json.loads(
+              Path(
+                  "outputs/automatable-preacquisition/after-readiness.json"
+              ).read_text(encoding="utf-8")
+          )
+          selection = after["registered_root_selection"]
+          action = after.get("next_action") or {}
+          assert selection["selection_status"] == "selected"
+          assert selection["selected_candidate_id"] == "workstation2-persistent"
+          assert after["conclusion"] == "next_action_requires_registered_human_role"
+          assert action.get("action_id") == "seal_operator_registry"
+          assert action.get("automatable") is False
+          assert action.get("physical_acquisition_required") is False
+          assert action.get("target_outcomes_permitted") is False
+          assert execution.get("target_outcomes_used") is False
+          assert execution.get("physical_command_sent") is False
+          assert execution.get("physical_evidence_increment") == 0
+          print("selected_root_candidate=workstation2-persistent")
+          print("executed_action=scaffold_operator_registry")
+          print(
+              "created_path="
+              f"{execution['created_template']['relative_path']}"
+          )
+          print("next_action=seal_operator_registry")
+          print("next_automatable=false")
+          print("next_physical=false")
+          print("physical_evidence_increment=0")
+          PY
+
+      - name: Record runner and GPU identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "runner_name=${RUNNER_NAME}"
+            echo "runner_os=${RUNNER_OS}"
+            echo "runner_arch=${RUNNER_ARCH}"
+            echo "repository=${GITHUB_REPOSITORY}"
+            echo "commit=${GITHUB_SHA}"
+            echo "workflow_run_id=${GITHUB_RUN_ID}"
+            uname -a
+          } | tee outputs/automatable-preacquisition/runner.txt
+          nvidia-smi -L \
+            | tee outputs/automatable-preacquisition/nvidia-smi-L.txt
+
+      - name: Upload the action evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: causal4d-automatable-preacquisition-action
+          path: outputs/automatable-preacquisition/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Remove isolated environment and wheel
+        if: always()
+        shell: bash
+        run: |
+          rm -rf \
+            .automatable-preacquisition-venv \
+            outputs/automatable-preacquisition/wheels
+
+  report:
+    name: Report the automatable action to the trigger issue
+    if: >-
+      always() &&
+      github.event_name == 'issues' &&
+      github.event.action == 'opened' &&
+      github.ref == 'refs/heads/main' &&
+      github.event.issue.user.login == 'FlorianPfaff' &&
+      github.event.issue.user.id == 6773539 &&
+      github.event.issue.title ==
+        '[self-hosted] execute Causal4D automatable next action'
+    needs: execute
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      EXECUTION_RESULT: ${{ needs.execute.result }}
+      SELECTED_ROOT_CANDIDATE: ${{ needs.execute.outputs.selected_root_candidate }}
+      EXECUTED_ACTION: ${{ needs.execute.outputs.executed_action }}
+      CREATED_PATH: ${{ needs.execute.outputs.created_path }}
+      NEXT_ACTION: ${{ needs.execute.outputs.next_action }}
+      NEXT_AUTOMATABLE: ${{ needs.execute.outputs.next_automatable }}
+      NEXT_PHYSICAL: ${{ needs.execute.outputs.next_physical }}
+      PHYSICAL_EVIDENCE_INCREMENT: ${{ needs.execute.outputs.physical_evidence_increment }}
+    steps:
+      - name: Comment with the sanitized execution result
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/"
+          run_url+="${GITHUB_RUN_ID}"
+          body="$(cat <<EOF
+          Self-hosted Causal4D automatable pre-acquisition action: **${EXECUTION_RESULT}**
+
+          - Exact reviewed main commit: \`${GITHUB_SHA}\`
+          - Selected root candidate: \`${SELECTED_ROOT_CANDIDATE:-unavailable}\`
+          - Executed action: \`${EXECUTED_ACTION:-unavailable}\`
+          - Created path: \`${CREATED_PATH:-unavailable}\`
+          - Derived next action: \`${NEXT_ACTION:-unavailable}\`
+          - Next action automatable: \`${NEXT_AUTOMATABLE:-unknown}\`
+          - Next action physical: \`${NEXT_PHYSICAL:-unknown}\`
+          - Workflow run: ${run_url}
+          - Artifact: \`causal4d-automatable-preacquisition-action\`
+          - Physical evidence increment: \`${PHYSICAL_EVIDENCE_INCREMENT:-0}\`
+          EOF
+          )"
+          gh issue comment "${ISSUE_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --body "${body}"

--- a/docs/self_hosted_preacquisition_automation.md
+++ b/docs/self_hosted_preacquisition_automation.md
@@ -1,0 +1,87 @@
+# Self-hosted automatable pre-acquisition actions
+
+Causal4D may execute a registered pre-acquisition action on `workstation2` only
+when the current hash-verified next-action decision classifies it as both
+nonphysical and mechanically automatable. This surface is deliberately narrower
+than the general Causal4D command line.
+
+The workflow can be dispatched manually from reviewed `main`, or triggered by the
+registered maintainer opening an issue with the exact title:
+
+```text
+[self-hosted] execute Causal4D automatable next action
+```
+
+The issue body, labels, and comments are not used as executable input. The
+self-hosted job is allocated only on reviewed `main`, checks out the exact issue
+event SHA, verifies a clean tree, builds and installs that exact Causal4D wheel,
+receives a read-only repository token, and receives no GitHub secrets.
+
+## Current allowlist
+
+The only executable action is:
+
+```text
+scaffold_operator_registry
+```
+
+It corresponds exactly to:
+
+```bash
+causal4d protocol readiness scaffold-operator-registry \
+  /mnt/lexar4tb/causal4d-physical/causal4d-frozen \
+  /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1
+```
+
+Before execution, the workflow requires all of the following:
+
+- exactly one registered repository/dataset root pair is complete;
+- that pair is `workstation2-persistent`;
+- the current registered action is exactly `scaffold_operator_registry`;
+- the action is marked `automatable=true`;
+- `physical_acquisition_required=false`;
+- `target_outcomes_permitted=false`;
+- `changes_registered_method=false`; and
+- the registered `command_argv` equals the allowlisted command byte-for-byte.
+
+The executor snapshots every ordinary file in the registered dataset before and
+after the action. Success requires exactly one added file and no modified or
+removed files:
+
+```text
+preacquisition/operator_registry.template.json
+```
+
+The created artifact must remain an empty, unsealed template with
+`target_outcomes_used=false`. It contains no operator identities, person
+digests, approval, seal, or scientific evidence.
+
+After execution, the workflow recomputes the hash-verified next action. Success
+requires the next boundary to be:
+
+```text
+seal_operator_registry
+```
+
+with `automatable=false` and `physical_acquisition_required=false`. The workflow
+then stops. It cannot populate identities, derive institutional HMACs, seal the
+registry, approve a gate, attest a freeze, publish source evidence, open a device
+node, or dispatch a robot or sensor command.
+
+## Evidence boundary
+
+The retained artifact includes the exact reviewed revision and wheel digest, the
+pre- and post-action readiness reports, the one-file dataset delta, the created
+template digest and byte count, runner identity, and GPU inventory.
+
+Creating the empty template is an operational dataset modification, but it does
+not count as a physical execution:
+
+```text
+target_outcomes_used=false
+physical_command_sent=false
+physical_evidence_increment=0
+```
+
+Any future automatable action requires a separate code change, tests, hosted CI,
+review, and explicit addition to the executor allowlist.

--- a/scripts/ci/execute_self_hosted_preacquisition_action.py
+++ b/scripts/ci/execute_self_hosted_preacquisition_action.py
@@ -170,8 +170,7 @@ def _registered_action(
         "registered action changes the registered method",
     )
     _require(
-        action.get("command_argv")
-        == _expected_command(repository_root, dataset_root),
+        action.get("command_argv") == _expected_command(repository_root, dataset_root),
         "registered action command differs from the exact allowlisted command",
     )
     return action

--- a/scripts/ci/execute_self_hosted_preacquisition_action.py
+++ b/scripts/ci/execute_self_hosted_preacquisition_action.py
@@ -9,7 +9,7 @@ import json
 import os
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from causal4d.operator_registry import (
     OPERATOR_REGISTRY_TEMPLATE_ARTIFACT_KIND,
@@ -147,7 +147,7 @@ def _registered_action(
     )
     action_value = decision.get("action")
     _require(isinstance(action_value, Mapping), "registered next action is missing")
-    action = dict(action_value)
+    action = dict(cast(Mapping[str, Any], action_value))
     _require(
         action.get("action_id") == expected_action_id,
         "registered next action differs from the requested allowlisted action",
@@ -180,7 +180,7 @@ def _registered_action(
 def _action_summary(decision: Mapping[str, Any]) -> dict[str, Any]:
     action_value = decision.get("action")
     _require(isinstance(action_value, Mapping), "registered next action is missing")
-    action = dict(action_value)
+    action = dict(cast(Mapping[str, Any], action_value))
     execution = action.get("registered_execution")
     execution_summary = None
     if isinstance(execution, Mapping):
@@ -260,7 +260,7 @@ def _validate_after_action(decision: Mapping[str, Any]) -> dict[str, Any]:
     )
     action_value = decision.get("action")
     _require(isinstance(action_value, Mapping), "post-action decision has no action")
-    action = dict(action_value)
+    action = dict(cast(Mapping[str, Any], action_value))
     _require(
         action.get("action_id") == EXPECTED_AFTER_ACTION_ID,
         "operator registry scaffold did not reach the registered sealing boundary",

--- a/scripts/ci/execute_self_hosted_preacquisition_action.py
+++ b/scripts/ci/execute_self_hosted_preacquisition_action.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""Execute one allowlisted, nonphysical registered pre-acquisition action."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from causal4d.operator_registry import (
+    OPERATOR_REGISTRY_TEMPLATE_ARTIFACT_KIND,
+    OPERATOR_REGISTRY_TEMPLATE_PATH,
+    scaffold_operator_registry,
+)
+from causal4d.preacquisition_operator_flow import (
+    build_preacquisition_operator_next_action,
+)
+
+
+REPORT_SCHEMA_VERSION = 1
+REPORT_ARTIFACT_KIND = "Causal4DSelfHostedAutomatablePreacquisitionAction"
+ALLOWED_ACTION_ID = "scaffold_operator_registry"
+EXPECTED_AFTER_ACTION_ID = "seal_operator_registry"
+_MAXIMUM_SNAPSHOT_FILES = 50_000
+_MAXIMUM_SNAPSHOT_BYTES = 4 * 1024**3
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _contains_symlink_component(path: Path) -> bool:
+    candidate = path.absolute()
+    return any(component.is_symlink() for component in (candidate, *candidate.parents))
+
+
+def _require_ordinary_directory(path: Path, *, name: str) -> Path:
+    _require(
+        not _contains_symlink_component(path),
+        f"{name} contains a symlink component",
+    )
+    _require(path.is_dir(), f"{name} must be an ordinary directory")
+    return path.resolve()
+
+
+def _sha256_file(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    byte_count = 0
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+            byte_count += len(block)
+    return digest.hexdigest(), byte_count
+
+
+def _snapshot_regular_files(root: Path) -> dict[str, dict[str, Any]]:
+    snapshot: dict[str, dict[str, Any]] = {}
+    total_bytes = 0
+    for path in sorted(root.rglob("*"), key=lambda value: value.as_posix()):
+        _require(not path.is_symlink(), f"dataset contains a symlink: {path}")
+        if path.is_dir():
+            continue
+        _require(path.is_file(), f"dataset contains a non-regular entry: {path}")
+        relative = path.relative_to(root).as_posix()
+        sha256, byte_count = _sha256_file(path)
+        snapshot[relative] = {"sha256": sha256, "bytes": byte_count}
+        total_bytes += byte_count
+        _require(
+            len(snapshot) <= _MAXIMUM_SNAPSHOT_FILES,
+            "dataset snapshot exceeds the registered file-count guard",
+        )
+        _require(
+            total_bytes <= _MAXIMUM_SNAPSHOT_BYTES,
+            "dataset snapshot exceeds the registered byte-count guard",
+        )
+    return snapshot
+
+
+def _snapshot_sha256(snapshot: Mapping[str, Mapping[str, Any]]) -> str:
+    encoded = json.dumps(
+        snapshot,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _snapshot_delta(
+    before: Mapping[str, Mapping[str, Any]],
+    after: Mapping[str, Mapping[str, Any]],
+) -> dict[str, list[str]]:
+    before_paths = set(before)
+    after_paths = set(after)
+    return {
+        "added": sorted(after_paths - before_paths),
+        "removed": sorted(before_paths - after_paths),
+        "modified": sorted(
+            path
+            for path in before_paths & after_paths
+            if dict(before[path]) != dict(after[path])
+        ),
+    }
+
+
+def _load_json_mapping(path: Path, *, name: str) -> dict[str, Any]:
+    _require(
+        not _contains_symlink_component(path),
+        f"{name} contains a symlink component",
+    )
+    _require(path.is_file(), f"{name} is missing")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    _require(isinstance(value, Mapping), f"{name} must contain a JSON object")
+    return dict(value)
+
+
+def _expected_command(repository_root: Path, dataset_root: Path) -> list[str]:
+    return [
+        "causal4d",
+        "protocol",
+        "readiness",
+        "scaffold-operator-registry",
+        str(repository_root),
+        str(dataset_root),
+    ]
+
+
+def _registered_action(
+    decision: Mapping[str, Any],
+    *,
+    expected_action_id: str,
+    repository_root: Path,
+    dataset_root: Path,
+) -> dict[str, Any]:
+    _require(
+        decision.get("valid") is True,
+        "registered next-action decision is invalid",
+    )
+    _require(
+        decision.get("target_outcomes_used") is False,
+        "registered next-action decision admits target outcomes",
+    )
+    action_value = decision.get("action")
+    _require(isinstance(action_value, Mapping), "registered next action is missing")
+    action = dict(action_value)
+    _require(
+        action.get("action_id") == expected_action_id,
+        "registered next action differs from the requested allowlisted action",
+    )
+    _require(
+        action.get("category") == "scaffold",
+        "registered action is not a scaffold",
+    )
+    _require(action.get("automatable") is True, "registered action is not automatable")
+    _require(
+        action.get("physical_acquisition_required") is False,
+        "registered action requires physical acquisition",
+    )
+    _require(
+        action.get("target_outcomes_permitted") is False,
+        "registered action permits target outcomes",
+    )
+    _require(
+        action.get("changes_registered_method") is False,
+        "registered action changes the registered method",
+    )
+    _require(
+        action.get("command_argv")
+        == _expected_command(repository_root, dataset_root),
+        "registered action command differs from the exact allowlisted command",
+    )
+    return action
+
+
+def _action_summary(decision: Mapping[str, Any]) -> dict[str, Any]:
+    action_value = decision.get("action")
+    _require(isinstance(action_value, Mapping), "registered next action is missing")
+    action = dict(action_value)
+    execution = action.get("registered_execution")
+    execution_summary = None
+    if isinstance(execution, Mapping):
+        execution_summary = {
+            "execution_id": execution.get("execution_id"),
+            "session_id": execution.get("session_id"),
+            "command_profile_id": execution.get("command_profile_id"),
+        }
+    return {
+        "action_id": action.get("action_id"),
+        "category": action.get("category"),
+        "operator_role": action.get("operator_role"),
+        "automatable": action.get("automatable") is True,
+        "physical_acquisition_required": (
+            action.get("physical_acquisition_required") is True
+        ),
+        "target_outcomes_permitted": action.get("target_outcomes_permitted") is True,
+        "blocking_item_count": len(action.get("blocking_items", [])),
+        "registered_execution": execution_summary,
+        "evidence_sha256": decision.get("evidence_sha256"),
+        "status_sha256": decision.get("status_sha256"),
+    }
+
+
+def _validate_created_template(
+    path: Path,
+    *,
+    decision_before: Mapping[str, Any],
+) -> dict[str, Any]:
+    template = _load_json_mapping(path, name="operator registry template")
+    _require(
+        template.get("artifact_kind") == OPERATOR_REGISTRY_TEMPLATE_ARTIFACT_KIND,
+        "operator registry template artifact kind is invalid",
+    )
+    _require(
+        template.get("status") == "template",
+        "operator registry is not a template",
+    )
+    _require(
+        template.get("target_outcomes_used") is False,
+        "target outcomes entered the operator registry template",
+    )
+    _require(template.get("operators") == [], "operator registry template is not empty")
+    _require(
+        template.get("sealed_at_utc") is None
+        and template.get("sealed_by_operator_id") is None
+        and template.get("artifact_sha256") is None,
+        "operator registry template contains seal metadata",
+    )
+    for field in (
+        "protocol_id",
+        "protocol_design_sha256",
+        "preacquisition_plan_id",
+        "preacquisition_amendment_sha256",
+    ):
+        _require(
+            template.get(field) == decision_before.get(field),
+            f"operator registry template {field} mismatch",
+        )
+    sha256, byte_count = _sha256_file(path)
+    return {
+        "relative_path": OPERATOR_REGISTRY_TEMPLATE_PATH,
+        "sha256": sha256,
+        "bytes": byte_count,
+        "artifact_kind": template["artifact_kind"],
+        "status": template["status"],
+        "operator_count": 0,
+        "target_outcomes_used": False,
+    }
+
+
+def _validate_after_action(decision: Mapping[str, Any]) -> dict[str, Any]:
+    _require(decision.get("valid") is True, "post-action decision is invalid")
+    _require(
+        decision.get("target_outcomes_used") is False,
+        "post-action decision admits target outcomes",
+    )
+    action_value = decision.get("action")
+    _require(isinstance(action_value, Mapping), "post-action decision has no action")
+    action = dict(action_value)
+    _require(
+        action.get("action_id") == EXPECTED_AFTER_ACTION_ID,
+        "operator registry scaffold did not reach the registered sealing boundary",
+    )
+    _require(
+        action.get("automatable") is False,
+        "post-scaffold operator registry action must require a human role",
+    )
+    _require(
+        action.get("physical_acquisition_required") is False,
+        "post-scaffold operator registry action unexpectedly requires acquisition",
+    )
+    _require(
+        action.get("target_outcomes_permitted") is False,
+        "post-scaffold operator registry action permits target outcomes",
+    )
+    return _action_summary(decision)
+
+
+def execute_allowlisted_action(
+    *,
+    repository_root: Path,
+    dataset_root: Path,
+    expected_action_id: str,
+) -> dict[str, Any]:
+    _require(
+        expected_action_id == ALLOWED_ACTION_ID,
+        "requested action is not in the self-hosted allowlist",
+    )
+    repository = _require_ordinary_directory(
+        repository_root,
+        name="repository root",
+    )
+    dataset = _require_ordinary_directory(dataset_root, name="dataset root")
+    target = dataset / OPERATOR_REGISTRY_TEMPLATE_PATH
+    _require(
+        not _contains_symlink_component(target),
+        "operator registry template path contains a symlink component",
+    )
+    _require(
+        not target.exists(),
+        "operator registry template already exists; refusing a non-exact action",
+    )
+
+    snapshot_before = _snapshot_regular_files(dataset)
+    decision_before = build_preacquisition_operator_next_action(
+        repository,
+        dataset,
+        verify_file_hashes=True,
+    )
+    action_before = _registered_action(
+        decision_before,
+        expected_action_id=expected_action_id,
+        repository_root=repository,
+        dataset_root=dataset,
+    )
+
+    scaffold_result = scaffold_operator_registry(repository, dataset)
+    _require(scaffold_result.get("passed") is True, "operator registry scaffold failed")
+    _require(
+        scaffold_result.get("created") is True
+        and scaffold_result.get("existing") is False,
+        "operator registry scaffold did not create exactly one new template",
+    )
+
+    snapshot_after = _snapshot_regular_files(dataset)
+    delta = _snapshot_delta(snapshot_before, snapshot_after)
+    _require(
+        delta
+        == {
+            "added": [OPERATOR_REGISTRY_TEMPLATE_PATH],
+            "removed": [],
+            "modified": [],
+        },
+        "allowlisted action changed files outside the registered template path",
+    )
+    template_summary = _validate_created_template(
+        target,
+        decision_before=decision_before,
+    )
+
+    decision_after = build_preacquisition_operator_next_action(
+        repository,
+        dataset,
+        verify_file_hashes=True,
+    )
+    action_after = _validate_after_action(decision_after)
+
+    report: dict[str, Any] = {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "artifact_kind": REPORT_ARTIFACT_KIND,
+        "reviewed_main_commit": os.environ.get("GITHUB_SHA"),
+        "repository_root": str(repository),
+        "dataset_root": str(dataset),
+        "executed_action": {
+            "action_id": action_before["action_id"],
+            "category": action_before["category"],
+            "operator_role": action_before["operator_role"],
+            "command_argv": list(action_before["command_argv"]),
+            "automatable": True,
+            "physical_acquisition_required": False,
+            "target_outcomes_permitted": False,
+            "changes_registered_method": False,
+        },
+        "scaffold_result": dict(scaffold_result),
+        "created_template": template_summary,
+        "dataset_delta": delta,
+        "snapshot_before_sha256": _snapshot_sha256(snapshot_before),
+        "snapshot_after_sha256": _snapshot_sha256(snapshot_after),
+        "next_action": action_after,
+        "target_outcomes_used": False,
+        "device_nodes_opened": False,
+        "physical_command_sent": False,
+        "dataset_modified": True,
+        "physical_evidence_increment": 0,
+        "claim_boundary": (
+            "Exactly one empty operator-registry template was created by the "
+            "registered nonphysical scaffold action. No identity was supplied, "
+            "no gate was sealed or approved, no device was opened, no robot or "
+            "sensor command was sent, no target outcome was read, and physical "
+            "evidence was not incremented."
+        ),
+    }
+    encoded = json.dumps(
+        report,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    report["report_sha256"] = hashlib.sha256(encoded).hexdigest()
+    return report
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository-root", type=Path, required=True)
+    parser.add_argument("--dataset-root", type=Path, required=True)
+    parser.add_argument(
+        "--expected-action-id",
+        choices=(ALLOWED_ACTION_ID,),
+        required=True,
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main() -> int:
+    arguments = _parser().parse_args()
+    report = execute_allowlisted_action(
+        repository_root=arguments.repository_root,
+        dataset_root=arguments.dataset_root,
+        expected_action_id=arguments.expected_action_id,
+    )
+    arguments.output.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(report, indent=2, sort_keys=True, allow_nan=False)
+    arguments.output.write_text(encoded + "\n", encoding="utf-8")
+    print(encoded)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_self_hosted_preacquisition_action.py
+++ b/tests/test_self_hosted_preacquisition_action.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "ci"
+    / "execute_self_hosted_preacquisition_action.py"
+)
+
+
+def _load_executor() -> ModuleType:
+    specification = importlib.util.spec_from_file_location(
+        "causal4d_self_hosted_preacquisition_action",
+        SCRIPT_PATH,
+    )
+    assert specification is not None
+    assert specification.loader is not None
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+executor = _load_executor()
+
+
+def _identity() -> dict[str, str]:
+    return {
+        "protocol_id": "protocol-v1",
+        "protocol_design_sha256": "a" * 64,
+        "preacquisition_plan_id": "plan-v1",
+        "preacquisition_amendment_sha256": "b" * 64,
+    }
+
+
+def _decision(
+    repository: Path,
+    dataset: Path,
+    *,
+    action_id: str,
+    automatable: bool,
+    physical: bool = False,
+    command: list[str] | None = None,
+) -> dict[str, object]:
+    category = (
+        "scaffold"
+        if action_id == "scaffold_operator_registry"
+        else "manual_evidence"
+    )
+    return {
+        "schema_version": 1,
+        "artifact_kind": "Causal4DPreacquisitionNextAction",
+        **_identity(),
+        "valid": True,
+        "ready": False,
+        "target_outcomes_used": False,
+        "evidence_sha256": "c" * 64,
+        "status_sha256": "d" * 64,
+        "action": {
+            "action_id": action_id,
+            "category": category,
+            "title": action_id,
+            "operator_role": "principal_investigator",
+            "physical_acquisition_required": physical,
+            "automatable": automatable,
+            "changes_registered_method": False,
+            "target_outcomes_permitted": False,
+            "command_argv": command,
+            "blocking_items": [],
+        },
+    }
+
+
+def _template() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "artifact_kind": "Causal4DOperatorIdentityRegistryTemplate",
+        "status": "template",
+        **_identity(),
+        "person_identity_digest_method": "hmac-sha256-domain-separated-v1",
+        "sealed_at_utc": None,
+        "sealed_by_operator_id": None,
+        "target_outcomes_used": False,
+        "operators": [],
+        "artifact_sha256": None,
+    }
+
+
+def _install_successful_stubs(
+    monkeypatch: pytest.MonkeyPatch,
+    repository: Path,
+    dataset: Path,
+    *,
+    mutate_extra_path: bool = False,
+) -> None:
+    expected_command = executor._expected_command(
+        repository.resolve(),
+        dataset.resolve(),
+    )
+    decisions = iter(
+        (
+            _decision(
+                repository.resolve(),
+                dataset.resolve(),
+                action_id="scaffold_operator_registry",
+                automatable=True,
+                command=expected_command,
+            ),
+            _decision(
+                repository.resolve(),
+                dataset.resolve(),
+                action_id="seal_operator_registry",
+                automatable=False,
+                command=None,
+            ),
+        )
+    )
+    monkeypatch.setattr(
+        executor,
+        "build_preacquisition_operator_next_action",
+        lambda *args, **kwargs: next(decisions),
+    )
+
+    def scaffold(repository_root: Path, dataset_root: Path) -> dict[str, object]:
+        target = dataset_root / executor.OPERATOR_REGISTRY_TEMPLATE_PATH
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(
+            json.dumps(_template(), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        if mutate_extra_path:
+            (dataset_root / "unexpected.txt").write_text("changed\n", encoding="utf-8")
+        return {
+            "passed": True,
+            "path": str(target.resolve()),
+            "created": True,
+            "existing": False,
+        }
+
+    monkeypatch.setattr(executor, "scaffold_operator_registry", scaffold)
+
+
+def test_execute_allowlisted_action_adds_only_the_empty_template(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    dataset = tmp_path / "dataset"
+    repository.mkdir()
+    dataset.mkdir()
+    (dataset / "existing.json").write_text("{}\n", encoding="utf-8")
+    _install_successful_stubs(monkeypatch, repository, dataset)
+
+    report = executor.execute_allowlisted_action(
+        repository_root=repository,
+        dataset_root=dataset,
+        expected_action_id="scaffold_operator_registry",
+    )
+
+    assert report["executed_action"]["action_id"] == "scaffold_operator_registry"
+    assert report["dataset_delta"] == {
+        "added": ["preacquisition/operator_registry.template.json"],
+        "removed": [],
+        "modified": [],
+    }
+    assert report["created_template"]["operator_count"] == 0
+    assert report["next_action"]["action_id"] == "seal_operator_registry"
+    assert report["next_action"]["automatable"] is False
+    assert report["target_outcomes_used"] is False
+    assert report["physical_command_sent"] is False
+    assert report["physical_evidence_increment"] == 0
+
+
+def test_execute_allowlisted_action_rejects_physical_registered_action(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    dataset = tmp_path / "dataset"
+    repository.mkdir()
+    dataset.mkdir()
+    command = executor._expected_command(repository.resolve(), dataset.resolve())
+    monkeypatch.setattr(
+        executor,
+        "build_preacquisition_operator_next_action",
+        lambda *args, **kwargs: _decision(
+            repository.resolve(),
+            dataset.resolve(),
+            action_id="scaffold_operator_registry",
+            automatable=True,
+            physical=True,
+            command=command,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="requires physical acquisition"):
+        executor.execute_allowlisted_action(
+            repository_root=repository,
+            dataset_root=dataset,
+            expected_action_id="scaffold_operator_registry",
+        )
+
+    assert not (dataset / executor.OPERATOR_REGISTRY_TEMPLATE_PATH).exists()
+
+
+def test_execute_allowlisted_action_rejects_command_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    dataset = tmp_path / "dataset"
+    repository.mkdir()
+    dataset.mkdir()
+    monkeypatch.setattr(
+        executor,
+        "build_preacquisition_operator_next_action",
+        lambda *args, **kwargs: _decision(
+            repository.resolve(),
+            dataset.resolve(),
+            action_id="scaffold_operator_registry",
+            automatable=True,
+            command=["causal4d", "unexpected"],
+        ),
+    )
+
+    with pytest.raises(ValueError, match="exact allowlisted command"):
+        executor.execute_allowlisted_action(
+            repository_root=repository,
+            dataset_root=dataset,
+            expected_action_id="scaffold_operator_registry",
+        )
+
+
+def test_execute_allowlisted_action_rejects_preexisting_template(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    dataset = tmp_path / "dataset"
+    repository.mkdir()
+    target = dataset / executor.OPERATOR_REGISTRY_TEMPLATE_PATH
+    target.parent.mkdir(parents=True)
+    target.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="already exists"):
+        executor.execute_allowlisted_action(
+            repository_root=repository,
+            dataset_root=dataset,
+            expected_action_id="scaffold_operator_registry",
+        )
+
+
+def test_execute_allowlisted_action_rejects_unexpected_dataset_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    dataset = tmp_path / "dataset"
+    repository.mkdir()
+    dataset.mkdir()
+    _install_successful_stubs(
+        monkeypatch,
+        repository,
+        dataset,
+        mutate_extra_path=True,
+    )
+
+    with pytest.raises(ValueError, match="outside the registered template path"):
+        executor.execute_allowlisted_action(
+            repository_root=repository,
+            dataset_root=dataset,
+            expected_action_id="scaffold_operator_registry",
+        )
+
+
+def test_execute_allowlisted_action_rejects_symlink_dataset_root(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    real_dataset = tmp_path / "real-dataset"
+    real_dataset.mkdir()
+    dataset = tmp_path / "dataset"
+    try:
+        dataset.symlink_to(real_dataset, target_is_directory=True)
+    except OSError as error:  # pragma: no cover - symlinks unavailable
+        pytest.skip(f"symlinks unavailable: {error}")
+
+    with pytest.raises(ValueError, match="symlink component"):
+        executor.execute_allowlisted_action(
+            repository_root=repository,
+            dataset_root=dataset,
+            expected_action_id="scaffold_operator_registry",
+        )

--- a/tests/test_self_hosted_preacquisition_action.py
+++ b/tests/test_self_hosted_preacquisition_action.py
@@ -50,9 +50,7 @@ def _decision(
     command: list[str] | None = None,
 ) -> dict[str, object]:
     category = (
-        "scaffold"
-        if action_id == "scaffold_operator_registry"
-        else "manual_evidence"
+        "scaffold" if action_id == "scaffold_operator_registry" else "manual_evidence"
     )
     return {
         "schema_version": 1,


### PR DESCRIPTION
## Summary

Add a reviewed-main self-hosted executor for exactly one registered, mechanically automatable pre-acquisition action: `scaffold_operator_registry`.

The current workstation2 readiness run `31415651049` selected the retained `workstation2-persistent` root pair and derived:

```text
action_id=scaffold_operator_registry
automatable=true
physical_acquisition_required=false
target_outcomes_permitted=false
```

This PR turns that registered decision into a narrow one-step workflow rather than introducing a general remote command surface.

## Execution contract

Before allocation and execution, the workflow requires reviewed `main`, an exact clean `GITHUB_SHA` checkout, a read-only repository token, no GitHub secrets, and either manual main dispatch or the exact registered-maintainer issue trigger.

Before writing, it re-derives the current root selection and next action and requires:

- exactly one complete ordinary-directory root pair;
- selected candidate `workstation2-persistent`;
- exact action `scaffold_operator_registry`;
- `automatable=true`;
- `physical_acquisition_required=false`;
- `target_outcomes_permitted=false`;
- `changes_registered_method=false`; and
- byte-for-byte equality of the registered `command_argv` with the allowlisted command.

The executor snapshots every regular dataset file before and after the action. Success permits exactly one addition and no removal or modification:

```text
preacquisition/operator_registry.template.json
```

The template must remain empty and unsealed, with no identities, approval, seal metadata, or target outcomes.

After execution, the workflow recomputes the hash-verified next action and requires:

```text
action_id=seal_operator_registry
automatable=false
physical_acquisition_required=false
```

It then stops at that human-governed boundary.

## Files

- add the allowlisted executor script;
- add the reviewed-main self-hosted workflow and hosted issue reporter;
- register the self-hosted job and its single-template-write dataset scope;
- add six adversarial/fail-closed executor tests; and
- document the automation and evidence boundary.

## Validation

Against the full Causal4D source distribution with the new files overlaid:

```text
14 passed
```

This includes the six new executor tests plus the complete self-hosted workflow-policy suite. Python compilation, workflow YAML parsing, JSON policy parsing, and an 88-column check also passed locally. Hosted CI on the PR merge result is authoritative.

## Safety and scientific boundary

This workflow cannot populate or seal the operator registry, derive person digests, approve a gate, attest a freeze, publish source evidence, open a device node, command a robot or sensor, or read target outcomes. It adds an empty operational template only.

The retained report explicitly records:

```text
target_outcomes_used=false
physical_command_sent=false
physical_evidence_increment=0
```

Any future automatable action requires a separately reviewed code change and explicit addition to the allowlist.