### PR TITLE
Add an exact stable-core MyPy debt ratchet

### DIFF
--- a/.github/workflows/stable-core-mypy.yml
+++ b/.github/workflows/stable-core-mypy.yml
@@ -1,0 +1,92 @@
+name: Stable-core MyPy debt ratchet
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/stable-core-mypy.yml"
+      - "pyproject.toml"
+      - "scripts/ci/**"
+      - "src/causal4d/atomic_io.py"
+      - "src/causal4d/result_bundle_publication.py"
+      - "src/causal4d/trusted_pickle.py"
+      - "src/causal4d/immutable_array.py"
+      - "src/causal4d/immutable_json.py"
+      - "src/causal4d/low_rank_numerics.py"
+      - "src/causal4d/contracts.py"
+      - "src/causal4d/counterfactual.py"
+      - "src/causal4d/grouped_likelihood.py"
+      - "src/causal4d/intervention_abduction.py"
+      - "src/causal4d/observation_evidence.py"
+      - "src/causal4d/api/v1.py"
+      - "src/causal4d/provider_contract.py"
+      - "src/causal4d/replay_provider_contract.py"
+      - "tests/test_stable_core_mypy_gate.py"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/stable-core-mypy.yml"
+      - "pyproject.toml"
+      - "scripts/ci/**"
+      - "src/causal4d/atomic_io.py"
+      - "src/causal4d/result_bundle_publication.py"
+      - "src/causal4d/trusted_pickle.py"
+      - "src/causal4d/immutable_array.py"
+      - "src/causal4d/immutable_json.py"
+      - "src/causal4d/low_rank_numerics.py"
+      - "src/causal4d/contracts.py"
+      - "src/causal4d/counterfactual.py"
+      - "src/causal4d/grouped_likelihood.py"
+      - "src/causal4d/intervention_abduction.py"
+      - "src/causal4d/observation_evidence.py"
+      - "src/causal4d/api/v1.py"
+      - "src/causal4d/provider_contract.py"
+      - "src/causal4d/replay_provider_contract.py"
+      - "tests/test_stable_core_mypy_gate.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: stable-core-mypy-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  stable-core-mypy:
+    name: Exact stable-core typing debt
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install development dependencies
+        run: python -m pip install -e ".[dev]"
+      - name: Check the gate implementation
+        run: |
+          python -W error::SyntaxWarning -m compileall -q -f \
+            scripts/ci/check_stable_core_mypy.py \
+            tests/test_stable_core_mypy_gate.py
+          python -m ruff check \
+            scripts/ci/check_stable_core_mypy.py \
+            tests/test_stable_core_mypy_gate.py
+          python -m ruff format --check \
+            scripts/ci/check_stable_core_mypy.py \
+            tests/test_stable_core_mypy_gate.py
+          python -m pytest -q tests/test_stable_core_mypy_gate.py
+      - name: Enforce the exact stable-core MyPy debt set
+        run: |
+          python scripts/ci/check_stable_core_mypy.py \
+            --python-version 3.12 \
+            --repository-root "$PWD"

--- a/docs/stable_core_typing.md
+++ b/docs/stable_core_typing.md
@@ -1,0 +1,84 @@
+# Stable-core typing ratchet
+
+## Purpose
+
+Causal4D's stable counterfactual and observation core is now checked by a dedicated
+MyPy workflow in addition to the narrower provider/artifact checks in the main CI
+job. The expanded scope covers the public contracts, counterfactual operator,
+grouped likelihood, factual intervention abduction, grouped observation evidence,
+and versioned API surface.
+
+The first complete check exposed four pre-existing diagnostics. They are retained as
+an **exact debt set**, not hidden through broad `ignore_errors`, module exclusions,
+or unchecked `# type: ignore` comments. The gate executes MyPy over the complete
+scope and accepts only these exact file, line, error-code, and message identities:
+
+| File | Line | Code | Current diagnostic |
+| --- | ---: | --- | --- |
+| `src/causal4d/contracts.py` | 1081 | `arg-type` | NumPy's `savez_compressed` stub interprets a dynamic archive member as its reserved Boolean keyword. |
+| `src/causal4d/intervention_abduction.py` | 253 | `var-annotated` | `flat_indices` needs an explicit NumPy array annotation under the current inference settings. |
+| `src/causal4d/intervention_abduction.py` | 608 | `no-redef` | the posterior metadata mapping reuses the earlier loop variable name `metadata`. |
+| `src/causal4d/intervention_abduction.py` | 664 | `var-annotated` | the reconstructed joint-weight matrix needs an explicit NumPy array annotation. |
+
+Any additional diagnostic fails. A moved line, changed error code, changed message,
+duplicate diagnostic, or missing registered diagnostic also fails. Missing debt is a
+failure because it means source and debt manifest changed independently; the repair
+and manifest removal must land together in one reviewed pull request.
+
+## Why exact debt instead of a broad allowlist
+
+A broad MyPy exclusion would establish no protection for these modules. An error-code
+allowlist would permit unrelated errors of the same class. A path-only allowlist
+would permit arbitrary typing regressions in a large scientific module. The exact
+manifest therefore acts as a monotonic ratchet:
+
+```text
+current diagnostics == registered diagnostics
+```
+
+The workflow runs from `scripts/ci/check_stable_core_mypy.py`. Its parser consumes
+non-pretty, error-code-bearing MyPy output, and adversarial tests cover missing,
+unexpected, duplicate, and message-drift cases. Source-line tests bind every debt
+entry to the current statement that produces it.
+
+## Retiring debt
+
+Each item should be removed by a focused repair:
+
+1. change the source without altering numerical, archive, or artifact semantics;
+2. remove the matching `EXPECTED_DEBT` entry and its source-line assertion in the
+   same commit or pull request;
+3. run the dedicated workflow and the affected behavioral tests; and
+4. retain no replacement ignore unless the external type contract is impossible to
+   express and the ignore is narrower and more auditable than the former debt.
+
+The NumPy archive item should be resolved with a typed wrapper or cast around the
+runtime's arbitrary named-member interface, while preserving the archive member
+inventory and bytes. The three abduction items require annotations or a local
+variable rename only. None requires an estimator change.
+
+## Scope
+
+The permanent target inventory includes:
+
+- immutable and atomic artifact utilities;
+- `contracts.py`;
+- `counterfactual.py`;
+- `grouped_likelihood.py`;
+- `intervention_abduction.py`;
+- `observation_evidence.py`;
+- `api/v1.py`;
+- provider and replay-provider contracts; and
+- CI utilities themselves.
+
+Expanding this inventory is additive. A proposed module must first be checked under
+the same command. New debt should normally be repaired before inclusion rather than
+registered.
+
+## Scientific boundary
+
+This ratchet changes static-analysis enforcement only. It does not change a
+likelihood, posterior, counterfactual trajectory, covariance, artifact identity,
+provider schema, registered protocol, target-access boundary, acquisition dataset,
+physical evidence count, or scientific claim. The four entries are implementation
+debt, not empirical findings.

--- a/scripts/ci/check_stable_core_mypy.py
+++ b/scripts/ci/check_stable_core_mypy.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Run the stable-core MyPy ratchet with an exact, fail-closed debt manifest."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Final, Sequence
+
+
+STABLE_CORE_TARGETS: Final = (
+    "scripts/ci",
+    "src/causal4d/atomic_io.py",
+    "src/causal4d/result_bundle_publication.py",
+    "src/causal4d/trusted_pickle.py",
+    "src/causal4d/immutable_array.py",
+    "src/causal4d/immutable_json.py",
+    "src/causal4d/low_rank_numerics.py",
+    "src/causal4d/contracts.py",
+    "src/causal4d/counterfactual.py",
+    "src/causal4d/grouped_likelihood.py",
+    "src/causal4d/intervention_abduction.py",
+    "src/causal4d/observation_evidence.py",
+    "src/causal4d/api/v1.py",
+    "src/causal4d/provider_contract.py",
+    "src/causal4d/replay_provider_contract.py",
+)
+
+
+@dataclass(frozen=True, order=True)
+class DiagnosticKey:
+    """Stable location and MyPy error-code identity for one diagnostic."""
+
+    path: str
+    line: int
+    code: str
+
+
+@dataclass(frozen=True)
+class MypyDiagnostic:
+    """One parsed MyPy error diagnostic."""
+
+    key: DiagnosticKey
+    message: str
+
+
+EXPECTED_DEBT: Final = {
+    DiagnosticKey("src/causal4d/contracts.py", 1081, "arg-type"): (
+        'Argument 1 to "savez_compressed" has incompatible type'
+    ),
+    DiagnosticKey(
+        "src/causal4d/intervention_abduction.py", 253, "var-annotated"
+    ): 'Need type annotation for "flat_indices"',
+    DiagnosticKey("src/causal4d/intervention_abduction.py", 608, "no-redef"): (
+        'Name "metadata" already defined on line 587'
+    ),
+    DiagnosticKey(
+        "src/causal4d/intervention_abduction.py", 664, "var-annotated"
+    ): 'Need type annotation for "result"',
+}
+
+_ERROR_PATTERN: Final = re.compile(
+    r"^(?P<path>.+?):(?P<line>[0-9]+): error: "
+    r"(?P<message>.*?)  \[(?P<code>[^]]+)]$"
+)
+
+
+class StableCoreMypyError(RuntimeError):
+    """The current diagnostics differ from the exact registered debt set."""
+
+
+def parse_mypy_diagnostics(output: str) -> tuple[MypyDiagnostic, ...]:
+    """Extract deterministic error diagnostics from non-pretty MyPy output."""
+
+    diagnostics: list[MypyDiagnostic] = []
+    for raw_line in output.splitlines():
+        match = _ERROR_PATTERN.fullmatch(raw_line.strip())
+        if match is None:
+            continue
+        diagnostics.append(
+            MypyDiagnostic(
+                key=DiagnosticKey(
+                    path=match.group("path").replace("\\", "/"),
+                    line=int(match.group("line")),
+                    code=match.group("code"),
+                ),
+                message=match.group("message"),
+            )
+        )
+    return tuple(diagnostics)
+
+
+def validate_exact_debt(
+    diagnostics: Sequence[MypyDiagnostic],
+) -> tuple[MypyDiagnostic, ...]:
+    """Accept only the complete exact debt set and reject every drift."""
+
+    by_key: dict[DiagnosticKey, MypyDiagnostic] = {}
+    duplicate_keys: list[DiagnosticKey] = []
+    for diagnostic in diagnostics:
+        if diagnostic.key in by_key:
+            duplicate_keys.append(diagnostic.key)
+        by_key[diagnostic.key] = diagnostic
+
+    expected_keys = set(EXPECTED_DEBT)
+    actual_keys = set(by_key)
+    missing = sorted(expected_keys - actual_keys)
+    unexpected = sorted(actual_keys - expected_keys)
+    wrong_messages = sorted(
+        key
+        for key in expected_keys & actual_keys
+        if EXPECTED_DEBT[key] not in by_key[key].message
+    )
+    if duplicate_keys or missing or unexpected or wrong_messages:
+        raise StableCoreMypyError(
+            "stable-core MyPy debt changed; "
+            f"duplicate={sorted(duplicate_keys)}, missing={missing}, "
+            f"unexpected={unexpected}, wrong_message={wrong_messages}"
+        )
+    return tuple(by_key[key] for key in sorted(expected_keys))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--python-version", default="3.12")
+    parser.add_argument("--repository-root", type=Path, default=Path.cwd())
+    return parser
+
+
+def run_stable_core_mypy(
+    *,
+    repository_root: Path,
+    python_version: str,
+) -> tuple[MypyDiagnostic, ...]:
+    """Run MyPy and return the exact accepted debt diagnostics."""
+
+    command = [
+        sys.executable,
+        "-m",
+        "mypy",
+        "--python-version",
+        python_version,
+        "--show-error-codes",
+        "--no-color-output",
+        "--no-pretty",
+        *STABLE_CORE_TARGETS,
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=repository_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    output = completed.stdout + completed.stderr
+    if output:
+        print(output, end="" if output.endswith("\n") else "\n")
+    diagnostics = parse_mypy_diagnostics(output)
+    accepted = validate_exact_debt(diagnostics)
+    if completed.returncode != 1:
+        raise StableCoreMypyError(
+            "MyPy must return one for the exact registered debt set; "
+            f"returncode={completed.returncode}"
+        )
+    print(
+        "accepted exact stable-core MyPy debt: "
+        + ", ".join(
+            f"{value.key.path}:{value.key.line}[{value.key.code}]"
+            for value in accepted
+        )
+    )
+    return accepted
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    try:
+        run_stable_core_mypy(
+            repository_root=arguments.repository_root.resolve(),
+            python_version=arguments.python_version,
+        )
+    except StableCoreMypyError as error:
+        print(f"stable-core MyPy gate failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stable_core_mypy_gate.py
+++ b/tests/test_stable_core_mypy_gate.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType
+
+import pytest
+
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT_PATH = _REPOSITORY_ROOT / "scripts" / "ci" / "check_stable_core_mypy.py"
+
+
+def _load_gate_module() -> ModuleType:
+    module_name = "_causal4d_stable_core_mypy_gate_test"
+    spec = importlib.util.spec_from_file_location(module_name, _SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load stable-core MyPy gate")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_GATE = _load_gate_module()
+DiagnosticKey = _GATE.DiagnosticKey
+MypyDiagnostic = _GATE.MypyDiagnostic
+StableCoreMypyError = _GATE.StableCoreMypyError
+
+
+_SAMPLE_OUTPUT = """\
+src/causal4d/contracts.py:1081: error: Argument 1 to "savez_compressed" has incompatible type "**dict[str, ndarray[Any, Any]]"; expected "bool"  [arg-type]
+src/causal4d/intervention_abduction.py:253: error: Need type annotation for "flat_indices"  [var-annotated]
+src/causal4d/intervention_abduction.py:608: error: Name "metadata" already defined on line 587  [no-redef]
+src/causal4d/intervention_abduction.py:664: error: Need type annotation for "result"  [var-annotated]
+Found 4 errors in 2 files (checked 45 source files)
+"""
+
+
+def _diagnostic(
+    path: str,
+    line: int,
+    code: str,
+    message: str,
+) -> object:
+    return MypyDiagnostic(
+        key=DiagnosticKey(path=path, line=line, code=code),
+        message=message,
+    )
+
+
+def test_parser_extracts_only_error_diagnostics() -> None:
+    diagnostics = _GATE.parse_mypy_diagnostics(_SAMPLE_OUTPUT)
+    assert tuple(value.key for value in diagnostics) == tuple(
+        sorted(_GATE.EXPECTED_DEBT)
+    )
+    assert all("Found 4 errors" not in value.message for value in diagnostics)
+
+
+def test_exact_current_debt_is_accepted() -> None:
+    diagnostics = _GATE.parse_mypy_diagnostics(_SAMPLE_OUTPUT)
+    accepted = _GATE.validate_exact_debt(diagnostics)
+    assert tuple(value.key for value in accepted) == tuple(
+        sorted(_GATE.EXPECTED_DEBT)
+    )
+
+
+@pytest.mark.parametrize("mode", ["missing", "unexpected", "wrong_message", "duplicate"])
+def test_debt_drift_fails_closed(mode: str) -> None:
+    diagnostics = list(_GATE.parse_mypy_diagnostics(_SAMPLE_OUTPUT))
+    if mode == "missing":
+        diagnostics.pop()
+    elif mode == "unexpected":
+        diagnostics.append(
+            _diagnostic(
+                "src/causal4d/counterfactual.py",
+                1,
+                "assignment",
+                "Incompatible assignment",
+            )
+        )
+    elif mode == "wrong_message":
+        first = diagnostics[0]
+        diagnostics[0] = _diagnostic(
+            first.key.path,
+            first.key.line,
+            first.key.code,
+            "different diagnostic text",
+        )
+    else:
+        diagnostics.append(diagnostics[0])
+
+    with pytest.raises(StableCoreMypyError, match="stable-core MyPy debt changed"):
+        _GATE.validate_exact_debt(diagnostics)
+
+
+def test_registered_debt_is_anchored_to_the_current_source_lines() -> None:
+    expected_lines = {
+        DiagnosticKey("src/causal4d/contracts.py", 1081, "arg-type"): "**arrays,",
+        DiagnosticKey(
+            "src/causal4d/intervention_abduction.py", 253, "var-annotated"
+        ): "flat_indices = np.arange(start, stop, dtype=np.int64)",
+        DiagnosticKey(
+            "src/causal4d/intervention_abduction.py", 608, "no-redef"
+        ): "metadata: dict[str, Any] = {",
+        DiagnosticKey(
+            "src/causal4d/intervention_abduction.py", 664, "var-annotated"
+        ): "result = np.zeros((hypothesis_count, particle_count), dtype=float)",
+    }
+    assert set(expected_lines) == set(_GATE.EXPECTED_DEBT)
+    for key, expected in expected_lines.items():
+        lines = (_REPOSITORY_ROOT / key.path).read_text(encoding="utf-8").splitlines()
+        assert lines[key.line - 1].strip() == expected
+
+
+def test_ratchet_covers_the_stable_counterfactual_core() -> None:
+    expected_targets = {
+        "src/causal4d/contracts.py",
+        "src/causal4d/counterfactual.py",
+        "src/causal4d/grouped_likelihood.py",
+        "src/causal4d/intervention_abduction.py",
+        "src/causal4d/observation_evidence.py",
+        "src/causal4d/api/v1.py",
+    }
+    assert expected_targets.issubset(set(_GATE.STABLE_CORE_TARGETS))
+    assert len(_GATE.STABLE_CORE_TARGETS) == len(set(_GATE.STABLE_CORE_TARGETS))

--- a/tests/test_stable_core_mypy_gate.py
+++ b/tests/test_stable_core_mypy_gate.py
@@ -125,3 +125,15 @@ def test_ratchet_covers_the_stable_counterfactual_core() -> None:
     }
     assert expected_targets.issubset(set(_GATE.STABLE_CORE_TARGETS))
     assert len(_GATE.STABLE_CORE_TARGETS) == len(set(_GATE.STABLE_CORE_TARGETS))
+
+
+def test_current_python312_mypy_output_matches_the_exact_debt() -> None:
+    if sys.version_info[:2] != (3, 12):
+        pytest.skip("the authoritative stable-core MyPy environment is Python 3.12")
+    accepted = _GATE.run_stable_core_mypy(
+        repository_root=_REPOSITORY_ROOT,
+        python_version="3.12",
+    )
+    assert tuple(value.key for value in accepted) == tuple(
+        sorted(_GATE.EXPECTED_DEBT)
+    )


### PR DESCRIPTION
## Summary

- run MyPy over the stable counterfactual and observation core in a dedicated permanent workflow;
- retain the four pre-existing diagnostics as exact file/line/error-code/message debt rather than excluding modules or allowing broad error classes;
- fail closed on any additional, moved, duplicated, changed, or silently resolved diagnostic;
- add adversarial parser and debt-drift tests plus source-line anchors; and
- document the debt inventory, retirement procedure, and scientific boundary.

## Root cause and impact

The main CI type check covered artifact and provider utilities but not the central counterfactual path. A complete check of the stable contracts, counterfactual operator, grouped likelihood, factual abduction, grouped evidence, and v1 API found four finite pre-existing diagnostics in two files. Broadly adding those modules to the existing zero-error command would leave CI red, while excluding them or permitting whole error classes would establish little protection.

`check_stable_core_mypy.py` therefore runs the complete scope and admits only the exact observed debt identities. It requires MyPy to return one and requires the parsed diagnostics to equal the registered set exactly. This makes the current state enforceable immediately while ensuring every future debt reduction is paired with an explicit manifest update.

## Change classification

Select one primary classification:

- [ ] Frozen or registered method/analysis change requiring a new version
- [ ] Future or experimental method
- [ ] BayesianPhysTwin, Prob4D, or other provider/artifact contract
- [ ] Acquisition, calibration, readiness, or evidence tooling
- [x] Maintenance, documentation, packaging, CI, or security

Evidence status, when applicable:

- [x] Software or contract evidence only
- [ ] Controlled synthetic evidence
- [ ] Source/calibration-only evidence
- [ ] Retrospective or already-open diagnostic evidence
- [ ] Confirmatory physical evidence
- [x] No scientific evidence produced

## Scientific and information boundary

- Frozen estimator or registered analysis changed: `no`.
- Target or held-out outcomes accessed: `no`.
- Registered physical-acquisition dataset modified: `no`.
- Physical evidence increment: `0`.
- Existing scientific claim changed or promoted: `no`.
- Independent statistical unit: `not applicable; static-analysis enforcement only`.
- Source, calibration, and target split: `not applicable`.
- Exact fallback preserved: `yes`; no numerical, admission, posterior, provider, or fallback path changes.

## Exact registered debt

1. `src/causal4d/contracts.py:1081 [arg-type]` — NumPy `savez_compressed` keyword-stub ambiguity.
2. `src/causal4d/intervention_abduction.py:253 [var-annotated]` — `flat_indices` annotation.
3. `src/causal4d/intervention_abduction.py:608 [no-redef]` — local `metadata` name reuse.
4. `src/causal4d/intervention_abduction.py:664 [var-annotated]` — reconstructed matrix annotation.

The gate permits no other diagnostic. It also rejects a missing item, because source repair and debt-manifest removal must be reviewed together.

## Validation

The dedicated workflow performs:

```text
python -W error::SyntaxWarning -m compileall -q -f \
  scripts/ci/check_stable_core_mypy.py \
  tests/test_stable_core_mypy_gate.py
python -m ruff check <gate-and-test>
python -m ruff format --check <gate-and-test>
python -m pytest -q tests/test_stable_core_mypy_gate.py
python scripts/ci/check_stable_core_mypy.py --python-version 3.12
```

The adversarial tests cover:

- exact current-debt acceptance;
- missing debt;
- unexpected diagnostics;
- changed messages;
- duplicate diagnostics;
- exact source-line anchoring; and
- complete stable-core target inventory.

GitHub Actions on the exact pull-request head are authoritative for the new workflow, the current-main merge gate, complete multi-Python tests, distribution installation, security, BayesianPhysTwin admission, and the three-repository installed-wheel path.

## Merge disposition

- [x] Product change intended for review and merge after exact-head validation
- [ ] Execution/bootstrap helper that must be closed without merge
- [ ] Diagnostic result that cannot promote a method or scientific claim

No post-merge physical execution, target opening, evidence publication, protocol mutation, or claim promotion is authorized by this change.