### PR TITLE
Add source-only session transition selection

### DIFF
--- a/docs/session_transition_selection.md
+++ b/docs/session_transition_selection.md
@@ -1,0 +1,105 @@
+# Source-only session-transition selection
+
+## Purpose
+
+Causal4D's session hierarchy can represent
+
+```text
+p(phi_session | phi_bar)
+```
+
+on the registered finite persistent-intervention support. Supplying that
+transition matrix manually is useful for controlled studies, but a future
+multi-session protocol needs an auditable source-only selection procedure.
+
+`causal4d.session_transition_selection` selects one matrix from a frozen finite
+candidate set by leave-one-independent-session-out log predictive density. It
+never estimates or selects the transition from confirmatory target outcomes.
+
+## Model and score
+
+For candidate transition `T[g, f]`, training source sessions update the global
+posterior over `(phi_bar=g, theta=p)`. The held-out source session is scored by
+
+```text
+sum_g,p,f
+    p(phi_bar=g, theta=p | training sessions)
+    T[g, f]
+    p(held-out session evidence | phi_session=f, theta=p).
+```
+
+Every source session contributes one predictive-score unit. Frames, executions,
+nodes, views, coordinates, and posterior components are not treated as
+independent selection units.
+
+The exact identity transition must be included and named explicitly. When its
+mean source score lies within the preregistered tolerance of the best candidate,
+the identity transition is selected. Otherwise the first highest-scoring
+candidate in the frozen candidate order is selected.
+
+## Usage
+
+```python
+from causal4d.session_transition_selection import (
+    select_session_phi_transition_source_only,
+)
+
+selection = select_session_phi_transition_source_only(
+    source_session_log_evidence,
+    source_session_ids=source_session_ids,
+    phi_prior=phi_prior,
+    parameter_prior=parameter_prior,
+    candidate_ids=("identity", "weak-variation", "moderate-variation"),
+    candidate_transitions=candidate_transition_matrices,
+    identity_candidate_id="identity",
+    selection_tolerance=1.0e-3,
+    metadata={"registered_before_target_access": True},
+)
+
+hierarchy = infer_session_phi_hierarchy(
+    target_closed_source_execution_log_evidence,
+    phi_prior=selection.phi_prior,
+    parameter_prior=selection.parameter_prior,
+    session_ids=source_execution_session_ids,
+    execution_evidence_powers=source_execution_powers,
+    session_phi_transition=selection.selected_transition,
+)
+```
+
+Candidate matrices must be finite, nonnegative, row-stochastic, and defined on
+the same finite `phi` support. The identity candidate must be the exact identity
+matrix rather than a numerically close approximation.
+
+## Artifact and validation
+
+`SessionTransitionSelectionV1` binds:
+
+- unique independent source-session IDs;
+- normalized `phi` and physical-parameter priors;
+- the complete session-level log-evidence tensor;
+- ordered candidate IDs and transition matrices;
+- the exact identity candidate;
+- every leave-one-session-out log score;
+- equal-session mean scores;
+- the identity-favoring selection tolerance and selected candidate; and
+- finite diagnostic metadata and the scientific claim boundary.
+
+Construction recomputes the complete source-fold score table and selected
+candidate. Supplied score or selection drift is rejected.
+
+Focused tests cover stable sessions selecting identity, variable sessions
+selecting a diffuse candidate, exact identity preference under a score tie,
+invalid source/candidate designs, and evidence-sensitive content identity.
+
+## Scientific boundary
+
+This selector is intended for a separately versioned future protocol. It does
+not enter or modify the frozen 36-execution estimator. A source-selected
+transition does not establish new-session calibration, correct hierarchy
+support, physical parameter identifiability, counterfactual accuracy, or object
+class generalization.
+
+Candidate matrices, candidate order, priors, score, tolerance, source-session
+roster, and all exclusions must be frozen before target access. A failed or
+identity-selected result is complete evidence and must not be retuned on the
+same target sessions.

--- a/src/causal4d/session_transition_selection.py
+++ b/src/causal4d/session_transition_selection.py
@@ -1,0 +1,481 @@
+"""Source-only selection of finite session-level intervention transitions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+import hashlib
+import json
+from typing import Any
+
+import numpy as np
+
+from causal4d.contracts import array_sha256
+from causal4d.immutable_array import readonly_array
+from causal4d.immutable_json import plain_json, validated_json_mapping
+from causal4d.session_hierarchy import infer_session_phi_hierarchy
+from causal4d.weighting import log_weights_from_probabilities
+
+
+SESSION_TRANSITION_SELECTION_SCHEMA_VERSION = 1
+SESSION_TRANSITION_SELECTION_CLAIM_BOUNDARY = (
+    "Source-only leave-one-session-out selection over a frozen finite transition "
+    "candidate set. It does not change the registered 36-execution estimator, "
+    "establish target calibration, or authorize target-informed retuning."
+)
+_SESSION_TRANSITION_SELECTION_KIND = "Causal4DSessionTransitionSelectionV1"
+
+
+def _nonempty_string(value: object, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _string_tuple(
+    values: Sequence[str],
+    *,
+    name: str,
+    minimum_count: int = 1,
+) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)):
+        raise ValueError(f"{name} must be a sequence of strings")
+    result = tuple(values)
+    if len(result) < minimum_count or any(
+        type(value) is not str or not value for value in result
+    ):
+        raise ValueError(
+            f"{name} must contain at least {minimum_count} nonempty strings"
+        )
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must not contain duplicates")
+    return result
+
+
+def _probability_vector(values: object, *, name: str) -> np.ndarray:
+    raw = np.asarray(values)
+    if raw.dtype.kind not in {"i", "u", "f"}:
+        raise ValueError(f"{name} must contain real numeric values")
+    result = readonly_array(raw, dtype=float)
+    if result.ndim != 1 or not len(result):
+        raise ValueError(f"{name} must be a nonempty vector")
+    if not np.all(np.isfinite(result)) or np.any(result < 0.0):
+        raise ValueError(f"{name} must be finite and nonnegative")
+    total = float(np.sum(result))
+    if total <= 0.0:
+        raise ValueError(f"{name} must contain positive mass")
+    return readonly_array(result / total, dtype=float)
+
+
+def _candidate_transitions(values: object, *, phi_count: int) -> np.ndarray:
+    raw = np.asarray(values)
+    if raw.dtype.kind not in {"i", "u", "f"}:
+        raise ValueError("candidate_transitions must contain real numeric values")
+    result = readonly_array(raw, dtype=float)
+    if result.ndim != 3 or result.shape[1:] != (phi_count, phi_count):
+        raise ValueError("candidate_transitions must have shape (candidate, phi, phi)")
+    if not len(result) or not np.all(np.isfinite(result)) or np.any(result < 0.0):
+        raise ValueError(
+            "candidate_transitions must be nonempty, finite, and nonnegative"
+        )
+    if not np.allclose(
+        np.sum(result, axis=2),
+        1.0,
+        atol=1.0e-12,
+        rtol=0.0,
+    ):
+        raise ValueError("candidate transition rows must sum to one")
+    return result
+
+
+def _session_evidence(
+    values: object,
+    *,
+    session_count: int,
+    phi_count: int,
+    parameter_count: int,
+) -> np.ndarray:
+    raw = np.asarray(values)
+    if raw.dtype.kind not in {"i", "u", "f"}:
+        raise ValueError("session_log_evidence must contain real numeric values")
+    result = readonly_array(raw, dtype=float)
+    if result.shape != (session_count, phi_count, parameter_count):
+        raise ValueError(
+            "session_log_evidence must have shape (session, phi, parameter)"
+        )
+    if np.any(np.isnan(result)) or np.any(np.isposinf(result)):
+        raise ValueError("session_log_evidence must not contain NaN or +inf")
+    if np.any(np.all(np.isneginf(result), axis=(1, 2))):
+        raise ValueError("every source session needs finite likelihood support")
+    return result
+
+
+def _logsumexp(values: np.ndarray) -> float:
+    maximum = float(np.max(values))
+    if not np.isfinite(maximum):
+        return -np.inf
+    return float(maximum + np.log(np.sum(np.exp(values - maximum))))
+
+
+def _heldout_predictive_log_score(
+    global_weights: np.ndarray,
+    transition: np.ndarray,
+    heldout_log_evidence: np.ndarray,
+) -> float:
+    global_log = log_weights_from_probabilities(
+        global_weights,
+        name="source hierarchy global weights",
+    )
+    transition_log = log_weights_from_probabilities(
+        transition,
+        name="session phi transition",
+    )
+    joint = (
+        global_log[:, None, :] + transition_log[:, :, None] + heldout_log_evidence[None]
+    )
+    score = _logsumexp(joint)
+    if not np.isfinite(score):
+        raise ValueError("held-out source session has zero predictive mass")
+    return score
+
+
+def _leave_one_session_out_scores(
+    session_log_evidence: np.ndarray,
+    *,
+    phi_prior: np.ndarray,
+    parameter_prior: np.ndarray,
+    candidate_transitions: np.ndarray,
+) -> np.ndarray:
+    session_count = len(session_log_evidence)
+    scores = np.empty((len(candidate_transitions), session_count), dtype=float)
+    source_ids = tuple(f"source-session-{index}" for index in range(session_count))
+    for candidate_index, transition in enumerate(candidate_transitions):
+        for heldout_index in range(session_count):
+            training = tuple(
+                evidence
+                for index, evidence in enumerate(session_log_evidence)
+                if index != heldout_index
+            )
+            training_ids = tuple(
+                identifier
+                for index, identifier in enumerate(source_ids)
+                if index != heldout_index
+            )
+            hierarchy = infer_session_phi_hierarchy(
+                training,
+                phi_prior=phi_prior,
+                parameter_prior=parameter_prior,
+                session_ids=training_ids,
+                execution_evidence_powers=np.ones(len(training), dtype=float),
+                session_phi_transition=transition,
+            )
+            scores[candidate_index, heldout_index] = _heldout_predictive_log_score(
+                hierarchy.global_weights,
+                transition,
+                session_log_evidence[heldout_index],
+            )
+    return scores
+
+
+def _selection_tolerance(value: object) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(
+        value,
+        (int, float, np.integer, np.floating),
+    ):
+        raise ValueError("selection_tolerance must be a real number")
+    result = float(value)
+    if not np.isfinite(result) or result < 0.0:
+        raise ValueError("selection_tolerance must be finite and nonnegative")
+    return result
+
+
+def _selected_index(
+    mean_scores: np.ndarray,
+    *,
+    identity_index: int,
+    tolerance: float,
+) -> int:
+    best_index = int(np.argmax(mean_scores))
+    best = float(mean_scores[best_index])
+    if float(mean_scores[identity_index]) >= best - tolerance:
+        return identity_index
+    return best_index
+
+
+@dataclass(frozen=True)
+class SessionTransitionSelectionV1:
+    """Content-addressed source-session transition selection result."""
+
+    source_session_ids: tuple[str, ...]
+    candidate_ids: tuple[str, ...]
+    identity_candidate_id: str
+    phi_prior: np.ndarray
+    parameter_prior: np.ndarray
+    session_log_evidence: np.ndarray
+    candidate_transitions: np.ndarray
+    leave_one_session_out_log_scores: np.ndarray
+    mean_log_scores: np.ndarray
+    selected_candidate_index: int
+    selection_tolerance: float
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        session_ids = _string_tuple(
+            self.source_session_ids,
+            name="source_session_ids",
+            minimum_count=2,
+        )
+        candidate_ids = _string_tuple(
+            self.candidate_ids,
+            name="candidate_ids",
+        )
+        identity_id = _nonempty_string(
+            self.identity_candidate_id,
+            name="identity_candidate_id",
+        )
+        if identity_id not in candidate_ids:
+            raise ValueError("identity_candidate_id must identify one candidate")
+        phi_prior = _probability_vector(self.phi_prior, name="phi_prior")
+        parameter_prior = _probability_vector(
+            self.parameter_prior,
+            name="parameter_prior",
+        )
+        transitions = _candidate_transitions(
+            self.candidate_transitions,
+            phi_count=len(phi_prior),
+        )
+        if len(transitions) != len(candidate_ids):
+            raise ValueError("candidate IDs and transition matrices must align")
+        identity_index = candidate_ids.index(identity_id)
+        if not np.array_equal(transitions[identity_index], np.eye(len(phi_prior))):
+            raise ValueError("identity candidate must be the exact identity matrix")
+        evidence = _session_evidence(
+            self.session_log_evidence,
+            session_count=len(session_ids),
+            phi_count=len(phi_prior),
+            parameter_count=len(parameter_prior),
+        )
+        tolerance = _selection_tolerance(self.selection_tolerance)
+        expected_scores = _leave_one_session_out_scores(
+            evidence,
+            phi_prior=phi_prior,
+            parameter_prior=parameter_prior,
+            candidate_transitions=transitions,
+        )
+        raw_supplied_scores = np.asarray(self.leave_one_session_out_log_scores)
+        if raw_supplied_scores.dtype.kind not in {"i", "u", "f"}:
+            raise ValueError(
+                "leave_one_session_out_log_scores must contain real numeric values"
+            )
+        supplied_scores = readonly_array(raw_supplied_scores, dtype=float)
+        if supplied_scores.shape != expected_scores.shape or not np.allclose(
+            supplied_scores,
+            expected_scores,
+            atol=1.0e-12,
+            rtol=1.0e-10,
+        ):
+            raise ValueError(
+                "leave_one_session_out_log_scores do not match source evidence"
+            )
+        expected_mean = np.mean(expected_scores, axis=1)
+        raw_supplied_mean = np.asarray(self.mean_log_scores)
+        if raw_supplied_mean.dtype.kind not in {"i", "u", "f"}:
+            raise ValueError("mean_log_scores must contain real numeric values")
+        supplied_mean = readonly_array(raw_supplied_mean, dtype=float)
+        if supplied_mean.shape != expected_mean.shape or not np.allclose(
+            supplied_mean,
+            expected_mean,
+            atol=1.0e-12,
+            rtol=1.0e-10,
+        ):
+            raise ValueError("mean_log_scores do not match source-fold scores")
+        selected = _selected_index(
+            expected_mean,
+            identity_index=identity_index,
+            tolerance=tolerance,
+        )
+        if type(self.selected_candidate_index) is not int or (
+            self.selected_candidate_index != selected
+        ):
+            raise ValueError("selected_candidate_index does not match source scores")
+        metadata = validated_json_mapping(
+            self.metadata,
+            error_message="transition-selection metadata must be finite JSON",
+        )
+        object.__setattr__(self, "source_session_ids", session_ids)
+        object.__setattr__(self, "candidate_ids", candidate_ids)
+        object.__setattr__(self, "identity_candidate_id", identity_id)
+        object.__setattr__(self, "phi_prior", phi_prior)
+        object.__setattr__(self, "parameter_prior", parameter_prior)
+        object.__setattr__(self, "session_log_evidence", evidence)
+        object.__setattr__(self, "candidate_transitions", transitions)
+        object.__setattr__(
+            self,
+            "leave_one_session_out_log_scores",
+            readonly_array(expected_scores, dtype=float),
+        )
+        object.__setattr__(
+            self,
+            "mean_log_scores",
+            readonly_array(expected_mean, dtype=float),
+        )
+        object.__setattr__(self, "selected_candidate_index", selected)
+        object.__setattr__(self, "selection_tolerance", tolerance)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def selected_candidate_id(self) -> str:
+        return self.candidate_ids[self.selected_candidate_index]
+
+    @property
+    def selected_transition(self) -> np.ndarray:
+        return self.candidate_transitions[self.selected_candidate_index]
+
+    @property
+    def artifact_id(self) -> str:
+        payload = {
+            "schema_version": SESSION_TRANSITION_SELECTION_SCHEMA_VERSION,
+            "artifact_kind": _SESSION_TRANSITION_SELECTION_KIND,
+            "source_session_ids": list(self.source_session_ids),
+            "candidate_ids": list(self.candidate_ids),
+            "identity_candidate_id": self.identity_candidate_id,
+            "selected_candidate_index": self.selected_candidate_index,
+            "selection_tolerance": self.selection_tolerance,
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": SESSION_TRANSITION_SELECTION_CLAIM_BOUNDARY,
+            "arrays": {
+                name: array_sha256(getattr(self, name))
+                for name in (
+                    "phi_prior",
+                    "parameter_prior",
+                    "session_log_evidence",
+                    "candidate_transitions",
+                    "leave_one_session_out_log_scores",
+                    "mean_log_scores",
+                )
+            },
+        }
+        encoded = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SESSION_TRANSITION_SELECTION_SCHEMA_VERSION,
+            "artifact_kind": _SESSION_TRANSITION_SELECTION_KIND,
+            "artifact_id": self.artifact_id,
+            "source_session_ids": list(self.source_session_ids),
+            "candidate_ids": list(self.candidate_ids),
+            "identity_candidate_id": self.identity_candidate_id,
+            "selected_candidate_index": self.selected_candidate_index,
+            "selected_candidate_id": self.selected_candidate_id,
+            "selected_transition": self.selected_transition.tolist(),
+            "selection_tolerance": self.selection_tolerance,
+            "mean_log_scores": self.mean_log_scores.tolist(),
+            "leave_one_session_out_log_scores": (
+                self.leave_one_session_out_log_scores.tolist()
+            ),
+            "source_evidence_sha256": array_sha256(self.session_log_evidence),
+            "candidate_transitions_sha256": array_sha256(self.candidate_transitions),
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": SESSION_TRANSITION_SELECTION_CLAIM_BOUNDARY,
+        }
+
+
+def select_session_phi_transition_source_only(
+    session_log_evidence: np.ndarray,
+    *,
+    source_session_ids: Sequence[str],
+    phi_prior: Sequence[float],
+    parameter_prior: Sequence[float],
+    candidate_ids: Sequence[str],
+    candidate_transitions: np.ndarray,
+    identity_candidate_id: str,
+    selection_tolerance: float = 1.0e-12,
+    metadata: Mapping[str, Any] | None = None,
+) -> SessionTransitionSelectionV1:
+    """Select one frozen transition by equal-session predictive log score."""
+
+    for value, name in (
+        (source_session_ids, "source_session_ids"),
+        (candidate_ids, "candidate_ids"),
+    ):
+        if isinstance(value, (str, bytes)):
+            raise ValueError(f"{name} must be a sequence of strings")
+    session_ids = _string_tuple(
+        source_session_ids,
+        name="source_session_ids",
+        minimum_count=2,
+    )
+    candidate_names = _string_tuple(
+        candidate_ids,
+        name="candidate_ids",
+    )
+    normalized_phi = _probability_vector(phi_prior, name="phi_prior")
+    normalized_parameter = _probability_vector(
+        parameter_prior,
+        name="parameter_prior",
+    )
+    transitions = _candidate_transitions(
+        candidate_transitions,
+        phi_count=len(normalized_phi),
+    )
+    evidence = _session_evidence(
+        session_log_evidence,
+        session_count=len(session_ids),
+        phi_count=len(normalized_phi),
+        parameter_count=len(normalized_parameter),
+    )
+    if len(transitions) != len(candidate_names):
+        raise ValueError("candidate IDs and transition matrices must align")
+    if identity_candidate_id not in candidate_names:
+        raise ValueError("identity_candidate_id must identify one candidate")
+    identity_index = candidate_names.index(identity_candidate_id)
+    if not np.array_equal(transitions[identity_index], np.eye(len(normalized_phi))):
+        raise ValueError("identity candidate must be the exact identity matrix")
+    tolerance = _selection_tolerance(selection_tolerance)
+    scores = _leave_one_session_out_scores(
+        evidence,
+        phi_prior=normalized_phi,
+        parameter_prior=normalized_parameter,
+        candidate_transitions=transitions,
+    )
+    means = np.mean(scores, axis=1)
+    selected = _selected_index(
+        means,
+        identity_index=identity_index,
+        tolerance=tolerance,
+    )
+    return SessionTransitionSelectionV1(
+        source_session_ids=session_ids,
+        candidate_ids=candidate_names,
+        identity_candidate_id=identity_candidate_id,
+        phi_prior=normalized_phi,
+        parameter_prior=normalized_parameter,
+        session_log_evidence=evidence,
+        candidate_transitions=transitions,
+        leave_one_session_out_log_scores=scores,
+        mean_log_scores=means,
+        selected_candidate_index=selected,
+        selection_tolerance=selection_tolerance,
+        metadata={
+            "selection_scope": "source_sessions_only",
+            "statistical_unit": "independent_session",
+            "score": "leave_one_session_out_log_predictive_density",
+            "identity_favored_within_tolerance": True,
+            "target_outcomes_used": False,
+            "user_metadata": plain_json(metadata or {}),
+        },
+    )
+
+
+__all__ = [
+    "SESSION_TRANSITION_SELECTION_CLAIM_BOUNDARY",
+    "SESSION_TRANSITION_SELECTION_SCHEMA_VERSION",
+    "SessionTransitionSelectionV1",
+    "select_session_phi_transition_source_only",
+]

--- a/tests/test_session_transition_selection.py
+++ b/tests/test_session_transition_selection.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from causal4d.session_transition_selection import (
+    SESSION_TRANSITION_SELECTION_CLAIM_BOUNDARY,
+    _selected_index,
+    select_session_phi_transition_source_only,
+)
+
+
+IDENTITY = np.eye(2, dtype=float)
+DIFFUSE = np.full((2, 2), 0.5, dtype=float)
+
+
+def _evidence(preferred: tuple[int, ...]) -> np.ndarray:
+    result = np.full((len(preferred), 2, 1), -8.0, dtype=float)
+    for session, state in enumerate(preferred):
+        result[session, state, 0] = 0.0
+    return result
+
+
+def _select(
+    preferred: tuple[int, ...],
+    *,
+    candidate_ids: tuple[str, ...] = ("identity", "diffuse"),
+    transitions: np.ndarray | None = None,
+    identity_candidate_id: str = "identity",
+    selection_tolerance: float = 1.0e-12,
+):
+    return select_session_phi_transition_source_only(
+        _evidence(preferred),
+        source_session_ids=tuple(
+            f"source-session-{index}" for index in range(len(preferred))
+        ),
+        phi_prior=(0.5, 0.5),
+        parameter_prior=(1.0,),
+        candidate_ids=candidate_ids,
+        candidate_transitions=(
+            np.stack((IDENTITY, DIFFUSE)) if transitions is None else transitions
+        ),
+        identity_candidate_id=identity_candidate_id,
+        selection_tolerance=selection_tolerance,
+        metadata={"registered_before_target_access": True},
+    )
+
+
+def test_identity_transition_wins_stable_source_sessions() -> None:
+    result = _select((0, 0, 0, 0))
+
+    assert result.selected_candidate_id == "identity"
+    assert result.mean_log_scores[0] > result.mean_log_scores[1]
+    np.testing.assert_array_equal(result.selected_transition, IDENTITY)
+    assert result.metadata["target_outcomes_used"] is False
+    assert result.as_dict()["claim_boundary"] == (
+        SESSION_TRANSITION_SELECTION_CLAIM_BOUNDARY
+    )
+
+
+def test_diffuse_transition_wins_variable_source_sessions() -> None:
+    result = _select((0, 1, 0, 1))
+
+    assert result.selected_candidate_id == "diffuse"
+    assert result.mean_log_scores[1] > result.mean_log_scores[0]
+    np.testing.assert_array_equal(result.selected_transition, DIFFUSE)
+
+
+def test_identity_is_selected_for_a_source_score_tie() -> None:
+    result = _select(
+        (0, 1, 0, 1),
+        candidate_ids=("duplicate", "identity"),
+        transitions=np.stack((IDENTITY, IDENTITY)),
+        identity_candidate_id="identity",
+        selection_tolerance=0.0,
+    )
+
+    np.testing.assert_allclose(result.mean_log_scores[0], result.mean_log_scores[1])
+    assert result.selected_candidate_id == "identity"
+
+
+def test_selection_rejects_invalid_source_design() -> None:
+    with pytest.raises(ValueError, match="at least 2"):
+        _select((0,))
+    with pytest.raises(ValueError, match="rows must sum to one"):
+        _select(
+            (0, 0),
+            transitions=np.asarray(
+                [IDENTITY, [[0.6, 0.6], [0.5, 0.5]]],
+                dtype=float,
+            ),
+        )
+    with pytest.raises(ValueError, match="identity matrix"):
+        _select(
+            (0, 0),
+            transitions=np.stack((DIFFUSE, IDENTITY)),
+        )
+    with pytest.raises(ValueError, match="finite and nonnegative"):
+        _select((0, 0), selection_tolerance=-1.0)
+
+
+def test_nonidentity_selection_returns_the_actual_best_candidate() -> None:
+    scores = np.asarray([0.80, 0.90, 1.00], dtype=float)
+
+    assert _selected_index(scores, identity_index=0, tolerance=0.15) == 2
+    assert _selected_index(scores, identity_index=0, tolerance=0.21) == 0
+
+
+def test_selection_rejects_coercive_inputs_and_derived_scores() -> None:
+    arguments = {
+        "session_log_evidence": _evidence((0, 1)),
+        "source_session_ids": ("source-session-0", "source-session-1"),
+        "phi_prior": (0.5, 0.5),
+        "parameter_prior": (1.0,),
+        "candidate_ids": ("identity", "diffuse"),
+        "candidate_transitions": np.stack((IDENTITY, DIFFUSE)),
+        "identity_candidate_id": "identity",
+    }
+
+    with pytest.raises(ValueError, match="source_session_ids must be a sequence"):
+        select_session_phi_transition_source_only(
+            **{**arguments, "source_session_ids": "ab"}
+        )
+    with pytest.raises(ValueError, match="candidate_ids must be a sequence"):
+        select_session_phi_transition_source_only(
+            **{**arguments, "candidate_ids": "identity"}
+        )
+    with pytest.raises(
+        ValueError, match="session_log_evidence must contain real numeric"
+    ):
+        select_session_phi_transition_source_only(
+            **{
+                **arguments,
+                "session_log_evidence": arguments["session_log_evidence"].astype(str),
+            }
+        )
+    with pytest.raises(ValueError, match="phi_prior must contain real numeric"):
+        select_session_phi_transition_source_only(
+            **{**arguments, "phi_prior": ("0.5", "0.5")}
+        )
+    with pytest.raises(
+        ValueError, match="candidate_transitions must contain real numeric"
+    ):
+        select_session_phi_transition_source_only(
+            **{
+                **arguments,
+                "candidate_transitions": arguments["candidate_transitions"].astype(str),
+            }
+        )
+    with pytest.raises(ValueError, match="selection_tolerance must be a real number"):
+        select_session_phi_transition_source_only(
+            **{**arguments, "selection_tolerance": "0.1"}
+        )
+
+    result = _select((0, 1, 0, 1))
+    with pytest.raises(ValueError, match="mean_log_scores must contain real numeric"):
+        replace(result, mean_log_scores=result.mean_log_scores.astype(str))
+    with pytest.raises(
+        ValueError,
+        match="leave_one_session_out_log_scores must contain real numeric",
+    ):
+        replace(
+            result,
+            leave_one_session_out_log_scores=(
+                result.leave_one_session_out_log_scores.astype(str)
+            ),
+        )
+
+
+def test_selection_identity_binds_source_evidence() -> None:
+    stable = _select((0, 0, 0, 0))
+    changed = _select((0, 0, 0, 1))
+
+    assert stable.artifact_id != changed.artifact_id


### PR DESCRIPTION
## Summary

- add `SessionTransitionSelectionV1`, a content-addressed source-session selection artifact for a frozen finite set of `p(phi_session | phi_bar)` transition candidates;
- score every candidate by exact leave-one-independent-session-out log predictive density using the existing finite session hierarchy;
- require the exact identity transition as a named conservative candidate;
- select identity when its mean source score lies within the preregistered tolerance of the best candidate;
- otherwise select the actual maximum-scoring candidate rather than the first merely near-best candidate;
- retain the complete source-session evidence tensor, priors, ordered transition candidates, fold scores, mean scores, tolerance, and selected candidate in the artifact identity;
- recompute and validate all fold scores and the selected index during construction; and
- reject coercive string or Boolean evidence, priors, transition matrices, identifiers, tolerances, and supplied derived scores.

## Root cause fixed during review

The original non-identity branch formed the complete tolerance set and returned its first member. When identity was outside tolerance, this could select a lower-scoring earlier candidate instead of the actual best candidate. For example, scores `[0.80, 0.90, 1.00]` with tolerance `0.15` selected candidate 1 even though candidate 2 was best.

The hardened rule is now exact:

```text
best_index = argmax(mean_source_score)
if identity_score >= best_score - tolerance:
    select identity
else:
    select best_index
```

Candidate ordering therefore affects only deterministic `argmax` ties, not which suboptimal candidate is selected outside the identity-favoring tolerance.

## Statistical semantics

For each held-out source session and candidate transition `T[g, f]`, the training sessions produce the global posterior over `(phi_bar=g, theta=p)`. The held-out score marginalizes

```text
p(phi_bar=g, theta=p | training)
* T[g, f]
* p(held-out evidence | phi_session=f, theta=p).
```

Complete independent source sessions are the selection units. Frames, commands, nodes, views, coordinates, and posterior components are not counted as independent folds.

## Validation

The branch was rebuilt as one clean commit directly on current `main`; the final diff contains only:

```text
docs/session_transition_selection.md
src/causal4d/session_transition_selection.py
tests/test_session_transition_selection.py
```

Focused tests cover:

- stable source sessions selecting exact identity;
- heterogeneous source sessions selecting a diffuse transition;
- identity preference inside tolerance;
- actual-best non-identity selection outside tolerance;
- malformed session counts, transition normalization, identity, and tolerance;
- coercive source evidence, priors, transitions, identifier sequences, tolerances, fold scores, and mean scores; and
- content identity changing with source evidence.

All authoritative workflows passed on exact head `843961e3e2231ede9f9f3e5022545eb9c0492c3b`:

- CI and release: https://github.com/IPS-Stuttgart/Causal4D/actions/runs/31592048106
  - Ruff, repaired exact-base handling, incremental formatting, MyPy, Python 3.10/3.12/3.14 suites, distributions, installed wheel/sdist CLI checks, result-bundle smoke tests, frozen manifest, and pinned BayesianPhysTwin integration passed;
- Causal4D merge gate: https://github.com/IPS-Stuttgart/Causal4D/actions/runs/31592048150
- Extended compatibility: https://github.com/IPS-Stuttgart/Causal4D/actions/runs/31592048081
- Security scanning: https://github.com/IPS-Stuttgart/Causal4D/actions/runs/31592048072

## Scientific and information boundary

- Frozen 36-execution estimator changed: `no`.
- Registered target analysis changed: `no`.
- Target or held-out confirmatory outcomes accessed: `no`.
- Physical evidence increment: `0`.
- Source-session statistical unit: complete independent session.
- Identity fallback retained: `yes`, through explicit tolerance preference.

This is future-protocol selection infrastructure. A selected transition does not establish new-session calibration, hierarchy-support adequacy, physical-parameter identifiability, counterfactual accuracy, object generalization, deployment safety, or state of the art. Candidate matrices, candidate order, priors, tolerance, source roster, and exclusions must be frozen before target access.

## Merge disposition

- [x] Additive future-protocol inference infrastructure intended for review and merge
- [ ] Frozen primary-method change
- [ ] Confirmatory evidence publication
