### PR TITLE
Add registered-query variance decomposition diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
   shell, source-verified effect reports, optional gate interpretation, and a
   semantic conformance record without changing the frozen method or physical
   evidence count.
+- Add a content-addressed registered-query variance decomposition with exact
+  Shapley attribution over caller-declared finite-support factors, retained
+  unresolved component covariance, additive conditional covariance sources,
+  strict portable validation, and a grouped diagnostic CLI. The diagnostic does
+  not change a posterior, identify a physical cause, establish calibration, or
+  authorize confirmatory method selection.
 - Make the historical package-root API lazy while preserving exact owning-module
   object identity, wildcard exports, and module introspection. Package an explicit
   `__init__.pyi` surface, promote physical-posterior query projection through API

--- a/README.md
+++ b/README.md
@@ -176,6 +176,28 @@ decisions, records exact hashes and byte counts, and can be independently
 reopened with `causal4d paper reproduce --verify <bundle-dir>`. See
 [the paper reproduction guide](docs/paper_reproduction.md).
 
+## Query-space uncertainty attribution
+
+Attribute one fixed finite-posterior query covariance to declared physical
+particle, actuation, contact, slip, or other support labels while retaining any
+unexplained component variation explicitly:
+
+```bash
+causal4d diagnostic uncertainty decompose-query build \
+  posterior-query-input.npz \
+  examples/query_variance_decomposition_spec.json \
+  query-variance-decomposition.json
+
+causal4d diagnostic uncertainty decompose-query validate \
+  query-variance-decomposition.json
+```
+
+The output uses exact Shapley attribution over the declared finite factor set,
+adds caller-declared conditional covariance sources, and verifies numerical
+additivity and content identity. It is diagnostic-only and cannot select or
+change the frozen physical method. See
+[the variance-decomposition guide](docs/query_variance_decomposition.md).
+
 ## Next Scientific Milestone
 
 The controlled result has passed. The next first-paper milestone is the locked

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -56,6 +56,21 @@ causal4d calibration execution-block --help
 `protocol acquisition` provides the method-neutral pre-session doctor, health
 snapshot evaluator, and append-only session journal.
 
+## Diagnostic workflows
+
+Diagnostics remain outside the default stable help view and cannot alter a
+registered method merely because their artifacts validate:
+
+```bash
+causal4d diagnostic uncertainty decompose-query build --help
+causal4d diagnostic uncertainty decompose-query validate --help
+```
+
+The query-variance decomposition attributes a fixed finite-posterior query to
+caller-declared support factors and additive conditional covariance sources. It
+retains unresolved component covariance and does not establish causal recovery
+or empirical calibration.
+
 ## Authoritative registry
 
 The registry records, for every supported route:

--- a/docs/query_variance_decomposition.md
+++ b/docs/query_variance_decomposition.md
@@ -1,0 +1,150 @@
+# Registered-query variance decomposition
+
+## Scope
+
+`causal4d diagnostic uncertainty decompose-query` attributes the covariance of
+one fixed finite-posterior query to caller-declared support factors and additive
+conditional covariance sources. It is an analysis diagnostic. It does not modify
+the posterior or infer that a named support factor is the true physical cause of
+an error.
+
+Let posterior component `c` have weight `w_c`, query mean `mu_c`, and declared
+conditional covariance sources `Sigma_{c,s}`. The total query covariance is
+
+```text
+Cov(Q) = Cov_c(mu_c) + sum_s E_c[Sigma_{c,s}].
+```
+
+The first term is finite-support uncertainty. The second contains within-component
+uncertainty sources such as observation, discrepancy, or numerical covariance,
+provided by the caller under an explicitly additive interpretation.
+
+## Exact factor attribution
+
+Suppose every component has labels for factors such as physical particle,
+actuator realization, contact patch, or slip regime. For a subset `S` of factor
+names, define
+
+```text
+V(S) = Cov(E[mu_c | labels in S]).
+```
+
+For factor `j`, Causal4D reports the exact Shapley covariance
+
+```text
+Phi_j = sum_{S subset F without j}
+        |S|! (|F|-|S|-1)! / |F|!
+        * (V(S union {j}) - V(S)).
+```
+
+The declared factor contributions satisfy
+
+```text
+sum_j Phi_j = V(F).
+```
+
+Any remaining finite-component variation is retained as
+
+```text
+unresolved_component = Cov_c(mu_c) - V(F).
+```
+
+It is never silently assigned to the nearest named factor. The complete
+reconstruction is therefore
+
+```text
+Cov(Q)
+  = sum_j Phi_j
+  + unresolved_component
+  + sum_s E_c[Sigma_{c,s}].
+```
+
+Exact attribution is intentionally limited to eight factors because its cost is
+exponential in the declared factor count.
+
+## Input archive
+
+The NPZ archive is non-pickled and must contain exactly the arrays named by the
+specification. The defaults are:
+
+```text
+component_weights       shape (component,)
+component_query_means   shape (component, query)
+```
+
+Every conditional covariance source has shape
+`(component, query, query)`. Unexpected arrays, duplicate array assignments,
+object arrays, Boolean/string numerical coercion, nonfinite values, and
+non-positive-semidefinite covariance matrices fail closed.
+
+Example specification:
+
+```json
+{
+  "schema_version": 1,
+  "artifact_kind": "Causal4DQueryVarianceDecompositionInputV1",
+  "query_id": "late-endpoint-position",
+  "query_labels": ["x", "y", "z"],
+  "query_units": ["m", "m", "m"],
+  "query_scales": [0.01, 0.01, 0.01],
+  "factor_values": {
+    "physical_particle": ["p0", "p0", "p1", "p1"],
+    "contact": ["left", "right", "left", "right"]
+  },
+  "conditional_covariance_arrays": {
+    "readout_discrepancy": "readout_covariance"
+  },
+  "metadata": {
+    "registered_before_target_access": true
+  }
+}
+```
+
+The number of labels in every factor array must equal the component count. The
+factor order in JSON does not affect the result identity.
+
+## Build and validate
+
+```bash
+causal4d diagnostic uncertainty decompose-query build \
+  posterior-query-input.npz \
+  query-decomposition-spec.json \
+  query-variance-decomposition.json
+
+causal4d diagnostic uncertainty decompose-query validate \
+  query-variance-decomposition.json
+```
+
+The output is content-addressed over:
+
+- the query definition and characteristic scales;
+- normalized posterior-weight and component-query identities;
+- complete factor labels;
+- conditional covariance archive identities;
+- every reported covariance, share, and diagnostic; and
+- finite JSON metadata, including verified input NPZ and specification hashes
+  when the CLI is used.
+
+Portable validation checks the schema, content identity, positive-semidefinite
+matrices, support inventories, between/total covariance reconstruction,
+coordinatewise variance shares, and scale-standardized trace shares.
+
+## Interpretation
+
+The artifact reports both native-coordinate variance shares and a scalar trace
+share after division by the registered query scales. The latter is useful when
+query coordinates have different units or characteristic magnitudes.
+
+Several boundaries remain essential:
+
+- Shapley attribution is relative to the declared factor set. Adding or removing
+  a correlated factor can redistribute attribution.
+- A support label is not an independently measured physical cause.
+- Conditional covariance sources are summed because the caller declares them
+  additive; the artifact does not infer independence or non-overlap.
+- Small posterior variance does not establish empirical calibration.
+- The diagnostic cannot select a confirmatory query, prefix, model, threshold,
+  exclusion, or optional branch from target outcomes.
+
+For paper-facing use, report this decomposition beside held-out execution-level
+proper scores, coverage, interval width, exact fallback, and oracle attribution.

--- a/examples/query_variance_decomposition_spec.json
+++ b/examples/query_variance_decomposition_spec.json
@@ -1,0 +1,40 @@
+{
+  "artifact_kind": "Causal4DQueryVarianceDecompositionInputV1",
+  "conditional_covariance_arrays": {
+    "readout_discrepancy": "readout_covariance"
+  },
+  "factor_values": {
+    "contact": [
+      "left",
+      "right",
+      "left",
+      "right"
+    ],
+    "physical_particle": [
+      "p0",
+      "p0",
+      "p1",
+      "p1"
+    ]
+  },
+  "metadata": {
+    "registered_before_target_access": true
+  },
+  "query_id": "late-endpoint-position",
+  "query_labels": [
+    "x",
+    "y",
+    "z"
+  ],
+  "query_scales": [
+    0.01,
+    0.01,
+    0.01
+  ],
+  "query_units": [
+    "m",
+    "m",
+    "m"
+  ],
+  "schema_version": 1
+}

--- a/src/causal4d/cli/command_registry.py
+++ b/src/causal4d/cli/command_registry.py
@@ -777,6 +777,12 @@ COMMANDS = (
         lifecycle="stable",
     ),
     CommandSpec(
+        route=("diagnostic", "uncertainty", "decompose-query"),
+        target="causal4d.cli.query_variance_decomposition:main",
+        summary="Attribute a fixed query covariance to declared sources.",
+        lifecycle="diagnostic",
+    ),
+    CommandSpec(
         route=("evidence", "interpret-real-result"),
         target="causal4d.cli.real_result_interpretation:main",
         summary="Apply the preregistered real-result interpretation tree.",

--- a/src/causal4d/cli/query_variance_decomposition.py
+++ b/src/causal4d/cli/query_variance_decomposition.py
@@ -1,0 +1,257 @@
+"""Build or validate a query-space uncertainty-attribution artifact."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+import json
+from pathlib import Path
+from typing import Any, cast
+
+from causal4d.artifact_io import (
+    load_strict_json_object,
+    read_regular_file_no_symlinks,
+)
+from causal4d.atomic_io import atomic_write_json
+from causal4d.numpy_archive import load_numpy_archive
+from causal4d.query_variance_decomposition import (
+    build_query_variance_decomposition,
+    validate_query_variance_decomposition,
+)
+
+_INPUT_SCHEMA_VERSION = 1
+_INPUT_ARTIFACT_KIND = "Causal4DQueryVarianceDecompositionInputV1"
+_REQUIRED_SPEC_FIELDS = frozenset(
+    {
+        "schema_version",
+        "artifact_kind",
+        "query_id",
+        "query_labels",
+        "query_units",
+        "query_scales",
+    }
+)
+_OPTIONAL_SPEC_FIELDS = frozenset(
+    {
+        "weights_array",
+        "means_array",
+        "factor_values",
+        "conditional_covariance_arrays",
+        "metadata",
+    }
+)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _mapping(value: object, *, name: str) -> Mapping[str, Any]:
+    _require(isinstance(value, Mapping), f"{name} must be a JSON object")
+    _require(
+        all(type(key) is str for key in value),
+        f"{name} keys must be strings",
+    )
+    return cast(Mapping[str, Any], value)
+
+
+def _string(value: object, *, name: str) -> str:
+    _require(type(value) is str and bool(value), f"{name} must be nonempty")
+    return cast(str, value)
+
+
+def _strings(value: object, *, name: str) -> tuple[str, ...]:
+    _require(
+        isinstance(value, Sequence) and not isinstance(value, (str, bytes)),
+        f"{name} must be a JSON array",
+    )
+    return tuple(
+        _string(item, name=f"{name}[{index}]") for index, item in enumerate(value)
+    )
+
+
+def _load_spec(path: str | Path) -> tuple[dict[str, Any], str, int]:
+    snapshot = read_regular_file_no_symlinks(
+        path,
+        name="query variance decomposition specification",
+    )
+    payload = load_strict_json_object(
+        snapshot.payload,
+        name="query variance decomposition specification",
+    )
+    actual = set(payload)
+    _require(
+        _REQUIRED_SPEC_FIELDS <= actual,
+        "decomposition specification is missing required fields",
+    )
+    _require(
+        actual <= _REQUIRED_SPEC_FIELDS | _OPTIONAL_SPEC_FIELDS,
+        "decomposition specification contains unsupported fields",
+    )
+    _require(
+        payload.get("schema_version") == _INPUT_SCHEMA_VERSION,
+        "unsupported decomposition input schema",
+    )
+    _require(
+        payload.get("artifact_kind") == _INPUT_ARTIFACT_KIND,
+        "unexpected decomposition input artifact kind",
+    )
+    return payload, snapshot.sha256, snapshot.byte_count
+
+
+def _build_parser(subparsers: Any) -> None:
+    build = subparsers.add_parser(
+        "build",
+        help="build one content-addressed decomposition from strict JSON and NPZ",
+    )
+    build.add_argument("input_npz")
+    build.add_argument("spec_json")
+    build.add_argument("output_json")
+    build.add_argument("--overwrite", action="store_true")
+
+
+def _validate_parser(subparsers: Any) -> None:
+    validate = subparsers.add_parser(
+        "validate",
+        help="validate a portable decomposition and numerical additivity",
+    )
+    validate.add_argument("decomposition_json")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="causal4d diagnostic uncertainty decompose-query",
+        description=__doc__,
+    )
+    subparsers = parser.add_subparsers(dest="operation", required=True)
+    _build_parser(subparsers)
+    _validate_parser(subparsers)
+    return parser
+
+
+def _build(args: argparse.Namespace) -> dict[str, Any]:
+    spec, spec_sha256, spec_bytes = _load_spec(args.spec_json)
+    archive = load_numpy_archive(
+        args.input_npz,
+        name="query variance decomposition input",
+    )
+    weights_key = _string(
+        spec.get("weights_array", "component_weights"),
+        name="weights_array",
+    )
+    means_key = _string(
+        spec.get("means_array", "component_query_means"),
+        name="means_array",
+    )
+    _require(weights_key != means_key, "weights and means arrays must differ")
+    conditional_keys = _mapping(
+        spec.get("conditional_covariance_arrays", {}),
+        name="conditional_covariance_arrays",
+    )
+    conditional_array_names = tuple(
+        _string(value, name=f"conditional array {name!r}")
+        for name, value in sorted(conditional_keys.items())
+    )
+    _require(
+        len(conditional_array_names) == len(set(conditional_array_names)),
+        "conditional covariance arrays must be unique",
+    )
+    _require(
+        weights_key not in conditional_array_names
+        and means_key not in conditional_array_names,
+        "conditional covariance arrays must not reuse weights or means",
+    )
+    expected_keys = {weights_key, means_key, *conditional_array_names}
+    _require(
+        set(archive.arrays) == expected_keys,
+        "input archive array inventory differs from the specification",
+    )
+
+    factors_raw = _mapping(spec.get("factor_values", {}), name="factor_values")
+    factors = {
+        _string(name, name="factor name"): _strings(
+            factors_raw[name],
+            name=f"factor_values[{name!r}]",
+        )
+        for name in sorted(factors_raw)
+    }
+    conditional = {
+        _string(name, name="conditional covariance source"): archive.arrays[
+            _string(
+                conditional_keys[name],
+                name=f"conditional array {name!r}",
+            )
+        ]
+        for name in sorted(conditional_keys)
+    }
+    metadata = dict(_mapping(spec.get("metadata", {}), name="metadata"))
+    _require(
+        "input_provenance" not in metadata,
+        "metadata.input_provenance is reserved for verified source identities",
+    )
+    metadata["input_provenance"] = {
+        "input_npz_sha256": archive.snapshot.sha256,
+        "input_npz_bytes": archive.snapshot.byte_count,
+        "spec_sha256": spec_sha256,
+        "spec_bytes": spec_bytes,
+    }
+    result = validate_query_variance_decomposition(
+        build_query_variance_decomposition(
+            archive.arrays[weights_key],
+            archive.arrays[means_key],
+            query_id=_string(spec.get("query_id"), name="query_id"),
+            query_labels=_strings(
+                spec.get("query_labels"),
+                name="query_labels",
+            ),
+            query_units=_strings(spec.get("query_units"), name="query_units"),
+            query_scales=spec.get("query_scales"),
+            factor_values=factors,
+            conditional_covariances=conditional,
+            metadata=metadata,
+        ).as_dict()
+    )
+    atomic_write_json(args.output_json, result, overwrite=args.overwrite)
+    return {
+        "passed": True,
+        "decomposition_id": result["decomposition_id"],
+        "output_json": str(Path(args.output_json).resolve()),
+        "component_count": result["support"]["component_count"],
+        "factor_names": result["support"]["factor_names"],
+    }
+
+
+def _validate(args: argparse.Namespace) -> dict[str, Any]:
+    snapshot = read_regular_file_no_symlinks(
+        args.decomposition_json,
+        name="query variance decomposition",
+    )
+    payload = load_strict_json_object(
+        snapshot.payload,
+        name="query variance decomposition",
+    )
+    result = validate_query_variance_decomposition(payload)
+    return {
+        "passed": True,
+        "decomposition_id": result["decomposition_id"],
+        "sha256": snapshot.sha256,
+        "bytes": snapshot.byte_count,
+        "component_count": result["support"]["component_count"],
+        "factor_names": result["support"]["factor_names"],
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        result = _build(args) if args.operation == "build" else _validate(args)
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        print(json.dumps({"passed": False, "error": str(error)}, indent=2))
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d/query_variance_decomposition.py
+++ b/src/causal4d/query_variance_decomposition.py
@@ -1,0 +1,1121 @@
+"""Query-space uncertainty attribution for finite posterior mixtures."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+import hashlib
+import json
+import math
+from types import MappingProxyType
+from typing import Any, Final, cast
+
+import numpy as np
+
+from causal4d.immutable_array import readonly_array
+from causal4d.immutable_json import plain_json, validated_json_mapping
+
+QUERY_VARIANCE_DECOMPOSITION_SCHEMA_VERSION: Final = 1
+QUERY_VARIANCE_DECOMPOSITION_ARTIFACT_KIND: Final = (
+    "Causal4DQueryVarianceDecompositionV1"
+)
+QUERY_VARIANCE_DECOMPOSITION_CLAIM_BOUNDARY: Final = (
+    "Diagnostic attribution of a fixed finite posterior query. It does not "
+    "change the posterior, identify a physical cause, establish empirical "
+    "calibration, or authorize confirmatory method selection."
+)
+MAX_EXACT_SHAPLEY_FACTORS: Final = 8
+_FACTOR_ATTRIBUTION = "exact_shapley_over_explained_covariance"
+_UNRESOLVED_ROLE = (
+    "between-component variation not distinguished by the declared factor labels"
+)
+_CONDITIONAL_SOURCE_SEMANTICS = (
+    "caller-declared additive conditional covariance sources; independence or "
+    "non-overlap is not inferred by this artifact"
+)
+_TOP_LEVEL_FIELDS = frozenset(
+    {
+        "schema_version",
+        "artifact_kind",
+        "decomposition_id",
+        "claim_boundary",
+        "query",
+        "support",
+        "input_identities",
+        "posterior_mean",
+        "covariance",
+        "variance_share_by_query_coordinate",
+        "standardized_trace_share",
+        "diagnostics",
+        "metadata",
+    }
+)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _mapping(value: object, *, name: str) -> Mapping[str, Any]:
+    _require(isinstance(value, Mapping), f"{name} must be a mapping")
+    _require(
+        all(type(key) is str for key in value),
+        f"{name} keys must be strings",
+    )
+    return cast(Mapping[str, Any], value)
+
+
+def _nonempty_string(value: object, *, name: str) -> str:
+    _require(type(value) is str and bool(value), f"{name} must be nonempty")
+    return cast(str, value)
+
+
+def _string_tuple(
+    values: object,
+    *,
+    name: str,
+    expected_count: int | None = None,
+    unique: bool = False,
+) -> tuple[str, ...]:
+    _require(
+        isinstance(values, Sequence) and not isinstance(values, (str, bytes)),
+        f"{name} must be a sequence of strings",
+    )
+    result = tuple(
+        _nonempty_string(value, name=f"{name}[{index}]")
+        for index, value in enumerate(values)
+    )
+    if expected_count is not None:
+        _require(
+            len(result) == expected_count,
+            f"{name} must contain {expected_count} values",
+        )
+    if unique:
+        _require(len(set(result)) == len(result), f"{name} must be unique")
+    return result
+
+
+def _float_array(values: object, *, name: str) -> np.ndarray:
+    source = np.asarray(values)
+    _require(
+        source.dtype.kind in {"i", "u", "f"},
+        f"{name} must contain real numbers without Boolean or string coercion",
+    )
+    result = np.asarray(source, dtype=np.float64)
+    if source.dtype.kind in {"i", "u"} and source.size:
+        round_trip = result.astype(source.dtype, copy=False)
+        _require(
+            np.array_equal(round_trip, source),
+            f"{name} contains integers not exactly representable as float64",
+        )
+    _require(np.all(np.isfinite(result)), f"{name} must be finite")
+    return readonly_array(result, dtype=np.float64)
+
+
+def _array_sha256(values: np.ndarray) -> str:
+    array = np.ascontiguousarray(values)
+    header = json.dumps(
+        {"dtype": array.dtype.str, "shape": list(array.shape)},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    digest = hashlib.sha256()
+    digest.update(header)
+    digest.update(b"\0")
+    digest.update(array.tobytes(order="C"))
+    return digest.hexdigest()
+
+
+def _validated_sha256(value: object, *, name: str) -> str:
+    text = _nonempty_string(value, name=name)
+    _require(
+        len(text) == 64 and all(character in "0123456789abcdef" for character in text),
+        f"{name} must be a lowercase SHA-256 digest",
+    )
+    return text
+
+
+def _canonical_sha256(payload: Mapping[str, Any], *, omitted: str) -> str:
+    values = dict(payload)
+    values.pop(omitted, None)
+    encoded = json.dumps(
+        values,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _symmetrize_psd(
+    matrix: np.ndarray,
+    *,
+    name: str,
+    tolerance_scale: float = 1.0e-10,
+) -> np.ndarray:
+    _require(matrix.ndim == 2, f"{name} must be a matrix")
+    _require(matrix.shape[0] == matrix.shape[1], f"{name} must be square")
+    symmetric = 0.5 * (matrix + matrix.T)
+    eigenvalues = np.linalg.eigvalsh(symmetric)
+    scale = max(
+        1.0,
+        float(np.max(np.abs(eigenvalues), initial=0.0)),
+        float(np.linalg.norm(symmetric, ord=2)),
+    )
+    tolerance = tolerance_scale * scale
+    minimum = float(np.min(eigenvalues, initial=0.0))
+    _require(minimum >= -tolerance, f"{name} is not positive semidefinite")
+    return readonly_array(symmetric, dtype=np.float64)
+
+
+def _validate_covariance_stack(
+    values: object,
+    *,
+    name: str,
+    component_count: int,
+    query_dimension: int,
+) -> np.ndarray:
+    stack = _float_array(values, name=name)
+    expected = (component_count, query_dimension, query_dimension)
+    _require(stack.shape == expected, f"{name} must have shape {expected}")
+    validated = np.empty_like(stack)
+    for index, covariance in enumerate(stack):
+        validated[index] = _symmetrize_psd(
+            covariance,
+            name=f"{name}[{index}]",
+        )
+    return readonly_array(validated, dtype=np.float64)
+
+
+def _weighted_covariance(
+    weights: np.ndarray,
+    values: np.ndarray,
+    mean: np.ndarray,
+) -> np.ndarray:
+    centered = values - mean[None, :]
+    covariance = np.einsum(
+        "c,ci,cj->ij",
+        weights,
+        centered,
+        centered,
+        optimize=True,
+    )
+    return _symmetrize_psd(covariance, name="weighted query covariance")
+
+
+def _explained_covariance(
+    weights: np.ndarray,
+    means: np.ndarray,
+    global_mean: np.ndarray,
+    factors: Mapping[str, tuple[str, ...]],
+    selected: tuple[str, ...],
+) -> np.ndarray:
+    dimension = means.shape[1]
+    if not selected:
+        return readonly_array(np.zeros((dimension, dimension), dtype=np.float64))
+
+    grouped: dict[tuple[str, ...], tuple[float, np.ndarray]] = {}
+    for component in range(means.shape[0]):
+        key = tuple(factors[name][component] for name in selected)
+        mass, weighted_sum = grouped.get(
+            key,
+            (0.0, np.zeros(dimension, dtype=np.float64)),
+        )
+        component_weight = float(weights[component])
+        grouped[key] = (
+            mass + component_weight,
+            weighted_sum + component_weight * means[component],
+        )
+
+    covariance = np.zeros((dimension, dimension), dtype=np.float64)
+    for mass, weighted_sum in grouped.values():
+        _require(mass > 0.0, "factor group has zero posterior mass")
+        group_mean = weighted_sum / mass
+        difference = group_mean - global_mean
+        covariance += mass * np.outer(difference, difference)
+    return _symmetrize_psd(covariance, name="factor-explained covariance")
+
+
+def _normalized_weights(values: object, *, component_count: int) -> np.ndarray:
+    weights = _float_array(values, name="component_weights")
+    _require(
+        weights.shape == (component_count,),
+        f"component_weights must have shape ({component_count},)",
+    )
+    _require(np.all(weights >= 0.0), "component_weights must be nonnegative")
+    total = float(np.sum(weights))
+    _require(total > 0.0, "component_weights must have positive total mass")
+    return readonly_array(weights / total, dtype=np.float64)
+
+
+def _factor_mapping(
+    values: Mapping[str, Sequence[str]],
+    *,
+    component_count: int,
+) -> Mapping[str, tuple[str, ...]]:
+    mapping = _mapping(values, name="factor_values")
+    names = tuple(sorted(mapping))
+    _require(
+        len(names) <= MAX_EXACT_SHAPLEY_FACTORS,
+        "too many factors for exact Shapley attribution",
+    )
+    result: dict[str, tuple[str, ...]] = {}
+    for name in names:
+        factor_name = _nonempty_string(name, name="factor name")
+        result[factor_name] = _string_tuple(
+            mapping[name],
+            name=f"factor_values[{factor_name!r}]",
+            expected_count=component_count,
+        )
+    return MappingProxyType(result)
+
+
+def _conditional_mapping(
+    values: Mapping[str, object],
+    *,
+    component_count: int,
+    query_dimension: int,
+) -> Mapping[str, np.ndarray]:
+    mapping = _mapping(values, name="conditional_covariances")
+    result: dict[str, np.ndarray] = {}
+    for name in sorted(mapping):
+        source = _nonempty_string(name, name="conditional covariance source")
+        result[source] = _validate_covariance_stack(
+            mapping[name],
+            name=f"conditional_covariances[{source!r}]",
+            component_count=component_count,
+            query_dimension=query_dimension,
+        )
+    return MappingProxyType(result)
+
+
+def _trace_in_registered_scale(
+    covariance: np.ndarray,
+    scales: np.ndarray,
+) -> float:
+    inverse = 1.0 / scales
+    standardized = covariance * inverse[:, None] * inverse[None, :]
+    return float(np.trace(standardized))
+
+
+def _safe_variance_share(
+    contribution: np.ndarray,
+    total: np.ndarray,
+) -> list[float]:
+    total_variance = np.diag(total)
+    contribution_variance = np.diag(contribution)
+    scale = max(1.0, float(np.max(np.abs(total_variance), initial=0.0)))
+    tolerance = 1.0e-12 * scale
+    shares = np.zeros_like(total_variance)
+    active = total_variance > tolerance
+    shares[active] = contribution_variance[active] / total_variance[active]
+    shares[np.abs(shares) < 1.0e-14] = 0.0
+    return [float(value) for value in shares]
+
+
+def _json_float(value: object, *, name: str) -> float:
+    _require(
+        type(value) in {int, float} and np.isfinite(value),
+        f"{name} must be a finite JSON number",
+    )
+    return float(cast(float, value))
+
+
+def _json_array(
+    value: object,
+    *,
+    name: str,
+    shape: tuple[int, ...],
+) -> np.ndarray:
+    array = _float_array(value, name=name)
+    _require(array.shape == shape, f"{name} must have shape {shape}")
+    return array
+
+
+@dataclass(frozen=True)
+class QueryVarianceDecompositionV1:
+    """Exact Shapley attribution of a fixed finite-mixture query covariance."""
+
+    query_id: str
+    query_labels: tuple[str, ...]
+    query_units: tuple[str, ...]
+    query_scales: np.ndarray
+    component_weights: np.ndarray
+    component_query_means: np.ndarray
+    factor_values: Mapping[str, Sequence[str]] = field(default_factory=dict)
+    conditional_covariances: Mapping[str, object] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    _posterior_mean: np.ndarray = field(init=False, repr=False)
+    _between_covariance: np.ndarray = field(init=False, repr=False)
+    _factor_covariances: Mapping[str, np.ndarray] = field(init=False, repr=False)
+    _unresolved_covariance: np.ndarray = field(init=False, repr=False)
+    _conditional_contributions: Mapping[str, np.ndarray] = field(
+        init=False,
+        repr=False,
+    )
+    _total_covariance: np.ndarray = field(init=False, repr=False)
+    _max_abs_additivity_error: float = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        query_id = _nonempty_string(self.query_id, name="query_id")
+        means = _float_array(
+            self.component_query_means,
+            name="component_query_means",
+        )
+        _require(
+            means.ndim == 2 and min(means.shape) >= 1,
+            "component_query_means must have shape (component, query)",
+        )
+        component_count, query_dimension = means.shape
+        labels = _string_tuple(
+            self.query_labels,
+            name="query_labels",
+            expected_count=query_dimension,
+            unique=True,
+        )
+        units = _string_tuple(
+            self.query_units,
+            name="query_units",
+            expected_count=query_dimension,
+        )
+        scales = _float_array(self.query_scales, name="query_scales")
+        _require(
+            scales.shape == (query_dimension,),
+            f"query_scales must have shape ({query_dimension},)",
+        )
+        _require(np.all(scales > 0.0), "query_scales must be positive")
+        weights = _normalized_weights(
+            self.component_weights,
+            component_count=component_count,
+        )
+        factors = _factor_mapping(
+            self.factor_values,
+            component_count=component_count,
+        )
+        conditional = _conditional_mapping(
+            self.conditional_covariances,
+            component_count=component_count,
+            query_dimension=query_dimension,
+        )
+        metadata = validated_json_mapping(
+            self.metadata,
+            error_message="metadata must be finite JSON data",
+        )
+
+        posterior_mean = readonly_array(weights @ means, dtype=np.float64)
+        between = _weighted_covariance(weights, means, posterior_mean)
+        factor_names = tuple(factors)
+        explained: dict[int, np.ndarray] = {}
+        for mask in range(1 << len(factor_names)):
+            selected = tuple(
+                factor_names[index]
+                for index in range(len(factor_names))
+                if mask & (1 << index)
+            )
+            explained[mask] = _explained_covariance(
+                weights,
+                means,
+                posterior_mean,
+                factors,
+                selected,
+            )
+
+        factor_covariances: dict[str, np.ndarray] = {}
+        factor_count = len(factor_names)
+        if factor_count:
+            denominator = math.factorial(factor_count)
+            for index, name in enumerate(factor_names):
+                contribution = np.zeros_like(between)
+                for mask in range(1 << factor_count):
+                    if mask & (1 << index):
+                        continue
+                    subset_size = int(mask.bit_count())
+                    coefficient = (
+                        math.factorial(subset_size)
+                        * math.factorial(factor_count - subset_size - 1)
+                        / denominator
+                    )
+                    contribution += coefficient * (
+                        explained[mask | (1 << index)] - explained[mask]
+                    )
+                factor_covariances[name] = _symmetrize_psd(
+                    contribution,
+                    name=f"Shapley covariance for factor {name!r}",
+                )
+            fully_explained = explained[(1 << factor_count) - 1]
+        else:
+            fully_explained = np.zeros_like(between)
+
+        unresolved = _symmetrize_psd(
+            between - fully_explained,
+            name="unresolved component covariance",
+        )
+        conditional_contributions = {
+            name: _symmetrize_psd(
+                np.einsum("c,cij->ij", weights, stack, optimize=True),
+                name=f"posterior conditional covariance {name!r}",
+            )
+            for name, stack in conditional.items()
+        }
+        total = np.array(between, copy=True)
+        for covariance in conditional_contributions.values():
+            total += covariance
+        total = _symmetrize_psd(total, name="total query covariance")
+
+        reconstructed = np.array(unresolved, copy=True)
+        for covariance in factor_covariances.values():
+            reconstructed += covariance
+        for covariance in conditional_contributions.values():
+            reconstructed += covariance
+        max_error = float(np.max(np.abs(total - reconstructed), initial=0.0))
+        tolerance = 1.0e-9 * max(
+            1.0,
+            float(np.max(np.abs(total), initial=0.0)),
+        )
+        _require(
+            max_error <= tolerance,
+            "query variance decomposition failed numerical additivity",
+        )
+
+        object.__setattr__(self, "query_id", query_id)
+        object.__setattr__(self, "query_labels", labels)
+        object.__setattr__(self, "query_units", units)
+        object.__setattr__(self, "query_scales", readonly_array(scales))
+        object.__setattr__(self, "component_weights", readonly_array(weights))
+        object.__setattr__(self, "component_query_means", readonly_array(means))
+        object.__setattr__(self, "factor_values", factors)
+        object.__setattr__(self, "conditional_covariances", conditional)
+        object.__setattr__(self, "metadata", metadata)
+        object.__setattr__(self, "_posterior_mean", posterior_mean)
+        object.__setattr__(self, "_between_covariance", between)
+        object.__setattr__(
+            self,
+            "_factor_covariances",
+            MappingProxyType(factor_covariances),
+        )
+        object.__setattr__(self, "_unresolved_covariance", unresolved)
+        object.__setattr__(
+            self,
+            "_conditional_contributions",
+            MappingProxyType(conditional_contributions),
+        )
+        object.__setattr__(self, "_total_covariance", total)
+        object.__setattr__(self, "_max_abs_additivity_error", max_error)
+
+    def summary_arrays(self) -> Mapping[str, np.ndarray]:
+        values: dict[str, np.ndarray] = {
+            "posterior_mean": self._posterior_mean,
+            "total_covariance": self._total_covariance,
+            "between_component_covariance": self._between_covariance,
+            "unresolved_component_covariance": self._unresolved_covariance,
+        }
+        values.update(
+            {
+                f"factor__{name}": covariance
+                for name, covariance in self._factor_covariances.items()
+            }
+        )
+        values.update(
+            {
+                f"conditional__{name}": covariance
+                for name, covariance in self._conditional_contributions.items()
+            }
+        )
+        return MappingProxyType(values)
+
+    def _contributions(self) -> dict[str, np.ndarray]:
+        values = {
+            f"factor:{name}": covariance
+            for name, covariance in self._factor_covariances.items()
+        }
+        values["unresolved_component"] = self._unresolved_covariance
+        values.update(
+            {
+                f"conditional:{name}": covariance
+                for name, covariance in self._conditional_contributions.items()
+            }
+        )
+        return values
+
+    def _payload_without_identity(self) -> dict[str, Any]:
+        contributions = self._contributions()
+        standardized_total_trace = _trace_in_registered_scale(
+            self._total_covariance,
+            self.query_scales,
+        )
+        trace_shares = {
+            name: (
+                _trace_in_registered_scale(covariance, self.query_scales)
+                / standardized_total_trace
+                if standardized_total_trace > 0.0
+                else 0.0
+            )
+            for name, covariance in contributions.items()
+        }
+        variance_shares = {
+            name: _safe_variance_share(covariance, self._total_covariance)
+            for name, covariance in contributions.items()
+        }
+        return {
+            "schema_version": QUERY_VARIANCE_DECOMPOSITION_SCHEMA_VERSION,
+            "artifact_kind": QUERY_VARIANCE_DECOMPOSITION_ARTIFACT_KIND,
+            "claim_boundary": QUERY_VARIANCE_DECOMPOSITION_CLAIM_BOUNDARY,
+            "query": {
+                "query_id": self.query_id,
+                "labels": list(self.query_labels),
+                "units": list(self.query_units),
+                "scales": self.query_scales.tolist(),
+            },
+            "support": {
+                "component_count": int(self.component_query_means.shape[0]),
+                "effective_component_count": float(
+                    1.0 / np.sum(self.component_weights**2)
+                ),
+                "factor_names": list(self.factor_values),
+                "factor_values": {
+                    name: list(values) for name, values in self.factor_values.items()
+                },
+                "conditional_covariance_sources": list(self.conditional_covariances),
+            },
+            "input_identities": {
+                "query_scales_sha256": _array_sha256(self.query_scales),
+                "component_weights_sha256": _array_sha256(self.component_weights),
+                "component_query_means_sha256": _array_sha256(
+                    self.component_query_means
+                ),
+                "conditional_covariance_sha256": {
+                    name: _array_sha256(values)
+                    for name, values in self.conditional_covariances.items()
+                },
+            },
+            "posterior_mean": self._posterior_mean.tolist(),
+            "covariance": {
+                "total": self._total_covariance.tolist(),
+                "between_components": self._between_covariance.tolist(),
+                "factor_shapley": {
+                    name: covariance.tolist()
+                    for name, covariance in self._factor_covariances.items()
+                },
+                "unresolved_component": self._unresolved_covariance.tolist(),
+                "conditional_sources": {
+                    name: covariance.tolist()
+                    for name, covariance in self._conditional_contributions.items()
+                },
+            },
+            "variance_share_by_query_coordinate": variance_shares,
+            "standardized_trace_share": {
+                name: float(value) for name, value in trace_shares.items()
+            },
+            "diagnostics": {
+                "max_abs_additivity_error": self._max_abs_additivity_error,
+                "standardized_total_trace": standardized_total_trace,
+                "factor_attribution": _FACTOR_ATTRIBUTION,
+                "unresolved_role": _UNRESOLVED_ROLE,
+                "conditional_source_semantics": _CONDITIONAL_SOURCE_SEMANTICS,
+            },
+            "metadata": plain_json(self.metadata),
+        }
+
+    @property
+    def decomposition_id(self) -> str:
+        return _canonical_sha256(
+            self._payload_without_identity(),
+            omitted="decomposition_id",
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        payload = self._payload_without_identity()
+        payload["decomposition_id"] = self.decomposition_id
+        return payload
+
+
+def _contribution_mapping(
+    covariance: Mapping[str, Any],
+    *,
+    query_dimension: int,
+) -> tuple[
+    np.ndarray,
+    np.ndarray,
+    Mapping[str, np.ndarray],
+    np.ndarray,
+    Mapping[str, np.ndarray],
+]:
+    _require(
+        set(covariance)
+        == {
+            "total",
+            "between_components",
+            "factor_shapley",
+            "unresolved_component",
+            "conditional_sources",
+        },
+        "covariance fields changed",
+    )
+    shape = (query_dimension, query_dimension)
+    total = _symmetrize_psd(
+        _json_array(covariance["total"], name="total covariance", shape=shape),
+        name="total covariance",
+    )
+    between = _symmetrize_psd(
+        _json_array(
+            covariance["between_components"],
+            name="between-component covariance",
+            shape=shape,
+        ),
+        name="between-component covariance",
+    )
+    factor_raw = _mapping(
+        covariance["factor_shapley"],
+        name="factor Shapley covariance",
+    )
+    factor = MappingProxyType(
+        {
+            name: _symmetrize_psd(
+                _json_array(
+                    value,
+                    name=f"factor covariance {name!r}",
+                    shape=shape,
+                ),
+                name=f"factor covariance {name!r}",
+            )
+            for name, value in sorted(factor_raw.items())
+        }
+    )
+    unresolved = _symmetrize_psd(
+        _json_array(
+            covariance["unresolved_component"],
+            name="unresolved component covariance",
+            shape=shape,
+        ),
+        name="unresolved component covariance",
+    )
+    conditional_raw = _mapping(
+        covariance["conditional_sources"],
+        name="conditional covariance sources",
+    )
+    conditional = MappingProxyType(
+        {
+            name: _symmetrize_psd(
+                _json_array(
+                    value,
+                    name=f"conditional covariance {name!r}",
+                    shape=shape,
+                ),
+                name=f"conditional covariance {name!r}",
+            )
+            for name, value in sorted(conditional_raw.items())
+        }
+    )
+    return total, between, factor, unresolved, conditional
+
+
+def validate_query_variance_decomposition(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate a portable decomposition summary and its numerical additivity."""
+
+    values = _mapping(payload, name="query variance decomposition")
+    _require(set(values) == _TOP_LEVEL_FIELDS, "decomposition fields changed")
+    _require(
+        values.get("schema_version") == QUERY_VARIANCE_DECOMPOSITION_SCHEMA_VERSION,
+        "unsupported query variance decomposition schema",
+    )
+    _require(
+        values.get("artifact_kind") == QUERY_VARIANCE_DECOMPOSITION_ARTIFACT_KIND,
+        "unexpected query variance decomposition artifact kind",
+    )
+    _require(
+        values.get("claim_boundary") == QUERY_VARIANCE_DECOMPOSITION_CLAIM_BOUNDARY,
+        "query variance decomposition claim boundary changed",
+    )
+
+    query = _mapping(values.get("query"), name="query")
+    _require(
+        set(query) == {"query_id", "labels", "units", "scales"},
+        "query fields changed",
+    )
+    query_id = _nonempty_string(query.get("query_id"), name="query_id")
+    labels = _string_tuple(query.get("labels"), name="query labels", unique=True)
+    _require(labels, "query labels must be nonempty")
+    dimension = len(labels)
+    units = _string_tuple(
+        query.get("units"),
+        name="query units",
+        expected_count=dimension,
+    )
+    scales = _json_array(
+        query.get("scales"),
+        name="query scales",
+        shape=(dimension,),
+    )
+    _require(np.all(scales > 0.0), "query scales must be positive")
+
+    support = _mapping(values.get("support"), name="support")
+    _require(
+        set(support)
+        == {
+            "component_count",
+            "effective_component_count",
+            "factor_names",
+            "factor_values",
+            "conditional_covariance_sources",
+        },
+        "support fields changed",
+    )
+    component_count_raw = support.get("component_count")
+    _require(
+        type(component_count_raw) is int and component_count_raw > 0,
+        "component_count must be a positive integer",
+    )
+    component_count = cast(int, component_count_raw)
+    effective_count = _json_float(
+        support.get("effective_component_count"),
+        name="effective_component_count",
+    )
+    _require(
+        1.0 - 1.0e-12 <= effective_count <= component_count + 1.0e-12,
+        "effective_component_count is outside the finite support",
+    )
+    factor_names = _string_tuple(
+        support.get("factor_names"),
+        name="factor names",
+        unique=True,
+    )
+    _require(
+        len(factor_names) <= MAX_EXACT_SHAPLEY_FACTORS,
+        "too many factors for exact Shapley attribution",
+    )
+    factor_values_raw = _mapping(
+        support.get("factor_values"),
+        name="factor values",
+    )
+    _require(
+        factor_names == tuple(sorted(factor_values_raw)),
+        "factor names do not match the factor-value inventory",
+    )
+    factor_values = {
+        name: list(
+            _string_tuple(
+                factor_values_raw[name],
+                name=f"factor values {name!r}",
+                expected_count=component_count,
+            )
+        )
+        for name in factor_names
+    }
+    conditional_names = _string_tuple(
+        support.get("conditional_covariance_sources"),
+        name="conditional covariance sources",
+        unique=True,
+    )
+    _require(
+        conditional_names == tuple(sorted(conditional_names)),
+        "conditional covariance sources must be sorted",
+    )
+
+    identities = _mapping(values.get("input_identities"), name="input identities")
+    _require(
+        set(identities)
+        == {
+            "query_scales_sha256",
+            "component_weights_sha256",
+            "component_query_means_sha256",
+            "conditional_covariance_sha256",
+        },
+        "input identity fields changed",
+    )
+    conditional_hashes_raw = _mapping(
+        identities.get("conditional_covariance_sha256"),
+        name="conditional covariance identities",
+    )
+    _require(
+        tuple(sorted(conditional_hashes_raw)) == conditional_names,
+        "conditional covariance identity inventory changed",
+    )
+    input_identities = {
+        "query_scales_sha256": _validated_sha256(
+            identities.get("query_scales_sha256"),
+            name="query scales SHA-256",
+        ),
+        "component_weights_sha256": _validated_sha256(
+            identities.get("component_weights_sha256"),
+            name="component weights SHA-256",
+        ),
+        "component_query_means_sha256": _validated_sha256(
+            identities.get("component_query_means_sha256"),
+            name="component query means SHA-256",
+        ),
+        "conditional_covariance_sha256": {
+            name: _validated_sha256(
+                conditional_hashes_raw[name],
+                name=f"conditional covariance {name!r} SHA-256",
+            )
+            for name in conditional_names
+        },
+    }
+    _require(
+        input_identities["query_scales_sha256"] == _array_sha256(scales),
+        "query scales identity changed",
+    )
+
+    posterior_mean = _json_array(
+        values.get("posterior_mean"),
+        name="posterior mean",
+        shape=(dimension,),
+    )
+    covariance = _mapping(values.get("covariance"), name="covariance")
+    total, between, factor, unresolved, conditional = _contribution_mapping(
+        covariance,
+        query_dimension=dimension,
+    )
+    _require(tuple(factor) == factor_names, "factor covariance inventory changed")
+    _require(
+        tuple(conditional) == conditional_names,
+        "conditional covariance inventory changed",
+    )
+
+    reconstructed_between = np.array(unresolved, copy=True)
+    for contribution in factor.values():
+        reconstructed_between += contribution
+    reconstructed_total = np.array(between, copy=True)
+    for contribution in conditional.values():
+        reconstructed_total += contribution
+    scale = max(1.0, float(np.max(np.abs(total), initial=0.0)))
+    tolerance = 1.0e-9 * scale
+    between_error = float(np.max(np.abs(between - reconstructed_between), initial=0.0))
+    total_error = float(np.max(np.abs(total - reconstructed_total), initial=0.0))
+    _require(
+        between_error <= tolerance,
+        "factor and unresolved covariance do not reconstruct between covariance",
+    )
+    _require(
+        total_error <= tolerance,
+        "between and conditional covariance do not reconstruct total covariance",
+    )
+
+    contributions: dict[str, np.ndarray] = {
+        **{f"factor:{name}": value for name, value in factor.items()},
+        "unresolved_component": unresolved,
+        **{f"conditional:{name}": value for name, value in conditional.items()},
+    }
+    expected_variance_shares = {
+        name: _safe_variance_share(value, total)
+        for name, value in contributions.items()
+    }
+    variance_shares_raw = _mapping(
+        values.get("variance_share_by_query_coordinate"),
+        name="coordinatewise variance shares",
+    )
+    _require(
+        set(variance_shares_raw) == set(contributions),
+        "coordinatewise variance share inventory changed",
+    )
+    normalized_variance_shares: dict[str, list[float]] = {}
+    for name in sorted(contributions):
+        share = _json_array(
+            variance_shares_raw[name],
+            name=f"coordinatewise variance share {name!r}",
+            shape=(dimension,),
+        )
+        _require(
+            np.allclose(
+                share,
+                expected_variance_shares[name],
+                rtol=1.0e-12,
+                atol=1.0e-12,
+            ),
+            f"coordinatewise variance share {name!r} changed",
+        )
+        normalized_variance_shares[name] = share.tolist()
+
+    standardized_total_trace = _trace_in_registered_scale(total, scales)
+    expected_trace_shares = {
+        name: (
+            _trace_in_registered_scale(value, scales) / standardized_total_trace
+            if standardized_total_trace > 0.0
+            else 0.0
+        )
+        for name, value in contributions.items()
+    }
+    trace_shares_raw = _mapping(
+        values.get("standardized_trace_share"),
+        name="standardized trace shares",
+    )
+    _require(
+        set(trace_shares_raw) == set(contributions),
+        "standardized trace share inventory changed",
+    )
+    normalized_trace_shares: dict[str, float] = {}
+    for name in sorted(contributions):
+        share = _json_float(
+            trace_shares_raw[name],
+            name=f"standardized trace share {name!r}",
+        )
+        _require(
+            math.isclose(
+                share,
+                expected_trace_shares[name],
+                rel_tol=1.0e-12,
+                abs_tol=1.0e-12,
+            ),
+            f"standardized trace share {name!r} changed",
+        )
+        normalized_trace_shares[name] = share
+
+    diagnostics = _mapping(values.get("diagnostics"), name="diagnostics")
+    _require(
+        set(diagnostics)
+        == {
+            "max_abs_additivity_error",
+            "standardized_total_trace",
+            "factor_attribution",
+            "unresolved_role",
+            "conditional_source_semantics",
+        },
+        "diagnostic fields changed",
+    )
+    reported_error = _json_float(
+        diagnostics.get("max_abs_additivity_error"),
+        name="max_abs_additivity_error",
+    )
+    expected_error = float(
+        np.max(
+            np.abs(
+                total
+                - sum(
+                    (value for value in contributions.values()),
+                    start=np.zeros_like(total),
+                )
+            ),
+            initial=0.0,
+        )
+    )
+    _require(
+        math.isclose(
+            reported_error,
+            expected_error,
+            rel_tol=1.0e-12,
+            abs_tol=1.0e-12,
+        ),
+        "reported additivity error changed",
+    )
+    reported_trace = _json_float(
+        diagnostics.get("standardized_total_trace"),
+        name="standardized_total_trace",
+    )
+    _require(
+        math.isclose(
+            reported_trace,
+            standardized_total_trace,
+            rel_tol=1.0e-12,
+            abs_tol=1.0e-12,
+        ),
+        "reported standardized total trace changed",
+    )
+    _require(
+        diagnostics.get("factor_attribution") == _FACTOR_ATTRIBUTION,
+        "factor attribution semantics changed",
+    )
+    _require(
+        diagnostics.get("unresolved_role") == _UNRESOLVED_ROLE,
+        "unresolved component semantics changed",
+    )
+    _require(
+        diagnostics.get("conditional_source_semantics")
+        == _CONDITIONAL_SOURCE_SEMANTICS,
+        "conditional covariance semantics changed",
+    )
+    metadata = plain_json(
+        validated_json_mapping(
+            _mapping(values.get("metadata"), name="metadata"),
+            error_message="metadata must be finite JSON data",
+        )
+    )
+
+    normalized: dict[str, Any] = {
+        "schema_version": QUERY_VARIANCE_DECOMPOSITION_SCHEMA_VERSION,
+        "artifact_kind": QUERY_VARIANCE_DECOMPOSITION_ARTIFACT_KIND,
+        "decomposition_id": values.get("decomposition_id"),
+        "claim_boundary": QUERY_VARIANCE_DECOMPOSITION_CLAIM_BOUNDARY,
+        "query": {
+            "query_id": query_id,
+            "labels": list(labels),
+            "units": list(units),
+            "scales": scales.tolist(),
+        },
+        "support": {
+            "component_count": component_count,
+            "effective_component_count": effective_count,
+            "factor_names": list(factor_names),
+            "factor_values": factor_values,
+            "conditional_covariance_sources": list(conditional_names),
+        },
+        "input_identities": input_identities,
+        "posterior_mean": posterior_mean.tolist(),
+        "covariance": {
+            "total": total.tolist(),
+            "between_components": between.tolist(),
+            "factor_shapley": {name: value.tolist() for name, value in factor.items()},
+            "unresolved_component": unresolved.tolist(),
+            "conditional_sources": {
+                name: value.tolist() for name, value in conditional.items()
+            },
+        },
+        "variance_share_by_query_coordinate": normalized_variance_shares,
+        "standardized_trace_share": normalized_trace_shares,
+        "diagnostics": {
+            "max_abs_additivity_error": reported_error,
+            "standardized_total_trace": reported_trace,
+            "factor_attribution": _FACTOR_ATTRIBUTION,
+            "unresolved_role": _UNRESOLVED_ROLE,
+            "conditional_source_semantics": _CONDITIONAL_SOURCE_SEMANTICS,
+        },
+        "metadata": metadata,
+    }
+    _require(
+        values.get("decomposition_id")
+        == _canonical_sha256(normalized, omitted="decomposition_id"),
+        "query variance decomposition content identity changed",
+    )
+    return normalized
+
+
+def build_query_variance_decomposition(
+    component_weights: object,
+    component_query_means: object,
+    *,
+    query_id: str,
+    query_labels: Sequence[str],
+    query_units: Sequence[str],
+    query_scales: object,
+    factor_values: Mapping[str, Sequence[str]] | None = None,
+    conditional_covariances: Mapping[str, object] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> QueryVarianceDecompositionV1:
+    """Build an immutable finite-mixture query variance decomposition."""
+
+    return QueryVarianceDecompositionV1(
+        query_id=query_id,
+        query_labels=tuple(query_labels),
+        query_units=tuple(query_units),
+        query_scales=np.asarray(query_scales),
+        component_weights=np.asarray(component_weights),
+        component_query_means=np.asarray(component_query_means),
+        factor_values={} if factor_values is None else factor_values,
+        conditional_covariances=(
+            {} if conditional_covariances is None else conditional_covariances
+        ),
+        metadata={} if metadata is None else metadata,
+    )
+
+
+__all__ = [
+    "MAX_EXACT_SHAPLEY_FACTORS",
+    "QUERY_VARIANCE_DECOMPOSITION_ARTIFACT_KIND",
+    "QUERY_VARIANCE_DECOMPOSITION_CLAIM_BOUNDARY",
+    "QUERY_VARIANCE_DECOMPOSITION_SCHEMA_VERSION",
+    "QueryVarianceDecompositionV1",
+    "build_query_variance_decomposition",
+    "validate_query_variance_decomposition",
+]

--- a/tests/test_query_variance_decomposition.py
+++ b/tests/test_query_variance_decomposition.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import copy
+
+import numpy as np
+import pytest
+
+from causal4d.query_variance_decomposition import (
+    build_query_variance_decomposition,
+    validate_query_variance_decomposition,
+)
+
+
+def test_additive_factor_attribution_and_conditional_covariance() -> None:
+    weights = np.full(4, 0.25)
+    means = np.array(
+        [
+            [0.0, 0.0],
+            [0.0, 2.0],
+            [1.0, 0.0],
+            [1.0, 2.0],
+        ]
+    )
+    observation = np.repeat(np.diag([0.1, 0.2])[None, :, :], 4, axis=0)
+    result = build_query_variance_decomposition(
+        weights,
+        means,
+        query_id="endpoint-position",
+        query_labels=("x", "y"),
+        query_units=("m", "m"),
+        query_scales=(1.0, 1.0),
+        factor_values={
+            "contact": ("left", "left", "right", "right"),
+            "gain": ("low", "high", "low", "high"),
+        },
+        conditional_covariances={"observation": observation},
+    )
+
+    arrays = result.summary_arrays()
+    np.testing.assert_allclose(arrays["factor__contact"], np.diag([0.25, 0.0]))
+    np.testing.assert_allclose(arrays["factor__gain"], np.diag([0.0, 1.0]))
+    np.testing.assert_allclose(
+        arrays["conditional__observation"],
+        np.diag([0.1, 0.2]),
+    )
+    np.testing.assert_allclose(
+        arrays["total_covariance"],
+        np.diag([0.35, 1.2]),
+    )
+    np.testing.assert_allclose(arrays["unresolved_component_covariance"], 0.0)
+    payload = result.as_dict()
+    assert payload["diagnostics"]["max_abs_additivity_error"] < 1.0e-12
+    assert validate_query_variance_decomposition(payload) == payload
+
+
+def test_factor_order_does_not_change_named_shapley_attribution() -> None:
+    weights = np.full(4, 0.25)
+    means = np.array([[0.0], [2.0], [1.0], [3.0]])
+    first = build_query_variance_decomposition(
+        weights,
+        means,
+        query_id="q",
+        query_labels=("q",),
+        query_units=("m",),
+        query_scales=(1.0,),
+        factor_values={
+            "a": ("0", "0", "1", "1"),
+            "b": ("0", "1", "0", "1"),
+        },
+    )
+    second = build_query_variance_decomposition(
+        weights,
+        means,
+        query_id="q",
+        query_labels=("q",),
+        query_units=("m",),
+        query_scales=(1.0,),
+        factor_values={
+            "b": ("0", "1", "0", "1"),
+            "a": ("0", "0", "1", "1"),
+        },
+    )
+
+    np.testing.assert_allclose(
+        first.summary_arrays()["factor__a"],
+        second.summary_arrays()["factor__a"],
+    )
+    np.testing.assert_allclose(
+        first.summary_arrays()["factor__b"],
+        second.summary_arrays()["factor__b"],
+    )
+    assert first.decomposition_id == second.decomposition_id
+
+
+def test_undeclared_component_identity_is_retained_as_unresolved() -> None:
+    result = build_query_variance_decomposition(
+        (0.5, 0.5),
+        ((0.0,), (2.0,)),
+        query_id="q",
+        query_labels=("q",),
+        query_units=("m",),
+        query_scales=(1.0,),
+        factor_values={"same-label": ("x", "x")},
+    )
+
+    np.testing.assert_allclose(result.summary_arrays()["factor__same-label"], 0.0)
+    np.testing.assert_allclose(
+        result.summary_arrays()["unresolved_component_covariance"],
+        [[1.0]],
+    )
+
+
+def test_portable_validator_rejects_tampered_covariance_and_identity() -> None:
+    payload = build_query_variance_decomposition(
+        (0.5, 0.5),
+        ((0.0,), (2.0,)),
+        query_id="q",
+        query_labels=("q",),
+        query_units=("m",),
+        query_scales=(1.0,),
+        factor_values={"state": ("a", "b")},
+    ).as_dict()
+
+    changed = copy.deepcopy(payload)
+    changed["covariance"]["factor_shapley"]["state"][0][0] = 0.5
+    with pytest.raises(ValueError, match="reconstruct"):
+        validate_query_variance_decomposition(changed)
+
+    changed = copy.deepcopy(payload)
+    changed["metadata"] = {"edited": True}
+    with pytest.raises(ValueError, match="content identity"):
+        validate_query_variance_decomposition(changed)
+
+
+def test_input_validation_and_irreversible_array_immutability() -> None:
+    result = build_query_variance_decomposition(
+        (0.5, 0.5),
+        ((0.0,), (1.0,)),
+        query_id="q",
+        query_labels=("q",),
+        query_units=("m",),
+        query_scales=(1.0,),
+    )
+    with pytest.raises(ValueError, match="positive"):
+        build_query_variance_decomposition(
+            (0.5, 0.5),
+            ((0.0,), (1.0,)),
+            query_id="q",
+            query_labels=("q",),
+            query_units=("m",),
+            query_scales=(0.0,),
+        )
+    with pytest.raises(ValueError, match="positive semidefinite"):
+        build_query_variance_decomposition(
+            (1.0,),
+            ((0.0, 0.0),),
+            query_id="q",
+            query_labels=("x", "y"),
+            query_units=("m", "m"),
+            query_scales=(1.0, 1.0),
+            conditional_covariances={"bad": np.array([[[1.0, 2.0], [2.0, 1.0]]])},
+        )
+    with pytest.raises(ValueError, match="without Boolean"):
+        build_query_variance_decomposition(
+            (True,),
+            ((0.0,),),
+            query_id="q",
+            query_labels=("q",),
+            query_units=("m",),
+            query_scales=(1.0,),
+        )
+    mean = result.summary_arrays()["posterior_mean"]
+    with pytest.raises(ValueError):
+        mean.setflags(write=True)

--- a/tests/test_query_variance_decomposition_cli.py
+++ b/tests/test_query_variance_decomposition_cli.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+
+from causal4d.cli.query_variance_decomposition import main
+from causal4d.query_variance_decomposition import (
+    validate_query_variance_decomposition,
+)
+
+
+def _write_spec(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "artifact_kind": ("Causal4DQueryVarianceDecompositionInputV1"),
+                "query_id": "endpoint-position",
+                "query_labels": ["x", "y"],
+                "query_units": ["m", "m"],
+                "query_scales": [0.01, 0.01],
+                "factor_values": {
+                    "contact": ["left", "left", "right", "right"],
+                    "gain": ["low", "high", "low", "high"],
+                },
+                "conditional_covariance_arrays": {
+                    "observation": "observation_covariance"
+                },
+                "metadata": {"registered_query": True},
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_cli_builds_and_revalidates_strict_artifact(tmp_path: Path) -> None:
+    input_npz = tmp_path / "input.npz"
+    spec = tmp_path / "spec.json"
+    output = tmp_path / "result.json"
+    np.savez(
+        input_npz,
+        component_weights=np.full(4, 0.25),
+        component_query_means=np.array(
+            [[0.0, 0.0], [0.0, 2.0], [1.0, 0.0], [1.0, 2.0]]
+        ),
+        observation_covariance=np.repeat(
+            np.diag([0.1, 0.2])[None, :, :],
+            4,
+            axis=0,
+        ),
+    )
+    _write_spec(spec)
+
+    assert main(["build", str(input_npz), str(spec), str(output)]) == 0
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    validate_query_variance_decomposition(payload)
+    assert payload["metadata"]["input_provenance"]["input_npz_sha256"]
+    assert main(["validate", str(output)]) == 0
+
+
+def test_cli_rejects_unregistered_npz_member(tmp_path: Path) -> None:
+    input_npz = tmp_path / "input.npz"
+    spec = tmp_path / "spec.json"
+    output = tmp_path / "result.json"
+    np.savez(
+        input_npz,
+        component_weights=np.array([1.0]),
+        component_query_means=np.array([[0.0, 0.0]]),
+        observation_covariance=np.zeros((1, 2, 2)),
+        unexpected=np.array([1.0]),
+    )
+    _write_spec(spec)
+
+    assert main(["build", str(input_npz), str(spec), str(output)]) == 2
+    assert not output.exists()

--- a/tests/test_query_variance_decomposition_route.py
+++ b/tests/test_query_variance_decomposition_route.py
@@ -1,0 +1,10 @@
+from causal4d.cli.command_registry import find_command
+
+
+def test_query_variance_decomposition_route_is_diagnostic() -> None:
+    command = find_command("diagnostic uncertainty decompose-query")
+
+    assert command.target == "causal4d.cli.query_variance_decomposition:main"
+    assert command.lifecycle == "diagnostic"
+    assert command.claim_bearing is False
+    assert command.historical_name is None


### PR DESCRIPTION
## Summary

- add `causal4d diagnostic uncertainty decompose-query`, a content-addressed diagnostic that attributes a fixed finite-posterior query covariance through exact Shapley values over caller-declared support factors;
- retain undeclared finite-support variation as explicit unresolved component covariance and add separately declared conditional covariance sources;
- add strict NPZ/JSON validation, immutable outputs, a worked specification, grouped CLI routing, documentation, numerical tests, CLI tests, and route tests.

## Numerical semantics

For finite component weights `w_c` and query means `mu_c`, the diagnostic uses

```text
Cov(Q) = Cov_c(mu_c) + sum_s E_c[Sigma_{c,s}].
```

For every declared support-factor subset `S`, it computes

```text
V(S) = Cov(E[mu_c | labels in S])
```

and assigns `V(F)` through exact Shapley covariance contributions. The remainder `Cov_c(mu_c) - V(F)` is retained as unresolved component covariance. The implementation checks numerical reconstruction within a scale-aware tolerance.

## Scope split

This PR was split from the reviewer-facing paper-reproduction route. It now contains only the independent diagnostic surface so it can be reviewed, scheduled, or deferred without blocking publication reproducibility.

It is intentionally kept as a draft and is not part of the frozen 36-execution acquisition path.

## Validation

The branch is rebased directly onto current `main` after #374. All authoritative workflows passed on exact head `4a34489eeb96c9c227a553a76a64ee7f73539207`:

- Release metadata integrity
- CI and release
- Extended compatibility
- Security scanning
- Causal4D merge gate, including the complete default suite and pinned installed-wheel BayesianPhysTwin integration

## Scientific and information boundary

- Frozen estimator changed: `no`.
- Registered physical protocol changed: `no`.
- Target or held-out outcomes accessed: `no`.
- Physical evidence increment: `0`.
- Scientific claim promoted: `no`.

The attribution is relative to the caller-declared factor set. It does not identify a physical cause, establish empirical calibration, or authorize confirmatory method selection.

## Merge disposition

- [x] Diagnostic-only tooling
- [ ] Frozen-method change
- [ ] Confirmatory evidence publication
- [ ] Physical acquisition
