### PR TITLE
Make package exports lazy and promote query projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- Make the historical package-root API lazy while preserving exact owning-module
+  object identity, wildcard exports, and module introspection. Package an explicit
+  `__init__.pyi` surface, promote physical-posterior query projection through API
+  v1, and verify the runtime and typing boundaries from installed wheels and sdists.
 - Formalize Causal4D's structural causal model and identification assumptions,
   and add a typed, content-addressed, analysis-only posterior for explicit
   `Q(branch_a) - Q(branch_b)` interventional trajectory contrasts. The API

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -2,9 +2,10 @@
 
 Causal4D contains stable contracts, registered evidence machinery, diagnostics, and
 fast-moving research prototypes. Importing every convenient top-level name made it
-unclear which interfaces downstream projects could rely on.
+unclear which interfaces downstream projects could rely on and forced even a simple
+package import to initialize unrelated research modules.
 
-The supported version-1 surface is now explicit:
+The supported version-1 surface is explicit:
 
 ```python
 from causal4d.api.v1 import (
@@ -12,6 +13,7 @@ from causal4d.api.v1 import (
     PhysicalPosterior,
     PrefixLikelihoodConfig,
     apply_counterfactual_operator,
+    project_physical_posterior,
 )
 ```
 
@@ -19,21 +21,90 @@ Only names listed in `causal4d.api.v1.__all__` are covered by the v1 compatibili
 promise. Existing imports such as `from causal4d import PhysicalPosterior` remain
 compatible, but new downstream code should prefer the versioned path.
 
+## Import behavior
+
+The unversioned package root retains its historical export inventory through lazy
+attribute loading. `import causal4d` now defines the version, export table, and lazy
+resolver without importing every experimental, protocol, semantic, or provider
+module. Accessing a historical export loads its owning module once and caches the
+exact object at the package root:
+
+```python
+import causal4d
+
+posterior_type = causal4d.PhysicalPosterior
+```
+
+This changes import cost, not object identity or public names. A wildcard import
+still resolves every name in `causal4d.__all__` and therefore deliberately loads the
+complete historical surface. Importing `causal4d.api.v1` loads the modules required
+by the supported API but not unrelated research families such as action-support,
+latent-contact-v2, semantic-freshness, or decision-trace machinery.
+
 ## What v1 contains
 
-The initial surface is deliberately conservative:
+The surface is deliberately conservative:
 
 - causal query and posterior contracts;
 - rollout-bank and prefix-likelihood interfaces;
-- the counterfactual operator;
+- the counterfactual operator and explicit physical-posterior query projection;
 - hierarchical intervention abduction;
-- full-joint Gaussian observation contracts and updates; and
+- full-joint Gaussian observation contracts and updates;
+- explicit interventional-contrast query and posterior contracts; and
 - the versioned BayesianPhysTwin provider boundary.
 
 Registered acquisition internals, CLI implementations, paper-specific report
 builders, prospective promotion machinery, semantic branches, and experimental
 contact models remain in their owning modules. They can evolve without expanding a
 stable compatibility promise accidentally.
+
+## Counterfactual query projection
+
+A counterfactual rollout bank contains one factual intervention-endpoint frame and
+then exactly `query.horizon_frames` future frames. The dense counterfactual operator
+retains that endpoint for compatibility. Use the explicit projection helper for a
+query-facing artifact:
+
+```python
+dense = apply_counterfactual_operator(
+    bank,
+    manifest,
+    twin_belief,
+    factual_intervention,
+    query,
+)
+future = project_physical_posterior(dense, query)
+```
+
+The default projection removes the endpoint and preserves the registered
+`query_node_indices` order. Set `include_endpoint=True` only when the endpoint is
+part of the intended output. The projected artifact retains component weights,
+causal ancestry, the source posterior identity, and the complete frame/node policy
+in its content-addressed metadata.
+
+## Execution-only grouped batching
+
+Large grouped-abduction studies may evaluate finite support in bounded component
+batches without changing the estimator:
+
+```python
+from causal4d.intervention_abduction import abduct_factual_intervention
+
+factual = abduct_factual_intervention(
+    bank,
+    twin_belief,
+    observations,
+    prefix_frame_count=6,
+    grouped_evidence=evidence,
+    grouped_component_batch_size=64,
+)
+```
+
+`grouped_component_batch_size` is an execution-only memory bound. It is not written
+to scientific metadata, and the batched path is required to reproduce the dense
+posterior weights, diagnostics, and artifact identity exactly. The dense path
+remains the default. This research entry point is documented here for resource
+control but is not thereby added to the v1 compatibility surface.
 
 ## Compatibility policy
 
@@ -52,5 +123,6 @@ every re-export is stable.
 ## Checking the surface
 
 The repository locks the exact v1 inventory and verifies that each versioned symbol
-is the same object as its historical top-level counterpart. This prevents silent
-wrappers, accidental copies, and unreviewed expansion of the stable namespace.
+is the same object as its historical top-level counterpart. Subprocess import probes
+also lock the lazy root boundary and prevent unrelated research modules from
+silently re-entering the stable import path.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 causal4d = [
+    "__init__.pyi",
     "py.typed",
     "contract_data/evidence_decision_v1/*.json",
     "contract_data/evidence_decision_v1/vectors/*.json",

--- a/scripts/ci/check_console_help.py
+++ b/scripts/ci/check_console_help.py
@@ -96,6 +96,25 @@ def verify_console_help(
 ) -> None:
     typing_marker = _require_installed_file(distribution, "causal4d/py.typed")
     print(f"verified installed PEP 561 marker: {typing_marker}")
+    typing_stub = _require_installed_file(distribution, "causal4d/__init__.pyi")
+    print(f"verified installed package-root typing stub: {typing_stub}")
+
+    environment = _clean_environment()
+    root_surface_script = Path(__file__).with_name("check_installed_root_surface.py")
+    root_surface = _run(
+        [
+            sys.executable,
+            str(root_surface_script),
+            "--repository-root",
+            str(pyproject.resolve().parent),
+        ],
+        cwd=str(pyproject.resolve().parent),
+        environment=environment,
+        timeout_seconds=timeout_seconds,
+    )
+    if root_surface.returncode != 0:
+        raise RuntimeError(root_surface.stdout + root_surface.stderr)
+    print(root_surface.stdout.strip())
 
     declared = _declared_scripts(pyproject)
     expected = {"causal4d": "causal4d.cli.root:main"}
@@ -114,7 +133,6 @@ def verify_console_help(
     executable = shutil.which("causal4d")
     if executable is None:
         raise RuntimeError("causal4d executable is not on PATH")
-    environment = _clean_environment()
     failures: list[str] = []
     with tempfile.TemporaryDirectory(prefix="causal4d-cli-help-") as directory:
         validation = _run(

--- a/scripts/ci/check_installed_root_surface.py
+++ b/scripts/ci/check_installed_root_surface.py
@@ -18,7 +18,7 @@ def _parser() -> argparse.ArgumentParser:
         "--repository-root",
         type=Path,
         required=True,
-        help="Source checkout that the installed import must not resolve beneath.",
+        help="Checkout whose src tree the installed import must not resolve beneath.",
     )
     return parser
 
@@ -53,10 +53,10 @@ def _require_installed_module(module: ModuleType, repository_root: Path) -> Path
     if not isinstance(file_name, str):
         raise RuntimeError("installed causal4d module has no ordinary file path")
     package_path = Path(file_name).resolve()
-    source_root = repository_root.resolve()
-    if package_path.is_relative_to(source_root):
+    source_tree = (repository_root.resolve() / "src").resolve()
+    if package_path.is_relative_to(source_tree):
         raise RuntimeError(
-            f"causal4d import resolved inside the source checkout: {package_path}"
+            f"causal4d import resolved inside the source tree: {package_path}"
         )
     return package_path
 

--- a/scripts/ci/check_installed_root_surface.py
+++ b/scripts/ci/check_installed_root_surface.py
@@ -1,0 +1,129 @@
+"""Validate the lazy package-root API from an isolated installed artifact."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib
+import json
+from pathlib import Path
+import sys
+from types import ModuleType
+from typing import Sequence
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--repository-root",
+        type=Path,
+        required=True,
+        help="Source checkout that the installed import must not resolve beneath.",
+    )
+    return parser
+
+
+def _stub_surface(path: Path) -> tuple[set[str], bool]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    exports: set[str] = set()
+    has_version_annotation = False
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.asname != alias.name:
+                    raise RuntimeError(
+                        "package-root typing imports must use explicit identity aliases"
+                    )
+                if alias.name in exports:
+                    raise RuntimeError(
+                        f"duplicate package-root typing export {alias.name!r}"
+                    )
+                exports.add(alias.name)
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "__version__"
+        ):
+            has_version_annotation = True
+    return exports, has_version_annotation
+
+
+def _require_installed_module(module: ModuleType, repository_root: Path) -> Path:
+    file_name = getattr(module, "__file__", None)
+    if not isinstance(file_name, str):
+        raise RuntimeError("installed causal4d module has no ordinary file path")
+    package_path = Path(file_name).resolve()
+    source_root = repository_root.resolve()
+    if package_path.is_relative_to(source_root):
+        raise RuntimeError(
+            f"causal4d import resolved inside the source checkout: {package_path}"
+        )
+    return package_path
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    loaded_before = set(sys.modules)
+    causal4d = importlib.import_module("causal4d")
+    eagerly_loaded = sorted(
+        name
+        for name in set(sys.modules) - loaded_before
+        if name.startswith("causal4d.")
+    )
+    if eagerly_loaded:
+        raise RuntimeError(
+            "installed package root eagerly imported implementation modules: "
+            f"{eagerly_loaded}"
+        )
+
+    package_path = _require_installed_module(causal4d, args.repository_root)
+    stub_path = package_path.with_suffix(".pyi")
+    if not stub_path.is_file():
+        raise RuntimeError(f"installed package is missing {stub_path.name}")
+
+    raw_exports = getattr(causal4d, "__all__", None)
+    if not isinstance(raw_exports, list) or not all(
+        isinstance(name, str) for name in raw_exports
+    ):
+        raise RuntimeError("installed causal4d.__all__ must be a string list")
+    exports = tuple(raw_exports)
+    if len(exports) != len(set(exports)):
+        raise RuntimeError("installed causal4d.__all__ contains duplicates")
+
+    typed_exports, has_version_annotation = _stub_surface(stub_path)
+    if typed_exports != set(exports):
+        missing = sorted(set(exports) - typed_exports)
+        unexpected = sorted(typed_exports - set(exports))
+        raise RuntimeError(
+            "installed root typing surface differs from runtime exports; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    if not has_version_annotation:
+        raise RuntimeError("installed root typing stub omits __version__")
+
+    for name in exports:
+        getattr(causal4d, name)
+
+    api_v1 = importlib.import_module("causal4d.api.v1")
+    for name in getattr(api_v1, "__all__"):
+        if name.startswith("PUBLIC_API_"):
+            continue
+        if getattr(api_v1, name) is not getattr(causal4d, name):
+            raise RuntimeError(f"v1/root object identity differs for {name!r}")
+
+    print(
+        json.dumps(
+            {
+                "package_path": str(package_path),
+                "root_export_count": len(exports),
+                "typing_stub": str(stub_path),
+                "v1_export_count": len(getattr(api_v1, "__all__")),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d/__init__.py
+++ b/src/causal4d/__init__.py
@@ -1,238 +1,376 @@
-"""Controlled counterfactual benchmarks for intervention-ready world models."""
+"""Public Causal4D exports with compatibility-preserving lazy loading.
 
-from causal4d.action_conditioned_counterfactual import (
-    ActionConditionedPhysicalPosterior,
-    apply_action_conditioned_counterfactual_operator,
+Importing the package root defines the historical export inventory without
+eagerly importing research, protocol, provider, or optional integration
+modules. Each public attribute is loaded from its owning module on first
+access and then cached in this module. New downstream code should prefer
+``causal4d.api.v1`` for the explicit compatibility promise.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Final
+
+
+_LAZY_EXPORT_GROUPS: Final = (
+    (
+        "causal4d.action_conditioned_counterfactual",
+        (
+            "ActionConditionedPhysicalPosterior",
+            "apply_action_conditioned_counterfactual_operator",
+        ),
+    ),
+    (
+        "causal4d.action_conditioned_discrepancy",
+        (
+            "ActionConditionedDiscrepancyFeatures",
+            "ActionConditionedDiscrepancyForecast",
+            "ActionConditionedDiscrepancyModel",
+            "build_action_conditioned_features",
+            "forecast_action_conditioned_persistence",
+        ),
+    ),
+    (
+        "causal4d.action_support",
+        (
+            "ACTION_SUPPORT_SCHEMA_VERSION",
+            "ActionSupportCalibration",
+            "ActionSupportDecision",
+            "ActionSupportSelection",
+            "ActionSupportSourceCase",
+            "evaluate_action_support",
+            "fit_action_support_calibration",
+            "load_action_support_calibration",
+            "load_claim_bearing_action_support_calibration",
+            "select_action_supported_candidate",
+            "write_action_support_calibration",
+        ),
+    ),
+    (
+        "causal4d.action_support_counterfactual",
+        ("apply_guarded_action_conditioned_counterfactual_operator",),
+    ),
+    (
+        "causal4d.counterfactual_regret",
+        (
+            "COUNTERFACTUAL_REGRET_ENDPOINTS",
+            "COUNTERFACTUAL_REGRET_SCHEMA_VERSION",
+            "CounterfactualRegretCertificate",
+            "CounterfactualRegretDecision",
+            "CounterfactualRegretFeatures",
+            "CounterfactualRegretPrerequisite",
+            "CounterfactualRegretSelection",
+            "CounterfactualRegretSourceCase",
+            "CounterfactualRegretTarget",
+            "evaluate_counterfactual_regret",
+            "fit_counterfactual_regret_certificate",
+            "load_claim_bearing_counterfactual_regret_certificate",
+            "load_counterfactual_regret_certificate",
+            "select_counterfactual_regret_candidate",
+            "write_counterfactual_regret_certificate",
+            "write_counterfactual_regret_decision",
+        ),
+    ),
+    (
+        "causal4d.latent_contact_v2",
+        (
+            "LATENT_CONTACT_V2_SCHEMA_VERSION",
+            "ContactEffectPosteriorV2",
+            "ContactEndpoint",
+            "ContactLikelihoodV2Diagnostics",
+            "ContactObservationEvidenceV2",
+            "ContactPatchHypothesisSupportV2",
+            "ContactPatchRolloutBankV2",
+            "ContactPatchStateV2",
+            "ContactV2Selection",
+            "ContactV2SupportDecision",
+            "ContactV2SupportPolicy",
+            "ContactV2SupportRejectedError",
+            "GraphContactPatchModelV2",
+            "LinearContactObservationGroup",
+            "SparseContactPatch",
+            "build_contact_patch_rollout_bank_v2",
+            "contact_component_log_likelihoods_v2",
+            "evaluate_contact_v2_support",
+            "gaussian_mixture_quantiles",
+            "posterior_weights_from_contact_evidence_v2",
+            "select_contact_v2_candidate",
+        ),
+    ),
+    (
+        "causal4d.decision_trace",
+        (
+            "DECISION_TRACE_ENDPOINTS",
+            "DECISION_TRACE_PIPELINE",
+            "DECISION_TRACE_SCHEMA_NAME",
+            "DECISION_TRACE_SCHEMA_VERSION",
+            "DECISION_TRACE_STAGE_KINDS",
+            "DecisionTraceArtifact",
+            "DecisionTraceBuildResult",
+            "DecisionTraceDecision",
+            "DecisionTraceSelection",
+            "DecisionTraceStage",
+            "UnifiedDecisionTrace",
+            "build_unified_decision_trace",
+            "load_claim_bearing_decision_trace",
+            "load_decision_trace",
+            "require_decision_trace_stack_lock",
+            "write_decision_trace",
+        ),
+    ),
+    (
+        "causal4d.benchmark",
+        (
+            "CounterfactualBenchmarkConfig",
+            "build_protocol",
+        ),
+    ),
+    (
+        "causal4d.causal_sufficiency",
+        (
+            "CausalSufficiencyResult",
+            "assess_command_residual_sufficiency",
+        ),
+    ),
+    (
+        "causal4d.claim_bearing_observation_lineage",
+        (
+            "load_claim_bearing_prob4d_observation_lineage",
+            "require_claim_bearing_prob4d_lineage",
+        ),
+    ),
+    (
+        "causal4d.contact_evaluation",
+        ("run_latent_contact_benchmark",),
+    ),
+    (
+        "causal4d.contact_inference",
+        ("LatentContactConfig",),
+    ),
+    (
+        "causal4d.contact_traction",
+        (
+            "graph_traction_field",
+            "integrate_contact_wrench",
+        ),
+    ),
+    (
+        "causal4d.contracts",
+        (
+            "CounterfactualQuery",
+            "FactualIntervention",
+            "PhysicalPosterior",
+            "TaskPosterior",
+            "TwinBelief",
+        ),
+    ),
+    (
+        "causal4d.counterfactual",
+        (
+            "apply_counterfactual_operator",
+            "project_physical_posterior",
+        ),
+    ),
+    (
+        "causal4d.discrepancy_belief",
+        (
+            "GraphDiscrepancyBelief",
+            "graph_discrepancy_group_covariances",
+            "load_graph_discrepancy_belief",
+            "write_graph_discrepancy_belief",
+        ),
+    ),
+    (
+        "causal4d.evaluation",
+        ("run_counterfactual_benchmark",),
+    ),
+    (
+        "causal4d.factual_abduction_uncertainty",
+        (
+            "FACTUAL_ABDUCTION_UNCERTAINTY_SCHEMA_VERSION",
+            "FactualAbductionUncertaintyV1",
+            "load_factual_abduction_uncertainty_npz",
+            "save_factual_abduction_uncertainty_npz",
+        ),
+    ),
+    (
+        "causal4d.finite_query_ambiguity",
+        (
+            "FiniteQueryAmbiguityConfig",
+            "FiniteQueryAmbiguityResult",
+            "assess_finite_query_ambiguity",
+        ),
+    ),
+    (
+        "causal4d.graph_mode_abduction",
+        (
+            "GraphModeAbductionConfig",
+            "abduct_factual_intervention_graph_mode",
+            "graph_mode_joint_weights",
+        ),
+    ),
+    (
+        "causal4d.grouped_likelihood",
+        (
+            "GroupLikelihoodDiagnostics",
+            "GroupedScoreSemantics",
+            "grouped_component_log_likelihoods",
+            "posterior_weights_from_grouped_evidence",
+        ),
+    ),
+    (
+        "causal4d.hierarchical_abduction",
+        (
+            "HierarchicalAbductionResult",
+            "abduct_hierarchical_interventions",
+        ),
+    ),
+    (
+        "causal4d.identifiability",
+        (
+            "IdentifiabilityConfig",
+            "InterventionIdentifiabilityResult",
+            "assess_intervention_identifiability",
+            "finite_response_sensitivity",
+            "project_identifiable_intervention_update",
+        ),
+    ),
+    (
+        "causal4d.interventional_contrast",
+        (
+            "INTERVENTIONAL_CONTRAST_SCHEMA_VERSION",
+            "ContrastConditionalVariancePolicy",
+            "ContrastCouplingPolicy",
+            "InterventionalContrastPosteriorV1",
+            "InterventionalContrastQueryV1",
+            "build_interventional_contrast",
+            "load_interventional_contrast",
+            "save_interventional_contrast",
+        ),
+    ),
+    (
+        "causal4d.joint_observation",
+        (
+            "JOINT_OBSERVATION_SCHEMA_VERSION",
+            "CovarianceRepresentation",
+            "JointGaussianLikelihoodDiagnostics",
+            "LinearJointObservationEvidence",
+            "block_diagonalize_covariance",
+            "joint_component_log_likelihoods",
+            "posterior_weights_from_joint_observation",
+        ),
+    ),
+    (
+        "causal4d.observation_evidence",
+        (
+            "GroupedObservationEvidence",
+            "ObservationGroup",
+        ),
+    ),
+    (
+        "causal4d.observation_factor_lineage",
+        (
+            "OBSERVATION_FACTOR_SCHEMA",
+            "OBSERVATION_FACTOR_SCHEMA_VERSION",
+            "ObservationFactorLineage",
+            "bind_twin_belief_observation_factor_lineage",
+            "load_observation_factor_lineage",
+            "validate_twin_belief_observation_factor_lineage",
+        ),
+    ),
+    (
+        "causal4d.partial_identifiability",
+        ("preserve_prior_within_unidentified_subspace",),
+    ),
+    (
+        "causal4d.prefix_likelihood",
+        (
+            "PrefixLikelihoodConfig",
+            "prefix_component_log_likelihood",
+            "update_joint_weights_from_prefix",
+        ),
+    ),
+    (
+        "causal4d.prob4d_joint_observation",
+        (
+            "PROB4D_JOINT_ADAPTER_SCHEMA_VERSION",
+            "Prob4DJointObservationDiagnostics",
+            "Prob4DReliabilityPolicy",
+            "joint_observation_from_prob4d",
+        ),
+    ),
+    (
+        "causal4d.prob4d_observation_lineage",
+        (
+            "validate_claim_bearing_prob4d_observation_metadata",
+            "validate_prob4d_causal_observation_metadata",
+        ),
+    ),
+    (
+        "causal4d.provider_contract",
+        (
+            "BASE_CAUSAL4D_PROVIDER_CAPABILITIES",
+            "BAYESIAN_PHYSTWIN_ARTIFACT_SCHEMA_VERSIONS",
+            "BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE",
+            "BAYESIAN_PHYSTWIN_PROVIDER_CAPABILITIES",
+            "PHYSICAL_BELIEF_PROVIDER_SCHEMA_VERSION",
+            "PhysicalBeliefProviderManifest",
+            "ProviderCompatibilityResult",
+            "load_bayesian_phystwin_provider_manifest",
+            "require_bayesian_phystwin_provider",
+            "validate_bayesian_phystwin_provider",
+            "validate_provider_compatibility",
+        ),
+    ),
+    (
+        "causal4d.rollout_bank",
+        (
+            "JointRolloutBank",
+            "SparseTrajectoryEvidence",
+        ),
+    ),
+    (
+        "causal4d.semantic_freshness",
+        (
+            "SEMANTIC_TIMING_SCHEMA_VERSION",
+            "SEMANTIC_TIMING_SCOPE",
+            "SemanticFreshnessDecision",
+            "SemanticFreshnessLimits",
+            "SemanticTimingMetadata",
+            "apply_semantic_freshness_gate",
+        ),
+    ),
+    (
+        "causal4d.sensor_evidence",
+        (
+            "INDEPENDENT_SENSOR_SCHEMA_VERSION",
+            "ActuatorEvidence",
+            "ContactWrenchEvidence",
+            "load_independent_sensor_evidence",
+            "save_independent_sensor_evidence",
+        ),
+    ),
+    (
+        "causal4d.sensor_factorized_abduction",
+        (
+            "IndependentSensorAbductionConfig",
+            "predict_affine_actuator_realizations",
+            "reweight_factual_intervention_with_independent_sensors",
+        ),
+    ),
+    (
+        "causal4d.stable_discrepancy_dynamics",
+        (
+            "StableDiscrepancyTransitionModel",
+            "forecast_action_conditioned_dynamics",
+        ),
+    ),
 )
-from causal4d.action_conditioned_discrepancy import (
-    ActionConditionedDiscrepancyFeatures,
-    ActionConditionedDiscrepancyForecast,
-    ActionConditionedDiscrepancyModel,
-    build_action_conditioned_features,
-    forecast_action_conditioned_persistence,
-)
-from causal4d.action_support import (
-    ACTION_SUPPORT_SCHEMA_VERSION,
-    ActionSupportCalibration,
-    ActionSupportDecision,
-    ActionSupportSelection,
-    ActionSupportSourceCase,
-    evaluate_action_support,
-    fit_action_support_calibration,
-    load_action_support_calibration,
-    load_claim_bearing_action_support_calibration,
-    select_action_supported_candidate,
-    write_action_support_calibration,
-)
-from causal4d.action_support_counterfactual import (
-    apply_guarded_action_conditioned_counterfactual_operator,
-)
-from causal4d.counterfactual_regret import (
-    COUNTERFACTUAL_REGRET_ENDPOINTS,
-    COUNTERFACTUAL_REGRET_SCHEMA_VERSION,
-    CounterfactualRegretCertificate,
-    CounterfactualRegretDecision,
-    CounterfactualRegretFeatures,
-    CounterfactualRegretPrerequisite,
-    CounterfactualRegretSelection,
-    CounterfactualRegretSourceCase,
-    CounterfactualRegretTarget,
-    evaluate_counterfactual_regret,
-    fit_counterfactual_regret_certificate,
-    load_claim_bearing_counterfactual_regret_certificate,
-    load_counterfactual_regret_certificate,
-    select_counterfactual_regret_candidate,
-    write_counterfactual_regret_certificate,
-    write_counterfactual_regret_decision,
-)
-from causal4d.latent_contact_v2 import (
-    LATENT_CONTACT_V2_SCHEMA_VERSION,
-    ContactEffectPosteriorV2,
-    ContactEndpoint,
-    ContactLikelihoodV2Diagnostics,
-    ContactObservationEvidenceV2,
-    ContactPatchHypothesisSupportV2,
-    ContactPatchRolloutBankV2,
-    ContactPatchStateV2,
-    ContactV2Selection,
-    ContactV2SupportDecision,
-    ContactV2SupportPolicy,
-    ContactV2SupportRejectedError,
-    GraphContactPatchModelV2,
-    LinearContactObservationGroup,
-    SparseContactPatch,
-    build_contact_patch_rollout_bank_v2,
-    contact_component_log_likelihoods_v2,
-    evaluate_contact_v2_support,
-    gaussian_mixture_quantiles,
-    posterior_weights_from_contact_evidence_v2,
-    select_contact_v2_candidate,
-)
-from causal4d.decision_trace import (
-    DECISION_TRACE_ENDPOINTS,
-    DECISION_TRACE_PIPELINE,
-    DECISION_TRACE_SCHEMA_NAME,
-    DECISION_TRACE_SCHEMA_VERSION,
-    DECISION_TRACE_STAGE_KINDS,
-    DecisionTraceArtifact,
-    DecisionTraceBuildResult,
-    DecisionTraceDecision,
-    DecisionTraceSelection,
-    DecisionTraceStage,
-    UnifiedDecisionTrace,
-    build_unified_decision_trace,
-    load_claim_bearing_decision_trace,
-    load_decision_trace,
-    require_decision_trace_stack_lock,
-    write_decision_trace,
-)
-from causal4d.benchmark import CounterfactualBenchmarkConfig, build_protocol
-from causal4d.causal_sufficiency import (
-    CausalSufficiencyResult,
-    assess_command_residual_sufficiency,
-)
-from causal4d.claim_bearing_observation_lineage import (
-    load_claim_bearing_prob4d_observation_lineage,
-    require_claim_bearing_prob4d_lineage,
-)
-from causal4d.contact_evaluation import run_latent_contact_benchmark
-from causal4d.contact_inference import LatentContactConfig
-from causal4d.contact_traction import graph_traction_field, integrate_contact_wrench
-from causal4d.contracts import (
-    CounterfactualQuery,
-    FactualIntervention,
-    PhysicalPosterior,
-    TaskPosterior,
-    TwinBelief,
-)
-from causal4d.counterfactual import apply_counterfactual_operator
-from causal4d.discrepancy_belief import (
-    GraphDiscrepancyBelief,
-    graph_discrepancy_group_covariances,
-    load_graph_discrepancy_belief,
-    write_graph_discrepancy_belief,
-)
-from causal4d.evaluation import run_counterfactual_benchmark
-from causal4d.factual_abduction_uncertainty import (
-    FACTUAL_ABDUCTION_UNCERTAINTY_SCHEMA_VERSION,
-    FactualAbductionUncertaintyV1,
-    load_factual_abduction_uncertainty_npz,
-    save_factual_abduction_uncertainty_npz,
-)
-from causal4d.finite_query_ambiguity import (
-    FiniteQueryAmbiguityConfig,
-    FiniteQueryAmbiguityResult,
-    assess_finite_query_ambiguity,
-)
-from causal4d.graph_mode_abduction import (
-    GraphModeAbductionConfig,
-    abduct_factual_intervention_graph_mode,
-    graph_mode_joint_weights,
-)
-from causal4d.grouped_likelihood import (
-    GroupLikelihoodDiagnostics,
-    GroupedScoreSemantics,
-    grouped_component_log_likelihoods,
-    posterior_weights_from_grouped_evidence,
-)
-from causal4d.hierarchical_abduction import (
-    HierarchicalAbductionResult,
-    abduct_hierarchical_interventions,
-)
-from causal4d.identifiability import (
-    IdentifiabilityConfig,
-    InterventionIdentifiabilityResult,
-    assess_intervention_identifiability,
-    finite_response_sensitivity,
-    project_identifiable_intervention_update,
-)
-from causal4d.interventional_contrast import (
-    INTERVENTIONAL_CONTRAST_SCHEMA_VERSION,
-    ContrastConditionalVariancePolicy,
-    ContrastCouplingPolicy,
-    InterventionalContrastPosteriorV1,
-    InterventionalContrastQueryV1,
-    build_interventional_contrast,
-    load_interventional_contrast,
-    save_interventional_contrast,
-)
-from causal4d.joint_observation import (
-    JOINT_OBSERVATION_SCHEMA_VERSION,
-    CovarianceRepresentation,
-    JointGaussianLikelihoodDiagnostics,
-    LinearJointObservationEvidence,
-    block_diagonalize_covariance,
-    joint_component_log_likelihoods,
-    posterior_weights_from_joint_observation,
-)
-from causal4d.observation_evidence import (
-    GroupedObservationEvidence,
-    ObservationGroup,
-)
-from causal4d.observation_factor_lineage import (
-    OBSERVATION_FACTOR_SCHEMA,
-    OBSERVATION_FACTOR_SCHEMA_VERSION,
-    ObservationFactorLineage,
-    bind_twin_belief_observation_factor_lineage,
-    load_observation_factor_lineage,
-    validate_twin_belief_observation_factor_lineage,
-)
-from causal4d.partial_identifiability import (
-    preserve_prior_within_unidentified_subspace,
-)
-from causal4d.prefix_likelihood import (
-    PrefixLikelihoodConfig,
-    prefix_component_log_likelihood,
-    update_joint_weights_from_prefix,
-)
-from causal4d.prob4d_joint_observation import (
-    PROB4D_JOINT_ADAPTER_SCHEMA_VERSION,
-    Prob4DJointObservationDiagnostics,
-    Prob4DReliabilityPolicy,
-    joint_observation_from_prob4d,
-)
-from causal4d.prob4d_observation_lineage import (
-    validate_claim_bearing_prob4d_observation_metadata,
-    validate_prob4d_causal_observation_metadata,
-)
-from causal4d.provider_contract import (
-    BASE_CAUSAL4D_PROVIDER_CAPABILITIES,
-    BAYESIAN_PHYSTWIN_ARTIFACT_SCHEMA_VERSIONS,
-    BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE,
-    BAYESIAN_PHYSTWIN_PROVIDER_CAPABILITIES,
-    PHYSICAL_BELIEF_PROVIDER_SCHEMA_VERSION,
-    PhysicalBeliefProviderManifest,
-    ProviderCompatibilityResult,
-    load_bayesian_phystwin_provider_manifest,
-    require_bayesian_phystwin_provider,
-    validate_bayesian_phystwin_provider,
-    validate_provider_compatibility,
-)
-from causal4d.rollout_bank import JointRolloutBank, SparseTrajectoryEvidence
-from causal4d.semantic_freshness import (
-    SEMANTIC_TIMING_SCHEMA_VERSION,
-    SEMANTIC_TIMING_SCOPE,
-    SemanticFreshnessDecision,
-    SemanticFreshnessLimits,
-    SemanticTimingMetadata,
-    apply_semantic_freshness_gate,
-)
-from causal4d.sensor_evidence import (
-    INDEPENDENT_SENSOR_SCHEMA_VERSION,
-    ActuatorEvidence,
-    ContactWrenchEvidence,
-    load_independent_sensor_evidence,
-    save_independent_sensor_evidence,
-)
-from causal4d.sensor_factorized_abduction import (
-    IndependentSensorAbductionConfig,
-    predict_affine_actuator_realizations,
-    reweight_factual_intervention_with_independent_sensors,
-)
-from causal4d.stable_discrepancy_dynamics import (
-    StableDiscrepancyTransitionModel,
-    forecast_action_conditioned_dynamics,
-)
+
+_LAZY_EXPORTS: Final = {
+    name: module_name for module_name, names in _LAZY_EXPORT_GROUPS for name in names
+}
 
 __all__ = [
     "DECISION_TRACE_ENDPOINTS",
@@ -394,6 +532,7 @@ __all__ = [
     "prefix_component_log_likelihood",
     "preserve_prior_within_unidentified_subspace",
     "project_identifiable_intervention_update",
+    "project_physical_posterior",
     "require_bayesian_phystwin_provider",
     "require_claim_bearing_prob4d_lineage",
     "reweight_factual_intervention_with_independent_sensors",
@@ -412,5 +551,28 @@ __all__ = [
     "write_action_support_calibration",
     "write_graph_discrepancy_belief",
 ]
+
+if len(_LAZY_EXPORTS) != sum(len(names) for _, names in _LAZY_EXPORT_GROUPS):
+    raise RuntimeError("duplicate Causal4D lazy export")
+if set(__all__) != set(_LAZY_EXPORTS):
+    raise RuntimeError("Causal4D lazy exports and __all__ differ")
+
+
+def __getattr__(name: str) -> object:
+    """Load one historical top-level export from its owning module."""
+
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(module_name), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Include lazy public exports in module introspection."""
+
+    return sorted(set(globals()) | set(__all__))
+
 
 __version__ = "0.5.0"

--- a/src/causal4d/__init__.pyi
+++ b/src/causal4d/__init__.pyi
@@ -1,0 +1,255 @@
+"""Typing surface for the compatibility-preserving package-root exports."""
+
+from causal4d.action_conditioned_counterfactual import (
+    ActionConditionedPhysicalPosterior as ActionConditionedPhysicalPosterior,
+    apply_action_conditioned_counterfactual_operator as apply_action_conditioned_counterfactual_operator,
+)
+from causal4d.action_conditioned_discrepancy import (
+    ActionConditionedDiscrepancyFeatures as ActionConditionedDiscrepancyFeatures,
+    ActionConditionedDiscrepancyForecast as ActionConditionedDiscrepancyForecast,
+    ActionConditionedDiscrepancyModel as ActionConditionedDiscrepancyModel,
+    build_action_conditioned_features as build_action_conditioned_features,
+    forecast_action_conditioned_persistence as forecast_action_conditioned_persistence,
+)
+from causal4d.action_support import (
+    ACTION_SUPPORT_SCHEMA_VERSION as ACTION_SUPPORT_SCHEMA_VERSION,
+    ActionSupportCalibration as ActionSupportCalibration,
+    ActionSupportDecision as ActionSupportDecision,
+    ActionSupportSelection as ActionSupportSelection,
+    ActionSupportSourceCase as ActionSupportSourceCase,
+    evaluate_action_support as evaluate_action_support,
+    fit_action_support_calibration as fit_action_support_calibration,
+    load_action_support_calibration as load_action_support_calibration,
+    load_claim_bearing_action_support_calibration as load_claim_bearing_action_support_calibration,
+    select_action_supported_candidate as select_action_supported_candidate,
+    write_action_support_calibration as write_action_support_calibration,
+)
+from causal4d.action_support_counterfactual import (
+    apply_guarded_action_conditioned_counterfactual_operator as apply_guarded_action_conditioned_counterfactual_operator,
+)
+from causal4d.counterfactual_regret import (
+    COUNTERFACTUAL_REGRET_ENDPOINTS as COUNTERFACTUAL_REGRET_ENDPOINTS,
+    COUNTERFACTUAL_REGRET_SCHEMA_VERSION as COUNTERFACTUAL_REGRET_SCHEMA_VERSION,
+    CounterfactualRegretCertificate as CounterfactualRegretCertificate,
+    CounterfactualRegretDecision as CounterfactualRegretDecision,
+    CounterfactualRegretFeatures as CounterfactualRegretFeatures,
+    CounterfactualRegretPrerequisite as CounterfactualRegretPrerequisite,
+    CounterfactualRegretSelection as CounterfactualRegretSelection,
+    CounterfactualRegretSourceCase as CounterfactualRegretSourceCase,
+    CounterfactualRegretTarget as CounterfactualRegretTarget,
+    evaluate_counterfactual_regret as evaluate_counterfactual_regret,
+    fit_counterfactual_regret_certificate as fit_counterfactual_regret_certificate,
+    load_claim_bearing_counterfactual_regret_certificate as load_claim_bearing_counterfactual_regret_certificate,
+    load_counterfactual_regret_certificate as load_counterfactual_regret_certificate,
+    select_counterfactual_regret_candidate as select_counterfactual_regret_candidate,
+    write_counterfactual_regret_certificate as write_counterfactual_regret_certificate,
+    write_counterfactual_regret_decision as write_counterfactual_regret_decision,
+)
+from causal4d.latent_contact_v2 import (
+    LATENT_CONTACT_V2_SCHEMA_VERSION as LATENT_CONTACT_V2_SCHEMA_VERSION,
+    ContactEffectPosteriorV2 as ContactEffectPosteriorV2,
+    ContactEndpoint as ContactEndpoint,
+    ContactLikelihoodV2Diagnostics as ContactLikelihoodV2Diagnostics,
+    ContactObservationEvidenceV2 as ContactObservationEvidenceV2,
+    ContactPatchHypothesisSupportV2 as ContactPatchHypothesisSupportV2,
+    ContactPatchRolloutBankV2 as ContactPatchRolloutBankV2,
+    ContactPatchStateV2 as ContactPatchStateV2,
+    ContactV2Selection as ContactV2Selection,
+    ContactV2SupportDecision as ContactV2SupportDecision,
+    ContactV2SupportPolicy as ContactV2SupportPolicy,
+    ContactV2SupportRejectedError as ContactV2SupportRejectedError,
+    GraphContactPatchModelV2 as GraphContactPatchModelV2,
+    LinearContactObservationGroup as LinearContactObservationGroup,
+    SparseContactPatch as SparseContactPatch,
+    build_contact_patch_rollout_bank_v2 as build_contact_patch_rollout_bank_v2,
+    contact_component_log_likelihoods_v2 as contact_component_log_likelihoods_v2,
+    evaluate_contact_v2_support as evaluate_contact_v2_support,
+    gaussian_mixture_quantiles as gaussian_mixture_quantiles,
+    posterior_weights_from_contact_evidence_v2 as posterior_weights_from_contact_evidence_v2,
+    select_contact_v2_candidate as select_contact_v2_candidate,
+)
+from causal4d.decision_trace import (
+    DECISION_TRACE_ENDPOINTS as DECISION_TRACE_ENDPOINTS,
+    DECISION_TRACE_PIPELINE as DECISION_TRACE_PIPELINE,
+    DECISION_TRACE_SCHEMA_NAME as DECISION_TRACE_SCHEMA_NAME,
+    DECISION_TRACE_SCHEMA_VERSION as DECISION_TRACE_SCHEMA_VERSION,
+    DECISION_TRACE_STAGE_KINDS as DECISION_TRACE_STAGE_KINDS,
+    DecisionTraceArtifact as DecisionTraceArtifact,
+    DecisionTraceBuildResult as DecisionTraceBuildResult,
+    DecisionTraceDecision as DecisionTraceDecision,
+    DecisionTraceSelection as DecisionTraceSelection,
+    DecisionTraceStage as DecisionTraceStage,
+    UnifiedDecisionTrace as UnifiedDecisionTrace,
+    build_unified_decision_trace as build_unified_decision_trace,
+    load_claim_bearing_decision_trace as load_claim_bearing_decision_trace,
+    load_decision_trace as load_decision_trace,
+    require_decision_trace_stack_lock as require_decision_trace_stack_lock,
+    write_decision_trace as write_decision_trace,
+)
+from causal4d.benchmark import (
+    CounterfactualBenchmarkConfig as CounterfactualBenchmarkConfig,
+    build_protocol as build_protocol,
+)
+from causal4d.causal_sufficiency import (
+    CausalSufficiencyResult as CausalSufficiencyResult,
+    assess_command_residual_sufficiency as assess_command_residual_sufficiency,
+)
+from causal4d.claim_bearing_observation_lineage import (
+    load_claim_bearing_prob4d_observation_lineage as load_claim_bearing_prob4d_observation_lineage,
+    require_claim_bearing_prob4d_lineage as require_claim_bearing_prob4d_lineage,
+)
+from causal4d.contact_evaluation import (
+    run_latent_contact_benchmark as run_latent_contact_benchmark,
+)
+from causal4d.contact_inference import (
+    LatentContactConfig as LatentContactConfig,
+)
+from causal4d.contact_traction import (
+    graph_traction_field as graph_traction_field,
+    integrate_contact_wrench as integrate_contact_wrench,
+)
+from causal4d.contracts import (
+    CounterfactualQuery as CounterfactualQuery,
+    FactualIntervention as FactualIntervention,
+    PhysicalPosterior as PhysicalPosterior,
+    TaskPosterior as TaskPosterior,
+    TwinBelief as TwinBelief,
+)
+from causal4d.counterfactual import (
+    apply_counterfactual_operator as apply_counterfactual_operator,
+    project_physical_posterior as project_physical_posterior,
+)
+from causal4d.discrepancy_belief import (
+    GraphDiscrepancyBelief as GraphDiscrepancyBelief,
+    graph_discrepancy_group_covariances as graph_discrepancy_group_covariances,
+    load_graph_discrepancy_belief as load_graph_discrepancy_belief,
+    write_graph_discrepancy_belief as write_graph_discrepancy_belief,
+)
+from causal4d.evaluation import (
+    run_counterfactual_benchmark as run_counterfactual_benchmark,
+)
+from causal4d.factual_abduction_uncertainty import (
+    FACTUAL_ABDUCTION_UNCERTAINTY_SCHEMA_VERSION as FACTUAL_ABDUCTION_UNCERTAINTY_SCHEMA_VERSION,
+    FactualAbductionUncertaintyV1 as FactualAbductionUncertaintyV1,
+    load_factual_abduction_uncertainty_npz as load_factual_abduction_uncertainty_npz,
+    save_factual_abduction_uncertainty_npz as save_factual_abduction_uncertainty_npz,
+)
+from causal4d.finite_query_ambiguity import (
+    FiniteQueryAmbiguityConfig as FiniteQueryAmbiguityConfig,
+    FiniteQueryAmbiguityResult as FiniteQueryAmbiguityResult,
+    assess_finite_query_ambiguity as assess_finite_query_ambiguity,
+)
+from causal4d.graph_mode_abduction import (
+    GraphModeAbductionConfig as GraphModeAbductionConfig,
+    abduct_factual_intervention_graph_mode as abduct_factual_intervention_graph_mode,
+    graph_mode_joint_weights as graph_mode_joint_weights,
+)
+from causal4d.grouped_likelihood import (
+    GroupLikelihoodDiagnostics as GroupLikelihoodDiagnostics,
+    GroupedScoreSemantics as GroupedScoreSemantics,
+    grouped_component_log_likelihoods as grouped_component_log_likelihoods,
+    posterior_weights_from_grouped_evidence as posterior_weights_from_grouped_evidence,
+)
+from causal4d.hierarchical_abduction import (
+    HierarchicalAbductionResult as HierarchicalAbductionResult,
+    abduct_hierarchical_interventions as abduct_hierarchical_interventions,
+)
+from causal4d.identifiability import (
+    IdentifiabilityConfig as IdentifiabilityConfig,
+    InterventionIdentifiabilityResult as InterventionIdentifiabilityResult,
+    assess_intervention_identifiability as assess_intervention_identifiability,
+    finite_response_sensitivity as finite_response_sensitivity,
+    project_identifiable_intervention_update as project_identifiable_intervention_update,
+)
+from causal4d.interventional_contrast import (
+    INTERVENTIONAL_CONTRAST_SCHEMA_VERSION as INTERVENTIONAL_CONTRAST_SCHEMA_VERSION,
+    ContrastConditionalVariancePolicy as ContrastConditionalVariancePolicy,
+    ContrastCouplingPolicy as ContrastCouplingPolicy,
+    InterventionalContrastPosteriorV1 as InterventionalContrastPosteriorV1,
+    InterventionalContrastQueryV1 as InterventionalContrastQueryV1,
+    build_interventional_contrast as build_interventional_contrast,
+    load_interventional_contrast as load_interventional_contrast,
+    save_interventional_contrast as save_interventional_contrast,
+)
+from causal4d.joint_observation import (
+    JOINT_OBSERVATION_SCHEMA_VERSION as JOINT_OBSERVATION_SCHEMA_VERSION,
+    CovarianceRepresentation as CovarianceRepresentation,
+    JointGaussianLikelihoodDiagnostics as JointGaussianLikelihoodDiagnostics,
+    LinearJointObservationEvidence as LinearJointObservationEvidence,
+    block_diagonalize_covariance as block_diagonalize_covariance,
+    joint_component_log_likelihoods as joint_component_log_likelihoods,
+    posterior_weights_from_joint_observation as posterior_weights_from_joint_observation,
+)
+from causal4d.observation_evidence import (
+    GroupedObservationEvidence as GroupedObservationEvidence,
+    ObservationGroup as ObservationGroup,
+)
+from causal4d.observation_factor_lineage import (
+    OBSERVATION_FACTOR_SCHEMA as OBSERVATION_FACTOR_SCHEMA,
+    OBSERVATION_FACTOR_SCHEMA_VERSION as OBSERVATION_FACTOR_SCHEMA_VERSION,
+    ObservationFactorLineage as ObservationFactorLineage,
+    bind_twin_belief_observation_factor_lineage as bind_twin_belief_observation_factor_lineage,
+    load_observation_factor_lineage as load_observation_factor_lineage,
+    validate_twin_belief_observation_factor_lineage as validate_twin_belief_observation_factor_lineage,
+)
+from causal4d.partial_identifiability import (
+    preserve_prior_within_unidentified_subspace as preserve_prior_within_unidentified_subspace,
+)
+from causal4d.prefix_likelihood import (
+    PrefixLikelihoodConfig as PrefixLikelihoodConfig,
+    prefix_component_log_likelihood as prefix_component_log_likelihood,
+    update_joint_weights_from_prefix as update_joint_weights_from_prefix,
+)
+from causal4d.prob4d_joint_observation import (
+    PROB4D_JOINT_ADAPTER_SCHEMA_VERSION as PROB4D_JOINT_ADAPTER_SCHEMA_VERSION,
+    Prob4DJointObservationDiagnostics as Prob4DJointObservationDiagnostics,
+    Prob4DReliabilityPolicy as Prob4DReliabilityPolicy,
+    joint_observation_from_prob4d as joint_observation_from_prob4d,
+)
+from causal4d.prob4d_observation_lineage import (
+    validate_claim_bearing_prob4d_observation_metadata as validate_claim_bearing_prob4d_observation_metadata,
+    validate_prob4d_causal_observation_metadata as validate_prob4d_causal_observation_metadata,
+)
+from causal4d.provider_contract import (
+    BASE_CAUSAL4D_PROVIDER_CAPABILITIES as BASE_CAUSAL4D_PROVIDER_CAPABILITIES,
+    BAYESIAN_PHYSTWIN_ARTIFACT_SCHEMA_VERSIONS as BAYESIAN_PHYSTWIN_ARTIFACT_SCHEMA_VERSIONS,
+    BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE as BAYESIAN_PHYSTWIN_COMPATIBILITY_RANGE,
+    BAYESIAN_PHYSTWIN_PROVIDER_CAPABILITIES as BAYESIAN_PHYSTWIN_PROVIDER_CAPABILITIES,
+    PHYSICAL_BELIEF_PROVIDER_SCHEMA_VERSION as PHYSICAL_BELIEF_PROVIDER_SCHEMA_VERSION,
+    PhysicalBeliefProviderManifest as PhysicalBeliefProviderManifest,
+    ProviderCompatibilityResult as ProviderCompatibilityResult,
+    load_bayesian_phystwin_provider_manifest as load_bayesian_phystwin_provider_manifest,
+    require_bayesian_phystwin_provider as require_bayesian_phystwin_provider,
+    validate_bayesian_phystwin_provider as validate_bayesian_phystwin_provider,
+    validate_provider_compatibility as validate_provider_compatibility,
+)
+from causal4d.rollout_bank import (
+    JointRolloutBank as JointRolloutBank,
+    SparseTrajectoryEvidence as SparseTrajectoryEvidence,
+)
+from causal4d.semantic_freshness import (
+    SEMANTIC_TIMING_SCHEMA_VERSION as SEMANTIC_TIMING_SCHEMA_VERSION,
+    SEMANTIC_TIMING_SCOPE as SEMANTIC_TIMING_SCOPE,
+    SemanticFreshnessDecision as SemanticFreshnessDecision,
+    SemanticFreshnessLimits as SemanticFreshnessLimits,
+    SemanticTimingMetadata as SemanticTimingMetadata,
+    apply_semantic_freshness_gate as apply_semantic_freshness_gate,
+)
+from causal4d.sensor_evidence import (
+    INDEPENDENT_SENSOR_SCHEMA_VERSION as INDEPENDENT_SENSOR_SCHEMA_VERSION,
+    ActuatorEvidence as ActuatorEvidence,
+    ContactWrenchEvidence as ContactWrenchEvidence,
+    load_independent_sensor_evidence as load_independent_sensor_evidence,
+    save_independent_sensor_evidence as save_independent_sensor_evidence,
+)
+from causal4d.sensor_factorized_abduction import (
+    IndependentSensorAbductionConfig as IndependentSensorAbductionConfig,
+    predict_affine_actuator_realizations as predict_affine_actuator_realizations,
+    reweight_factual_intervention_with_independent_sensors as reweight_factual_intervention_with_independent_sensors,
+)
+from causal4d.stable_discrepancy_dynamics import (
+    StableDiscrepancyTransitionModel as StableDiscrepancyTransitionModel,
+    forecast_action_conditioned_dynamics as forecast_action_conditioned_dynamics,
+)
+
+__version__: str

--- a/src/causal4d/api/v1.py
+++ b/src/causal4d/api/v1.py
@@ -16,7 +16,10 @@ from causal4d.contracts import (
     TaskPosterior,
     TwinBelief,
 )
-from causal4d.counterfactual import apply_counterfactual_operator
+from causal4d.counterfactual import (
+    apply_counterfactual_operator,
+    project_physical_posterior,
+)
 from causal4d.hierarchical_abduction import (
     HierarchicalAbductionResult,
     abduct_hierarchical_interventions,
@@ -94,6 +97,7 @@ __all__ = [
     "TwinBelief",
     "abduct_hierarchical_interventions",
     "apply_counterfactual_operator",
+    "project_physical_posterior",
     "block_diagonalize_covariance",
     "build_interventional_contrast",
     "joint_component_log_likelihoods",

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -36,6 +36,7 @@ EXPECTED_V1_EXPORTS = (
     "TwinBelief",
     "abduct_hierarchical_interventions",
     "apply_counterfactual_operator",
+    "project_physical_posterior",
     "block_diagonalize_covariance",
     "build_interventional_contrast",
     "joint_component_log_likelihoods",

--- a/tests/test_lazy_package_imports.py
+++ b/tests/test_lazy_package_imports.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+import causal4d
+import pytest
+
+
+def _run_probe(source: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(source)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_root_import_does_not_eagerly_load_public_implementation_modules() -> None:
+    _run_probe(
+        """
+        import sys
+        import causal4d
+
+        forbidden = {
+            "causal4d.action_support",
+            "causal4d.counterfactual",
+            "causal4d.counterfactual_regret",
+            "causal4d.decision_trace",
+            "causal4d.interventional_contrast",
+            "causal4d.latent_contact_v2",
+            "causal4d.provider_contract",
+        }
+        loaded = forbidden.intersection(sys.modules)
+        if loaded:
+            raise SystemExit(f"eager Causal4D imports: {sorted(loaded)}")
+        if "PhysicalPosterior" in causal4d.__dict__:
+            raise SystemExit("lazy export was populated before first access")
+        if "project_physical_posterior" not in causal4d.__all__:
+            raise SystemExit("projection helper is absent from the public inventory")
+        if "project_physical_posterior" not in dir(causal4d):
+            raise SystemExit("lazy export is absent from module introspection")
+        """
+    )
+
+
+def test_v1_import_does_not_load_unrelated_research_surfaces() -> None:
+    _run_probe(
+        """
+        import sys
+        import causal4d
+        from causal4d.api import v1
+
+        forbidden = {
+            "causal4d.action_support",
+            "causal4d.counterfactual_regret",
+            "causal4d.decision_trace",
+            "causal4d.latent_contact_v2",
+            "causal4d.semantic_freshness",
+        }
+        loaded = forbidden.intersection(sys.modules)
+        if loaded:
+            raise SystemExit(f"unrelated v1 imports: {sorted(loaded)}")
+        if v1.PhysicalPosterior is not causal4d.PhysicalPosterior:
+            raise SystemExit("v1 contract identity differs from the root export")
+        if v1.project_physical_posterior is not causal4d.project_physical_posterior:
+            raise SystemExit("v1 projection identity differs from the root export")
+        """
+    )
+
+
+def test_lazy_root_export_is_loaded_once_and_cached() -> None:
+    _run_probe(
+        """
+        import causal4d
+        from causal4d.contracts import PhysicalPosterior
+
+        if "PhysicalPosterior" in causal4d.__dict__:
+            raise SystemExit("root export was populated by the submodule import")
+        if causal4d.PhysicalPosterior is not PhysicalPosterior:
+            raise SystemExit("lazy export differs from the owning module object")
+        if causal4d.__dict__["PhysicalPosterior"] is not PhysicalPosterior:
+            raise SystemExit("lazy export was not cached in the package root")
+        if causal4d.PhysicalPosterior is not PhysicalPosterior:
+            raise SystemExit("cached export identity changed on repeated access")
+        """
+    )
+
+
+def test_lazy_export_inventory_is_complete_and_unique() -> None:
+    assert len(causal4d.__all__) == len(set(causal4d.__all__))
+    assert set(causal4d.__all__) == set(causal4d._LAZY_EXPORTS)
+
+
+def test_package_root_typing_stub_covers_every_lazy_export() -> None:
+    stub_path = Path(causal4d.__file__).with_suffix(".pyi")
+    assert stub_path.is_file()
+    tree = ast.parse(stub_path.read_text(encoding="utf-8"))
+    stub_exports: set[str] = set()
+    has_version_annotation = False
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                assert alias.asname == alias.name
+                stub_exports.add(alias.name)
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "__version__"
+        ):
+            has_version_annotation = True
+    assert stub_exports == set(causal4d.__all__)
+    assert has_version_annotation
+
+
+def test_unknown_root_attribute_raises_standard_attribute_error() -> None:
+    with pytest.raises(
+        AttributeError,
+        match="module 'causal4d' has no attribute 'definitely_not_an_export'",
+    ):
+        getattr(causal4d, "definitely_not_an_export")


### PR DESCRIPTION
## Summary

- replace the eager `causal4d` package initializer with compatibility-preserving PEP 562 lazy exports;
- retain the exact historical owning-module object for every existing top-level name and cache each object after first access;
- keep `__all__`, wildcard-import behavior, `dir(causal4d)`, `__version__`, and standard `AttributeError` semantics explicit;
- package a complete `__init__.pyi` stub so static type checkers retain the historical root surface without executing runtime imports;
- promote the merged `project_physical_posterior` helper through the package root and `causal4d.api.v1`;
- retain the current-main `GroupedScoreSemantics` export while converting the root to lazy loading;
- verify the lazy runtime and typing surface from both installed wheels and source distributions; and
- document lazy import behavior, query projection, and execution-only grouped batching.

## Root cause and impact

Python imports a package's `__init__.py` before loading `causal4d.api.v1`. The versioned API was therefore explicit in name only: importing it first executed the full package-root import graph spanning stable contracts, experimental contact models, action-support selection, decision traces, semantic timing, provider adapters, and retrospective diagnostics.

The new root initializer records an explicit export-to-module inventory and resolves a requested object only on first attribute access. A bare `import causal4d` now loads zero `causal4d.*` implementation modules. Existing top-level imports continue to return the exact object from the same owning module, while `from causal4d import *` deliberately resolves the complete historical surface as before. The packaged stub keeps static imports explicit rather than exposing every unknown attribute as `Any` through the runtime `__getattr__`.

## Change classification

Select one primary classification:

- [ ] Frozen or registered method/analysis change requiring a new version
- [ ] Future or experimental method
- [ ] BayesianPhysTwin, Prob4D, or other provider/artifact contract
- [ ] Acquisition, calibration, readiness, or evidence tooling
- [x] Maintenance, documentation, packaging, CI, or security

Evidence status, when applicable:

- [x] Software or contract evidence only
- [ ] Controlled synthetic evidence
- [ ] Source/calibration-only evidence
- [ ] Retrospective or already-open diagnostic evidence
- [ ] Confirmatory physical evidence
- [x] No scientific evidence produced

## Scientific and information boundary

- Frozen estimator or registered analysis changed: `no`.
- Target or held-out outcomes accessed: `no`.
- Registered physical-acquisition dataset modified: `no`.
- Physical evidence increment: `0`.
- Existing scientific claim changed or promoted: `no`.
- Independent statistical unit: `not applicable; import, typing, packaging, and API contract tests only`.
- Source, calibration, and target split: `not applicable`.
- Exact fallback preserved for rejected optional evidence: `yes`; no likelihood, admission, fallback, posterior, or counterfactual calculation changes.

## Provenance and compatibility

- Exact validated PR head: `1362d02702474fdd4165c340d6cd6912baee2b6d`.
- Current merge-result base: `6a3baed665d33aeb704e70446649021c7ffde80f`.
- The merge result retains the intervening coupling-bound, grouped-likelihood-v3, and acquisition-operator-registry changes from current `main`.
- Existing top-level export identities: preserved and verified across all **177** current exports, including `GroupedScoreSemantics` and the additive query-projection helper.
- Static root API: the packaged `__init__.pyi` lists the same 177 exports and `__version__`; AST and installed-artifact checks reject omissions, additions, duplicate aliases, or runtime/stub drift.
- Stable API: additive `project_physical_posterior`; `PUBLIC_API_VERSION` remains `1`.
- Provider, artifact, protocol, and frozen-milestone schemas: unchanged.
- Wildcard imports: unchanged semantically; they still resolve all names in `causal4d.__all__`.
- Package metadata version discovery becomes lightweight because `causal4d.__version__` no longer imports the complete research surface.

## Validation

Focused source validation:

```text
PYTHONPATH=src pytest -q \
  tests/test_api_v1.py \
  tests/test_lazy_package_imports.py \
  tests/test_joint_observation_public_api.py

11 passed
```

Wider related validation:

```text
PYTHONPATH=src pytest -q \
  tests/test_api_v1.py \
  tests/test_lazy_package_imports.py \
  tests/test_joint_observation_public_api.py \
  tests/test_causal4d_contracts.py \
  tests/test_package_contract.py \
  tests/test_interventional_contrast.py \
  tests/test_causal4d_counterfactual.py \
  tests/test_causal4d_grouped_abduction.py

63 passed
```

Additional checks:

- a bare root import loaded zero `causal4d.*` implementation submodules;
- all current root exports resolve from their owning modules and are cached by identity;
- the source-tree typing stub exactly matches the lazy export inventory;
- Python byte compilation and package `compileall` passed;
- every changed Python file parses under Python 3.10 grammar; and
- wheel and sdist smoke jobs invoke `check_installed_root_surface.py` before CLI-help validation.

### Exact-head GitHub Actions

All authoritative workflows passed on `1362d02702474fdd4165c340d6cd6912baee2b6d`:

- **Causal4D merge gate:** repository quality, complete default suite, distribution validation, isolated wheel installation, and pinned BayesianPhysTwin integration against the current-main merge result;
- **CI and release:** Ruff, formatting, stable-contract MyPy, Python 3.10/3.12/3.14, deterministic bundles, frozen manifest, wheel and sdist installation, installed root/stub verification, all CLI-help routes, and pinned-provider integration;
- **Extended compatibility:** declared dependency floors on Python 3.10 and core suites on Python 3.11/3.13;
- **Security scanning:** dependency audit and CodeQL for Python and Actions;
- **BayesianPhysTwin evidence-decision admission:** pinned three-repository installed admission; and
- **Three-repository installed-wheel compatibility:** complete Prob4D → BayesianPhysTwin → Causal4D golden path and strict provider-v2 admission.

## Merge disposition

- [x] Product change intended for review and merge
- [ ] Execution/bootstrap helper that must be closed without merge
- [ ] Diagnostic result that cannot promote a method or scientific claim

No post-merge physical execution, target opening, evidence publication, protocol mutation, or claim promotion is authorized by this change.