### PR TITLE
Rebase grouped covariance-normalized likelihood v3 on bounded-memory abduction

### DIFF
--- a/docs/grouped_normalized_likelihood_v3.md
+++ b/docs/grouped_normalized_likelihood_v3.md
@@ -1,0 +1,127 @@
+# Grouped normalized likelihood v3
+
+## Purpose and status
+
+The robust grouped likelihood preserves full observation covariance, fixed prior
+outlier reliability, component-specific discrepancy covariance, and
+contributor-aware duplicate caps. Its original `legacy_sum_v1` score is retained
+unchanged for frozen and historical analyses.
+
+`normalized_coordinate_mean_v3` is an **opt-in development comparator** for
+cases where the number and dimension of admitted groups vary across providers or
+prefixes. It does not change the registered 18-session/36-execution physical
+estimator, authorize confirmatory collection, or establish calibration or
+physical benefit. The score is never selected implicitly from evidence shape,
+covariance representation, or provider identity.
+
+## Score
+
+For group `g`, let:
+
+- `ell_g(theta)` be the existing full-covariance robust multivariate Student-t
+  mixture log density;
+- `c_g` be the source-declared `composite_weight`;
+- `m_g` be the largest multiplicity of any contributor named by the group;
+- `a_g = 1 / m_g` be the duplicate-evidence power cap; and
+- `d_g` be the number of jointly scored coordinates.
+
+The normalized score is
+
+```text
+L_v3(theta) = beta * sum_g a_g c_g ell_g(theta)
+                     / sum_g a_g d_g,
+```
+
+where `beta` is the explicit `likelihood_power`.
+
+The denominator uses contributor caps but not `composite_weight`. Consequently:
+
+- exact duplicated evidence carrying the same contributor identity cannot
+  sharpen or weaken the posterior;
+- source reliability temperatures remain multiplicative and do not cancel;
+- raw coordinate count does not silently determine posterior concentration; and
+- the declared likelihood power is applied explicitly on the grouped path.
+
+Group boundaries still define shared robust-mixture states. Repartitioning one
+multivariate Student-t group into several groups therefore changes the declared
+outlier model unless those groups are explicitly intended as independent
+reliability units. The implementation does not claim arbitrary split-group
+invariance.
+
+## Covariance handling
+
+Each group continues to use its complete positive-definite covariance. Optional
+component uncertainty can be supplied as diagonal variance, dense covariance, a
+low-rank factor, or nonoverlapping combinations of those representations. Dense
+and low-rank forms are required to agree numerically.
+
+Normalized v3 additionally fails closed when a source covariance condition
+number exceeds the preregistered limit. The default limit is `1e12`; a study may
+choose a stricter value before target access. No hidden jitter, clipping, or
+pseudoinverse is introduced.
+
+## Diagnostics
+
+`GroupLikelihoodDiagnostics` records:
+
+- score semantics and applied likelihood power;
+- contributor power caps and effective group weights;
+- coordinate counts and normalization coordinate mass;
+- source covariance condition numbers;
+- effective information fractions; and
+- nominal/outlier responsibilities plus dense/low-rank covariance usage.
+
+Legacy artifact metadata remains unchanged. The additional fields are emitted
+only when normalized v3 is selected.
+
+## API
+
+```python
+posterior, diagnostics = posterior_weights_from_grouped_evidence(
+    prior_weights,
+    predicted_components_m,
+    evidence,
+    prefix_frame_count=prefix_frame_count,
+    component_group_covariance_factor_m=structured_covariance,
+    score_semantics="normalized_coordinate_mean_v3",
+    likelihood_power=12.0,
+    max_source_covariance_condition_number=1.0e10,
+)
+```
+
+For factual intervention abduction:
+
+```python
+config = FactualAbductionConfig(
+    grouped_likelihood_semantics="normalized_v3",
+    likelihood_power=12.0,
+    grouped_covariance_condition_number_limit=1.0e10,
+)
+```
+
+The command-line development path is:
+
+```bash
+causal4d experiment phystwin abduct-intervention \
+  bank.npz belief.npz final_data.pkl factual.npz evaluation.json \
+  --grouped-observation-likelihood \
+  --grouped-likelihood-semantics normalized_v3 \
+  --grouped-covariance-condition-number-limit 1e10
+```
+
+## Tested invariants
+
+The test suite verifies:
+
+- exact duplicate-contributor power capping;
+- preservation of source `composite_weight` as a reliability temperature;
+- coordinate-permutation and group-order invariance;
+- dense versus low-rank covariance equivalence;
+- normalized information accounting;
+- fail-closed handling of ill-conditioned covariance and invalid settings;
+- exact preservation of legacy factual artifact identity; and
+- explicit separation from dense `normalized_v2`.
+
+These are numerical and provenance guarantees, not empirical evidence that v3
+improves prediction, coverage, transfer, or causal identification. Any promotion
+requires a separately frozen source-only comparison and held-out evaluation.

--- a/docs/structured_grouped_likelihood.md
+++ b/docs/structured_grouped_likelihood.md
@@ -90,3 +90,14 @@ They also verify broadcasting, fail-closed factor validation, diagnostics, and
 that the structured path does not call dense determinant evaluation. These are
 numerical and engineering guarantees, not new empirical accuracy or calibration
 evidence.
+
+## Coordinate-normalized development score
+
+The structured covariance representation is also supported by the opt-in
+[`normalized_coordinate_mean_v3`](grouped_normalized_likelihood_v3.md) grouped
+score. That score preserves the dense/low-rank equivalence described here while
+adding contributor-capped coordinate normalization, an explicit likelihood
+power, conditioning diagnostics, and a fail-closed source-covariance threshold.
+Supplying dense or low-rank structured covariance alone never selects v3; callers
+must choose its score semantics explicitly. `legacy_sum_v1` remains the default
+and the registered physical estimator is unchanged.

--- a/src/causal4d/__init__.py
+++ b/src/causal4d/__init__.py
@@ -131,6 +131,7 @@ from causal4d.graph_mode_abduction import (
 )
 from causal4d.grouped_likelihood import (
     GroupLikelihoodDiagnostics,
+    GroupedScoreSemantics,
     grouped_component_log_likelihoods,
     posterior_weights_from_grouped_evidence,
 )
@@ -317,6 +318,7 @@ __all__ = [
     "GraphModeAbductionConfig",
     "GroupLikelihoodDiagnostics",
     "GroupedObservationEvidence",
+    "GroupedScoreSemantics",
     "HierarchicalAbductionResult",
     "INDEPENDENT_SENSOR_SCHEMA_VERSION",
     "INTERVENTIONAL_CONTRAST_SCHEMA_VERSION",

--- a/src/causal4d/cli/abduct_phystwin_intervention.py
+++ b/src/causal4d/cli/abduct_phystwin_intervention.py
@@ -17,6 +17,8 @@ def _load_runtime_dependencies() -> None:
     global TwinBelief
     global load_contract
     global save_contract
+    global FactualAbductionUncertaintyV1
+    global load_factual_abduction_uncertainty_npz
     global IdentifiabilityConfig
     global InterventionIdentifiabilityResult
     global assess_intervention_identifiability
@@ -28,6 +30,10 @@ def _load_runtime_dependencies() -> None:
 
     from bayesian_phystwin.causal4d_provider_v1 import target_validity
     from causal4d.contracts import TwinBelief, load_contract, save_contract
+    from causal4d.factual_abduction_uncertainty import (
+        FactualAbductionUncertaintyV1,
+        load_factual_abduction_uncertainty_npz,
+    )
     from causal4d.identifiability import (
         IdentifiabilityConfig,
         InterventionIdentifiabilityResult,
@@ -72,9 +78,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--difference-correlation",
         type=float,
         default=0.0,
-        help=(
-            "Adjacent-frame observation correlation used only by normalized_v2."
-        ),
+        help=("Adjacent-frame observation correlation used only by normalized_v2."),
     )
     parser.add_argument(
         "--grouped-observation-likelihood",
@@ -107,11 +111,21 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--identifiability-npz",
         help=(
-            "Optional NPZ with intervention_sensitivity and optional "
-            "nuisance_sensitivity/covariance arrays, fitted without target future."
+            "Optional source-only NPZ with intervention_sensitivity and optional "
+            "nuisance_sensitivity, covariance, covariance_factor, "
+            "parameter_scales, and registered query_sensitivity arrays."
         ),
     )
     parser.add_argument("--abstain-when-unidentifiable", action="store_true")
+    parser.add_argument(
+        "--identifiability-policy",
+        choices=("full_parameter", "registered_query"),
+        default="full_parameter",
+        help=(
+            "Use the historical full-parameter gate or the opt-in decision for a "
+            "source-registered future query. The latter requires query_sensitivity."
+        ),
+    )
     parser.add_argument("--identifiability-rank-tolerance", type=float, default=1e-6)
     parser.add_argument("--minimum-information-eigenvalue", type=float, default=1e-6)
     parser.add_argument("--maximum-condition-number", type=float, default=1e8)
@@ -119,6 +133,18 @@ def build_parser() -> argparse.ArgumentParser:
         "--minimum-residualized-response-fraction", type=float, default=0.10
     )
     parser.add_argument("--maximum-subspace-cosine", type=float, default=0.995)
+    parser.add_argument(
+        "--maximum-query-null-response-fraction",
+        type=float,
+        default=0.10,
+    )
+    parser.add_argument(
+        "--factual-abduction-uncertainty-npz",
+        help=(
+            "Optional content-verified FactualAbductionUncertaintyV1 NPZ. Requires "
+            "grouped observation likelihood and exact bank/belief/evidence bindings."
+        ),
+    )
     return parser
 
 
@@ -145,10 +171,28 @@ def _load_identifiability(
             if "covariance" in payload
             else None
         )
+        covariance_factor = (
+            np.asarray(payload["covariance_factor"], dtype=float)
+            if "covariance_factor" in payload
+            else None
+        )
+        parameter_scales = (
+            np.asarray(payload["parameter_scales"], dtype=float)
+            if "parameter_scales" in payload
+            else None
+        )
+        query_sensitivity = (
+            np.asarray(payload["query_sensitivity"], dtype=float)
+            if "query_sensitivity" in payload
+            else None
+        )
     return assess_intervention_identifiability(
         intervention,
         nuisance,
         covariance=covariance,
+        covariance_factor=covariance_factor,
+        parameter_scales=parameter_scales,
+        query_sensitivity=query_sensitivity,
         config=config,
     )
 
@@ -160,12 +204,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         raise ValueError("--o-plus-prefix-frames must be positive")
     if args.abstain_when_unidentifiable and args.identifiability_npz is None:
         raise ValueError("--abstain-when-unidentifiable requires --identifiability-npz")
+    if args.identifiability_policy == "registered_query" and (
+        args.identifiability_npz is None
+    ):
+        raise ValueError("registered_query policy requires --identifiability-npz")
     if (
         args.grouped_likelihood_semantics != "legacy_v1"
         and not args.grouped_observation_likelihood
     ):
         raise ValueError(
             "--grouped-likelihood-semantics normalized_v3 requires "
+            "--grouped-observation-likelihood"
+        )
+    if args.factual_abduction_uncertainty_npz is not None and (
+        not args.grouped_observation_likelihood
+    ):
+        raise ValueError(
+            "--factual-abduction-uncertainty-npz requires "
             "--grouped-observation-likelihood"
         )
     bank, manifest = load_rollout_bank(args.rollout_bank_npz)
@@ -216,8 +271,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                 args.minimum_residualized_response_fraction
             ),
             maximum_subspace_cosine=args.maximum_subspace_cosine,
+            maximum_query_null_response_fraction=(
+                args.maximum_query_null_response_fraction
+            ),
         ),
     )
+    abduction_uncertainty: FactualAbductionUncertaintyV1 | None = None
+    if args.factual_abduction_uncertainty_npz is not None:
+        abduction_uncertainty = load_factual_abduction_uncertainty_npz(
+            args.factual_abduction_uncertainty_npz
+        )
     factual = abduct_factual_intervention(
         bank,
         artifact,
@@ -228,6 +291,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         grouped_evidence=grouped_evidence,
         identifiability=identifiability,
         abstain_when_unidentifiable=args.abstain_when_unidentifiable,
+        identifiability_policy=args.identifiability_policy,
+        abduction_uncertainty=abduction_uncertainty,
     )
     evaluation = evaluate_factual_abduction(
         bank,
@@ -238,6 +303,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         prefix_frame_count=prefix_frame_count,
         config=settings,
         grouped_evidence=grouped_evidence,
+        abduction_uncertainty=abduction_uncertainty,
     )
     evaluation.update(
         {
@@ -251,6 +317,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             ),
             "intervention_identifiability": (
                 None if identifiability is None else identifiability.as_dict()
+            ),
+            "identifiability_policy": args.identifiability_policy,
+            "factual_abduction_uncertainty_id": (
+                None
+                if abduction_uncertainty is None
+                else abduction_uncertainty.artifact_id
             ),
         }
     )

--- a/src/causal4d/cli/abduct_phystwin_intervention.py
+++ b/src/causal4d/cli/abduct_phystwin_intervention.py
@@ -17,8 +17,6 @@ def _load_runtime_dependencies() -> None:
     global TwinBelief
     global load_contract
     global save_contract
-    global FactualAbductionUncertaintyV1
-    global load_factual_abduction_uncertainty_npz
     global IdentifiabilityConfig
     global InterventionIdentifiabilityResult
     global assess_intervention_identifiability
@@ -30,10 +28,6 @@ def _load_runtime_dependencies() -> None:
 
     from bayesian_phystwin.causal4d_provider_v1 import target_validity
     from causal4d.contracts import TwinBelief, load_contract, save_contract
-    from causal4d.factual_abduction_uncertainty import (
-        FactualAbductionUncertaintyV1,
-        load_factual_abduction_uncertainty_npz,
-    )
     from causal4d.identifiability import (
         IdentifiabilityConfig,
         InterventionIdentifiabilityResult,
@@ -78,7 +72,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--difference-correlation",
         type=float,
         default=0.0,
-        help=("Adjacent-frame observation correlation used only by normalized_v2."),
+        help=(
+            "Adjacent-frame observation correlation used only by normalized_v2."
+        ),
     )
     parser.add_argument(
         "--grouped-observation-likelihood",
@@ -88,26 +84,34 @@ def build_parser() -> argparse.ArgumentParser:
             "frame instead of the legacy dense generalized likelihood."
         ),
     )
+    parser.add_argument(
+        "--grouped-likelihood-semantics",
+        choices=("legacy_v1", "normalized_v3"),
+        default="legacy_v1",
+        help=(
+            "Grouped full-covariance score. normalized_v3 is an opt-in, "
+            "contributor-capped coordinate-normalized development comparator."
+        ),
+    )
+    parser.add_argument(
+        "--grouped-covariance-condition-number-limit",
+        type=float,
+        default=1.0e12,
+        help=(
+            "Fail-closed source-covariance condition-number limit used by "
+            "grouped normalized_v3."
+        ),
+    )
     parser.add_argument("--prior-nominal-probability", type=float, default=0.95)
     parser.add_argument("--outlier-scale-multiplier", type=float, default=100.0)
     parser.add_argument(
         "--identifiability-npz",
         help=(
-            "Optional source-only NPZ with intervention_sensitivity and optional "
-            "nuisance_sensitivity, covariance, covariance_factor, "
-            "parameter_scales, and registered query_sensitivity arrays."
+            "Optional NPZ with intervention_sensitivity and optional "
+            "nuisance_sensitivity/covariance arrays, fitted without target future."
         ),
     )
     parser.add_argument("--abstain-when-unidentifiable", action="store_true")
-    parser.add_argument(
-        "--identifiability-policy",
-        choices=("full_parameter", "registered_query"),
-        default="full_parameter",
-        help=(
-            "Use the historical full-parameter gate or the opt-in decision for a "
-            "source-registered future query. The latter requires query_sensitivity."
-        ),
-    )
     parser.add_argument("--identifiability-rank-tolerance", type=float, default=1e-6)
     parser.add_argument("--minimum-information-eigenvalue", type=float, default=1e-6)
     parser.add_argument("--maximum-condition-number", type=float, default=1e8)
@@ -115,18 +119,6 @@ def build_parser() -> argparse.ArgumentParser:
         "--minimum-residualized-response-fraction", type=float, default=0.10
     )
     parser.add_argument("--maximum-subspace-cosine", type=float, default=0.995)
-    parser.add_argument(
-        "--maximum-query-null-response-fraction",
-        type=float,
-        default=0.10,
-    )
-    parser.add_argument(
-        "--factual-abduction-uncertainty-npz",
-        help=(
-            "Optional content-verified FactualAbductionUncertaintyV1 NPZ. Requires "
-            "grouped observation likelihood and exact bank/belief/evidence bindings."
-        ),
-    )
     return parser
 
 
@@ -153,28 +145,10 @@ def _load_identifiability(
             if "covariance" in payload
             else None
         )
-        covariance_factor = (
-            np.asarray(payload["covariance_factor"], dtype=float)
-            if "covariance_factor" in payload
-            else None
-        )
-        parameter_scales = (
-            np.asarray(payload["parameter_scales"], dtype=float)
-            if "parameter_scales" in payload
-            else None
-        )
-        query_sensitivity = (
-            np.asarray(payload["query_sensitivity"], dtype=float)
-            if "query_sensitivity" in payload
-            else None
-        )
     return assess_intervention_identifiability(
         intervention,
         nuisance,
         covariance=covariance,
-        covariance_factor=covariance_factor,
-        parameter_scales=parameter_scales,
-        query_sensitivity=query_sensitivity,
         config=config,
     )
 
@@ -186,15 +160,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         raise ValueError("--o-plus-prefix-frames must be positive")
     if args.abstain_when_unidentifiable and args.identifiability_npz is None:
         raise ValueError("--abstain-when-unidentifiable requires --identifiability-npz")
-    if args.identifiability_policy == "registered_query" and (
-        args.identifiability_npz is None
-    ):
-        raise ValueError("registered_query policy requires --identifiability-npz")
-    if args.factual_abduction_uncertainty_npz is not None and (
-        not args.grouped_observation_likelihood
+    if (
+        args.grouped_likelihood_semantics != "legacy_v1"
+        and not args.grouped_observation_likelihood
     ):
         raise ValueError(
-            "--factual-abduction-uncertainty-npz requires "
+            "--grouped-likelihood-semantics normalized_v3 requires "
             "--grouped-observation-likelihood"
         )
     bank, manifest = load_rollout_bank(args.rollout_bank_npz)
@@ -218,6 +189,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         degrees_of_freedom=args.degrees_of_freedom,
         likelihood_semantics=args.likelihood_semantics,
         difference_correlation=args.difference_correlation,
+        grouped_likelihood_semantics=args.grouped_likelihood_semantics,
+        grouped_covariance_condition_number_limit=(
+            args.grouped_covariance_condition_number_limit
+        ),
     )
     grouped_evidence = None
     if args.grouped_observation_likelihood:
@@ -241,16 +216,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 args.minimum_residualized_response_fraction
             ),
             maximum_subspace_cosine=args.maximum_subspace_cosine,
-            maximum_query_null_response_fraction=(
-                args.maximum_query_null_response_fraction
-            ),
         ),
     )
-    abduction_uncertainty: FactualAbductionUncertaintyV1 | None = None
-    if args.factual_abduction_uncertainty_npz is not None:
-        abduction_uncertainty = load_factual_abduction_uncertainty_npz(
-            args.factual_abduction_uncertainty_npz
-        )
     factual = abduct_factual_intervention(
         bank,
         artifact,
@@ -261,8 +228,6 @@ def main(argv: Sequence[str] | None = None) -> int:
         grouped_evidence=grouped_evidence,
         identifiability=identifiability,
         abstain_when_unidentifiable=args.abstain_when_unidentifiable,
-        identifiability_policy=args.identifiability_policy,
-        abduction_uncertainty=abduction_uncertainty,
     )
     evaluation = evaluate_factual_abduction(
         bank,
@@ -273,7 +238,6 @@ def main(argv: Sequence[str] | None = None) -> int:
         prefix_frame_count=prefix_frame_count,
         config=settings,
         grouped_evidence=grouped_evidence,
-        abduction_uncertainty=abduction_uncertainty,
     )
     evaluation.update(
         {
@@ -287,12 +251,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             ),
             "intervention_identifiability": (
                 None if identifiability is None else identifiability.as_dict()
-            ),
-            "identifiability_policy": args.identifiability_policy,
-            "factual_abduction_uncertainty_id": (
-                None
-                if abduction_uncertainty is None
-                else abduction_uncertainty.artifact_id
             ),
         }
     )

--- a/src/causal4d/grouped_likelihood.py
+++ b/src/causal4d/grouped_likelihood.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from math import lgamma
-from typing import Mapping
+from typing import Literal, Mapping
 
 import numpy as np
 
@@ -16,6 +16,12 @@ from causal4d.observation_evidence import (
 from causal4d.weighting import log_weights_from_probabilities
 
 
+GroupedScoreSemantics = Literal[
+    "legacy_sum_v1",
+    "normalized_coordinate_mean_v3",
+]
+
+
 @dataclass(frozen=True)
 class GroupLikelihoodDiagnostics:
     """Nominal responsibilities and effective powers for one grouped update."""
@@ -25,6 +31,13 @@ class GroupLikelihoodDiagnostics:
     nominal_responsibilities: np.ndarray
     full_covariance_group_ids: tuple[str, ...] = ()
     low_rank_covariance_group_ids: tuple[str, ...] = ()
+    score_semantics: GroupedScoreSemantics = "legacy_sum_v1"
+    likelihood_power: float = 1.0
+    contributor_power_caps: tuple[float, ...] = ()
+    group_coordinate_counts: tuple[int, ...] = ()
+    normalization_coordinate_mass: float | None = None
+    source_covariance_condition_numbers: tuple[float, ...] = ()
+    normalization_coordinate_fractions: tuple[float, ...] = ()
 
 
 def _student_t_log_density_from_terms(
@@ -324,6 +337,9 @@ def grouped_component_log_likelihoods(
     component_variance_m2: np.ndarray | None = None,
     component_group_covariance_m2: Mapping[str, np.ndarray] | None = None,
     component_group_covariance_factor_m: Mapping[str, np.ndarray] | None = None,
+    score_semantics: GroupedScoreSemantics = "legacy_sum_v1",
+    likelihood_power: float = 1.0,
+    max_source_covariance_condition_number: float = 1.0e12,
 ) -> tuple[np.ndarray, GroupLikelihoodDiagnostics]:
     """Score arbitrary leading component dimensions against grouped O-plus evidence.
 
@@ -332,7 +348,28 @@ def grouped_component_log_likelihoods(
     meters. Each factor must broadcast to
     ``component_shape + (group_coordinate, rank)`` and contributes
     ``factor @ factor.T`` without dense materialization.
+
+    ``legacy_sum_v1`` preserves the original robust composite likelihood. The
+    experimental ``normalized_coordinate_mean_v3`` divides the contributor-capped
+    score by contributor-capped coordinate mass and then applies the explicit
+    likelihood power. Source ``composite_weight`` values remain multiplicative
+    reliability temperatures and therefore do not cancel in the normalization.
     """
+
+    if score_semantics not in {
+        "legacy_sum_v1",
+        "normalized_coordinate_mean_v3",
+    }:
+        raise ValueError("unsupported grouped score semantics")
+    if not np.isfinite(likelihood_power) or likelihood_power <= 0.0:
+        raise ValueError("likelihood_power must be finite and positive")
+    if (
+        not np.isfinite(max_source_covariance_condition_number)
+        or max_source_covariance_condition_number < 1.0
+    ):
+        raise ValueError(
+            "max_source_covariance_condition_number must be finite and at least one"
+        )
 
     components = np.asarray(predicted_components_m, dtype=float)
     if components.ndim < 4:
@@ -368,10 +405,22 @@ def grouped_component_log_likelihoods(
         )
     total = np.zeros(leading_shape, dtype=float)
     responsibilities = []
+    contributor_caps = evidence.contributor_power_caps
     effective_weights = evidence.effective_group_weights
+    coordinate_counts = tuple(group.coordinate_count for group in evidence.groups)
+    condition_numbers = []
     full_covariance_groups = []
     low_rank_covariance_groups = []
     for group, weight in zip(evidence.groups, effective_weights, strict=True):
+        if score_semantics == "normalized_coordinate_mean_v3":
+            eigenvalues = np.linalg.eigvalsh(group.covariance_m2)
+            condition_number = float(eigenvalues[-1] / eigenvalues[0])
+            condition_numbers.append(condition_number)
+            if condition_number > max_source_covariance_condition_number:
+                raise ValueError(
+                    f"group {group.group_id!r} source covariance condition number "
+                    "exceeds the normalized-v3 limit"
+                )
         selected = group.selected_predictions(components)
         selected_variance = (
             None if variance is None else group.selected_predictions(variance)
@@ -391,12 +440,47 @@ def grouped_component_log_likelihoods(
         )
         total += weight * log_likelihood
         responsibilities.append(responsibility)
+
+    normalization_mass: float | None = None
+    normalization_fractions: tuple[float, ...] = ()
+    if score_semantics == "normalized_coordinate_mean_v3":
+        normalization_mass = float(
+            sum(
+                cap * coordinate_count
+                for cap, coordinate_count in zip(
+                    contributor_caps,
+                    coordinate_counts,
+                    strict=True,
+                )
+            )
+        )
+        if not np.isfinite(normalization_mass) or normalization_mass <= 0.0:
+            raise RuntimeError("normalized grouped coordinate mass is invalid")
+        total = likelihood_power * total / normalization_mass
+        normalization_fractions = tuple(
+            cap * coordinate_count / normalization_mass
+            for cap, coordinate_count in zip(
+                contributor_caps,
+                coordinate_counts,
+                strict=True,
+            )
+        )
+    else:
+        total = likelihood_power * total
+
     diagnostics = GroupLikelihoodDiagnostics(
         group_ids=tuple(group.group_id for group in evidence.groups),
         effective_group_weights=effective_weights,
         nominal_responsibilities=np.stack(responsibilities, axis=-1),
         full_covariance_group_ids=tuple(full_covariance_groups),
         low_rank_covariance_group_ids=tuple(low_rank_covariance_groups),
+        score_semantics=score_semantics,
+        likelihood_power=float(likelihood_power),
+        contributor_power_caps=contributor_caps,
+        group_coordinate_counts=coordinate_counts,
+        normalization_coordinate_mass=normalization_mass,
+        source_covariance_condition_numbers=tuple(condition_numbers),
+        normalization_coordinate_fractions=normalization_fractions,
     )
     return total, diagnostics
 
@@ -410,6 +494,9 @@ def posterior_weights_from_grouped_evidence(
     component_variance_m2: np.ndarray | None = None,
     component_group_covariance_m2: Mapping[str, np.ndarray] | None = None,
     component_group_covariance_factor_m: Mapping[str, np.ndarray] | None = None,
+    score_semantics: GroupedScoreSemantics = "legacy_sum_v1",
+    likelihood_power: float = 1.0,
+    max_source_covariance_condition_number: float = 1.0e12,
 ) -> tuple[np.ndarray, GroupLikelihoodDiagnostics]:
     """Apply grouped evidence to finite component support in log space."""
 
@@ -425,6 +512,11 @@ def posterior_weights_from_grouped_evidence(
         component_variance_m2=component_variance_m2,
         component_group_covariance_m2=component_group_covariance_m2,
         component_group_covariance_factor_m=(component_group_covariance_factor_m),
+        score_semantics=score_semantics,
+        likelihood_power=likelihood_power,
+        max_source_covariance_condition_number=(
+            max_source_covariance_condition_number
+        ),
     )
     log_posterior = log_weights_from_probabilities(prior, name="prior_weights") + score
     maximum = float(np.max(log_posterior))

--- a/src/causal4d/intervention_abduction.py
+++ b/src/causal4d/intervention_abduction.py
@@ -8,11 +8,10 @@ from typing import Any, Literal
 import numpy as np
 
 from causal4d.contracts import FactualIntervention, TwinBelief, array_sha256
-from causal4d.factual_abduction_uncertainty import (
-    FactualAbductionUncertaintyV1,
-)
+from causal4d.factual_abduction_uncertainty import FactualAbductionUncertaintyV1
 from causal4d.grouped_likelihood import (
     GroupLikelihoodDiagnostics,
+    GroupedScoreSemantics,
     grouped_component_log_likelihoods,
     posterior_weights_from_grouped_evidence,
 )
@@ -27,6 +26,7 @@ from causal4d.weighting import log_weights_from_probabilities
 
 
 DenseLikelihoodSemantics = Literal["legacy_v1", "normalized_v2"]
+GroupedLikelihoodSemantics = Literal["legacy_v1", "normalized_v3"]
 IdentifiabilityPolicy = Literal["full_parameter", "registered_query"]
 
 
@@ -36,7 +36,10 @@ class FactualAbductionConfig:
 
     ``legacy_v1`` preserves the registered dense score exactly. ``normalized_v2``
     is an opt-in development path that uses the endpoint-inclusive, scale-normalized
-    prefix likelihood. The legacy defaults remain unchanged.
+    prefix likelihood. ``grouped_likelihood_semantics`` independently controls the
+    full-covariance grouped path; ``normalized_v3`` is a contributor-capped,
+    coordinate-normalized development comparator. All legacy defaults remain
+    unchanged.
     """
 
     observation_scale_m: float = 0.01
@@ -45,6 +48,8 @@ class FactualAbductionConfig:
     degrees_of_freedom: float = 4.0
     likelihood_semantics: DenseLikelihoodSemantics = "legacy_v1"
     difference_correlation: float = 0.0
+    grouped_likelihood_semantics: GroupedLikelihoodSemantics = "legacy_v1"
+    grouped_covariance_condition_number_limit: float = 1.0e12
 
     def __post_init__(self) -> None:
         positive = (
@@ -64,6 +69,16 @@ class FactualAbductionConfig:
             raise ValueError("dynamic_likelihood_weight must be finite and nonnegative")
         if self.likelihood_semantics not in {"legacy_v1", "normalized_v2"}:
             raise ValueError("unsupported dense likelihood semantics")
+        if self.grouped_likelihood_semantics not in {"legacy_v1", "normalized_v3"}:
+            raise ValueError("unsupported grouped likelihood semantics")
+        if (
+            not np.isfinite(self.grouped_covariance_condition_number_limit)
+            or self.grouped_covariance_condition_number_limit < 1.0
+        ):
+            raise ValueError(
+                "grouped covariance condition-number limit must be finite and at "
+                "least one"
+            )
         if not np.isfinite(self.difference_correlation) or not (
             -1.0 < self.difference_correlation < 1.0
         ):
@@ -88,6 +103,11 @@ class FactualAbductionConfig:
         if self.likelihood_semantics != "legacy_v1":
             result["likelihood_semantics"] = self.likelihood_semantics
             result["difference_correlation"] = self.difference_correlation
+        if self.grouped_likelihood_semantics != "legacy_v1":
+            result["grouped_likelihood_semantics"] = self.grouped_likelihood_semantics
+            result["grouped_covariance_condition_number_limit"] = (
+                self.grouped_covariance_condition_number_limit
+            )
         return result
 
 
@@ -131,7 +151,7 @@ def _grouped_diagnostics_summary(
 ) -> dict[str, Any]:
     responsibilities = np.asarray(diagnostics.nominal_responsibilities, dtype=float)
     reduction_axes = tuple(range(responsibilities.ndim - 1))
-    result = {
+    result: dict[str, Any] = {
         "group_ids": list(diagnostics.group_ids),
         "effective_group_weights": list(diagnostics.effective_group_weights),
         "mean_nominal_responsibility_by_group": np.mean(
@@ -149,12 +169,28 @@ def _grouped_diagnostics_summary(
         result["low_rank_covariance_group_ids"] = list(
             diagnostics.low_rank_covariance_group_ids
         )
+    if diagnostics.score_semantics != "legacy_sum_v1":
+        result.update(
+            {
+                "score_semantics": diagnostics.score_semantics,
+                "likelihood_power": diagnostics.likelihood_power,
+                "contributor_power_caps": list(diagnostics.contributor_power_caps),
+                "group_coordinate_counts": list(diagnostics.group_coordinate_counts),
+                "normalization_coordinate_mass": (
+                    diagnostics.normalization_coordinate_mass
+                ),
+                "source_covariance_condition_numbers": list(
+                    diagnostics.source_covariance_condition_numbers
+                ),
+                "normalization_coordinate_fractions": list(
+                    diagnostics.normalization_coordinate_fractions
+                ),
+            }
+        )
     return result
 
 
-def _validated_grouped_component_batch_size(
-    value: int | None,
-) -> int | None:
+def _validated_grouped_component_batch_size(value: int | None) -> int | None:
     if value is None:
         return None
     if type(value) is not int or value < 1:
@@ -173,6 +209,9 @@ def _posterior_weights_from_grouped_evidence_batched(
     group_covariance_m2: dict[str, np.ndarray],
     group_covariance_factor_m: dict[str, np.ndarray],
     component_batch_size: int,
+    score_semantics: GroupedScoreSemantics,
+    likelihood_power: float,
+    max_source_covariance_condition_number: float,
 ) -> tuple[np.ndarray, GroupLikelihoodDiagnostics]:
     """Evaluate grouped evidence without a full discrepancy-aware rollout copy."""
 
@@ -201,6 +240,13 @@ def _posterior_weights_from_grouped_evidence_batched(
     effective_group_weights: tuple[float, ...] | None = None
     full_covariance_group_ids: tuple[str, ...] | None = None
     low_rank_covariance_group_ids: tuple[str, ...] | None = None
+    diagnostic_score_semantics: GroupedScoreSemantics | None = None
+    diagnostic_likelihood_power: float | None = None
+    contributor_power_caps: tuple[float, ...] | None = None
+    group_coordinate_counts: tuple[int, ...] | None = None
+    normalization_coordinate_mass: float | None = None
+    source_covariance_condition_numbers: tuple[float, ...] | None = None
+    normalization_coordinate_fractions: tuple[float, ...] | None = None
 
     for start in range(0, component_count, component_batch_size):
         stop = min(start + component_batch_size, component_count)
@@ -216,12 +262,10 @@ def _posterior_weights_from_grouped_evidence_batched(
         if additional_independent_variance_m2 is not None:
             component_variance = (
                 component_variance
-                + (
-                    additional_independent_variance_m2[
-                        hypothesis_indices,
-                        particle_indices,
-                    ]
-                )
+                + additional_independent_variance_m2[
+                    hypothesis_indices,
+                    particle_indices,
+                ]
             )
         dense_batch = {
             group_id: covariance[hypothesis_indices, particle_indices]
@@ -238,6 +282,11 @@ def _posterior_weights_from_grouped_evidence_batched(
             component_variance_m2=component_variance,
             component_group_covariance_m2=dense_batch,
             component_group_covariance_factor_m=factor_batch,
+            score_semantics=score_semantics,
+            likelihood_power=likelihood_power,
+            max_source_covariance_condition_number=(
+                max_source_covariance_condition_number
+            ),
         )
         scores[start:stop] = batch_scores.reshape(-1)
         batch_responsibilities = np.asarray(
@@ -253,12 +302,33 @@ def _posterior_weights_from_grouped_evidence_batched(
             effective_group_weights = diagnostics.effective_group_weights
             full_covariance_group_ids = diagnostics.full_covariance_group_ids
             low_rank_covariance_group_ids = diagnostics.low_rank_covariance_group_ids
+            diagnostic_score_semantics = diagnostics.score_semantics
+            diagnostic_likelihood_power = diagnostics.likelihood_power
+            contributor_power_caps = diagnostics.contributor_power_caps
+            group_coordinate_counts = diagnostics.group_coordinate_counts
+            normalization_coordinate_mass = diagnostics.normalization_coordinate_mass
+            source_covariance_condition_numbers = (
+                diagnostics.source_covariance_condition_numbers
+            )
+            normalization_coordinate_fractions = (
+                diagnostics.normalization_coordinate_fractions
+            )
         elif (
             diagnostics.group_ids != group_ids
             or diagnostics.effective_group_weights != effective_group_weights
             or diagnostics.full_covariance_group_ids != full_covariance_group_ids
             or diagnostics.low_rank_covariance_group_ids
             != low_rank_covariance_group_ids
+            or diagnostics.score_semantics != diagnostic_score_semantics
+            or diagnostics.likelihood_power != diagnostic_likelihood_power
+            or diagnostics.contributor_power_caps != contributor_power_caps
+            or diagnostics.group_coordinate_counts != group_coordinate_counts
+            or diagnostics.normalization_coordinate_mass
+            != normalization_coordinate_mass
+            or diagnostics.source_covariance_condition_numbers
+            != source_covariance_condition_numbers
+            or diagnostics.normalization_coordinate_fractions
+            != normalization_coordinate_fractions
         ):
             raise RuntimeError("grouped diagnostics changed between component batches")
         responsibilities[start:stop] = batch_responsibilities
@@ -269,6 +339,12 @@ def _posterior_weights_from_grouped_evidence_batched(
         or effective_group_weights is None
         or full_covariance_group_ids is None
         or low_rank_covariance_group_ids is None
+        or diagnostic_score_semantics is None
+        or diagnostic_likelihood_power is None
+        or contributor_power_caps is None
+        or group_coordinate_counts is None
+        or source_covariance_condition_numbers is None
+        or normalization_coordinate_fractions is None
     ):
         raise RuntimeError("grouped batched abduction produced no component scores")
     log_posterior = (
@@ -291,6 +367,13 @@ def _posterior_weights_from_grouped_evidence_batched(
         ),
         full_covariance_group_ids=full_covariance_group_ids,
         low_rank_covariance_group_ids=low_rank_covariance_group_ids,
+        score_semantics=diagnostic_score_semantics,
+        likelihood_power=diagnostic_likelihood_power,
+        contributor_power_caps=contributor_power_caps,
+        group_coordinate_counts=group_coordinate_counts,
+        normalization_coordinate_mass=normalization_coordinate_mass,
+        source_covariance_condition_numbers=source_covariance_condition_numbers,
+        normalization_coordinate_fractions=normalization_coordinate_fractions,
     )
     return posterior.reshape(hypothesis_count, particle_count), diagnostics
 
@@ -312,6 +395,11 @@ def _update_joint_weights(
         raise ValueError(
             "normalized_v2 cannot be combined with grouped observation evidence"
         )
+    if (
+        grouped_evidence is None
+        and settings.grouped_likelihood_semantics != "legacy_v1"
+    ):
+        raise ValueError("normalized_v3 requires grouped observation evidence")
     batch_size = _validated_grouped_component_batch_size(grouped_component_batch_size)
     if batch_size is not None and grouped_evidence is None:
         raise ValueError(
@@ -363,6 +451,11 @@ def _update_joint_weights(
             )
         )
     prior = bank.prior_joint_weights if base_weights is None else base_weights
+    normalized_grouped = settings.grouped_likelihood_semantics == "normalized_v3"
+    grouped_score_semantics: GroupedScoreSemantics = (
+        "normalized_coordinate_mean_v3" if normalized_grouped else "legacy_sum_v1"
+    )
+    grouped_likelihood_power = settings.likelihood_power if normalized_grouped else 1.0
     if batch_size is not None:
         return _posterior_weights_from_grouped_evidence_batched(
             bank,
@@ -374,6 +467,11 @@ def _update_joint_weights(
             group_covariance_m2=group_covariance,
             group_covariance_factor_m=group_covariance_factor,
             component_batch_size=batch_size,
+            score_semantics=grouped_score_semantics,
+            likelihood_power=grouped_likelihood_power,
+            max_source_covariance_condition_number=(
+                settings.grouped_covariance_condition_number_limit
+            ),
         )
     components = physical_readout_components(bank, belief)
     component_variance = np.broadcast_to(
@@ -389,6 +487,11 @@ def _update_joint_weights(
         component_variance_m2=component_variance,
         component_group_covariance_m2=group_covariance,
         component_group_covariance_factor_m=group_covariance_factor,
+        score_semantics=grouped_score_semantics,
+        likelihood_power=grouped_likelihood_power,
+        max_source_covariance_condition_number=(
+            settings.grouped_covariance_condition_number_limit
+        ),
     )
 
 
@@ -703,7 +806,11 @@ def evaluate_factual_abduction(
         "abduction_prefix_frame_count_including_endpoint": prefix_frame_count,
         "held_out_rollout_interval": [prefix_frame_count, bank.frame_count],
         "evidence_model": (
-            "grouped_robust_composite"
+            (
+                "grouped_normalized_v3"
+                if settings.grouped_likelihood_semantics == "normalized_v3"
+                else "grouped_robust_composite"
+            )
             if grouped_evidence is not None
             else (
                 "legacy_dense"

--- a/src/causal4d/observation_evidence.py
+++ b/src/causal4d/observation_evidence.py
@@ -250,12 +250,31 @@ class GroupedObservationEvidence:
         return result
 
     @property
-    def effective_group_weights(self) -> tuple[float, ...]:
+    def contributor_power_caps(self) -> tuple[float, ...]:
+        """Return duplicate-evidence caps before source reliability weighting.
+
+        The cap is one over the largest contributor multiplicity in each group.
+        Keeping it separate from ``composite_weight`` lets normalized composite
+        scores preserve both duplicate invariance and source-calibrated
+        reliability temperatures.
+        """
+
         multiplicity = self.contributor_multiplicity
         return tuple(
-            group.composite_weight
+            1.0
             / max(multiplicity[contributor] for contributor in group.contributor_ids)
             for group in self.groups
+        )
+
+    @property
+    def effective_group_weights(self) -> tuple[float, ...]:
+        return tuple(
+            group.composite_weight * cap
+            for group, cap in zip(
+                self.groups,
+                self.contributor_power_caps,
+                strict=True,
+            )
         )
 
     def validate_prefix(

--- a/tests/test_factual_likelihood_semantics.py
+++ b/tests/test_factual_likelihood_semantics.py
@@ -275,6 +275,8 @@ def test_normalized_v2_evaluation_records_effective_model() -> None:
         ("degrees_of_freedom", np.inf),
         ("difference_correlation", np.nan),
         ("difference_correlation", 1.0),
+        ("grouped_covariance_condition_number_limit", np.nan),
+        ("grouped_covariance_condition_number_limit", 0.5),
     ],
 )
 def test_factual_abduction_config_rejects_nonfinite_or_invalid_values(
@@ -283,6 +285,11 @@ def test_factual_abduction_config_rejects_nonfinite_or_invalid_values(
 ) -> None:
     with pytest.raises(ValueError):
         FactualAbductionConfig(**{keyword: value})
+
+
+def test_factual_abduction_config_rejects_unknown_grouped_semantics() -> None:
+    with pytest.raises(ValueError, match="unsupported grouped likelihood semantics"):
+        FactualAbductionConfig(grouped_likelihood_semantics="unknown")
 
 
 def test_difference_correlation_requires_normalized_v2() -> None:
@@ -333,3 +340,90 @@ def test_cli_defaults_to_legacy_and_exposes_normalized_v2() -> None:
     assert default.difference_correlation == 0.0
     assert normalized.likelihood_semantics == "normalized_v2"
     assert normalized.difference_correlation == 0.25
+
+
+def test_grouped_normalized_v3_records_effective_model_and_diagnostics() -> None:
+    bank, belief, observations, mask, _ = _registered_problem()
+    grouped = GroupedObservationEvidence.from_dense_prefix(
+        observations,
+        prefix_frame_count=4,
+        scale_m=0.001,
+        mask=mask,
+        source_id="unit",
+    )
+    config = FactualAbductionConfig(
+        observation_scale_m=0.001,
+        likelihood_power=12.0,
+        grouped_likelihood_semantics="normalized_v3",
+    )
+
+    factual = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=config,
+        grouped_evidence=grouped,
+    )
+    result = evaluate_factual_abduction(
+        bank,
+        belief,
+        factual,
+        observations,
+        observation_mask=mask,
+        prefix_frame_count=4,
+        config=config,
+        grouped_evidence=grouped,
+    )
+
+    assert result["evidence_model"] == "grouped_normalized_v3"
+    assert factual.metadata["abduction_likelihood"] == {
+        "observation_scale_m": 0.001,
+        "likelihood_power": 12.0,
+        "dynamic_likelihood_weight": 0.25,
+        "degrees_of_freedom": 4.0,
+        "grouped_likelihood_semantics": "normalized_v3",
+        "grouped_covariance_condition_number_limit": 1.0e12,
+    }
+    diagnostics = factual.metadata["grouped_observation_evidence"]["diagnostics"]
+    assert diagnostics["score_semantics"] == "normalized_coordinate_mean_v3"
+    assert diagnostics["likelihood_power"] == 12.0
+    assert np.isclose(sum(diagnostics["normalization_coordinate_fractions"]), 1.0)
+
+
+def test_grouped_normalized_v3_requires_grouped_evidence() -> None:
+    bank, belief, observations, mask, _ = _registered_problem()
+
+    with pytest.raises(ValueError, match="requires grouped observation evidence"):
+        abduct_factual_intervention(
+            bank,
+            belief,
+            observations,
+            prefix_frame_count=4,
+            observation_mask=mask,
+            config=FactualAbductionConfig(
+                grouped_likelihood_semantics="normalized_v3"
+            ),
+        )
+
+
+def test_cli_exposes_grouped_normalized_v3_separately() -> None:
+    parsed = build_parser().parse_args(
+        [
+            "bank",
+            "belief",
+            "data",
+            "factual",
+            "evaluation",
+            "--grouped-observation-likelihood",
+            "--grouped-likelihood-semantics",
+            "normalized_v3",
+            "--grouped-covariance-condition-number-limit",
+            "1000000",
+        ]
+    )
+
+    assert parsed.likelihood_semantics == "legacy_v1"
+    assert parsed.grouped_likelihood_semantics == "normalized_v3"
+    assert parsed.grouped_covariance_condition_number_limit == 1.0e6

--- a/tests/test_grouped_normalized_v3.py
+++ b/tests/test_grouped_normalized_v3.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from causal4d.grouped_likelihood import (
+    GroupLikelihoodDiagnostics,
+    grouped_component_log_likelihoods,
+    posterior_weights_from_grouped_evidence,
+)
+from causal4d.observation_evidence import GroupedObservationEvidence, ObservationGroup
+
+
+def _group(
+    group_id: str,
+    *,
+    values: np.ndarray,
+    covariance: np.ndarray,
+    contributor: str,
+    composite_weight: float = 1.0,
+) -> ObservationGroup:
+    dimension = len(values)
+    return ObservationGroup(
+        group_id=group_id,
+        values_m=np.asarray(values, dtype=float),
+        frame_indices=np.ones(dimension, dtype=np.int64),
+        node_indices=np.zeros(dimension, dtype=np.int64),
+        coordinate_indices=np.arange(dimension, dtype=np.int64),
+        covariance_m2=np.asarray(covariance, dtype=float),
+        contributor_ids=(contributor,),
+        prior_nominal_probability=0.93,
+        outlier_scale_multiplier=40.0,
+        degrees_of_freedom=5.0,
+        composite_weight=composite_weight,
+        source_id="unit",
+    )
+
+
+def _posterior(
+    evidence: GroupedObservationEvidence,
+    components: np.ndarray,
+    *,
+    likelihood_power: float = 8.0,
+) -> tuple[np.ndarray, GroupLikelihoodDiagnostics]:
+    return posterior_weights_from_grouped_evidence(
+        np.asarray([0.5, 0.5]),
+        components,
+        evidence,
+        prefix_frame_count=2,
+        score_semantics="normalized_coordinate_mean_v3",
+        likelihood_power=likelihood_power,
+    )
+
+
+def test_normalized_v3_duplicate_contributor_is_exactly_power_capped() -> None:
+    components = np.zeros((2, 3, 1, 1), dtype=float)
+    components[1, 1, 0, 0] = 1.0
+    group = _group(
+        "g1",
+        values=np.asarray([1.0]),
+        covariance=np.asarray([[0.01]]),
+        contributor="same",
+    )
+    duplicate = _group(
+        "g2",
+        values=np.asarray([1.0]),
+        covariance=np.asarray([[0.01]]),
+        contributor="same",
+    )
+
+    single, single_diagnostics = _posterior(
+        GroupedObservationEvidence(groups=(group,)),
+        components,
+    )
+    doubled, doubled_diagnostics = _posterior(
+        GroupedObservationEvidence(groups=(group, duplicate)),
+        components,
+    )
+
+    np.testing.assert_allclose(doubled, single, rtol=1e-13, atol=1e-13)
+    assert single_diagnostics.contributor_power_caps == (1.0,)
+    assert doubled_diagnostics.contributor_power_caps == (0.5, 0.5)
+    assert doubled_diagnostics.normalization_coordinate_mass == 1.0
+
+
+def test_normalized_v3_preserves_composite_weight_as_reliability_temperature() -> None:
+    components = np.zeros((2, 3, 1, 1), dtype=float)
+    components[1, 1, 0, 0] = 1.0
+    full = GroupedObservationEvidence(
+        groups=(
+            _group(
+                "full",
+                values=np.asarray([1.0]),
+                covariance=np.asarray([[0.01]]),
+                contributor="source",
+                composite_weight=1.0,
+            ),
+        )
+    )
+    tempered = GroupedObservationEvidence(
+        groups=(
+            _group(
+                "tempered",
+                values=np.asarray([1.0]),
+                covariance=np.asarray([[0.01]]),
+                contributor="source",
+                composite_weight=0.25,
+            ),
+        )
+    )
+
+    full_posterior, _ = _posterior(full, components)
+    tempered_posterior, _ = _posterior(tempered, components)
+
+    assert full_posterior[1] > tempered_posterior[1] > 0.5
+
+
+def test_normalized_v3_is_invariant_to_coordinate_permutation() -> None:
+    covariance = np.asarray(
+        [
+            [0.040, 0.010, -0.004],
+            [0.010, 0.030, 0.006],
+            [-0.004, 0.006, 0.020],
+        ]
+    )
+    values = np.asarray([0.4, -0.1, 0.2])
+    components = np.zeros((2, 3, 1, 3), dtype=float)
+    components[0, 1, 0] = np.asarray([0.35, -0.05, 0.18])
+    components[1, 1, 0] = np.asarray([-0.2, 0.2, 0.5])
+    group = _group(
+        "original",
+        values=values,
+        covariance=covariance,
+        contributor="source",
+    )
+    original, _ = _posterior(
+        GroupedObservationEvidence(groups=(group,)),
+        components,
+    )
+
+    permutation = np.asarray([2, 0, 1])
+    permuted_group = ObservationGroup(
+        group_id="permuted",
+        values_m=values[permutation],
+        frame_indices=group.frame_indices[permutation],
+        node_indices=group.node_indices[permutation],
+        coordinate_indices=group.coordinate_indices[permutation],
+        covariance_m2=covariance[np.ix_(permutation, permutation)],
+        contributor_ids=("source",),
+        prior_nominal_probability=group.prior_nominal_probability,
+        outlier_scale_multiplier=group.outlier_scale_multiplier,
+        degrees_of_freedom=group.degrees_of_freedom,
+        source_id="unit",
+    )
+    permuted, _ = _posterior(
+        GroupedObservationEvidence(groups=(permuted_group,)),
+        components,
+    )
+
+    np.testing.assert_allclose(permuted, original, rtol=1e-12, atol=1e-12)
+
+
+def test_normalized_v3_is_invariant_to_group_order() -> None:
+    components = np.zeros((2, 3, 1, 2), dtype=float)
+    components[0, 1, 0] = np.asarray([0.3, -0.2])
+    components[1, 1, 0] = np.asarray([-0.1, 0.4])
+    first = ObservationGroup(
+        group_id="first",
+        values_m=np.asarray([0.25]),
+        frame_indices=np.asarray([1]),
+        node_indices=np.asarray([0]),
+        coordinate_indices=np.asarray([0]),
+        covariance_m2=np.asarray([[0.02]]),
+        contributor_ids=("first",),
+        source_id="unit",
+    )
+    second = ObservationGroup(
+        group_id="second",
+        values_m=np.asarray([-0.15]),
+        frame_indices=np.asarray([1]),
+        node_indices=np.asarray([0]),
+        coordinate_indices=np.asarray([1]),
+        covariance_m2=np.asarray([[0.03]]),
+        contributor_ids=("second",),
+        source_id="unit",
+    )
+
+    forward, _ = _posterior(
+        GroupedObservationEvidence(groups=(first, second)),
+        components,
+    )
+    reverse, _ = _posterior(
+        GroupedObservationEvidence(groups=(second, first)),
+        components,
+    )
+
+    np.testing.assert_allclose(reverse, forward, rtol=1e-13, atol=1e-13)
+
+
+def test_normalized_v3_dense_and_low_rank_covariance_updates_agree() -> None:
+    generator = np.random.default_rng(17)
+    group = _group(
+        "structured",
+        values=np.asarray([0.2, -0.1, 0.4]),
+        covariance=np.asarray(
+            [
+                [0.4, 0.05, 0.0],
+                [0.05, 0.3, 0.02],
+                [0.0, 0.02, 0.2],
+            ]
+        ),
+        contributor="structured",
+    )
+    evidence = GroupedObservationEvidence(groups=(group,))
+    components = generator.normal(size=(2, 3, 1, 3))
+    factor = generator.normal(scale=0.1, size=(2, 3, 2))
+    dense = np.einsum("...ir,...jr->...ij", factor, factor)
+
+    dense_posterior, _ = posterior_weights_from_grouped_evidence(
+        np.asarray([0.5, 0.5]),
+        components,
+        evidence,
+        prefix_frame_count=2,
+        component_group_covariance_m2={"structured": dense},
+        score_semantics="normalized_coordinate_mean_v3",
+        likelihood_power=3.0,
+    )
+    low_rank_posterior, diagnostics = posterior_weights_from_grouped_evidence(
+        np.asarray([0.5, 0.5]),
+        components,
+        evidence,
+        prefix_frame_count=2,
+        component_group_covariance_factor_m={"structured": factor},
+        score_semantics="normalized_coordinate_mean_v3",
+        likelihood_power=3.0,
+    )
+
+    np.testing.assert_allclose(
+        low_rank_posterior,
+        dense_posterior,
+        rtol=1e-11,
+        atol=1e-11,
+    )
+    assert diagnostics.low_rank_covariance_group_ids == ("structured",)
+
+
+def test_normalized_v3_reports_information_fractions_and_conditioning() -> None:
+    groups = (
+        _group(
+            "one",
+            values=np.asarray([0.0]),
+            covariance=np.asarray([[0.2]]),
+            contributor="one",
+        ),
+        _group(
+            "two",
+            values=np.asarray([0.0, 0.0]),
+            covariance=np.asarray([[0.2, 0.05], [0.05, 0.1]]),
+            contributor="two",
+        ),
+    )
+    components = np.zeros((2, 3, 1, 2), dtype=float)
+    score, diagnostics = grouped_component_log_likelihoods(
+        components,
+        GroupedObservationEvidence(groups=groups),
+        prefix_frame_count=2,
+        score_semantics="normalized_coordinate_mean_v3",
+        likelihood_power=2.0,
+    )
+
+    assert score.shape == (2,)
+    assert diagnostics.group_coordinate_counts == (1, 2)
+    assert diagnostics.normalization_coordinate_mass == 3.0
+    assert np.isclose(sum(diagnostics.normalization_coordinate_fractions), 1.0)
+    assert diagnostics.normalization_coordinate_fractions == pytest.approx(
+        (1 / 3, 2 / 3)
+    )
+    assert all(
+        value >= 1.0
+        for value in diagnostics.source_covariance_condition_numbers
+    )
+
+
+def test_normalized_v3_rejects_ill_conditioned_source_covariance() -> None:
+    group = _group(
+        "ill-conditioned",
+        values=np.asarray([0.0, 0.0]),
+        covariance=np.diag([1.0, 1.0e-14]),
+        contributor="source",
+    )
+    components = np.zeros((2, 3, 1, 2), dtype=float)
+
+    with pytest.raises(ValueError, match="condition number"):
+        grouped_component_log_likelihoods(
+            components,
+            GroupedObservationEvidence(groups=(group,)),
+            prefix_frame_count=2,
+            score_semantics="normalized_coordinate_mean_v3",
+            max_source_covariance_condition_number=1.0e10,
+        )
+
+
+def test_grouped_score_settings_fail_closed() -> None:
+    group = _group(
+        "valid",
+        values=np.asarray([0.0]),
+        covariance=np.asarray([[1.0]]),
+        contributor="source",
+    )
+    components = np.zeros((2, 3, 1, 1), dtype=float)
+    evidence = GroupedObservationEvidence(groups=(group,))
+
+    with pytest.raises(ValueError, match="unsupported grouped score"):
+        grouped_component_log_likelihoods(
+            components,
+            evidence,
+            prefix_frame_count=2,
+            score_semantics="unknown",  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="likelihood_power"):
+        grouped_component_log_likelihoods(
+            components,
+            evidence,
+            prefix_frame_count=2,
+            likelihood_power=np.nan,
+        )
+    with pytest.raises(ValueError, match="condition_number"):
+        grouped_component_log_likelihoods(
+            components,
+            evidence,
+            prefix_frame_count=2,
+            max_source_covariance_condition_number=0.5,
+        )

--- a/tests/test_grouped_normalized_v3_batched.py
+++ b/tests/test_grouped_normalized_v3_batched.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import numpy as np
+
+from causal4d.contracts import TwinBelief, build_causal_context
+from causal4d.intervention_abduction import (
+    FactualAbductionConfig,
+    abduct_factual_intervention,
+)
+from causal4d.observation_evidence import GroupedObservationEvidence
+from causal4d.rollout_bank import JointRolloutBank
+
+
+def _metadata(identifier: str, *, gain: float, shift: int) -> dict:
+    return {
+        "hypothesis_id": identifier,
+        "action": {
+            "proposal_id": "known",
+            "future_action_observed": True,
+            "provenance": "normalized-v3 batching unit test",
+        },
+        "contact": {
+            "attachment_shifts": [shift],
+            "gain_multiplier": gain,
+            "delay_steps": 0,
+            "slip_fraction": 0.0,
+            "rotation_degrees": 0.0,
+        },
+    }
+
+
+def _problem() -> tuple[
+    JointRolloutBank,
+    TwinBelief,
+    np.ndarray,
+    np.ndarray,
+    GroupedObservationEvidence,
+]:
+    frame_count = 7
+    trajectories = np.zeros((3, 2, frame_count, 1, 3), dtype=float)
+    time = np.arange(frame_count, dtype=float)
+    trajectories[1, :, :, 0, 0] = 0.01 * time
+    trajectories[2, :, :, 0, 0] = -0.01 * time
+    trajectories[:, 1, :, 0, 1] = 0.002 * time
+    bank = JointRolloutBank(
+        hypothesis_ids=("nominal", "high_gain", "shifted"),
+        hypothesis_metadata=(
+            _metadata("nominal", gain=1.0, shift=0),
+            _metadata("high_gain", gain=1.15, shift=0),
+            _metadata("shifted", gain=1.0, shift=1),
+        ),
+        hypothesis_prior_weights=np.asarray([0.6, 0.2, 0.2]),
+        parameter_particles=np.asarray([[0.0], [1.0]]),
+        parameter_weights=np.asarray([0.4, 0.6]),
+        trajectories=trajectories,
+        variance_floor_m2=1e-8,
+    )
+    full_frames = frame_count + 3
+    intervention_frame = 4
+    context = build_causal_context(
+        protocol_id="normalized-v3-batching-unit",
+        case_id="synthetic",
+        observations=np.zeros((full_frames, 1, 3)),
+        observed_actions=np.zeros((full_frames, 1, 3)),
+        counterfactual_actions=np.zeros((full_frames, 1, 3)),
+        intervention_frame=intervention_frame,
+    )
+    state_shape = (2, 1, 3)
+    discrepancy = np.zeros(state_shape)
+    discrepancy[1, 0, 1] = 0.001
+    belief = TwinBelief(
+        context=context,
+        endpoint_frame=intervention_frame - 1,
+        particle_ids=("p0", "p1"),
+        theta_names=("spring",),
+        endpoint_position_m=np.zeros(state_shape),
+        endpoint_velocity_mps=np.zeros(state_shape),
+        theta=bank.parameter_particles,
+        discrepancy_mean_m=discrepancy,
+        discrepancy_variance_m2=np.full(state_shape, 1e-8),
+        weights=bank.parameter_weights,
+    )
+    observations = trajectories[1, 0].copy()
+    mask = np.ones((frame_count, 1), dtype=bool)
+    evidence = GroupedObservationEvidence.from_dense_prefix(
+        observations,
+        prefix_frame_count=4,
+        scale_m=0.001,
+        mask=mask,
+        source_id="unit",
+    )
+    return bank, belief, observations, mask, evidence
+
+
+def test_grouped_component_batching_preserves_normalized_v3_semantics() -> None:
+    bank, belief, observations, mask, evidence = _problem()
+    config = FactualAbductionConfig(
+        observation_scale_m=0.001,
+        grouped_likelihood_semantics="normalized_v3",
+    )
+    dense = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=config,
+        grouped_evidence=evidence,
+    )
+    batched = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=config,
+        grouped_evidence=evidence,
+        grouped_component_batch_size=1,
+    )
+
+    assert np.array_equal(batched.weights, dense.weights)
+    assert batched.metadata == dense.metadata
+    assert batched.artifact_id == dense.artifact_id
+    diagnostics = batched.metadata["grouped_observation_evidence"]["diagnostics"]
+    assert diagnostics["score_semantics"] == "normalized_coordinate_mean_v3"
+    assert diagnostics["likelihood_power"] == config.likelihood_power


### PR DESCRIPTION
## Summary

This replaces the stale/conflicted implementation in #344 with a clean branch based on current `main` (`308cbd92a11b602b9483b08aec655e385b3f6b1e`).

It preserves the current registered-query identifiability, factual-abduction uncertainty, interventional-contrast API, and bounded-memory grouped-component path while adding the opt-in grouped normalized-v3 comparator:

- contributor-aware duplicate-evidence power caps;
- coordinate-mass normalization with explicit likelihood power;
- full source-covariance conditioning diagnostics and a fail-closed limit;
- dense and low-rank covariance support;
- CLI/config/artifact metadata integration;
- exact dense-versus-batched posterior, metadata, and artifact parity tests.

## Compatibility and claim boundary

- `legacy_v1` remains the default for dense and grouped paths.
- Legacy metadata and registered artifact identity are tested unchanged.
- `normalized_v2` and grouped `normalized_v3` remain explicitly separate.
- Normalized-v3 is a development comparator only. It does not modify the registered physical estimator and does not establish calibration, transfer, causal identification, or physical benefit.
- Promotion still requires the separately frozen source-only and held-out study in #333.

## Supersedes

- Supersedes conflicted PR #344.
- The helper publisher PR #324 is no longer needed.
