### PR TITLE
feat: add exact dense component batching

### DIFF
--- a/src/causal4d/dense_likelihood.py
+++ b/src/causal4d/dense_likelihood.py
@@ -1,0 +1,371 @@
+"""Exact bounded-memory evaluation for dense rollout-bank likelihoods."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal
+
+import numpy as np
+
+from causal4d.immutable_array import readonly_integer_array
+from causal4d.prefix_likelihood import PrefixLikelihoodConfig
+from causal4d.rollout_bank import JointRolloutBank
+from causal4d.weighting import log_weights_from_probabilities
+
+
+DenseLikelihoodSemantics = Literal["legacy_v1", "normalized_v2"]
+
+
+def _validated_component_batch_size(value: int) -> int:
+    if type(value) is not int or value < 1:
+        raise ValueError("component_batch_size must be a positive integer")
+    return value
+
+
+def _coordinate_mask(
+    observations: np.ndarray,
+    mask: np.ndarray | None,
+) -> np.ndarray:
+    finite = np.isfinite(observations)
+    if mask is None:
+        return finite
+    supplied = np.asarray(mask, dtype=bool)
+    if supplied.shape == observations.shape[:2]:
+        supplied = np.repeat(supplied[:, :, None], observations.shape[2], axis=2)
+    if supplied.shape != observations.shape:
+        raise ValueError("observation mask must have shape (T, N) or (T, N, C)")
+    return finite & supplied
+
+
+def _legacy_student_t_mean_log_score(
+    residual: np.ndarray,
+    valid: np.ndarray,
+    *,
+    scale_m: np.ndarray | float,
+    degrees_of_freedom: float,
+    reduction_axes: tuple[int, ...],
+) -> np.ndarray:
+    if not np.isfinite(degrees_of_freedom) or degrees_of_freedom <= 0.0:
+        raise ValueError("degrees_of_freedom must be finite and positive")
+    scale = np.asarray(scale_m, dtype=float)
+    if np.any(~np.isfinite(scale)) or np.any(scale <= 0.0):
+        raise ValueError("likelihood scales must be finite and positive")
+    standardized = residual / scale
+    terms = (
+        -0.5
+        * (degrees_of_freedom + 1.0)
+        * np.log1p(np.square(standardized) / degrees_of_freedom)
+    )
+    valid_float = np.asarray(valid, dtype=float)
+    while valid_float.ndim < terms.ndim:
+        valid_float = valid_float[None]
+    count = np.sum(valid_float, axis=reduction_axes)
+    if np.any(count <= 0.0):
+        raise ValueError("likelihood update has no valid coordinates")
+    return (
+        np.sum(
+            np.where(valid_float > 0.0, terms, 0.0),
+            axis=reduction_axes,
+        )
+        / count
+    )
+
+
+def _normalized_student_t_mean_log_score(
+    residual: np.ndarray,
+    valid: np.ndarray,
+    *,
+    scale_m: np.ndarray | float,
+    degrees_of_freedom: float,
+    reduction_axes: tuple[int, ...],
+) -> np.ndarray:
+    values = np.asarray(residual, dtype=float)
+    scale = np.asarray(scale_m, dtype=float)
+    if np.any(~np.isfinite(scale)) or np.any(scale <= 0.0):
+        raise ValueError("likelihood scales must be finite and positive")
+    try:
+        standardized = values / scale
+        log_scale = np.broadcast_to(np.log(scale), values.shape)
+    except ValueError as error:
+        raise ValueError(
+            "likelihood scale is not broadcastable to residuals"
+        ) from error
+    terms = -log_scale - 0.5 * (degrees_of_freedom + 1.0) * np.log1p(
+        np.square(standardized) / degrees_of_freedom
+    )
+    valid_float = np.asarray(valid, dtype=float)
+    while valid_float.ndim < terms.ndim:
+        valid_float = valid_float[None]
+    count = np.sum(valid_float, axis=reduction_axes)
+    if np.any(count <= 0.0):
+        raise ValueError("likelihood update has no valid coordinates")
+    return (
+        np.sum(
+            np.where(valid_float > 0.0, terms, 0.0),
+            axis=reduction_axes,
+        )
+        / count
+    )
+
+
+def _validated_base_weights(
+    bank: JointRolloutBank,
+    base_weights: np.ndarray | None,
+) -> np.ndarray:
+    weights = (
+        bank.prior_joint_weights
+        if base_weights is None
+        else np.asarray(base_weights, dtype=float)
+    )
+    if weights.shape != bank.prior_joint_weights.shape:
+        raise ValueError("base_weights must match the joint rollout support")
+    if (
+        not np.all(np.isfinite(weights))
+        or np.any(weights < 0.0)
+        or not np.isclose(np.sum(weights), 1.0)
+    ):
+        raise ValueError("base_weights must be finite, nonnegative, and sum to one")
+    return weights
+
+
+def _normalize_joint_log_weights(
+    log_weights: np.ndarray,
+    *,
+    reject_invalid_support: bool,
+) -> np.ndarray:
+    values = np.asarray(log_weights, dtype=float)
+    if reject_invalid_support:
+        if values.ndim != 2:
+            raise ValueError("joint log weights must be a matrix")
+        if np.any(np.isnan(values)) or np.any(np.isposinf(values)):
+            raise ValueError("joint log weights may contain only finite values or -inf")
+    if values.ndim != 2 or not np.any(np.isfinite(values)):
+        raise ValueError("joint log weights must contain finite support")
+    maximum = float(np.max(values[np.isfinite(values)]))
+    weights = np.exp(np.where(np.isfinite(values), values - maximum, -np.inf))
+    total = float(np.sum(weights))
+    if not np.isfinite(total) or total <= 0.0:
+        raise RuntimeError("joint posterior normalization failed")
+    return weights / total
+
+
+def _validated_nodes(
+    bank: JointRolloutBank,
+    observed_nodes: Sequence[int] | None,
+) -> np.ndarray:
+    raw_nodes = (
+        tuple(range(bank.node_count))
+        if observed_nodes is None
+        else tuple(observed_nodes)
+    )
+    nodes = readonly_integer_array(raw_nodes, name="observed_nodes")
+    if (
+        nodes.ndim != 1
+        or not len(nodes)
+        or np.any(nodes < 0)
+        or np.any(nodes >= bank.node_count)
+        or len(np.unique(nodes)) != len(nodes)
+    ):
+        raise ValueError(
+            "observed_nodes must uniquely identify available rollout nodes"
+        )
+    return nodes
+
+
+def _validated_discrepancy(
+    bank: JointRolloutBank,
+    particle_discrepancy_m: np.ndarray | None,
+    particle_discrepancy_variance_m2: np.ndarray | None,
+) -> tuple[np.ndarray | None, np.ndarray | None]:
+    expected_shape = (
+        len(bank.parameter_weights),
+        bank.node_count,
+        bank.coordinate_count,
+    )
+    discrepancy: np.ndarray | None = None
+    if particle_discrepancy_m is not None:
+        discrepancy = np.asarray(particle_discrepancy_m, dtype=float)
+        if discrepancy.shape != expected_shape:
+            raise ValueError(f"particle_discrepancy_m must have shape {expected_shape}")
+        if not np.all(np.isfinite(discrepancy)):
+            raise ValueError("particle discrepancy must be finite")
+
+    discrepancy_variance: np.ndarray | None = None
+    if particle_discrepancy_variance_m2 is not None:
+        discrepancy_variance = np.asarray(
+            particle_discrepancy_variance_m2,
+            dtype=float,
+        )
+        if discrepancy_variance.shape != expected_shape:
+            raise ValueError(
+                f"particle_discrepancy_variance_m2 must have shape {expected_shape}"
+            )
+        if not np.all(np.isfinite(discrepancy_variance)) or np.any(
+            discrepancy_variance < 0.0
+        ):
+            raise ValueError("particle discrepancy variance must be nonnegative")
+    return discrepancy, discrepancy_variance
+
+
+def update_dense_joint_weights_batched(
+    bank: JointRolloutBank,
+    observations_m: np.ndarray,
+    *,
+    prefix_frame_count: int,
+    component_batch_size: int,
+    likelihood_semantics: DenseLikelihoodSemantics,
+    observation_scale_m: float,
+    likelihood_power: float = 1.0,
+    dynamic_likelihood_weight: float = 0.0,
+    degrees_of_freedom: float = 4.0,
+    difference_correlation: float = 0.0,
+    mask: np.ndarray | None = None,
+    observed_nodes: Sequence[int] | None = None,
+    base_weights: np.ndarray | None = None,
+    particle_discrepancy_m: np.ndarray | None = None,
+    particle_discrepancy_variance_m2: np.ndarray | None = None,
+) -> np.ndarray:
+    """Update dense support without materializing all component residuals.
+
+    Components are traversed in the same hypothesis-major order used by the
+    rollout bank. The batch size is execution-only: score reductions, posterior
+    normalization, and artifact-visible values are identical to the corresponding
+    unbatched ``legacy_v1`` or ``normalized_v2`` implementation.
+    """
+
+    batch_size = _validated_component_batch_size(component_batch_size)
+    if likelihood_semantics not in {"legacy_v1", "normalized_v2"}:
+        raise ValueError("unsupported dense likelihood semantics")
+
+    observations = np.asarray(observations_m, dtype=float)
+    expected = bank.trajectories.shape[2:]
+    if observations.shape != expected:
+        raise ValueError(f"observations must have shape {expected}")
+    if not 2 <= prefix_frame_count < bank.frame_count:
+        raise ValueError("prefix_frame_count must leave at least one future frame")
+
+    if likelihood_semantics == "legacy_v1":
+        if (
+            not np.isfinite(observation_scale_m)
+            or observation_scale_m <= 0.0
+            or not np.isfinite(likelihood_power)
+            or likelihood_power <= 0.0
+        ):
+            raise ValueError(
+                "observation scale and likelihood power must be finite and positive"
+            )
+        if (
+            not np.isfinite(dynamic_likelihood_weight)
+            or dynamic_likelihood_weight < 0.0
+        ):
+            raise ValueError("dynamic_likelihood_weight must be finite and nonnegative")
+        if difference_correlation != 0.0:
+            raise ValueError(
+                "difference_correlation is available only with normalized_v2"
+            )
+        normalized_config = None
+    else:
+        normalized_config = PrefixLikelihoodConfig(
+            observation_scale_m=observation_scale_m,
+            likelihood_power=likelihood_power,
+            position_likelihood_weight=1.0,
+            dynamic_likelihood_weight=dynamic_likelihood_weight,
+            degrees_of_freedom=degrees_of_freedom,
+            difference_correlation=difference_correlation,
+        )
+
+    nodes = _validated_nodes(bank, observed_nodes)
+    coordinate_valid = _coordinate_mask(observations, mask)
+    discrepancy, discrepancy_variance = _validated_discrepancy(
+        bank,
+        particle_discrepancy_m,
+        particle_discrepancy_variance_m2,
+    )
+    weights = _validated_base_weights(bank, base_weights)
+
+    hypothesis_count = len(bank.hypothesis_ids)
+    particle_count = len(bank.parameter_weights)
+    component_count = hypothesis_count * particle_count
+    component_scores = np.empty(component_count, dtype=float)
+
+    if likelihood_semantics == "legacy_v1":
+        observed_prefix = observations[1:prefix_frame_count, nodes]
+        valid_prefix = coordinate_valid[1:prefix_frame_count, nodes]
+    else:
+        observed_prefix = observations[:prefix_frame_count, nodes]
+        valid_prefix = coordinate_valid[:prefix_frame_count, nodes]
+
+    for start in range(0, component_count, batch_size):
+        stop = min(start + batch_size, component_count)
+        flat_indices = np.arange(start, stop, dtype=np.int64)
+        hypothesis_indices = flat_indices // particle_count
+        particle_indices = flat_indices % particle_count
+        predicted = bank.trajectories[hypothesis_indices, particle_indices]
+
+        if likelihood_semantics == "legacy_v1":
+            predicted_prefix = predicted[:, 1:prefix_frame_count, nodes]
+        else:
+            predicted_prefix = predicted[:, :prefix_frame_count, nodes].astype(float)
+
+        if discrepancy is not None:
+            predicted_prefix = (
+                predicted_prefix + discrepancy[particle_indices][:, None, nodes]
+            )
+
+        position_scale: np.ndarray | float = observation_scale_m
+        if discrepancy_variance is not None:
+            position_scale = np.sqrt(
+                observation_scale_m**2
+                + discrepancy_variance[particle_indices][:, None, nodes]
+            )
+
+        if likelihood_semantics == "legacy_v1":
+            score = _legacy_student_t_mean_log_score(
+                predicted_prefix - observed_prefix[None],
+                valid_prefix,
+                scale_m=position_scale,
+                degrees_of_freedom=degrees_of_freedom,
+                reduction_axes=(1, 2, 3),
+            )
+            if dynamic_likelihood_weight and prefix_frame_count >= 4:
+                score += dynamic_likelihood_weight * _legacy_student_t_mean_log_score(
+                    np.diff(predicted_prefix, axis=1)
+                    - np.diff(observed_prefix, axis=0)[None],
+                    valid_prefix[1:] & valid_prefix[:-1],
+                    scale_m=observation_scale_m,
+                    degrees_of_freedom=degrees_of_freedom,
+                    reduction_axes=(1, 2, 3),
+                )
+        else:
+            if normalized_config is None:
+                raise RuntimeError("normalized dense configuration was not initialized")
+            score = _normalized_student_t_mean_log_score(
+                predicted_prefix[:, 1:] - observed_prefix[None, 1:],
+                valid_prefix[1:],
+                scale_m=position_scale,
+                degrees_of_freedom=normalized_config.degrees_of_freedom,
+                reduction_axes=(1, 2, 3),
+            )
+            if normalized_config.dynamic_likelihood_weight > 0.0:
+                difference_scale = normalized_config.observation_scale_m * np.sqrt(
+                    2.0 * (1.0 - normalized_config.difference_correlation)
+                )
+                score += (
+                    normalized_config.dynamic_likelihood_weight
+                    * _normalized_student_t_mean_log_score(
+                        np.diff(predicted_prefix, axis=1)
+                        - np.diff(observed_prefix, axis=0)[None],
+                        valid_prefix[1:] & valid_prefix[:-1],
+                        scale_m=difference_scale,
+                        degrees_of_freedom=normalized_config.degrees_of_freedom,
+                        reduction_axes=(1, 2, 3),
+                    )
+                )
+        component_scores[start:stop] = score
+
+    score_matrix = component_scores.reshape(hypothesis_count, particle_count)
+    scaled_score = likelihood_power * score_matrix
+    return _normalize_joint_log_weights(
+        log_weights_from_probabilities(weights, name="base_weights") + scaled_score,
+        reject_invalid_support=likelihood_semantics == "legacy_v1",
+    )

--- a/src/causal4d/intervention_abduction.py
+++ b/src/causal4d/intervention_abduction.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, cast
 import numpy as np
 
 from causal4d.contracts import FactualIntervention, TwinBelief, array_sha256
+from causal4d.dense_likelihood import update_dense_joint_weights_batched
 from causal4d.factual_abduction_uncertainty import FactualAbductionUncertaintyV1
 from causal4d.grouped_likelihood import (
     GroupLikelihoodDiagnostics,
@@ -392,6 +393,7 @@ def _update_joint_weights(
     base_weights: np.ndarray | None = None,
     grouped_evidence: GroupedObservationEvidence | None = None,
     abduction_uncertainty: FactualAbductionUncertaintyV1 | None = None,
+    dense_component_batch_size: int | None = None,
     grouped_component_batch_size: int | None = None,
 ) -> tuple[np.ndarray, GroupLikelihoodDiagnostics | None]:
     if grouped_evidence is not None and settings.likelihood_semantics != "legacy_v1":
@@ -403,6 +405,11 @@ def _update_joint_weights(
         and settings.grouped_likelihood_semantics != "legacy_v1"
     ):
         raise ValueError("normalized_v3 requires grouped observation evidence")
+    if dense_component_batch_size is not None and grouped_evidence is not None:
+        raise ValueError(
+            "dense_component_batch_size cannot be combined with grouped "
+            "observation evidence"
+        )
     batch_size = _validated_grouped_component_batch_size(grouped_component_batch_size)
     if batch_size is not None and grouped_evidence is None:
         raise ValueError(
@@ -410,7 +417,24 @@ def _update_joint_weights(
         )
     discrepancy, discrepancy_variance = _belief_readout(bank, belief)
     if grouped_evidence is None:
-        if settings.likelihood_semantics == "legacy_v1":
+        if dense_component_batch_size is not None:
+            joint_weights = update_dense_joint_weights_batched(
+                bank,
+                observations_from_endpoint_m,
+                prefix_frame_count=prefix_frame_count,
+                component_batch_size=dense_component_batch_size,
+                likelihood_semantics=settings.likelihood_semantics,
+                observation_scale_m=settings.observation_scale_m,
+                likelihood_power=settings.likelihood_power,
+                dynamic_likelihood_weight=settings.dynamic_likelihood_weight,
+                degrees_of_freedom=settings.degrees_of_freedom,
+                difference_correlation=settings.difference_correlation,
+                mask=observation_mask,
+                base_weights=base_weights,
+                particle_discrepancy_m=discrepancy,
+                particle_discrepancy_variance_m2=discrepancy_variance,
+            )
+        elif settings.likelihood_semantics == "legacy_v1":
             joint_weights = bank.update_from_observations_legacy_v1(
                 observations_from_endpoint_m,
                 prefix_frame_count=prefix_frame_count,
@@ -511,6 +535,7 @@ def abduct_factual_intervention(
     abstain_when_unidentifiable: bool = False,
     identifiability_policy: IdentifiabilityPolicy = "full_parameter",
     abduction_uncertainty: FactualAbductionUncertaintyV1 | None = None,
+    dense_component_batch_size: int | None = None,
     grouped_component_batch_size: int | None = None,
 ) -> FactualIntervention:
     """Infer persistent ``phi`` and factual event ``kappa_obs`` from O+ only.
@@ -522,9 +547,10 @@ def abduct_factual_intervention(
     result returns the unchanged joint prior over physical and intervention
     support rather than a falsely concentrated posterior.
 
-    ``grouped_component_batch_size`` is an execution-only memory bound for the
-    grouped-evidence path. It does not enter artifact metadata and must preserve
-    the exact posterior and artifact identity of the dense implementation.
+    ``dense_component_batch_size`` and ``grouped_component_batch_size`` are
+    mutually exclusive execution-only memory bounds for the corresponding
+    evidence paths. They do not enter artifact metadata and must preserve the
+    exact posterior and artifact identity of the unbatched implementations.
     """
 
     settings = config or FactualAbductionConfig()
@@ -575,6 +601,7 @@ def abduct_factual_intervention(
             settings=settings,
             grouped_evidence=grouped_evidence,
             abduction_uncertainty=abduction_uncertainty,
+            dense_component_batch_size=dense_component_batch_size,
             grouped_component_batch_size=grouped_component_batch_size,
         )
     hand_count = len(bank.hypothesis_metadata[0]["contact"]["attachment_shifts"])
@@ -731,12 +758,13 @@ def evaluate_factual_abduction(
     config: FactualAbductionConfig | None = None,
     grouped_evidence: GroupedObservationEvidence | None = None,
     abduction_uncertainty: FactualAbductionUncertaintyV1 | None = None,
+    dense_component_batch_size: int | None = None,
     grouped_component_batch_size: int | None = None,
 ) -> dict[str, Any]:
     """Compare BPT+z with a same-evidence BPT posterior fixed to nominal z.
 
-    ``grouped_component_batch_size`` has the same execution-only semantics as in
-    :func:`abduct_factual_intervention`.
+    The component batch-size arguments have the same execution-only semantics as
+    in :func:`abduct_factual_intervention`.
     """
 
     settings = config or FactualAbductionConfig()
@@ -760,6 +788,7 @@ def evaluate_factual_abduction(
         base_weights=nominal_base,
         grouped_evidence=grouped_evidence,
         abduction_uncertainty=abduction_uncertainty,
+        dense_component_batch_size=dense_component_batch_size,
         grouped_component_batch_size=grouped_component_batch_size,
     )
     components = physical_readout_components(bank, belief)

--- a/tests/test_dense_likelihood_batched.py
+++ b/tests/test_dense_likelihood_batched.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from causal4d.contracts import TwinBelief, build_causal_context
+from causal4d.intervention_abduction import (
+    FactualAbductionConfig,
+    abduct_factual_intervention,
+    evaluate_factual_abduction,
+)
+from causal4d.observation_evidence import GroupedObservationEvidence
+from causal4d.rollout_bank import JointRolloutBank
+
+
+def _metadata(identifier: str, *, gain: float, shift: int) -> dict:
+    return {
+        "hypothesis_id": identifier,
+        "action": {
+            "proposal_id": "known",
+            "future_action_observed": True,
+            "provenance": "dense batching unit test",
+        },
+        "contact": {
+            "attachment_shifts": [shift],
+            "gain_multiplier": gain,
+            "delay_steps": 0,
+            "slip_fraction": 0.0,
+            "rotation_degrees": 0.0,
+        },
+    }
+
+
+def _problem() -> tuple[JointRolloutBank, TwinBelief, np.ndarray, np.ndarray]:
+    frame_count = 7
+    trajectories = np.zeros((3, 2, frame_count, 2, 3), dtype=float)
+    time = np.arange(frame_count, dtype=float)
+    trajectories[0, :, :, 0, 0] = 0.003 * time
+    trajectories[1, :, :, 0, 0] = 0.010 * time
+    trajectories[2, :, :, 0, 0] = -0.008 * time
+    trajectories[:, 1, :, 0, 1] = 0.002 * time
+    trajectories[1, :, :, 1, 2] = 0.004 * np.square(time)
+
+    bank = JointRolloutBank(
+        hypothesis_ids=("nominal", "high_gain", "shifted"),
+        hypothesis_metadata=(
+            _metadata("nominal", gain=1.0, shift=0),
+            _metadata("high_gain", gain=1.15, shift=0),
+            _metadata("shifted", gain=1.0, shift=1),
+        ),
+        hypothesis_prior_weights=np.asarray([0.6, 0.25, 0.15]),
+        parameter_particles=np.asarray([[0.0], [1.0]]),
+        parameter_weights=np.asarray([0.4, 0.6]),
+        trajectories=trajectories,
+        variance_floor_m2=1e-8,
+    )
+
+    full_frames = frame_count + 3
+    intervention_frame = 4
+    context = build_causal_context(
+        protocol_id="dense-batching-unit",
+        case_id="synthetic",
+        observations=np.zeros((full_frames, 2, 3)),
+        observed_actions=np.zeros((full_frames, 1, 3)),
+        counterfactual_actions=np.zeros((full_frames, 1, 3)),
+        intervention_frame=intervention_frame,
+    )
+    state_shape = (2, 2, 3)
+    discrepancy = np.zeros(state_shape)
+    discrepancy[0, 1, 0] = 0.0007
+    discrepancy[1, 0, 1] = 0.0011
+    discrepancy_variance = np.full(state_shape, 1e-8)
+    discrepancy_variance[1, 1, 2] = 4e-8
+    belief = TwinBelief(
+        context=context,
+        endpoint_frame=intervention_frame - 1,
+        particle_ids=("p0", "p1"),
+        theta_names=("spring",),
+        endpoint_position_m=np.zeros(state_shape),
+        endpoint_velocity_mps=np.zeros(state_shape),
+        theta=bank.parameter_particles,
+        discrepancy_mean_m=discrepancy,
+        discrepancy_variance_m2=discrepancy_variance,
+        weights=bank.parameter_weights,
+    )
+
+    observations = trajectories[1, 0].astype(float)
+    observations[:, 1, 1] = 0.001 * time
+    observations[2, 1, 2] = np.nan
+    mask = np.ones((frame_count, 2), dtype=bool)
+    mask[1, 0] = False
+    return bank, belief, observations, mask
+
+
+@pytest.mark.parametrize("likelihood_semantics", ["legacy_v1", "normalized_v2"])
+@pytest.mark.parametrize("batch_size", [1, 2, 4, 20])
+def test_dense_component_batching_preserves_posterior_and_artifact_identity(
+    likelihood_semantics: str,
+    batch_size: int,
+) -> None:
+    bank, belief, observations, mask = _problem()
+    config = FactualAbductionConfig(
+        observation_scale_m=0.003,
+        likelihood_power=7.0,
+        dynamic_likelihood_weight=0.4,
+        degrees_of_freedom=3.5,
+        likelihood_semantics=likelihood_semantics,
+        difference_correlation=(
+            0.2 if likelihood_semantics == "normalized_v2" else 0.0
+        ),
+    )
+    dense = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=config,
+    )
+    batched = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=config,
+        dense_component_batch_size=batch_size,
+    )
+
+    assert np.array_equal(batched.weights, dense.weights)
+    assert batched.metadata == dense.metadata
+    assert batched.artifact_id == dense.artifact_id
+
+
+@pytest.mark.parametrize("likelihood_semantics", ["legacy_v1", "normalized_v2"])
+def test_dense_component_batching_preserves_nominal_comparator(
+    likelihood_semantics: str,
+) -> None:
+    bank, belief, observations, mask = _problem()
+    config = FactualAbductionConfig(
+        observation_scale_m=0.003,
+        likelihood_power=7.0,
+        dynamic_likelihood_weight=0.4,
+        likelihood_semantics=likelihood_semantics,
+        difference_correlation=(
+            0.2 if likelihood_semantics == "normalized_v2" else 0.0
+        ),
+    )
+    factual = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=4,
+        observation_mask=mask,
+        config=config,
+    )
+    dense = evaluate_factual_abduction(
+        bank,
+        belief,
+        factual,
+        observations,
+        observation_mask=mask,
+        prefix_frame_count=4,
+        config=config,
+    )
+    batched = evaluate_factual_abduction(
+        bank,
+        belief,
+        factual,
+        observations,
+        observation_mask=mask,
+        prefix_frame_count=4,
+        config=config,
+        dense_component_batch_size=2,
+    )
+
+    assert batched == dense
+
+
+@pytest.mark.parametrize("invalid_batch_size", [0, -1, True, 1.5])
+def test_dense_component_batch_size_must_be_a_positive_integer(
+    invalid_batch_size: object,
+) -> None:
+    bank, belief, observations, mask = _problem()
+
+    with pytest.raises(
+        ValueError,
+        match="component_batch_size must be a positive integer",
+    ):
+        abduct_factual_intervention(
+            bank,
+            belief,
+            observations,
+            prefix_frame_count=4,
+            observation_mask=mask,
+            dense_component_batch_size=invalid_batch_size,  # type: ignore[arg-type]
+        )
+
+
+def test_dense_component_batching_rejects_grouped_evidence() -> None:
+    bank, belief, observations, mask = _problem()
+    evidence = GroupedObservationEvidence.from_dense_prefix(
+        observations,
+        prefix_frame_count=4,
+        scale_m=0.003,
+        mask=mask,
+        source_id="unit",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="dense_component_batch_size cannot be combined",
+    ):
+        abduct_factual_intervention(
+            bank,
+            belief,
+            observations,
+            prefix_frame_count=4,
+            observation_mask=mask,
+            grouped_evidence=evidence,
+            dense_component_batch_size=2,
+        )


### PR DESCRIPTION
## Summary

- add an opt-in bounded-memory component evaluator for both registered `legacy_v1` and development `normalized_v2` dense likelihood semantics
- route `dense_component_batch_size` through factual abduction and its nominal-contact evaluation comparator
- keep the default unbatched implementation unchanged and exclude the execution-only batch size from artifact metadata
- reject invalid batch sizes and dense/grouped batching combinations fail-closed

## Scientific invariants

The batched path traverses components in the existing hypothesis-major order and retains the same per-component reduction order and final posterior normalization. Tests require exact equality of posterior arrays, metadata, and `FactualIntervention.artifact_id` against the unbatched reference for multiple batch sizes, both dense likelihood semantics, discrepancy mean/variance, masking, missing observations, and the nominal comparator with restricted base support.

This changes no frozen estimator default, likelihood semantics, acquisition protocol, evidence status, or cross-repository contract.

## Validation

All required workflows pass on head `d55a5af734efd164132d83cf821dff427ae6fa7c`:

- **CI and release**: Ruff, incremental formatting, typing, core suites on Python 3.10/3.12/3.14, distribution builds, isolated wheel/sdist CLI checks, deterministic result bundles, frozen milestone validation, and pinned Bayesian-PhysTwin installed-wheel integration
- **Extended compatibility**: Python 3.11/3.13 and exact declared dependency floors on Python 3.10
- **Security scanning**: resolved dependency audit and CodeQL for Python and Actions
- **Causal4D merge gate**: complete default test suite, package validation, and isolated pinned-provider integration on the tested merge result

The dedicated tests additionally bind exact posterior, metadata, artifact-identity, and comparator parity for batch sizes `1`, `2`, `4`, and larger-than-support, plus fail-closed argument validation.