### PR TITLE
Make registered real-effect interval gating fail closed

### DIFF
--- a/docs/causal4d_real_analysis_interval_diagnostics.md
+++ b/docs/causal4d_real_analysis_interval_diagnostics.md
@@ -24,6 +24,14 @@ bootstrap-t interval containing zero, or a Student-t interval containing zero
 precludes a positive claim. The complete negative or bounded result remains
 reportable.
 
+The decision gate validates that the two required interval records use the exact
+registered methods, confidence level, session count, and point estimate. It
+rejects mixed or relabelled interval objects rather than combining incomparable
+results. A zero between-session variance panel is also non-estimable for the two
+claim-bearing intervals: it may be reported descriptively through the historical
+sensitivity interval, but a zero-width interval cannot authorize a positive
+claim because between-session uncertainty was not estimated.
+
 ## Target-free evidence
 
 All interval-selection studies evaluated the immutable implementation at

--- a/src/causal4d/real_analysis_intervals.py
+++ b/src/causal4d/real_analysis_intervals.py
@@ -21,6 +21,9 @@ REAL_EFFECT_CONFIDENCE_LEVEL = 0.95
 REAL_EFFECT_BOOTSTRAP_REPLICATES = 20_000
 REAL_EFFECT_BOOTSTRAP_SEED = 20_260_726
 
+_PRIMARY_INTERVAL_METHOD = "target_session_bootstrap_t"
+_ROBUSTNESS_INTERVAL_METHOD = "student_t_mean"
+
 FloatArray: TypeAlias = NDArray[np.float64]
 
 
@@ -100,7 +103,7 @@ def percentile_bootstrap_mean_interval(
     )
     means = np.mean(array[indices], axis=1)
     tail = 0.5 * (1.0 - confidence_level)
-    lower, upper = np.quantile(means, [tail, 1.0 - tail])
+    lower, upper = np.quantile(means, [tail, 1.0 - tail], method="linear")
     return {
         "estimable": True,
         "method": "target_session_percentile_bootstrap",
@@ -111,6 +114,7 @@ def percentile_bootstrap_mean_interval(
         "upper": float(upper),
         "replicates": replicates,
         "seed": seed,
+        "degenerate_sample": float(np.std(array, ddof=1)) == 0.0,
         "finite_sample_coverage_guaranteed": False,
     }
 
@@ -126,7 +130,7 @@ def student_t_mean_interval(
     array = _validated_values(values)
     if len(array) < 2:
         return _not_estimable_interval(
-            method="student_t_mean",
+            method=_ROBUSTNESS_INTERVAL_METHOD,
             sample_count=len(array),
             confidence_level=confidence_level,
             reason="at least two included sessions are required",
@@ -135,12 +139,33 @@ def student_t_mean_interval(
     point = float(np.mean(array))
     sample_sd = float(np.std(array, ddof=1))
     standard_error = sample_sd / math.sqrt(len(array))
+    assumptions = [
+        "independent session effects",
+        "approximately normal sampling distribution of the session mean",
+    ]
+    if sample_sd == 0.0:
+        result = _not_estimable_interval(
+            method=_ROBUSTNESS_INTERVAL_METHOD,
+            sample_count=len(array),
+            confidence_level=confidence_level,
+            reason="zero between-session variance prevents uncertainty estimation",
+        )
+        result.update(
+            degrees_of_freedom=len(array) - 1,
+            point_estimate=point,
+            sample_standard_deviation=sample_sd,
+            standard_error=standard_error,
+            degenerate_sample=True,
+            coverage_assumptions=assumptions,
+        )
+        return result
+
     tail = 0.5 * (1.0 - confidence_level)
     critical_value = float(student_t_distribution.ppf(1.0 - tail, df=len(array) - 1))
     half_width = critical_value * standard_error
     return {
         "estimable": True,
-        "method": "student_t_mean",
+        "method": _ROBUSTNESS_INTERVAL_METHOD,
         "confidence_level": confidence_level,
         "sample_count": len(array),
         "degrees_of_freedom": len(array) - 1,
@@ -150,11 +175,8 @@ def student_t_mean_interval(
         "critical_value": critical_value,
         "lower": point - half_width,
         "upper": point + half_width,
-        "degenerate_sample": sample_sd == 0.0,
-        "coverage_assumptions": [
-            "independent session effects",
-            "approximately normal sampling distribution of the session mean",
-        ],
+        "degenerate_sample": False,
+        "coverage_assumptions": assumptions,
         "finite_sample_coverage_guaranteed": False,
     }
 
@@ -176,7 +198,7 @@ def bootstrap_t_mean_interval(
     array = _validated_values(values)
     if len(array) < 2:
         result = _not_estimable_interval(
-            method="target_session_bootstrap_t",
+            method=_PRIMARY_INTERVAL_METHOD,
             sample_count=len(array),
             confidence_level=confidence_level,
             reason="at least two included sessions are required",
@@ -189,21 +211,23 @@ def bootstrap_t_mean_interval(
     sample_sd = float(np.std(array, ddof=1))
     sample_standard_error = sample_sd / math.sqrt(sample_count)
     if sample_standard_error == 0.0:
-        return {
-            "estimable": True,
-            "method": "target_session_bootstrap_t",
-            "confidence_level": confidence_level,
-            "sample_count": sample_count,
-            "point_estimate": point,
-            "lower": point,
-            "upper": point,
-            "replicates": replicates,
-            "seed": seed,
-            "finite_studentized_replicate_count": replicates,
-            "finite_studentized_replicate_fraction": 1.0,
-            "degenerate_sample": True,
-            "finite_sample_coverage_guaranteed": False,
-        }
+        result = _not_estimable_interval(
+            method=_PRIMARY_INTERVAL_METHOD,
+            sample_count=sample_count,
+            confidence_level=confidence_level,
+            reason="zero between-session variance prevents studentization",
+        )
+        result.update(
+            point_estimate=point,
+            sample_standard_deviation=sample_sd,
+            standard_error=sample_standard_error,
+            replicates=replicates,
+            seed=seed,
+            finite_studentized_replicate_count=0,
+            finite_studentized_replicate_fraction=0.0,
+            degenerate_sample=True,
+        )
+        return result
 
     generator = np.random.default_rng(seed)
     indices = generator.integers(
@@ -231,27 +255,32 @@ def bootstrap_t_mean_interval(
         lower_pivot, upper_pivot = np.quantile(
             studentized,
             [tail, 1.0 - tail],
+            method="linear",
         )
     lower = point - float(upper_pivot) * sample_standard_error
     upper = point - float(lower_pivot) * sample_standard_error
     if not np.isfinite(lower) or not np.isfinite(upper):
         result = _not_estimable_interval(
-            method="target_session_bootstrap_t",
+            method=_PRIMARY_INTERVAL_METHOD,
             sample_count=sample_count,
             confidence_level=confidence_level,
             reason="too many degenerate bootstrap resamples for finite pivots",
         )
         result.update(
+            point_estimate=point,
+            sample_standard_deviation=sample_sd,
+            standard_error=sample_standard_error,
             replicates=replicates,
             seed=seed,
             finite_studentized_replicate_count=int(np.sum(finite)),
             finite_studentized_replicate_fraction=float(np.mean(finite)),
+            degenerate_sample=False,
         )
         return result
 
     return {
         "estimable": True,
-        "method": "target_session_bootstrap_t",
+        "method": _PRIMARY_INTERVAL_METHOD,
         "confidence_level": confidence_level,
         "sample_count": sample_count,
         "point_estimate": point,
@@ -271,12 +300,65 @@ def bootstrap_t_mean_interval(
 
 
 def interval_excludes_nonpositive_effect(interval: Mapping[str, Any]) -> bool:
-    """Return whether one estimable interval has a strictly positive lower bound."""
+    """Return whether one usable interval has a strictly positive lower bound."""
 
     if interval.get("estimable") is not True:
         return False
+    if interval.get("degenerate_sample") is True:
+        return False
     lower = interval.get("lower")
     return type(lower) in {int, float} and np.isfinite(float(lower)) and lower > 0.0
+
+
+def _validated_registered_interval_pair(
+    primary: Mapping[str, Any],
+    robustness: Mapping[str, Any],
+) -> int:
+    if primary.get("method") != _PRIMARY_INTERVAL_METHOD:
+        raise ValueError("primary interval method is not the registered bootstrap-t")
+    if robustness.get("method") != _ROBUSTNESS_INTERVAL_METHOD:
+        raise ValueError("robustness interval method is not the registered Student-t")
+
+    primary_count = primary.get("sample_count")
+    robustness_count = robustness.get("sample_count")
+    if type(primary_count) is not int or primary_count < 0:
+        raise ValueError("primary interval sample_count must be nonnegative")
+    if type(robustness_count) is not int or robustness_count < 0:
+        raise ValueError("robustness interval sample_count must be nonnegative")
+    if primary_count != robustness_count:
+        raise ValueError("registered intervals must use the same session sample")
+
+    for name, interval in (("primary", primary), ("robustness", robustness)):
+        confidence_level = interval.get("confidence_level")
+        if type(confidence_level) not in {int, float} or not np.isclose(
+            float(confidence_level),
+            REAL_EFFECT_CONFIDENCE_LEVEL,
+            rtol=0.0,
+            atol=0.0,
+        ):
+            raise ValueError(
+                f"{name} interval confidence_level differs from the registered value"
+            )
+
+    if primary.get("estimable") is True and robustness.get("estimable") is True:
+        primary_point = primary.get("point_estimate")
+        robustness_point = robustness.get("point_estimate")
+        if type(primary_point) not in {int, float} or not np.isfinite(
+            float(primary_point)
+        ):
+            raise ValueError("primary interval point estimate must be finite")
+        if type(robustness_point) not in {int, float} or not np.isfinite(
+            float(robustness_point)
+        ):
+            raise ValueError("robustness interval point estimate must be finite")
+        if not np.isclose(
+            float(primary_point),
+            float(robustness_point),
+            rtol=0.0,
+            atol=0.0,
+        ):
+            raise ValueError("registered intervals must estimate the same session mean")
+    return primary_count
 
 
 def registered_positive_effect_interval_decision(
@@ -285,18 +367,37 @@ def registered_positive_effect_interval_decision(
 ) -> dict[str, Any]:
     """Apply the predeclared two-interval positive-claim rule.
 
-    Bootstrap-t is primary.  Student-t may veto a positive claim but can never
-    rescue a primary interval that includes zero or is not estimable.
+    Bootstrap-t is primary. Student-t may veto a positive claim but can never
+    rescue a primary interval that includes zero or is not estimable. The gate
+    also fails closed for a zero-variance session panel because neither required
+    method can estimate between-session uncertainty in that case.
     """
 
+    sample_count = _validated_registered_interval_pair(primary, robustness)
     primary_passed = interval_excludes_nonpositive_effect(primary)
     robustness_passed = interval_excludes_nonpositive_effect(robustness)
+    degenerate = (
+        primary.get("degenerate_sample") is True
+        or robustness.get("degenerate_sample") is True
+    )
     return {
         "primary_interval_method": primary.get("method"),
         "required_robustness_interval_method": robustness.get("method"),
+        "sample_count": sample_count,
+        "registered_interval_inputs_match": True,
+        "primary_interval_estimable": primary.get("estimable") is True,
+        "required_robustness_interval_estimable": (
+            robustness.get("estimable") is True
+        ),
+        "degenerate_session_panel": degenerate,
+        "degenerate_session_panel_blocks_positive_claim": True,
         "primary_interval_excludes_nonpositive_effect": primary_passed,
-        "required_robustness_interval_excludes_nonpositive_effect": (robustness_passed),
-        "positive_claim_interval_gate_passed": (primary_passed and robustness_passed),
+        "required_robustness_interval_excludes_nonpositive_effect": (
+            robustness_passed
+        ),
+        "positive_claim_interval_gate_passed": (
+            primary_passed and robustness_passed and not degenerate
+        ),
         "robustness_interval_may_veto_positive_claim": True,
         "robustness_interval_may_rescue_primary_failure": False,
         "negative_or_bounded_result_remains_reportable": True,

--- a/src/causal4d/real_analysis_intervals.py
+++ b/src/causal4d/real_analysis_intervals.py
@@ -386,15 +386,11 @@ def registered_positive_effect_interval_decision(
         "sample_count": sample_count,
         "registered_interval_inputs_match": True,
         "primary_interval_estimable": primary.get("estimable") is True,
-        "required_robustness_interval_estimable": (
-            robustness.get("estimable") is True
-        ),
+        "required_robustness_interval_estimable": (robustness.get("estimable") is True),
         "degenerate_session_panel": degenerate,
         "degenerate_session_panel_blocks_positive_claim": True,
         "primary_interval_excludes_nonpositive_effect": primary_passed,
-        "required_robustness_interval_excludes_nonpositive_effect": (
-            robustness_passed
-        ),
+        "required_robustness_interval_excludes_nonpositive_effect": (robustness_passed),
         "positive_claim_interval_gate_passed": (
             primary_passed and robustness_passed and not degenerate
         ),

--- a/tests/test_real_analysis_interval_diagnostics.py
+++ b/tests/test_real_analysis_interval_diagnostics.py
@@ -214,17 +214,20 @@ def test_bootstrap_t_is_deterministic_and_finite() -> None:
     assert first["lower"] <= first["point_estimate"] <= first["upper"]
 
 
-def test_degenerate_samples_produce_explicit_point_intervals() -> None:
+def test_degenerate_samples_remain_descriptive_but_not_claim_estimable() -> None:
     values = [1.5] * 12
 
     for result in (
         student_t_sensitivity_interval(values),
         bootstrap_t_sensitivity_interval(values),
     ):
-        assert result["estimable"] is True
+        assert result["estimable"] is False
         assert result["degenerate_sample"] is True
-        assert result["lower"] == pytest.approx(1.5)
-        assert result["upper"] == pytest.approx(1.5)
+        assert result["point_estimate"] == pytest.approx(1.5)
+        assert result["lower"] is None
+        assert result["upper"] is None
+        assert result["may_change_primary_decision"] is False
+        assert result["finite_sample_coverage_guaranteed"] is False
 
 
 def test_companion_artifact_verifies_registered_intervals_and_sources(

--- a/tests/test_real_analysis_intervals.py
+++ b/tests/test_real_analysis_intervals.py
@@ -29,6 +29,24 @@ from causal4d.real_analysis_intervals import (
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def _interval(
+    *,
+    method: str,
+    lower: float,
+    sample_count: int = 12,
+    point_estimate: float = 0.2,
+) -> dict[str, object]:
+    return {
+        "estimable": True,
+        "method": method,
+        "confidence_level": 0.95,
+        "sample_count": sample_count,
+        "point_estimate": point_estimate,
+        "lower": lower,
+        "degenerate_sample": False,
+    }
+
+
 def test_registered_interval_implementations_are_deterministic() -> None:
     values = np.linspace(-0.25, 0.75, 18).tolist()
 
@@ -46,31 +64,42 @@ def test_registered_interval_implementations_are_deterministic() -> None:
     assert robustness["method"] == "student_t_mean"
 
 
-def test_degenerate_session_panels_have_exact_point_intervals() -> None:
+def test_degenerate_session_panel_cannot_authorize_a_positive_claim() -> None:
     values = [1.25] * 12
 
-    for interval in (
-        bootstrap_t_mean_interval(values),
-        percentile_bootstrap_mean_interval(values),
-        student_t_mean_interval(values),
-    ):
-        assert interval["estimable"] is True
+    primary = bootstrap_t_mean_interval(values)
+    robustness = student_t_mean_interval(values)
+    historical = percentile_bootstrap_mean_interval(values)
+
+    for interval in (primary, robustness):
+        assert interval["estimable"] is False
         assert interval["point_estimate"] == pytest.approx(1.25)
-        assert interval["lower"] == pytest.approx(1.25)
-        assert interval["upper"] == pytest.approx(1.25)
+        assert interval["lower"] is None
+        assert interval["upper"] is None
+        assert interval["degenerate_sample"] is True
+
+    assert historical["estimable"] is True
+    assert historical["point_estimate"] == pytest.approx(1.25)
+    assert historical["lower"] == pytest.approx(1.25)
+    assert historical["upper"] == pytest.approx(1.25)
+    assert historical["degenerate_sample"] is True
+
+    decision = registered_positive_effect_interval_decision(primary, robustness)
+    assert decision["registered_interval_inputs_match"] is True
+    assert decision["degenerate_session_panel"] is True
+    assert decision["degenerate_session_panel_blocks_positive_claim"] is True
+    assert decision["positive_claim_interval_gate_passed"] is False
 
 
 def test_student_t_can_veto_but_never_rescue_primary_interval() -> None:
-    primary_pass = {
-        "estimable": True,
-        "method": "target_session_bootstrap_t",
-        "lower": 0.1,
-    }
-    robustness_fail = {
-        "estimable": True,
-        "method": "student_t_mean",
-        "lower": -0.01,
-    }
+    primary_pass = _interval(
+        method="target_session_bootstrap_t",
+        lower=0.1,
+    )
+    robustness_fail = _interval(
+        method="student_t_mean",
+        lower=-0.01,
+    )
     decision = registered_positive_effect_interval_decision(
         primary_pass,
         robustness_fail,
@@ -87,6 +116,38 @@ def test_student_t_can_veto_but_never_rescue_primary_interval() -> None:
     )
     assert decision["positive_claim_interval_gate_passed"] is False
     assert decision["robustness_interval_may_rescue_primary_failure"] is False
+
+
+@pytest.mark.parametrize(
+    ("primary_update", "robustness_update", "message"),
+    [
+        (
+            {"method": "target_session_percentile_bootstrap"},
+            {},
+            "primary interval method",
+        ),
+        ({}, {"method": "bootstrap_t_mean"}, "robustness interval method"),
+        ({"sample_count": 11}, {}, "same session sample"),
+        ({"confidence_level": 0.9}, {}, "registered value"),
+        ({"point_estimate": 0.3}, {}, "same session mean"),
+    ],
+)
+def test_positive_claim_gate_rejects_mismatched_interval_inputs(
+    primary_update: dict[str, object],
+    robustness_update: dict[str, object],
+    message: str,
+) -> None:
+    primary = {
+        **_interval(method="target_session_bootstrap_t", lower=0.1),
+        **primary_update,
+    }
+    robustness = {
+        **_interval(method="student_t_mean", lower=0.1),
+        **robustness_update,
+    }
+
+    with pytest.raises(ValueError, match=message):
+        registered_positive_effect_interval_decision(primary, robustness)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_real_analysis_reporting.py
+++ b/tests/test_real_analysis_reporting.py
@@ -148,14 +148,36 @@ def test_report_uses_sessions_as_the_resampling_unit(tmp_path: Path) -> None:
     assert primary["session_is_resampling_unit"] is True
     assert primary["executions_are_not_treated_as_independent"] is True
     assert primary["equal_session_weighted_improvement"]["mean"] == pytest.approx(1.0)
-    assert primary["confidence_interval"]["method"] == ("target_session_bootstrap_t")
-    assert primary["confidence_interval"]["lower"] == pytest.approx(1.0)
-    assert primary["confidence_interval"]["upper"] == pytest.approx(1.0)
-    assert primary["required_robustness_interval"]["method"] == "student_t_mean"
-    assert primary["historical_percentile_sensitivity_interval"]["method"] == (
-        "target_session_percentile_bootstrap"
-    )
-    assert primary["interval_decision"]["positive_claim_interval_gate_passed"]
+
+    registered = primary["confidence_interval"]
+    robustness = primary["required_robustness_interval"]
+    historical = primary["historical_percentile_sensitivity_interval"]
+    decision = primary["interval_decision"]
+
+    assert registered["method"] == "target_session_bootstrap_t"
+    assert registered["estimable"] is False
+    assert registered["point_estimate"] == pytest.approx(1.0)
+    assert registered["lower"] is None
+    assert registered["upper"] is None
+    assert registered["degenerate_sample"] is True
+
+    assert robustness["method"] == "student_t_mean"
+    assert robustness["estimable"] is False
+    assert robustness["point_estimate"] == pytest.approx(1.0)
+    assert robustness["lower"] is None
+    assert robustness["upper"] is None
+    assert robustness["degenerate_sample"] is True
+
+    assert historical["method"] == "target_session_percentile_bootstrap"
+    assert historical["estimable"] is True
+    assert historical["lower"] == pytest.approx(1.0)
+    assert historical["upper"] == pytest.approx(1.0)
+    assert historical["degenerate_sample"] is True
+
+    assert decision["registered_interval_inputs_match"] is True
+    assert decision["degenerate_session_panel"] is True
+    assert decision["degenerate_session_panel_blocks_positive_claim"] is True
+    assert decision["positive_claim_interval_gate_passed"] is False
     assert report["claim_boundary"]["object_class_generalization_claimed"] is False
     assert (
         report["design_diagnostics"]["condition_comparisons_are_descriptive_only"]


### PR DESCRIPTION
## What changed

- reject primary or robustness interval records whose methods do not match the registered bootstrap-t and Student-t policy;
- require the two claim-bearing intervals to use the same session count, 95% confidence level, and finite point estimate;
- treat zero between-session variance as non-estimable for bootstrap-t studentization and Student-t uncertainty rather than returning a claim-bearing zero-width interval;
- keep the historical percentile result available as descriptive sensitivity for a degenerate panel;
- make the decision receipt expose interval-input agreement, estimability, sample count, and the degenerate-panel veto; and
- add adversarial tests and document the fail-closed boundary.

## Why

PR #319 correctly promoted a target-free bootstrap-t primary interval with a Student-t veto, but two edge cases remained:

1. the decision helper accepted arbitrary or mutually inconsistent interval dictionaries; and
2. an exactly zero-variance positive session panel could produce zero-width intervals and authorize a positive claim even though between-session uncertainty was not estimated.

The follow-up prevents both failure modes before the first confirmatory physical execution.

## Compatibility

- No estimator, physical protocol, statistical unit, confidence level, bootstrap seed, target split, exclusion rule, evidence count, or target-access boundary changes.
- Ordinary nondegenerate registered analyses retain the same numerical interval algorithms.
- The change is conservative: it can only reject unsupported claim authorization or mark a required interval non-estimable.
- Negative and bounded results remain fully reportable.

## Validation

Focused tests cover deterministic registered intervals, zero-variance panels, Student-t veto behavior, wrong method labels, mismatched session counts, changed confidence levels, changed point estimates, coercive settings, and the content-addressed amendment.

GitHub Actions on the exact pull-request head are authoritative for formatting, typing, the full test suite, distribution validation, installed-wheel integration, compatibility, and security.

## Scientific boundary

This is target-free inference hardening. It does not add physical evidence or change the registered primary effect definition; it prevents a malformed or non-estimable interval pair from authorizing a positive claim.