### PR TITLE
Isolate dedicated BayesianPhysTwin provider checks

### DIFF
--- a/tests/test_bpt_provider_import_boundary.py
+++ b/tests/test_bpt_provider_import_boundary.py
@@ -36,6 +36,9 @@ def _allowed_bayesian_phystwin_modules() -> frozenset[str]:
 ALLOWED_BAYESIAN_PHYSTWIN_MODULES = _allowed_bayesian_phystwin_modules()
 
 _DEDICATED_PROVIDER_REQUIREMENTS = {
+    "bayesian_phystwin.causal4d_belief_provider_v3": (
+        "CAUSAL4D_REQUIRE_BPT_BELIEF_PROVIDER_V3"
+    ),
     "bayesian_phystwin.causal4d_tree_block_provider_v1": (
         "CAUSAL4D_REQUIRE_TREE_BLOCK_QUERY_PROVIDER"
     ),


### PR DESCRIPTION
## What changed

- treat `bayesian_phystwin.causal4d_belief_provider_v3` like the existing tree-block provider: an opt-in dedicated installed-provider boundary;
- allow historical/purpose-specific BayesianPhysTwin pins to omit provider v3 unless `CAUSAL4D_REQUIRE_BPT_BELIEF_PROVIDER_V3=1` is explicitly set;
- preserve strict resolution when the dedicated v3 integration lane requires the provider.

## Why

The repository-wide import-boundary test can run inside purpose-specific BayesianPhysTwin environments. The tree-block workflow intentionally pins a revision that contains the tree-block provider but predates belief-provider v3. After provider v3 was registered, the generic resolver test incorrectly required it in that historical environment and failed with `ModuleNotFoundError`.

This fix keeps exact historical pins intact instead of widening or updating them merely to satisfy an unrelated provider contract.

## Scientific boundary

This is CI/test isolation only. It does not promote belief-provider v3, reopen the negative full-22 discrepancy decision, change the retained `last_residual` reference, modify the frozen 36-execution protocol, or alter any estimator, evidence, calibration, Prob4D admission, or physical result.

## Validation target

The relevant regression is the tree-block installed-provider integration that previously failed because provider v3 was absent from its intentionally older BayesianPhysTwin pin. The dedicated belief-provider-v3 lane remains strict through `CAUSAL4D_REQUIRE_BPT_BELIEF_PROVIDER_V3=1`.