### PR TITLE
Add registered-query prequential stability diagnostics

### DIFF
--- a/docs/prequential_query_stability.md
+++ b/docs/prequential_query_stability.md
@@ -1,0 +1,110 @@
+# Prequential registered-query stability
+
+## Scope
+
+`causal4d.prequential_query_stability` projects an unchanged
+`PrequentialAbductionPathV1` into one caller-registered finite query. It answers a
+different question from posterior-weight stability:
+
+```text
+Did the posterior move between prefixes?
+```
+
+versus:
+
+```text
+Did that movement materially change the registered physical query?
+```
+
+A large component-space KL divergence can be harmless when the affected
+components make nearly identical query predictions. Conversely, a small change
+in posterior mass can matter when it moves a low-dimensional safety- or
+paper-relevant query. The diagnostic keeps those interpretations separate.
+
+It does not change factual abduction, feed one prefix posterior into another,
+select a prefix, read held-out future observations, or alter the frozen
+36-execution method.
+
+## Construction
+
+Supply one deterministic query vector for every complete prequential support
+component, together with registered coordinate labels, units, and positive
+characteristic scales:
+
+```python
+from causal4d.prequential_query_stability import (
+    build_prequential_query_stability,
+)
+
+stability = build_prequential_query_stability(
+    prequential.path,
+    component_query_values_m,
+    query_id=registered_query.query_id,
+    query_labels=("late-track-x", "late-track-y", "late-track-z"),
+    query_units=("m", "m", "m"),
+    query_scales=(0.01, 0.01, 0.01),
+    confidence_level=0.90,
+    metadata={"registered_before_target_access": True},
+)
+
+summary = stability.summary_arrays()
+print(summary["final_mean_shift_standardized_l2"])
+print(summary["final_gaussian_wasserstein_standardized"])
+```
+
+`component_query_values_m[c, q]` must use the same component order as the source
+prequential path. The content identity binds the source path, query definition,
+scales, confidence level, complete component-query matrix, posterior weights,
+prefix stops, and diagnostic metadata.
+
+## Reported quantities
+
+For every causal prefix, the artifact reports:
+
+- posterior query mean and covariance in the declared native units;
+- coordinatewise equal-tail credible intervals;
+- coordinatewise absolute mean movement from the preceding prefix;
+- coordinatewise absolute mean movement from the final declared prefix;
+- scale-normalized Euclidean mean movement from the preceding and final prefixes;
+- scale-normalized moment-matched Gaussian 2-Wasserstein distance from the
+  preceding and final prefixes; and
+- mean coordinatewise credible-interval overlap with the preceding and final
+  prefixes.
+
+Characteristic query scales are mandatory. They make multivariate distances
+meaningful when coordinates differ in magnitude or units and make the
+standardized diagnostics invariant to a consistent conversion such as metres to
+millimetres. Native-unit summaries remain available for physical interpretation.
+
+The Wasserstein quantity compares Gaussian distributions with the exact mixture
+mean and covariance at each prefix. It is a moment diagnostic, not a claim that
+the finite posterior query is Gaussian. The credible intervals are instead
+computed directly from the weighted finite support, coordinate by coordinate.
+
+## Invariances and validation
+
+Focused tests establish that:
+
+- a consistent unit conversion changes native values but not standardized drift;
+- a simultaneous permutation of component identities, posterior columns, and
+  query rows leaves every reported diagnostic unchanged;
+- the first previous-prefix and final final-prefix distances are exact zeros;
+- the corresponding interval-overlap controls are exact ones;
+- nonpositive scales, duplicate query labels, nonfinite values, and component
+  count mismatches fail closed; and
+- changing either the source posterior path or any component query value changes
+  the content identity.
+
+## Interpretation boundary
+
+This artifact can diagnose the earliest prefix at which a registered query
+appears stable, but it must not choose a new confirmatory prefix from target
+outcomes. Prefix selection, tolerances, and any stability threshold must be
+frozen on source or calibration executions in a separately versioned protocol.
+
+A stable query does not establish provider competence, intervention
+identifiability, empirical calibration, counterfactual accuracy, physical
+contact truth, deployment safety, or state of the art. It should be interpreted
+alongside held-out execution-level proper scores, coverage, interval width,
+finite-support adequacy, exact fallback accounting, and the registered physical
+experiment.

--- a/src/causal4d/prequential_query_stability.py
+++ b/src/causal4d/prequential_query_stability.py
@@ -1,0 +1,484 @@
+"""Registered-query diagnostics over leakage-safe prequential posteriors."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+import hashlib
+import json
+import re
+from typing import Any
+
+import numpy as np
+
+from causal4d.contracts import array_sha256
+from causal4d.immutable_array import readonly_array
+from causal4d.immutable_json import plain_json, validated_json_mapping
+from causal4d.prequential_abduction import PrequentialAbductionPathV1
+
+
+PREQUENTIAL_QUERY_STABILITY_SCHEMA_VERSION = 1
+PREQUENTIAL_QUERY_STABILITY_CLAIM_BOUNDARY = (
+    "Diagnostic projection of an unchanged prequential factual-abduction path. "
+    "It does not select a prefix, change the estimator, establish calibration, "
+    "or authorize confirmatory use."
+)
+_PREQUENTIAL_QUERY_STABILITY_KIND = "Causal4DPrequentialQueryStabilityV1"
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _require_sha256(value: object, *, name: str) -> str:
+    if type(value) is not str or _SHA256_RE.fullmatch(value) is None:
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _require_nonempty_string(value: object, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _string_tuple(
+    values: Sequence[str],
+    *,
+    name: str,
+    expected_count: int,
+    unique: bool = False,
+) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)):
+        raise ValueError(f"{name} must be a sequence of strings")
+    result = tuple(values)
+    if len(result) != expected_count or any(
+        type(value) is not str or not value for value in result
+    ):
+        raise ValueError(f"{name} must contain {expected_count} nonempty strings")
+    if unique and len(set(result)) != len(result):
+        raise ValueError(f"{name} must not contain duplicates")
+    return result
+
+
+def _positive_vector(values: object, *, length: int, name: str) -> np.ndarray:
+    raw = np.asarray(values)
+    if raw.dtype.kind not in {"i", "u", "f"}:
+        raise ValueError(f"{name} must contain real numeric values")
+    result = readonly_array(raw, dtype=float)
+    if result.shape != (length,):
+        raise ValueError(f"{name} must have shape ({length},)")
+    if not np.all(np.isfinite(result)) or np.any(result <= 0.0):
+        raise ValueError(f"{name} must be finite and positive")
+    return result
+
+
+def _weighted_quantile(
+    values: np.ndarray,
+    weights: np.ndarray,
+    probability: float,
+) -> float:
+    order = np.argsort(values, kind="stable")
+    sorted_values = values[order]
+    cumulative = np.cumsum(weights[order])
+    index = int(np.searchsorted(cumulative, probability, side="left"))
+    return float(sorted_values[min(index, len(sorted_values) - 1)])
+
+
+def _psd_square_root(matrix: np.ndarray, *, name: str) -> np.ndarray:
+    symmetric = 0.5 * (matrix + matrix.T)
+    eigenvalues, eigenvectors = np.linalg.eigh(symmetric)
+    scale = max(1.0, float(np.max(np.abs(eigenvalues), initial=0.0)))
+    tolerance = 1.0e-10 * scale
+    if float(np.min(eigenvalues, initial=0.0)) < -tolerance:
+        raise ValueError(f"{name} must be positive semidefinite")
+    clipped = np.maximum(eigenvalues, 0.0)
+    return (eigenvectors * np.sqrt(clipped)) @ eigenvectors.T
+
+
+def _gaussian_wasserstein_distance(
+    first_mean: np.ndarray,
+    first_covariance: np.ndarray,
+    second_mean: np.ndarray,
+    second_covariance: np.ndarray,
+) -> float:
+    second_root = _psd_square_root(
+        second_covariance,
+        name="second Gaussian covariance",
+    )
+    middle_root = _psd_square_root(
+        second_root @ first_covariance @ second_root,
+        name="Gaussian covariance transport term",
+    )
+    mean_difference = first_mean - second_mean
+    squared = float(
+        mean_difference @ mean_difference
+        + np.trace(first_covariance)
+        + np.trace(second_covariance)
+        - 2.0 * np.trace(middle_root)
+    )
+    tolerance = 1.0e-10 * max(
+        1.0,
+        float(np.trace(first_covariance) + np.trace(second_covariance)),
+    )
+    if squared < -tolerance:
+        raise ValueError("Gaussian Wasserstein distance became negative")
+    return float(np.sqrt(max(0.0, squared)))
+
+
+def _interval_overlap_fraction(
+    first_lower: np.ndarray,
+    first_upper: np.ndarray,
+    second_lower: np.ndarray,
+    second_upper: np.ndarray,
+) -> float:
+    overlap = np.maximum(
+        0.0,
+        np.minimum(first_upper, second_upper) - np.maximum(first_lower, second_lower),
+    )
+    union = np.maximum(first_upper, second_upper) - np.minimum(
+        first_lower,
+        second_lower,
+    )
+    fractions = np.empty_like(union)
+    nondegenerate = union > 0.0
+    fractions[nondegenerate] = overlap[nondegenerate] / union[nondegenerate]
+    fractions[~nondegenerate] = np.isclose(
+        first_lower[~nondegenerate],
+        second_lower[~nondegenerate],
+        atol=0.0,
+        rtol=0.0,
+    ).astype(float)
+    return float(np.mean(fractions))
+
+
+@dataclass(frozen=True)
+class PrequentialQueryStabilityV1:
+    """Query-space evolution of one immutable prequential posterior path."""
+
+    source_prequential_path_id: str
+    query_id: str
+    query_labels: tuple[str, ...]
+    query_units: tuple[str, ...]
+    query_scales: np.ndarray
+    confidence_level: float
+    prefix_frame_counts: np.ndarray
+    posterior_weights: np.ndarray
+    component_query_values: np.ndarray
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        path_id = _require_sha256(
+            self.source_prequential_path_id,
+            name="source_prequential_path_id",
+        )
+        query_id = _require_nonempty_string(self.query_id, name="query_id")
+        raw_query_values = np.asarray(self.component_query_values)
+        if raw_query_values.dtype.kind not in {"i", "u", "f"}:
+            raise ValueError("component_query_values must contain real numeric values")
+        query_values = readonly_array(raw_query_values, dtype=float)
+        if query_values.ndim != 2 or min(query_values.shape) < 1:
+            raise ValueError(
+                "component_query_values must have shape (component, query)"
+            )
+        if not np.all(np.isfinite(query_values)):
+            raise ValueError("component_query_values must be finite")
+        component_count, query_dimension = query_values.shape
+        labels = _string_tuple(
+            self.query_labels,
+            name="query_labels",
+            expected_count=query_dimension,
+            unique=True,
+        )
+        units = _string_tuple(
+            self.query_units,
+            name="query_units",
+            expected_count=query_dimension,
+        )
+        scales = _positive_vector(
+            self.query_scales,
+            length=query_dimension,
+            name="query_scales",
+        )
+        if isinstance(self.confidence_level, (bool, np.bool_)) or not isinstance(
+            self.confidence_level,
+            (int, float, np.integer, np.floating),
+        ):
+            raise ValueError("confidence_level must be a real number")
+        confidence = float(self.confidence_level)
+        if not np.isfinite(confidence) or not 0.0 < confidence < 1.0:
+            raise ValueError("confidence_level must lie strictly between zero and one")
+        raw_prefixes = np.asarray(self.prefix_frame_counts)
+        if (
+            raw_prefixes.ndim != 1
+            or not len(raw_prefixes)
+            or not np.issubdtype(raw_prefixes.dtype, np.integer)
+        ):
+            raise ValueError("prefix_frame_counts must be a nonempty integer vector")
+        prefixes = readonly_array(raw_prefixes, dtype=np.int64)
+        if prefixes[0] < 2 or np.any(np.diff(prefixes) <= 0):
+            raise ValueError(
+                "prefix_frame_counts must be strictly increasing and start at two"
+            )
+        raw_weights = np.asarray(self.posterior_weights)
+        if raw_weights.dtype.kind not in {"i", "u", "f"}:
+            raise ValueError("posterior_weights must contain real numeric values")
+        weights = readonly_array(raw_weights, dtype=float)
+        if weights.shape != (len(prefixes), component_count):
+            raise ValueError("posterior_weights must have shape (prefix, component)")
+        if (
+            not np.all(np.isfinite(weights))
+            or np.any(weights < 0.0)
+            or not np.allclose(
+                np.sum(weights, axis=1),
+                1.0,
+                atol=1.0e-12,
+                rtol=1.0e-10,
+            )
+        ):
+            raise ValueError(
+                "posterior_weights must be finite, nonnegative, and row-normalized"
+            )
+        metadata = validated_json_mapping(
+            self.metadata,
+            error_message="query-stability metadata must contain finite JSON data",
+        )
+        object.__setattr__(self, "source_prequential_path_id", path_id)
+        object.__setattr__(self, "query_id", query_id)
+        object.__setattr__(self, "query_labels", labels)
+        object.__setattr__(self, "query_units", units)
+        object.__setattr__(self, "query_scales", scales)
+        object.__setattr__(self, "confidence_level", confidence)
+        object.__setattr__(self, "prefix_frame_counts", prefixes)
+        object.__setattr__(self, "posterior_weights", weights)
+        object.__setattr__(self, "component_query_values", query_values)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def query_dimension(self) -> int:
+        return self.component_query_values.shape[1]
+
+    @property
+    def step_count(self) -> int:
+        return len(self.prefix_frame_counts)
+
+    def summary_arrays(self) -> dict[str, np.ndarray]:
+        """Return deterministic native-unit and standardized diagnostics."""
+
+        means = self.posterior_weights @ self.component_query_values
+        centered = self.component_query_values[None] - means[:, None]
+        covariance = np.einsum(
+            "sc,scd,sce->sde",
+            self.posterior_weights,
+            centered,
+            centered,
+        )
+        lower_probability = 0.5 * (1.0 - self.confidence_level)
+        upper_probability = 1.0 - lower_probability
+        lower = np.empty_like(means)
+        upper = np.empty_like(means)
+        for step in range(self.step_count):
+            for coordinate in range(self.query_dimension):
+                values = self.component_query_values[:, coordinate]
+                weights = self.posterior_weights[step]
+                lower[step, coordinate] = _weighted_quantile(
+                    values,
+                    weights,
+                    lower_probability,
+                )
+                upper[step, coordinate] = _weighted_quantile(
+                    values,
+                    weights,
+                    upper_probability,
+                )
+
+        previous_native = np.zeros_like(means)
+        previous_native[1:] = np.abs(means[1:] - means[:-1])
+        final_native = np.abs(means - means[-1])
+        standardized_means = means / self.query_scales
+        standardized_covariance = covariance / (
+            self.query_scales[None, :, None] * self.query_scales[None, None, :]
+        )
+        previous_mean_l2 = np.zeros(self.step_count, dtype=float)
+        previous_mean_l2[1:] = np.linalg.norm(
+            standardized_means[1:] - standardized_means[:-1],
+            axis=1,
+        )
+        final_mean_l2 = np.linalg.norm(
+            standardized_means - standardized_means[-1],
+            axis=1,
+        )
+        previous_wasserstein = np.zeros(self.step_count, dtype=float)
+        final_wasserstein = np.zeros(self.step_count, dtype=float)
+        previous_overlap = np.ones(self.step_count, dtype=float)
+        final_overlap = np.ones(self.step_count, dtype=float)
+        for step in range(1, self.step_count):
+            previous_wasserstein[step] = _gaussian_wasserstein_distance(
+                standardized_means[step - 1],
+                standardized_covariance[step - 1],
+                standardized_means[step],
+                standardized_covariance[step],
+            )
+            previous_overlap[step] = _interval_overlap_fraction(
+                lower[step - 1],
+                upper[step - 1],
+                lower[step],
+                upper[step],
+            )
+        for step in range(self.step_count - 1):
+            final_wasserstein[step] = _gaussian_wasserstein_distance(
+                standardized_means[step],
+                standardized_covariance[step],
+                standardized_means[-1],
+                standardized_covariance[-1],
+            )
+            final_overlap[step] = _interval_overlap_fraction(
+                lower[step],
+                upper[step],
+                lower[-1],
+                upper[-1],
+            )
+        return {
+            "posterior_query_mean": readonly_array(means, dtype=float),
+            "posterior_query_covariance": readonly_array(covariance, dtype=float),
+            "credible_lower": readonly_array(lower, dtype=float),
+            "credible_upper": readonly_array(upper, dtype=float),
+            "previous_mean_shift_native": readonly_array(
+                previous_native,
+                dtype=float,
+            ),
+            "final_mean_shift_native": readonly_array(final_native, dtype=float),
+            "previous_mean_shift_standardized_l2": readonly_array(
+                previous_mean_l2,
+                dtype=float,
+            ),
+            "final_mean_shift_standardized_l2": readonly_array(
+                final_mean_l2,
+                dtype=float,
+            ),
+            "previous_gaussian_wasserstein_standardized": readonly_array(
+                previous_wasserstein,
+                dtype=float,
+            ),
+            "final_gaussian_wasserstein_standardized": readonly_array(
+                final_wasserstein,
+                dtype=float,
+            ),
+            "previous_interval_overlap_fraction": readonly_array(
+                previous_overlap,
+                dtype=float,
+            ),
+            "final_interval_overlap_fraction": readonly_array(
+                final_overlap,
+                dtype=float,
+            ),
+        }
+
+    @property
+    def artifact_id(self) -> str:
+        payload = {
+            "schema_version": PREQUENTIAL_QUERY_STABILITY_SCHEMA_VERSION,
+            "artifact_kind": _PREQUENTIAL_QUERY_STABILITY_KIND,
+            "source_prequential_path_id": self.source_prequential_path_id,
+            "query_id": self.query_id,
+            "query_labels": list(self.query_labels),
+            "query_units": list(self.query_units),
+            "confidence_level": self.confidence_level,
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": PREQUENTIAL_QUERY_STABILITY_CLAIM_BOUNDARY,
+            "arrays": {
+                "query_scales": array_sha256(self.query_scales),
+                "prefix_frame_counts": array_sha256(self.prefix_frame_counts),
+                "posterior_weights": array_sha256(self.posterior_weights),
+                "component_query_values": array_sha256(self.component_query_values),
+            },
+        }
+        encoded = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def as_dict(self) -> dict[str, Any]:
+        summaries = self.summary_arrays()
+        return {
+            "schema_version": PREQUENTIAL_QUERY_STABILITY_SCHEMA_VERSION,
+            "artifact_kind": _PREQUENTIAL_QUERY_STABILITY_KIND,
+            "artifact_id": self.artifact_id,
+            "source_prequential_path_id": self.source_prequential_path_id,
+            "query_id": self.query_id,
+            "query_labels": list(self.query_labels),
+            "query_units": list(self.query_units),
+            "query_scales": self.query_scales.tolist(),
+            "confidence_level": self.confidence_level,
+            "prefix_frame_counts": self.prefix_frame_counts.tolist(),
+            "component_query_values_sha256": array_sha256(self.component_query_values),
+            "posterior_weights_sha256": array_sha256(self.posterior_weights),
+            "summaries": {name: values.tolist() for name, values in summaries.items()},
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": PREQUENTIAL_QUERY_STABILITY_CLAIM_BOUNDARY,
+        }
+
+
+def build_prequential_query_stability(
+    path: PrequentialAbductionPathV1,
+    component_query_values: np.ndarray,
+    *,
+    query_id: str,
+    query_labels: Sequence[str],
+    query_units: Sequence[str],
+    query_scales: Sequence[float],
+    confidence_level: float = 0.90,
+    metadata: Mapping[str, Any] | None = None,
+) -> PrequentialQueryStabilityV1:
+    """Project one prequential posterior path into a registered query space."""
+
+    if not isinstance(path, PrequentialAbductionPathV1):
+        raise TypeError("path must be PrequentialAbductionPathV1")
+    if path.metadata.get("future_frames_read") != 0:
+        raise ValueError("source prequential path must declare future_frames_read=0")
+    for value, name in (
+        (query_labels, "query_labels"),
+        (query_units, "query_units"),
+        (query_scales, "query_scales"),
+    ):
+        if isinstance(value, (str, bytes)):
+            raise ValueError(f"{name} must be a sequence")
+    raw_values = np.asarray(component_query_values)
+    if raw_values.dtype.kind not in {"i", "u", "f"}:
+        raise ValueError("component_query_values must contain real numeric values")
+    values = np.asarray(raw_values, dtype=float)
+    raw_scales = np.asarray(tuple(query_scales))
+    if raw_scales.dtype.kind not in {"i", "u", "f"}:
+        raise ValueError("query_scales must contain real numeric values")
+    if values.ndim != 2 or values.shape[0] != len(path.component_ids):
+        raise ValueError(
+            "component_query_values must contain one row per path component"
+        )
+    result = PrequentialQueryStabilityV1(
+        source_prequential_path_id=path.artifact_id,
+        query_id=query_id,
+        query_labels=tuple(query_labels),
+        query_units=tuple(query_units),
+        query_scales=raw_scales,
+        confidence_level=confidence_level,
+        prefix_frame_counts=path.prefix_frame_counts,
+        posterior_weights=path.posterior_weights,
+        component_query_values=values,
+        metadata={
+            "diagnostic_only": True,
+            "changes_estimator": False,
+            "selects_prefix": False,
+            "future_frames_read": 0,
+            "user_metadata": plain_json(metadata or {}),
+        },
+    )
+    result.summary_arrays()
+    return result
+
+
+__all__ = [
+    "PREQUENTIAL_QUERY_STABILITY_CLAIM_BOUNDARY",
+    "PREQUENTIAL_QUERY_STABILITY_SCHEMA_VERSION",
+    "PrequentialQueryStabilityV1",
+    "build_prequential_query_stability",
+]

--- a/tests/test_prequential_query_stability.py
+++ b/tests/test_prequential_query_stability.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from causal4d.prequential_abduction import PrequentialAbductionPathV1
+from causal4d.prequential_query_stability import (
+    PREQUENTIAL_QUERY_STABILITY_CLAIM_BOUNDARY,
+    build_prequential_query_stability,
+)
+
+
+def _posterior_summaries(
+    weights: np.ndarray,
+) -> tuple[np.ndarray, ...]:
+    positive = weights > 0.0
+    entropy_terms = np.zeros_like(weights)
+    entropy_terms[positive] = weights[positive] * np.log(weights[positive])
+    entropy = -np.sum(entropy_terms, axis=1)
+    effective_sample_size = 1.0 / np.sum(np.square(weights), axis=1)
+    maximum_weight = np.max(weights, axis=1)
+    map_component_indices = np.argmax(weights, axis=1).astype(np.int64)
+    previous_step_kl = np.zeros(len(weights), dtype=float)
+    previous_step_total_variation = np.zeros(len(weights), dtype=float)
+    for index in range(1, len(weights)):
+        current = weights[index]
+        previous = weights[index - 1]
+        selected = current > 0.0
+        previous_safe = np.maximum(previous[selected], np.finfo(float).tiny)
+        previous_step_kl[index] = float(
+            np.sum(current[selected] * np.log(current[selected] / previous_safe))
+        )
+        previous_step_total_variation[index] = float(
+            0.5 * np.sum(np.abs(current - previous))
+        )
+    return (
+        entropy,
+        effective_sample_size,
+        maximum_weight,
+        map_component_indices,
+        previous_step_kl,
+        previous_step_total_variation,
+    )
+
+
+def _path(
+    weights: np.ndarray | None = None,
+    *,
+    component_ids: tuple[str, ...] = ("component-a", "component-b"),
+) -> PrequentialAbductionPathV1:
+    posterior = np.asarray(
+        weights if weights is not None else [[0.5, 0.5], [0.75, 0.25], [1.0, 0.0]],
+        dtype=float,
+    )
+    summaries = _posterior_summaries(posterior)
+    return PrequentialAbductionPathV1(
+        source_rollout_bank_id="a" * 64,
+        source_twin_belief_id="b" * 64,
+        component_ids=component_ids,
+        factual_intervention_ids=("c" * 64, "d" * 64, "e" * 64),
+        step_evidence_ids=(
+            "dense-prefix:2",
+            "dense-prefix:3",
+            "dense-prefix:4",
+        ),
+        prefix_frame_counts=np.asarray([2, 3, 4], dtype=np.int64),
+        evidence_frame_stops=np.asarray([10, 11, 12], dtype=np.int64),
+        posterior_weights=posterior,
+        posterior_entropy=summaries[0],
+        posterior_effective_sample_size=summaries[1],
+        posterior_maximum_weight=summaries[2],
+        map_component_indices=summaries[3],
+        previous_step_kl=summaries[4],
+        previous_step_total_variation=summaries[5],
+        metadata={"future_frames_read": 0},
+    )
+
+
+def _build(
+    path: PrequentialAbductionPathV1,
+    values: np.ndarray | None = None,
+    *,
+    scales: tuple[float, ...] = (2.0, 4.0),
+):
+    return build_prequential_query_stability(
+        path,
+        np.asarray(values if values is not None else [[0.0, 0.0], [2.0, 4.0]]),
+        query_id="registered-track-query-v1",
+        query_labels=("track-x", "track-y"),
+        query_units=("m", "m"),
+        query_scales=scales,
+        metadata={"registered_before_target_access": True},
+    )
+
+
+def test_query_stability_reports_native_and_standardized_drift() -> None:
+    result = _build(_path())
+    summaries = result.summary_arrays()
+
+    np.testing.assert_allclose(
+        summaries["posterior_query_mean"],
+        [[1.0, 2.0], [0.5, 1.0], [0.0, 0.0]],
+    )
+    np.testing.assert_allclose(
+        summaries["final_mean_shift_standardized_l2"],
+        [np.sqrt(0.5), np.sqrt(0.125), 0.0],
+    )
+    assert summaries["previous_gaussian_wasserstein_standardized"][0] == 0.0
+    assert summaries["final_gaussian_wasserstein_standardized"][-1] == 0.0
+    assert summaries["previous_interval_overlap_fraction"][0] == 1.0
+    assert summaries["final_interval_overlap_fraction"][-1] == 1.0
+    assert result.as_dict()["claim_boundary"] == (
+        PREQUENTIAL_QUERY_STABILITY_CLAIM_BOUNDARY
+    )
+
+
+def test_query_stability_is_invariant_to_consistent_unit_conversion() -> None:
+    metres = _build(_path())
+    millimetres = _build(
+        _path(),
+        values=np.asarray([[0.0, 0.0], [2000.0, 4000.0]]),
+        scales=(2000.0, 4000.0),
+    )
+    metres_summary = metres.summary_arrays()
+    millimetres_summary = millimetres.summary_arrays()
+
+    for name in (
+        "previous_mean_shift_standardized_l2",
+        "final_mean_shift_standardized_l2",
+        "previous_gaussian_wasserstein_standardized",
+        "final_gaussian_wasserstein_standardized",
+        "previous_interval_overlap_fraction",
+        "final_interval_overlap_fraction",
+    ):
+        np.testing.assert_allclose(
+            metres_summary[name],
+            millimetres_summary[name],
+            rtol=1.0e-12,
+            atol=1.0e-12,
+        )
+    np.testing.assert_allclose(
+        millimetres_summary["posterior_query_mean"],
+        1000.0 * metres_summary["posterior_query_mean"],
+    )
+
+
+def test_query_stability_is_invariant_to_component_permutation() -> None:
+    original_path = _path()
+    permuted_weights = original_path.posterior_weights[:, ::-1]
+    permuted_path = _path(
+        permuted_weights,
+        component_ids=tuple(reversed(original_path.component_ids)),
+    )
+    original = _build(original_path)
+    permuted = _build(
+        permuted_path,
+        values=np.asarray([[2.0, 4.0], [0.0, 0.0]]),
+    )
+
+    for name, values in original.summary_arrays().items():
+        np.testing.assert_allclose(
+            values,
+            permuted.summary_arrays()[name],
+            rtol=1.0e-12,
+            atol=1.0e-12,
+        )
+
+
+def test_query_stability_rejects_shape_and_scale_errors() -> None:
+    path = _path()
+    with pytest.raises(ValueError, match="one row per path component"):
+        _build(path, values=np.asarray([[0.0, 0.0]]))
+    with pytest.raises(ValueError, match="finite and positive"):
+        _build(path, scales=(2.0, 0.0))
+    with pytest.raises(ValueError, match="real numeric"):
+        _build(
+            path,
+            values=np.asarray([["0.0", "0.0"], ["2.0", "4.0"]]),
+        )
+    with pytest.raises(ValueError, match="query_labels must be a sequence"):
+        build_prequential_query_stability(
+            path,
+            np.asarray([[0.0, 0.0], [2.0, 4.0]]),
+            query_id="registered-track-query-v1",
+            query_labels="xy",
+            query_units=("m", "m"),
+            query_scales=(2.0, 4.0),
+        )
+    with pytest.raises(ValueError, match="query_scales must be a sequence"):
+        build_prequential_query_stability(
+            path,
+            np.asarray([[0.0, 0.0], [2.0, 4.0]]),
+            query_id="registered-track-query-v1",
+            query_labels=("track-x", "track-y"),
+            query_units=("m", "m"),
+            query_scales="24",
+        )
+    with pytest.raises(
+        ValueError,
+        match="query_scales must contain real numeric",
+    ):
+        build_prequential_query_stability(
+            path,
+            np.asarray([[0.0, 0.0], [2.0, 4.0]]),
+            query_id="registered-track-query-v1",
+            query_labels=("track-x", "track-y"),
+            query_units=("m", "m"),
+            query_scales=("2", "4"),
+        )
+    with pytest.raises(
+        ValueError,
+        match="confidence_level must be a real number",
+    ):
+        build_prequential_query_stability(
+            path,
+            np.asarray([[0.0, 0.0], [2.0, 4.0]]),
+            query_id="registered-track-query-v1",
+            query_labels=("track-x", "track-y"),
+            query_units=("m", "m"),
+            query_scales=(2.0, 4.0),
+            confidence_level="0.90",
+        )
+    with pytest.raises(ValueError, match="query_labels"):
+        build_prequential_query_stability(
+            path,
+            np.asarray([[0.0, 0.0], [2.0, 4.0]]),
+            query_id="registered-track-query-v1",
+            query_labels=("duplicate", "duplicate"),
+            query_units=("m", "m"),
+            query_scales=(2.0, 4.0),
+        )
+
+
+def test_query_stability_rejects_noncausal_source_and_coercive_weights() -> None:
+    path = _path()
+    with pytest.raises(ValueError, match="future_frames_read=0"):
+        _build(replace(path, metadata={"future_frames_read": 1}))
+
+    result = _build(path)
+    with pytest.raises(ValueError, match="posterior_weights must contain real numeric"):
+        replace(
+            result,
+            posterior_weights=result.posterior_weights.astype(str),
+        )
+
+
+def test_query_stability_identity_binds_path_and_query_values() -> None:
+    path = _path()
+    first = _build(path)
+    changed_values = _build(
+        path,
+        values=np.asarray([[0.0, 0.0], [2.0, 4.1]]),
+    )
+    changed_path = _build(
+        _path([[0.4, 0.6], [0.75, 0.25], [1.0, 0.0]]),
+    )
+
+    assert first.artifact_id != changed_values.artifact_id
+    assert first.artifact_id != changed_path.artifact_id


### PR DESCRIPTION
## Summary

- add `PrequentialQueryStabilityV1`, a content-addressed projection of an unchanged `PrequentialAbductionPathV1` into one caller-registered finite query;
- report exact finite-mixture query means, covariances, and coordinatewise equal-tail intervals at every causal prefix;
- report native-coordinate movement, scale-standardized mean movement, moment-matched Gaussian 2-Wasserstein movement, and interval overlap against the preceding and final prefixes;
- bind the complete source path, posterior weights, component-query values, prefix stops, query definition, scales, confidence level, and metadata into one deterministic identity;
- reject source paths that do not explicitly declare zero future-frame access;
- reject coercive string or Boolean query values, scales, posterior weights, labels, units, and confidence levels rather than silently converting them; and
- document the interpretation and confirmatory-use boundary.

## Why

Weight-space KL divergence or total variation does not determine whether a registered physical query changed materially. A posterior can relabel components with nearly identical query predictions, while a small mass movement can materially change a low-dimensional held-out query. This diagnostic exposes that distinction without changing factual abduction or selecting a prefix.

## Numerical semantics

For each prefix, the implementation computes the exact finite-mixture mean and covariance and exact coordinatewise weighted quantiles. Multivariate Wasserstein distances are computed between moment-matched Gaussians after division by caller-registered positive characteristic scales. The Wasserstein quantity is explicitly a moment diagnostic; it does not relabel the finite posterior query as Gaussian.

The diagnostic is invariant to:

- consistent unit conversion when query values and characteristic scales are converted together; and
- simultaneous permutation of component identities, posterior columns, and query-value rows.

## Validation

The branch was rebuilt as one clean commit directly on current `main`; the final diff contains only:

```text
docs/prequential_query_stability.md
src/causal4d/prequential_query_stability.py
tests/test_prequential_query_stability.py
```

Focused hardening tests cover native and standardized drift, unit invariance, component-permutation invariance, malformed shapes and scales, coercive values, direct posterior construction, noncausal source metadata, and content-identity sensitivity.

All authoritative workflows passed on exact head `38b02ca0332a2c9c3e6f07949621e78c2494e27d`:

- Causal4D merge gate: https://github.com/IPS-Stuttgart/Causal4D/actions/runs/31590591748
- CI and release: https://github.com/IPS-Stuttgart/Causal4D/actions/runs/31590591838
- Extended compatibility: https://github.com/IPS-Stuttgart/Causal4D/actions/runs/31590591928
- Security scanning: https://github.com/IPS-Stuttgart/Causal4D/actions/runs/31590592024

## Scientific and information boundary

- Frozen estimator changed: `no`.
- Registered physical protocol changed: `no`.
- Target or held-out outcomes accessed: `no`.
- Physical evidence increment: `0`.
- Prefix selected automatically: `no`.
- Future frames read: `0`, enforced from the source path.
- Existing scientific claim promoted: `no`.

Any threshold or promotion rule based on this diagnostic must be frozen on source or calibration executions in a separately versioned protocol. It does not establish provider competence, intervention identifiability, empirical calibration, counterfactual accuracy, contact truth, deployment safety, or state of the art.

## Merge disposition

- [x] Additive diagnostic product change intended for review and merge
- [ ] Frozen-method change
- [ ] Confirmatory evidence publication
