### PR TITLE
Add coupling-robust interventional contrast bounds

### DIFF
--- a/docs/interventional_contrast_bounds.md
+++ b/docs/interventional_contrast_bounds.md
@@ -1,0 +1,117 @@
+# Coupling-robust interventional contrast bounds
+
+## Purpose and status
+
+`InterventionalContrastPosteriorV1` reports a contrast under one explicit
+cross-world coupling. Branch marginals alone do not identify that coupling.
+`InterventionalContrastBoundsV1` is an analysis-only sensitivity artifact that
+shows which marginal contrast conclusions remain valid when the pair weights are
+allowed to vary.
+
+The bounds do not modify either physical posterior, the factual intervention,
+the estimator, or a registered physical protocol. They do not use target truth
+and do not create individual-level real counterfactual ground truth.
+
+## Bound set
+
+The builder starts from one verified `InterventionalContrastPosteriorV1`. It
+keeps:
+
+- both source component marginals exactly fixed;
+- the source artifact's allowed pair support fixed;
+- the declared component contrast means; and
+- the declared conditional-variance policy fixed.
+
+Only the nonnegative weights assigned to allowed pairs may change. Therefore:
+
+- an `independent_product` source exposes the full marginal Frechet class;
+- a `shared_twin_phi` source gives bounds restricted to its declared shared
+  strata and optional shared event coordinates; and
+- a `shared_component` source has only one feasible coupling and therefore
+  produces collapsed bounds.
+
+The implementation never adds a pair that the source coupling declared
+structurally impossible.
+
+## Reported quantities
+
+For each query output, the artifact reports:
+
+- the coupling-invariant posterior mean;
+- lower and upper variance;
+- lower and upper `P(Q(branch_a) - Q(branch_b) > 0)`; and
+- lower and upper CDF values at registered thresholds.
+
+For a threshold `t`, the CDF objective for allowed pair `k` is the conditional
+probability
+
+```text
+P(Delta_k <= t).
+```
+
+For deterministic component means this is an indicator. Under
+`independent_readout`, it is the corresponding Gaussian probability using the
+already-declared pair covariance. Variance bounds optimize the conditional
+second moment and then subtract the squared coupling-invariant mean.
+
+Each coordinate and threshold is optimized separately. Different endpoints may
+therefore use different extremal couplings; the artifact is not one joint
+worst-case posterior across every reported output simultaneously.
+
+## Example
+
+```python
+from causal4d.interventional_contrast import (
+    build_interventional_contrast,
+    build_interventional_contrast_bounds,
+    save_interventional_contrast_bounds,
+)
+
+contrast = build_interventional_contrast(
+    branch_a,
+    branch_b,
+    query,
+    branch_a_label="do(lift_high)",
+    branch_b_label="do(lateral_low)",
+    coupling_policy="independent_product",
+    conditional_variance_policy="independent_readout",
+)
+
+bounds = build_interventional_contrast_bounds(
+    contrast,
+    cdf_thresholds=(-0.01, 0.0, 0.01),
+    metadata={"registered_before_target_access": True},
+)
+
+print(bounds.probability_positive_lower)
+print(bounds.probability_positive_upper)
+save_interventional_contrast_bounds("contrast-bounds.npz", bounds)
+```
+
+For multiple query outputs, pass thresholds with shape
+`(threshold, query_output)`. A scalar threshold is broadcast to every output.
+
+## Numerical and provenance contract
+
+The transport problems are linear programs solved with SciPy HiGHS. The source
+pair weights are verified as a feasible coupling before optimization. A
+configurable pair-count guard prevents accidental materialization of an
+unbounded analysis problem. Solver failure, malformed thresholds, non-finite
+objectives, source-marginal mismatch, and invalid result bounds fail closed.
+
+The result is content addressed and supports strict atomic non-pickled NPZ I/O.
+Its identity binds the source contrast and query identities, coupling and
+conditional-variance semantics, every threshold and bound, source-coupling
+summaries, and finite metadata.
+
+## Interpretation
+
+A narrow interval supports a conclusion that is insensitive to the remaining
+coupling ambiguity inside the declared structural support. A wide interval says
+that the branch marginals and current structural restrictions do not determine
+that conclusion. The selected-coupling estimate should then be reported next to,
+not instead of, the sensitivity interval.
+
+These are posterior identification bounds. They are not empirical calibration,
+physical-effect confirmation, deployment authorization, or evidence that the
+chosen allowed pair support is causally complete.

--- a/src/causal4d/_interventional_contrast_bounds.py
+++ b/src/causal4d/_interventional_contrast_bounds.py
@@ -1,0 +1,706 @@
+"""Coupling-robust bounds for an interventional contrast posterior."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+import hashlib
+import json
+from typing import Any
+
+import numpy as np
+from scipy.optimize import linprog
+from scipy.sparse import coo_matrix, csr_matrix
+from scipy.special import ndtr
+
+from causal4d.contracts import array_sha256
+from causal4d.immutable_array import readonly_array
+from causal4d.immutable_json import plain_json, validated_json_mapping
+from causal4d._interventional_contrast_common import (
+    ContrastConditionalVariancePolicy,
+    ContrastCouplingPolicy,
+    _require_mapping,
+    _require_nonempty_string,
+    _require_positive_integer,
+    _require_sha256,
+    _validated_string_tuple,
+)
+from causal4d._interventional_contrast_posterior import (
+    InterventionalContrastPosteriorV1,
+)
+
+
+INTERVENTIONAL_CONTRAST_BOUNDS_SCHEMA_VERSION = 1
+_BOUNDS_ARTIFACT_KIND = "Causal4DInterventionalContrastBoundsV1"
+_BOUNDS_DESCRIPTOR_FIELDS = frozenset(
+    {
+        "schema_version",
+        "artifact_kind",
+        "artifact_id",
+        "source_contrast_id",
+        "source_query_id",
+        "branch_a_label",
+        "branch_b_label",
+        "coupling_policy",
+        "shared_kappa_names",
+        "conditional_variance_policy",
+        "query_name",
+        "query_labels",
+        "query_units",
+        "metadata",
+    }
+)
+_BOUNDS_ARRAY_FIELDS = frozenset(
+    {
+        "cdf_thresholds",
+        "cdf_lower",
+        "cdf_upper",
+        "mean",
+        "variance_lower",
+        "variance_upper",
+        "probability_positive_lower",
+        "probability_positive_upper",
+        "source_variance",
+        "source_probability_positive",
+    }
+)
+_BOUNDS_ARRAY_DTYPES = {
+    name: np.dtype(np.float64) for name in _BOUNDS_ARRAY_FIELDS
+}
+_BOUNDS_CLAIM_BOUNDARY = {
+    "analysis_only": True,
+    "changes_estimator": False,
+    "changes_source_posterior": False,
+    "changes_registered_protocol": False,
+    "uses_target_truth": False,
+    "individual_real_counterfactual_ground_truth_claimed": False,
+    "coupling_identified_from_branch_marginals": False,
+}
+
+
+def _validated_probability_bounds(
+    lower_values: Any,
+    upper_values: Any,
+    *,
+    shape: tuple[int, ...],
+    name: str,
+) -> tuple[np.ndarray, np.ndarray]:
+    lower = readonly_array(lower_values, dtype=float)
+    upper = readonly_array(upper_values, dtype=float)
+    if lower.shape != shape or upper.shape != shape:
+        raise ValueError(f"{name} bounds must both have shape {shape}")
+    if not np.all(np.isfinite(lower)) or not np.all(np.isfinite(upper)):
+        raise ValueError(f"{name} bounds must be finite")
+    tolerance = 1e-10
+    if (
+        np.any(lower < -tolerance)
+        or np.any(upper > 1.0 + tolerance)
+        or np.any(lower > upper + tolerance)
+    ):
+        raise ValueError(f"{name} bounds must satisfy 0 <= lower <= upper <= 1")
+    return (
+        readonly_array(np.clip(lower, 0.0, 1.0), dtype=float),
+        readonly_array(np.clip(upper, 0.0, 1.0), dtype=float),
+    )
+
+
+def _validated_variance_bounds(
+    lower_values: Any,
+    upper_values: Any,
+    *,
+    output_count: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    lower = readonly_array(lower_values, dtype=float)
+    upper = readonly_array(upper_values, dtype=float)
+    expected = (output_count,)
+    if lower.shape != expected or upper.shape != expected:
+        raise ValueError(f"variance bounds must both have shape {expected}")
+    if not np.all(np.isfinite(lower)) or not np.all(np.isfinite(upper)):
+        raise ValueError("variance bounds must be finite")
+    tolerance = 1e-10
+    if np.any(lower < -tolerance) or np.any(lower > upper + tolerance):
+        raise ValueError("variance bounds must satisfy 0 <= lower <= upper")
+    return (
+        readonly_array(np.maximum(lower, 0.0), dtype=float),
+        readonly_array(np.maximum(upper, 0.0), dtype=float),
+    )
+
+
+@dataclass(frozen=True)
+class InterventionalContrastBoundsV1:
+    """Coordinatewise sharp bounds over the declared allowed pair support.
+
+    Each lower or upper endpoint may be attained by a different coupling. The
+    artifact therefore reports marginal sensitivity bounds, not one joint
+    extremal posterior over all query outputs and thresholds simultaneously.
+    """
+
+    source_contrast_id: str
+    source_query_id: str
+    branch_a_label: str
+    branch_b_label: str
+    coupling_policy: ContrastCouplingPolicy
+    shared_kappa_names: tuple[str, ...]
+    conditional_variance_policy: ContrastConditionalVariancePolicy
+    query_name: str
+    query_labels: tuple[str, ...]
+    query_units: tuple[str, ...]
+    cdf_thresholds: np.ndarray
+    cdf_lower: np.ndarray
+    cdf_upper: np.ndarray
+    mean: np.ndarray
+    variance_lower: np.ndarray
+    variance_upper: np.ndarray
+    probability_positive_lower: np.ndarray
+    probability_positive_upper: np.ndarray
+    source_variance: np.ndarray
+    source_probability_positive: np.ndarray
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        source_contrast_id = _require_sha256(
+            self.source_contrast_id,
+            name="source_contrast_id",
+        )
+        source_query_id = _require_sha256(
+            self.source_query_id,
+            name="source_query_id",
+        )
+        branch_a = _require_nonempty_string(
+            self.branch_a_label,
+            name="branch_a_label",
+        )
+        branch_b = _require_nonempty_string(
+            self.branch_b_label,
+            name="branch_b_label",
+        )
+        if branch_a == branch_b:
+            raise ValueError("branch labels must be distinct")
+        coupling = _require_nonempty_string(
+            self.coupling_policy,
+            name="coupling_policy",
+        )
+        if coupling not in {
+            "shared_component",
+            "shared_twin_phi",
+            "independent_product",
+        }:
+            raise ValueError("unsupported contrast coupling policy")
+        shared_kappa_names = _validated_string_tuple(
+            self.shared_kappa_names,
+            name="shared_kappa_names",
+            unique=True,
+            allow_empty=True,
+        )
+        if coupling != "shared_twin_phi" and shared_kappa_names:
+            raise ValueError("shared_kappa_names require shared_twin_phi coupling")
+        variance_policy = _require_nonempty_string(
+            self.conditional_variance_policy,
+            name="conditional_variance_policy",
+        )
+        if variance_policy not in {
+            "component_means_only",
+            "independent_readout",
+        }:
+            raise ValueError("unsupported conditional variance policy")
+        query_name = _require_nonempty_string(self.query_name, name="query_name")
+        query_labels = _validated_string_tuple(
+            self.query_labels,
+            name="query_labels",
+            unique=True,
+        )
+        query_units = _validated_string_tuple(
+            self.query_units,
+            name="query_units",
+            unique=False,
+        )
+        if len(query_units) != len(query_labels):
+            raise ValueError("query labels and units must align")
+        output_count = len(query_labels)
+        thresholds = readonly_array(self.cdf_thresholds, dtype=float)
+        if (
+            thresholds.ndim != 2
+            or thresholds.shape[0] == 0
+            or thresholds.shape[1] != output_count
+            or not np.all(np.isfinite(thresholds))
+        ):
+            raise ValueError(
+                "cdf_thresholds must have finite shape (threshold, query_output)"
+            )
+        cdf_lower, cdf_upper = _validated_probability_bounds(
+            self.cdf_lower,
+            self.cdf_upper,
+            shape=thresholds.shape,
+            name="CDF",
+        )
+        mean = readonly_array(self.mean, dtype=float)
+        if mean.shape != (output_count,) or not np.all(np.isfinite(mean)):
+            raise ValueError("mean must be a finite query-output vector")
+        variance_lower, variance_upper = _validated_variance_bounds(
+            self.variance_lower,
+            self.variance_upper,
+            output_count=output_count,
+        )
+        positive_lower, positive_upper = _validated_probability_bounds(
+            self.probability_positive_lower,
+            self.probability_positive_upper,
+            shape=(output_count,),
+            name="probability-positive",
+        )
+        source_variance = readonly_array(self.source_variance, dtype=float)
+        source_positive = readonly_array(
+            self.source_probability_positive,
+            dtype=float,
+        )
+        if (
+            source_variance.shape != (output_count,)
+            or not np.all(np.isfinite(source_variance))
+            or np.any(source_variance < -1e-10)
+        ):
+            raise ValueError("source_variance must be finite and nonnegative")
+        if (
+            source_positive.shape != (output_count,)
+            or not np.all(np.isfinite(source_positive))
+            or np.any(source_positive < -1e-10)
+            or np.any(source_positive > 1.0 + 1e-10)
+        ):
+            raise ValueError("source_probability_positive must lie in [0, 1]")
+        if np.any(source_variance < variance_lower - 1e-8) or np.any(
+            source_variance > variance_upper + 1e-8
+        ):
+            raise ValueError("source variance lies outside its coupling bounds")
+        if np.any(source_positive < positive_lower - 1e-8) or np.any(
+            source_positive > positive_upper + 1e-8
+        ):
+            raise ValueError(
+                "source probability-positive lies outside its coupling bounds"
+            )
+
+        object.__setattr__(self, "source_contrast_id", source_contrast_id)
+        object.__setattr__(self, "source_query_id", source_query_id)
+        object.__setattr__(self, "branch_a_label", branch_a)
+        object.__setattr__(self, "branch_b_label", branch_b)
+        object.__setattr__(self, "coupling_policy", coupling)
+        object.__setattr__(self, "shared_kappa_names", shared_kappa_names)
+        object.__setattr__(self, "conditional_variance_policy", variance_policy)
+        object.__setattr__(self, "query_name", query_name)
+        object.__setattr__(self, "query_labels", query_labels)
+        object.__setattr__(self, "query_units", query_units)
+        object.__setattr__(self, "cdf_thresholds", thresholds)
+        object.__setattr__(self, "cdf_lower", cdf_lower)
+        object.__setattr__(self, "cdf_upper", cdf_upper)
+        object.__setattr__(self, "mean", mean)
+        object.__setattr__(self, "variance_lower", variance_lower)
+        object.__setattr__(self, "variance_upper", variance_upper)
+        object.__setattr__(self, "probability_positive_lower", positive_lower)
+        object.__setattr__(self, "probability_positive_upper", positive_upper)
+        object.__setattr__(
+            self,
+            "source_variance",
+            readonly_array(np.maximum(source_variance, 0.0), dtype=float),
+        )
+        object.__setattr__(
+            self,
+            "source_probability_positive",
+            readonly_array(np.clip(source_positive, 0.0, 1.0), dtype=float),
+        )
+        object.__setattr__(
+            self,
+            "metadata",
+            validated_json_mapping(
+                self.metadata,
+                error_message="contrast-bound metadata must contain finite JSON data",
+            ),
+        )
+
+    def _scalar_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": INTERVENTIONAL_CONTRAST_BOUNDS_SCHEMA_VERSION,
+            "artifact_kind": _BOUNDS_ARTIFACT_KIND,
+            "source_contrast_id": self.source_contrast_id,
+            "source_query_id": self.source_query_id,
+            "branch_a_label": self.branch_a_label,
+            "branch_b_label": self.branch_b_label,
+            "coupling_policy": self.coupling_policy,
+            "shared_kappa_names": list(self.shared_kappa_names),
+            "conditional_variance_policy": self.conditional_variance_policy,
+            "query_name": self.query_name,
+            "query_labels": list(self.query_labels),
+            "query_units": list(self.query_units),
+            "metadata": plain_json(self.metadata),
+        }
+
+    def _array_payload(self) -> dict[str, np.ndarray]:
+        return {
+            "cdf_thresholds": self.cdf_thresholds,
+            "cdf_lower": self.cdf_lower,
+            "cdf_upper": self.cdf_upper,
+            "mean": self.mean,
+            "variance_lower": self.variance_lower,
+            "variance_upper": self.variance_upper,
+            "probability_positive_lower": self.probability_positive_lower,
+            "probability_positive_upper": self.probability_positive_upper,
+            "source_variance": self.source_variance,
+            "source_probability_positive": self.source_probability_positive,
+        }
+
+    @property
+    def artifact_id(self) -> str:
+        digest = hashlib.sha256()
+        digest.update(
+            json.dumps(
+                self._scalar_payload(),
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            ).encode("utf-8")
+        )
+        for name, values in sorted(self._array_payload().items()):
+            digest.update(name.encode("utf-8"))
+            digest.update(array_sha256(values).encode("ascii"))
+        return digest.hexdigest()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            **self._scalar_payload(),
+            "artifact_id": self.artifact_id,
+            "cdf_thresholds": self.cdf_thresholds.tolist(),
+            "cdf_lower": self.cdf_lower.tolist(),
+            "cdf_upper": self.cdf_upper.tolist(),
+            "mean": self.mean.tolist(),
+            "variance_lower": self.variance_lower.tolist(),
+            "variance_upper": self.variance_upper.tolist(),
+            "probability_positive_lower": (
+                self.probability_positive_lower.tolist()
+            ),
+            "probability_positive_upper": (
+                self.probability_positive_upper.tolist()
+            ),
+            "source_variance": self.source_variance.tolist(),
+            "source_probability_positive": (
+                self.source_probability_positive.tolist()
+            ),
+        }
+
+
+def _validated_thresholds(
+    values: Any,
+    *,
+    output_count: int,
+) -> np.ndarray:
+    if values is None:
+        return np.zeros((1, output_count), dtype=float)
+    thresholds = np.asarray(values, dtype=float)
+    if thresholds.ndim == 0:
+        thresholds = np.full((1, output_count), float(thresholds), dtype=float)
+    elif thresholds.ndim == 1:
+        if output_count == 1:
+            thresholds = thresholds[:, None]
+        elif thresholds.shape == (output_count,):
+            thresholds = thresholds[None]
+        else:
+            raise ValueError(
+                "one-dimensional cdf_thresholds must match query outputs"
+            )
+    if (
+        thresholds.ndim != 2
+        or thresholds.shape[0] == 0
+        or thresholds.shape[1] != output_count
+        or not np.all(np.isfinite(thresholds))
+    ):
+        raise ValueError(
+            "cdf_thresholds must have finite shape (threshold, query_output)"
+        )
+    return thresholds
+
+
+def _transport_constraints(
+    posterior: InterventionalContrastPosteriorV1,
+    *,
+    marginal_tolerance: float,
+) -> tuple[csr_matrix, np.ndarray, float, float]:
+    pairs = np.asarray(posterior.pair_indices, dtype=np.int64)
+    weights = np.asarray(posterior.weights, dtype=float)
+    row_indices = np.unique(pairs[:, 0])
+    column_indices = np.unique(pairs[:, 1])
+    row_lookup = {int(value): index for index, value in enumerate(row_indices)}
+    column_lookup = {
+        int(value): index for index, value in enumerate(column_indices)
+    }
+    variable_count = len(pairs)
+    variable_indices = np.arange(variable_count, dtype=np.int64)
+    constraint_rows = np.concatenate(
+        (
+            np.asarray([row_lookup[int(value)] for value in pairs[:, 0]]),
+            len(row_indices)
+            + np.asarray(
+                [column_lookup[int(value)] for value in pairs[:, 1]],
+                dtype=np.int64,
+            ),
+        )
+    )
+    constraint_columns = np.concatenate((variable_indices, variable_indices))
+    constraints = coo_matrix(
+        (
+            np.ones(2 * variable_count, dtype=float),
+            (constraint_rows, constraint_columns),
+        ),
+        shape=(len(row_indices) + len(column_indices), variable_count),
+    ).tocsr()
+    branch_a_marginal = np.bincount(
+        pairs[:, 0],
+        weights=weights,
+        minlength=posterior.branch_a_component_count,
+    )
+    branch_b_marginal = np.bincount(
+        pairs[:, 1],
+        weights=weights,
+        minlength=posterior.branch_b_component_count,
+    )
+    right_hand_side = np.concatenate(
+        (branch_a_marginal[row_indices], branch_b_marginal[column_indices])
+    )
+    residual = np.asarray(constraints @ weights - right_hand_side)
+    maximum_error = float(np.max(np.abs(residual), initial=0.0))
+    if maximum_error > marginal_tolerance:
+        raise ValueError("source contrast weights do not preserve their marginals")
+    return constraints, right_hand_side, maximum_error, float(np.sum(weights))
+
+
+def _optimize_transport(
+    cost: np.ndarray,
+    *,
+    constraints: csr_matrix,
+    right_hand_side: np.ndarray,
+    maximize: bool,
+) -> float:
+    objective = -np.asarray(cost, dtype=float) if maximize else np.asarray(cost)
+    if objective.ndim != 1 or objective.shape[0] != constraints.shape[1]:
+        raise ValueError("transport objective must match the allowed pair support")
+    if not np.all(np.isfinite(objective)):
+        raise ValueError("transport objective must be finite")
+    result = linprog(
+        objective,
+        A_eq=constraints,
+        b_eq=right_hand_side,
+        bounds=(0.0, None),
+        method="highs",
+    )
+    if not result.success or result.fun is None or not np.isfinite(result.fun):
+        raise RuntimeError(
+            "coupling-bound transport optimization failed: "
+            f"status={result.status}, message={result.message}"
+        )
+    value = float(-result.fun if maximize else result.fun)
+    return value
+
+
+def _component_cdf(
+    means: np.ndarray,
+    variances: np.ndarray,
+    threshold: float,
+) -> np.ndarray:
+    probabilities = np.empty_like(means, dtype=float)
+    positive_variance = variances > 0.0
+    probabilities[positive_variance] = ndtr(
+        (threshold - means[positive_variance])
+        / np.sqrt(variances[positive_variance])
+    )
+    probabilities[~positive_variance] = means[~positive_variance] <= threshold
+    return probabilities
+
+
+def _component_probability_positive(
+    means: np.ndarray,
+    variances: np.ndarray,
+) -> np.ndarray:
+    probabilities = np.empty_like(means, dtype=float)
+    positive_variance = variances > 0.0
+    probabilities[positive_variance] = ndtr(
+        means[positive_variance] / np.sqrt(variances[positive_variance])
+    )
+    probabilities[~positive_variance] = means[~positive_variance] > 0.0
+    return probabilities
+
+
+def build_interventional_contrast_bounds(
+    posterior: InterventionalContrastPosteriorV1,
+    *,
+    cdf_thresholds: Any = None,
+    maximum_pair_count: int = 1_000_000,
+    marginal_tolerance: float = 1e-12,
+    metadata: Mapping[str, Any] | None = None,
+) -> InterventionalContrastBoundsV1:
+    """Bound coupling-dependent summaries over the allowed pair support.
+
+    The optimization changes only pair weights. It preserves both source
+    marginals exactly and never introduces a pair that was absent from the
+    source contrast artifact. Thus an ``independent_product`` source gives the
+    complete marginal Fréchet class, ``shared_twin_phi`` gives stratum-restricted
+    bounds, and ``shared_component`` collapses to the source coupling.
+    """
+
+    if not isinstance(posterior, InterventionalContrastPosteriorV1):
+        raise TypeError("posterior must be InterventionalContrastPosteriorV1")
+    pair_limit = _require_positive_integer(
+        maximum_pair_count,
+        name="maximum_pair_count",
+    )
+    if len(posterior.pair_indices) > pair_limit:
+        raise ValueError(
+            "contrast bound requires "
+            f"{len(posterior.pair_indices)} pairs, exceeding "
+            f"maximum_pair_count={pair_limit}"
+        )
+    if (
+        isinstance(marginal_tolerance, (bool, np.bool_))
+        or not isinstance(marginal_tolerance, (int, float, np.integer, np.floating))
+        or not np.isfinite(marginal_tolerance)
+        or float(marginal_tolerance) < 0.0
+    ):
+        raise ValueError("marginal_tolerance must be finite and nonnegative")
+    tolerance = float(marginal_tolerance)
+    user_metadata: Mapping[str, Any]
+    if metadata is None:
+        user_metadata = {}
+    else:
+        user_metadata = _require_mapping(metadata, name="metadata")
+    output_count = len(posterior.query_labels)
+    thresholds = _validated_thresholds(
+        cdf_thresholds,
+        output_count=output_count,
+    )
+    constraints, right_hand_side, marginal_error, source_mass = (
+        _transport_constraints(
+            posterior,
+            marginal_tolerance=tolerance,
+        )
+    )
+    if not np.isclose(source_mass, 1.0, atol=tolerance, rtol=tolerance):
+        raise ValueError("source contrast pair weights must sum to one")
+
+    component_means = np.asarray(posterior.contrast_values, dtype=float)
+    component_variances = np.diagonal(
+        np.asarray(posterior.conditional_covariance, dtype=float),
+        axis1=-2,
+        axis2=-1,
+    )
+    source_weights = np.asarray(posterior.weights, dtype=float)
+    source_mean = np.asarray(posterior.mean, dtype=float)
+
+    cdf_lower = np.empty_like(thresholds)
+    cdf_upper = np.empty_like(thresholds)
+    for threshold_index in range(len(thresholds)):
+        for output_index in range(output_count):
+            cost = _component_cdf(
+                component_means[:, output_index],
+                component_variances[:, output_index],
+                float(thresholds[threshold_index, output_index]),
+            )
+            cdf_lower[threshold_index, output_index] = _optimize_transport(
+                cost,
+                constraints=constraints,
+                right_hand_side=right_hand_side,
+                maximize=False,
+            )
+            cdf_upper[threshold_index, output_index] = _optimize_transport(
+                cost,
+                constraints=constraints,
+                right_hand_side=right_hand_side,
+                maximize=True,
+            )
+
+    positive_lower = np.empty(output_count, dtype=float)
+    positive_upper = np.empty(output_count, dtype=float)
+    source_positive = np.empty(output_count, dtype=float)
+    variance_lower = np.empty(output_count, dtype=float)
+    variance_upper = np.empty(output_count, dtype=float)
+    source_variance = np.empty(output_count, dtype=float)
+    for output_index in range(output_count):
+        positive_cost = _component_probability_positive(
+            component_means[:, output_index],
+            component_variances[:, output_index],
+        )
+        positive_lower[output_index] = _optimize_transport(
+            positive_cost,
+            constraints=constraints,
+            right_hand_side=right_hand_side,
+            maximize=False,
+        )
+        positive_upper[output_index] = _optimize_transport(
+            positive_cost,
+            constraints=constraints,
+            right_hand_side=right_hand_side,
+            maximize=True,
+        )
+        source_positive[output_index] = float(source_weights @ positive_cost)
+
+        second_moment_cost = (
+            np.square(component_means[:, output_index])
+            + component_variances[:, output_index]
+        )
+        minimum_second_moment = _optimize_transport(
+            second_moment_cost,
+            constraints=constraints,
+            right_hand_side=right_hand_side,
+            maximize=False,
+        )
+        maximum_second_moment = _optimize_transport(
+            second_moment_cost,
+            constraints=constraints,
+            right_hand_side=right_hand_side,
+            maximize=True,
+        )
+        squared_mean = float(np.square(source_mean[output_index]))
+        variance_lower[output_index] = max(
+            0.0,
+            minimum_second_moment - squared_mean,
+        )
+        variance_upper[output_index] = max(
+            0.0,
+            maximum_second_moment - squared_mean,
+        )
+        source_second_moment = float(source_weights @ second_moment_cost)
+        source_variance[output_index] = max(
+            0.0,
+            source_second_moment - squared_mean,
+        )
+
+    result_metadata = {
+        "claim_boundary": _BOUNDS_CLAIM_BOUNDARY,
+        "bound_semantics": (
+            "coordinatewise sharp over nonnegative pair weights preserving "
+            "both source marginals and the source artifact's allowed pair support"
+        ),
+        "cdf_event": "contrast <= threshold",
+        "probability_positive_event": "contrast > 0",
+        "coordinate_extrema_may_use_different_couplings": True,
+        "source_pair_count": len(posterior.pair_indices),
+        "source_marginal_max_abs_error": marginal_error,
+        "source_marginal_tolerance": tolerance,
+        "transport_solver": "scipy.optimize.linprog(method='highs')",
+        "user": plain_json(user_metadata),
+    }
+    return InterventionalContrastBoundsV1(
+        source_contrast_id=posterior.artifact_id,
+        source_query_id=posterior.query_id,
+        branch_a_label=posterior.branch_a_label,
+        branch_b_label=posterior.branch_b_label,
+        coupling_policy=posterior.coupling_policy,
+        shared_kappa_names=posterior.shared_kappa_names,
+        conditional_variance_policy=posterior.conditional_variance_policy,
+        query_name=posterior.query_name,
+        query_labels=posterior.query_labels,
+        query_units=posterior.query_units,
+        cdf_thresholds=thresholds,
+        cdf_lower=np.clip(cdf_lower, 0.0, 1.0),
+        cdf_upper=np.clip(cdf_upper, 0.0, 1.0),
+        mean=source_mean,
+        variance_lower=variance_lower,
+        variance_upper=variance_upper,
+        probability_positive_lower=np.clip(positive_lower, 0.0, 1.0),
+        probability_positive_upper=np.clip(positive_upper, 0.0, 1.0),
+        source_variance=source_variance,
+        source_probability_positive=np.clip(source_positive, 0.0, 1.0),
+        metadata=result_metadata,
+    )

--- a/src/causal4d/_interventional_contrast_bounds_build.py
+++ b/src/causal4d/_interventional_contrast_bounds_build.py
@@ -1,0 +1,79 @@
+"""Public builder hardening for coupling-robust contrast bounds."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import replace
+from typing import Any
+
+import numpy as np
+
+from causal4d._interventional_contrast_bounds import (
+    InterventionalContrastBoundsV1,
+    _optimize_transport,
+    _transport_constraints,
+    build_interventional_contrast_bounds as _build_bounds,
+)
+from causal4d._interventional_contrast_posterior import (
+    InterventionalContrastPosteriorV1,
+)
+
+
+def build_interventional_contrast_bounds(
+    posterior: InterventionalContrastPosteriorV1,
+    *,
+    cdf_thresholds: Any = None,
+    maximum_pair_count: int = 1_000_000,
+    marginal_tolerance: float = 1e-12,
+    metadata: Mapping[str, Any] | None = None,
+) -> InterventionalContrastBoundsV1:
+    """Build bounds and verify that the contrast mean is coupling invariant.
+
+    Source builders produce pair values of the form ``Q(a_i) - Q(b_j)``, whose
+    expectation is fixed by the two marginals. A syntactically valid but
+    independently fabricated archive need not preserve that additive identity.
+    The public builder therefore solves the mean extrema and rejects a source
+    artifact whose pair values would make the reported mean coupling dependent.
+    """
+
+    result = _build_bounds(
+        posterior,
+        cdf_thresholds=cdf_thresholds,
+        maximum_pair_count=maximum_pair_count,
+        marginal_tolerance=marginal_tolerance,
+        metadata=metadata,
+    )
+    tolerance = float(result.metadata["source_marginal_tolerance"])
+    constraints, right_hand_side, _, _ = _transport_constraints(
+        posterior,
+        marginal_tolerance=tolerance,
+    )
+    component_means = np.asarray(posterior.contrast_values, dtype=float)
+    mean_spans = np.empty(component_means.shape[1], dtype=float)
+    for output_index in range(component_means.shape[1]):
+        minimum_mean = _optimize_transport(
+            component_means[:, output_index],
+            constraints=constraints,
+            right_hand_side=right_hand_side,
+            maximize=False,
+        )
+        maximum_mean = _optimize_transport(
+            component_means[:, output_index],
+            constraints=constraints,
+            right_hand_side=right_hand_side,
+            maximize=True,
+        )
+        mean_spans[output_index] = maximum_mean - minimum_mean
+        if (
+            mean_spans[output_index] > max(1e-8, 10.0 * tolerance)
+            or result.mean[output_index] < minimum_mean - 1e-8
+            or result.mean[output_index] > maximum_mean + 1e-8
+        ):
+            raise ValueError(
+                "contrast pair values do not define a coupling-invariant mean"
+            )
+    result_metadata = dict(result.metadata)
+    result_metadata["maximum_coupling_mean_span"] = float(
+        np.max(mean_spans, initial=0.0)
+    )
+    return replace(result, metadata=result_metadata)

--- a/src/causal4d/_interventional_contrast_bounds_io.py
+++ b/src/causal4d/_interventional_contrast_bounds_io.py
@@ -1,0 +1,164 @@
+"""Strict archive I/O for coupling-robust interventional contrast bounds."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import BinaryIO
+
+import numpy as np
+
+from causal4d.atomic_io import atomic_write_binary
+from causal4d.numpy_archive import load_numpy_archive
+from causal4d._interventional_contrast_bounds import (
+    INTERVENTIONAL_CONTRAST_BOUNDS_SCHEMA_VERSION,
+    InterventionalContrastBoundsV1,
+    _BOUNDS_ARRAY_DTYPES,
+    _BOUNDS_ARRAY_FIELDS,
+    _BOUNDS_ARTIFACT_KIND,
+    _BOUNDS_DESCRIPTOR_FIELDS,
+)
+from causal4d._interventional_contrast_common import (
+    _reject_duplicate_json_keys,
+    _reject_nonfinite_json_constant,
+    _require_exact_fields,
+    _require_mapping,
+    _require_nonempty_string,
+    _require_positive_integer,
+    _require_sha256,
+    _validated_string_tuple,
+)
+
+
+def save_interventional_contrast_bounds(
+    path: str | Path,
+    bounds: InterventionalContrastBoundsV1,
+    *,
+    overwrite: bool = True,
+) -> None:
+    """Atomically publish a strict non-pickled contrast-bound archive."""
+
+    if not isinstance(bounds, InterventionalContrastBoundsV1):
+        raise TypeError("bounds must be InterventionalContrastBoundsV1")
+    descriptor = {**bounds._scalar_payload(), "artifact_id": bounds.artifact_id}
+
+    def write_archive(handle: BinaryIO) -> None:
+        np.savez_compressed(
+            handle,
+            descriptor_json=np.asarray(
+                json.dumps(descriptor, sort_keys=True, separators=(",", ":"))
+            ),
+            **bounds._array_payload(),
+        )
+
+    def validate_archive(temporary: Path) -> None:
+        restored = load_interventional_contrast_bounds(temporary)
+        if restored.artifact_id != bounds.artifact_id:
+            raise ValueError("written interventional contrast bounds failed validation")
+
+    atomic_write_binary(
+        path,
+        write_archive,
+        overwrite=overwrite,
+        validate=validate_archive,
+    )
+
+
+def load_interventional_contrast_bounds(
+    path: str | Path,
+    *,
+    expected_sha256: str | None = None,
+) -> InterventionalContrastBoundsV1:
+    """Load and revalidate one exact interventional-contrast-bound archive."""
+
+    archive = load_numpy_archive(
+        path,
+        expected_sha256=expected_sha256,
+        name="interventional contrast bounds archive",
+    )
+    archive_arrays = archive.arrays
+    if "descriptor_json" not in archive_arrays:
+        raise ValueError("contrast bounds archive is missing descriptor_json")
+    descriptor_array = np.asarray(archive_arrays["descriptor_json"])
+    if descriptor_array.shape != () or type(descriptor_array.item()) is not str:
+        raise ValueError("descriptor_json must be a scalar string")
+    descriptor = json.loads(
+        descriptor_array.item(),
+        object_pairs_hook=_reject_duplicate_json_keys,
+        parse_constant=_reject_nonfinite_json_constant,
+    )
+    fields = _require_exact_fields(
+        descriptor,
+        name="interventional contrast bounds descriptor",
+        required=_BOUNDS_DESCRIPTOR_FIELDS,
+    )
+    schema_version = _require_positive_integer(
+        fields["schema_version"],
+        name="schema_version",
+    )
+    if schema_version != INTERVENTIONAL_CONTRAST_BOUNDS_SCHEMA_VERSION:
+        raise ValueError("unsupported interventional contrast bounds schema version")
+    artifact_kind = _require_nonempty_string(
+        fields["artifact_kind"],
+        name="artifact_kind",
+    )
+    if artifact_kind != _BOUNDS_ARTIFACT_KIND:
+        raise ValueError("unexpected interventional contrast bounds artifact kind")
+    declared_id = _require_sha256(fields["artifact_id"], name="artifact_id")
+    declared_source_id = _require_sha256(
+        fields["source_contrast_id"],
+        name="source_contrast_id",
+    )
+    declared_query_id = _require_sha256(
+        fields["source_query_id"],
+        name="source_query_id",
+    )
+    array_names = set(archive_arrays) - {"descriptor_json"}
+    if array_names != _BOUNDS_ARRAY_FIELDS:
+        raise ValueError(
+            "interventional contrast bounds array fields do not match schema; "
+            f"missing={sorted(_BOUNDS_ARRAY_FIELDS - array_names)}, "
+            f"unexpected={sorted(array_names - _BOUNDS_ARRAY_FIELDS)}"
+        )
+    arrays: dict[str, np.ndarray] = {}
+    for name in sorted(array_names):
+        values = np.asarray(archive_arrays[name])
+        if values.dtype != _BOUNDS_ARRAY_DTYPES[name]:
+            raise ValueError(
+                f"interventional contrast bounds array {name!r} must use dtype "
+                f"{_BOUNDS_ARRAY_DTYPES[name]}; got {values.dtype}"
+            )
+        arrays[name] = values
+
+    restored = InterventionalContrastBoundsV1(
+        source_contrast_id=declared_source_id,
+        source_query_id=declared_query_id,
+        branch_a_label=fields["branch_a_label"],
+        branch_b_label=fields["branch_b_label"],
+        coupling_policy=fields["coupling_policy"],
+        shared_kappa_names=_validated_string_tuple(
+            fields["shared_kappa_names"],
+            name="shared_kappa_names",
+            unique=True,
+            allow_empty=True,
+        ),
+        conditional_variance_policy=fields["conditional_variance_policy"],
+        query_name=fields["query_name"],
+        query_labels=_validated_string_tuple(
+            fields["query_labels"],
+            name="query_labels",
+            unique=True,
+        ),
+        query_units=_validated_string_tuple(
+            fields["query_units"],
+            name="query_units",
+            unique=False,
+        ),
+        metadata=_require_mapping(fields["metadata"], name="metadata"),
+        **arrays,
+    )
+    if restored.artifact_id != declared_id:
+        raise ValueError(
+            "interventional contrast bounds digest does not match its payload"
+        )
+    return restored

--- a/src/causal4d/interventional_contrast.py
+++ b/src/causal4d/interventional_contrast.py
@@ -1,5 +1,14 @@
-"""Analysis-only posteriors for explicit interventional contrasts."""
+"""Analysis-only posteriors and bounds for interventional contrasts."""
 
+from causal4d._interventional_contrast_bounds import (
+    INTERVENTIONAL_CONTRAST_BOUNDS_SCHEMA_VERSION,
+    InterventionalContrastBoundsV1,
+    build_interventional_contrast_bounds,
+)
+from causal4d._interventional_contrast_bounds_io import (
+    load_interventional_contrast_bounds,
+    save_interventional_contrast_bounds,
+)
 from causal4d._interventional_contrast_build import build_interventional_contrast
 from causal4d._interventional_contrast_common import (
     INTERVENTIONAL_CONTRAST_SCHEMA_VERSION,
@@ -19,12 +28,17 @@ from causal4d._interventional_contrast_query import (
 
 
 __all__ = [
+    "INTERVENTIONAL_CONTRAST_BOUNDS_SCHEMA_VERSION",
     "INTERVENTIONAL_CONTRAST_SCHEMA_VERSION",
     "ContrastConditionalVariancePolicy",
     "ContrastCouplingPolicy",
+    "InterventionalContrastBoundsV1",
     "InterventionalContrastPosteriorV1",
     "InterventionalContrastQueryV1",
     "build_interventional_contrast",
+    "build_interventional_contrast_bounds",
     "load_interventional_contrast",
+    "load_interventional_contrast_bounds",
     "save_interventional_contrast",
+    "save_interventional_contrast_bounds",
 ]

--- a/src/causal4d/interventional_contrast.py
+++ b/src/causal4d/interventional_contrast.py
@@ -3,6 +3,8 @@
 from causal4d._interventional_contrast_bounds import (
     INTERVENTIONAL_CONTRAST_BOUNDS_SCHEMA_VERSION,
     InterventionalContrastBoundsV1,
+)
+from causal4d._interventional_contrast_bounds_build import (
     build_interventional_contrast_bounds,
 )
 from causal4d._interventional_contrast_bounds_io import (

--- a/tests/test_interventional_contrast_bounds.py
+++ b/tests/test_interventional_contrast_bounds.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from causal4d.interventional_contrast import (
+    InterventionalContrastPosteriorV1,
+    build_interventional_contrast_bounds,
+    load_interventional_contrast_bounds,
+    save_interventional_contrast_bounds,
+)
+
+
+def _digest(name: str) -> str:
+    return hashlib.sha256(name.encode("utf-8")).hexdigest()
+
+
+def _independent_product_posterior(
+    *,
+    conditional_variance: float = 0.0,
+) -> InterventionalContrastPosteriorV1:
+    variance_policy = (
+        "component_means_only"
+        if conditional_variance == 0.0
+        else "independent_readout"
+    )
+    return InterventionalContrastPosteriorV1(
+        source_branch_a_posterior_id=_digest("branch-a"),
+        source_branch_b_posterior_id=_digest("branch-b"),
+        source_branch_a_query_id=_digest("query-a"),
+        source_branch_b_query_id=_digest("query-b"),
+        branch_a_label="do(a)",
+        branch_b_label="do(b)",
+        trajectory_shape=(1, 1, 3),
+        branch_a_component_count=2,
+        branch_b_component_count=2,
+        coupling_policy="independent_product",
+        shared_kappa_names=(),
+        conditional_variance_policy=variance_policy,
+        query_name="x",
+        query_matrix=np.asarray([[1.0, 0.0, 0.0]]),
+        query_labels=("x",),
+        query_units=("m",),
+        pair_indices=np.asarray([[0, 0], [0, 1], [1, 0], [1, 1]]),
+        weights=np.full(4, 0.25),
+        contrast_values=np.asarray([[0.0], [-2.0], [2.0], [0.0]]),
+        conditional_covariance=np.full((4, 1, 1), conditional_variance),
+        query_metadata={"registered": True},
+        metadata={"source": "unit-test"},
+    )
+
+
+def _shared_component_posterior() -> InterventionalContrastPosteriorV1:
+    return InterventionalContrastPosteriorV1(
+        source_branch_a_posterior_id=_digest("branch-a"),
+        source_branch_b_posterior_id=_digest("branch-b"),
+        source_branch_a_query_id=_digest("query-a"),
+        source_branch_b_query_id=_digest("query-b"),
+        branch_a_label="do(a)",
+        branch_b_label="do(b)",
+        trajectory_shape=(1, 1, 3),
+        branch_a_component_count=2,
+        branch_b_component_count=2,
+        coupling_policy="shared_component",
+        shared_kappa_names=(),
+        conditional_variance_policy="component_means_only",
+        query_name="x",
+        query_matrix=np.asarray([[1.0, 0.0, 0.0]]),
+        query_labels=("x",),
+        query_units=("m",),
+        pair_indices=np.asarray([[0, 0], [1, 1]]),
+        weights=np.asarray([0.5, 0.5]),
+        contrast_values=np.asarray([[1.0], [3.0]]),
+        conditional_covariance=np.zeros((2, 1, 1)),
+        query_metadata={"registered": True},
+    )
+
+
+def test_full_product_reports_sharp_coupling_sensitivity() -> None:
+    result = build_interventional_contrast_bounds(
+        _independent_product_posterior(),
+        cdf_thresholds=(-1.0, 0.0, 1.0),
+    )
+
+    np.testing.assert_allclose(result.mean, [0.0])
+    np.testing.assert_allclose(result.variance_lower, [0.0])
+    np.testing.assert_allclose(result.variance_upper, [4.0])
+    np.testing.assert_allclose(result.probability_positive_lower, [0.0])
+    np.testing.assert_allclose(result.probability_positive_upper, [0.5])
+    np.testing.assert_allclose(result.source_probability_positive, [0.25])
+    np.testing.assert_allclose(result.cdf_lower[:, 0], [0.0, 0.5, 0.5])
+    np.testing.assert_allclose(result.cdf_upper[:, 0], [0.5, 1.0, 1.0])
+    assert result.metadata["coordinate_extrema_may_use_different_couplings"]
+    assert result.metadata["claim_boundary"]["uses_target_truth"] is False
+
+
+def test_fixed_component_support_collapses_to_source_posterior() -> None:
+    posterior = _shared_component_posterior()
+    result = build_interventional_contrast_bounds(posterior)
+
+    np.testing.assert_allclose(result.variance_lower, posterior.covariance.diagonal())
+    np.testing.assert_allclose(result.variance_upper, posterior.covariance.diagonal())
+    np.testing.assert_allclose(
+        result.probability_positive_lower,
+        posterior.probability_positive,
+    )
+    np.testing.assert_allclose(
+        result.probability_positive_upper,
+        posterior.probability_positive,
+    )
+
+
+def test_conditional_variance_is_included_in_transport_objectives() -> None:
+    deterministic = build_interventional_contrast_bounds(
+        _independent_product_posterior(),
+    )
+    uncertain = build_interventional_contrast_bounds(
+        _independent_product_posterior(conditional_variance=1.0),
+    )
+
+    np.testing.assert_allclose(
+        uncertain.variance_lower,
+        deterministic.variance_lower + 1.0,
+    )
+    np.testing.assert_allclose(
+        uncertain.variance_upper,
+        deterministic.variance_upper + 1.0,
+    )
+    assert 0.0 < uncertain.probability_positive_lower[0]
+    assert uncertain.probability_positive_upper[0] < 1.0
+
+
+def test_bound_artifact_round_trip_is_content_addressed(tmp_path: Path) -> None:
+    result = build_interventional_contrast_bounds(
+        _independent_product_posterior(),
+        cdf_thresholds=(-1.0, 0.0, 1.0),
+        metadata={"registered_before_target_access": True},
+    )
+    path = tmp_path / "contrast-bounds.npz"
+    save_interventional_contrast_bounds(path, result, overwrite=False)
+    expected_sha256 = hashlib.sha256(path.read_bytes()).hexdigest()
+
+    restored = load_interventional_contrast_bounds(
+        path,
+        expected_sha256=expected_sha256,
+    )
+
+    assert restored.artifact_id == result.artifact_id
+    assert restored.source_contrast_id == result.source_contrast_id
+    np.testing.assert_array_equal(restored.cdf_thresholds, result.cdf_thresholds)
+    np.testing.assert_array_equal(restored.cdf_lower, result.cdf_lower)
+    np.testing.assert_array_equal(restored.cdf_upper, result.cdf_upper)
+
+
+def test_inputs_fail_closed() -> None:
+    posterior = _independent_product_posterior()
+    with pytest.raises(ValueError, match="maximum_pair_count"):
+        build_interventional_contrast_bounds(posterior, maximum_pair_count=3)
+    with pytest.raises(ValueError, match="cdf_thresholds"):
+        build_interventional_contrast_bounds(
+            posterior,
+            cdf_thresholds=np.ones((2, 2)),
+        )
+    with pytest.raises(ValueError, match="metadata must be a mapping"):
+        build_interventional_contrast_bounds(posterior, metadata=[])
+    with pytest.raises(TypeError, match="InterventionalContrastPosteriorV1"):
+        build_interventional_contrast_bounds(object())

--- a/tests/test_interventional_contrast_bounds_adversarial.py
+++ b/tests/test_interventional_contrast_bounds_adversarial.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import hashlib
+
+import numpy as np
+import pytest
+
+from causal4d.interventional_contrast import (
+    InterventionalContrastPosteriorV1,
+    build_interventional_contrast_bounds,
+)
+
+
+def _digest(name: str) -> str:
+    return hashlib.sha256(name.encode("utf-8")).hexdigest()
+
+
+def test_pair_values_must_define_a_coupling_invariant_mean() -> None:
+    malformed = InterventionalContrastPosteriorV1(
+        source_branch_a_posterior_id=_digest("branch-a"),
+        source_branch_b_posterior_id=_digest("branch-b"),
+        source_branch_a_query_id=_digest("query-a"),
+        source_branch_b_query_id=_digest("query-b"),
+        branch_a_label="do(a)",
+        branch_b_label="do(b)",
+        trajectory_shape=(1, 1, 3),
+        branch_a_component_count=2,
+        branch_b_component_count=2,
+        coupling_policy="independent_product",
+        shared_kappa_names=(),
+        conditional_variance_policy="component_means_only",
+        query_name="x",
+        query_matrix=np.asarray([[1.0, 0.0, 0.0]]),
+        query_labels=("x",),
+        query_units=("m",),
+        pair_indices=np.asarray([[0, 0], [0, 1], [1, 0], [1, 1]]),
+        weights=np.full(4, 0.25),
+        contrast_values=np.asarray([[0.0], [0.0], [0.0], [10.0]]),
+        conditional_covariance=np.zeros((4, 1, 1)),
+        query_metadata={"registered": True},
+    )
+
+    with pytest.raises(ValueError, match="coupling-invariant mean"):
+        build_interventional_contrast_bounds(malformed)


### PR DESCRIPTION
## Summary

- add `InterventionalContrastBoundsV1`, a content-addressed analysis-only artifact for coordinatewise sharp coupling-sensitivity bounds;
- optimize pair weights over the source contrast artifact's existing allowed pair support while preserving both source marginals exactly;
- report coupling-invariant mean, variance bounds, `P(contrast > 0)` bounds, and CDF bounds at registered thresholds;
- include declared independent-readout conditional variance in the linear objectives without inventing cross-branch covariance;
- reject syntactically valid but independently fabricated pair values whose mean changes across feasible couplings;
- add strict atomic non-pickled NPZ save/load with exact schema, dtype, hash, and payload validation; and
- document the interpretation and claim boundary.

## Motivation

Branch marginals do not identify a cross-world coupling. The existing contrast API correctly requires one explicit coupling, but a selected-coupling probability or interval can still look more definite than the structural assumption warrants. This patch turns that limitation into an explicit sensitivity analysis.

The builder changes only nonnegative weights on pairs already present in `InterventionalContrastPosteriorV1`. It never adds a structurally disallowed pair:

- `independent_product` exposes the complete marginal Fréchet class;
- `shared_twin_phi` produces bounds inside the declared shared strata and optional shared event coordinates; and
- `shared_component` collapses to the original fixed coupling.

Each coordinate and threshold is optimized separately, so endpoints may correspond to different extremal couplings. The artifact records this explicitly.

## Scientific boundary

- Frozen estimator or registered analysis changed: `no`.
- Source physical posteriors or contrast artifact changed: `no`.
- Target or held-out truth accessed: `no`.
- Registered physical-acquisition dataset modified: `no`.
- Physical evidence increment: `0`.
- Existing scientific claim changed or promoted: `no`.
- Individual-level real counterfactual ground truth claimed: `no`.

The output is a posterior identification/sensitivity artifact. It is not empirical calibration, physical-effect confirmation, deployment authorization, or evidence that the allowed pair support is causally complete.

## Numerical contract

The implementation uses sparse equality constraints and SciPy HiGHS linear programming. It:

- verifies the source pair weights are a feasible coupling;
- preserves both source marginals;
- verifies that the pair values retain the coupling-invariant mean implied by `Q(a_i) - Q(b_j)`;
- guards pair count before optimization;
- fails closed on malformed thresholds, non-finite objectives, solver failure, invalid result bounds, archive mutation, and non-additive fabricated pair values;
- includes pair-specific conditional Gaussian variance only under the source artifact's declared `independent_readout` policy; and
- binds every input, result, semantic declaration, and metadata field into the artifact identity.

## Validation

Local focused checks completed before publication:

- Python byte compilation for all new and modified Python files;
- 88-character line-length audit;
- deterministic full-product case with sharp probability, CDF, and variance bounds;
- fixed-component case with collapsed bounds;
- independent-readout Gaussian conditional-variance case;
- adversarial rejection of coupling-dependent fabricated pair means; and
- strict archive round trip with content identity.

GitHub Actions on the exact pull-request head are authoritative for Ruff, MyPy, the complete test matrix, package builds, installed checks, security, and cross-repository compatibility.

## Merge disposition

Product change intended for review and merge after authoritative checks pass. No physical execution, target opening, protocol mutation, evidence publication, or claim promotion is authorized by this change.