### PR TITLE
Harden issue dispatch and add rolling compatibility checks

### DIFF
--- a/.github/workflows/acquisition-readiness-self-hosted.yml
+++ b/.github/workflows/acquisition-readiness-self-hosted.yml
@@ -8,10 +8,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: acquisition-readiness-${{ github.sha }}
-  cancel-in-progress: false
-
 jobs:
   inspect:
     name: Inspect registered acquisition readiness on workstation2
@@ -28,6 +24,10 @@ jobs:
             '[self-hosted] inspect Causal4D acquisition readiness'
         )
       )
+    concurrency:
+      group: acquisition-readiness-${{ github.sha }}
+      cancel-in-progress: false
+      queue: max
     runs-on: [self-hosted, Linux, X64, nvidia-smi]
     timeout-minutes: 45
     outputs:

--- a/.github/workflows/automatable-preacquisition-self-hosted.yml
+++ b/.github/workflows/automatable-preacquisition-self-hosted.yml
@@ -8,10 +8,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: automatable-preacquisition-${{ github.sha }}
-  cancel-in-progress: false
-
 jobs:
   execute:
     name: Execute one registered nonphysical action on workstation2
@@ -28,6 +24,10 @@ jobs:
             '[self-hosted] execute Causal4D automatable next action'
         )
       )
+    concurrency:
+      group: automatable-preacquisition-${{ github.sha }}
+      cancel-in-progress: false
+      queue: max
     runs-on: [self-hosted, Linux, X64, nvidia-smi]
     timeout-minutes: 45
     outputs:

--- a/.github/workflows/controlled-execution-campaign.yml
+++ b/.github/workflows/controlled-execution-campaign.yml
@@ -9,10 +9,6 @@ permissions:
   contents: read
   issues: write
 
-concurrency:
-  group: controlled-execution-campaign-${{ github.sha }}
-  cancel-in-progress: false
-
 jobs:
   dispatch:
     name: Dispatch target-free executions from reviewed main
@@ -24,6 +20,10 @@ jobs:
       github.event.issue.user.id == 6773539 &&
       github.event.issue.title ==
         '[self-hosted] run Causal4D controlled execution campaign'
+    concurrency:
+      group: controlled-execution-campaign-${{ github.sha }}
+      cancel-in-progress: false
+      queue: max
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/correct-operator-registry-self-hosted.yml
+++ b/.github/workflows/correct-operator-registry-self-hosted.yml
@@ -8,10 +8,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: correct-operator-registry-${{ github.sha }}
-  cancel-in-progress: false
-
 jobs:
   correct:
     name: Correct the registered operator roster on workstation2
@@ -28,6 +24,10 @@ jobs:
             '[self-hosted] correct Causal4D operator registry'
         )
       )
+    concurrency:
+      group: correct-operator-registry-${{ github.sha }}
+      cancel-in-progress: false
+      queue: max
     runs-on: [self-hosted, Linux, X64, nvidia-smi]
     timeout-minutes: 45
     outputs:

--- a/.github/workflows/deform360-reset-mechanics-issue-dispatch.yml
+++ b/.github/workflows/deform360-reset-mechanics-issue-dispatch.yml
@@ -9,10 +9,6 @@ permissions:
   contents: read
   issues: write
 
-concurrency:
-  group: deform360-reset-mechanics-issue-dispatch-${{ github.sha }}
-  cancel-in-progress: false
-
 jobs:
   dispatch:
     name: Dispatch corrected reset-mechanics diagnostic
@@ -24,6 +20,10 @@ jobs:
       github.event.issue.user.id == 6773539 &&
       github.event.issue.title ==
         '[self-hosted] run Causal4D Deform360 reset mechanics'
+    concurrency:
+      group: deform360-reset-mechanics-issue-dispatch-${{ github.sha }}
+      cancel-in-progress: false
+      queue: max
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/prepared-joint-observation-self-hosted.yml
+++ b/.github/workflows/prepared-joint-observation-self-hosted.yml
@@ -7,10 +7,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: prepared-joint-observation-${{ github.sha }}
-  cancel-in-progress: false
-
 jobs:
   validate:
     name: Validate prepared joint observations on workstation2
@@ -22,6 +18,10 @@ jobs:
       github.event.issue.user.id == 6773539 &&
       github.event.issue.title ==
         '[self-hosted] validate prepared joint observation'
+    concurrency:
+      group: prepared-joint-observation-${{ github.sha }}
+      cancel-in-progress: false
+      queue: max
     runs-on: [self-hosted, Linux, X64, nvidia-smi]
     timeout-minutes: 90
     steps:

--- a/.github/workflows/release-metadata-integrity.yml
+++ b/.github/workflows/release-metadata-integrity.yml
@@ -1,0 +1,247 @@
+name: Release metadata integrity
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/release-metadata-integrity.yml"
+      - "CHANGELOG.md"
+      - "CITATION.cff"
+      - "ci/project_status_v2.json"
+      - "pyproject.toml"
+      - "scripts/ci/check_release_metadata.py"
+      - "src/causal4d/__init__.py"
+      - "tests/test_release_metadata_policy.py"
+      - "tests/test_release_metadata_workflow_policy.py"
+  push:
+    branches: [main]
+    tags: ["v*"]
+    paths:
+      - ".github/workflows/release-metadata-integrity.yml"
+      - "CHANGELOG.md"
+      - "CITATION.cff"
+      - "ci/project_status_v2.json"
+      - "pyproject.toml"
+      - "scripts/ci/check_release_metadata.py"
+      - "src/causal4d/__init__.py"
+      - "tests/test_release_metadata_policy.py"
+      - "tests/test_release_metadata_workflow_policy.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-metadata-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Metadata, tag, and built-distribution versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Validate source release metadata and exact tag
+        id: metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p outputs/release-metadata
+          arguments=(
+            --root .
+            --output outputs/release-metadata/source-metadata.json
+          )
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            arguments+=(--tag "${GITHUB_REF_NAME}")
+          fi
+          python scripts/ci/check_release_metadata.py "${arguments[@]}" \
+            | tee outputs/release-metadata/source-metadata.txt
+          package_version="$(
+            python - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(
+              Path("outputs/release-metadata/source-metadata.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          print(report["package_version"])
+          PY
+          )"
+          echo "package_version=${package_version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build and inspect wheel and source distribution
+        shell: bash
+        env:
+          EXPECTED_VERSION: ${{ steps.metadata.outputs.package_version }}
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade \
+            "build>=1.2" \
+            "packaging>=23" \
+            "twine>=5"
+          python -m build --sdist --wheel --outdir dist .
+          python -m twine check dist/*
+          sha256sum dist/* | sort \
+            | tee outputs/release-metadata/distribution-sha256.txt
+          python - <<'PY'
+          import email
+          import json
+          import os
+          import tarfile
+          import zipfile
+          from pathlib import Path
+
+          from packaging.utils import parse_sdist_filename, parse_wheel_filename
+
+          expected = os.environ["EXPECTED_VERSION"]
+          dist = Path("dist")
+          wheels = sorted(dist.glob("*.whl"))
+          sdists = sorted(dist.glob("*.tar.gz"))
+          if len(wheels) != 1 or len(sdists) != 1:
+              raise SystemExit(
+                  f"expected one wheel and one sdist, got {wheels!r}, {sdists!r}"
+              )
+
+          wheel_name, wheel_version, _, _ = parse_wheel_filename(wheels[0].name)
+          sdist_name, sdist_version = parse_sdist_filename(sdists[0].name)
+          if wheel_name != "causal4d" or sdist_name != "causal4d":
+              raise SystemExit("built distribution name is not causal4d")
+
+          with zipfile.ZipFile(wheels[0]) as archive:
+              metadata_members = [
+                  name
+                  for name in archive.namelist()
+                  if name.endswith(".dist-info/METADATA")
+              ]
+              if len(metadata_members) != 1:
+                  raise SystemExit("wheel must contain exactly one METADATA file")
+              wheel_metadata = email.message_from_bytes(
+                  archive.read(metadata_members[0])
+              )
+
+          with tarfile.open(sdists[0], mode="r:gz") as archive:
+              pkg_info_members = [
+                  member
+                  for member in archive.getmembers()
+                  if member.isfile() and member.name.count("/") == 1
+                  and member.name.endswith("/PKG-INFO")
+              ]
+              if len(pkg_info_members) != 1:
+                  raise SystemExit("sdist must contain exactly one root PKG-INFO")
+              extracted = archive.extractfile(pkg_info_members[0])
+              if extracted is None:
+                  raise SystemExit("could not read sdist PKG-INFO")
+              sdist_metadata = email.message_from_bytes(extracted.read())
+
+          observed = {
+              "source": expected,
+              "wheel_filename": str(wheel_version),
+              "wheel_metadata": wheel_metadata["Version"],
+              "sdist_filename": str(sdist_version),
+              "sdist_metadata": sdist_metadata["Version"],
+          }
+          if set(observed.values()) != {expected}:
+              raise SystemExit(
+                  f"distribution version mismatch: {observed!r}, expected {expected!r}"
+              )
+          Path("outputs/release-metadata/distribution-metadata.json").write_text(
+              json.dumps(observed, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print(json.dumps(observed, indent=2, sort_keys=True))
+          PY
+
+      - name: Verify installed runtime and distribution metadata agree
+        shell: bash
+        env:
+          EXPECTED_VERSION: ${{ steps.metadata.outputs.package_version }}
+        run: |
+          set -euo pipefail
+          python -m venv outputs/release-metadata/installed-venv
+          venv="outputs/release-metadata/installed-venv"
+          "${venv}/bin/python" -m pip install --upgrade pip
+          wheel="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
+          test -n "${wheel}"
+          "${venv}/bin/python" -m pip install "${wheel}"
+          "${venv}/bin/python" -m pip check
+          "${venv}/bin/python" -m pip freeze --all \
+            > outputs/release-metadata/installed-freeze.txt
+          "${venv}/bin/python" - <<'PY'
+          import json
+          import os
+          from importlib.metadata import version
+          from pathlib import Path
+
+          import causal4d
+
+          expected = os.environ["EXPECTED_VERSION"]
+          observed = {
+              "expected": expected,
+              "runtime": causal4d.__version__,
+              "distribution": version("causal4d"),
+              "module_origin": str(Path(causal4d.__file__).resolve()),
+          }
+          if observed["runtime"] != expected:
+              raise SystemExit(f"runtime version mismatch: {observed!r}")
+          if observed["distribution"] != expected:
+              raise SystemExit(f"distribution version mismatch: {observed!r}")
+          Path("outputs/release-metadata/installed-metadata.json").write_text(
+              json.dumps(observed, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print(json.dumps(observed, indent=2, sort_keys=True))
+          PY
+          rm -rf "${venv}"
+
+      - name: Publish release-integrity summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Release metadata integrity"
+            echo
+            for artifact in \
+              outputs/release-metadata/source-metadata.json \
+              outputs/release-metadata/distribution-metadata.json \
+              outputs/release-metadata/installed-metadata.json \
+              outputs/release-metadata/distribution-sha256.txt
+            do
+              if [[ -f "${artifact}" ]]; then
+                echo "### $(basename "${artifact}")"
+                echo '```text'
+                cat "${artifact}"
+                echo '```'
+              fi
+            done
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload release-integrity evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: causal4d-release-metadata-integrity
+          path: |
+            dist/*
+            outputs/release-metadata/source-metadata.json
+            outputs/release-metadata/source-metadata.txt
+            outputs/release-metadata/distribution-metadata.json
+            outputs/release-metadata/distribution-sha256.txt
+            outputs/release-metadata/installed-metadata.json
+            outputs/release-metadata/installed-freeze.txt
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/three-repository-rolling-canary.yml
+++ b/.github/workflows/three-repository-rolling-canary.yml
@@ -1,0 +1,318 @@
+name: Rolling three-repository compatibility canary
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "41 3 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rolling-three-repository-compatibility
+  cancel-in-progress: true
+
+env:
+  CAUSAL4D_COMPATIBILITY_LANE: rolling-non-claim-bearing
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  current-default-branches:
+    name: Current default branches / non-claim-bearing
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Check out current Causal4D main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/Causal4D
+          ref: main
+          path: causal4d
+          persist-credentials: false
+
+      - name: Check out current BayesianPhysTwin main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/BayesianPhysTwin
+          ref: main
+          path: bayesian-phystwin
+          persist-credentials: false
+
+      - name: Check out current Prob4D main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/Prob4D
+          ref: main
+          path: prob4d
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            causal4d/pyproject.toml
+            bayesian-phystwin/pyproject.toml
+            prob4d/pyproject.toml
+
+      - name: Record exact current-head revisions
+        id: revisions
+        shell: bash
+        run: |
+          set -euo pipefail
+          for repository in prob4d bayesian-phystwin causal4d; do
+            test -z "$(git -C "${repository}" status --porcelain=v1 --untracked-files=all)"
+          done
+          prob4d_sha="$(git -C prob4d rev-parse HEAD)"
+          bpt_sha="$(git -C bayesian-phystwin rev-parse HEAD)"
+          causal4d_sha="$(git -C causal4d rev-parse HEAD)"
+          echo "prob4d=${prob4d_sha}" >> "${GITHUB_OUTPUT}"
+          echo "bpt=${bpt_sha}" >> "${GITHUB_OUTPUT}"
+          echo "causal4d=${causal4d_sha}" >> "${GITHUB_OUTPUT}"
+          export PROB4D_SHA="${prob4d_sha}"
+          export BPT_SHA="${bpt_sha}"
+          export CAUSAL4D_SHA="${causal4d_sha}"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = {
+              "schema_version": 1,
+              "artifact_kind": "Causal4DRollingCompatibilityCanary",
+              "lane": os.environ["CAUSAL4D_COMPATIBILITY_LANE"],
+              "claim_bearing": False,
+              "frozen_pins_used": False,
+              "repository_revisions": {
+                  "IPS-Stuttgart/Prob4D": os.environ["PROB4D_SHA"],
+                  "IPS-Stuttgart/BayesianPhysTwin": os.environ["BPT_SHA"],
+                  "IPS-Stuttgart/Causal4D": os.environ["CAUSAL4D_SHA"],
+              },
+              "claim_boundary": (
+                  "This canary detects integration drift on moving default branches. "
+                  "It cannot replace an immutable stack lock or support scientific, "
+                  "physical, calibration, accuracy, or deployment claims."
+              ),
+          }
+          output = Path(os.environ["RUNNER_TEMP"]) / (
+              "rolling-three-repository-revisions.json"
+          )
+          output.write_text(
+              json.dumps(payload, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print(json.dumps(payload, indent=2, sort_keys=True))
+          PY
+
+      - name: Build all current-head wheels
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade build pip
+          wheelhouse="${RUNNER_TEMP}/rolling-three-repository-wheelhouse"
+          mkdir -p "${wheelhouse}"
+          python -m build --wheel --outdir "${wheelhouse}" prob4d
+          python -m build --wheel --outdir "${wheelhouse}" bayesian-phystwin
+          python -m build --wheel --outdir "${wheelhouse}" causal4d
+          test "$(find "${wheelhouse}" -maxdepth 1 -name '*.whl' | wc -l)" -eq 3
+          (
+            cd "${wheelhouse}"
+            sha256sum ./*.whl | sort
+          ) | tee "${RUNNER_TEMP}/rolling-three-repository-wheel-sha256.txt"
+
+      - name: Install current-head wheels in isolation
+        shell: bash
+        run: |
+          set -euo pipefail
+          venv="${RUNNER_TEMP}/rolling-three-repository-venv"
+          wheelhouse="${RUNNER_TEMP}/rolling-three-repository-wheelhouse"
+          python -m venv "${venv}"
+          "${venv}/bin/python" -m pip install --upgrade pip
+          mapfile -t wheels < <(
+            find "${wheelhouse}" -maxdepth 1 -name '*.whl' -print | sort
+          )
+          "${venv}/bin/python" -m pip install \
+            "${wheels[@]}" \
+            pytest \
+            opencv-python-headless
+          "${venv}/bin/python" -m pip check
+          "${venv}/bin/python" -m pip freeze --all \
+            > "${RUNNER_TEMP}/rolling-three-repository-pip-freeze.txt"
+
+      - name: Verify imports originate only from installed wheels
+        shell: bash
+        env:
+          CAUSAL4D_SOURCE: ${{ github.workspace }}/causal4d
+          BPT_SOURCE: ${{ github.workspace }}/bayesian-phystwin
+          PROB4D_SOURCE: ${{ github.workspace }}/prob4d
+        run: |
+          set -euo pipefail
+          "${RUNNER_TEMP}/rolling-three-repository-venv/bin/python" - <<'PY'
+          import os
+          from pathlib import Path
+
+          import bayesian_phystwin
+          import causal4d
+          import prob4d
+          from causal4d import decision_trace
+
+          roots = tuple(
+              Path(os.environ[name]).resolve()
+              for name in ("CAUSAL4D_SOURCE", "BPT_SOURCE", "PROB4D_SOURCE")
+          )
+          for module in (causal4d, decision_trace, bayesian_phystwin, prob4d):
+              origin = Path(module.__file__).resolve()
+              print(module.__name__, origin)
+              if any(origin.is_relative_to(root) for root in roots):
+                  raise SystemExit(f"source-tree import detected: {origin}")
+          PY
+
+      - name: Create and verify an ephemeral current-head stack lock
+        shell: bash
+        run: |
+          set -euo pipefail
+          venv="${RUNNER_TEMP}/rolling-three-repository-venv"
+          wheelhouse="${RUNNER_TEMP}/rolling-three-repository-wheelhouse"
+          lock="${RUNNER_TEMP}/rolling-three-repository-stack-lock.json"
+          report="${RUNNER_TEMP}/rolling-three-repository-stack-lock-verification.json"
+          mapfile -t wheels < <(
+            find "${wheelhouse}" -maxdepth 1 -name '*.whl' -print | sort
+          )
+
+          create=("${venv}/bin/causal4d" stack create)
+          for wheel in "${wheels[@]}"; do
+            create+=(--wheel "${wheel}")
+          done
+          create+=(
+            --revision "prob4d=${{ steps.revisions.outputs.prob4d }}"
+            --revision "bayesian-phystwin=${{ steps.revisions.outputs.bpt }}"
+            --revision "causal4d=${{ steps.revisions.outputs.causal4d }}"
+            --output "${lock}"
+            --json
+          )
+          "${create[@]}" > "${RUNNER_TEMP}/rolling-stack-lock-create.json"
+          cmp "${lock}" "${RUNNER_TEMP}/rolling-stack-lock-create.json"
+
+          verify=("${venv}/bin/causal4d" stack verify --lock "${lock}")
+          for wheel in "${wheels[@]}"; do
+            verify+=(--wheel "${wheel}")
+          done
+          verify+=(--json)
+          "${verify[@]}" | tee "${report}"
+          "${venv}/bin/python" -m json.tool "${lock}" >/dev/null
+          "${venv}/bin/python" -m json.tool "${report}" >/dev/null
+
+      - name: Run current-head compatibility and provider-v2 paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_dir="${RUNNER_TEMP}/rolling-three-repository-run"
+          mkdir -p "${run_dir}"
+          cp causal4d/ci/three_repository_*.py "${run_dir}/"
+          cd "${run_dir}"
+          env -u PYTHONPATH \
+            "${RUNNER_TEMP}/rolling-three-repository-venv/bin/python" \
+            three_repository_golden_path.py \
+              --prob4d-fixture \
+                "${GITHUB_WORKSPACE}/prob4d/tests/fixtures/prob4d_joint_observation_v1.json" \
+              --prob4d-revision "${{ steps.revisions.outputs.prob4d }}" \
+              --bpt-revision "${{ steps.revisions.outputs.bpt }}" \
+              --causal4d-revision "${{ steps.revisions.outputs.causal4d }}" \
+              --checkout-root "${GITHUB_WORKSPACE}/prob4d" \
+              --checkout-root "${GITHUB_WORKSPACE}/bayesian-phystwin" \
+              --checkout-root "${GITHUB_WORKSPACE}/causal4d" \
+              --output "${RUNNER_TEMP}/rolling-three-repository-summary.json" \
+            | tee "${RUNNER_TEMP}/rolling-three-repository-golden-path.log"
+          test -s "${RUNNER_TEMP}/rolling-three-repository-summary.json"
+
+          env -u PYTHONPATH \
+            "${RUNNER_TEMP}/rolling-three-repository-venv/bin/python" \
+            three_repository_provider_v2_attestation.py \
+              --prob4d-fixture \
+                "${GITHUB_WORKSPACE}/prob4d/tests/fixtures/prob4d_joint_observation_v1.json" \
+              --prob4d-revision "${{ steps.revisions.outputs.prob4d }}" \
+              --output-dir \
+                "${RUNNER_TEMP}/rolling-three-repository-provider-v2-work" \
+              --output \
+                "${RUNNER_TEMP}/rolling-three-repository-provider-v2-summary.json" \
+            | tee "${RUNNER_TEMP}/rolling-three-repository-provider-v2.log"
+          test -s "${RUNNER_TEMP}/rolling-three-repository-provider-v2-summary.json"
+
+      - name: Run focused current-head contract tests
+        shell: bash
+        env:
+          CAUSAL4D_REQUIRE_BPT_PROVIDER: "1"
+        run: |
+          set -euo pipefail
+          cd "${RUNNER_TEMP}/rolling-three-repository-run"
+          env -u PYTHONPATH \
+            "${RUNNER_TEMP}/rolling-three-repository-venv/bin/python" -m pytest -q \
+              --import-mode=importlib \
+              --junitxml="${RUNNER_TEMP}/rolling-three-repository-tests.xml" \
+              "${GITHUB_WORKSPACE}/prob4d/tests/test_claim_bearing_observation.py" \
+              "${GITHUB_WORKSPACE}/prob4d/tests/test_joint_observation_contract_fixture.py" \
+              "${GITHUB_WORKSPACE}/bayesian-phystwin/tests/test_causal4d_provider_v1.py" \
+              "${GITHUB_WORKSPACE}/bayesian-phystwin/tests/test_causal4d_provider_v2.py" \
+              "${GITHUB_WORKSPACE}/bayesian-phystwin/tests/test_causal4d_artifacts_v2.py" \
+              "${GITHUB_WORKSPACE}/bayesian-phystwin/tests/test_observation_belief_gauge_adapter.py" \
+              "${GITHUB_WORKSPACE}/bayesian-phystwin/tests/test_prob4d_causal_lineage.py" \
+              "${GITHUB_WORKSPACE}/bayesian-phystwin/tests/test_run_manifest_v2.py" \
+              "${GITHUB_WORKSPACE}/causal4d/tests/test_bpt_provider_import_boundary.py" \
+              "${GITHUB_WORKSPACE}/causal4d/tests/test_bpt_provider_integration.py" \
+              "${GITHUB_WORKSPACE}/causal4d/tests/test_causal4d_provider_contract.py" \
+              "${GITHUB_WORKSPACE}/causal4d/tests/test_causal4d_phystwin_backend.py" \
+              "${GITHUB_WORKSPACE}/causal4d/tests/test_causal4d_bpt_belief.py" \
+              "${GITHUB_WORKSPACE}/causal4d/tests/test_decision_trace.py" \
+              "${GITHUB_WORKSPACE}/causal4d/tests/test_observation_lineage.py" \
+              "${GITHUB_WORKSPACE}/causal4d/tests/test_prob4d_joint_contract_fixture.py" \
+              "${GITHUB_WORKSPACE}/causal4d/tests/test_prob4d_stream_contract_version.py" \
+              "${GITHUB_WORKSPACE}/causal4d/tests/test_stack_lock.py"
+
+      - name: Publish the non-claim-bearing boundary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Rolling three-repository compatibility canary"
+            echo
+            echo "This lane follows the moving \`main\` branches."
+            echo "It is **non-claim-bearing** and does not update frozen pins."
+            echo
+            for artifact in \
+              "${RUNNER_TEMP}/rolling-three-repository-revisions.json" \
+              "${RUNNER_TEMP}/rolling-three-repository-stack-lock.json" \
+              "${RUNNER_TEMP}/rolling-three-repository-stack-lock-verification.json" \
+              "${RUNNER_TEMP}/rolling-three-repository-summary.json" \
+              "${RUNNER_TEMP}/rolling-three-repository-provider-v2-summary.json" \
+              "${RUNNER_TEMP}/rolling-three-repository-wheel-sha256.txt"
+            do
+              if [[ -f "${artifact}" ]]; then
+                echo "### $(basename "${artifact}")"
+                echo '```text'
+                cat "${artifact}"
+                echo '```'
+              fi
+            done
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload rolling compatibility diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: three-repository-rolling-canary
+          path: |
+            ${{ runner.temp }}/rolling-three-repository-wheelhouse/*.whl
+            ${{ runner.temp }}/rolling-three-repository-wheel-sha256.txt
+            ${{ runner.temp }}/rolling-three-repository-pip-freeze.txt
+            ${{ runner.temp }}/rolling-three-repository-revisions.json
+            ${{ runner.temp }}/rolling-three-repository-stack-lock.json
+            ${{ runner.temp }}/rolling-three-repository-stack-lock-verification.json
+            ${{ runner.temp }}/rolling-three-repository-summary.json
+            ${{ runner.temp }}/rolling-three-repository-golden-path.log
+            ${{ runner.temp }}/rolling-three-repository-provider-v2-summary.json
+            ${{ runner.temp }}/rolling-three-repository-provider-v2.log
+            ${{ runner.temp }}/rolling-three-repository-tests.xml
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/automation_integrity.md
+++ b/docs/automation_integrity.md
@@ -1,0 +1,74 @@
+# Automation integrity
+
+This document separates three automation concerns that have different trust and
+reproducibility requirements.
+
+## Authenticated issue commands
+
+Several workflows intentionally use a newly opened issue as a narrowly scoped
+operator command. Each command authenticates the exact account login and numeric
+account ID, requires one exact title, and requires the reviewed `main` revision.
+
+Concurrency belongs to the authenticated execution job, not to the workflow as a
+whole. GitHub Actions permits at most one pending run in a concurrency group. If
+all opened issues enter a workflow-level group before the job guard is evaluated,
+an unrelated issue can replace a pending authorized command. Job-scoped
+concurrency means an unrelated issue produces only skipped jobs and never enters
+the command's serialization group. The execution-job groups also use `queue: max`, so
+multiple authenticated commands wait instead of replacing an earlier pending
+command.
+
+The policy test in `tests/test_issue_command_concurrency.py` inventories every
+opened-issue workflow. Adding another issue command therefore requires an
+explicit job name and concurrency group in the registry.
+
+## Frozen and rolling compatibility lanes
+
+The existing three-repository installed-wheel workflow is the frozen lane. It
+uses reviewed immutable BayesianPhysTwin and Prob4D revisions, creates a
+content-addressed stack lock, and remains the lane used for reproducibility and
+claim-bearing release checks.
+
+`three-repository-rolling-canary.yml` is intentionally different. It follows the
+current `main` branches of Prob4D, BayesianPhysTwin, and Causal4D, records their
+exact revisions, builds all three wheels, verifies installed-only imports, creates
+an ephemeral stack lock, and runs the shared compatibility and provider-v2
+contracts. Its artifacts always declare:
+
+- `claim_bearing = false`;
+- `frozen_pins_used = false`; and
+- the exact three repository revisions used by the run.
+
+A successful rolling canary detects compatibility at those moving revisions. It
+does not update immutable pins and does not establish physical accuracy,
+calibration, counterfactual validity, deployment safety, or any scientific claim.
+A failure is an integration signal; frozen revisions remain unchanged until a
+reviewed pin update passes the frozen lane.
+
+## Release metadata integrity
+
+`scripts/ci/check_release_metadata.py` validates the package version against
+`CITATION.cff`, setuptools' dynamic version source, the current project-status
+contract, and the changelog. The release workflow then builds one wheel and one
+source distribution and requires agreement among:
+
+- `causal4d.__version__`;
+- the wheel filename and wheel `METADATA`;
+- the source-distribution filename and `PKG-INFO`;
+- the installed distribution metadata; and
+- the citation and project-status metadata required for a tag.
+
+For a tag, the tag must be exactly `v<package-version>`, the package must not be a
+development or prerelease version, the `Unreleased` section must contain no
+pending changes, and the project-status required version must match. The workflow
+is read-only: it validates release inputs and uploads evidence but does not create
+a tag or publish a release.
+
+## Change procedure
+
+For an issue-command workflow, keep the authorization guard on the execution job
+and place its concurrency block below that guard. For compatibility changes, run
+both the moving-head canary and the immutable installed-wheel lane before updating
+any frozen pin. For a software release, first move all pending changelog entries
+into the release section, synchronize package, citation, and project-status
+versions, and only then create the exact matching tag.

--- a/scripts/ci/check_release_metadata.py
+++ b/scripts/ci/check_release_metadata.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Validate Causal4D package, citation, changelog, and release-tag metadata."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+_VERSION_ASSIGNMENT = "__version__"
+_CFF_SCALAR = re.compile(r"(?m)^{key}:\s*([^\n]+)$")
+_PRERELEASE = re.compile(
+    r"(?:\d)(?:alpha|beta|preview|pre|rc|dev|a|b|c)\d*"
+    r"(?=$|[.+-])|(?:^|[._-])dev\d*(?=$|[.+-])",
+    re.IGNORECASE,
+)
+_TOML_SECTION = re.compile(r"(?m)^\[([^\]]+)\]\s*$")
+
+
+class ReleaseMetadataError(ValueError):
+    """Raised when release-facing metadata is inconsistent."""
+
+
+@dataclass(frozen=True)
+class ReleaseMetadataSummary:
+    schema_version: int
+    artifact_kind: str
+    package_version: str
+    citation_version: str
+    project_status_required_version: str
+    setuptools_version_attribute: str
+    changelog_heading_present: bool
+    unreleased_section_present: bool
+    unreleased_changes_present: bool
+    prerelease: bool
+    tag: str | None
+    tag_validated: bool
+    release_ready: bool
+
+
+def _required_file(root: Path, relative: str) -> Path:
+    path = root / relative
+    if not path.is_file():
+        raise ReleaseMetadataError(f"required metadata file is missing: {relative}")
+    return path
+
+
+def _package_version(root: Path) -> str:
+    path = _required_file(root, "src/causal4d/__init__.py")
+    module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    values: list[str] = []
+    for node in module.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets: tuple[ast.expr, ...]
+        value: ast.expr | None
+        if isinstance(node, ast.Assign):
+            targets = tuple(node.targets)
+            value = node.value
+        else:
+            targets = (node.target,)
+            value = node.value
+        if not any(
+            isinstance(target, ast.Name) and target.id == _VERSION_ASSIGNMENT
+            for target in targets
+        ):
+            continue
+        if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+            raise ReleaseMetadataError("causal4d.__version__ must be a string literal")
+        values.append(value.value)
+    if len(values) != 1:
+        raise ReleaseMetadataError(
+            "src/causal4d/__init__.py must define exactly one string __version__"
+        )
+    version = values[0].strip()
+    if not version or any(character.isspace() for character in version):
+        raise ReleaseMetadataError(f"invalid package version: {version!r}")
+    return version
+
+
+def _cff_scalar(root: Path, key: str) -> str:
+    path = _required_file(root, "CITATION.cff")
+    text = path.read_text(encoding="utf-8")
+    match = re.search(
+        _CFF_SCALAR.pattern.format(key=re.escape(key)),
+        text,
+        flags=_CFF_SCALAR.flags,
+    )
+    if match is None:
+        raise ReleaseMetadataError(f"CITATION.cff is missing {key!r}")
+    return match.group(1).strip().strip("\"'")
+
+
+def _toml_section(text: str, name: str) -> str:
+    matches = list(_TOML_SECTION.finditer(text))
+    for index, match in enumerate(matches):
+        if match.group(1).strip() != name:
+            continue
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        return text[start:end]
+    raise ReleaseMetadataError(f"pyproject.toml is missing [{name}]")
+
+
+def _setuptools_version_attribute(root: Path) -> str:
+    path = _required_file(root, "pyproject.toml")
+    text = path.read_text(encoding="utf-8")
+    project = _toml_section(text, "project")
+    dynamic_match = re.search(
+        r"(?ms)^dynamic\s*=\s*\[(?P<body>.*?)\]\s*$",
+        project,
+    )
+    if dynamic_match is None:
+        raise ReleaseMetadataError("project.version must remain dynamic")
+    dynamic_values = re.findall(r"[\"']([^\"']+)[\"']", dynamic_match.group("body"))
+    if "version" not in dynamic_values:
+        raise ReleaseMetadataError("project.version must remain dynamic")
+
+    setuptools_dynamic = _toml_section(text, "tool.setuptools.dynamic")
+    attribute_match = re.search(
+        r"(?m)^version\s*=\s*\{\s*attr\s*=\s*[\"']([^\"']+)[\"']\s*\}\s*$",
+        setuptools_dynamic,
+    )
+    if attribute_match is None:
+        raise ReleaseMetadataError(
+            "pyproject.toml must derive version from a setuptools attribute"
+        )
+    return attribute_match.group(1)
+
+
+def _project_status_required_version(root: Path) -> str:
+    path = _required_file(root, "ci/project_status_v2.json")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        version = payload["packages"]["causal4d"]["required_version"]
+    except (KeyError, TypeError) as error:
+        raise ReleaseMetadataError(
+            "ci/project_status_v2.json is missing packages.causal4d.required_version"
+        ) from error
+    if not isinstance(version, str) or not version:
+        raise ReleaseMetadataError(
+            "project-status Causal4D required_version must be a non-empty string"
+        )
+    return version
+
+
+def _changelog_state(root: Path, version: str) -> tuple[bool, bool, bool]:
+    changelog = _required_file(root, "CHANGELOG.md").read_text(encoding="utf-8")
+    heading_present = bool(
+        re.search(rf"(?m)^##\s+{re.escape(version)}\s*$", changelog)
+    )
+    unreleased_match = re.search(
+        r"(?ms)^##\s+Unreleased\s*$\n(?P<body>.*?)(?=^##\s+|\Z)",
+        changelog,
+    )
+    unreleased_present = unreleased_match is not None
+    unreleased_changes = bool(
+        unreleased_match is not None and unreleased_match.group("body").strip()
+    )
+    return heading_present, unreleased_present, unreleased_changes
+
+
+def inspect_repository(
+    root: Path,
+    *,
+    tag: str | None = None,
+) -> ReleaseMetadataSummary:
+    """Return validated release metadata for ``root`` or raise fail closed."""
+
+    resolved_root = root.resolve()
+    package_version = _package_version(resolved_root)
+    citation_version = _cff_scalar(resolved_root, "version")
+    if citation_version != package_version:
+        raise ReleaseMetadataError(
+            "CITATION.cff version does not match causal4d.__version__: "
+            f"{citation_version!r} != {package_version!r}"
+        )
+
+    attribute = _setuptools_version_attribute(resolved_root)
+    if attribute != "causal4d.__version__":
+        raise ReleaseMetadataError(
+            "setuptools must derive distribution metadata from causal4d.__version__"
+        )
+
+    heading_present, unreleased_present, unreleased_changes = _changelog_state(
+        resolved_root,
+        package_version,
+    )
+    prerelease = _PRERELEASE.search(package_version) is not None
+    if prerelease:
+        if not unreleased_present:
+            raise ReleaseMetadataError(
+                "development/prerelease versions require an Unreleased "
+                "changelog section"
+            )
+    elif not heading_present:
+        raise ReleaseMetadataError(
+            f"CHANGELOG.md has no exact '## {package_version}' release heading"
+        )
+
+    project_status_version = _project_status_required_version(resolved_root)
+    if project_status_version != package_version:
+        raise ReleaseMetadataError(
+            "project-status required_version does not match causal4d.__version__: "
+            f"{project_status_version!r} != {package_version!r}"
+        )
+
+    tag_validated = False
+    if tag is not None:
+        expected_tag = f"v{package_version}"
+        if tag != expected_tag:
+            raise ReleaseMetadataError(
+                f"release tag must be {expected_tag!r}, received {tag!r}"
+            )
+        if prerelease:
+            raise ReleaseMetadataError(
+                "development/prerelease package versions cannot be published "
+                "as releases"
+            )
+        if unreleased_changes:
+            raise ReleaseMetadataError(
+                "tagged releases require an empty Unreleased changelog section"
+            )
+        tag_validated = True
+
+    release_ready = (
+        not prerelease
+        and heading_present
+        and not unreleased_changes
+        and citation_version == package_version
+        and project_status_version == package_version
+    )
+    return ReleaseMetadataSummary(
+        schema_version=1,
+        artifact_kind="Causal4DReleaseMetadataIntegrity",
+        package_version=package_version,
+        citation_version=citation_version,
+        project_status_required_version=project_status_version,
+        setuptools_version_attribute=attribute,
+        changelog_heading_present=heading_present,
+        unreleased_section_present=unreleased_present,
+        unreleased_changes_present=unreleased_changes,
+        prerelease=prerelease,
+        tag=tag,
+        tag_validated=tag_validated,
+        release_ready=release_ready,
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--tag")
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        summary = inspect_repository(args.root, tag=args.tag)
+    except (ReleaseMetadataError, json.JSONDecodeError, SyntaxError) as error:
+        print(f"release metadata integrity failed: {error}", file=sys.stderr)
+        return 1
+
+    rendered = json.dumps(asdict(summary), indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_release_metadata.py
+++ b/scripts/ci/check_release_metadata.py
@@ -152,9 +152,7 @@ def _project_status_required_version(root: Path) -> str:
 
 def _changelog_state(root: Path, version: str) -> tuple[bool, bool, bool]:
     changelog = _required_file(root, "CHANGELOG.md").read_text(encoding="utf-8")
-    heading_present = bool(
-        re.search(rf"(?m)^##\s+{re.escape(version)}\s*$", changelog)
-    )
+    heading_present = bool(re.search(rf"(?m)^##\s+{re.escape(version)}\s*$", changelog))
     unreleased_match = re.search(
         r"(?ms)^##\s+Unreleased\s*$\n(?P<body>.*?)(?=^##\s+|\Z)",
         changelog,

--- a/tests/test_issue_command_concurrency.py
+++ b/tests/test_issue_command_concurrency.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+ISSUE_COMMAND_JOBS = {
+    "acquisition-readiness-self-hosted.yml": (
+        "inspect",
+        "acquisition-readiness-${{ github.sha }}",
+    ),
+    "automatable-preacquisition-self-hosted.yml": (
+        "execute",
+        "automatable-preacquisition-${{ github.sha }}",
+    ),
+    "controlled-execution-campaign.yml": (
+        "dispatch",
+        "controlled-execution-campaign-${{ github.sha }}",
+    ),
+    "correct-operator-registry-self-hosted.yml": (
+        "correct",
+        "correct-operator-registry-${{ github.sha }}",
+    ),
+    "deform360-reset-mechanics-issue-dispatch.yml": (
+        "dispatch",
+        "deform360-reset-mechanics-issue-dispatch-${{ github.sha }}",
+    ),
+    "prepared-joint-observation-self-hosted.yml": (
+        "validate",
+        "prepared-joint-observation-${{ github.sha }}",
+    ),
+}
+
+
+def _job_block(text: str, job_name: str) -> str:
+    lines = text.splitlines()
+    marker = f"  {job_name}:"
+    start = lines.index(marker)
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if re.fullmatch(r"  [A-Za-z0-9_-]+:", lines[index]):
+            end = index
+            break
+    return "\n".join(lines[start:end])
+
+
+def test_every_opened_issue_workflow_is_registered() -> None:
+    actual = {
+        path.name
+        for path in WORKFLOWS.glob("*.yml")
+        if "\n  issues:\n    types: [opened]\n" in path.read_text(encoding="utf-8")
+    }
+
+    assert actual == set(ISSUE_COMMAND_JOBS)
+
+
+def test_unrelated_issue_events_cannot_replace_pending_authorized_jobs() -> None:
+    for filename, (job_name, group) in ISSUE_COMMAND_JOBS.items():
+        text = (WORKFLOWS / filename).read_text(encoding="utf-8")
+        block = _job_block(text, job_name)
+
+        assert "concurrency:" not in {
+            line for line in text.splitlines() if not line.startswith(" ")
+        }
+        assert "github.event.issue.title" in block
+        assert "    concurrency:\n" in block
+        assert f"      group: {group}\n" in block
+        assert "      cancel-in-progress: false\n" in block
+        assert "      queue: max\n" in block
+
+
+def test_issue_command_concurrency_remains_job_scoped() -> None:
+    for filename, (job_name, _) in ISSUE_COMMAND_JOBS.items():
+        text = (WORKFLOWS / filename).read_text(encoding="utf-8")
+        jobs_prefix, jobs_text = text.split("\njobs:\n", maxsplit=1)
+        block = _job_block(text, job_name)
+
+        assert "\nconcurrency:\n" not in f"\n{jobs_prefix}\n"
+        assert block.count("    concurrency:\n") == 1
+        assert jobs_text.count("    concurrency:\n") == 1

--- a/tests/test_release_metadata_policy.py
+++ b/tests/test_release_metadata_policy.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "ci" / "check_release_metadata.py"
+SPEC = importlib.util.spec_from_file_location("check_release_metadata", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+ReleaseMetadataError = MODULE.ReleaseMetadataError
+inspect_repository = MODULE.inspect_repository
+
+
+def _write_fixture(
+    root: Path,
+    *,
+    package_version: str = "1.2.3",
+    citation_version: str | None = None,
+    status_version: str | None = None,
+    setuptools_attribute: str = "causal4d.__version__",
+    changelog: str | None = None,
+) -> Path:
+    citation_version = citation_version or package_version
+    status_version = status_version or package_version
+    if changelog is None:
+        changelog = f"# Changelog\n\n## Unreleased\n\n## {package_version}\n"
+
+    (root / "src" / "causal4d").mkdir(parents=True)
+    (root / "ci").mkdir(parents=True)
+    (root / "src" / "causal4d" / "__init__.py").write_text(
+        f'__version__ = "{package_version}"\n',
+        encoding="utf-8",
+    )
+    (root / "CITATION.cff").write_text(
+        f"cff-version: 1.2.0\ntitle: Causal4D\nversion: {citation_version}\n",
+        encoding="utf-8",
+    )
+    (root / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "causal4d"\n'
+        'dynamic = ["version"]\n\n'
+        "[tool.setuptools.dynamic]\n"
+        f'version = {{ attr = "{setuptools_attribute}" }}\n',
+        encoding="utf-8",
+    )
+    (root / "ci" / "project_status_v2.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "causal4d": {
+                        "required_version": status_version,
+                    }
+                }
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "CHANGELOG.md").write_text(changelog, encoding="utf-8")
+    return root
+
+
+def test_current_repository_metadata_is_internally_consistent() -> None:
+    summary = inspect_repository(ROOT)
+
+    assert summary.package_version == summary.citation_version
+    assert summary.setuptools_version_attribute == "causal4d.__version__"
+    assert summary.tag_validated is False
+    assert summary.release_ready is (
+        not summary.prerelease
+        and summary.changelog_heading_present
+        and not summary.unreleased_changes_present
+        and summary.project_status_required_version == summary.package_version
+    )
+
+
+def test_current_release_tag_obeys_unreleased_boundary() -> None:
+    summary = inspect_repository(ROOT)
+
+    if summary.unreleased_changes_present:
+        with pytest.raises(ReleaseMetadataError, match="empty Unreleased"):
+            inspect_repository(ROOT, tag=f"v{summary.package_version}")
+    elif summary.prerelease:
+        with pytest.raises(ReleaseMetadataError, match="cannot be published"):
+            inspect_repository(ROOT, tag=f"v{summary.package_version}")
+    else:
+        tagged = inspect_repository(ROOT, tag=f"v{summary.package_version}")
+        assert tagged.tag_validated is True
+
+
+def test_clean_stable_release_validates_exact_tag(tmp_path: Path) -> None:
+    root = _write_fixture(tmp_path)
+
+    summary = inspect_repository(root, tag="v1.2.3")
+
+    assert summary.tag_validated is True
+    assert summary.release_ready is True
+    assert summary.unreleased_changes_present is False
+
+
+def test_release_tag_must_match_package_version(tmp_path: Path) -> None:
+    root = _write_fixture(tmp_path)
+
+    with pytest.raises(ReleaseMetadataError, match="release tag must be"):
+        inspect_repository(root, tag="v1.2.4")
+
+
+@pytest.mark.parametrize("version", ["2.0.0.dev0", "2.0.0rc1", "2.0.0a2", "2.0.0b3"])
+def test_prerelease_versions_are_non_publishable(version: str, tmp_path: Path) -> None:
+    root = _write_fixture(
+        tmp_path,
+        package_version=version,
+        status_version=version,
+        changelog="# Changelog\n\n## Unreleased\n\n- development work\n",
+    )
+
+    summary = inspect_repository(root)
+    assert summary.prerelease is True
+    assert summary.release_ready is False
+    with pytest.raises(ReleaseMetadataError, match="cannot be published"):
+        inspect_repository(root, tag=f"v{version}")
+
+
+def test_local_build_metadata_is_not_misclassified_as_prerelease(
+    tmp_path: Path,
+) -> None:
+    root = _write_fixture(
+        tmp_path,
+        package_version="1.2.3+build.7",
+        changelog="# Changelog\n\n## Unreleased\n\n## 1.2.3+build.7\n",
+    )
+
+    summary = inspect_repository(root)
+
+    assert summary.prerelease is False
+    assert summary.release_ready is True
+
+
+def test_citation_version_mismatch_fails_closed(tmp_path: Path) -> None:
+    root = _write_fixture(tmp_path, citation_version="1.2.4")
+
+    with pytest.raises(ReleaseMetadataError, match="CITATION.cff version"):
+        inspect_repository(root)
+
+
+def test_setuptools_version_source_mismatch_fails_closed(tmp_path: Path) -> None:
+    root = _write_fixture(tmp_path, setuptools_attribute="causal4d._version")
+
+    with pytest.raises(ReleaseMetadataError, match="setuptools must derive"):
+        inspect_repository(root)
+
+
+def test_project_status_version_mismatch_fails_closed(tmp_path: Path) -> None:
+    root = _write_fixture(tmp_path, status_version="1.2.2")
+
+    with pytest.raises(ReleaseMetadataError, match="project-status required_version"):
+        inspect_repository(root)
+
+
+def test_stable_version_requires_changelog_release_heading(tmp_path: Path) -> None:
+    root = _write_fixture(
+        tmp_path,
+        changelog="# Changelog\n\n## Unreleased\n",
+    )
+
+    with pytest.raises(ReleaseMetadataError, match="no exact"):
+        inspect_repository(root)

--- a/tests/test_release_metadata_workflow_policy.py
+++ b/tests/test_release_metadata_workflow_policy.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "release-metadata-integrity.yml"
+CHECKER = ROOT / "scripts" / "ci" / "check_release_metadata.py"
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_release_integrity_runs_for_metadata_changes_and_tags() -> None:
+    text = _workflow_text()
+
+    assert "name: Release metadata integrity" in text
+    assert "pull_request:" in text
+    assert "push:" in text
+    assert 'tags: ["v*"]' in text
+    assert "workflow_dispatch:" in text
+    for path in (
+        ".github/workflows/release-metadata-integrity.yml",
+        "CHANGELOG.md",
+        "CITATION.cff",
+        "ci/project_status_v2.json",
+        "pyproject.toml",
+        "scripts/ci/check_release_metadata.py",
+        "src/causal4d/__init__.py",
+        "tests/test_release_metadata_policy.py",
+        "tests/test_release_metadata_workflow_policy.py",
+    ):
+        assert text.count(f'"{path}"') == 2
+
+
+def test_release_integrity_is_read_only_and_pins_external_actions() -> None:
+    text = _workflow_text()
+
+    assert "permissions:\n  contents: read\n" in text
+    assert "contents: write" not in text
+    assert "packages: write" not in text
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("uses:"):
+            continue
+        reference = stripped.rsplit("@", maxsplit=1)[1].split()[0]
+        assert len(reference) == 40
+        assert all(character in "0123456789abcdef" for character in reference)
+
+
+def test_release_integrity_validates_tag_and_built_artifact_versions() -> None:
+    text = _workflow_text()
+
+    assert "check_release_metadata.py" in text
+    assert 'if [[ "${GITHUB_REF_TYPE}" == "tag" ]]' in text
+    assert 'arguments+=(--tag "${GITHUB_REF_NAME}")' in text
+    assert "python -m build --sdist --wheel" in text
+    assert "python -m twine check dist/*" in text
+    assert "parse_wheel_filename" in text
+    assert "parse_sdist_filename" in text
+    assert 'wheel_metadata["Version"]' in text
+    assert 'sdist_metadata["Version"]' in text
+    assert 'version("causal4d")' in text
+    assert "causal4d.__version__" in text
+    assert "distribution-sha256.txt" in text
+    assert "causal4d-release-metadata-integrity" in text
+
+
+def test_release_checker_fails_closed_on_unreleased_tagging() -> None:
+    text = CHECKER.read_text(encoding="utf-8")
+
+    assert "tagged releases require an empty Unreleased changelog section" in text
+    assert 'expected_tag = f"v{package_version}"' in text
+    assert "development/prerelease package versions cannot be published" in text
+    assert "project-status required_version does not match" in text
+    assert 'attribute != "causal4d.__version__"' in text

--- a/tests/test_three_repository_rolling_canary_policy.py
+++ b/tests/test_three_repository_rolling_canary_policy.py
@@ -4,9 +4,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-WORKFLOW = (
-    ROOT / ".github" / "workflows" / "three-repository-rolling-canary.yml"
-)
+WORKFLOW = ROOT / ".github" / "workflows" / "three-repository-rolling-canary.yml"
 
 
 def _text() -> str:

--- a/tests/test_three_repository_rolling_canary_policy.py
+++ b/tests/test_three_repository_rolling_canary_policy.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = (
+    ROOT / ".github" / "workflows" / "three-repository-rolling-canary.yml"
+)
+
+
+def _text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_canary_is_scheduled_manual_and_non_claim_bearing() -> None:
+    text = _text()
+
+    assert "name: Rolling three-repository compatibility canary" in text
+    assert "  workflow_dispatch:" in text
+    assert "  schedule:" in text
+    assert "pull_request:" not in text
+    assert "push:" not in text
+    assert "issues:" not in text
+    assert "CAUSAL4D_COMPATIBILITY_LANE: rolling-non-claim-bearing" in text
+    assert '"claim_bearing": False' in text
+    assert '"frozen_pins_used": False' in text
+    assert "does not update frozen pins" in text
+
+
+def test_canary_follows_all_three_current_default_branches() -> None:
+    text = _text()
+
+    assert "repository: IPS-Stuttgart/Causal4D" in text
+    assert "repository: IPS-Stuttgart/BayesianPhysTwin" in text
+    assert "repository: IPS-Stuttgart/Prob4D" in text
+    assert text.count("          ref: main\n") == 3
+    assert "bayesian-phystwin-three-repository.sha" not in text
+    assert "prob4d-three-repository.sha" not in text
+    assert "Record exact current-head revisions" in text
+    assert "rolling-three-repository-revisions.json" in text
+
+
+def test_canary_builds_installs_and_exercises_the_contract_stack() -> None:
+    text = _text()
+
+    assert "Build all current-head wheels" in text
+    assert text.count("python -m build --wheel") == 3
+    assert "Install current-head wheels in isolation" in text
+    assert "Verify imports originate only from installed wheels" in text
+    assert "source-tree import detected" in text
+    assert "Create and verify an ephemeral current-head stack lock" in text
+    assert "three_repository_golden_path.py" in text
+    assert "three_repository_provider_v2_attestation.py" in text
+    assert "Run focused current-head contract tests" in text
+    assert "test_claim_bearing_observation.py" in text
+    assert "test_prob4d_causal_lineage.py" in text
+    assert "test_decision_trace.py" in text
+    assert "three-repository-rolling-canary" in text
+
+
+def test_canary_pins_external_actions_and_has_read_only_permissions() -> None:
+    text = _text()
+
+    assert "permissions:\n  contents: read\n" in text
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("uses:"):
+            continue
+        reference = stripped.rsplit("@", maxsplit=1)[1].split()[0]
+        assert len(reference) == 40
+        assert all(character in "0123456789abcdef" for character in reference)


### PR DESCRIPTION
## Summary

- move concurrency for six issue-command workflows behind their authenticated job guards, set `cancel-in-progress: false`, and serialize accepted commands with `queue: max`
- add a daily/manual, explicitly non-claim-bearing compatibility canary against the current `main` branches of Causal4D, BayesianPhysTwin, and Prob4D
- add a fail-closed release metadata and built-distribution integrity gate
- add focused policy tests and document the frozen-versus-rolling compatibility boundary

## Root cause fixed

The issue-command workflows subscribed to every opened issue while defining concurrency at workflow scope. An unrelated issue event at the same repository SHA could therefore enter the same concurrency group before the authenticated job guard was evaluated and replace a pending authorized command. Concurrency now exists only on the authenticated execution job, so unrelated issue events create no concurrency participant.

## Claim boundary

This change does **not** modify an estimator, inference result, registered experimental protocol, frozen BayesianPhysTwin/Prob4D pin, immutable evidence artifact, target boundary, or physical-evidence count. The rolling lane is labelled non-claim-bearing and cannot rewrite the frozen lane.

## Validation

- `24 passed` across the focused new and adjacent policy tests
- all eight added or modified workflow files parse as YAML
- every embedded Bash `run` block in those workflows passes `bash -n`
- added Python files compile and satisfy the repository formatter and 88-column limit
- reverse-transform blob verification confirmed that each of the six existing workflows changed only by relocating concurrency and adding queue serialization
- the final branch is two commits ahead of `main` with exactly 14 changed files
- all pull-request workflows are green:
  - Causal4D merge gate, including the complete default suite, distribution build, and pinned installed-wheel provider integration
  - CI and release
  - Extended compatibility
  - Security scanning, including dependency audit and CodeQL for Python and Actions
  - Release metadata integrity
