### PR TITLE
Package the evidence-decision v1 contract bundle

### DIFF
--- a/.github/workflows/evidence-decision-admission.yml
+++ b/.github/workflows/evidence-decision-admission.yml
@@ -6,14 +6,22 @@ on:
     paths:
       - ".github/workflows/evidence-decision-admission.yml"
       - "docs/evidence-decision-admission-v1.md"
+      - "docs/evidence-decision-contract-bundle-v1.md"
+      - "pyproject.toml"
+      - "src/causal4d/contract_data/evidence_decision_v1/**"
       - "src/causal4d/evidence_decision_v1.py"
+      - "tests/test_evidence_decision_contract_bundle.py"
       - "tests/test_evidence_decision_v1.py"
   pull_request:
     branches: [main]
     paths:
       - ".github/workflows/evidence-decision-admission.yml"
       - "docs/evidence-decision-admission-v1.md"
+      - "docs/evidence-decision-contract-bundle-v1.md"
+      - "pyproject.toml"
+      - "src/causal4d/contract_data/evidence_decision_v1/**"
       - "src/causal4d/evidence_decision_v1.py"
+      - "tests/test_evidence_decision_contract_bundle.py"
       - "tests/test_evidence_decision_v1.py"
   workflow_dispatch:
 
@@ -77,6 +85,7 @@ jobs:
           from __future__ import annotations
 
           import hashlib
+          import json
           import os
           from importlib.resources import files
           from pathlib import Path
@@ -91,6 +100,7 @@ jobs:
               EVIDENCE_DECISION_JSON_SCHEMA_SHA256,
               admit_causal_claim_v1,
               load_evidence_decision_v1,
+              validate_evidence_decision_v1,
           )
           from prob4d.api.evidence_decision_v1 import (
               EVIDENCE_DECISION_JSON_SCHEMA_SHA256 as PROB4D_SCHEMA_SHA256,
@@ -99,20 +109,48 @@ jobs:
               require_prob4d_evidence_binding_v1,
           )
 
+          expected_schema_sha256 = os.environ["BPT_SCHEMA_SHA256"]
+          bpt_revision = os.environ["BPT_CONTRACT_REVISION"]
+          causal4d_revision = os.environ["CAUSAL4D_CONSUMER_REVISION"]
+          prob4d_revision = os.environ["PROB4D_CONSUMER_REVISION"]
+
           schema = files("bayesian_phystwin").joinpath(
               "contract_data",
               "evidence_decision_v1",
               "evidence-decision-v1.schema.json",
           )
           schema_sha256 = hashlib.sha256(schema.read_bytes()).hexdigest()
-          expected_schema_sha256 = os.environ["BPT_SCHEMA_SHA256"]
           assert schema_sha256 == expected_schema_sha256
           assert EVIDENCE_DECISION_JSON_SCHEMA_SHA256 == expected_schema_sha256
           assert PROB4D_SCHEMA_SHA256 == expected_schema_sha256
 
-          bpt_revision = os.environ["BPT_CONTRACT_REVISION"]
-          causal4d_revision = os.environ["CAUSAL4D_CONSUMER_REVISION"]
-          prob4d_revision = os.environ["PROB4D_CONSUMER_REVISION"]
+          causal4d_bundle = files("causal4d").joinpath(
+              "contract_data",
+              "evidence_decision_v1",
+          )
+          bundle_manifest = json.loads(
+              causal4d_bundle.joinpath("manifest.json").read_text(encoding="utf-8")
+          )
+          causal4d_schema = causal4d_bundle.joinpath(
+              bundle_manifest["json_schema"]["path"]
+          )
+          assert (
+              hashlib.sha256(causal4d_schema.read_bytes()).hexdigest()
+              == expected_schema_sha256
+          )
+          assert bundle_manifest["json_schema"]["sha256"] == expected_schema_sha256
+          assert bundle_manifest["source_revision"] == bpt_revision
+
+          vector_record = bundle_manifest["vectors"]["authorized"]
+          vector = causal4d_bundle
+          for part in vector_record["path"].split("/"):
+              vector = vector.joinpath(part)
+          vector_bytes = vector.read_bytes()
+          assert hashlib.sha256(vector_bytes).hexdigest() == vector_record["sha256"]
+          retained = validate_evidence_decision_v1(json.loads(vector_bytes))
+          assert retained.claim_authorized
+          assert retained.metadata["synthetic"] is True
+
           decision = EvidenceDecisionV1(
               claim_id="contract.causal-admission",
               protocol_id="evidence-decision-causal-admission-v1",

--- a/docs/evidence-decision-contract-bundle-v1.md
+++ b/docs/evidence-decision-contract-bundle-v1.md
@@ -1,0 +1,57 @@
+# Evidence-decision contract bundle v1
+
+Causal4D retains an offline-auditable copy of the exact
+`bayesian_phystwin.evidence_decision` version-1 wire contract consumed by
+`causal4d.evidence_decision_v1`.
+
+The bundle is installed with the Causal4D wheel under:
+
+```text
+causal4d/contract_data/evidence_decision_v1/
+├── evidence-decision-v1.schema.json
+├── manifest.json
+└── vectors/
+    └── authorized.json
+```
+
+## Source lock
+
+The schema bytes come from `IPS-Stuttgart/BayesianPhysTwin` revision
+`4ee702f5130cfedbea7bce6be5e72483c92f63da`. Their SHA-256 digest is:
+
+```text
+d5615258c6cf666d0ed9684a87930989adf91817fe99b0387e83a31479dcd465
+```
+
+`manifest.json` binds that source revision, digest, wire name, wire version,
+consumer module, and every retained vector digest. A change to any retained
+byte therefore requires an explicit new source lock or a new contract version.
+
+## Offline verification
+
+The installed package can be checked without a BayesianPhysTwin checkout:
+
+```python
+import hashlib
+import json
+from importlib.resources import files
+
+root = files("causal4d").joinpath(
+    "contract_data", "evidence_decision_v1"
+)
+manifest = json.loads(root.joinpath("manifest.json").read_text())
+schema = root.joinpath(manifest["json_schema"]["path"]).read_bytes()
+assert hashlib.sha256(schema).hexdigest() == manifest["json_schema"]["sha256"]
+```
+
+The retained authorized vector is synthetic. It verifies closed-shape parsing,
+content identity, repository-role binding, exact revisions, and downstream
+admission; it is not scientific evidence.
+
+## Scientific boundary
+
+This bundle establishes contract identity and independent consumer conformance.
+It does not establish physical-state identification, calibrated uncertainty,
+causal sufficiency, intervention benefit, transfer, deployment safety, or state
+of the art. Those claims require separately registered evidence decisions and
+exact repository bindings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,8 @@ where = ["src"]
 [tool.setuptools.package-data]
 causal4d = [
     "py.typed",
+    "contract_data/evidence_decision_v1/*.json",
+    "contract_data/evidence_decision_v1/vectors/*.json",
     "contract_data/observation_belief_v1/*.json",
     "contract_data/observation_belief_v1/vectors/*.json",
     "contract_data/provider_v2_factors_v1/*.json",

--- a/src/causal4d/contract_data/evidence_decision_v1/evidence-decision-v1.schema.json
+++ b/src/causal4d/contract_data/evidence_decision_v1/evidence-decision-v1.schema.json
@@ -1,0 +1,253 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ips-stuttgart.github.io/BayesianPhysTwin/contracts/evidence-decision-v1.schema.json",
+  "title": "Bayesian-PhysTwin evidence decision v1",
+  "description": "Compact content-addressed decision bound to a run manifest and exact repository states.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "decision_id",
+    "schema_name",
+    "schema_version",
+    "created_utc",
+    "claim_id",
+    "protocol_id",
+    "status",
+    "run_classification",
+    "claim_authorized",
+    "evidence_level",
+    "metric",
+    "run_manifest_id",
+    "evidence_fingerprint",
+    "evidence_summary_sha256",
+    "repositories",
+    "limitations",
+    "metadata"
+  ],
+  "properties": {
+    "decision_id": {
+      "$ref": "#/$defs/sha256"
+    },
+    "schema_name": {
+      "const": "bayesian_phystwin.evidence_decision"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "created_utc": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "(?:Z|\\+00:00)$"
+    },
+    "claim_id": {
+      "$ref": "#/$defs/canonicalText"
+    },
+    "protocol_id": {
+      "$ref": "#/$defs/canonicalText"
+    },
+    "status": {
+      "enum": [
+        "pass",
+        "fail",
+        "degraded",
+        "inconclusive"
+      ]
+    },
+    "run_classification": {
+      "enum": [
+        "controlled",
+        "exploratory",
+        "confirmatory",
+        "diagnostic",
+        "infrastructure"
+      ]
+    },
+    "claim_authorized": {
+      "type": "boolean"
+    },
+    "evidence_level": {
+      "enum": [
+        1,
+        2,
+        3
+      ]
+    },
+    "metric": {
+      "$ref": "#/$defs/metric"
+    },
+    "run_manifest_id": {
+      "$ref": "#/$defs/sha256"
+    },
+    "evidence_fingerprint": {
+      "$ref": "#/$defs/sha256"
+    },
+    "evidence_summary_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "repositories": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/repository"
+      },
+      "contains": {
+        "type": "object",
+        "required": [
+          "role"
+        ],
+        "properties": {
+          "role": {
+            "const": "primary"
+          }
+        }
+      },
+      "minContains": 1,
+      "maxContains": 1
+    },
+    "limitations": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/canonicalText"
+      }
+    },
+    "metadata": {
+      "type": "object"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "claim_authorized": {
+            "const": true
+          }
+        },
+        "required": [
+          "claim_authorized"
+        ]
+      },
+      "then": {
+        "properties": {
+          "status": {
+            "const": "pass"
+          },
+          "repositories": {
+            "items": {
+              "properties": {
+                "dirty": {
+                  "const": false
+                }
+              }
+            }
+          },
+          "run_classification": {
+            "const": "confirmatory"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "enum": [
+              "degraded",
+              "inconclusive"
+            ]
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "then": {
+        "properties": {
+          "limitations": {
+            "minItems": 1
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "canonicalText": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^\\S(?:.*\\S)?$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "metric": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "comparison",
+        "rule",
+        "observed_value",
+        "threshold_value",
+        "unit"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/canonicalText"
+        },
+        "comparison": {
+          "$ref": "#/$defs/canonicalText"
+        },
+        "rule": {
+          "$ref": "#/$defs/canonicalText"
+        },
+        "observed_value": {
+          "type": "number"
+        },
+        "threshold_value": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "unit": {
+          "$ref": "#/$defs/canonicalText"
+        }
+      }
+    },
+    "repository": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository",
+        "revision",
+        "dirty",
+        "role"
+      ],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "pattern": "^[^/\\s]+/[^/\\s]+$"
+        },
+        "revision": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "dirty": {
+          "type": "boolean"
+        },
+        "role": {
+          "enum": [
+            "primary",
+            "upstream",
+            "observation",
+            "downstream",
+            "paper",
+            "environment",
+            "dependency"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/src/causal4d/contract_data/evidence_decision_v1/manifest.json
+++ b/src/causal4d/contract_data/evidence_decision_v1/manifest.json
@@ -1,0 +1,20 @@
+{
+  "bundle_schema": "causal4d.evidence_decision_contract_bundle",
+  "bundle_version": 1,
+  "consumer_module": "causal4d.evidence_decision_v1",
+  "json_schema": {
+    "path": "evidence-decision-v1.schema.json",
+    "sha256": "d5615258c6cf666d0ed9684a87930989adf91817fe99b0387e83a31479dcd465"
+  },
+  "scientific_boundary": "Contract conformance only; the bundle is not physical, causal, calibration, transfer, or deployment evidence.",
+  "source_repository": "IPS-Stuttgart/BayesianPhysTwin",
+  "source_revision": "4ee702f5130cfedbea7bce6be5e72483c92f63da",
+  "vectors": {
+    "authorized": {
+      "path": "vectors/authorized.json",
+      "sha256": "3913156de73b6d92512df7e6975852b27d8ac21a8431caaf04e41069c935d902"
+    }
+  },
+  "wire_schema": "bayesian_phystwin.evidence_decision",
+  "wire_schema_version": 1
+}

--- a/src/causal4d/contract_data/evidence_decision_v1/vectors/authorized.json
+++ b/src/causal4d/contract_data/evidence_decision_v1/vectors/authorized.json
@@ -1,0 +1,49 @@
+{
+  "claim_authorized": true,
+  "claim_id": "contract.conformance.authorized",
+  "created_utc": "2026-08-10T12:00:00+00:00",
+  "decision_id": "702f941a2dc113dd79de53acc5eabcf7e250d375907735621917d745cc635baf",
+  "evidence_fingerprint": "5555555555555555555555555555555555555555555555555555555555555555",
+  "evidence_level": 3,
+  "evidence_summary_sha256": "6666666666666666666666666666666666666666666666666666666666666666",
+  "limitations": [
+    "synthetic contract vector; not scientific evidence"
+  ],
+  "metadata": {
+    "synthetic": true
+  },
+  "metric": {
+    "comparison": "reference_contract",
+    "name": "synthetic_contract_metric",
+    "observed_value": 1.0,
+    "rule": "observed_value_ge_threshold",
+    "threshold_value": 1.0,
+    "unit": "dimensionless"
+  },
+  "protocol_id": "evidence-decision-conformance-v1",
+  "repositories": [
+    {
+      "dirty": false,
+      "repository": "IPS-Stuttgart/BayesianPhysTwin",
+      "revision": "4ee702f5130cfedbea7bce6be5e72483c92f63da",
+      "role": "primary"
+    },
+    {
+      "dirty": false,
+      "repository": "IPS-Stuttgart/Causal4D",
+      "revision": "9432fef79a9dec7ca7977c29b9fc6a9e4517939d",
+      "role": "downstream"
+    },
+    {
+      "dirty": false,
+      "repository": "IPS-Stuttgart/Prob4D",
+      "revision": "c9273e8a55f812c532105a86c885a5a7627d3df3",
+      "role": "observation"
+    }
+  ],
+  "run_classification": "confirmatory",
+  "run_manifest_id": "4444444444444444444444444444444444444444444444444444444444444444",
+  "schema_name": "bayesian_phystwin.evidence_decision",
+  "schema_version": 1,
+  "status": "pass"
+}

--- a/tests/test_evidence_decision_contract_bundle.py
+++ b/tests/test_evidence_decision_contract_bundle.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from importlib.resources import files
+from typing import Any
+
+from causal4d.evidence_decision_v1 import (
+    EVIDENCE_DECISION_JSON_SCHEMA_SHA256,
+    EVIDENCE_DECISION_SCHEMA,
+    EVIDENCE_DECISION_SCHEMA_VERSION,
+    EVIDENCE_DECISION_SOURCE_REPOSITORY,
+    EVIDENCE_DECISION_SOURCE_REVISION,
+    admit_causal_claim_v1,
+    validate_evidence_decision_v1,
+)
+
+_BUNDLE = files("causal4d").joinpath("contract_data", "evidence_decision_v1")
+_MANIFEST_FIELDS = {
+    "bundle_schema",
+    "bundle_version",
+    "consumer_module",
+    "json_schema",
+    "scientific_boundary",
+    "source_repository",
+    "source_revision",
+    "vectors",
+    "wire_schema",
+    "wire_schema_version",
+}
+
+
+def _resource(path: str):
+    result = _BUNDLE
+    for part in path.split("/"):
+        result = result.joinpath(part)
+    return result
+
+
+def _json(path: str) -> dict[str, Any]:
+    value = json.loads(_resource(path).read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_packaged_schema_and_manifest_match_the_independent_binding() -> None:
+    manifest = _json("manifest.json")
+
+    assert set(manifest) == _MANIFEST_FIELDS
+    assert manifest["bundle_schema"] == (
+        "causal4d.evidence_decision_contract_bundle"
+    )
+    assert manifest["bundle_version"] == 1
+    assert manifest["consumer_module"] == "causal4d.evidence_decision_v1"
+    assert manifest["source_repository"] == EVIDENCE_DECISION_SOURCE_REPOSITORY
+    assert manifest["source_revision"] == EVIDENCE_DECISION_SOURCE_REVISION
+    assert manifest["wire_schema"] == EVIDENCE_DECISION_SCHEMA
+    assert manifest["wire_schema_version"] == EVIDENCE_DECISION_SCHEMA_VERSION
+    assert "not physical" in manifest["scientific_boundary"]
+
+    schema_record = manifest["json_schema"]
+    assert set(schema_record) == {"path", "sha256"}
+    schema_bytes = _resource(schema_record["path"]).read_bytes()
+    schema_sha256 = hashlib.sha256(schema_bytes).hexdigest()
+    assert schema_sha256 == schema_record["sha256"]
+    assert schema_sha256 == EVIDENCE_DECISION_JSON_SCHEMA_SHA256
+
+    schema = json.loads(schema_bytes)
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["schema_name"]["const"] == EVIDENCE_DECISION_SCHEMA
+    assert schema["properties"]["schema_version"]["const"] == (
+        EVIDENCE_DECISION_SCHEMA_VERSION
+    )
+    assert schema["properties"]["repositories"]["maxContains"] == 1
+
+
+def test_packaged_authorized_vector_is_sealed_and_admissible() -> None:
+    manifest = _json("manifest.json")
+    vector_record = manifest["vectors"]["authorized"]
+    assert set(vector_record) == {"path", "sha256"}
+
+    vector_resource = _resource(vector_record["path"])
+    vector_bytes = vector_resource.read_bytes()
+    assert hashlib.sha256(vector_bytes).hexdigest() == vector_record["sha256"]
+
+    payload = json.loads(vector_bytes)
+    decision = validate_evidence_decision_v1(payload)
+    assert decision.as_dict() == payload
+    assert decision.claim_authorized
+    assert decision.metadata["synthetic"] is True
+    assert decision.limitations == (
+        "synthetic contract vector; not scientific evidence",
+    )
+
+    repositories = {state.repository: state for state in decision.repositories}
+    admission = admit_causal_claim_v1(
+        decision,
+        claim_id=decision.claim_id,
+        protocol_id=decision.protocol_id,
+        expected_bayesian_phystwin_revision=(
+            repositories["IPS-Stuttgart/BayesianPhysTwin"].revision
+        ),
+        expected_causal4d_revision=(
+            repositories["IPS-Stuttgart/Causal4D"].revision
+        ),
+        expected_prob4d_revision=repositories["IPS-Stuttgart/Prob4D"].revision,
+        minimum_evidence_level=3,
+        require_prob4d_binding=True,
+    )
+
+    assert admission.decision.decision_id == (
+        "702f941a2dc113dd79de53acc5eabcf7e250d375907735621917d745cc635baf"
+    )
+    assert admission.bayesian_phystwin.role == "primary"
+    assert admission.causal4d.role == "downstream"
+    assert admission.prob4d is not None
+    assert admission.prob4d.role == "observation"

--- a/tests/test_evidence_decision_contract_bundle.py
+++ b/tests/test_evidence_decision_contract_bundle.py
@@ -47,9 +47,7 @@ def test_packaged_schema_and_manifest_match_the_independent_binding() -> None:
     manifest = _json("manifest.json")
 
     assert set(manifest) == _MANIFEST_FIELDS
-    assert manifest["bundle_schema"] == (
-        "causal4d.evidence_decision_contract_bundle"
-    )
+    assert manifest["bundle_schema"] == "causal4d.evidence_decision_contract_bundle"
     assert manifest["bundle_version"] == 1
     assert manifest["consumer_module"] == "causal4d.evidence_decision_v1"
     assert manifest["source_repository"] == EVIDENCE_DECISION_SOURCE_REPOSITORY
@@ -101,9 +99,7 @@ def test_packaged_authorized_vector_is_sealed_and_admissible() -> None:
         expected_bayesian_phystwin_revision=(
             repositories["IPS-Stuttgart/BayesianPhysTwin"].revision
         ),
-        expected_causal4d_revision=(
-            repositories["IPS-Stuttgart/Causal4D"].revision
-        ),
+        expected_causal4d_revision=repositories["IPS-Stuttgart/Causal4D"].revision,
         expected_prob4d_revision=repositories["IPS-Stuttgart/Prob4D"].revision,
         minimum_evidence_level=3,
         require_prob4d_binding=True,


### PR DESCRIPTION
## What changed

- retain the exact BayesianPhysTwin `bayesian_phystwin.evidence_decision` v1 JSON Schema bytes inside the Causal4D package;
- bind the schema to BayesianPhysTwin revision `4ee702f5130cfedbea7bce6be5e72483c92f63da` and SHA-256 `d5615258c6cf666d0ed9684a87930989adf91817fe99b0387e83a31479dcd465` through a machine-readable manifest;
- add a sealed synthetic authorized vector with its own content digest;
- package the schema, manifest, and vector in wheels and sdists;
- add independent tests for schema identity, manifest closure, vector integrity, parsing, and exact three-repository admission;
- extend the installed three-repository workflow to verify the retained Causal4D bundle against the producer schema and source lock; and
- document offline verification and the scientific boundary.

## Why

The evidence-decision consumer was independently implemented and its schema digest was checked in CI, but the exact contract bytes were not retained in the installed Causal4D artifact. Keeping a content-addressed bundle makes the consumer auditable offline, prevents undocumented schema drift, and lets downstream users verify the contract without a BayesianPhysTwin checkout.

## Compatibility

- No estimator, abduction, intervention, prediction, acquisition, target-access, or evidence semantics change.
- No runtime dependency is added.
- No package-root API is widened.
- The retained vector is synthetic conformance data and cannot authorize a scientific claim by itself.

## Validation

- The retained schema text hashes to `d5615258c6cf666d0ed9684a87930989adf91817fe99b0387e83a31479dcd465`.
- The retained vector hashes to `3913156de73b6d92512df7e6975852b27d8ac21a8431caaf04e41069c935d902` and carries decision ID `702f941a2dc113dd79de53acc5eabcf7e250d375907735621917d745cc635baf`.
- GitHub Actions on the exact PR head are authoritative for formatting, tests, distribution contents, security, compatibility, and installed three-repository agreement.

## Scientific boundary

This is contract and provenance infrastructure only. It does not establish physical-state identification, calibrated uncertainty, causal sufficiency, intervention benefit, transfer, deployment safety, or state of the art.