### PR TITLE
Harden counterfactual queries and batch grouped abduction

### DIFF
--- a/src/causal4d/counterfactual.py
+++ b/src/causal4d/counterfactual.py
@@ -89,6 +89,21 @@ def _validate_factual_context(
             raise ValueError(f"counterfactual artifacts disagree on factual {name}")
 
 
+def _validated_query_node_indices(
+    query: CounterfactualQuery,
+    *,
+    node_count: int,
+) -> np.ndarray:
+    if query.query_node_indices is None:
+        return np.arange(node_count, dtype=np.int64)
+    nodes = np.asarray(query.query_node_indices, dtype=np.int64)
+    if np.any(nodes >= node_count):
+        raise ValueError("query_node_indices exceed the rollout-bank node count")
+    if len(np.unique(nodes)) != len(nodes):
+        raise ValueError("query_node_indices must not contain duplicates")
+    return nodes
+
+
 def _validate_query_bank(
     bank: JointRolloutBank,
     query: CounterfactualQuery,
@@ -104,6 +119,13 @@ def _validate_query_bank(
     }
     if action_ids != {query.context.u_cf.action_id}:
         raise ValueError("rollout bank does not contain exactly the queried action")
+    expected_frame_count = query.horizon_frames + 1
+    if bank.frame_count != expected_frame_count:
+        raise ValueError(
+            "rollout bank must contain one intervention-endpoint frame plus "
+            "query.horizon_frames future frames"
+        )
+    _validated_query_node_indices(query, node_count=bank.node_count)
 
 
 def _new_contact_weights(
@@ -343,6 +365,89 @@ def apply_counterfactual_operator(
             "discrepancy_injected_into_simulator_state": False,
             "discrepancy_applied_to_readout": True,
         },
+    )
+
+
+def project_physical_posterior(
+    posterior: PhysicalPosterior,
+    query: CounterfactualQuery,
+    *,
+    include_endpoint: bool = False,
+) -> PhysicalPosterior:
+    """Project a dense posterior onto the registered query horizon and nodes.
+
+    Counterfactual rollout banks contain the factual intervention endpoint at
+    frame zero followed by exactly ``query.horizon_frames`` future frames.  The
+    default projection removes that endpoint and preserves the requested node
+    order.  The source posterior is not modified, and its identity is recorded
+    in the projected artifact metadata.
+    """
+
+    if type(include_endpoint) is not bool:
+        raise ValueError("include_endpoint must be boolean")
+    if posterior.source_query_id != query.artifact_id:
+        raise ValueError("physical posterior does not descend from the query")
+    if posterior.context != query.context:
+        raise ValueError("physical posterior and query contexts differ")
+    expected_frame_count = query.horizon_frames + 1
+    if posterior.state_trajectories_m.shape[1] != expected_frame_count:
+        raise ValueError(
+            "physical posterior must contain one endpoint frame plus the query horizon"
+        )
+    nodes = _validated_query_node_indices(
+        query,
+        node_count=posterior.state_trajectories_m.shape[2],
+    )
+    frame_start = 0 if include_endpoint else 1
+    state = np.take(
+        posterior.state_trajectories_m[:, frame_start:],
+        nodes,
+        axis=2,
+    )
+    readout = np.take(
+        posterior.readout_trajectories_m[:, frame_start:],
+        nodes,
+        axis=2,
+    )
+    variance = np.take(posterior.readout_variance_m2, nodes, axis=1)
+    metadata = dict(posterior.metadata)
+    metadata.update(
+        {
+            "operator": "physical-posterior-query-projection",
+            "source_physical_posterior_id": posterior.artifact_id,
+            "rollout_includes_pre_intervention_endpoint": include_endpoint,
+            "projection_includes_intervention_endpoint": include_endpoint,
+            "projection_frame_start_relative_to_endpoint": frame_start,
+            "projection_frame_stop_relative_to_endpoint": expected_frame_count,
+            "projection_node_selection": (
+                "all" if query.query_node_indices is None else "explicit"
+            ),
+            "projection_node_count": len(nodes),
+            "projection_node_indices": (
+                None
+                if query.query_node_indices is None
+                else nodes.tolist()
+            ),
+            "projection_preserves_component_weights": True,
+        }
+    )
+    return PhysicalPosterior(
+        context=posterior.context,
+        component_ids=posterior.component_ids,
+        state_trajectories_m=state,
+        readout_trajectories_m=readout,
+        readout_variance_m2=variance,
+        weights=posterior.weights,
+        phi=posterior.phi,
+        kappa_cf=posterior.kappa_cf,
+        hypothesis_indices=posterior.hypothesis_indices,
+        twin_particle_indices=posterior.twin_particle_indices,
+        phi_names=posterior.phi_names,
+        kappa_names=posterior.kappa_names,
+        source_twin_belief_id=posterior.source_twin_belief_id,
+        source_factual_intervention_id=posterior.source_factual_intervention_id,
+        source_query_id=posterior.source_query_id,
+        metadata=metadata,
     )
 
 

--- a/src/causal4d/counterfactual.py
+++ b/src/causal4d/counterfactual.py
@@ -424,9 +424,7 @@ def project_physical_posterior(
             ),
             "projection_node_count": len(nodes),
             "projection_node_indices": (
-                None
-                if query.query_node_indices is None
-                else nodes.tolist()
+                None if query.query_node_indices is None else nodes.tolist()
             ),
             "projection_preserves_component_weights": True,
         }

--- a/src/causal4d/intervention_abduction.py
+++ b/src/causal4d/intervention_abduction.py
@@ -13,6 +13,7 @@ from causal4d.factual_abduction_uncertainty import (
 )
 from causal4d.grouped_likelihood import (
     GroupLikelihoodDiagnostics,
+    grouped_component_log_likelihoods,
     posterior_weights_from_grouped_evidence,
 )
 from causal4d.identifiability import InterventionIdentifiabilityResult
@@ -22,6 +23,7 @@ from causal4d.prefix_likelihood import (
     update_joint_weights_from_prefix,
 )
 from causal4d.rollout_bank import JointRolloutBank
+from causal4d.weighting import log_weights_from_probabilities
 
 
 DenseLikelihoodSemantics = Literal["legacy_v1", "normalized_v2"]
@@ -150,6 +152,148 @@ def _grouped_diagnostics_summary(
     return result
 
 
+def _validated_grouped_component_batch_size(
+    value: int | None,
+) -> int | None:
+    if value is None:
+        return None
+    if type(value) is not int or value < 1:
+        raise ValueError("grouped_component_batch_size must be a positive integer")
+    return value
+
+
+def _posterior_weights_from_grouped_evidence_batched(
+    bank: JointRolloutBank,
+    belief: TwinBelief,
+    evidence: GroupedObservationEvidence,
+    *,
+    prefix_frame_count: int,
+    prior_weights: np.ndarray,
+    additional_independent_variance_m2: np.ndarray | None,
+    group_covariance_m2: dict[str, np.ndarray],
+    group_covariance_factor_m: dict[str, np.ndarray],
+    component_batch_size: int,
+) -> tuple[np.ndarray, GroupLikelihoodDiagnostics]:
+    """Evaluate grouped evidence without a full discrepancy-aware rollout copy."""
+
+    trajectories = np.asarray(bank.trajectories)
+    if trajectories.ndim != 5:
+        raise ValueError(
+            "grouped batched abduction requires rollout shape "
+            "(hypothesis, particle, frame, node, coordinate)"
+        )
+    hypothesis_count, particle_count = trajectories.shape[:2]
+    component_count = hypothesis_count * particle_count
+    prior = np.asarray(prior_weights, dtype=float)
+    if prior.shape != (hypothesis_count, particle_count):
+        raise ValueError("prior_weights must match rollout hypotheses and particles")
+    if (
+        not np.all(np.isfinite(prior))
+        or np.any(prior < 0.0)
+        or not np.isclose(np.sum(prior), 1.0)
+    ):
+        raise ValueError("prior_weights must be nonnegative and sum to one")
+    discrepancy, discrepancy_variance = _belief_readout(bank, belief)
+
+    scores = np.empty(component_count, dtype=float)
+    responsibilities: np.ndarray | None = None
+    group_ids: tuple[str, ...] | None = None
+    effective_group_weights: tuple[float, ...] | None = None
+    full_covariance_group_ids: tuple[str, ...] | None = None
+    low_rank_covariance_group_ids: tuple[str, ...] | None = None
+
+    for start in range(0, component_count, component_batch_size):
+        stop = min(start + component_batch_size, component_count)
+        flat_indices = np.arange(start, stop, dtype=np.int64)
+        hypothesis_indices = flat_indices // particle_count
+        particle_indices = flat_indices % particle_count
+        components = trajectories[hypothesis_indices, particle_indices].astype(float)
+        components = components + discrepancy[particle_indices, None]
+        component_variance = np.broadcast_to(
+            discrepancy_variance[particle_indices, None],
+            components.shape,
+        )
+        if additional_independent_variance_m2 is not None:
+            component_variance = component_variance + (
+                additional_independent_variance_m2[
+                    hypothesis_indices,
+                    particle_indices,
+                ]
+            )
+        dense_batch = {
+            group_id: covariance[hypothesis_indices, particle_indices]
+            for group_id, covariance in group_covariance_m2.items()
+        }
+        factor_batch = {
+            group_id: factor[hypothesis_indices, particle_indices]
+            for group_id, factor in group_covariance_factor_m.items()
+        }
+        batch_scores, diagnostics = grouped_component_log_likelihoods(
+            components,
+            evidence,
+            prefix_frame_count=prefix_frame_count,
+            component_variance_m2=component_variance,
+            component_group_covariance_m2=dense_batch,
+            component_group_covariance_factor_m=factor_batch,
+        )
+        scores[start:stop] = batch_scores.reshape(-1)
+        batch_responsibilities = np.asarray(
+            diagnostics.nominal_responsibilities,
+            dtype=float,
+        ).reshape(stop - start, -1)
+        if responsibilities is None:
+            responsibilities = np.empty(
+                (component_count, batch_responsibilities.shape[1]),
+                dtype=float,
+            )
+            group_ids = diagnostics.group_ids
+            effective_group_weights = diagnostics.effective_group_weights
+            full_covariance_group_ids = diagnostics.full_covariance_group_ids
+            low_rank_covariance_group_ids = (
+                diagnostics.low_rank_covariance_group_ids
+            )
+        elif (
+            diagnostics.group_ids != group_ids
+            or diagnostics.effective_group_weights != effective_group_weights
+            or diagnostics.full_covariance_group_ids != full_covariance_group_ids
+            or diagnostics.low_rank_covariance_group_ids
+            != low_rank_covariance_group_ids
+        ):
+            raise RuntimeError("grouped diagnostics changed between component batches")
+        responsibilities[start:stop] = batch_responsibilities
+
+    if (
+        responsibilities is None
+        or group_ids is None
+        or effective_group_weights is None
+        or full_covariance_group_ids is None
+        or low_rank_covariance_group_ids is None
+    ):
+        raise RuntimeError("grouped batched abduction produced no component scores")
+    log_posterior = (
+        log_weights_from_probabilities(
+            prior.reshape(-1),
+            name="prior_weights",
+        )
+        + scores
+    )
+    maximum = float(np.max(log_posterior))
+    posterior = np.exp(log_posterior - maximum)
+    posterior /= np.sum(posterior)
+    diagnostics = GroupLikelihoodDiagnostics(
+        group_ids=group_ids,
+        effective_group_weights=effective_group_weights,
+        nominal_responsibilities=responsibilities.reshape(
+            hypothesis_count,
+            particle_count,
+            -1,
+        ),
+        full_covariance_group_ids=full_covariance_group_ids,
+        low_rank_covariance_group_ids=low_rank_covariance_group_ids,
+    )
+    return posterior.reshape(hypothesis_count, particle_count), diagnostics
+
+
 def _update_joint_weights(
     bank: JointRolloutBank,
     belief: TwinBelief,
@@ -161,10 +305,18 @@ def _update_joint_weights(
     base_weights: np.ndarray | None = None,
     grouped_evidence: GroupedObservationEvidence | None = None,
     abduction_uncertainty: FactualAbductionUncertaintyV1 | None = None,
+    grouped_component_batch_size: int | None = None,
 ) -> tuple[np.ndarray, GroupLikelihoodDiagnostics | None]:
     if grouped_evidence is not None and settings.likelihood_semantics != "legacy_v1":
         raise ValueError(
             "normalized_v2 cannot be combined with grouped observation evidence"
+        )
+    batch_size = _validated_grouped_component_batch_size(
+        grouped_component_batch_size
+    )
+    if batch_size is not None and grouped_evidence is None:
+        raise ValueError(
+            "grouped_component_batch_size requires grouped observation evidence"
         )
     discrepancy, discrepancy_variance = _belief_readout(bank, belief)
     if grouped_evidence is None:
@@ -200,10 +352,7 @@ def _update_joint_weights(
                 particle_discrepancy_variance_m2=discrepancy_variance,
             )
         return joint_weights, None
-    components = physical_readout_components(bank, belief)
-    component_variance = np.broadcast_to(
-        discrepancy_variance[None, :, None], components.shape
-    )
+    additional_variance: np.ndarray | None = None
     group_covariance: dict[str, np.ndarray] = {}
     group_covariance_factor: dict[str, np.ndarray] = {}
     if abduction_uncertainty is not None:
@@ -214,9 +363,25 @@ def _update_joint_weights(
                 grouped_evidence,
             )
         )
-        if additional_variance is not None:
-            component_variance = component_variance + additional_variance
     prior = bank.prior_joint_weights if base_weights is None else base_weights
+    if batch_size is not None:
+        return _posterior_weights_from_grouped_evidence_batched(
+            bank,
+            belief,
+            grouped_evidence,
+            prefix_frame_count=prefix_frame_count,
+            prior_weights=prior,
+            additional_independent_variance_m2=additional_variance,
+            group_covariance_m2=group_covariance,
+            group_covariance_factor_m=group_covariance_factor,
+            component_batch_size=batch_size,
+        )
+    components = physical_readout_components(bank, belief)
+    component_variance = np.broadcast_to(
+        discrepancy_variance[None, :, None], components.shape
+    )
+    if additional_variance is not None:
+        component_variance = component_variance + additional_variance
     return posterior_weights_from_grouped_evidence(
         prior,
         components,
@@ -241,6 +406,7 @@ def abduct_factual_intervention(
     abstain_when_unidentifiable: bool = False,
     identifiability_policy: IdentifiabilityPolicy = "full_parameter",
     abduction_uncertainty: FactualAbductionUncertaintyV1 | None = None,
+    grouped_component_batch_size: int | None = None,
 ) -> FactualIntervention:
     """Infer persistent ``phi`` and factual event ``kappa_obs`` from O+ only.
 
@@ -250,6 +416,10 @@ def abduct_factual_intervention(
     ``abstain_when_unidentifiable`` is true, a failed supplied identifiability
     result returns the unchanged joint prior over physical and intervention
     support rather than a falsely concentrated posterior.
+
+    ``grouped_component_batch_size`` is an execution-only memory bound for the
+    grouped-evidence path. It does not enter artifact metadata and must preserve
+    the exact posterior and artifact identity of the dense implementation.
     """
 
     settings = config or FactualAbductionConfig()
@@ -300,6 +470,7 @@ def abduct_factual_intervention(
             settings=settings,
             grouped_evidence=grouped_evidence,
             abduction_uncertainty=abduction_uncertainty,
+            grouped_component_batch_size=grouped_component_batch_size,
         )
     hand_count = len(bank.hypothesis_metadata[0]["contact"]["attachment_shifts"])
     phi_names = ("gain_multiplier", "delay_steps", "rotation_degrees")
@@ -452,8 +623,13 @@ def evaluate_factual_abduction(
     config: FactualAbductionConfig | None = None,
     grouped_evidence: GroupedObservationEvidence | None = None,
     abduction_uncertainty: FactualAbductionUncertaintyV1 | None = None,
+    grouped_component_batch_size: int | None = None,
 ) -> dict[str, Any]:
-    """Compare BPT+z with a same-evidence BPT posterior fixed to nominal z."""
+    """Compare BPT+z with a same-evidence BPT posterior fixed to nominal z.
+
+    ``grouped_component_batch_size`` has the same execution-only semantics as in
+    :func:`abduct_factual_intervention`.
+    """
 
     settings = config or FactualAbductionConfig()
     z_weights = factual_joint_weights(
@@ -476,6 +652,7 @@ def evaluate_factual_abduction(
         base_weights=nominal_base,
         grouped_evidence=grouped_evidence,
         abduction_uncertainty=abduction_uncertainty,
+        grouped_component_batch_size=grouped_component_batch_size,
     )
     components = physical_readout_components(bank, belief)
     hypothesis_marginal = np.sum(z_weights, axis=1)

--- a/src/causal4d/intervention_abduction.py
+++ b/src/causal4d/intervention_abduction.py
@@ -214,11 +214,14 @@ def _posterior_weights_from_grouped_evidence_batched(
             components.shape,
         )
         if additional_independent_variance_m2 is not None:
-            component_variance = component_variance + (
-                additional_independent_variance_m2[
-                    hypothesis_indices,
-                    particle_indices,
-                ]
+            component_variance = (
+                component_variance
+                + (
+                    additional_independent_variance_m2[
+                        hypothesis_indices,
+                        particle_indices,
+                    ]
+                )
             )
         dense_batch = {
             group_id: covariance[hypothesis_indices, particle_indices]
@@ -249,9 +252,7 @@ def _posterior_weights_from_grouped_evidence_batched(
             group_ids = diagnostics.group_ids
             effective_group_weights = diagnostics.effective_group_weights
             full_covariance_group_ids = diagnostics.full_covariance_group_ids
-            low_rank_covariance_group_ids = (
-                diagnostics.low_rank_covariance_group_ids
-            )
+            low_rank_covariance_group_ids = diagnostics.low_rank_covariance_group_ids
         elif (
             diagnostics.group_ids != group_ids
             or diagnostics.effective_group_weights != effective_group_weights
@@ -311,9 +312,7 @@ def _update_joint_weights(
         raise ValueError(
             "normalized_v2 cannot be combined with grouped observation evidence"
         )
-    batch_size = _validated_grouped_component_batch_size(
-        grouped_component_batch_size
-    )
+    batch_size = _validated_grouped_component_batch_size(grouped_component_batch_size)
     if batch_size is not None and grouped_evidence is None:
         raise ValueError(
             "grouped_component_batch_size requires grouped observation evidence"

--- a/tests/test_causal4d_counterfactual.py
+++ b/tests/test_causal4d_counterfactual.py
@@ -105,15 +105,9 @@ def _setup(
     trajectories = np.zeros((3, 1, 6, node_count, 3), dtype=np.float32)
     for node_index in range(node_count):
         node_offset = node_index * 0.1
-        trajectories[0, 0, :, node_index, 0] = (
-            np.arange(6) * 0.01 + node_offset
-        )
-        trajectories[1, 0, :, node_index, 0] = (
-            np.arange(6) * 0.012 + node_offset
-        )
-        trajectories[2, 0, :, node_index, 0] = (
-            np.arange(6) * 0.014 + node_offset
-        )
+        trajectories[0, 0, :, node_index, 0] = np.arange(6) * 0.01 + node_offset
+        trajectories[1, 0, :, node_index, 0] = np.arange(6) * 0.012 + node_offset
+        trajectories[2, 0, :, node_index, 0] = np.arange(6) * 0.014 + node_offset
     bank = JointRolloutBank(
         hypothesis_ids=("nominal", "shift", "gain"),
         hypothesis_metadata=(

--- a/tests/test_causal4d_counterfactual.py
+++ b/tests/test_causal4d_counterfactual.py
@@ -1,4 +1,7 @@
+from dataclasses import replace
+
 import numpy as np
+import pytest
 
 from causal4d.contracts import (
     CounterfactualQuery,
@@ -9,14 +12,21 @@ from causal4d.contracts import (
 from causal4d.counterfactual import (
     apply_counterfactual_operator,
     physical_posterior_mean,
+    project_physical_posterior,
 )
 from causal4d.rollout_bank import JointRolloutBank
 
 
-def _setup(factual_weights=(0.1, 0.8, 0.1), *, contact_policy="new_contact"):
+def _setup(
+    factual_weights=(0.1, 0.8, 0.1),
+    *,
+    contact_policy="new_contact",
+    node_count=1,
+    query_node_indices=None,
+):
     full_frames = 9
     train_end = 4
-    observations = np.zeros((full_frames, 1, 3), dtype=float)
+    observations = np.zeros((full_frames, node_count, 3), dtype=float)
     factual_actions = np.zeros((full_frames, 1, 3), dtype=float)
     original_cf = factual_actions.copy()
     factual_context = build_causal_context(
@@ -33,11 +43,14 @@ def _setup(factual_weights=(0.1, 0.8, 0.1), *, contact_policy="new_contact"):
         endpoint_frame=train_end - 1,
         particle_ids=("p0",),
         theta_names=("spring",),
-        endpoint_position_m=np.zeros((1, 1, 3)),
-        endpoint_velocity_mps=np.zeros((1, 1, 3)),
+        endpoint_position_m=np.zeros((1, node_count, 3)),
+        endpoint_velocity_mps=np.zeros((1, node_count, 3)),
         theta=np.asarray([[0.0]]),
-        discrepancy_mean_m=np.asarray([[[0.002, 0.0, 0.0]]]),
-        discrepancy_variance_m2=np.full((1, 1, 3), 1e-6),
+        discrepancy_mean_m=np.broadcast_to(
+            np.asarray([[[0.002, 0.0, 0.0]]]),
+            (1, node_count, 3),
+        ),
+        discrepancy_variance_m2=np.full((1, node_count, 3), 1e-6),
         weights=np.asarray([1.0]),
     )
     factual = FactualIntervention(
@@ -70,6 +83,7 @@ def _setup(factual_weights=(0.1, 0.8, 0.1), *, contact_policy="new_contact"):
         horizon_frames=full_frames - train_end,
         contact_policy=contact_policy,
         source_factual_intervention_id=factual.artifact_id,
+        query_node_indices=query_node_indices,
     )
 
     def metadata(identifier, gain, shift):
@@ -88,10 +102,18 @@ def _setup(factual_weights=(0.1, 0.8, 0.1), *, contact_policy="new_contact"):
             },
         }
 
-    trajectories = np.zeros((3, 1, 6, 1, 3), dtype=np.float32)
-    trajectories[0, 0, :, 0, 0] = np.arange(6) * 0.01
-    trajectories[1, 0, :, 0, 0] = np.arange(6) * 0.012
-    trajectories[2, 0, :, 0, 0] = np.arange(6) * 0.014
+    trajectories = np.zeros((3, 1, 6, node_count, 3), dtype=np.float32)
+    for node_index in range(node_count):
+        node_offset = node_index * 0.1
+        trajectories[0, 0, :, node_index, 0] = (
+            np.arange(6) * 0.01 + node_offset
+        )
+        trajectories[1, 0, :, node_index, 0] = (
+            np.arange(6) * 0.012 + node_offset
+        )
+        trajectories[2, 0, :, node_index, 0] = (
+            np.arange(6) * 0.014 + node_offset
+        )
     bank = JointRolloutBank(
         hypothesis_ids=("nominal", "shift", "gain"),
         hypothesis_metadata=(
@@ -155,3 +177,90 @@ def test_counterfactual_keeps_state_and_discrepancy_readout_distinct() -> None:
         physical_posterior_mean(posterior),
         physical_posterior_mean(posterior, readout=False),
     )
+
+
+def test_counterfactual_requires_endpoint_plus_query_horizon() -> None:
+    bank, manifest, belief, factual, query = _setup()
+    short_bank = replace(bank, trajectories=bank.trajectories[:, :, :-1])
+    with pytest.raises(ValueError, match="one intervention-endpoint frame"):
+        apply_counterfactual_operator(
+            short_bank,
+            manifest,
+            belief,
+            factual,
+            query,
+        )
+
+
+def test_counterfactual_rejects_invalid_query_node_indices() -> None:
+    out_of_range = _setup(query_node_indices=np.asarray([1], dtype=np.int64))
+    with pytest.raises(ValueError, match="exceed the rollout-bank node count"):
+        apply_counterfactual_operator(*out_of_range)
+
+    duplicated = _setup(query_node_indices=np.asarray([0, 0], dtype=np.int64))
+    with pytest.raises(ValueError, match="must not contain duplicates"):
+        apply_counterfactual_operator(*duplicated)
+
+
+def test_project_physical_posterior_applies_registered_horizon_and_nodes() -> None:
+    bank, manifest, belief, factual, query = _setup(
+        node_count=3,
+        query_node_indices=np.asarray([2, 0], dtype=np.int64),
+    )
+    posterior = apply_counterfactual_operator(
+        bank,
+        manifest,
+        belief,
+        factual,
+        query,
+    )
+    original_state = posterior.state_trajectories_m.copy()
+    projected = project_physical_posterior(posterior, query)
+
+    assert projected.state_trajectories_m.shape[1:] == (
+        query.horizon_frames,
+        2,
+        3,
+    )
+    expected_state = np.take(
+        posterior.state_trajectories_m[:, 1:],
+        query.query_node_indices,
+        axis=2,
+    )
+    expected_readout = np.take(
+        posterior.readout_trajectories_m[:, 1:],
+        query.query_node_indices,
+        axis=2,
+    )
+    assert np.array_equal(projected.state_trajectories_m, expected_state)
+    assert np.array_equal(projected.readout_trajectories_m, expected_readout)
+    assert np.array_equal(projected.weights, posterior.weights)
+    assert projected.metadata["source_physical_posterior_id"] == posterior.artifact_id
+    assert projected.metadata["projection_node_indices"] == [2, 0]
+    assert not projected.metadata["projection_includes_intervention_endpoint"]
+    assert not projected.metadata["rollout_includes_pre_intervention_endpoint"]
+    assert np.array_equal(posterior.state_trajectories_m, original_state)
+
+
+def test_project_physical_posterior_can_preserve_endpoint() -> None:
+    bank, manifest, belief, factual, query = _setup()
+    posterior = apply_counterfactual_operator(
+        bank,
+        manifest,
+        belief,
+        factual,
+        query,
+    )
+    projected = project_physical_posterior(
+        posterior,
+        query,
+        include_endpoint=True,
+    )
+    assert np.array_equal(
+        projected.state_trajectories_m,
+        posterior.state_trajectories_m,
+    )
+    assert projected.metadata["projection_includes_intervention_endpoint"]
+    assert projected.metadata["rollout_includes_pre_intervention_endpoint"]
+    assert projected.metadata["projection_node_selection"] == "all"
+    assert projected.metadata["projection_node_indices"] is None

--- a/tests/test_causal4d_grouped_abduction.py
+++ b/tests/test_causal4d_grouped_abduction.py
@@ -341,3 +341,127 @@ def test_abduction_uncertainty_rejects_duplicate_dense_and_factor_routes() -> No
                 group.group_id: np.zeros((group.coordinate_count, 1))
             },
         )
+
+
+def test_grouped_component_batching_is_artifact_identical() -> None:
+    bank, belief, observations, mask, config, evidence = _problem()
+    dense = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=config,
+        grouped_evidence=evidence,
+    )
+    batched = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=config,
+        grouped_evidence=evidence,
+        grouped_component_batch_size=1,
+    )
+    assert np.array_equal(batched.weights, dense.weights)
+    assert batched.metadata == dense.metadata
+    assert batched.artifact_id == dense.artifact_id
+
+
+def test_grouped_component_batching_preserves_structured_uncertainty() -> None:
+    bank, belief, observations, mask, config, evidence = _problem()
+    group = evidence.groups[0]
+    factor = np.zeros((group.coordinate_count, 1), dtype=float)
+    factor[0, 0] = 0.002
+    uncertainty = FactualAbductionUncertaintyV1(
+        rollout_bank_id=bank.artifact_id,
+        twin_belief_id=belief.artifact_id,
+        grouped_evidence_id=evidence.evidence_id,
+        source_artifact_ids=("batched-structured-covariance",),
+        source_only=True,
+        disjoint_from_twin_belief_uncertainty=True,
+        disjoint_from_grouped_observation_covariance=True,
+        additional_independent_variance_m2=np.asarray(1e-7),
+        group_covariance_factor_m={group.group_id: factor},
+        independent_and_correlated_terms_are_disjoint=True,
+    )
+    dense = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=config,
+        grouped_evidence=evidence,
+        abduction_uncertainty=uncertainty,
+    )
+    batched = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=config,
+        grouped_evidence=evidence,
+        abduction_uncertainty=uncertainty,
+        grouped_component_batch_size=2,
+    )
+    assert np.array_equal(batched.weights, dense.weights)
+    assert batched.metadata == dense.metadata
+    assert batched.artifact_id == dense.artifact_id
+
+
+@pytest.mark.parametrize("batch_size", [0, -1, True, 1.5])
+def test_grouped_component_batching_rejects_invalid_sizes(batch_size) -> None:
+    bank, belief, observations, mask, config, evidence = _problem()
+    with pytest.raises(ValueError, match="positive integer"):
+        abduct_factual_intervention(
+            bank,
+            belief,
+            observations,
+            prefix_frame_count=4,
+            observation_mask=mask,
+            config=config,
+            grouped_evidence=evidence,
+            grouped_component_batch_size=batch_size,
+        )
+
+
+def test_grouped_component_batching_requires_grouped_evidence() -> None:
+    bank, belief, observations, mask, config, _ = _problem()
+    with pytest.raises(ValueError, match="requires grouped observation evidence"):
+        abduct_factual_intervention(
+            bank,
+            belief,
+            observations,
+            prefix_frame_count=4,
+            observation_mask=mask,
+            config=config,
+            grouped_component_batch_size=1,
+        )
+
+
+def test_grouped_component_batching_avoids_full_readout_materialization(
+    monkeypatch,
+) -> None:
+    bank, belief, observations, mask, config, evidence = _problem()
+
+    def fail_full_materialization(*_args, **_kwargs):
+        raise AssertionError("batched path materialized the complete readout bank")
+
+    monkeypatch.setattr(
+        "causal4d.intervention_abduction.physical_readout_components",
+        fail_full_materialization,
+    )
+    factual = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=config,
+        grouped_evidence=evidence,
+        grouped_component_batch_size=1,
+    )
+    assert np.argmax(factual.weights) == 1


### PR DESCRIPTION
## Summary

- enforce the counterfactual rollout invariant `bank.frame_count == query.horizon_frames + 1`, where frame zero is the intervention endpoint;
- validate query-node selections against the rollout bank and reject duplicate or out-of-range indices;
- add `project_physical_posterior()` as an explicit, content-addressed projection onto the registered future horizon and query nodes, with optional endpoint retention and complete source-posterior lineage;
- add an opt-in `grouped_component_batch_size` execution bound for grouped factual abduction and its matched nominal evaluation;
- score hypothesis/particle components in bounded batches without materializing the complete discrepancy-aware rollout bank during grouped likelihood evaluation;
- retain the historical dense grouped path as the default; and
- require exact equality of weights, metadata, and artifact identity between dense and batched execution, including independent plus low-rank structured uncertainty.

## Root cause and impact

`CounterfactualQuery` already carried a future horizon and optional query-node indices, but the counterfactual operator did not validate either field against the finite rollout bank. A malformed bank could therefore pass the causal-context checks while using an ambiguous endpoint/horizon layout, and invalid node selections were discovered only by downstream consumers, if at all.

The grouped-abduction path also formed a complete discrepancy-aware rollout copy and a full broadcast component-variance tensor before selecting the comparatively sparse registered observation groups. This made likelihood-stage memory scale with the complete rollout bank even when the evidence used only a small causal prefix.

The patch makes the query contract fail closed and adds a bounded-memory likelihood path without changing valid historical outputs.

## Change classification

Select one primary classification:

- [ ] Frozen or registered method/analysis change requiring a new version
- [ ] Future or experimental method
- [ ] BayesianPhysTwin, Prob4D, or other provider/artifact contract
- [ ] Acquisition, calibration, readiness, or evidence tooling
- [x] Maintenance, documentation, packaging, CI, or security

Evidence status, when applicable:

- [x] Software or contract evidence only
- [ ] Controlled synthetic evidence
- [ ] Source/calibration-only evidence
- [ ] Retrospective or already-open diagnostic evidence
- [ ] Confirmatory physical evidence
- [x] No scientific evidence produced

## Scientific and information boundary

- Frozen estimator or registered analysis changed: `no`; the default dense path and every valid historical posterior remain unchanged. The new batch-size argument is execution-only and excluded from artifact metadata.
- Target or held-out outcomes accessed: `no`.
- Registered physical-acquisition dataset modified: `no`.
- Physical evidence increment: `0`.
- Existing scientific claim changed or promoted: `no`.
- Independent statistical unit: `not applicable; deterministic contract and execution-parity tests only`.
- Source, calibration, and target split: `not applicable; no empirical outcomes are opened or scored`.
- Exact fallback preserved for rejected optional evidence: `yes`; no admission, identifiability, fallback, or posterior-selection rule is changed.

## Provenance and compatibility

- Exact validated head: `43cdda2c4d72563a656527f315df7bf7b6f7c594`.
- Base branch: current `main`; the branch is mergeable and contains only focused implementation and regression-test commits.
- Contract, schema, provider, or protocol versions: unchanged.
- Frozen artifacts or milestones affected: none.
- Compatibility and migration: existing `apply_counterfactual_operator()` remains endpoint-inclusive and returns the same dense `PhysicalPosterior` for valid inputs. `project_physical_posterior()` is additive and explicit. Existing grouped abduction remains dense unless a positive batch size is supplied.
- The new projection reuses the existing `PhysicalPosterior` contract and records the exact source posterior identity, frame policy, and node policy in metadata.

## Validation

- [x] A regression fails on the unpatched implementation: endpoint/horizon mismatch, invalid query nodes, and avoidance of complete readout materialization are newly enforced.
- [x] Valid inputs and expected behavior are covered.
- [x] Malformed, mutable, or provenance-inconsistent inputs are covered.
- [x] Serialization, distribution, and installed-artifact behavior are covered by the authoritative workflows.
- [x] Cross-repository compatibility is covered by the pinned installed-wheel BayesianPhysTwin integration; no provider boundary changed.

Local focused validation:

```text
PYTHONPATH=src pytest -q \
  tests/test_causal4d_counterfactual.py \
  tests/test_causal4d_grouped_abduction.py

24 passed
```

Local wider validation:

```text
PYTHONPATH=src pytest -q \
  tests/test_causal4d_counterfactual.py \
  tests/test_causal4d_same_patch_counterfactual.py \
  tests/test_counterfactual_prior_transport.py \
  tests/test_causal4d_action_conditioned_counterfactual.py \
  tests/test_causal4d_grouped_abduction.py \
  tests/test_grouped_likelihood_low_rank.py \
  tests/test_causal4d_intervention_abduction.py \
  tests/test_causal4d_contracts.py \
  tests/test_api_v1.py

62 passed
```

Additional local checks passed:

- Python byte compilation and package `compileall`;
- Python 3.10 grammar parsing of all changed Python files;
- whitespace/error diff validation; and
- canonical Ruff 0.16.2 formatting.

### Exact-head GitHub Actions

All authoritative workflows passed on `43cdda2c4d72563a656527f315df7bf7b6f7c594`:

- **Causal4D merge gate:** repository quality, complete default suite, wheel/sdist validation, isolated wheel installation, and pinned BayesianPhysTwin provider integration;
- **CI and release:** Ruff, incremental formatting, stable-contract MyPy, Python 3.10/3.12/3.14 core suites, deterministic result bundles, frozen milestone verification, wheel and sdist installation, complete CLI-help checks, distributions, and pinned-provider integration;
- **Extended compatibility:** exact declared dependency floors on Python 3.10 and core-only suites on Python 3.11 and 3.13; and
- **Security scanning:** resolved dependency audit plus CodeQL for Python and GitHub Actions.

## Merge disposition

- [x] Product change intended for review and merge
- [ ] Execution/bootstrap helper that must be closed without merge
- [ ] Diagnostic result that cannot promote a method or scientific claim

No post-merge physical execution, target opening, evidence publication, protocol mutation, or claim promotion is authorized by this change.