### PR TITLE
Repair and re-dispatch Deform360 reset mechanics

### DIFF
--- a/.github/workflows/deform360-reset-mechanics-issue-dispatch.yml
+++ b/.github/workflows/deform360-reset-mechanics-issue-dispatch.yml
@@ -1,0 +1,155 @@
+name: Deform360 reset-mechanics issue dispatcher
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+
+concurrency:
+  group: deform360-reset-mechanics-issue-dispatch-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: Dispatch corrected reset-mechanics diagnostic
+    if: >-
+      github.event_name == 'issues' &&
+      github.event.action == 'opened' &&
+      github.ref == 'refs/heads/main' &&
+      github.event.issue.user.login == 'FlorianPfaff' &&
+      github.event.issue.user.id == 6773539 &&
+      github.event.issue.title ==
+        '[self-hosted] run Causal4D Deform360 reset mechanics'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+    steps:
+      - name: Verify exact reviewed main revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          main_sha="$(
+            gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq .sha
+          )"
+          test "${main_sha}" = "${GITHUB_SHA}"
+          echo "MAIN_SHA=${main_sha}" >> "${GITHUB_ENV}"
+
+      - name: Record existing workflow-dispatch runs
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh run list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --workflow deform360-reset-mechanics.yml \
+            --branch main \
+            --event workflow_dispatch \
+            --limit 100 \
+            --json databaseId \
+            --jq '.[].databaseId' \
+            | sort -n > "${RUNNER_TEMP}/reset-mechanics.before"
+
+      - name: Dispatch locked source-only reset mechanics
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run deform360-reset-mechanics.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref main \
+            -f run_source_diagnostic=true
+
+      - name: Resolve and verify dispatched run
+        id: run
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_id=""
+          for _ in $(seq 1 60); do
+            after="$(mktemp)"
+            gh run list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --workflow deform360-reset-mechanics.yml \
+              --branch main \
+              --event workflow_dispatch \
+              --limit 100 \
+              --json databaseId \
+              --jq '.[].databaseId' \
+              | sort -n > "${after}"
+            run_id="$(
+              comm -13 "${RUNNER_TEMP}/reset-mechanics.before" "${after}" \
+                | tail -n 1
+            )"
+            rm -f "${after}"
+            if [[ -n "${run_id}" ]]; then
+              break
+            fi
+            sleep 2
+          done
+          test -n "${run_id}"
+          readarray -t identity < <(
+            gh run view "${run_id}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --json event,headSha,url \
+              --jq '.event, .headSha, .url'
+          )
+          test "${identity[0]}" = "workflow_dispatch"
+          test "${identity[1]}" = "${MAIN_SHA}"
+          echo "run_id=${run_id}" >> "${GITHUB_OUTPUT}"
+          echo "run_url=${identity[2]}" >> "${GITHUB_OUTPUT}"
+
+      - name: Write dispatch receipt
+        shell: bash
+        env:
+          RUN_ID: ${{ steps.run.outputs.run_id }}
+          RUN_URL: ${{ steps.run.outputs.run_url }}
+        run: |
+          set -euo pipefail
+          mkdir -p outputs/reset-mechanics-dispatch
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          receipt = {
+              "schema_version": 1,
+              "artifact_kind": "Causal4DDeform360ResetMechanicsDispatch",
+              "repository": os.environ["GITHUB_REPOSITORY"],
+              "reviewed_main_sha": os.environ["MAIN_SHA"],
+              "trigger_issue_number": int(os.environ["ISSUE_NUMBER"]),
+              "workflow_run_id": int(os.environ["RUN_ID"]),
+              "workflow_run_url": os.environ["RUN_URL"],
+              "run_source_diagnostic": True,
+              "target_outcomes_used": False,
+              "registered_physical_dataset_modified": False,
+              "physical_evidence_increment": 0,
+          }
+          Path("outputs/reset-mechanics-dispatch/dispatch.json").write_text(
+              json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print(json.dumps(receipt, indent=2, sort_keys=True))
+          PY
+
+      - name: Upload dispatch receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: causal4d-deform360-reset-mechanics-dispatch
+          path: outputs/reset-mechanics-dispatch/dispatch.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Report dispatched run
+        shell: bash
+        env:
+          RUN_URL: ${{ steps.run.outputs.run_url }}
+        run: |
+          set -euo pipefail
+          gh issue comment "${ISSUE_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --body "Deform360 reset-mechanics source-only diagnostic dispatched from reviewed main \`${MAIN_SHA}\`: ${RUN_URL}
+
+          Target outcomes used: \`false\`. Registered physical dataset modified: \`false\`. Physical evidence increment: \`0\`."

--- a/tests/test_deform360_reset_mechanics_issue_dispatch_policy.py
+++ b/tests/test_deform360_reset_mechanics_issue_dispatch_policy.py
@@ -5,10 +5,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = (
-    ROOT
-    / ".github"
-    / "workflows"
-    / "deform360-reset-mechanics-issue-dispatch.yml"
+    ROOT / ".github" / "workflows" / "deform360-reset-mechanics-issue-dispatch.yml"
 )
 
 
@@ -47,8 +44,8 @@ def test_dispatcher_is_hosted_and_dispatches_fixed_reviewed_main() -> None:
     assert "gh workflow run deform360-reset-mechanics.yml" in text
     assert "--ref main" in text
     assert "-f run_source_diagnostic=true" in text
-    assert "test \"${identity[0]}\" = \"workflow_dispatch\"" in text
-    assert "test \"${identity[1]}\" = \"${MAIN_SHA}\"" in text
+    assert 'test "${identity[0]}" = "workflow_dispatch"' in text
+    assert 'test "${identity[1]}" = "${MAIN_SHA}"' in text
 
 
 def test_dispatcher_retains_a_nonphysical_receipt() -> None:

--- a/tests/test_deform360_reset_mechanics_issue_dispatch_policy.py
+++ b/tests/test_deform360_reset_mechanics_issue_dispatch_policy.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = (
+    ROOT
+    / ".github"
+    / "workflows"
+    / "deform360-reset-mechanics-issue-dispatch.yml"
+)
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_dispatcher_uses_only_the_exact_maintainer_issue() -> None:
+    text = _workflow_text()
+
+    assert "on:\n  issues:\n    types: [opened]\n" in text
+    assert "github.event_name == 'issues'" in text
+    assert "github.event.action == 'opened'" in text
+    assert "github.ref == 'refs/heads/main'" in text
+    assert "github.event.issue.user.login == 'FlorianPfaff'" in text
+    assert "github.event.issue.user.id == 6773539" in text
+    assert "'[self-hosted] run Causal4D Deform360 reset mechanics'" in text
+    assert text.count("github.event.issue.title") == 1
+    assert "github.event.issue.body" not in text
+    assert "github.event.issue.labels" not in text
+    assert "github.event.comment" not in text
+
+
+def test_dispatcher_is_hosted_and_dispatches_fixed_reviewed_main() -> None:
+    text = _workflow_text()
+
+    assert "runs-on: ubuntu-latest" in text
+    assert "runs-on: [self-hosted" not in text
+    assert "actions: write" in text
+    assert "contents: read" in text
+    assert "issues: write" in text
+    assert "GH_TOKEN: ${{ github.token }}" in text
+    assert "${{ secrets." not in text
+    assert "commits/main" in text
+    assert 'test "${main_sha}" = "${GITHUB_SHA}"' in text
+    assert "gh workflow run deform360-reset-mechanics.yml" in text
+    assert "--ref main" in text
+    assert "-f run_source_diagnostic=true" in text
+    assert "test \"${identity[0]}\" = \"workflow_dispatch\"" in text
+    assert "test \"${identity[1]}\" = \"${MAIN_SHA}\"" in text
+
+
+def test_dispatcher_retains_a_nonphysical_receipt() -> None:
+    text = _workflow_text()
+
+    assert "Causal4DDeform360ResetMechanicsDispatch" in text
+    assert '"target_outcomes_used": False' in text
+    assert '"registered_physical_dataset_modified": False' in text
+    assert '"physical_evidence_increment": 0' in text
+    assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in text
+    assert "causal4d-deform360-reset-mechanics-dispatch" in text

--- a/tests/test_deform360_reset_mechanics_workflow_policy.py
+++ b/tests/test_deform360_reset_mechanics_workflow_policy.py
@@ -12,7 +12,9 @@ def test_reset_mechanics_workflow_is_read_only_and_source_scoped() -> None:
     assert "permissions:\n  contents: read" in text
     assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
     assert "github.ref == 'refs/heads/main'" in text
-    assert "github.event.pull_request.head.repo.full_name == github.repository" not in text
+    assert (
+        "github.event.pull_request.head.repo.full_name == github.repository" not in text
+    )
     assert "workflow_dispatch:" in text
     assert "run_source_diagnostic:" in text
     assert "Check out pinned public BayesianPhysTwin" in text


### PR DESCRIPTION
## What changed

- apply Ruff's canonical formatting to the pre-existing reset-mechanics workflow-policy test that blocked run `31464665817` before any source diagnostic executed;
- add a hosted exact-maintainer issue dispatcher for only the reviewed-main Deform360 reset-mechanics workflow;
- bind the downstream workflow-dispatch run to the exact current `main` SHA and fixed `run_source_diagnostic=true` input;
- reject issue body, labels, comments, branch code, secrets, or caller-selected paths as execution inputs;
- retain a dispatch receipt and exact downstream run URL; and
- add policy tests for the issue identity, hosted trust boundary, fixed workflow input, exact-main verification, and nonphysical claim boundary.

## Why

The controlled campaign correctly stopped at the hosted surface check because `tests/test_deform360_reset_mechanics_workflow_policy.py` was not in Ruff's canonical layout. The scientific implementation and source-only evaluation were never reached. After fixing that source defect, a targeted dispatcher is preferable to rerunning or cancelling the other five ongoing workflows.

## Safety boundary

- The dispatcher runs only on GitHub-hosted infrastructure.
- The self-hosted workflow remains the existing reviewed-main workflow.
- No issue text becomes a command or path.
- No target outcomes or registered physical-acquisition data are used.
- Physical evidence increment remains zero.
- The change does not alter the reset-mechanics estimator, lock, dataset, metric, thresholds, or scientific decision.

## Validation

Repository CI and the merge gate are authoritative for Ruff, formatting, the full test suite, workflow policy, packaging, compatibility, security, and installed BayesianPhysTwin integration. After merge, the exact issue trigger will dispatch only the corrected reset-mechanics source diagnostic.