### PR TITLE
Require evidence and information-boundary declarations in PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,75 @@
+<!--
+Complete every field or write "not applicable". Do not remove the scientific and
+information-boundary section. See CONTRIBUTING.md for the repository rules.
+-->
+
+## Summary
+
+<!-- Explain what changed, why it changed, and the user or scientific impact. -->
+
+## Change classification
+
+Select one primary classification:
+
+- [ ] Frozen or registered method/analysis change requiring a new version
+- [ ] Future or experimental method
+- [ ] BayesianPhysTwin, Prob4D, or other provider/artifact contract
+- [ ] Acquisition, calibration, readiness, or evidence tooling
+- [ ] Diagnostic, source-only, retrospective, or controlled study
+- [ ] Maintenance, documentation, packaging, CI, or security
+
+Evidence status, when applicable:
+
+- [ ] Software or contract evidence only
+- [ ] Controlled synthetic evidence
+- [ ] Source/calibration-only evidence
+- [ ] Retrospective or already-open diagnostic evidence
+- [ ] Confirmatory physical evidence
+- [ ] No scientific evidence produced
+
+## Scientific and information boundary
+
+Replace each placeholder and explain every `yes` answer.
+
+- Frozen estimator or registered analysis changed: `<yes/no>`
+- Target or held-out outcomes accessed: `<yes/no>`
+- Registered physical-acquisition dataset modified: `<yes/no>`
+- Physical evidence increment: `<integer, normally 0>`
+- Existing scientific claim changed or promoted: `<yes/no>`
+- Independent statistical unit: `<object/session/execution/not applicable>`
+- Source, calibration, and target split: `<identities or not applicable>`
+- Exact fallback preserved for rejected optional evidence: `<yes/no/not applicable>`
+
+Do not combine a method change with target evaluation or claim promotion. A negative
+or bounded result must remain reportable without retuning on the same target cohort.
+
+## Provenance and compatibility
+
+- Base revision or frozen source identity:
+- Contract, schema, provider, or protocol versions:
+- Frozen artifacts or milestones affected:
+- Compatibility, migration, and fallback behavior:
+
+## Validation
+
+- [ ] A regression fails on the unpatched implementation, when applicable
+- [ ] Valid inputs and expected behavior are covered
+- [ ] Malformed, mutable, or provenance-inconsistent inputs are covered
+- [ ] Serialization, distribution, or installed-artifact behavior is covered
+- [ ] Cross-repository compatibility is covered when a provider boundary changes
+
+Commands and results:
+
+```text
+<commands, passed checks, and meaningful skips>
+```
+
+## Merge disposition
+
+Select one:
+
+- [ ] Product change intended for review and merge
+- [ ] Execution/bootstrap helper that must be closed without merge
+- [ ] Diagnostic result that cannot promote a method or scientific claim
+
+Describe any required post-merge execution, human-governed action, or cleanup:

--- a/tests/test_pull_request_template_policy.py
+++ b/tests/test_pull_request_template_policy.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / ".github" / "pull_request_template.md"
+
+
+def test_pull_request_template_requires_scientific_boundaries() -> None:
+    text = TEMPLATE.read_text(encoding="utf-8")
+    required = (
+        "## Change classification",
+        "## Scientific and information boundary",
+        "Frozen estimator or registered analysis changed",
+        "Target or held-out outcomes accessed",
+        "Registered physical-acquisition dataset modified",
+        "Physical evidence increment",
+        "Independent statistical unit",
+        "Source, calibration, and target split",
+        "Exact fallback preserved",
+        "## Provenance and compatibility",
+        "## Validation",
+        "## Merge disposition",
+        "Execution/bootstrap helper that must be closed without merge",
+        "Do not combine a method change with target evaluation or claim promotion",
+    )
+    missing = [value for value in required if value not in text]
+    assert missing == [], f"pull-request template is missing required fields: {missing}"
+
+
+def test_pull_request_template_makes_no_prechecked_declaration() -> None:
+    text = TEMPLATE.read_text(encoding="utf-8").lower()
+    assert "- [x]" not in text


### PR DESCRIPTION
## What changed

- add a repository pull-request template that requires one primary change classification;
- separate software/contract, controlled, source-only, retrospective, and confirmatory evidence states;
- require explicit declarations for frozen-method changes, target access, physical-dataset mutation, evidence count, statistical units, source/calibration/target splits, and exact fallback;
- distinguish product PRs from execution/bootstrap helpers and non-promoting diagnostic results; and
- add a repository policy test that prevents removal of the scientific-boundary fields or introduction of prechecked declarations.

## Why

`CONTRIBUTING.md` already explains that technically correct changes can invalidate a frozen comparison or target-access boundary, but GitHub did not present those declarations when a pull request was opened. The template moves the repository's evidence-first rules into the normal review path and makes temporary automation PRs visibly different from mergeable product changes.

## User and scientific impact

Reviewers can identify scope drift, pseudo-replication, target-informed selection, evidence-count changes, and helper PRs before interpreting code or CI. The template does not authorize evidence or make declarations true; it provides a consistent, reviewable record.

## Validation

- focused policy tests: `2 passed`;
- Python byte compilation passed;
- changed-file 88-column check passed;
- branch comparison: two new files, two commits, zero commits behind current `main` at publication.

## Scientific and compatibility boundary

This is contribution and review infrastructure only. It changes no estimator, provider contract, registered protocol, acquisition schedule, target boundary, artifact identity, physical dataset, evidence count, or scientific claim.