### PR TITLE
Add grouped covariance-normalized likelihood v3

### DIFF
--- a/docs/grouped_normalized_likelihood_v3.md
+++ b/docs/grouped_normalized_likelihood_v3.md
@@ -11,7 +11,8 @@ unchanged for frozen and historical analyses.
 cases where the number and dimension of admitted groups vary across providers or
 prefixes. It does not change the registered 18-session/36-execution physical
 estimator, authorize confirmatory collection, or establish calibration or
-physical benefit.
+physical benefit. The score is never selected implicitly from evidence shape,
+covariance representation, or provider identity.
 
 ## Score
 

--- a/docs/grouped_normalized_likelihood_v3.md
+++ b/docs/grouped_normalized_likelihood_v3.md
@@ -1,0 +1,126 @@
+# Grouped normalized likelihood v3
+
+## Purpose and status
+
+The robust grouped likelihood preserves full observation covariance, fixed prior
+outlier reliability, component-specific discrepancy covariance, and
+contributor-aware duplicate caps. Its original `legacy_sum_v1` score is retained
+unchanged for frozen and historical analyses.
+
+`normalized_coordinate_mean_v3` is an **opt-in development comparator** for
+cases where the number and dimension of admitted groups vary across providers or
+prefixes. It does not change the registered 18-session/36-execution physical
+estimator, authorize confirmatory collection, or establish calibration or
+physical benefit.
+
+## Score
+
+For group `g`, let:
+
+- `ell_g(theta)` be the existing full-covariance robust multivariate Student-t
+  mixture log density;
+- `c_g` be the source-declared `composite_weight`;
+- `m_g` be the largest multiplicity of any contributor named by the group;
+- `a_g = 1 / m_g` be the duplicate-evidence power cap; and
+- `d_g` be the number of jointly scored coordinates.
+
+The normalized score is
+
+```text
+L_v3(theta) = beta * sum_g a_g c_g ell_g(theta)
+                     / sum_g a_g d_g,
+```
+
+where `beta` is the explicit `likelihood_power`.
+
+The denominator uses contributor caps but not `composite_weight`. Consequently:
+
+- exact duplicated evidence carrying the same contributor identity cannot
+  sharpen or weaken the posterior;
+- source reliability temperatures remain multiplicative and do not cancel;
+- raw coordinate count does not silently determine posterior concentration; and
+- the declared likelihood power is applied explicitly on the grouped path.
+
+Group boundaries still define shared robust-mixture states. Repartitioning one
+multivariate Student-t group into several groups therefore changes the declared
+outlier model unless those groups are explicitly intended as independent
+reliability units. The implementation does not claim arbitrary split-group
+invariance.
+
+## Covariance handling
+
+Each group continues to use its complete positive-definite covariance. Optional
+component uncertainty can be supplied as diagonal variance, dense covariance, a
+low-rank factor, or nonoverlapping combinations of those representations. Dense
+and low-rank forms are required to agree numerically.
+
+Normalized v3 additionally fails closed when a source covariance condition
+number exceeds the preregistered limit. The default limit is `1e12`; a study may
+choose a stricter value before target access. No hidden jitter, clipping, or
+pseudoinverse is introduced.
+
+## Diagnostics
+
+`GroupLikelihoodDiagnostics` records:
+
+- score semantics and applied likelihood power;
+- contributor power caps and effective group weights;
+- coordinate counts and normalization coordinate mass;
+- source covariance condition numbers;
+- effective information fractions; and
+- nominal/outlier responsibilities plus dense/low-rank covariance usage.
+
+Legacy artifact metadata remains unchanged. The additional fields are emitted
+only when normalized v3 is selected.
+
+## API
+
+```python
+posterior, diagnostics = posterior_weights_from_grouped_evidence(
+    prior_weights,
+    predicted_components_m,
+    evidence,
+    prefix_frame_count=prefix_frame_count,
+    component_group_covariance_factor_m=structured_covariance,
+    score_semantics="normalized_coordinate_mean_v3",
+    likelihood_power=12.0,
+    max_source_covariance_condition_number=1.0e10,
+)
+```
+
+For factual intervention abduction:
+
+```python
+config = FactualAbductionConfig(
+    grouped_likelihood_semantics="normalized_v3",
+    likelihood_power=12.0,
+    grouped_covariance_condition_number_limit=1.0e10,
+)
+```
+
+The command-line development path is:
+
+```bash
+causal4d experiment phystwin abduct-intervention \
+  bank.npz belief.npz final_data.pkl factual.npz evaluation.json \
+  --grouped-observation-likelihood \
+  --grouped-likelihood-semantics normalized_v3 \
+  --grouped-covariance-condition-number-limit 1e10
+```
+
+## Tested invariants
+
+The test suite verifies:
+
+- exact duplicate-contributor power capping;
+- preservation of source `composite_weight` as a reliability temperature;
+- coordinate-permutation and group-order invariance;
+- dense versus low-rank covariance equivalence;
+- normalized information accounting;
+- fail-closed handling of ill-conditioned covariance and invalid settings;
+- exact preservation of legacy factual artifact identity; and
+- explicit separation from dense `normalized_v2`.
+
+These are numerical and provenance guarantees, not empirical evidence that v3
+improves prediction, coverage, transfer, or causal identification. Any promotion
+requires a separately frozen source-only comparison and held-out evaluation.

--- a/docs/structured_grouped_likelihood.md
+++ b/docs/structured_grouped_likelihood.md
@@ -90,3 +90,13 @@ They also verify broadcasting, fail-closed factor validation, diagnostics, and
 that the structured path does not call dense determinant evaluation. These are
 numerical and engineering guarantees, not new empirical accuracy or calibration
 evidence.
+
+## Coordinate-normalized development score
+
+The structured covariance representation is also supported by the opt-in
+[`normalized_coordinate_mean_v3`](grouped_normalized_likelihood_v3.md) grouped
+score. That score preserves the dense/low-rank equivalence described here while
+adding contributor-capped coordinate normalization, an explicit likelihood
+power, conditioning diagnostics, and a fail-closed source-covariance threshold.
+`legacy_sum_v1` remains the default and the registered physical estimator is
+unchanged.

--- a/docs/structured_grouped_likelihood.md
+++ b/docs/structured_grouped_likelihood.md
@@ -98,5 +98,6 @@ The structured covariance representation is also supported by the opt-in
 score. That score preserves the dense/low-rank equivalence described here while
 adding contributor-capped coordinate normalization, an explicit likelihood
 power, conditioning diagnostics, and a fail-closed source-covariance threshold.
-`legacy_sum_v1` remains the default and the registered physical estimator is
-unchanged.
+Supplying dense or low-rank structured covariance alone never selects v3; callers
+must choose its score semantics explicitly. `legacy_sum_v1` remains the default
+and the registered physical estimator is unchanged.

--- a/src/causal4d/__init__.py
+++ b/src/causal4d/__init__.py
@@ -113,6 +113,12 @@ from causal4d.discrepancy_belief import (
     write_graph_discrepancy_belief,
 )
 from causal4d.evaluation import run_counterfactual_benchmark
+from causal4d.factual_abduction_uncertainty import (
+    FACTUAL_ABDUCTION_UNCERTAINTY_SCHEMA_VERSION,
+    FactualAbductionUncertaintyV1,
+    load_factual_abduction_uncertainty_npz,
+    save_factual_abduction_uncertainty_npz,
+)
 from causal4d.finite_query_ambiguity import (
     FiniteQueryAmbiguityConfig,
     FiniteQueryAmbiguityResult,
@@ -139,6 +145,16 @@ from causal4d.identifiability import (
     assess_intervention_identifiability,
     finite_response_sensitivity,
     project_identifiable_intervention_update,
+)
+from causal4d.interventional_contrast import (
+    INTERVENTIONAL_CONTRAST_SCHEMA_VERSION,
+    ContrastConditionalVariancePolicy,
+    ContrastCouplingPolicy,
+    InterventionalContrastPosteriorV1,
+    InterventionalContrastQueryV1,
+    build_interventional_contrast,
+    load_interventional_contrast,
+    save_interventional_contrast,
 )
 from causal4d.joint_observation import (
     JOINT_OBSERVATION_SCHEMA_VERSION,
@@ -288,9 +304,13 @@ __all__ = [
     "BAYESIAN_PHYSTWIN_PROVIDER_CAPABILITIES",
     "CausalSufficiencyResult",
     "ContactWrenchEvidence",
+    "ContrastConditionalVariancePolicy",
+    "ContrastCouplingPolicy",
     "CounterfactualBenchmarkConfig",
     "CounterfactualQuery",
     "CovarianceRepresentation",
+    "FACTUAL_ABDUCTION_UNCERTAINTY_SCHEMA_VERSION",
+    "FactualAbductionUncertaintyV1",
     "FactualIntervention",
     "FiniteQueryAmbiguityConfig",
     "FiniteQueryAmbiguityResult",
@@ -301,6 +321,9 @@ __all__ = [
     "GroupedScoreSemantics",
     "HierarchicalAbductionResult",
     "INDEPENDENT_SENSOR_SCHEMA_VERSION",
+    "INTERVENTIONAL_CONTRAST_SCHEMA_VERSION",
+    "InterventionalContrastPosteriorV1",
+    "InterventionalContrastQueryV1",
     "IdentifiabilityConfig",
     "IndependentSensorAbductionConfig",
     "InterventionIdentifiabilityResult",
@@ -342,6 +365,7 @@ __all__ = [
     "bind_twin_belief_observation_factor_lineage",
     "block_diagonalize_covariance",
     "build_action_conditioned_features",
+    "build_interventional_contrast",
     "build_protocol",
     "evaluate_action_support",
     "finite_response_sensitivity",
@@ -359,8 +383,10 @@ __all__ = [
     "load_bayesian_phystwin_provider_manifest",
     "load_claim_bearing_action_support_calibration",
     "load_claim_bearing_prob4d_observation_lineage",
+    "load_factual_abduction_uncertainty_npz",
     "load_graph_discrepancy_belief",
     "load_independent_sensor_evidence",
+    "load_interventional_contrast",
     "load_observation_factor_lineage",
     "posterior_weights_from_grouped_evidence",
     "posterior_weights_from_joint_observation",
@@ -373,7 +399,9 @@ __all__ = [
     "reweight_factual_intervention_with_independent_sensors",
     "run_counterfactual_benchmark",
     "run_latent_contact_benchmark",
+    "save_factual_abduction_uncertainty_npz",
     "save_independent_sensor_evidence",
+    "save_interventional_contrast",
     "select_action_supported_candidate",
     "update_joint_weights_from_prefix",
     "validate_bayesian_phystwin_provider",

--- a/src/causal4d/__init__.py
+++ b/src/causal4d/__init__.py
@@ -125,6 +125,7 @@ from causal4d.graph_mode_abduction import (
 )
 from causal4d.grouped_likelihood import (
     GroupLikelihoodDiagnostics,
+    GroupedScoreSemantics,
     grouped_component_log_likelihoods,
     posterior_weights_from_grouped_evidence,
 )
@@ -297,6 +298,7 @@ __all__ = [
     "GraphModeAbductionConfig",
     "GroupLikelihoodDiagnostics",
     "GroupedObservationEvidence",
+    "GroupedScoreSemantics",
     "HierarchicalAbductionResult",
     "INDEPENDENT_SENSOR_SCHEMA_VERSION",
     "IdentifiabilityConfig",

--- a/src/causal4d/cli/abduct_phystwin_intervention.py
+++ b/src/causal4d/cli/abduct_phystwin_intervention.py
@@ -84,6 +84,24 @@ def build_parser() -> argparse.ArgumentParser:
             "frame instead of the legacy dense generalized likelihood."
         ),
     )
+    parser.add_argument(
+        "--grouped-likelihood-semantics",
+        choices=("legacy_v1", "normalized_v3"),
+        default="legacy_v1",
+        help=(
+            "Grouped full-covariance score. normalized_v3 is an opt-in, "
+            "contributor-capped coordinate-normalized development comparator."
+        ),
+    )
+    parser.add_argument(
+        "--grouped-covariance-condition-number-limit",
+        type=float,
+        default=1.0e12,
+        help=(
+            "Fail-closed source-covariance condition-number limit used by "
+            "grouped normalized_v3."
+        ),
+    )
     parser.add_argument("--prior-nominal-probability", type=float, default=0.95)
     parser.add_argument("--outlier-scale-multiplier", type=float, default=100.0)
     parser.add_argument(
@@ -142,6 +160,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         raise ValueError("--o-plus-prefix-frames must be positive")
     if args.abstain_when_unidentifiable and args.identifiability_npz is None:
         raise ValueError("--abstain-when-unidentifiable requires --identifiability-npz")
+    if (
+        args.grouped_likelihood_semantics != "legacy_v1"
+        and not args.grouped_observation_likelihood
+    ):
+        raise ValueError(
+            "--grouped-likelihood-semantics normalized_v3 requires "
+            "--grouped-observation-likelihood"
+        )
     bank, manifest = load_rollout_bank(args.rollout_bank_npz)
     artifact = load_contract(args.twin_belief_npz)
     if not isinstance(artifact, TwinBelief):
@@ -163,6 +189,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         degrees_of_freedom=args.degrees_of_freedom,
         likelihood_semantics=args.likelihood_semantics,
         difference_correlation=args.difference_correlation,
+        grouped_likelihood_semantics=args.grouped_likelihood_semantics,
+        grouped_covariance_condition_number_limit=(
+            args.grouped_covariance_condition_number_limit
+        ),
     )
     grouped_evidence = None
     if args.grouped_observation_likelihood:

--- a/src/causal4d/grouped_likelihood.py
+++ b/src/causal4d/grouped_likelihood.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from math import lgamma
-from typing import Mapping
+from typing import Literal, Mapping
 
 import numpy as np
 
@@ -16,6 +16,12 @@ from causal4d.observation_evidence import (
 from causal4d.weighting import log_weights_from_probabilities
 
 
+GroupedScoreSemantics = Literal[
+    "legacy_sum_v1",
+    "normalized_coordinate_mean_v3",
+]
+
+
 @dataclass(frozen=True)
 class GroupLikelihoodDiagnostics:
     """Nominal responsibilities and effective powers for one grouped update."""
@@ -25,6 +31,13 @@ class GroupLikelihoodDiagnostics:
     nominal_responsibilities: np.ndarray
     full_covariance_group_ids: tuple[str, ...] = ()
     low_rank_covariance_group_ids: tuple[str, ...] = ()
+    score_semantics: GroupedScoreSemantics = "legacy_sum_v1"
+    likelihood_power: float = 1.0
+    contributor_power_caps: tuple[float, ...] = ()
+    group_coordinate_counts: tuple[int, ...] = ()
+    normalization_coordinate_mass: float | None = None
+    source_covariance_condition_numbers: tuple[float, ...] = ()
+    normalization_coordinate_fractions: tuple[float, ...] = ()
 
 
 def _student_t_log_density_from_terms(
@@ -324,6 +337,9 @@ def grouped_component_log_likelihoods(
     component_variance_m2: np.ndarray | None = None,
     component_group_covariance_m2: Mapping[str, np.ndarray] | None = None,
     component_group_covariance_factor_m: Mapping[str, np.ndarray] | None = None,
+    score_semantics: GroupedScoreSemantics = "legacy_sum_v1",
+    likelihood_power: float = 1.0,
+    max_source_covariance_condition_number: float = 1.0e12,
 ) -> tuple[np.ndarray, GroupLikelihoodDiagnostics]:
     """Score arbitrary leading component dimensions against grouped O-plus evidence.
 
@@ -332,7 +348,28 @@ def grouped_component_log_likelihoods(
     meters. Each factor must broadcast to
     ``component_shape + (group_coordinate, rank)`` and contributes
     ``factor @ factor.T`` without dense materialization.
+
+    ``legacy_sum_v1`` preserves the original robust composite likelihood. The
+    experimental ``normalized_coordinate_mean_v3`` divides the contributor-capped
+    score by contributor-capped coordinate mass and then applies the explicit
+    likelihood power. Source ``composite_weight`` values remain multiplicative
+    reliability temperatures and therefore do not cancel in the normalization.
     """
+
+    if score_semantics not in {
+        "legacy_sum_v1",
+        "normalized_coordinate_mean_v3",
+    }:
+        raise ValueError("unsupported grouped score semantics")
+    if not np.isfinite(likelihood_power) or likelihood_power <= 0.0:
+        raise ValueError("likelihood_power must be finite and positive")
+    if (
+        not np.isfinite(max_source_covariance_condition_number)
+        or max_source_covariance_condition_number < 1.0
+    ):
+        raise ValueError(
+            "max_source_covariance_condition_number must be finite and at least one"
+        )
 
     components = np.asarray(predicted_components_m, dtype=float)
     if components.ndim < 4:
@@ -368,10 +405,22 @@ def grouped_component_log_likelihoods(
         )
     total = np.zeros(leading_shape, dtype=float)
     responsibilities = []
+    contributor_caps = evidence.contributor_power_caps
     effective_weights = evidence.effective_group_weights
+    coordinate_counts = tuple(group.coordinate_count for group in evidence.groups)
+    condition_numbers = []
     full_covariance_groups = []
     low_rank_covariance_groups = []
     for group, weight in zip(evidence.groups, effective_weights, strict=True):
+        if score_semantics == "normalized_coordinate_mean_v3":
+            eigenvalues = np.linalg.eigvalsh(group.covariance_m2)
+            condition_number = float(eigenvalues[-1] / eigenvalues[0])
+            condition_numbers.append(condition_number)
+            if condition_number > max_source_covariance_condition_number:
+                raise ValueError(
+                    f"group {group.group_id!r} source covariance condition number "
+                    "exceeds the normalized-v3 limit"
+                )
         selected = group.selected_predictions(components)
         selected_variance = (
             None if variance is None else group.selected_predictions(variance)
@@ -391,12 +440,47 @@ def grouped_component_log_likelihoods(
         )
         total += weight * log_likelihood
         responsibilities.append(responsibility)
+
+    normalization_mass: float | None = None
+    normalization_fractions: tuple[float, ...] = ()
+    if score_semantics == "normalized_coordinate_mean_v3":
+        normalization_mass = float(
+            sum(
+                cap * coordinate_count
+                for cap, coordinate_count in zip(
+                    contributor_caps,
+                    coordinate_counts,
+                    strict=True,
+                )
+            )
+        )
+        if not np.isfinite(normalization_mass) or normalization_mass <= 0.0:
+            raise RuntimeError("normalized grouped coordinate mass is invalid")
+        total = likelihood_power * total / normalization_mass
+        normalization_fractions = tuple(
+            cap * coordinate_count / normalization_mass
+            for cap, coordinate_count in zip(
+                contributor_caps,
+                coordinate_counts,
+                strict=True,
+            )
+        )
+    else:
+        total = likelihood_power * total
+
     diagnostics = GroupLikelihoodDiagnostics(
         group_ids=tuple(group.group_id for group in evidence.groups),
         effective_group_weights=effective_weights,
         nominal_responsibilities=np.stack(responsibilities, axis=-1),
         full_covariance_group_ids=tuple(full_covariance_groups),
         low_rank_covariance_group_ids=tuple(low_rank_covariance_groups),
+        score_semantics=score_semantics,
+        likelihood_power=float(likelihood_power),
+        contributor_power_caps=contributor_caps,
+        group_coordinate_counts=coordinate_counts,
+        normalization_coordinate_mass=normalization_mass,
+        source_covariance_condition_numbers=tuple(condition_numbers),
+        normalization_coordinate_fractions=normalization_fractions,
     )
     return total, diagnostics
 
@@ -410,6 +494,9 @@ def posterior_weights_from_grouped_evidence(
     component_variance_m2: np.ndarray | None = None,
     component_group_covariance_m2: Mapping[str, np.ndarray] | None = None,
     component_group_covariance_factor_m: Mapping[str, np.ndarray] | None = None,
+    score_semantics: GroupedScoreSemantics = "legacy_sum_v1",
+    likelihood_power: float = 1.0,
+    max_source_covariance_condition_number: float = 1.0e12,
 ) -> tuple[np.ndarray, GroupLikelihoodDiagnostics]:
     """Apply grouped evidence to finite component support in log space."""
 
@@ -425,6 +512,11 @@ def posterior_weights_from_grouped_evidence(
         component_variance_m2=component_variance_m2,
         component_group_covariance_m2=component_group_covariance_m2,
         component_group_covariance_factor_m=(component_group_covariance_factor_m),
+        score_semantics=score_semantics,
+        likelihood_power=likelihood_power,
+        max_source_covariance_condition_number=(
+            max_source_covariance_condition_number
+        ),
     )
     log_posterior = log_weights_from_probabilities(prior, name="prior_weights") + score
     maximum = float(np.max(log_posterior))

--- a/src/causal4d/intervention_abduction.py
+++ b/src/causal4d/intervention_abduction.py
@@ -22,6 +22,7 @@ from causal4d.rollout_bank import JointRolloutBank
 
 
 DenseLikelihoodSemantics = Literal["legacy_v1", "normalized_v2"]
+GroupedLikelihoodSemantics = Literal["legacy_v1", "normalized_v3"]
 
 
 @dataclass(frozen=True)
@@ -30,7 +31,10 @@ class FactualAbductionConfig:
 
     ``legacy_v1`` preserves the registered dense score exactly. ``normalized_v2``
     is an opt-in development path that uses the endpoint-inclusive, scale-normalized
-    prefix likelihood. The legacy defaults remain unchanged.
+    prefix likelihood. ``grouped_likelihood_semantics`` independently controls the
+    full-covariance grouped path; ``normalized_v3`` is a contributor-capped,
+    coordinate-normalized development comparator. All legacy defaults remain
+    unchanged.
     """
 
     observation_scale_m: float = 0.01
@@ -39,6 +43,8 @@ class FactualAbductionConfig:
     degrees_of_freedom: float = 4.0
     likelihood_semantics: DenseLikelihoodSemantics = "legacy_v1"
     difference_correlation: float = 0.0
+    grouped_likelihood_semantics: GroupedLikelihoodSemantics = "legacy_v1"
+    grouped_covariance_condition_number_limit: float = 1.0e12
 
     def __post_init__(self) -> None:
         positive = (
@@ -58,6 +64,16 @@ class FactualAbductionConfig:
             raise ValueError("dynamic_likelihood_weight must be finite and nonnegative")
         if self.likelihood_semantics not in {"legacy_v1", "normalized_v2"}:
             raise ValueError("unsupported dense likelihood semantics")
+        if self.grouped_likelihood_semantics not in {"legacy_v1", "normalized_v3"}:
+            raise ValueError("unsupported grouped likelihood semantics")
+        if (
+            not np.isfinite(self.grouped_covariance_condition_number_limit)
+            or self.grouped_covariance_condition_number_limit < 1.0
+        ):
+            raise ValueError(
+                "grouped covariance condition-number limit must be finite and at "
+                "least one"
+            )
         if not np.isfinite(self.difference_correlation) or not (
             -1.0 < self.difference_correlation < 1.0
         ):
@@ -82,6 +98,13 @@ class FactualAbductionConfig:
         if self.likelihood_semantics != "legacy_v1":
             result["likelihood_semantics"] = self.likelihood_semantics
             result["difference_correlation"] = self.difference_correlation
+        if self.grouped_likelihood_semantics != "legacy_v1":
+            result["grouped_likelihood_semantics"] = (
+                self.grouped_likelihood_semantics
+            )
+            result["grouped_covariance_condition_number_limit"] = (
+                self.grouped_covariance_condition_number_limit
+            )
         return result
 
 
@@ -125,7 +148,7 @@ def _grouped_diagnostics_summary(
 ) -> dict[str, Any]:
     responsibilities = np.asarray(diagnostics.nominal_responsibilities, dtype=float)
     reduction_axes = tuple(range(responsibilities.ndim - 1))
-    return {
+    result: dict[str, Any] = {
         "group_ids": list(diagnostics.group_ids),
         "effective_group_weights": list(diagnostics.effective_group_weights),
         "mean_nominal_responsibility_by_group": np.mean(
@@ -135,6 +158,29 @@ def _grouped_diagnostics_summary(
             responsibilities, axis=reduction_axes
         ).tolist(),
     }
+    if diagnostics.score_semantics != "legacy_sum_v1":
+        result.update(
+            {
+                "score_semantics": diagnostics.score_semantics,
+                "likelihood_power": diagnostics.likelihood_power,
+                "contributor_power_caps": list(
+                    diagnostics.contributor_power_caps
+                ),
+                "group_coordinate_counts": list(
+                    diagnostics.group_coordinate_counts
+                ),
+                "normalization_coordinate_mass": (
+                    diagnostics.normalization_coordinate_mass
+                ),
+                "source_covariance_condition_numbers": list(
+                    diagnostics.source_covariance_condition_numbers
+                ),
+                "normalization_coordinate_fractions": list(
+                    diagnostics.normalization_coordinate_fractions
+                ),
+            }
+        )
+    return result
 
 
 def _update_joint_weights(
@@ -152,6 +198,11 @@ def _update_joint_weights(
         raise ValueError(
             "normalized_v2 cannot be combined with grouped observation evidence"
         )
+    if (
+        grouped_evidence is None
+        and settings.grouped_likelihood_semantics != "legacy_v1"
+    ):
+        raise ValueError("normalized_v3 requires grouped observation evidence")
     discrepancy, discrepancy_variance = _belief_readout(bank, belief)
     if grouped_evidence is None:
         if settings.likelihood_semantics == "legacy_v1":
@@ -191,12 +242,22 @@ def _update_joint_weights(
         discrepancy_variance[None, :, None], components.shape
     )
     prior = bank.prior_joint_weights if base_weights is None else base_weights
+    normalized_grouped = settings.grouped_likelihood_semantics == "normalized_v3"
     return posterior_weights_from_grouped_evidence(
         prior,
         components,
         grouped_evidence,
         prefix_frame_count=prefix_frame_count,
         component_variance_m2=component_variance,
+        score_semantics=(
+            "normalized_coordinate_mean_v3"
+            if normalized_grouped
+            else "legacy_sum_v1"
+        ),
+        likelihood_power=settings.likelihood_power if normalized_grouped else 1.0,
+        max_source_covariance_condition_number=(
+            settings.grouped_covariance_condition_number_limit
+        ),
     )
 
 
@@ -467,7 +528,11 @@ def evaluate_factual_abduction(
         "abduction_prefix_frame_count_including_endpoint": prefix_frame_count,
         "held_out_rollout_interval": [prefix_frame_count, bank.frame_count],
         "evidence_model": (
-            "grouped_robust_composite"
+            (
+                "grouped_normalized_v3"
+                if settings.grouped_likelihood_semantics == "normalized_v3"
+                else "grouped_robust_composite"
+            )
             if grouped_evidence is not None
             else (
                 "legacy_dense"

--- a/src/causal4d/observation_evidence.py
+++ b/src/causal4d/observation_evidence.py
@@ -250,12 +250,31 @@ class GroupedObservationEvidence:
         return result
 
     @property
-    def effective_group_weights(self) -> tuple[float, ...]:
+    def contributor_power_caps(self) -> tuple[float, ...]:
+        """Return duplicate-evidence caps before source reliability weighting.
+
+        The cap is one over the largest contributor multiplicity in each group.
+        Keeping it separate from ``composite_weight`` lets normalized composite
+        scores preserve both duplicate invariance and source-calibrated
+        reliability temperatures.
+        """
+
         multiplicity = self.contributor_multiplicity
         return tuple(
-            group.composite_weight
+            1.0
             / max(multiplicity[contributor] for contributor in group.contributor_ids)
             for group in self.groups
+        )
+
+    @property
+    def effective_group_weights(self) -> tuple[float, ...]:
+        return tuple(
+            group.composite_weight * cap
+            for group, cap in zip(
+                self.groups,
+                self.contributor_power_caps,
+                strict=True,
+            )
         )
 
     def validate_prefix(

--- a/tests/test_factual_likelihood_semantics.py
+++ b/tests/test_factual_likelihood_semantics.py
@@ -275,6 +275,8 @@ def test_normalized_v2_evaluation_records_effective_model() -> None:
         ("degrees_of_freedom", np.inf),
         ("difference_correlation", np.nan),
         ("difference_correlation", 1.0),
+        ("grouped_covariance_condition_number_limit", np.nan),
+        ("grouped_covariance_condition_number_limit", 0.5),
     ],
 )
 def test_factual_abduction_config_rejects_nonfinite_or_invalid_values(
@@ -283,6 +285,11 @@ def test_factual_abduction_config_rejects_nonfinite_or_invalid_values(
 ) -> None:
     with pytest.raises(ValueError):
         FactualAbductionConfig(**{keyword: value})
+
+
+def test_factual_abduction_config_rejects_unknown_grouped_semantics() -> None:
+    with pytest.raises(ValueError, match="unsupported grouped likelihood semantics"):
+        FactualAbductionConfig(grouped_likelihood_semantics="unknown")
 
 
 def test_difference_correlation_requires_normalized_v2() -> None:
@@ -333,3 +340,90 @@ def test_cli_defaults_to_legacy_and_exposes_normalized_v2() -> None:
     assert default.difference_correlation == 0.0
     assert normalized.likelihood_semantics == "normalized_v2"
     assert normalized.difference_correlation == 0.25
+
+
+def test_grouped_normalized_v3_records_effective_model_and_diagnostics() -> None:
+    bank, belief, observations, mask, _ = _registered_problem()
+    grouped = GroupedObservationEvidence.from_dense_prefix(
+        observations,
+        prefix_frame_count=4,
+        scale_m=0.001,
+        mask=mask,
+        source_id="unit",
+    )
+    config = FactualAbductionConfig(
+        observation_scale_m=0.001,
+        likelihood_power=12.0,
+        grouped_likelihood_semantics="normalized_v3",
+    )
+
+    factual = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=config,
+        grouped_evidence=grouped,
+    )
+    result = evaluate_factual_abduction(
+        bank,
+        belief,
+        factual,
+        observations,
+        observation_mask=mask,
+        prefix_frame_count=4,
+        config=config,
+        grouped_evidence=grouped,
+    )
+
+    assert result["evidence_model"] == "grouped_normalized_v3"
+    assert factual.metadata["abduction_likelihood"] == {
+        "observation_scale_m": 0.001,
+        "likelihood_power": 12.0,
+        "dynamic_likelihood_weight": 0.25,
+        "degrees_of_freedom": 4.0,
+        "grouped_likelihood_semantics": "normalized_v3",
+        "grouped_covariance_condition_number_limit": 1.0e12,
+    }
+    diagnostics = factual.metadata["grouped_observation_evidence"]["diagnostics"]
+    assert diagnostics["score_semantics"] == "normalized_coordinate_mean_v3"
+    assert diagnostics["likelihood_power"] == 12.0
+    assert np.isclose(sum(diagnostics["normalization_coordinate_fractions"]), 1.0)
+
+
+def test_grouped_normalized_v3_requires_grouped_evidence() -> None:
+    bank, belief, observations, mask, _ = _registered_problem()
+
+    with pytest.raises(ValueError, match="requires grouped observation evidence"):
+        abduct_factual_intervention(
+            bank,
+            belief,
+            observations,
+            prefix_frame_count=4,
+            observation_mask=mask,
+            config=FactualAbductionConfig(
+                grouped_likelihood_semantics="normalized_v3"
+            ),
+        )
+
+
+def test_cli_exposes_grouped_normalized_v3_separately() -> None:
+    parsed = build_parser().parse_args(
+        [
+            "bank",
+            "belief",
+            "data",
+            "factual",
+            "evaluation",
+            "--grouped-observation-likelihood",
+            "--grouped-likelihood-semantics",
+            "normalized_v3",
+            "--grouped-covariance-condition-number-limit",
+            "1000000",
+        ]
+    )
+
+    assert parsed.likelihood_semantics == "legacy_v1"
+    assert parsed.grouped_likelihood_semantics == "normalized_v3"
+    assert parsed.grouped_covariance_condition_number_limit == 1.0e6

--- a/tests/test_grouped_normalized_v3.py
+++ b/tests/test_grouped_normalized_v3.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from causal4d.grouped_likelihood import (
+    GroupLikelihoodDiagnostics,
+    grouped_component_log_likelihoods,
+    posterior_weights_from_grouped_evidence,
+)
+from causal4d.observation_evidence import GroupedObservationEvidence, ObservationGroup
+
+
+def _group(
+    group_id: str,
+    *,
+    values: np.ndarray,
+    covariance: np.ndarray,
+    contributor: str,
+    composite_weight: float = 1.0,
+) -> ObservationGroup:
+    dimension = len(values)
+    return ObservationGroup(
+        group_id=group_id,
+        values_m=np.asarray(values, dtype=float),
+        frame_indices=np.ones(dimension, dtype=np.int64),
+        node_indices=np.zeros(dimension, dtype=np.int64),
+        coordinate_indices=np.arange(dimension, dtype=np.int64),
+        covariance_m2=np.asarray(covariance, dtype=float),
+        contributor_ids=(contributor,),
+        prior_nominal_probability=0.93,
+        outlier_scale_multiplier=40.0,
+        degrees_of_freedom=5.0,
+        composite_weight=composite_weight,
+        source_id="unit",
+    )
+
+
+def _posterior(
+    evidence: GroupedObservationEvidence,
+    components: np.ndarray,
+    *,
+    likelihood_power: float = 8.0,
+) -> tuple[np.ndarray, GroupLikelihoodDiagnostics]:
+    return posterior_weights_from_grouped_evidence(
+        np.asarray([0.5, 0.5]),
+        components,
+        evidence,
+        prefix_frame_count=2,
+        score_semantics="normalized_coordinate_mean_v3",
+        likelihood_power=likelihood_power,
+    )
+
+
+def test_normalized_v3_duplicate_contributor_is_exactly_power_capped() -> None:
+    components = np.zeros((2, 3, 1, 1), dtype=float)
+    components[1, 1, 0, 0] = 1.0
+    group = _group(
+        "g1",
+        values=np.asarray([1.0]),
+        covariance=np.asarray([[0.01]]),
+        contributor="same",
+    )
+    duplicate = _group(
+        "g2",
+        values=np.asarray([1.0]),
+        covariance=np.asarray([[0.01]]),
+        contributor="same",
+    )
+
+    single, single_diagnostics = _posterior(
+        GroupedObservationEvidence(groups=(group,)),
+        components,
+    )
+    doubled, doubled_diagnostics = _posterior(
+        GroupedObservationEvidence(groups=(group, duplicate)),
+        components,
+    )
+
+    np.testing.assert_allclose(doubled, single, rtol=1e-13, atol=1e-13)
+    assert single_diagnostics.contributor_power_caps == (1.0,)
+    assert doubled_diagnostics.contributor_power_caps == (0.5, 0.5)
+    assert doubled_diagnostics.normalization_coordinate_mass == 1.0
+
+
+def test_normalized_v3_preserves_composite_weight_as_reliability_temperature() -> None:
+    components = np.zeros((2, 3, 1, 1), dtype=float)
+    components[1, 1, 0, 0] = 1.0
+    full = GroupedObservationEvidence(
+        groups=(
+            _group(
+                "full",
+                values=np.asarray([1.0]),
+                covariance=np.asarray([[0.01]]),
+                contributor="source",
+                composite_weight=1.0,
+            ),
+        )
+    )
+    tempered = GroupedObservationEvidence(
+        groups=(
+            _group(
+                "tempered",
+                values=np.asarray([1.0]),
+                covariance=np.asarray([[0.01]]),
+                contributor="source",
+                composite_weight=0.25,
+            ),
+        )
+    )
+
+    full_posterior, _ = _posterior(full, components)
+    tempered_posterior, _ = _posterior(tempered, components)
+
+    assert full_posterior[1] > tempered_posterior[1] > 0.5
+
+
+def test_normalized_v3_is_invariant_to_coordinate_permutation() -> None:
+    covariance = np.asarray(
+        [
+            [0.040, 0.010, -0.004],
+            [0.010, 0.030, 0.006],
+            [-0.004, 0.006, 0.020],
+        ]
+    )
+    values = np.asarray([0.4, -0.1, 0.2])
+    components = np.zeros((2, 3, 1, 3), dtype=float)
+    components[0, 1, 0] = np.asarray([0.35, -0.05, 0.18])
+    components[1, 1, 0] = np.asarray([-0.2, 0.2, 0.5])
+    group = _group(
+        "original",
+        values=values,
+        covariance=covariance,
+        contributor="source",
+    )
+    original, _ = _posterior(
+        GroupedObservationEvidence(groups=(group,)),
+        components,
+    )
+
+    permutation = np.asarray([2, 0, 1])
+    permuted_group = ObservationGroup(
+        group_id="permuted",
+        values_m=values[permutation],
+        frame_indices=group.frame_indices[permutation],
+        node_indices=group.node_indices[permutation],
+        coordinate_indices=group.coordinate_indices[permutation],
+        covariance_m2=covariance[np.ix_(permutation, permutation)],
+        contributor_ids=("source",),
+        prior_nominal_probability=group.prior_nominal_probability,
+        outlier_scale_multiplier=group.outlier_scale_multiplier,
+        degrees_of_freedom=group.degrees_of_freedom,
+        source_id="unit",
+    )
+    permuted, _ = _posterior(
+        GroupedObservationEvidence(groups=(permuted_group,)),
+        components,
+    )
+
+    np.testing.assert_allclose(permuted, original, rtol=1e-12, atol=1e-12)
+
+
+def test_normalized_v3_is_invariant_to_group_order() -> None:
+    components = np.zeros((2, 3, 1, 2), dtype=float)
+    components[0, 1, 0] = np.asarray([0.3, -0.2])
+    components[1, 1, 0] = np.asarray([-0.1, 0.4])
+    first = ObservationGroup(
+        group_id="first",
+        values_m=np.asarray([0.25]),
+        frame_indices=np.asarray([1]),
+        node_indices=np.asarray([0]),
+        coordinate_indices=np.asarray([0]),
+        covariance_m2=np.asarray([[0.02]]),
+        contributor_ids=("first",),
+        source_id="unit",
+    )
+    second = ObservationGroup(
+        group_id="second",
+        values_m=np.asarray([-0.15]),
+        frame_indices=np.asarray([1]),
+        node_indices=np.asarray([0]),
+        coordinate_indices=np.asarray([1]),
+        covariance_m2=np.asarray([[0.03]]),
+        contributor_ids=("second",),
+        source_id="unit",
+    )
+
+    forward, _ = _posterior(
+        GroupedObservationEvidence(groups=(first, second)),
+        components,
+    )
+    reverse, _ = _posterior(
+        GroupedObservationEvidence(groups=(second, first)),
+        components,
+    )
+
+    np.testing.assert_allclose(reverse, forward, rtol=1e-13, atol=1e-13)
+
+
+def test_normalized_v3_dense_and_low_rank_covariance_updates_agree() -> None:
+    generator = np.random.default_rng(17)
+    group = _group(
+        "structured",
+        values=np.asarray([0.2, -0.1, 0.4]),
+        covariance=np.asarray(
+            [
+                [0.4, 0.05, 0.0],
+                [0.05, 0.3, 0.02],
+                [0.0, 0.02, 0.2],
+            ]
+        ),
+        contributor="structured",
+    )
+    evidence = GroupedObservationEvidence(groups=(group,))
+    components = generator.normal(size=(2, 3, 1, 3))
+    factor = generator.normal(scale=0.1, size=(2, 3, 2))
+    dense = np.einsum("...ir,...jr->...ij", factor, factor)
+
+    dense_posterior, _ = posterior_weights_from_grouped_evidence(
+        np.asarray([0.5, 0.5]),
+        components,
+        evidence,
+        prefix_frame_count=2,
+        component_group_covariance_m2={"structured": dense},
+        score_semantics="normalized_coordinate_mean_v3",
+        likelihood_power=3.0,
+    )
+    low_rank_posterior, diagnostics = posterior_weights_from_grouped_evidence(
+        np.asarray([0.5, 0.5]),
+        components,
+        evidence,
+        prefix_frame_count=2,
+        component_group_covariance_factor_m={"structured": factor},
+        score_semantics="normalized_coordinate_mean_v3",
+        likelihood_power=3.0,
+    )
+
+    np.testing.assert_allclose(
+        low_rank_posterior,
+        dense_posterior,
+        rtol=1e-11,
+        atol=1e-11,
+    )
+    assert diagnostics.low_rank_covariance_group_ids == ("structured",)
+
+
+def test_normalized_v3_reports_information_fractions_and_conditioning() -> None:
+    groups = (
+        _group(
+            "one",
+            values=np.asarray([0.0]),
+            covariance=np.asarray([[0.2]]),
+            contributor="one",
+        ),
+        _group(
+            "two",
+            values=np.asarray([0.0, 0.0]),
+            covariance=np.asarray([[0.2, 0.05], [0.05, 0.1]]),
+            contributor="two",
+        ),
+    )
+    components = np.zeros((2, 3, 1, 2), dtype=float)
+    score, diagnostics = grouped_component_log_likelihoods(
+        components,
+        GroupedObservationEvidence(groups=groups),
+        prefix_frame_count=2,
+        score_semantics="normalized_coordinate_mean_v3",
+        likelihood_power=2.0,
+    )
+
+    assert score.shape == (2,)
+    assert diagnostics.group_coordinate_counts == (1, 2)
+    assert diagnostics.normalization_coordinate_mass == 3.0
+    assert np.isclose(sum(diagnostics.normalization_coordinate_fractions), 1.0)
+    assert diagnostics.normalization_coordinate_fractions == pytest.approx(
+        (1 / 3, 2 / 3)
+    )
+    assert all(
+        value >= 1.0
+        for value in diagnostics.source_covariance_condition_numbers
+    )
+
+
+def test_normalized_v3_rejects_ill_conditioned_source_covariance() -> None:
+    group = _group(
+        "ill-conditioned",
+        values=np.asarray([0.0, 0.0]),
+        covariance=np.diag([1.0, 1.0e-14]),
+        contributor="source",
+    )
+    components = np.zeros((2, 3, 1, 2), dtype=float)
+
+    with pytest.raises(ValueError, match="condition number"):
+        grouped_component_log_likelihoods(
+            components,
+            GroupedObservationEvidence(groups=(group,)),
+            prefix_frame_count=2,
+            score_semantics="normalized_coordinate_mean_v3",
+            max_source_covariance_condition_number=1.0e10,
+        )
+
+
+def test_grouped_score_settings_fail_closed() -> None:
+    group = _group(
+        "valid",
+        values=np.asarray([0.0]),
+        covariance=np.asarray([[1.0]]),
+        contributor="source",
+    )
+    components = np.zeros((2, 3, 1, 1), dtype=float)
+    evidence = GroupedObservationEvidence(groups=(group,))
+
+    with pytest.raises(ValueError, match="unsupported grouped score"):
+        grouped_component_log_likelihoods(
+            components,
+            evidence,
+            prefix_frame_count=2,
+            score_semantics="unknown",  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="likelihood_power"):
+        grouped_component_log_likelihoods(
+            components,
+            evidence,
+            prefix_frame_count=2,
+            likelihood_power=np.nan,
+        )
+    with pytest.raises(ValueError, match="condition_number"):
+        grouped_component_log_likelihoods(
+            components,
+            evidence,
+            prefix_frame_count=2,
+            max_source_covariance_condition_number=0.5,
+        )


### PR DESCRIPTION
## Summary

This PR adds an opt-in grouped full-covariance likelihood comparator on top of the merged registered-query/structured-uncertainty path:

- contributor-aware duplicate-evidence power caps;
- coordinate-mass normalization with explicit likelihood power;
- source covariance conditioning diagnostics and a fail-closed threshold;
- preservation of source `composite_weight` as a reliability temperature;
- dense/low-rank covariance support and invariant tests; and
- CLI, factual-abduction, documentation, and diagnostic integration.

`legacy_sum_v1` / `legacy_v1` remain the defaults. The registered physical-study estimator and historical artifact identity are unchanged.

## Provenance

The combined implementation was reconstructed against reviewed `main` revision `de5116f0bd7e6c04c1ccd4af6b5f4cc8b089f65f` from content-addressed gzip payload `sha256:4712e2415882409cc8b292d5c3addc1fa612de37b39f26d66d56c094f8299fb2`.

The publisher verified the exact base, gzip digest, exact nine-file set, every full Git postimage blob ID, `git diff --cached --check`, and byte compilation. Focused grouped scoring, factual semantics, abduction, covariance, evidence, and CLI validation passed: **53 tests**.

The fresh review branch points to the exact implementation/documentation commit previously shown in PR #343; no files were changed while moving refs.

## Scientific boundary

This is a prospective development comparator. It does not establish improved prediction, calibration, transfer, causal identification, or physical benefit. Promotion requires the separately frozen source-only and held-out evaluation registered in issue #333. It does not modify the frozen 18-session/36-execution study, target boundary, physical data, or evidence counts.

## Merge disposition

Product change intended for review and merge after authoritative formatting, typing, full tests, packaging, security, and cross-repository compatibility pass on the exact head.