### PR TITLE
Format the Deform360 reset workflow policy test

### DIFF
--- a/tests/test_deform360_reset_mechanics_workflow_policy.py
+++ b/tests/test_deform360_reset_mechanics_workflow_policy.py
@@ -12,7 +12,9 @@ def test_reset_mechanics_workflow_is_read_only_and_source_scoped() -> None:
     assert "permissions:\n  contents: read" in text
     assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
     assert "github.ref == 'refs/heads/main'" in text
-    assert "github.event.pull_request.head.repo.full_name == github.repository" not in text
+    assert (
+        "github.event.pull_request.head.repo.full_name == github.repository" not in text
+    )
     assert "workflow_dispatch:" in text
     assert "run_source_diagnostic:" in text
     assert "Check out pinned public BayesianPhysTwin" in text


### PR DESCRIPTION
## Summary

Apply the canonical Ruff layout to one long negative-membership assertion in `tests/test_deform360_reset_mechanics_workflow_policy.py`.

This fixes the hosted preflight failure in controlled/source-only run `31465049874`; that run stopped before the self-hosted diagnostic and did not access or modify data.

## Scientific and evidence declarations

- Scientific behavior changed: **no**.
- Target outcomes accessed or used: **no**.
- Registered physical dataset modified: **no**.
- Statistical units, endpoint, estimator, thresholds, fallback, and artifact identities changed: **no**.
- Physical evidence increment: **0**.
- Provenance: exact failure was `ruff format --check` on reviewed-main run `31465049874`, job `93696126911`.

## Validation

The patch is exactly the formatter-proposed layout. PR CI runs Ruff, the complete default suite, distribution builds, compatibility, security, and pinned BayesianPhysTwin integration on the merge result.

## Merge disposition

Merge after the exact-head required checks pass, then rerun the locked Deform360 reset-mechanics workflow from reviewed `main`.