### PR TITLE
Add recursive BayesianPhysTwin belief handoff

### DIFF
--- a/.github/workflows/recursive-belief-handoff-integration.yml
+++ b/.github/workflows/recursive-belief-handoff-integration.yml
@@ -1,0 +1,123 @@
+name: Recursive belief-handoff installed-wheel integration
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/recursive-belief-handoff-integration.yml"
+      - "docs/recursive_bayesian_phystwin_handoff.md"
+      - "src/causal4d/belief_provider_v2_recursive_contract.py"
+      - "src/causal4d/recursive_bpt_handoff_contract.py"
+      - "src/causal4d/recursive_bpt_belief_handoff.py"
+      - "tests/test_belief_provider_v2_recursive_contract.py"
+      - "tests/test_recursive_bpt_belief_handoff.py"
+      - "tests/test_recursive_bpt_belief_handoff_workflow_policy.py"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/recursive-belief-handoff-integration.yml"
+      - "docs/recursive_bayesian_phystwin_handoff.md"
+      - "src/causal4d/belief_provider_v2_recursive_contract.py"
+      - "src/causal4d/recursive_bpt_handoff_contract.py"
+      - "src/causal4d/recursive_bpt_belief_handoff.py"
+      - "tests/test_belief_provider_v2_recursive_contract.py"
+      - "tests/test_recursive_bpt_belief_handoff.py"
+      - "tests/test_recursive_bpt_belief_handoff_workflow_policy.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: recursive-belief-handoff-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  installed-wheel-contract:
+    name: BPT recursive stream -> Causal4D belief handoff
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact Causal4D revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          path: causal4d
+          persist-credentials: false
+
+      - name: Verify tested Causal4D revision
+        working-directory: causal4d
+        env:
+          EXPECTED_CAUSAL4D_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          actual_sha="$(git rev-parse HEAD)"
+          test "$actual_sha" = "$EXPECTED_CAUSAL4D_SHA"
+          echo "Tested Causal4D revision: $actual_sha"
+
+      - name: Check out exact BayesianPhysTwin recursive-provider revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/BayesianPhysTwin
+          ref: d2b38ce72a0ecb07cce7e252a0af6fb32c9411dc
+          path: bayesian-phystwin
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            causal4d/pyproject.toml
+            bayesian-phystwin/pyproject.toml
+
+      - name: Build both wheels
+        run: |
+          python -m pip install --upgrade build pip
+          wheelhouse="$RUNNER_TEMP/recursive-belief-handoff-wheelhouse"
+          mkdir -p "$wheelhouse"
+          python -m build --wheel --outdir "$wheelhouse" bayesian-phystwin
+          python -m build --wheel --outdir "$wheelhouse" causal4d
+          test "$(find "$wheelhouse" -maxdepth 1 -name '*.whl' | wc -l)" -eq 2
+
+      - name: Install wheels in an isolated environment
+        run: |
+          venv="$RUNNER_TEMP/recursive-belief-handoff-venv"
+          wheelhouse="$RUNNER_TEMP/recursive-belief-handoff-wheelhouse"
+          python -m venv "$venv"
+          "$venv/bin/python" -m pip install --upgrade pip
+          mapfile -t wheels < <(find "$wheelhouse" -maxdepth 1 -name '*.whl' -print | sort)
+          "$venv/bin/python" -m pip install "${wheels[@]}" pytest
+          "$venv/bin/python" -m pip check
+
+      - name: Exercise the installed recursive handoff contract
+        run: |
+          cd "$RUNNER_TEMP"
+          env -u PYTHONPATH \
+            "$RUNNER_TEMP/recursive-belief-handoff-venv/bin/python" -m pytest -q \
+              --import-mode=importlib \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_belief_provider_v2_contract.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_belief_provider_v2_recursive_contract.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_recursive_bpt_belief_handoff.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_recursive_bpt_belief_handoff_workflow_policy.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_evidence_ownership.py" \
+              "$GITHUB_WORKSPACE/causal4d/tests/test_bpt_provider_import_boundary.py"
+
+      - name: Check Causal4D source quality
+        if: always()
+        run: |
+          python -m pip install "ruff>=0.15.22,<0.17"
+          python -m ruff check \
+            causal4d/src/causal4d/belief_provider_v2_recursive_contract.py \
+            causal4d/src/causal4d/recursive_bpt_handoff_contract.py \
+            causal4d/src/causal4d/recursive_bpt_belief_handoff.py \
+            causal4d/tests/test_belief_provider_v2_recursive_contract.py \
+            causal4d/tests/test_recursive_bpt_belief_handoff.py \
+            causal4d/tests/test_recursive_bpt_belief_handoff_workflow_policy.py
+          python -m ruff format --check --diff \
+            causal4d/src/causal4d/belief_provider_v2_recursive_contract.py \
+            causal4d/src/causal4d/recursive_bpt_handoff_contract.py \
+            causal4d/src/causal4d/recursive_bpt_belief_handoff.py \
+            causal4d/tests/test_belief_provider_v2_recursive_contract.py \
+            causal4d/tests/test_recursive_bpt_belief_handoff.py \
+            causal4d/tests/test_recursive_bpt_belief_handoff_workflow_policy.py

--- a/docs/recursive_bayesian_phystwin_handoff.md
+++ b/docs/recursive_bayesian_phystwin_handoff.md
@@ -1,0 +1,114 @@
+# Recursive BayesianPhysTwin belief handoff
+
+## Scope
+
+`causal4d.recursive_bpt_belief_handoff` is an additive ownership boundary for a
+completed BayesianPhysTwin recursive Prob4D stream run. It consumes the selected
+complete BayesianPhysTwin belief; it does not reopen or reinterpret the raw
+Prob4D factor bundles.
+
+The existing `causal4d.belief_provider_v2_contract` remains the narrow contract
+for model-averaged endpoint and horizon-discrepancy use. The separate
+`causal4d.belief_provider_v2_recursive_contract` requires the complete recursive
+provider-v2 surface:
+
+- append-only Prob4D stream validation;
+- complete-belief candidate or exact-prior routing;
+- persistent recursive nuisance policy;
+- fixed provider, calibration, and runtime identities;
+- explicit posterior-covariance semantics; and
+- immutable stream-step and stream-run records.
+
+No existing provider or handoff API changes behavior.
+
+## Handoff
+
+A claim-bearing caller first completes a BayesianPhysTwin
+`ClaimBearingProb4DStreamRunV1`. It then converts the selected complete belief to
+one Causal4D `TwinBelief` with the same causal context, particle identities,
+physical-parameter support, and state shape.
+
+```python
+from causal4d.recursive_bpt_belief_handoff import (
+    bind_recursive_bayesian_phystwin_belief_handoff,
+)
+
+bound = bind_recursive_bayesian_phystwin_belief_handoff(
+    stream_run,
+    selected_bpt_belief,
+    baseline_belief=causal4d_baseline,
+    candidate_belief=causal4d_candidate,
+    prob4d_source_revision=prob4d_revision,
+)
+```
+
+The selected BayesianPhysTwin artifact identity must equal
+`stream_run.final_belief_id`. The run and every step must bind the installed
+recursive provider manifest, one recursive nuisance policy, one covariance
+policy, one calibration-artifact set, and independently verified runtime
+revision evidence.
+
+The Causal4D candidate may contain updated state, discrepancy, and particle
+weights. It may not relabel particles, change physical-parameter values, change
+the endpoint, change the causal context, or change the state shape.
+
+## Evidence ownership
+
+Each accepted stream member appends exactly one `state_update` record to the
+existing `ConsumedEvidenceLedgerV1`. The record binds:
+
+- the stream, run, step, and stream-update identities;
+- the claim-bearing update and underlying observation-factor identities;
+- the observation binding and physical linearization;
+- guard, selection, covariance-semantics, covariance-policy, and nuisance-policy
+  identities; and
+- the member's half-open causal frame interval.
+
+Rejected members append nothing. Their exact fallback status remains visible in
+the recursive run and handoff receipt, but a factor that did not enter the final
+posterior is not recorded as consumed posterior evidence.
+
+The ledger rejects duplicate updates, duplicate raw factors, relabelled source
+bytes, and incompatible cross-stage use. Several accepted recursive members may
+share one correlation group because BayesianPhysTwin has already evaluated them
+through one explicitly persistent nuisance policy.
+
+## Exact fallback
+
+When every stream member falls back, all of the following are required:
+
+- the selected BayesianPhysTwin belief equals the stream's initial belief;
+- the supplied Causal4D candidate is the exact baseline artifact;
+- the prior evidence ledger is unchanged;
+- zero Prob4D factors are consumed; and
+- the returned Causal4D belief is the original baseline object.
+
+When at least one member is accepted, the returned belief embeds the complete
+ownership ledger and a compact recursive handoff descriptor. The
+content-addressed receipt separately lists accepted and fallback step IDs and
+binds the selected BayesianPhysTwin and delivered Causal4D belief identities.
+
+## Causal interval
+
+Every admitted member must lie inside the Causal4D pre-intervention observation
+window. Member intervals must be ordered and non-overlapping. A member that
+begins before the declared prefix, crosses its exclusive stop, or overlaps a
+preceding member fails before the Causal4D belief or ledger is changed.
+
+## Scientific boundary
+
+The recursive provider contract and handoff establish software compatibility,
+identity, causal-prefix integrity, complete-belief routing, covariance-policy
+provenance, exact fallback, and evidence ownership. They do not establish:
+
+- real Prob4D provider competence;
+- calibrated predictive uncertainty;
+- physical-state or intervention identifiability;
+- improvement on a fresh object or acquisition session;
+- Causal4D counterfactual benefit;
+- deployment safety; or
+- state of the art.
+
+This path is prospective infrastructure. It does not modify the frozen
+18-session/36-execution estimator, admit Prob4D into that primary method, open a
+target outcome, or increment physical evidence.

--- a/src/causal4d/belief_provider_v2_recursive_contract.py
+++ b/src/causal4d/belief_provider_v2_recursive_contract.py
@@ -116,12 +116,66 @@ def require_bayesian_phystwin_belief_provider_v2_recursive(
     return manifest
 
 
+# Compatibility names used by the initial recursive-handoff prototype. These
+# delegate to the canonical contract above; no second validator is maintained.
+BAYESIAN_PHYSTWIN_RECURSIVE_BELIEF_PROVIDER_V2_CAPABILITIES = (
+    BAYESIAN_PHYSTWIN_BELIEF_V2_COMPLETE_CAPABILITIES
+)
+BAYESIAN_PHYSTWIN_RECURSIVE_BELIEF_V2_ARTIFACT_SCHEMA_VERSIONS = (
+    BAYESIAN_PHYSTWIN_BELIEF_V2_COMPLETE_ARTIFACT_SCHEMA_VERSIONS
+)
+BAYESIAN_PHYSTWIN_RECURSIVE_STREAM_CLAIM = (
+    BAYESIAN_PHYSTWIN_BELIEF_V2_RECURSIVE_STREAM_CLAIM
+)
+
+
+def load_bayesian_phystwin_recursive_belief_provider_v2_manifest(
+    *,
+    provider_revision: str | None = None,
+) -> PhysicalBeliefProviderManifest:
+    """Load the complete recursive provider through the canonical loader."""
+
+    return load_bayesian_phystwin_belief_provider_v2_manifest(
+        provider_revision=provider_revision
+    )
+
+
+def validate_bayesian_phystwin_recursive_belief_provider_v2(
+    manifest: PhysicalBeliefProviderManifest | None = None,
+    *,
+    provider_revision: str | None = None,
+) -> ProviderCompatibilityResult:
+    """Validate the complete recursive provider through the canonical contract."""
+
+    return validate_bayesian_phystwin_belief_provider_v2_recursive(
+        manifest,
+        provider_revision=provider_revision,
+    )
+
+
+def require_bayesian_phystwin_recursive_belief_provider_v2(
+    *,
+    provider_revision: str | None = None,
+) -> PhysicalBeliefProviderManifest:
+    """Require the complete recursive provider through the canonical contract."""
+
+    return require_bayesian_phystwin_belief_provider_v2_recursive(
+        provider_revision=provider_revision
+    )
+
+
 __all__ = [
     "BAYESIAN_PHYSTWIN_BELIEF_V2_COMPLETE_ARTIFACT_SCHEMA_VERSIONS",
     "BAYESIAN_PHYSTWIN_BELIEF_V2_COMPLETE_CAPABILITIES",
     "BAYESIAN_PHYSTWIN_BELIEF_V2_RECURSIVE_ARTIFACT_SCHEMA_VERSIONS",
     "BAYESIAN_PHYSTWIN_BELIEF_V2_RECURSIVE_CAPABILITIES",
     "BAYESIAN_PHYSTWIN_BELIEF_V2_RECURSIVE_STREAM_CLAIM",
+    "BAYESIAN_PHYSTWIN_RECURSIVE_BELIEF_PROVIDER_V2_CAPABILITIES",
+    "BAYESIAN_PHYSTWIN_RECURSIVE_BELIEF_V2_ARTIFACT_SCHEMA_VERSIONS",
+    "BAYESIAN_PHYSTWIN_RECURSIVE_STREAM_CLAIM",
+    "load_bayesian_phystwin_recursive_belief_provider_v2_manifest",
     "require_bayesian_phystwin_belief_provider_v2_recursive",
+    "require_bayesian_phystwin_recursive_belief_provider_v2",
     "validate_bayesian_phystwin_belief_provider_v2_recursive",
+    "validate_bayesian_phystwin_recursive_belief_provider_v2",
 ]

--- a/src/causal4d/recursive_bpt_belief_handoff.py
+++ b/src/causal4d/recursive_bpt_belief_handoff.py
@@ -1,0 +1,434 @@
+"""Strict recursive BayesianPhysTwin-to-Causal4D belief handoff."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from causal4d.belief_provider_v2_recursive_contract import (
+    require_bayesian_phystwin_recursive_belief_provider_v2,
+)
+from causal4d.contracts import TwinBelief
+from causal4d.evidence_ownership import (
+    ConsumedEvidenceLedgerV1,
+    EvidenceConsumptionV1,
+)
+from causal4d.immutable_json import plain_json, validated_json_mapping
+from causal4d.recursive_bpt_handoff_contract import (
+    RECURSIVE_BPT_BELIEF_HANDOFF_ARTIFACT_KIND,
+    RECURSIVE_BPT_BELIEF_HANDOFF_CLAIM_BOUNDARY,
+    RECURSIVE_BPT_BELIEF_HANDOFF_METADATA_KEY,
+    RECURSIVE_BPT_BELIEF_HANDOFF_SCHEMA_VERSION,
+    RecursiveBayesianPhysTwinBeliefHandoffReceiptV1,
+    _calibrations,
+    _revision,
+    _sha256,
+    _string,
+)
+
+
+def _embedded_ledger(belief: TwinBelief) -> ConsumedEvidenceLedgerV1 | None:
+    value = belief.metadata.get("consumed_evidence_ledger")
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ValueError("belief embeds an invalid consumed-evidence ledger")
+    payload = plain_json(value)
+    if not isinstance(payload, dict):
+        raise ValueError("belief embeds an invalid consumed-evidence ledger")
+    try:
+        return ConsumedEvidenceLedgerV1.from_dict(payload)
+    except (TypeError, ValueError) as error:
+        raise ValueError("belief embeds an invalid consumed-evidence ledger") from error
+
+
+def _validate_ledger(
+    ledger: ConsumedEvidenceLedgerV1,
+    belief: TwinBelief,
+) -> None:
+    if not isinstance(ledger, ConsumedEvidenceLedgerV1):
+        raise TypeError("prior_evidence_ledger must be ConsumedEvidenceLedgerV1")
+    if ledger.protocol_id != belief.context.protocol_id:
+        raise ValueError("evidence ledger identifies a different protocol")
+    if ledger.case_id != belief.context.case_id:
+        raise ValueError("evidence ledger identifies a different case")
+    if ledger.causal_frame_stop != belief.context.o_minus.frame_stop:
+        raise ValueError("evidence ledger and causal prefix stops differ")
+    embedded = _embedded_ledger(belief)
+    if embedded is not None and embedded.as_dict() != ledger.as_dict():
+        raise ValueError(
+            "supplied evidence ledger differs from the ledger embedded in the belief"
+        )
+
+
+def _prior_ledger(
+    baseline: TwinBelief,
+    candidate: TwinBelief,
+    supplied: ConsumedEvidenceLedgerV1 | None,
+) -> ConsumedEvidenceLedgerV1:
+    ledger = supplied or _embedded_ledger(baseline) or _embedded_ledger(candidate)
+    if ledger is None:
+        ledger = ConsumedEvidenceLedgerV1(
+            protocol_id=baseline.context.protocol_id,
+            case_id=baseline.context.case_id,
+            causal_frame_stop=baseline.context.o_minus.frame_stop,
+        )
+    _validate_ledger(ledger, baseline)
+    _validate_ledger(ledger, candidate)
+    return ledger
+
+
+def _validate_candidate(baseline: TwinBelief, candidate: TwinBelief) -> None:
+    if candidate.context.as_dict() != baseline.context.as_dict():
+        raise ValueError("candidate belief identifies a different causal context")
+    if candidate.endpoint_frame != baseline.endpoint_frame:
+        raise ValueError("candidate belief endpoint frame changed")
+    if candidate.particle_ids != baseline.particle_ids:
+        raise ValueError("candidate belief particle identities changed")
+    if candidate.theta_names != baseline.theta_names:
+        raise ValueError("candidate belief parameter names changed")
+    if not np.array_equal(candidate.theta, baseline.theta):
+        raise ValueError("candidate belief physical parameters changed")
+    if candidate.endpoint_position_m.shape != baseline.endpoint_position_m.shape:
+        raise ValueError("candidate belief physical-state shape changed")
+
+
+@dataclass(frozen=True)
+class BoundRecursiveBayesianPhysTwinBeliefV1:
+    """Delivered belief with its recursive ownership ledger and receipt."""
+
+    belief: TwinBelief
+    evidence_ledger: ConsumedEvidenceLedgerV1
+    receipt: RecursiveBayesianPhysTwinBeliefHandoffReceiptV1
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.belief, TwinBelief):
+            raise TypeError("belief must be a TwinBelief")
+        if not isinstance(self.evidence_ledger, ConsumedEvidenceLedgerV1):
+            raise TypeError("evidence_ledger must be ConsumedEvidenceLedgerV1")
+        if not isinstance(
+            self.receipt,
+            RecursiveBayesianPhysTwinBeliefHandoffReceiptV1,
+        ):
+            raise TypeError("receipt has the wrong recursive handoff type")
+        if self.belief.artifact_id != self.receipt.delivered_belief_id:
+            raise ValueError("delivered belief and recursive receipt identities differ")
+        if self.evidence_ledger.artifact_id != self.receipt.evidence_ledger_id:
+            raise ValueError("evidence ledger and recursive receipt identities differ")
+        embedded = _embedded_ledger(self.belief)
+        if self.receipt.accepted_step_count and embedded is None:
+            raise ValueError("accepted recursive belief omits its evidence ledger")
+        if (
+            embedded is not None
+            and embedded.as_dict() != self.evidence_ledger.as_dict()
+        ):
+            raise ValueError("delivered belief embeds a different evidence ledger")
+
+
+def _bound_belief(
+    candidate: TwinBelief,
+    *,
+    run: Any,
+    selected_bpt_belief_id: str,
+    evidence_ledger: ConsumedEvidenceLedgerV1,
+    accepted_step_count: int,
+    exact_fallback_count: int,
+) -> TwinBelief:
+    metadata = plain_json(candidate.metadata)
+    if not isinstance(metadata, dict):
+        raise ValueError("candidate belief metadata must be a JSON object")
+    if RECURSIVE_BPT_BELIEF_HANDOFF_METADATA_KEY in metadata:
+        raise ValueError("candidate belief already contains a recursive handoff")
+    metadata["consumed_evidence_ledger"] = evidence_ledger.as_dict()
+    metadata[RECURSIVE_BPT_BELIEF_HANDOFF_METADATA_KEY] = {
+        "schema_version": RECURSIVE_BPT_BELIEF_HANDOFF_SCHEMA_VERSION,
+        "stream_artifact_id": run.stream_artifact_id,
+        "stream_run_id": run.run_id,
+        "final_stream_step_id": run.steps[-1].step_id,
+        "selected_bpt_belief_id": selected_bpt_belief_id,
+        "provider_manifest_id": run.provider_manifest_id,
+        "recursive_nuisance_policy_id": run.recursive_nuisance_policy_id,
+        "covariance_policy_id": run.covariance_policy_id,
+        "accepted_step_count": accepted_step_count,
+        "exact_fallback_count": exact_fallback_count,
+        "evidence_consumed_count": accepted_step_count,
+        "raw_prob4d_reinterpreted": False,
+    }
+    return TwinBelief(
+        context=candidate.context,
+        endpoint_frame=candidate.endpoint_frame,
+        particle_ids=candidate.particle_ids,
+        theta_names=candidate.theta_names,
+        endpoint_position_m=candidate.endpoint_position_m,
+        endpoint_velocity_mps=candidate.endpoint_velocity_mps,
+        theta=candidate.theta,
+        discrepancy_mean_m=candidate.discrepancy_mean_m,
+        discrepancy_variance_m2=candidate.discrepancy_variance_m2,
+        weights=candidate.weights,
+        metadata=metadata,
+    )
+
+
+def _classify_steps(
+    run: Any,
+    *,
+    stream_id: str,
+    provider_manifest_id: str,
+    nuisance_policy_id: str,
+    covariance_policy_id: str,
+    prefix_start: int,
+    prefix_stop: int,
+) -> tuple[list[tuple[str, Any]], list[tuple[str, Any]]]:
+    accepted_steps = []
+    fallback_steps = []
+    previous_stop: int | None = None
+    for index, step in enumerate(run.steps):
+        step_id = _sha256(step.step_id, name=f"steps[{index}].step_id")
+        if step.stream_artifact_id != stream_id:
+            raise ValueError("recursive step identifies a different stream")
+        if step.provider_manifest_id != provider_manifest_id:
+            raise ValueError("recursive step provider manifest changed")
+        if step.recursive_nuisance_policy_id != nuisance_policy_id:
+            raise ValueError("recursive step nuisance policy changed")
+        if step.covariance_policy_id != covariance_policy_id:
+            raise ValueError("recursive step covariance policy changed")
+        if step.admitted_frame_start < prefix_start:
+            raise ValueError("recursive step begins before the Causal4D prefix")
+        if step.causal_frame_stop > prefix_stop:
+            raise ValueError("recursive step crosses the Causal4D causal prefix")
+        if previous_stop is not None and step.admitted_frame_start < previous_stop:
+            raise ValueError("recursive step intervals overlap")
+        previous_stop = step.causal_frame_stop
+        if step.selected_candidate is True and step.exact_fallback is False:
+            accepted_steps.append((step_id, step))
+        elif step.selected_candidate is False and step.exact_fallback is True:
+            fallback_steps.append((step_id, step))
+        else:
+            raise ValueError("recursive step selection and fallback flags disagree")
+    return accepted_steps, fallback_steps
+
+
+def _consumption(
+    step_id: str,
+    step: Any,
+    *,
+    run_id: str,
+    stream_id: str,
+    source_repository: str,
+    source_revision: str,
+    clock_id: str,
+    correlation_group_id: str,
+    covariance_policy_id: str,
+    nuisance_policy_id: str,
+) -> EvidenceConsumptionV1:
+    return EvidenceConsumptionV1(
+        evidence_id=_sha256(step.claim_update_id, name="claim_update_id"),
+        raw_factor_id=_sha256(
+            step.observation_artifact_id,
+            name="observation_artifact_id",
+        ),
+        source_repository=source_repository,
+        source_revision=source_revision,
+        sensor_family="prob4d_observation_factor",
+        stream_id=stream_id,
+        clock_id=clock_id,
+        correlation_group_id=correlation_group_id,
+        frame_start=step.admitted_frame_start,
+        frame_stop=step.causal_frame_stop,
+        role="state_update",
+        source_file_sha256=step.observation_artifact_id,
+        metadata={
+            "stream_run_id": run_id,
+            "stream_step_id": step_id,
+            "stream_update_id": step.stream_update_id,
+            "observation_binding_id": step.observation_binding_id,
+            "linearization_artifact_id": step.linearization_artifact_id,
+            "guard_decision_id": step.guard_decision_id,
+            "selection_id": step.selection_id,
+            "covariance_semantics_id": step.covariance_semantics_id,
+            "covariance_policy_id": covariance_policy_id,
+            "recursive_nuisance_policy_id": nuisance_policy_id,
+            "selected_candidate": True,
+            "exact_fallback": False,
+        },
+    )
+
+
+def bind_recursive_bayesian_phystwin_belief_handoff(
+    run: object,
+    selected_bpt_belief: object,
+    *,
+    baseline_belief: TwinBelief,
+    candidate_belief: TwinBelief,
+    prob4d_source_revision: str,
+    prior_evidence_ledger: ConsumedEvidenceLedgerV1 | None = None,
+    prob4d_source_repository: str = "IPS-Stuttgart/Prob4D",
+    correlation_group_id: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> BoundRecursiveBayesianPhysTwinBeliefV1:
+    """Bind one populated recursive BPT run to a Causal4D twin belief."""
+
+    from bayesian_phystwin.causal4d_belief_provider_v2 import (
+        ClaimBearingProb4DStreamRunV1,
+    )
+
+    if not isinstance(run, ClaimBearingProb4DStreamRunV1):
+        raise TypeError("run must be ClaimBearingProb4DStreamRunV1")
+    if not isinstance(baseline_belief, TwinBelief):
+        raise TypeError("baseline_belief must be a TwinBelief")
+    if not isinstance(candidate_belief, TwinBelief):
+        raise TypeError("candidate_belief must be a TwinBelief")
+    if not run.steps:
+        raise ValueError("recursive handoff requires a populated stream run")
+    _validate_candidate(baseline_belief, candidate_belief)
+    source_repository = _string(
+        prob4d_source_repository,
+        name="prob4d_source_repository",
+    )
+    source_revision = _revision(
+        prob4d_source_revision,
+        name="prob4d_source_revision",
+    )
+    receipt_metadata = validated_json_mapping(
+        metadata or {},
+        error_message="recursive handoff metadata must be finite JSON",
+    )
+
+    manifest = require_bayesian_phystwin_recursive_belief_provider_v2()
+    if run.provider_manifest_id != manifest.manifest_id:
+        raise ValueError("recursive run binds a different provider manifest")
+    run_id = _sha256(run.run_id, name="stream_run_id")
+    stream_id = _sha256(run.stream_artifact_id, name="stream_artifact_id")
+    initial_bpt_id = _sha256(
+        run.initial_belief_id,
+        name="initial_bpt_belief_id",
+    )
+    selected_bpt_id = _sha256(
+        getattr(selected_bpt_belief, "artifact_id", None),
+        name="selected_bpt_belief.artifact_id",
+    )
+    if selected_bpt_id != run.final_belief_id:
+        raise ValueError("selected BPT belief does not match the recursive run")
+    nuisance_policy_id = _sha256(
+        run.recursive_nuisance_policy_id,
+        name="recursive_nuisance_policy_id",
+    )
+    covariance_policy_id = _sha256(
+        run.covariance_policy_id,
+        name="covariance_policy_id",
+    )
+    calibration_ids = _calibrations(run.calibration_artifact_ids)
+    runtime_source = _string(
+        run.runtime_revision_source,
+        name="runtime_revision_source",
+    )
+    if run.runtime_revision_independently_verified is not True:
+        raise ValueError("recursive run lacks independently verified runtime evidence")
+
+    accepted_steps, fallback_steps = _classify_steps(
+        run,
+        stream_id=stream_id,
+        provider_manifest_id=manifest.manifest_id,
+        nuisance_policy_id=nuisance_policy_id,
+        covariance_policy_id=covariance_policy_id,
+        prefix_start=baseline_belief.context.o_minus.frame_start,
+        prefix_stop=baseline_belief.context.o_minus.frame_stop,
+    )
+    ledger = _prior_ledger(
+        baseline_belief,
+        candidate_belief,
+        prior_evidence_ledger,
+    )
+    accepted_count = len(accepted_steps)
+    fallback_count = len(fallback_steps)
+    if accepted_count == 0:
+        if candidate_belief.artifact_id != baseline_belief.artifact_id:
+            raise ValueError(
+                "an all-fallback run must retain the exact baseline belief"
+            )
+        if selected_bpt_id != initial_bpt_id:
+            raise ValueError("an all-fallback run changed the BPT belief")
+        next_ledger = ledger
+        delivered = baseline_belief
+        exact_baseline = True
+    else:
+        if candidate_belief.artifact_id == baseline_belief.artifact_id:
+            raise ValueError("an accepted recursive run requires a candidate belief")
+        group_id = _string(
+            correlation_group_id or nuisance_policy_id,
+            name="correlation_group_id",
+        )
+        consumptions = tuple(
+            _consumption(
+                step_id,
+                step,
+                run_id=run_id,
+                stream_id=stream_id,
+                source_repository=source_repository,
+                source_revision=source_revision,
+                clock_id=baseline_belief.context.o_minus.content_sha256,
+                correlation_group_id=group_id,
+                covariance_policy_id=covariance_policy_id,
+                nuisance_policy_id=nuisance_policy_id,
+            )
+            for step_id, step in accepted_steps
+        )
+        next_ledger = ledger.extend(*consumptions)
+        delivered = _bound_belief(
+            candidate_belief,
+            run=run,
+            selected_bpt_belief_id=selected_bpt_id,
+            evidence_ledger=next_ledger,
+            accepted_step_count=accepted_count,
+            exact_fallback_count=fallback_count,
+        )
+        exact_baseline = False
+
+    receipt = RecursiveBayesianPhysTwinBeliefHandoffReceiptV1(
+        protocol_id=baseline_belief.context.protocol_id,
+        case_id=baseline_belief.context.case_id,
+        causal_frame_stop=baseline_belief.context.o_minus.frame_stop,
+        stream_artifact_id=stream_id,
+        stream_run_id=run_id,
+        stream_step_count=len(run.steps),
+        accepted_step_count=accepted_count,
+        exact_fallback_count=fallback_count,
+        accepted_step_ids=tuple(step_id for step_id, _ in accepted_steps),
+        exact_fallback_step_ids=tuple(step_id for step_id, _ in fallback_steps),
+        final_stream_step_id=run.steps[-1].step_id,
+        initial_bpt_belief_id=initial_bpt_id,
+        selected_bpt_belief_id=selected_bpt_id,
+        provider_manifest_id=manifest.manifest_id,
+        calibration_artifact_ids=calibration_ids,
+        runtime_revision_source=runtime_source,
+        covariance_policy_id=covariance_policy_id,
+        recursive_nuisance_policy_id=nuisance_policy_id,
+        prob4d_source_repository=source_repository,
+        prob4d_source_revision=source_revision,
+        baseline_belief_id=baseline_belief.artifact_id,
+        delivered_belief_id=delivered.artifact_id,
+        evidence_consumed_count=accepted_count,
+        evidence_ledger_id=next_ledger.artifact_id,
+        exact_baseline_retained=exact_baseline,
+        raw_prob4d_reinterpreted=False,
+        metadata=receipt_metadata,
+    )
+    return BoundRecursiveBayesianPhysTwinBeliefV1(
+        belief=delivered,
+        evidence_ledger=next_ledger,
+        receipt=receipt,
+    )
+
+
+__all__ = [
+    "RECURSIVE_BPT_BELIEF_HANDOFF_ARTIFACT_KIND",
+    "RECURSIVE_BPT_BELIEF_HANDOFF_CLAIM_BOUNDARY",
+    "RECURSIVE_BPT_BELIEF_HANDOFF_METADATA_KEY",
+    "RECURSIVE_BPT_BELIEF_HANDOFF_SCHEMA_VERSION",
+    "BoundRecursiveBayesianPhysTwinBeliefV1",
+    "RecursiveBayesianPhysTwinBeliefHandoffReceiptV1",
+    "bind_recursive_bayesian_phystwin_belief_handoff",
+]

--- a/src/causal4d/recursive_bpt_handoff_contract.py
+++ b/src/causal4d/recursive_bpt_handoff_contract.py
@@ -1,0 +1,301 @@
+"""Content-addressed contract for recursive BayesianPhysTwin handoffs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field, fields as dataclass_fields
+import hashlib
+import json
+from typing import Any
+
+from causal4d.immutable_json import plain_json, validated_json_mapping
+
+
+RECURSIVE_BPT_BELIEF_HANDOFF_SCHEMA_VERSION = 1
+RECURSIVE_BPT_BELIEF_HANDOFF_ARTIFACT_KIND = (
+    "RecursiveBayesianPhysTwinBeliefHandoffReceipt"
+)
+RECURSIVE_BPT_BELIEF_HANDOFF_METADATA_KEY = "bayesian_phystwin_recursive_handoff"
+RECURSIVE_BPT_BELIEF_HANDOFF_CLAIM_BOUNDARY = (
+    "This receipt establishes recursive stream, provider, complete-belief, "
+    "causal-prefix, covariance-policy, and evidence-ownership identities. It "
+    "does not establish Prob4D provider competence, empirical calibration, "
+    "physical benefit, Causal4D intervention benefit, deployment safety, or "
+    "state of the art."
+)
+
+
+def _canonical_id(value: Any) -> str:
+    payload = json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _string(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _sha256(value: Any, *, name: str) -> str:
+    result = _string(value, name=name)
+    if len(result) != 64 or any(
+        character not in "0123456789abcdef" for character in result
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return result
+
+
+def _revision(value: Any, *, name: str) -> str:
+    result = _string(value, name=name).lower()
+    if len(result) != 40 or any(
+        character not in "0123456789abcdef" for character in result
+    ):
+        raise ValueError(f"{name} must be a 40-character hexadecimal revision")
+    return result
+
+
+def _count(value: Any, *, name: str, minimum: int = 0) -> int:
+    if type(value) is not int or value < minimum:
+        raise ValueError(f"{name} must be an integer of at least {minimum}")
+    return value
+
+
+def _boolean(value: Any, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise TypeError(f"{name} must be a bool")
+    return value
+
+
+def _digests(
+    values: Sequence[str],
+    *,
+    name: str,
+    expected_count: int,
+) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)):
+        raise ValueError(f"{name} must be a sequence of digests")
+    result = tuple(
+        _sha256(value, name=f"{name}[{index}]") for index, value in enumerate(values)
+    )
+    if len(result) != expected_count:
+        raise ValueError(f"{name} must contain {expected_count} entries")
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must not contain duplicates")
+    return result
+
+
+def _calibrations(values: Mapping[str, str]) -> Mapping[str, str]:
+    if not isinstance(values, Mapping) or not values:
+        raise ValueError("calibration_artifact_ids must be a nonempty mapping")
+    result: dict[str, str] = {}
+    for raw_name, raw_value in values.items():
+        name = _string(raw_name, name="calibration artifact name")
+        if name in result:
+            raise ValueError("calibration artifact names must be unique")
+        result[name] = _sha256(
+            raw_value,
+            name=f"calibration_artifact_ids[{name!r}]",
+        )
+    return validated_json_mapping(
+        dict(sorted(result.items())),
+        error_message="calibration artifact IDs must contain finite JSON data",
+    )
+
+
+@dataclass(frozen=True)
+class RecursiveBayesianPhysTwinBeliefHandoffReceiptV1:
+    """Content-addressed proof of one recursive complete-belief handoff."""
+
+    protocol_id: str
+    case_id: str
+    causal_frame_stop: int
+    stream_artifact_id: str
+    stream_run_id: str
+    stream_step_count: int
+    accepted_step_count: int
+    exact_fallback_count: int
+    accepted_step_ids: tuple[str, ...]
+    exact_fallback_step_ids: tuple[str, ...]
+    final_stream_step_id: str
+    initial_bpt_belief_id: str
+    selected_bpt_belief_id: str
+    provider_manifest_id: str
+    calibration_artifact_ids: Mapping[str, str]
+    runtime_revision_source: str
+    covariance_policy_id: str
+    recursive_nuisance_policy_id: str
+    prob4d_source_repository: str
+    prob4d_source_revision: str
+    baseline_belief_id: str
+    delivered_belief_id: str
+    evidence_consumed_count: int
+    evidence_ledger_id: str
+    exact_baseline_retained: bool
+    raw_prob4d_reinterpreted: bool
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for name in (
+            "protocol_id",
+            "case_id",
+            "runtime_revision_source",
+            "prob4d_source_repository",
+        ):
+            object.__setattr__(self, name, _string(getattr(self, name), name=name))
+        object.__setattr__(
+            self,
+            "prob4d_source_revision",
+            _revision(self.prob4d_source_revision, name="prob4d_source_revision"),
+        )
+        object.__setattr__(
+            self,
+            "causal_frame_stop",
+            _count(self.causal_frame_stop, name="causal_frame_stop", minimum=1),
+        )
+        for name in (
+            "stream_artifact_id",
+            "stream_run_id",
+            "final_stream_step_id",
+            "initial_bpt_belief_id",
+            "selected_bpt_belief_id",
+            "provider_manifest_id",
+            "covariance_policy_id",
+            "recursive_nuisance_policy_id",
+            "baseline_belief_id",
+            "delivered_belief_id",
+            "evidence_ledger_id",
+        ):
+            object.__setattr__(self, name, _sha256(getattr(self, name), name=name))
+        step_count = _count(
+            self.stream_step_count,
+            name="stream_step_count",
+            minimum=1,
+        )
+        accepted = _count(self.accepted_step_count, name="accepted_step_count")
+        fallback = _count(
+            self.exact_fallback_count,
+            name="exact_fallback_count",
+        )
+        consumed = _count(
+            self.evidence_consumed_count,
+            name="evidence_consumed_count",
+        )
+        if accepted + fallback != step_count:
+            raise ValueError("accepted and fallback counts must cover every step")
+        if consumed != accepted:
+            raise ValueError("only accepted stream steps may consume evidence")
+        accepted_ids = _digests(
+            self.accepted_step_ids,
+            name="accepted_step_ids",
+            expected_count=accepted,
+        )
+        fallback_ids = _digests(
+            self.exact_fallback_step_ids,
+            name="exact_fallback_step_ids",
+            expected_count=fallback,
+        )
+        if set(accepted_ids) & set(fallback_ids):
+            raise ValueError("accepted and fallback step IDs must be disjoint")
+        if self.final_stream_step_id not in set(accepted_ids) | set(fallback_ids):
+            raise ValueError("final_stream_step_id is not present in the run steps")
+        exact_baseline = _boolean(
+            self.exact_baseline_retained,
+            name="exact_baseline_retained",
+        )
+        raw_reinterpreted = _boolean(
+            self.raw_prob4d_reinterpreted,
+            name="raw_prob4d_reinterpreted",
+        )
+        if raw_reinterpreted:
+            raise ValueError("Causal4D must not reinterpret raw Prob4D factors")
+        if accepted == 0:
+            if not exact_baseline:
+                raise ValueError("an all-fallback run must retain the exact baseline")
+            if self.delivered_belief_id != self.baseline_belief_id:
+                raise ValueError("an all-fallback run changed the baseline belief")
+            if self.selected_bpt_belief_id != self.initial_bpt_belief_id:
+                raise ValueError("an all-fallback run changed the BPT belief")
+        elif exact_baseline or self.delivered_belief_id == self.baseline_belief_id:
+            raise ValueError("an accepted recursive run must bind a new belief")
+        object.__setattr__(self, "stream_step_count", step_count)
+        object.__setattr__(self, "accepted_step_count", accepted)
+        object.__setattr__(self, "exact_fallback_count", fallback)
+        object.__setattr__(self, "evidence_consumed_count", consumed)
+        object.__setattr__(self, "accepted_step_ids", accepted_ids)
+        object.__setattr__(self, "exact_fallback_step_ids", fallback_ids)
+        object.__setattr__(self, "exact_baseline_retained", exact_baseline)
+        object.__setattr__(self, "raw_prob4d_reinterpreted", raw_reinterpreted)
+        object.__setattr__(
+            self,
+            "calibration_artifact_ids",
+            _calibrations(self.calibration_artifact_ids),
+        )
+        object.__setattr__(
+            self,
+            "metadata",
+            validated_json_mapping(
+                self.metadata,
+                error_message="recursive handoff metadata must be finite JSON",
+            ),
+        )
+
+    def _payload(self) -> dict[str, Any]:
+        payload = {
+            item.name: plain_json(getattr(self, item.name))
+            for item in dataclass_fields(self)
+        }
+        payload.update(
+            schema_version=RECURSIVE_BPT_BELIEF_HANDOFF_SCHEMA_VERSION,
+            artifact_kind=RECURSIVE_BPT_BELIEF_HANDOFF_ARTIFACT_KIND,
+            claim_boundary=RECURSIVE_BPT_BELIEF_HANDOFF_CLAIM_BOUNDARY,
+        )
+        return payload
+
+    @property
+    def receipt_id(self) -> str:
+        return _canonical_id(self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "receipt_id": self.receipt_id}
+
+    @classmethod
+    def from_dict(
+        cls,
+        values: Mapping[str, Any],
+    ) -> RecursiveBayesianPhysTwinBeliefHandoffReceiptV1:
+        field_names = {item.name for item in dataclass_fields(cls)}
+        expected = field_names | {
+            "schema_version",
+            "artifact_kind",
+            "claim_boundary",
+            "receipt_id",
+        }
+        if not isinstance(values, Mapping) or set(values) != expected:
+            raise ValueError("recursive handoff receipt fields changed")
+        if values["schema_version"] != RECURSIVE_BPT_BELIEF_HANDOFF_SCHEMA_VERSION:
+            raise ValueError("unsupported recursive handoff schema version")
+        if values["artifact_kind"] != RECURSIVE_BPT_BELIEF_HANDOFF_ARTIFACT_KIND:
+            raise ValueError("unsupported recursive handoff artifact kind")
+        if values["claim_boundary"] != RECURSIVE_BPT_BELIEF_HANDOFF_CLAIM_BOUNDARY:
+            raise ValueError("recursive handoff claim boundary changed")
+        kwargs = {name: values[name] for name in field_names}
+        kwargs["accepted_step_ids"] = tuple(kwargs["accepted_step_ids"])
+        kwargs["exact_fallback_step_ids"] = tuple(kwargs["exact_fallback_step_ids"])
+        receipt = cls(**kwargs)
+        if values["receipt_id"] != receipt.receipt_id:
+            raise ValueError("recursive handoff receipt identity changed")
+        return receipt
+
+
+__all__ = [
+    "RECURSIVE_BPT_BELIEF_HANDOFF_ARTIFACT_KIND",
+    "RECURSIVE_BPT_BELIEF_HANDOFF_CLAIM_BOUNDARY",
+    "RECURSIVE_BPT_BELIEF_HANDOFF_METADATA_KEY",
+    "RECURSIVE_BPT_BELIEF_HANDOFF_SCHEMA_VERSION",
+    "RecursiveBayesianPhysTwinBeliefHandoffReceiptV1",
+]

--- a/tests/test_recursive_bpt_belief_handoff.py
+++ b/tests/test_recursive_bpt_belief_handoff.py
@@ -1,0 +1,557 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import hashlib
+import sys
+from types import ModuleType
+
+import numpy as np
+import pytest
+
+from causal4d.belief_provider_v2_contract import (
+    BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API,
+    BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API_VERSION,
+    BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_SCHEMA_VERSIONS,
+    BAYESIAN_PHYSTWIN_BELIEF_V2_COMPATIBILITY,
+    BAYESIAN_PHYSTWIN_BELIEF_V2_INFERENCE_ROLE,
+    BAYESIAN_PHYSTWIN_BELIEF_V2_RAW_COVARIANCE_CLAIM,
+)
+from causal4d.belief_provider_v2_recursive_contract import (
+    BAYESIAN_PHYSTWIN_RECURSIVE_BELIEF_PROVIDER_V2_CAPABILITIES,
+    BAYESIAN_PHYSTWIN_RECURSIVE_BELIEF_V2_ARTIFACT_SCHEMA_VERSIONS,
+    BAYESIAN_PHYSTWIN_RECURSIVE_STREAM_CLAIM,
+    load_bayesian_phystwin_recursive_belief_provider_v2_manifest,
+)
+from causal4d.contracts import TwinBelief, build_causal_context
+from causal4d.evidence_ownership import (
+    ConsumedEvidenceLedgerV1,
+    EvidenceConsumptionV1,
+)
+from causal4d.provider_contract import PhysicalBeliefProviderManifest
+from causal4d.recursive_bpt_belief_handoff import (
+    RECURSIVE_BPT_BELIEF_HANDOFF_METADATA_KEY,
+    RecursiveBayesianPhysTwinBeliefHandoffReceiptV1,
+    bind_recursive_bayesian_phystwin_belief_handoff,
+)
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _provider_descriptor() -> dict[str, object]:
+    return {
+        "provider_name": "bayesian-phystwin",
+        "provider_version": "0.4.0",
+        "provider_revision": "f" * 40,
+        "schema_version": BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_SCHEMA_VERSIONS[0],
+        "capabilities": list(
+            BAYESIAN_PHYSTWIN_RECURSIVE_BELIEF_PROVIDER_V2_CAPABILITIES
+        ),
+        "artifact_schema_versions": dict(
+            BAYESIAN_PHYSTWIN_RECURSIVE_BELIEF_V2_ARTIFACT_SCHEMA_VERSIONS
+        ),
+        "metadata": {
+            "provider_api": BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API,
+            "provider_api_version": (BAYESIAN_PHYSTWIN_BELIEF_PROVIDER_V2_API_VERSION),
+            "inference_role": BAYESIAN_PHYSTWIN_BELIEF_V2_INFERENCE_ROLE,
+            "compatibility": BAYESIAN_PHYSTWIN_BELIEF_V2_COMPATIBILITY,
+            "raw_covariance_claim": (BAYESIAN_PHYSTWIN_BELIEF_V2_RAW_COVARIANCE_CLAIM),
+            "recursive_stream_claim": BAYESIAN_PHYSTWIN_RECURSIVE_STREAM_CLAIM,
+        },
+    }
+
+
+def _provider_manifest_id() -> str:
+    return PhysicalBeliefProviderManifest.from_provider_descriptor(
+        _provider_descriptor()
+    ).manifest_id
+
+
+@dataclass(frozen=True)
+class _FakeStep:
+    step_id: str
+    stream_artifact_id: str
+    stream_update_id: str
+    observation_binding_id: str
+    admitted_frame_start: int
+    causal_frame_stop: int
+    claim_update_id: str
+    observation_artifact_id: str
+    linearization_artifact_id: str
+    guard_decision_id: str
+    selection_id: str
+    covariance_semantics_id: str
+    provider_manifest_id: str
+    recursive_nuisance_policy_id: str
+    covariance_policy_id: str
+    selected_candidate: bool
+    exact_fallback: bool
+
+
+@dataclass(frozen=True)
+class _FakeRun:
+    stream_artifact_id: str
+    initial_belief_id: str
+    recursive_nuisance_policy_id: str
+    steps: tuple[_FakeStep, ...]
+    provider_manifest_id: str
+    calibration_artifact_ids: dict[str, str]
+    runtime_revision_source: str
+    runtime_revision_independently_verified: bool
+    covariance_policy_id: str
+    run_id: str
+    final_belief_id: str
+
+
+@dataclass(frozen=True)
+class _FakeArtifactBelief:
+    artifact_id: str
+
+
+def _install_fake_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    package = ModuleType("bayesian_phystwin")
+    package.__path__ = []  # type: ignore[attr-defined]
+    provider = ModuleType("bayesian_phystwin.causal4d_belief_provider_v2")
+    provider.causal4d_belief_provider_v2_manifest = lambda *, provider_revision=None: (
+        _provider_descriptor()
+    )
+    provider.ClaimBearingProb4DStreamRunV1 = _FakeRun
+    monkeypatch.setitem(sys.modules, "bayesian_phystwin", package)
+    monkeypatch.setitem(
+        sys.modules,
+        "bayesian_phystwin.causal4d_belief_provider_v2",
+        provider,
+    )
+
+
+def _step(
+    index: int,
+    *,
+    start: int,
+    stop: int,
+    accepted: bool,
+    provider_manifest_id: str | None = None,
+) -> _FakeStep:
+    return _FakeStep(
+        step_id=_digest(f"step:{index}:{accepted}:{start}:{stop}"),
+        stream_artifact_id=_digest("stream"),
+        stream_update_id=_digest(f"stream-update:{index}"),
+        observation_binding_id=_digest(f"observation-binding:{index}"),
+        admitted_frame_start=start,
+        causal_frame_stop=stop,
+        claim_update_id=_digest(f"claim-update:{index}"),
+        observation_artifact_id=_digest(f"observation:{index}"),
+        linearization_artifact_id=_digest(f"linearization:{index}"),
+        guard_decision_id=_digest(f"guard:{index}"),
+        selection_id=_digest(f"selection:{index}"),
+        covariance_semantics_id=_digest(f"covariance-semantics:{index}"),
+        provider_manifest_id=(
+            _provider_manifest_id()
+            if provider_manifest_id is None
+            else provider_manifest_id
+        ),
+        recursive_nuisance_policy_id=_digest("nuisance-policy"),
+        covariance_policy_id=_digest("covariance-policy"),
+        selected_candidate=accepted,
+        exact_fallback=not accepted,
+    )
+
+
+def _run(
+    *,
+    accepted_first: bool = True,
+    provider_manifest_id: str | None = None,
+    steps: tuple[_FakeStep, ...] | None = None,
+) -> _FakeRun:
+    provider_id = (
+        _provider_manifest_id()
+        if provider_manifest_id is None
+        else provider_manifest_id
+    )
+    run_steps = steps
+    if run_steps is None:
+        run_steps = (
+            _step(
+                0,
+                start=0,
+                stop=2,
+                accepted=accepted_first,
+                provider_manifest_id=provider_id,
+            ),
+            _step(
+                1,
+                start=2,
+                stop=4,
+                accepted=False,
+                provider_manifest_id=provider_id,
+            ),
+        )
+    final_belief_id = (
+        _digest("bpt-selected")
+        if any(step.selected_candidate for step in run_steps)
+        else _digest("bpt-initial")
+    )
+    return _FakeRun(
+        stream_artifact_id=_digest("stream"),
+        initial_belief_id=_digest("bpt-initial"),
+        recursive_nuisance_policy_id=_digest("nuisance-policy"),
+        steps=run_steps,
+        provider_manifest_id=provider_id,
+        calibration_artifact_ids={"prob4d": _digest("calibration")},
+        runtime_revision_source="installed-wheel",
+        runtime_revision_independently_verified=True,
+        covariance_policy_id=_digest("covariance-policy"),
+        run_id=_digest("run"),
+        final_belief_id=final_belief_id,
+    )
+
+
+def _belief(
+    *,
+    offset: float = 0.0,
+    weights: tuple[float, float] = (0.4, 0.6),
+    metadata: dict[str, object] | None = None,
+) -> TwinBelief:
+    observations = np.zeros((8, 2, 3), dtype=np.float64)
+    actions = np.zeros((8, 1, 3), dtype=np.float64)
+    context = build_causal_context(
+        protocol_id="recursive-bpt-handoff-unit",
+        case_id="case-001",
+        observations=observations,
+        observed_actions=actions,
+        counterfactual_actions=actions,
+        intervention_frame=4,
+    )
+    positions = np.full((2, 2, 3), offset, dtype=np.float64)
+    return TwinBelief(
+        context=context,
+        endpoint_frame=3,
+        particle_ids=("p0", "p1"),
+        theta_names=("spring_log_scale",),
+        endpoint_position_m=positions,
+        endpoint_velocity_mps=np.zeros_like(positions),
+        theta=np.asarray([[0.1], [0.2]], dtype=np.float64),
+        discrepancy_mean_m=np.zeros_like(positions),
+        discrepancy_variance_m2=np.full_like(positions, 1.0e-4),
+        weights=np.asarray(weights, dtype=np.float64),
+        metadata=metadata or {},
+    )
+
+
+def _empty_ledger(belief: TwinBelief) -> ConsumedEvidenceLedgerV1:
+    return ConsumedEvidenceLedgerV1(
+        protocol_id=belief.context.protocol_id,
+        case_id=belief.context.case_id,
+        causal_frame_stop=belief.context.o_minus.frame_stop,
+    )
+
+
+def test_mixed_recursive_run_consumes_only_accepted_steps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_provider(monkeypatch)
+    run = _run()
+    baseline = _belief()
+    candidate = _belief(offset=0.01, weights=(0.7, 0.3))
+
+    bound = bind_recursive_bayesian_phystwin_belief_handoff(
+        run,
+        _FakeArtifactBelief(run.final_belief_id),
+        baseline_belief=baseline,
+        candidate_belief=candidate,
+        prob4d_source_revision="a" * 40,
+    )
+
+    assert bound.belief.artifact_id != baseline.artifact_id
+    assert np.array_equal(bound.belief.weights, candidate.weights)
+    assert bound.receipt.stream_step_count == 2
+    assert bound.receipt.accepted_step_count == 1
+    assert bound.receipt.exact_fallback_count == 1
+    assert bound.receipt.evidence_consumed_count == 1
+    assert not bound.receipt.exact_baseline_retained
+    assert not bound.receipt.raw_prob4d_reinterpreted
+    assert len(bound.evidence_ledger.entries) == 1
+    consumption = bound.evidence_ledger.entries[0]
+    assert consumption.evidence_id == run.steps[0].claim_update_id
+    assert consumption.raw_factor_id == run.steps[0].observation_artifact_id
+    assert consumption.frame_start == 0
+    assert consumption.frame_stop == 2
+    handoff = bound.belief.metadata[RECURSIVE_BPT_BELIEF_HANDOFF_METADATA_KEY]
+    assert handoff["stream_run_id"] == run.run_id
+    assert handoff["accepted_step_count"] == 1
+    assert handoff["exact_fallback_count"] == 1
+
+
+def test_all_fallback_run_retains_exact_baseline_and_ledger(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_provider(monkeypatch)
+    run = _run(accepted_first=False)
+    baseline = _belief()
+    prior = _empty_ledger(baseline)
+
+    bound = bind_recursive_bayesian_phystwin_belief_handoff(
+        run,
+        _FakeArtifactBelief(run.final_belief_id),
+        baseline_belief=baseline,
+        candidate_belief=baseline,
+        prior_evidence_ledger=prior,
+        prob4d_source_revision="b" * 40,
+    )
+
+    assert bound.belief is baseline
+    assert bound.evidence_ledger is prior
+    assert bound.receipt.accepted_step_count == 0
+    assert bound.receipt.exact_fallback_count == 2
+    assert bound.receipt.evidence_consumed_count == 0
+    assert bound.receipt.exact_baseline_retained
+
+
+def test_recursive_handoff_rejects_provider_and_selected_belief_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_provider(monkeypatch)
+    baseline = _belief()
+    candidate = _belief(offset=0.01)
+
+    with pytest.raises(ValueError, match="different provider manifest"):
+        run = _run(provider_manifest_id=_digest("wrong-provider"))
+        bind_recursive_bayesian_phystwin_belief_handoff(
+            run,
+            _FakeArtifactBelief(run.final_belief_id),
+            baseline_belief=baseline,
+            candidate_belief=candidate,
+            prob4d_source_revision="c" * 40,
+        )
+
+    run = _run()
+    with pytest.raises(ValueError, match="does not match"):
+        bind_recursive_bayesian_phystwin_belief_handoff(
+            run,
+            _FakeArtifactBelief(_digest("wrong-selected-belief")),
+            baseline_belief=baseline,
+            candidate_belief=candidate,
+            prob4d_source_revision="c" * 40,
+        )
+
+
+def test_recursive_handoff_rejects_overlapping_or_future_intervals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_provider(monkeypatch)
+    baseline = _belief()
+    candidate = _belief(offset=0.01)
+
+    overlap = (
+        _step(0, start=0, stop=3, accepted=True),
+        _step(1, start=2, stop=4, accepted=False),
+    )
+    run = _run(steps=overlap)
+    with pytest.raises(ValueError, match="overlap"):
+        bind_recursive_bayesian_phystwin_belief_handoff(
+            run,
+            _FakeArtifactBelief(run.final_belief_id),
+            baseline_belief=baseline,
+            candidate_belief=candidate,
+            prob4d_source_revision="d" * 40,
+        )
+
+    future = (_step(0, start=0, stop=5, accepted=True),)
+    run = _run(steps=future)
+    with pytest.raises(ValueError, match="causal prefix"):
+        bind_recursive_bayesian_phystwin_belief_handoff(
+            run,
+            _FakeArtifactBelief(run.final_belief_id),
+            baseline_belief=baseline,
+            candidate_belief=candidate,
+            prob4d_source_revision="d" * 40,
+        )
+
+
+def test_recursive_handoff_rejects_duplicate_factor_consumption(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_provider(monkeypatch)
+    run = _run()
+    baseline = _belief()
+    candidate = _belief(offset=0.01)
+    duplicate = EvidenceConsumptionV1(
+        evidence_id=run.steps[0].claim_update_id,
+        raw_factor_id=run.steps[0].observation_artifact_id,
+        source_repository="IPS-Stuttgart/Prob4D",
+        source_revision="prior",
+        sensor_family="prob4d_observation_factor",
+        stream_id=run.stream_artifact_id,
+        clock_id=baseline.context.o_minus.content_sha256,
+        correlation_group_id=run.recursive_nuisance_policy_id,
+        frame_start=0,
+        frame_stop=2,
+        role="state_update",
+        source_file_sha256=run.steps[0].observation_artifact_id,
+    )
+    prior = _empty_ledger(baseline).extend(duplicate)
+
+    with pytest.raises(ValueError, match="consumed more than once"):
+        bind_recursive_bayesian_phystwin_belief_handoff(
+            run,
+            _FakeArtifactBelief(run.final_belief_id),
+            baseline_belief=baseline,
+            candidate_belief=candidate,
+            prior_evidence_ledger=prior,
+            prob4d_source_revision="e" * 40,
+        )
+
+
+def test_recursive_handoff_preserves_support_but_allows_updated_weights(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_provider(monkeypatch)
+    run = _run()
+    baseline = _belief()
+    changed_weights = _belief(offset=0.01, weights=(0.8, 0.2))
+
+    bound = bind_recursive_bayesian_phystwin_belief_handoff(
+        run,
+        _FakeArtifactBelief(run.final_belief_id),
+        baseline_belief=baseline,
+        candidate_belief=changed_weights,
+        prob4d_source_revision="f" * 40,
+    )
+    assert np.array_equal(bound.belief.weights, changed_weights.weights)
+
+    changed_theta = TwinBelief(
+        context=changed_weights.context,
+        endpoint_frame=changed_weights.endpoint_frame,
+        particle_ids=changed_weights.particle_ids,
+        theta_names=changed_weights.theta_names,
+        endpoint_position_m=changed_weights.endpoint_position_m,
+        endpoint_velocity_mps=changed_weights.endpoint_velocity_mps,
+        theta=changed_weights.theta + 1.0,
+        discrepancy_mean_m=changed_weights.discrepancy_mean_m,
+        discrepancy_variance_m2=changed_weights.discrepancy_variance_m2,
+        weights=changed_weights.weights,
+    )
+    with pytest.raises(ValueError, match="physical parameters"):
+        bind_recursive_bayesian_phystwin_belief_handoff(
+            run,
+            _FakeArtifactBelief(run.final_belief_id),
+            baseline_belief=baseline,
+            candidate_belief=changed_theta,
+            prob4d_source_revision="f" * 40,
+        )
+
+
+def test_recursive_receipt_round_trip_and_tamper_detection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_provider(monkeypatch)
+    run = _run()
+    bound = bind_recursive_bayesian_phystwin_belief_handoff(
+        run,
+        _FakeArtifactBelief(run.final_belief_id),
+        baseline_belief=_belief(),
+        candidate_belief=_belief(offset=0.01),
+        prob4d_source_revision="1" * 40,
+        metadata={"purpose": "unit-test"},
+    )
+
+    restored = RecursiveBayesianPhysTwinBeliefHandoffReceiptV1.from_dict(
+        bound.receipt.as_dict()
+    )
+    assert restored.as_dict() == bound.receipt.as_dict()
+
+    tampered = bound.receipt.as_dict()
+    tampered["delivered_belief_id"] = _digest("tampered-belief")
+    with pytest.raises(ValueError, match="identity changed"):
+        RecursiveBayesianPhysTwinBeliefHandoffReceiptV1.from_dict(tampered)
+
+    forbidden = dict(bound.receipt.as_dict())
+    forbidden["raw_prob4d_reinterpreted"] = True
+    forbidden["receipt_id"] = _digest("forbidden")
+    with pytest.raises(ValueError, match="must not reinterpret"):
+        RecursiveBayesianPhysTwinBeliefHandoffReceiptV1.from_dict(forbidden)
+
+
+def test_recursive_handoff_requires_a_populated_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_provider(monkeypatch)
+    run = replace(
+        _run(),
+        steps=(),
+        final_belief_id=_digest("bpt-initial"),
+    )
+
+    with pytest.raises(ValueError, match="populated"):
+        bind_recursive_bayesian_phystwin_belief_handoff(
+            run,
+            _FakeArtifactBelief(run.final_belief_id),
+            baseline_belief=_belief(),
+            candidate_belief=_belief(),
+            prob4d_source_revision="2" * 40,
+        )
+
+
+def test_installed_recursive_run_handoff() -> None:
+    provider_module = pytest.importorskip(
+        "bayesian_phystwin.causal4d_belief_provider_v2"
+    )
+    step_type = provider_module.ClaimBearingProb4DStreamStepV1
+    run_type = provider_module.ClaimBearingProb4DStreamRunV1
+    manifest = load_bayesian_phystwin_recursive_belief_provider_v2_manifest()
+    initial_id = _digest("installed-bpt-initial")
+    selected_id = _digest("installed-bpt-selected")
+    nuisance_policy_id = _digest("installed-nuisance-policy")
+    covariance_policy_id = _digest("installed-covariance-policy")
+    calibration_ids = {"prob4d": _digest("installed-calibration")}
+    step = step_type(
+        stream_artifact_id=_digest("installed-stream"),
+        stream_update_id=_digest("installed-stream-update"),
+        observation_binding_id=_digest("installed-binding"),
+        update_index=0,
+        admitted_frame_start=0,
+        causal_frame_stop=2,
+        prior_belief_id=initial_id,
+        observation_artifact_id=_digest("installed-observation"),
+        linearization_artifact_id=_digest("installed-linearization"),
+        claim_update_id=_digest("installed-update"),
+        candidate_belief_id=selected_id,
+        guard_decision_id=_digest("installed-guard"),
+        selection_id=_digest("installed-selection"),
+        selected_belief_id=selected_id,
+        selected_candidate=True,
+        exact_fallback=False,
+        provider_manifest_id=manifest.manifest_id,
+        calibration_artifact_ids=calibration_ids,
+        runtime_revision_source="installed-wheel",
+        runtime_revision_independently_verified=True,
+        covariance_semantics_id=_digest("installed-covariance-semantics"),
+        covariance_policy_id=covariance_policy_id,
+        recursive_nuisance_policy_id=nuisance_policy_id,
+        previous_step_id=None,
+        reason="inference-admissible",
+    )
+    run = run_type(
+        stream_artifact_id=_digest("installed-stream"),
+        initial_belief_id=initial_id,
+        recursive_nuisance_policy_id=nuisance_policy_id,
+        steps=(step,),
+        provider_manifest_id=manifest.manifest_id,
+        calibration_artifact_ids=calibration_ids,
+        runtime_revision_source="installed-wheel",
+        runtime_revision_independently_verified=True,
+        covariance_policy_id=covariance_policy_id,
+    )
+
+    bound = bind_recursive_bayesian_phystwin_belief_handoff(
+        run,
+        _FakeArtifactBelief(selected_id),
+        baseline_belief=_belief(),
+        candidate_belief=_belief(offset=0.01, weights=(0.65, 0.35)),
+        prob4d_source_revision="3" * 40,
+    )
+
+    assert bound.receipt.stream_run_id == run.run_id
+    assert bound.receipt.accepted_step_ids == (step.step_id,)
+    assert len(bound.evidence_ledger.entries) == 1

--- a/tests/test_recursive_bpt_belief_handoff_workflow_policy.py
+++ b/tests/test_recursive_bpt_belief_handoff_workflow_policy.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WORKFLOW_PATH = ".github/workflows/recursive-belief-handoff-integration.yml"
+WORKFLOW = Path(__file__).resolve().parents[1] / WORKFLOW_PATH
+BPT_RECURSIVE_PROVIDER_REVISION = "d2b38ce72a0ecb07cce7e252a0af6fb32c9411dc"
+CAUSAL4D_HEAD_REF = "${{ github.event.pull_request.head.sha || github.sha }}"
+CHECKOUT_ACTION = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+SETUP_PYTHON_ACTION = "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97"
+
+
+def test_recursive_handoff_workflow_uses_exact_public_provider_revision() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "repository: IPS-Stuttgart/BayesianPhysTwin" in text
+    assert f"ref: {BPT_RECURSIVE_PROVIDER_REVISION}" in text
+    assert "persist-credentials: false" in text
+    assert "BPT_READ_SSH_KEY" not in text
+
+
+def test_recursive_handoff_workflow_records_exact_causal4d_revision() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert f"ref: {CAUSAL4D_HEAD_REF}" in text
+    assert f"EXPECTED_CAUSAL4D_SHA: {CAUSAL4D_HEAD_REF}" in text
+    assert 'actual_sha="$(git rev-parse HEAD)"' in text
+    assert 'test "$actual_sha" = "$EXPECTED_CAUSAL4D_SHA"' in text
+
+
+def test_recursive_handoff_workflow_exercises_installed_wheels() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "python -m build --wheel" in text
+    assert "recursive-belief-handoff-wheelhouse" in text
+    assert "recursive-belief-handoff-venv" in text
+    assert "--import-mode=importlib" in text
+    assert "env -u PYTHONPATH" in text
+    assert "test_belief_provider_v2_recursive_contract.py" in text
+    assert "test_recursive_bpt_belief_handoff.py" in text
+    assert "test_evidence_ownership.py" in text
+    assert "test_bpt_provider_import_boundary.py" in text
+
+
+def test_recursive_handoff_pull_request_validation_is_hosted_read_only() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "pull_request:" in text
+    assert "permissions:\n  contents: read\n" in text
+    assert "runs-on: ubuntu-latest" in text
+    assert "self-hosted" not in text
+
+
+def test_recursive_handoff_contract_runs_before_local_quality() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    contract_index = text.index(
+        "- name: Exercise the installed recursive handoff contract"
+    )
+    quality_index = text.index("- name: Check Causal4D source quality")
+
+    assert contract_index < quality_index
+    assert "if: always()" in text[quality_index:]
+
+
+def test_recursive_handoff_workflow_pins_external_actions() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert text.count(CHECKOUT_ACTION) == 2
+    assert SETUP_PYTHON_ACTION in text
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("uses:"):
+            assert "@" in stripped
+            reference = stripped.rsplit("@", 1)[1].split()[0]
+            assert len(reference) == 40
+            assert all(character in "0123456789abcdef" for character in reference)


### PR DESCRIPTION
## Summary

- add a separate complete BayesianPhysTwin provider-v2 contract for recursive Prob4D stream routing, without widening or changing the existing horizon-discrepancy subset contract;
- add a strict handoff from one populated `ClaimBearingProb4DStreamRunV1` and its selected complete BayesianPhysTwin belief to a Causal4D `TwinBelief`;
- preserve causal context, endpoint, particle identities, physical-parameter support, and state shape while allowing the accepted Bayesian belief to update state, discrepancy, and particle weights;
- append exactly one existing `ConsumedEvidenceLedgerV1` `state_update` record for every accepted stream member and consume no posterior evidence for exact-fallback members;
- require every member interval to remain ordered, non-overlapping, and inside the Causal4D pre-intervention observation prefix;
- preserve the exact original Causal4D baseline object and unchanged ledger when every recursive member falls back;
- bind stream, run, step, selected-belief, provider, calibration, runtime, covariance-policy, recursive-nuisance-policy, Prob4D source, delivered-belief, and evidence-ledger identities in a content-addressed receipt; and
- add focused adversarial tests, documentation, and a hosted read-only installed-wheel integration lane pinned to BayesianPhysTwin revision `d2b38ce72a0ecb07cce7e252a0af6fb32c9411dc`.

## Why

Prob4D and BayesianPhysTwin already expose append-only recursive observation streams and immutable complete-belief routing. Causal4D had contracts for the provider-v2 horizon subset and for one-shot tree-block belief handoff, but no explicit boundary proving that a completed recursive BayesianPhysTwin run is consumed exactly once without reopening raw Prob4D factors.

This PR closes that integration gap while retaining ownership in the correct repository:

```text
Prob4D append-only observation factors
        |
        v
BayesianPhysTwin recursive complete belief
        |
        v
Causal4D TwinBelief + consumed-evidence ledger
```

## Ownership and fallback semantics

- Accepted stream members enter the Causal4D ownership ledger once, with their exact half-open frame interval and stream/update/binding/linearization/guard/selection/covariance identities.
- Exact-fallback members are retained in the recursive run and receipt but do not become consumed posterior evidence.
- Several accepted members may share the same correlation group because BayesianPhysTwin has already evaluated them under one explicit persistent recursive nuisance policy.
- Duplicate updates, duplicate raw factors, relabelled source bytes, incompatible cross-stage use, provider drift, policy drift, overlapping intervals, future-prefix access, or selected-belief drift fail before the delivered belief is created.
- An all-fallback run must select the initial BayesianPhysTwin belief, supply the exact baseline Causal4D artifact, consume zero evidence, and return the original baseline object.

## Validation

Local focused validation on the exact proposed source:

```text
13 passed, 2 optional installed-provider skips
Python byte compilation passed
all changed Python lines <= 88 columns
```

The hosted installed-wheel workflow builds exact Causal4D and BayesianPhysTwin wheels, installs them outside both source trees with `PYTHONPATH` removed, exercises the real recursive provider records and handoff, checks evidence ownership and the versioned import boundary, and then runs Ruff lint and canonical formatting. GitHub Actions on the exact pull-request head are authoritative for the complete repository, packaging, compatibility, merge-result, and security gates.

## Change classification

- [ ] Frozen or registered method/analysis change requiring a new version
- [x] Future or experimental method
- [x] BayesianPhysTwin, Prob4D, or other provider/artifact contract
- [ ] Acquisition, calibration, readiness, or evidence tooling
- [ ] Maintenance, documentation, packaging, CI, or security

Evidence status:

- [x] Software or contract evidence only
- [ ] Controlled synthetic evidence
- [ ] Source/calibration-only evidence
- [ ] Retrospective or already-open diagnostic evidence
- [ ] Confirmatory physical evidence
- [x] No scientific evidence produced

## Scientific and information boundary

- Frozen estimator or registered analysis changed: `no`.
- Target or held-out outcomes accessed: `no`.
- Registered physical-acquisition dataset modified: `no`.
- Physical evidence increment: `0`.
- Existing scientific claim changed or promoted: `no`.
- Prob4D admitted into the frozen 36-execution primary method: `no`.
- Provider competence, calibration, fresh-object physical benefit, Causal4D intervention benefit, deployment safety, or state of the art established: `no`.
- Exact fallback preserved: `yes`, including Python object identity for an all-fallback run.

## Merge disposition

- [x] Product/interface change intended for review and merge
- [ ] Execution/bootstrap helper that must be closed without merge
- [ ] Scientific claim promotion

No acquisition, target opening, evidence publication, protocol mutation, or claim promotion is authorized by this change.