### PR TITLE
Require exact Prob4D revision for mandatory evidence admission

### DIFF
--- a/.github/workflows/execute-evidence-decision-prob4d-revision-gate-v2.yml
+++ b/.github/workflows/execute-evidence-decision-prob4d-revision-gate-v2.yml
@@ -1,0 +1,189 @@
+name: Execute evidence-decision Prob4D revision gate v2
+
+on:
+  pull_request:
+    branches: [codex/evidence-decision-admission-v1]
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+
+jobs:
+  execute:
+    if: >-
+      github.event.pull_request.head.ref ==
+      'agent/fix-evidence-decision-prob4d-revision-gate'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: codex/evidence-decision-admission-v1
+          fetch-depth: 0
+          persist-credentials: true
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Apply exact revision gate and regressions
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
+
+          source = Path("src/causal4d/evidence_decision_v1.py")
+          text = source.read_text(encoding="utf-8")
+          anchor = "\n".join(
+              [
+                  "    validated = require_authorized_evidence_decision_v1(",
+                  "        decision,",
+                  "        claim_id=claim_id,",
+                  "        protocol_id=protocol_id,",
+                  "        minimum_evidence_level=minimum_evidence_level,",
+                  "    )",
+                  "",
+              ]
+          )
+          inserted = anchor + "\n".join(
+              [
+                  "    require_prob4d = _require_bool(",
+                  "        require_prob4d_binding,",
+                  '        name="require_prob4d_binding",',
+                  "    )",
+                  "    if require_prob4d and expected_prob4d_revision is None:",
+                  "        raise ValueError(",
+                  '            "require_prob4d_binding requires '
+                  'expected_prob4d_revision"',
+                  "        )",
+                  "",
+              ]
+          )
+          if text.count(anchor) != 1:
+              raise SystemExit("admission anchor changed")
+          text = text.replace(anchor, inserted, 1)
+          old = (
+              "    if expected_prob4d_revision is not None or "
+              "require_prob4d_binding:\n"
+          )
+          new = "    if expected_prob4d_revision is not None or require_prob4d:\n"
+          if text.count(old) != 1:
+              raise SystemExit("Prob4D branch changed")
+          source.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+          tests = Path("tests/test_evidence_decision_v1.py")
+          test_text = tests.read_text(encoding="utf-8")
+          old_missing = "\n".join(
+              [
+                  '    with pytest.raises(ValueError, match="exactly one Prob4D"):',
+                  "        admit_causal_claim_v1(",
+                  "            payload,",
+                  "            claim_id=CLAIM_ID,",
+                  "            protocol_id=PROTOCOL_ID,",
+                  "            expected_bayesian_phystwin_revision=BPT_REVISION,",
+                  "            expected_causal4d_revision=CAUSAL4D_REVISION,",
+                  "            require_prob4d_binding=True,",
+                  "        )",
+              ]
+          )
+          new_missing = old_missing.replace(
+              "            require_prob4d_binding=True,",
+              "            expected_prob4d_revision=PROB4D_REVISION,\n"
+              "            require_prob4d_binding=True,",
+          )
+          if test_text.count(old_missing) != 1:
+              raise SystemExit("missing-binding regression changed")
+          test_text = test_text.replace(old_missing, new_missing, 1)
+
+          test_anchor = "\n".join(
+              [
+                  "def test_admission_and_repository_binding_errors() -> None:",
+                  "    payload = _authorized()",
+                  "",
+              ]
+          )
+          test_cases = "\n".join(
+              [
+                  "    with pytest.raises(",
+                  "        ValueError,",
+                  "        match=(",
+                  '            "require_prob4d_binding requires '
+                  'expected_prob4d_revision"',
+                  "        ),",
+                  "    ):",
+                  "        admit_causal_claim_v1(",
+                  "            payload,",
+                  "            claim_id=CLAIM_ID,",
+                  "            protocol_id=PROTOCOL_ID,",
+                  "            expected_bayesian_phystwin_revision=BPT_REVISION,",
+                  "            expected_causal4d_revision=CAUSAL4D_REVISION,",
+                  "            require_prob4d_binding=True,",
+                  "        )",
+                  "    with pytest.raises(",
+                  "        ValueError,",
+                  '        match="require_prob4d_binding must be boolean",',
+                  "    ):",
+                  "        admit_causal_claim_v1(",
+                  "            payload,",
+                  "            claim_id=CLAIM_ID,",
+                  "            protocol_id=PROTOCOL_ID,",
+                  "            expected_bayesian_phystwin_revision=BPT_REVISION,",
+                  "            expected_causal4d_revision=CAUSAL4D_REVISION,",
+                  "            require_prob4d_binding=1,  # type: ignore[arg-type]",
+                  "        )",
+                  "",
+              ]
+          )
+          if test_text.count(test_anchor) != 1:
+              raise SystemExit("admission error test changed")
+          tests.write_text(
+              test_text.replace(test_anchor, test_anchor + test_cases, 1),
+              encoding="utf-8",
+          )
+
+          docs = Path("docs/evidence-decision-admission-v1.md")
+          doc_text = docs.read_text(encoding="utf-8")
+          old_doc = (
+              "A Prob4D binding is optional for decisions whose evidence path genuinely does\n"
+              "not use Prob4D. When one is present, it is still validated. Set\n"
+              "`require_prob4d_binding=True` to make it mandatory for a registered lane.\n"
+          )
+          new_doc = old_doc.rstrip("\n") + (
+              " A mandatory Prob4D lane must also provide\n"
+              "`expected_prob4d_revision`; presence without an exact revision lock is\n"
+              "rejected.\n"
+          )
+          if doc_text.count(old_doc) != 1:
+              raise SystemExit("Prob4D documentation changed")
+          docs.write_text(doc_text.replace(old_doc, new_doc, 1), encoding="utf-8")
+          PY
+
+      - name: Validate and publish
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]"
+          files=(
+            src/causal4d/evidence_decision_v1.py
+            tests/test_evidence_decision_v1.py
+          )
+          python -m ruff format "${files[@]}"
+          python -m ruff check "${files[@]}"
+          python -m ruff format --check "${files[@]}"
+          python -m mypy src/causal4d/evidence_decision_v1.py
+          python -m pytest -q tests/test_evidence_decision_v1.py
+          python -m py_compile src/causal4d/evidence_decision_v1.py
+          git diff --check
+          git config user.name "github-actions[bot]"
+          git config user.email \
+            "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            src/causal4d/evidence_decision_v1.py \
+            tests/test_evidence_decision_v1.py \
+            docs/evidence-decision-admission-v1.md
+          git diff --cached --check
+          test -n "$(git diff --cached --name-only)"
+          git commit -m "Require exact Prob4D revision for mandatory admission"
+          git push origin HEAD:codex/evidence-decision-admission-v1

--- a/.github/workflows/execute-evidence-decision-prob4d-revision-gate.yml
+++ b/.github/workflows/execute-evidence-decision-prob4d-revision-gate.yml
@@ -48,16 +48,19 @@ jobs:
               "        minimum_evidence_level=minimum_evidence_level,\n"
               "    )\n"
           )
-          admission_replacement = admission_anchor + (
-              "    require_prob4d = _require_bool(\n"
-              "        require_prob4d_binding,\n"
-              "        name=\"require_prob4d_binding\",\n"
-              "    )\n"
-              "    if require_prob4d and expected_prob4d_revision is None:\n"
-              "        raise ValueError(\n"
-              "            \"require_prob4d_binding requires \"
-              "\"expected_prob4d_revision\"\n"
-              "        )\n"
+          admission_lines = [
+              "    require_prob4d = _require_bool(",
+              "        require_prob4d_binding,",
+              '        name="require_prob4d_binding",',
+              "    )",
+              "    if require_prob4d and expected_prob4d_revision is None:",
+              "        raise ValueError(",
+              '            "require_prob4d_binding requires '
+              'expected_prob4d_revision"',
+              "        )",
+          ]
+          admission_replacement = (
+              admission_anchor + "\n".join(admission_lines) + "\n"
           )
           if text.count(admission_anchor) != 1:
               raise SystemExit("admission insertion point changed")
@@ -83,35 +86,37 @@ jobs:
               "def test_admission_and_repository_binding_errors() -> None:\n"
               "    payload = _authorized()\n\n"
           )
-          test_replacement = test_anchor + (
-              "    with pytest.raises(\n"
-              "        ValueError,\n"
-              "        match=(\n"
-              "            \"require_prob4d_binding requires \"
-              "\"expected_prob4d_revision\"\n"
-              "        ),\n"
-              "    ):\n"
-              "        admit_causal_claim_v1(\n"
-              "            payload,\n"
-              "            claim_id=CLAIM_ID,\n"
-              "            protocol_id=PROTOCOL_ID,\n"
-              "            expected_bayesian_phystwin_revision=BPT_REVISION,\n"
-              "            expected_causal4d_revision=CAUSAL4D_REVISION,\n"
-              "            require_prob4d_binding=True,\n"
-              "        )\n"
-              "    with pytest.raises(\n"
-              "        ValueError,\n"
-              "        match=\"require_prob4d_binding must be boolean\",\n"
-              "    ):\n"
-              "        admit_causal_claim_v1(\n"
-              "            payload,\n"
-              "            claim_id=CLAIM_ID,\n"
-              "            protocol_id=PROTOCOL_ID,\n"
-              "            expected_bayesian_phystwin_revision=BPT_REVISION,\n"
-              "            expected_causal4d_revision=CAUSAL4D_REVISION,\n"
-              "            require_prob4d_binding=1,  # type: ignore[arg-type]\n"
-              "        )\n\n"
-          )
+          test_lines = [
+              "    with pytest.raises(",
+              "        ValueError,",
+              "        match=(",
+              '            "require_prob4d_binding requires '
+              'expected_prob4d_revision"',
+              "        ),",
+              "    ):",
+              "        admit_causal_claim_v1(",
+              "            payload,",
+              "            claim_id=CLAIM_ID,",
+              "            protocol_id=PROTOCOL_ID,",
+              "            expected_bayesian_phystwin_revision=BPT_REVISION,",
+              "            expected_causal4d_revision=CAUSAL4D_REVISION,",
+              "            require_prob4d_binding=True,",
+              "        )",
+              "    with pytest.raises(",
+              "        ValueError,",
+              '        match="require_prob4d_binding must be boolean",',
+              "    ):",
+              "        admit_causal_claim_v1(",
+              "            payload,",
+              "            claim_id=CLAIM_ID,",
+              "            protocol_id=PROTOCOL_ID,",
+              "            expected_bayesian_phystwin_revision=BPT_REVISION,",
+              "            expected_causal4d_revision=CAUSAL4D_REVISION,",
+              "            require_prob4d_binding=1,  # type: ignore[arg-type]",
+              "        )",
+              "",
+          ]
+          test_replacement = test_anchor + "\n".join(test_lines) + "\n"
           if test_text.count(test_anchor) != 1:
               raise SystemExit("admission test insertion point changed")
           tests.write_text(

--- a/.github/workflows/execute-evidence-decision-prob4d-revision-gate.yml
+++ b/.github/workflows/execute-evidence-decision-prob4d-revision-gate.yml
@@ -1,0 +1,182 @@
+name: Execute evidence-decision Prob4D revision gate
+
+on:
+  pull_request:
+    branches:
+      - codex/evidence-decision-admission-v1
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+
+jobs:
+  execute:
+    if: >-
+      github.event.pull_request.head.ref ==
+      'agent/fix-evidence-decision-prob4d-revision-gate'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out the exact target branch
+        uses: actions/checkout@v7
+        with:
+          ref: codex/evidence-decision-admission-v1
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Apply the fail-closed Prob4D revision gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
+
+          source = Path("src/causal4d/evidence_decision_v1.py")
+          text = source.read_text(encoding="utf-8")
+          old_admission = '''    validated = require_authorized_evidence_decision_v1(
+              decision,
+              claim_id=claim_id,
+              protocol_id=protocol_id,
+              minimum_evidence_level=minimum_evidence_level,
+          )
+          bayesian_phystwin = require_bayesian_phystwin_evidence_binding_v1(
+          '''.replace("          ", "")
+          new_admission = '''    validated = require_authorized_evidence_decision_v1(
+              decision,
+              claim_id=claim_id,
+              protocol_id=protocol_id,
+              minimum_evidence_level=minimum_evidence_level,
+          )
+          require_prob4d = _require_bool(
+              require_prob4d_binding,
+              name="require_prob4d_binding",
+          )
+          if require_prob4d and expected_prob4d_revision is None:
+              raise ValueError(
+                  "require_prob4d_binding requires expected_prob4d_revision"
+              )
+          bayesian_phystwin = require_bayesian_phystwin_evidence_binding_v1(
+          '''.replace("          ", "")
+          if text.count(old_admission) != 1:
+              raise SystemExit("admission insertion point changed")
+          text = text.replace(old_admission, new_admission, 1)
+
+          old_condition = (
+              "    if expected_prob4d_revision is not None or "
+              "require_prob4d_binding:\n"
+          )
+          new_condition = (
+              "    if expected_prob4d_revision is not None or require_prob4d:\n"
+          )
+          if text.count(old_condition) != 1:
+              raise SystemExit("Prob4D admission condition changed")
+          source.write_text(
+              text.replace(old_condition, new_condition, 1),
+              encoding="utf-8",
+          )
+
+          tests = Path("tests/test_evidence_decision_v1.py")
+          test_text = tests.read_text(encoding="utf-8")
+          old_test = '''def test_admission_and_repository_binding_errors() -> None:
+              payload = _authorized()
+
+              with pytest.raises(ValueError, match="claim_id"):
+          '''.replace("              ", "")
+          new_test = '''def test_admission_and_repository_binding_errors() -> None:
+              payload = _authorized()
+
+              with pytest.raises(
+                  ValueError,
+                  match="require_prob4d_binding requires expected_prob4d_revision",
+              ):
+                  admit_causal_claim_v1(
+                      payload,
+                      claim_id=CLAIM_ID,
+                      protocol_id=PROTOCOL_ID,
+                      expected_bayesian_phystwin_revision=BPT_REVISION,
+                      expected_causal4d_revision=CAUSAL4D_REVISION,
+                      require_prob4d_binding=True,
+                  )
+              with pytest.raises(
+                  ValueError,
+                  match="require_prob4d_binding must be boolean",
+              ):
+                  admit_causal_claim_v1(
+                      payload,
+                      claim_id=CLAIM_ID,
+                      protocol_id=PROTOCOL_ID,
+                      expected_bayesian_phystwin_revision=BPT_REVISION,
+                      expected_causal4d_revision=CAUSAL4D_REVISION,
+                      require_prob4d_binding=1,  # type: ignore[arg-type]
+                  )
+
+              with pytest.raises(ValueError, match="claim_id"):
+          '''.replace("              ", "")
+          if test_text.count(old_test) != 1:
+              raise SystemExit("admission test insertion point changed")
+          tests.write_text(
+              test_text.replace(old_test, new_test, 1),
+              encoding="utf-8",
+          )
+
+          docs = Path("docs/evidence-decision-admission-v1.md")
+          doc_text = docs.read_text(encoding="utf-8")
+          old_doc = (
+              "A Prob4D binding is optional for decisions whose evidence path genuinely does\n"
+              "not use Prob4D. When one is present, it is still validated. Set\n"
+              "`require_prob4d_binding=True` to make it mandatory for a registered lane.\n"
+          )
+          new_doc = (
+              "A Prob4D binding is optional for decisions whose evidence path genuinely does\n"
+              "not use Prob4D. When one is present, it is still validated. Set\n"
+              "`require_prob4d_binding=True` to make it mandatory for a registered lane. A\n"
+              "mandatory Prob4D lane must also provide `expected_prob4d_revision`; requiring\n"
+              "presence without locking the exact revision is rejected.\n"
+          )
+          if doc_text.count(old_doc) != 1:
+              raise SystemExit("Prob4D documentation insertion point changed")
+          docs.write_text(
+              doc_text.replace(old_doc, new_doc, 1),
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Validate formatting, typing, and focused admission contracts
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]"
+          files=(
+            src/causal4d/evidence_decision_v1.py
+            tests/test_evidence_decision_v1.py
+          )
+          python -m ruff format "${files[@]}"
+          python -m ruff check "${files[@]}"
+          python -m ruff format --check "${files[@]}"
+          python -m mypy src/causal4d/evidence_decision_v1.py
+          python -m pytest -q tests/test_evidence_decision_v1.py
+          python -m py_compile src/causal4d/evidence_decision_v1.py
+          git diff --check
+
+      - name: Publish only the validated source, test, and documentation patch
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email \
+            "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            src/causal4d/evidence_decision_v1.py \
+            tests/test_evidence_decision_v1.py \
+            docs/evidence-decision-admission-v1.md
+          git diff --cached --check
+          test -n "$(git diff --cached --name-only)"
+          git commit -m "Require exact Prob4D revision for mandatory admission"
+          git push origin HEAD:codex/evidence-decision-admission-v1

--- a/.github/workflows/execute-evidence-decision-prob4d-revision-gate.yml
+++ b/.github/workflows/execute-evidence-decision-prob4d-revision-gate.yml
@@ -40,33 +40,28 @@ jobs:
 
           source = Path("src/causal4d/evidence_decision_v1.py")
           text = source.read_text(encoding="utf-8")
-          old_admission = '''    validated = require_authorized_evidence_decision_v1(
-              decision,
-              claim_id=claim_id,
-              protocol_id=protocol_id,
-              minimum_evidence_level=minimum_evidence_level,
+          admission_anchor = (
+              "    validated = require_authorized_evidence_decision_v1(\n"
+              "        decision,\n"
+              "        claim_id=claim_id,\n"
+              "        protocol_id=protocol_id,\n"
+              "        minimum_evidence_level=minimum_evidence_level,\n"
+              "    )\n"
           )
-          bayesian_phystwin = require_bayesian_phystwin_evidence_binding_v1(
-          '''.replace("          ", "")
-          new_admission = '''    validated = require_authorized_evidence_decision_v1(
-              decision,
-              claim_id=claim_id,
-              protocol_id=protocol_id,
-              minimum_evidence_level=minimum_evidence_level,
+          admission_replacement = admission_anchor + (
+              "    require_prob4d = _require_bool(\n"
+              "        require_prob4d_binding,\n"
+              "        name=\"require_prob4d_binding\",\n"
+              "    )\n"
+              "    if require_prob4d and expected_prob4d_revision is None:\n"
+              "        raise ValueError(\n"
+              "            \"require_prob4d_binding requires \"
+              "\"expected_prob4d_revision\"\n"
+              "        )\n"
           )
-          require_prob4d = _require_bool(
-              require_prob4d_binding,
-              name="require_prob4d_binding",
-          )
-          if require_prob4d and expected_prob4d_revision is None:
-              raise ValueError(
-                  "require_prob4d_binding requires expected_prob4d_revision"
-              )
-          bayesian_phystwin = require_bayesian_phystwin_evidence_binding_v1(
-          '''.replace("          ", "")
-          if text.count(old_admission) != 1:
+          if text.count(admission_anchor) != 1:
               raise SystemExit("admission insertion point changed")
-          text = text.replace(old_admission, new_admission, 1)
+          text = text.replace(admission_anchor, admission_replacement, 1)
 
           old_condition = (
               "    if expected_prob4d_revision is not None or "
@@ -84,45 +79,43 @@ jobs:
 
           tests = Path("tests/test_evidence_decision_v1.py")
           test_text = tests.read_text(encoding="utf-8")
-          old_test = '''def test_admission_and_repository_binding_errors() -> None:
-              payload = _authorized()
-
-              with pytest.raises(ValueError, match="claim_id"):
-          '''.replace("              ", "")
-          new_test = '''def test_admission_and_repository_binding_errors() -> None:
-              payload = _authorized()
-
-              with pytest.raises(
-                  ValueError,
-                  match="require_prob4d_binding requires expected_prob4d_revision",
-              ):
-                  admit_causal_claim_v1(
-                      payload,
-                      claim_id=CLAIM_ID,
-                      protocol_id=PROTOCOL_ID,
-                      expected_bayesian_phystwin_revision=BPT_REVISION,
-                      expected_causal4d_revision=CAUSAL4D_REVISION,
-                      require_prob4d_binding=True,
-                  )
-              with pytest.raises(
-                  ValueError,
-                  match="require_prob4d_binding must be boolean",
-              ):
-                  admit_causal_claim_v1(
-                      payload,
-                      claim_id=CLAIM_ID,
-                      protocol_id=PROTOCOL_ID,
-                      expected_bayesian_phystwin_revision=BPT_REVISION,
-                      expected_causal4d_revision=CAUSAL4D_REVISION,
-                      require_prob4d_binding=1,  # type: ignore[arg-type]
-                  )
-
-              with pytest.raises(ValueError, match="claim_id"):
-          '''.replace("              ", "")
-          if test_text.count(old_test) != 1:
+          test_anchor = (
+              "def test_admission_and_repository_binding_errors() -> None:\n"
+              "    payload = _authorized()\n\n"
+          )
+          test_replacement = test_anchor + (
+              "    with pytest.raises(\n"
+              "        ValueError,\n"
+              "        match=(\n"
+              "            \"require_prob4d_binding requires \"
+              "\"expected_prob4d_revision\"\n"
+              "        ),\n"
+              "    ):\n"
+              "        admit_causal_claim_v1(\n"
+              "            payload,\n"
+              "            claim_id=CLAIM_ID,\n"
+              "            protocol_id=PROTOCOL_ID,\n"
+              "            expected_bayesian_phystwin_revision=BPT_REVISION,\n"
+              "            expected_causal4d_revision=CAUSAL4D_REVISION,\n"
+              "            require_prob4d_binding=True,\n"
+              "        )\n"
+              "    with pytest.raises(\n"
+              "        ValueError,\n"
+              "        match=\"require_prob4d_binding must be boolean\",\n"
+              "    ):\n"
+              "        admit_causal_claim_v1(\n"
+              "            payload,\n"
+              "            claim_id=CLAIM_ID,\n"
+              "            protocol_id=PROTOCOL_ID,\n"
+              "            expected_bayesian_phystwin_revision=BPT_REVISION,\n"
+              "            expected_causal4d_revision=CAUSAL4D_REVISION,\n"
+              "            require_prob4d_binding=1,  # type: ignore[arg-type]\n"
+              "        )\n\n"
+          )
+          if test_text.count(test_anchor) != 1:
               raise SystemExit("admission test insertion point changed")
           tests.write_text(
-              test_text.replace(old_test, new_test, 1),
+              test_text.replace(test_anchor, test_replacement, 1),
               encoding="utf-8",
           )
 


### PR DESCRIPTION
Execution-only pull request. Its workflow checks out `codex/evidence-decision-admission-v1`, makes `require_prob4d_binding=True` fail closed unless `expected_prob4d_revision` is supplied, rejects non-Boolean flag values, adds focused regressions, and documents the exact-revision requirement. It runs Ruff, strict MyPy, the complete focused evidence-decision suite, and byte-compilation before pushing only the validated source/test/doc patch to the target branch. Do not merge this PR; close it after the target branch advances.