### PR TITLE
Align next-action packet test with verifier stop

### DIFF
--- a/tests/test_preacquisition_next_action_packet.py
+++ b/tests/test_preacquisition_next_action_packet.py
@@ -165,7 +165,7 @@ def test_packet_bytes_are_deterministic_and_bind_human_instructions() -> None:
     assert first_manifest["packet_id"] == next_action_packet_id(first_manifest)
     assert first_manifest["decision_evidence_sha256"] == decision["evidence_sha256"]
     assert first_manifest["action_identity"]["action_id"] == (
-        "begin_first_confirmatory_session"
+        "stop_independent_verifier_unavailable"
     )
 
     with ZipFile(io.BytesIO(first_bytes), mode="r") as archive:


### PR DESCRIPTION
## Summary

Align the deterministic next-action packet regression with the merged operator-registry correction from #359.

The repository now intentionally has only FlorianPfaff in the operator roster. Therefore, even when the synthetic readiness and source-panel fixtures are otherwise complete, the next action must fail closed as `stop_independent_verifier_unavailable`; it must not instruct the operator to begin the first confirmatory session.

This changes only the stale test expectation. The packet implementation, readiness calculation, operator registry, physical protocol, target boundary, and evidence remain unchanged.

## Validation

The failing merge-gate run on PR #357 showed exactly this mismatch after 1,955 tests passed. GitHub Actions on this exact head are authoritative for the focused packet tests, complete suite, distributions, installed integrations, and security.

## Scientific boundary

- Physical command executed: `no`.
- Target or held-out outcomes opened: `no`.
- Independent verifier fabricated or bypassed: `no`.
- Physical evidence increment: `0`.
- Confirmatory acquisition authorized: `no`.

The corrected expectation preserves the intended fail-closed stop until a genuinely distinct verifier is available.