### PR TITLE
Use shallow exact-base checkout in routine CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
       - name: Set up Python 3.10
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -63,6 +63,14 @@ jobs:
             ruff-exit-status.txt
           if-no-files-found: warn
           retention-days: 14
+      - name: Fetch exact comparison base
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        shell: bash
+        run: |
+          if [[ -n "${BASE_SHA:-}" && ! "$BASE_SHA" =~ ^0+$ ]]; then
+            git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          fi
       - name: Select changed Python files
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}

--- a/tests/test_ci_checkout_policy.py
+++ b/tests/test_ci_checkout_policy.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci.yml"
+)
+BASE_EXPRESSION = "${{ github.event.pull_request.base.sha || github.event.before }}"
+
+
+def _quality_job() -> str:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    return text.split("  quality:\n", 1)[1].split("\n  core:\n", 1)[0]
+
+
+def test_quality_checkout_fetches_only_the_exact_comparison_history() -> None:
+    quality = _quality_job()
+
+    assert "fetch-depth: 0" not in quality
+    assert "fetch-depth: 1" in quality
+    assert "- name: Fetch exact comparison base" in quality
+    assert f"BASE_SHA: {BASE_EXPRESSION}" in quality
+    assert 'git fetch --no-tags --depth=1 origin "$BASE_SHA"' in quality
+    assert quality.index("- name: Fetch exact comparison base") < quality.index(
+        "- name: Select changed Python files"
+    )
+
+
+def test_quality_checkout_keeps_credentials_disabled() -> None:
+    quality = _quality_job()
+
+    checkout = quality.split("- name: Check out repository", 1)[1].split(
+        "- name: Set up Python 3.10", 1
+    )[0]
+    assert "persist-credentials: false" in checkout

--- a/tests/test_ci_checkout_policy.py
+++ b/tests/test_ci_checkout_policy.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 
-WORKFLOW = (
-    Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci.yml"
-)
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci.yml"
 BASE_EXPRESSION = "${{ github.event.pull_request.base.sha || github.event.before }}"
 
 


### PR DESCRIPTION
## Summary

- replace the quality job's all-history checkout (`fetch-depth: 0`) with a depth-one checkout;
- fetch only the exact pull-request base or push-before SHA needed by the incremental formatting comparison;
- avoid fetching tags and unrelated branch history;
- keep checkout credentials disabled;
- add a workflow-policy regression test that prevents a return to all-history fetching and verifies operation ordering.

## Why

The repository has a large and growing ref surface, while routine Ruff, formatting, and MyPy checks only need the event head and one exact comparison commit. Fetching the entire history and every reachable ref adds avoidable network and Git overhead without improving these checks.

`changed_python_files.py` retains its existing fail-safe behavior: when no valid comparison SHA is available, it formats the full tracked Python set.

## Validation

All authoritative workflows passed on exact head `648bd09375d0732475c4832f7a583d8d9623fa28` before merge:

- CI and release, including the real depth-one checkout, exact-base fetch, incremental Ruff formatting, MyPy, distribution build, installed wheel/sdist CLI checks, result-bundle smoke tests, and pinned BayesianPhysTwin installed-wheel integration;
- Causal4D merge gate, including the complete default suite and pinned provider pair;
- Extended compatibility;
- Security scanning.

## Scope

- Scientific code changed: `no`.
- Frozen estimator changed: `no`.
- Registered protocol changed: `no`.
- Release-history or evidence-provenance jobs changed: `no`.

The optimization is confined to the routine quality job; workflows that genuinely require history remain untouched.
