### PR TITLE
Harden shallow CI base fetch trust handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 1
+          fetch-depth: 2
           persist-credentials: false
       - name: Set up Python 3.10
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -68,8 +68,10 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
         shell: bash
         run: |
-          if [[ -n "${BASE_SHA:-}" && ! "$BASE_SHA" =~ ^0+$ ]]; then
-            git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          if [[ -n "${BASE_SHA:-}" && ! "$BASE_SHA" =~ ^0+$ ]] && ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            ca_file=/etc/ssl/certs/ca-certificates.crt
+            test -r "$ca_file"
+            git -c http.sslCAInfo="$ca_file" fetch --no-tags --depth=1 origin "$BASE_SHA"
           fi
       - name: Select changed Python files
         env:

--- a/tests/test_ci_checkout_policy.py
+++ b/tests/test_ci_checkout_policy.py
@@ -12,14 +12,17 @@ def _quality_job() -> str:
     return text.split("  quality:\n", 1)[1].split("\n  core:\n", 1)[0]
 
 
-def test_quality_checkout_fetches_only_the_exact_comparison_history() -> None:
+def test_quality_checkout_fetches_only_required_comparison_history() -> None:
     quality = _quality_job()
 
     assert "fetch-depth: 0" not in quality
-    assert "fetch-depth: 1" in quality
+    assert "fetch-depth: 2" in quality
     assert "- name: Fetch exact comparison base" in quality
     assert f"BASE_SHA: {BASE_EXPRESSION}" in quality
-    assert 'git fetch --no-tags --depth=1 origin "$BASE_SHA"' in quality
+    assert 'git cat-file -e "${BASE_SHA}^{commit}"' in quality
+    assert "ca_file=/etc/ssl/certs/ca-certificates.crt" in quality
+    assert 'git -c http.sslCAInfo="$ca_file" fetch' in quality
+    assert '--no-tags --depth=1 origin "$BASE_SHA"' in quality
     assert quality.index("- name: Fetch exact comparison base") < quality.index(
         "- name: Select changed Python files"
     )


### PR DESCRIPTION
## Summary

- keep the routine quality checkout shallow while increasing depth from one to two so pull-request merge commits normally include their exact base parent;
- skip the network fetch when the comparison commit is already available locally;
- when a fallback fetch is required, explicitly use Ubuntu's system CA bundle instead of relying on runner-local Git trust configuration that may be removed after `actions/checkout` with `persist-credentials: false`;
- retain `--no-tags`, a one-commit fallback depth, and disabled persisted credentials;
- extend the workflow-policy regression test to lock the local-object check, explicit CA bundle, and bounded fallback fetch.

## Root cause

On PR #369, the quality job completed Ruff lint but failed before incremental formatting because the post-checkout command

```text
git fetch --no-tags --depth=1 origin <base-sha>
```

reported `server certificate verification failed. CAfile: none`. The checkout action itself had succeeded, and every scientific test, distribution build, result-bundle smoke test, and pinned BayesianPhysTwin integration job passed. The failure was therefore in the follow-up Git transport path, not in the proposed Python change.

## Validation

The branch is one clean two-file commit. All authoritative workflows passed on exact head `2a390590c5e8778c9f8816d7e924ca8442e9efe8`:

- CI and release: https://github.com/IPS-Stuttgart/Causal4D/actions/runs/31591769263
  - the real merge-ref quality job passed checkout, Ruff, exact-base acquisition, changed-file selection, incremental formatting, and MyPy;
  - Python 3.10/3.12/3.14 core suites, distributions, installed wheel/sdist CLI checks, result-bundle smoke tests, frozen manifest, and pinned BayesianPhysTwin integration passed;
- Causal4D merge gate: https://github.com/IPS-Stuttgart/Causal4D/actions/runs/31591769454
- Extended compatibility: https://github.com/IPS-Stuttgart/Causal4D/actions/runs/31591769269
- Security scanning: https://github.com/IPS-Stuttgart/Causal4D/actions/runs/31591769261

A separate hosted preparation run also verified the explicit system CA bundle with `git ls-remote` before publishing the exact workflow blob.

## Scope

- Scientific implementation changed: `no`.
- Frozen estimator or registered protocol changed: `no`.
- Target outcomes accessed: `no`.
- Physical evidence increment: `0`.
- Release or evidence-history jobs changed: `no`.
