### PR TITLE
Complete acquisition-input and SBC identity hardening

### DIFF
--- a/.github/workflows/acquisition-journal-contract.yml
+++ b/.github/workflows/acquisition-journal-contract.yml
@@ -8,8 +8,11 @@ on:
       - "src/causal4d/acquisition_journal_io.py"
       - "src/causal4d/acquisition_journal_lock.py"
       - "src/causal4d/acquisition_journal_seal.py"
+      - "src/causal4d/artifact_io.py"
+      - "src/causal4d/cli/acquisition_operations.py"
       - "tests/test_acquisition_flight_recorder.py"
       - "tests/test_acquisition_journal_locking.py"
+      - "tests/test_acquisition_operations.py"
       - "docs/causal4d_acquisition_flight_recorder.md"
   push:
     branches: [main]
@@ -18,8 +21,11 @@ on:
       - "src/causal4d/acquisition_journal_io.py"
       - "src/causal4d/acquisition_journal_lock.py"
       - "src/causal4d/acquisition_journal_seal.py"
+      - "src/causal4d/artifact_io.py"
+      - "src/causal4d/cli/acquisition_operations.py"
       - "tests/test_acquisition_flight_recorder.py"
       - "tests/test_acquisition_journal_locking.py"
+      - "tests/test_acquisition_operations.py"
   workflow_dispatch:
 
 permissions:
@@ -48,25 +54,31 @@ jobs:
       - name: Install development environment
         run: python -m pip install -e ".[dev]"
 
-      - name: Check claim-bearing journal code
+      - name: Check claim-bearing acquisition code
         run: |
           python -m ruff check \
             src/causal4d/acquisition_journal_io.py \
             src/causal4d/acquisition_journal_lock.py \
             src/causal4d/acquisition_journal_seal.py \
-            tests/test_acquisition_journal_locking.py
+            src/causal4d/cli/acquisition_operations.py \
+            tests/test_acquisition_journal_locking.py \
+            tests/test_acquisition_operations.py
           python -m ruff format --check \
             src/causal4d/acquisition_journal_io.py \
             src/causal4d/acquisition_journal_lock.py \
             src/causal4d/acquisition_journal_seal.py \
-            tests/test_acquisition_journal_locking.py
+            src/causal4d/cli/acquisition_operations.py \
+            tests/test_acquisition_journal_locking.py \
+            tests/test_acquisition_operations.py
           python -m mypy \
             src/causal4d/acquisition_journal_io.py \
             src/causal4d/acquisition_journal_lock.py \
-            src/causal4d/acquisition_journal_seal.py
+            src/causal4d/acquisition_journal_seal.py \
+            src/causal4d/cli/acquisition_operations.py
 
       - name: Exercise journal invariants and process races
         run: |
           python -m pytest -q \
             tests/test_acquisition_journal_locking.py \
-            tests/test_acquisition_flight_recorder.py
+            tests/test_acquisition_flight_recorder.py \
+            tests/test_acquisition_operations.py

--- a/src/causal4d/cli/acquisition_operations.py
+++ b/src/causal4d/cli/acquisition_operations.py
@@ -17,15 +17,17 @@ from causal4d.acquisition_flight_recorder import (
     validate_acquisition_journal,
     validate_acquisition_journal_seal,
 )
+from causal4d.artifact_io import (
+    load_strict_json_object,
+    read_regular_file_no_symlinks,
+)
 from causal4d.atomic_io import atomic_write_json
 from causal4d.real_protocol import validate_protocol
 
 
 def _json_object(path: Path, *, name: str) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError(f"{name} must contain a JSON object")
-    return payload
+    snapshot = read_regular_file_no_symlinks(path, name=name)
+    return load_strict_json_object(snapshot.payload, name=name)
 
 
 def _gib(value: str | float) -> int:

--- a/src/causal4d/cli/latent_contact_benchmark.py
+++ b/src/causal4d/cli/latent_contact_benchmark.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence
 from importlib import metadata
 from pathlib import Path
 
+from causal4d.artifact_io import read_regular_file
 from causal4d.atomic_io import atomic_write_json
 from causal4d.benchmark import CounterfactualBenchmarkConfig
 from causal4d.contact_evaluation import (
@@ -177,8 +178,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         except FileExistsError:
             return _report_existing_sbc_output(sbc_path)
+        sbc_snapshot = read_regular_file(sbc_path, name="SBC result")
         summary["sbc"] = {
             "path": str(sbc_path.resolve()),
+            "sha256": sbc_snapshot.sha256,
+            "byte_count": sbc_snapshot.byte_count,
+            "configuration": {
+                "seeds": seeds,
+                "trials_per_fold": args.sbc_trials_per_fold,
+                "bin_count": args.sbc_bins,
+                "benchmark": benchmark_config.as_dict(),
+                "contact": contact_config.as_dict(),
+            },
             "aggregate": sbc["aggregate"],
             "interpretation": sbc["interpretation"],
             "producer": sbc["producer"],

--- a/tests/test_acquisition_operations.py
+++ b/tests/test_acquisition_operations.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from causal4d.artifact_io import ArtifactValidationError
+from causal4d.cli.acquisition_operations import _json_object, main
+
+
+@pytest.mark.parametrize(
+    ("payload", "error_pattern"),
+    [
+        (b'{"value": 1, "value": 2}\n', "duplicate JSON object key"),
+        (b'{"value": NaN}\n', "non-finite JSON number"),
+        (b'{"value": Infinity}\n', "non-finite JSON number"),
+        (b'{"value": -Infinity}\n', "non-finite JSON number"),
+        (b'{"value": 1e999}\n', "non-finite JSON number"),
+        (b"\xff", "not valid UTF-8 JSON"),
+        (b"[]\n", "must contain one JSON object"),
+    ],
+    ids=[
+        "duplicate-key",
+        "nan",
+        "positive-infinity",
+        "negative-infinity",
+        "overflowing-float",
+        "invalid-utf8",
+        "non-object",
+    ],
+)
+def test_json_object_rejects_ambiguous_or_nonfinite_inputs(
+    tmp_path: Path,
+    payload: bytes,
+    error_pattern: str,
+) -> None:
+    path = tmp_path / "input.json"
+    path.write_bytes(payload)
+
+    with pytest.raises(ArtifactValidationError, match=error_pattern):
+        _json_object(path, name="test input")
+
+
+def test_json_object_accepts_one_finite_utf8_object(tmp_path: Path) -> None:
+    path = tmp_path / "input.json"
+    path.write_bytes(b'{"nested": {"value": 1.25}, "enabled": true}\n')
+
+    assert _json_object(path, name="test input") == {
+        "nested": {"value": 1.25},
+        "enabled": True,
+    }
+
+
+def test_json_object_rejects_a_file_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "target.json"
+    target.write_text('{"value": 1}\n', encoding="utf-8")
+    link = tmp_path / "input.json"
+    try:
+        link.symlink_to(target)
+    except (NotImplementedError, OSError) as error:  # pragma: no cover - platform
+        pytest.skip(f"symlinks unavailable: {error}")
+
+    with pytest.raises(ArtifactValidationError, match="ordinary readable file"):
+        _json_object(link, name="test input")
+
+
+def test_json_object_rejects_a_symlinked_parent_directory(tmp_path: Path) -> None:
+    real_parent = tmp_path / "real"
+    real_parent.mkdir()
+    (real_parent / "input.json").write_text('{"value": 1}\n', encoding="utf-8")
+    linked_parent = tmp_path / "linked"
+    try:
+        linked_parent.symlink_to(real_parent, target_is_directory=True)
+    except (NotImplementedError, OSError) as error:  # pragma: no cover - platform
+        pytest.skip(f"symlinks unavailable: {error}")
+
+    with pytest.raises(ArtifactValidationError, match="ordinary readable file"):
+        _json_object(linked_parent / "input.json", name="test input")
+
+
+def test_invalid_journal_payload_never_appends_bytes(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = tmp_path / "payload.json"
+    payload.write_bytes(b'{"note": "first", "note": "second"}\n')
+    journal = tmp_path / "acquisition.jsonl"
+
+    status = main(
+        [
+            "journal",
+            "append",
+            str(journal),
+            "session_started",
+            "--protocol-id",
+            "protocol-v1",
+            "--session-id",
+            "session-1",
+            "--source",
+            "test",
+            "--payload-json",
+            str(payload),
+            "--recorded-at-utc",
+            "2026-08-10T12:00:00+00:00",
+            "--monotonic-ns",
+            "1",
+        ]
+    )
+
+    assert status == 2
+    assert not journal.exists()
+    assert "duplicate JSON object key" in capsys.readouterr().out

--- a/tests/test_latent_contact_benchmark_cli.py
+++ b/tests/test_latent_contact_benchmark_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -90,6 +91,44 @@ def test_sbc_cli_publishes_atomically_with_producer_identity(
     assert summary["sbc"]["producer"] == artifact["producer"]
 
 
+def test_sbc_summary_binds_exact_artifact_and_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _patch_runtime(monkeypatch)
+    output = tmp_path / "run" / "sbc.json"
+
+    code = cli.main(
+        [
+            "--seeds",
+            "2,5",
+            "--frames",
+            "24",
+            "--sbc-trials-per-fold",
+            "7",
+            "--sbc-bins",
+            "4",
+            "--sbc-output-json",
+            str(output),
+        ]
+    )
+
+    assert code == 0
+    payload = output.read_bytes()
+    summary = json.loads(capsys.readouterr().out)
+    assert payload.endswith(b"\n")
+    assert summary["sbc"]["path"] == str(output.resolve())
+    assert summary["sbc"]["sha256"] == hashlib.sha256(payload).hexdigest()
+    assert summary["sbc"]["byte_count"] == len(payload)
+    assert summary["sbc"]["configuration"]["seeds"] == [2, 5]
+    assert summary["sbc"]["configuration"]["trials_per_fold"] == 7
+    assert summary["sbc"]["configuration"]["bin_count"] == 4
+    assert summary["sbc"]["configuration"]["benchmark"]["frame_count"] == 24
+    contact = summary["sbc"]["configuration"]["contact"]
+    assert contact["parameter_particle_count"] == 12
+
+
 def test_sbc_cli_refuses_existing_output_before_running_benchmark(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -127,6 +166,30 @@ def test_sbc_cli_requires_explicit_overwrite(
     artifact = json.loads(output.read_text(encoding="utf-8"))
     assert "old" not in artifact
     assert artifact["producer"]["module_sha256"] == "a" * 64
+
+
+def test_invalid_sbc_json_cannot_partially_replace_existing_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _patch_runtime(monkeypatch)
+    monkeypatch.setattr(
+        cli,
+        "run_controlled_latent_contact_sbc",
+        lambda **kwargs: {
+            "aggregate": {},
+            "interpretation": "invalid test payload",
+            "nonfinite": float("nan"),
+        },
+    )
+    output = tmp_path / "sbc.json"
+    sentinel = b'{"previous": true}\n'
+    output.write_bytes(sentinel)
+
+    with pytest.raises(ValueError, match="Out of range float values"):
+        cli.main(_arguments(output, overwrite=True))
+
+    assert output.read_bytes() == sentinel
 
 
 def test_sbc_cli_handles_no_overwrite_race(


### PR DESCRIPTION
## What changed

- route acquisition protocol and journal-payload JSON through the existing exact-byte, no-symlink strict reader;
- reject duplicate keys, non-finite values, invalid UTF-8, non-object roots, file symlinks, and symlinked parent components before any acquisition mutation;
- add CLI-level coverage proving an invalid journal payload cannot create or append journal bytes;
- extend the dedicated acquisition-journal workflow to lint, format, type-check, and exercise the acquisition CLI boundary;
- retain the atomic, once-only SBC publication and runtime-producer identity merged in #303;
- additionally snapshot the exact published SBC bytes and report SHA-256, byte count, seeds, trial count, bin count, benchmark configuration, and contact configuration; and
- verify that a non-finite replacement payload cannot alter an existing SBC artifact.

## Why

PR #303 safely implemented the publication and source-panel staging half of #299, but the original PR then conflicted on the same SBC files. This PR reapplies only the still-unique protections on top of current `main`, preserving #303's overwrite policy and producer binding rather than choosing either older branch wholesale.

## Scientific boundary

This changes input validation, publication provenance, and regression coverage only. It does not alter the frozen estimator, registered interventions, acquisition protocol, target boundary, posterior, comparison arms, or physical evidence count.

## Validation

GitHub Actions on the exact proposed head are authoritative. The focused tests cover strict JSON decoding, symlink rejection, mutation ordering, exact SBC digest/configuration binding, existing-output protection, publication races, explicit overwrite, producer identity, and atomic rollback on serialization failure.

Supersedes the unmerged remainder of #299 after #303.