### PR TITLE
Use a shallow exact-SHA checkout in the merge gate

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Check out pull-request merge result
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          ref: ${{ github.sha }}
+          fetch-depth: 1
           persist-credentials: false
 
       - name: Record tested merge and head revisions

--- a/tests/test_merge_gate_workflow_policy.py
+++ b/tests/test_merge_gate_workflow_policy.py
@@ -28,7 +28,10 @@ def test_merge_gate_validates_the_pull_request_merge_result() -> None:
     record_index = text.index("- name: Record tested merge and head revisions")
     checkout_block = text[checkout_index:record_index]
 
-    assert "ref:" not in checkout_block
+    assert "ref: ${{ github.sha }}" in checkout_block
+    assert "fetch-depth: 1" in checkout_block
+    assert "fetch-depth: 0" not in checkout_block
+    assert "persist-credentials: false" in checkout_block
     assert "EXPECTED_MERGE_SHA: ${{ github.sha }}" in text
     assert "PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}" in text
     assert 'actual_merge_sha="$(git rev-parse HEAD)"' in text


### PR DESCRIPTION
## What changed

- pin the first merge-gate checkout explicitly to `${{ github.sha }}`;
- reduce its history depth from the complete repository history to one commit;
- preserve credential isolation and the existing exact checked-out-SHA assertion; and
- update the workflow policy test so future changes cannot silently restore a full-history checkout or remove the exact-ref binding.

## Why

The merge gate does not use commit history: it validates the event merge revision, runs quality checks and the complete test suite, builds distributions, and executes the pinned BayesianPhysTwin integration. Fetching every historical branch and tag adds network, storage, and branch-inventory overhead without strengthening those checks.

## Validation

The authoritative PR workflows exercise the modified merge gate itself. The focused policy test also verifies the exact ref, depth-one checkout, disabled persisted credentials, and unchanged revision equality check.

## Scientific boundary

CI efficiency and workflow policy only. This changes no estimator, provider contract, protocol, source/target split, physical data, evidence count, artifact identity, or claim.