### PR TITLE
Add cross-branch readout correlation sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- Add an analysis-only, content-addressed sensitivity artifact for assumed
+  cross-branch conditional readout correlation in interventional contrasts.
+  It preserves the source coupling and means, reproduces the existing
+  independent-readout posterior exactly at zero correlation, and reports
+  marginal variance and sign-probability envelopes without identifying a
+  cross-world covariance or changing the frozen estimator.
 - Add a non-claim-bearing `causal4d paper reproduce` route that atomically
   publishes and independently reopens reviewer-facing bundles. It binds the
   exact protocol, method freeze, registered analysis, deterministic report

--- a/docs/interventional_contrast.md
+++ b/docs/interventional_contrast.md
@@ -91,6 +91,16 @@ No current source artifact identifies cross-branch conditional discrepancy
 covariance. The independent policy records zero cross-branch covariance rather
 than inventing cancellation.
 
+### Cross-branch correlation sensitivity
+
+An `independent_readout` contrast can be passed to
+`build_interventional_contrast_readout_correlation_sensitivity` together with
+its two unchanged source branches. The additive artifact evaluates each query
+marginal over a declared correlation grid and requires its zero-correlation row
+to reproduce the source contrast exactly. It does not estimate correlation or
+construct one joint cross-output covariance. See
+[`interventional_contrast_readout_correlation.md`](interventional_contrast_readout_correlation.md).
+
 ## Posterior summaries
 
 ```python

--- a/docs/interventional_contrast_readout_correlation.md
+++ b/docs/interventional_contrast_readout_correlation.md
@@ -1,0 +1,117 @@
+# Cross-branch readout-correlation sensitivity
+
+`PhysicalPosterior` currently provides branch-marginal conditional readout
+variance but no identified cross-branch conditional discrepancy covariance. An
+`independent_readout` interventional contrast therefore adds the two branch
+query covariances and sets the unobserved cross term to zero.
+
+`causal4d.interventional_contrast` now provides an additive sensitivity artifact
+for the uncertainty in that assumption. It does not replace the source contrast
+or construct a new physical posterior.
+
+## Marginal model
+
+For one paired finite-support component and one registered scalar query output,
+let
+
+```text
+v_a = Var(Q(R_a) | component)
+v_b = Var(Q(R_b) | component).
+```
+
+At declared conditional correlation `rho`, the marginal contrast variance is
+
+```text
+v_delta(rho) = v_a + v_b - 2 rho sqrt(v_a v_b),
+-1 <= rho <= 1.
+```
+
+This is the exact scalar Cauchy-Schwarz range. The same scalar grid is evaluated
+for every query output, but the result remains coordinatewise. It does not claim
+that all output-wise extrema belong to one simultaneous multivariate
+cross-branch covariance.
+
+## Build the sensitivity artifact
+
+Start with an ordinary contrast whose conditional-variance policy is
+`independent_readout`:
+
+```python
+from causal4d.interventional_contrast import (
+    build_interventional_contrast,
+    build_interventional_contrast_readout_correlation_sensitivity,
+)
+
+contrast = build_interventional_contrast(
+    branch_a,
+    branch_b,
+    query,
+    branch_a_label="do(lift_high)",
+    branch_b_label="do(lateral_low)",
+    coupling_policy="shared_twin_phi",
+    conditional_variance_policy="independent_readout",
+)
+
+sensitivity = (
+    build_interventional_contrast_readout_correlation_sensitivity(
+        branch_a,
+        branch_b,
+        contrast,
+        correlations=(-1.0, -0.5, 0.0, 0.5, 1.0),
+        metadata={"registered_before_target_access": True},
+    )
+)
+```
+
+The builder binds both branch posterior IDs, the complete source contrast, its
+query and coupling, and the exact correlation grid. It independently
+reconstructs each branch's query-marginal variance and requires the zero-
+correlation row to reproduce the source contrast's variance and
+`P(Q_a-Q_b>0)`.
+
+The artifact reports, for every grid value and query output:
+
+- conditional variance;
+- total mixture variance;
+- posterior probability that branch A exceeds branch B; and
+- the grid envelopes of total variance and probability.
+
+The finite-support component means, coupling weights, and posterior mean remain
+unchanged.
+
+## Strict archive
+
+```python
+import hashlib
+from pathlib import Path
+
+from causal4d.interventional_contrast import (
+    load_interventional_contrast_readout_correlation_sensitivity,
+    save_interventional_contrast_readout_correlation_sensitivity,
+)
+
+path = Path("contrast-readout-correlation.npz")
+save_interventional_contrast_readout_correlation_sensitivity(
+    path,
+    sensitivity,
+    overwrite=False,
+)
+archive_sha256 = hashlib.sha256(path.read_bytes()).hexdigest()
+restored = load_interventional_contrast_readout_correlation_sensitivity(
+    path,
+    expected_sha256=archive_sha256,
+)
+assert restored.artifact_id == sensitivity.artifact_id
+```
+
+The archive is atomically published, non-pickled, strictly typed, loaded from one
+bounded symlink-free snapshot, and content addressed.
+
+## Interpretation boundary
+
+The correlation grid is an assumption or source-frozen sensitivity range. The
+artifact does not estimate correlation from branch marginals, establish
+calibration, provide individual-level real counterfactual ground truth, or
+select a favorable correlation after target access. A source-estimated
+cross-branch covariance requires a separately registered artifact and independent
+source or controlled paired evidence.

--- a/src/causal4d/_interventional_contrast_readout_correlation.py
+++ b/src/causal4d/_interventional_contrast_readout_correlation.py
@@ -272,9 +272,7 @@ class InterventionalContrastReadoutCorrelationSensitivityV1:
                 "total_variance must equal between plus conditional variance"
             )
         if np.any(np.diff(conditional, axis=0) > 1e-10):
-            raise ValueError(
-                "conditional_variance must not increase with correlation"
-            )
+            raise ValueError("conditional_variance must not increase with correlation")
         zero_index = int(zero_indices[0])
         if not np.allclose(
             total[zero_index],
@@ -372,9 +370,7 @@ class InterventionalContrastReadoutCorrelationSensitivityV1:
             "total_variance": self.total_variance,
             "probability_positive": self.probability_positive,
             "independent_total_variance": self.independent_total_variance,
-            "independent_probability_positive": (
-                self.independent_probability_positive
-            ),
+            "independent_probability_positive": (self.independent_probability_positive),
         }
 
     @property
@@ -401,15 +397,11 @@ class InterventionalContrastReadoutCorrelationSensitivityV1:
             "artifact_id": self.artifact_id,
             "correlation_grid": self.correlation_grid.tolist(),
             "mean": self.mean.tolist(),
-            "between_component_variance": (
-                self.between_component_variance.tolist()
-            ),
+            "between_component_variance": (self.between_component_variance.tolist()),
             "conditional_variance": self.conditional_variance.tolist(),
             "total_variance": self.total_variance.tolist(),
             "probability_positive": self.probability_positive.tolist(),
-            "independent_total_variance": (
-                self.independent_total_variance.tolist()
-            ),
+            "independent_total_variance": (self.independent_total_variance.tolist()),
             "independent_probability_positive": (
                 self.independent_probability_positive.tolist()
             ),

--- a/src/causal4d/_interventional_contrast_readout_correlation.py
+++ b/src/causal4d/_interventional_contrast_readout_correlation.py
@@ -1,0 +1,422 @@
+"""Marginal sensitivity to cross-branch conditional readout correlation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+import hashlib
+import json
+from typing import Any
+
+import numpy as np
+
+from causal4d.contracts import array_sha256
+from causal4d.immutable_array import readonly_array
+from causal4d.immutable_json import plain_json, validated_json_mapping
+from causal4d._interventional_contrast_common import (
+    ContrastCouplingPolicy,
+    _require_nonempty_string,
+    _require_sha256,
+    _validated_string_tuple,
+)
+
+
+INTERVENTIONAL_CONTRAST_READOUT_CORRELATION_SCHEMA_VERSION = 1
+_READOUT_CORRELATION_ARTIFACT_KIND = (
+    "Causal4DInterventionalContrastReadoutCorrelationSensitivityV1"
+)
+_READOUT_CORRELATION_DESCRIPTOR_FIELDS = frozenset(
+    {
+        "schema_version",
+        "artifact_kind",
+        "artifact_id",
+        "source_contrast_id",
+        "source_branch_a_posterior_id",
+        "source_branch_b_posterior_id",
+        "source_query_id",
+        "branch_a_label",
+        "branch_b_label",
+        "coupling_policy",
+        "shared_kappa_names",
+        "query_name",
+        "query_labels",
+        "query_units",
+        "metadata",
+    }
+)
+_READOUT_CORRELATION_ARRAY_FIELDS = frozenset(
+    {
+        "correlation_grid",
+        "mean",
+        "between_component_variance",
+        "conditional_variance",
+        "total_variance",
+        "probability_positive",
+        "independent_total_variance",
+        "independent_probability_positive",
+    }
+)
+_READOUT_CORRELATION_ARRAY_DTYPES = {
+    name: np.dtype(np.float64) for name in _READOUT_CORRELATION_ARRAY_FIELDS
+}
+_READOUT_CORRELATION_CLAIM_BOUNDARY = {
+    "analysis_only": True,
+    "changes_estimator": False,
+    "changes_source_posterior": False,
+    "changes_registered_protocol": False,
+    "uses_target_truth": False,
+    "cross_branch_conditional_covariance_identified": False,
+    "simultaneous_cross_output_covariance_claimed": False,
+    "empirical_calibration_claimed": False,
+}
+
+
+def _validated_vector(
+    values: Any,
+    *,
+    name: str,
+    length: int,
+    nonnegative: bool = False,
+    probability: bool = False,
+) -> np.ndarray:
+    supplied = readonly_array(values, dtype=float)
+    if supplied.shape != (length,) or not np.all(np.isfinite(supplied)):
+        raise ValueError(f"{name} must be a finite vector of length {length}")
+    tolerance = 1e-10
+    if nonnegative and np.any(supplied < -tolerance):
+        raise ValueError(f"{name} must be nonnegative")
+    if probability and (
+        np.any(supplied < -tolerance) or np.any(supplied > 1.0 + tolerance)
+    ):
+        raise ValueError(f"{name} must lie in [0, 1]")
+    if nonnegative:
+        supplied = readonly_array(np.maximum(supplied, 0.0), dtype=float)
+    if probability:
+        supplied = readonly_array(np.clip(supplied, 0.0, 1.0), dtype=float)
+    return supplied
+
+
+def _validated_matrix(
+    values: Any,
+    *,
+    name: str,
+    shape: tuple[int, int],
+    nonnegative: bool = False,
+    probability: bool = False,
+) -> np.ndarray:
+    supplied = readonly_array(values, dtype=float)
+    if supplied.shape != shape or not np.all(np.isfinite(supplied)):
+        raise ValueError(f"{name} must have finite shape {shape}")
+    tolerance = 1e-10
+    if nonnegative and np.any(supplied < -tolerance):
+        raise ValueError(f"{name} must be nonnegative")
+    if probability and (
+        np.any(supplied < -tolerance) or np.any(supplied > 1.0 + tolerance)
+    ):
+        raise ValueError(f"{name} must lie in [0, 1]")
+    if nonnegative:
+        supplied = readonly_array(np.maximum(supplied, 0.0), dtype=float)
+    if probability:
+        supplied = readonly_array(np.clip(supplied, 0.0, 1.0), dtype=float)
+    return supplied
+
+
+@dataclass(frozen=True)
+class InterventionalContrastReadoutCorrelationSensitivityV1:
+    """Marginal contrast sensitivity over a declared correlation grid.
+
+    One scalar correlation value is applied to the conditional readout errors of
+    each paired branch component. Summaries are marginal for every query output;
+    the artifact does not construct or identify one simultaneous cross-output
+    covariance matrix.
+    """
+
+    source_contrast_id: str
+    source_branch_a_posterior_id: str
+    source_branch_b_posterior_id: str
+    source_query_id: str
+    branch_a_label: str
+    branch_b_label: str
+    coupling_policy: ContrastCouplingPolicy
+    shared_kappa_names: tuple[str, ...]
+    query_name: str
+    query_labels: tuple[str, ...]
+    query_units: tuple[str, ...]
+    correlation_grid: np.ndarray
+    mean: np.ndarray
+    between_component_variance: np.ndarray
+    conditional_variance: np.ndarray
+    total_variance: np.ndarray
+    probability_positive: np.ndarray
+    independent_total_variance: np.ndarray
+    independent_probability_positive: np.ndarray
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for name in (
+            "source_contrast_id",
+            "source_branch_a_posterior_id",
+            "source_branch_b_posterior_id",
+            "source_query_id",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _require_sha256(getattr(self, name), name=name),
+            )
+        branch_a = _require_nonempty_string(
+            self.branch_a_label,
+            name="branch_a_label",
+        )
+        branch_b = _require_nonempty_string(
+            self.branch_b_label,
+            name="branch_b_label",
+        )
+        if branch_a == branch_b:
+            raise ValueError("branch labels must be distinct")
+        coupling = _require_nonempty_string(
+            self.coupling_policy,
+            name="coupling_policy",
+        )
+        if coupling not in {
+            "shared_component",
+            "shared_twin_phi",
+            "independent_product",
+        }:
+            raise ValueError("unsupported contrast coupling policy")
+        shared_kappa_names = _validated_string_tuple(
+            self.shared_kappa_names,
+            name="shared_kappa_names",
+            unique=True,
+            allow_empty=True,
+        )
+        if coupling != "shared_twin_phi" and shared_kappa_names:
+            raise ValueError("shared_kappa_names require shared_twin_phi coupling")
+        query_name = _require_nonempty_string(self.query_name, name="query_name")
+        query_labels = _validated_string_tuple(
+            self.query_labels,
+            name="query_labels",
+            unique=True,
+        )
+        query_units = _validated_string_tuple(
+            self.query_units,
+            name="query_units",
+            unique=False,
+        )
+        if len(query_units) != len(query_labels):
+            raise ValueError("query labels and units must align")
+
+        raw_grid = np.asarray(self.correlation_grid)
+        if raw_grid.dtype.kind == "b":
+            raise ValueError("correlation_grid must contain numbers, not Booleans")
+        grid = readonly_array(raw_grid, dtype=float)
+        if grid.ndim != 1 or len(grid) == 0 or not np.all(np.isfinite(grid)):
+            raise ValueError("correlation_grid must be a nonempty finite vector")
+        tolerance = 1e-10
+        if np.any(grid < -1.0 - tolerance) or np.any(grid > 1.0 + tolerance):
+            raise ValueError("correlation_grid must lie in [-1, 1]")
+        if np.any(np.diff(grid) <= 0.0):
+            raise ValueError("correlation_grid must be strictly increasing")
+        zero_indices = np.flatnonzero(grid == 0.0)
+        if len(zero_indices) != 1:
+            raise ValueError("correlation_grid must contain zero exactly once")
+        grid = readonly_array(np.clip(grid, -1.0, 1.0), dtype=float)
+
+        output_count = len(query_labels)
+        row_count = len(grid)
+        mean = _validated_vector(
+            self.mean,
+            name="mean",
+            length=output_count,
+        )
+        between = _validated_vector(
+            self.between_component_variance,
+            name="between_component_variance",
+            length=output_count,
+            nonnegative=True,
+        )
+        conditional = _validated_matrix(
+            self.conditional_variance,
+            name="conditional_variance",
+            shape=(row_count, output_count),
+            nonnegative=True,
+        )
+        total = _validated_matrix(
+            self.total_variance,
+            name="total_variance",
+            shape=(row_count, output_count),
+            nonnegative=True,
+        )
+        positive = _validated_matrix(
+            self.probability_positive,
+            name="probability_positive",
+            shape=(row_count, output_count),
+            probability=True,
+        )
+        independent_total = _validated_vector(
+            self.independent_total_variance,
+            name="independent_total_variance",
+            length=output_count,
+            nonnegative=True,
+        )
+        independent_positive = _validated_vector(
+            self.independent_probability_positive,
+            name="independent_probability_positive",
+            length=output_count,
+            probability=True,
+        )
+
+        expected_total = between[None] + conditional
+        if not np.allclose(total, expected_total, atol=1e-12, rtol=1e-10):
+            raise ValueError(
+                "total_variance must equal between plus conditional variance"
+            )
+        if np.any(np.diff(conditional, axis=0) > 1e-10):
+            raise ValueError(
+                "conditional_variance must not increase with correlation"
+            )
+        zero_index = int(zero_indices[0])
+        if not np.allclose(
+            total[zero_index],
+            independent_total,
+            atol=1e-12,
+            rtol=1e-10,
+        ):
+            raise ValueError(
+                "zero-correlation total variance must match the independent baseline"
+            )
+        if not np.allclose(
+            positive[zero_index],
+            independent_positive,
+            atol=1e-12,
+            rtol=1e-10,
+        ):
+            raise ValueError(
+                "zero-correlation probability must match the independent baseline"
+            )
+
+        object.__setattr__(self, "branch_a_label", branch_a)
+        object.__setattr__(self, "branch_b_label", branch_b)
+        object.__setattr__(self, "coupling_policy", coupling)
+        object.__setattr__(self, "shared_kappa_names", shared_kappa_names)
+        object.__setattr__(self, "query_name", query_name)
+        object.__setattr__(self, "query_labels", query_labels)
+        object.__setattr__(self, "query_units", query_units)
+        object.__setattr__(self, "correlation_grid", grid)
+        object.__setattr__(self, "mean", mean)
+        object.__setattr__(self, "between_component_variance", between)
+        object.__setattr__(self, "conditional_variance", conditional)
+        object.__setattr__(self, "total_variance", total)
+        object.__setattr__(self, "probability_positive", positive)
+        object.__setattr__(self, "independent_total_variance", independent_total)
+        object.__setattr__(
+            self,
+            "independent_probability_positive",
+            independent_positive,
+        )
+        object.__setattr__(
+            self,
+            "metadata",
+            validated_json_mapping(
+                self.metadata,
+                error_message=(
+                    "readout-correlation metadata must contain finite JSON data"
+                ),
+            ),
+        )
+
+    @property
+    def zero_correlation_index(self) -> int:
+        return int(np.flatnonzero(self.correlation_grid == 0.0)[0])
+
+    @property
+    def total_variance_envelope(self) -> tuple[np.ndarray, np.ndarray]:
+        return (
+            readonly_array(np.min(self.total_variance, axis=0), dtype=float),
+            readonly_array(np.max(self.total_variance, axis=0), dtype=float),
+        )
+
+    @property
+    def probability_positive_envelope(self) -> tuple[np.ndarray, np.ndarray]:
+        return (
+            readonly_array(np.min(self.probability_positive, axis=0), dtype=float),
+            readonly_array(np.max(self.probability_positive, axis=0), dtype=float),
+        )
+
+    def _scalar_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": (
+                INTERVENTIONAL_CONTRAST_READOUT_CORRELATION_SCHEMA_VERSION
+            ),
+            "artifact_kind": _READOUT_CORRELATION_ARTIFACT_KIND,
+            "source_contrast_id": self.source_contrast_id,
+            "source_branch_a_posterior_id": self.source_branch_a_posterior_id,
+            "source_branch_b_posterior_id": self.source_branch_b_posterior_id,
+            "source_query_id": self.source_query_id,
+            "branch_a_label": self.branch_a_label,
+            "branch_b_label": self.branch_b_label,
+            "coupling_policy": self.coupling_policy,
+            "shared_kappa_names": list(self.shared_kappa_names),
+            "query_name": self.query_name,
+            "query_labels": list(self.query_labels),
+            "query_units": list(self.query_units),
+            "metadata": plain_json(self.metadata),
+        }
+
+    def _array_payload(self) -> dict[str, np.ndarray]:
+        return {
+            "correlation_grid": self.correlation_grid,
+            "mean": self.mean,
+            "between_component_variance": self.between_component_variance,
+            "conditional_variance": self.conditional_variance,
+            "total_variance": self.total_variance,
+            "probability_positive": self.probability_positive,
+            "independent_total_variance": self.independent_total_variance,
+            "independent_probability_positive": (
+                self.independent_probability_positive
+            ),
+        }
+
+    @property
+    def artifact_id(self) -> str:
+        digest = hashlib.sha256()
+        digest.update(
+            json.dumps(
+                self._scalar_payload(),
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            ).encode("utf-8")
+        )
+        for name, values in sorted(self._array_payload().items()):
+            digest.update(name.encode("utf-8"))
+            digest.update(array_sha256(values).encode("ascii"))
+        return digest.hexdigest()
+
+    def as_dict(self) -> dict[str, Any]:
+        variance_lower, variance_upper = self.total_variance_envelope
+        positive_lower, positive_upper = self.probability_positive_envelope
+        return {
+            **self._scalar_payload(),
+            "artifact_id": self.artifact_id,
+            "correlation_grid": self.correlation_grid.tolist(),
+            "mean": self.mean.tolist(),
+            "between_component_variance": (
+                self.between_component_variance.tolist()
+            ),
+            "conditional_variance": self.conditional_variance.tolist(),
+            "total_variance": self.total_variance.tolist(),
+            "probability_positive": self.probability_positive.tolist(),
+            "independent_total_variance": (
+                self.independent_total_variance.tolist()
+            ),
+            "independent_probability_positive": (
+                self.independent_probability_positive.tolist()
+            ),
+            "grid_envelope": {
+                "total_variance_lower": variance_lower.tolist(),
+                "total_variance_upper": variance_upper.tolist(),
+                "probability_positive_lower": positive_lower.tolist(),
+                "probability_positive_upper": positive_upper.tolist(),
+            },
+        }

--- a/src/causal4d/_interventional_contrast_readout_correlation_build.py
+++ b/src/causal4d/_interventional_contrast_readout_correlation_build.py
@@ -236,9 +236,7 @@ def build_interventional_contrast_readout_correlation_sensitivity(
             "pairwise marginal conditional readout-error correlation"
         ),
         "correlation_applied_per_query_output": True,
-        "source_conditional_variance_policy": (
-            contrast.conditional_variance_policy
-        ),
+        "source_conditional_variance_policy": (contrast.conditional_variance_policy),
         "source_pair_count": len(pairs),
         "user": plain_json(user_metadata),
     }

--- a/src/causal4d/_interventional_contrast_readout_correlation_build.py
+++ b/src/causal4d/_interventional_contrast_readout_correlation_build.py
@@ -1,0 +1,266 @@
+"""Build marginal cross-branch readout-correlation sensitivity artifacts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+from scipy.special import ndtr
+
+from causal4d.contracts import PhysicalPosterior
+from causal4d.immutable_json import plain_json
+from causal4d._interventional_contrast_common import _require_mapping
+from causal4d._interventional_contrast_posterior import (
+    InterventionalContrastPosteriorV1,
+)
+from causal4d._interventional_contrast_query import (
+    InterventionalContrastQueryV1,
+)
+from causal4d._interventional_contrast_readout_correlation import (
+    InterventionalContrastReadoutCorrelationSensitivityV1,
+    _READOUT_CORRELATION_CLAIM_BOUNDARY,
+)
+
+
+def _validated_correlation_grid(values: Sequence[float]) -> np.ndarray:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise ValueError("correlations must be a sequence of numbers")
+    raw = np.asarray(values)
+    if raw.dtype.kind == "b":
+        raise ValueError("correlations must contain numbers, not Booleans")
+    correlations = np.asarray(raw, dtype=float)
+    if (
+        correlations.ndim != 1
+        or len(correlations) == 0
+        or not np.all(np.isfinite(correlations))
+    ):
+        raise ValueError("correlations must be a nonempty finite vector")
+    if np.any(correlations < -1.0) or np.any(correlations > 1.0):
+        raise ValueError("correlations must lie in [-1, 1]")
+    if np.any(np.diff(correlations) <= 0.0):
+        raise ValueError("correlations must be strictly increasing")
+    if np.sum(correlations == 0.0) != 1:
+        raise ValueError("correlations must contain zero exactly once")
+    return correlations
+
+
+def _query_component_covariance(
+    posterior: PhysicalPosterior,
+    query: InterventionalContrastQueryV1,
+) -> np.ndarray:
+    trajectories = np.asarray(posterior.readout_trajectories_m, dtype=float)
+    if trajectories.ndim != 4 or trajectories.shape[-1] != 3:
+        raise ValueError("source readout trajectories have the wrong shape")
+    if query.trajectory_dimension != int(np.prod(trajectories.shape[1:])):
+        raise ValueError("contrast query does not match a source trajectory")
+    component_variance = np.asarray(posterior.readout_variance_m2, dtype=float)
+    expected = (len(trajectories), trajectories.shape[2], trajectories.shape[3])
+    if component_variance.shape != expected:
+        raise ValueError("source readout variance has the wrong shape")
+    if not np.all(np.isfinite(component_variance)) or np.any(component_variance < 0.0):
+        raise ValueError("source readout variance must be finite and nonnegative")
+    full_variance = np.broadcast_to(
+        component_variance[:, None],
+        trajectories.shape,
+    ).reshape(len(trajectories), -1)
+    return np.einsum(
+        "qi,ki,ri->kqr",
+        query.matrix,
+        full_variance,
+        query.matrix,
+    )
+
+
+def _component_probability_positive(
+    means: np.ndarray,
+    variances: np.ndarray,
+) -> np.ndarray:
+    probabilities = np.zeros_like(means)
+    positive_variance = variances > 0.0
+    probabilities[positive_variance] = ndtr(
+        means[positive_variance] / np.sqrt(variances[positive_variance])
+    )
+    probabilities[~positive_variance] = means[~positive_variance] > 0.0
+    return probabilities
+
+
+def _validate_sources(
+    branch_a: PhysicalPosterior,
+    branch_b: PhysicalPosterior,
+    contrast: InterventionalContrastPosteriorV1,
+) -> InterventionalContrastQueryV1:
+    if not isinstance(branch_a, PhysicalPosterior) or not isinstance(
+        branch_b,
+        PhysicalPosterior,
+    ):
+        raise TypeError("both branches must be PhysicalPosterior instances")
+    if not isinstance(contrast, InterventionalContrastPosteriorV1):
+        raise TypeError("contrast must be InterventionalContrastPosteriorV1")
+    if contrast.conditional_variance_policy != "independent_readout":
+        raise ValueError(
+            "readout-correlation sensitivity requires an independent_readout "
+            "source contrast"
+        )
+    if contrast.source_branch_a_posterior_id != branch_a.artifact_id:
+        raise ValueError("branch A does not match the source contrast")
+    if contrast.source_branch_b_posterior_id != branch_b.artifact_id:
+        raise ValueError("branch B does not match the source contrast")
+    if contrast.source_branch_a_query_id != branch_a.source_query_id:
+        raise ValueError("branch A query ancestry does not match the source contrast")
+    if contrast.source_branch_b_query_id != branch_b.source_query_id:
+        raise ValueError("branch B query ancestry does not match the source contrast")
+    if contrast.branch_a_component_count != len(branch_a.weights):
+        raise ValueError("branch A support count does not match the source contrast")
+    if contrast.branch_b_component_count != len(branch_b.weights):
+        raise ValueError("branch B support count does not match the source contrast")
+    return InterventionalContrastQueryV1(
+        name=contrast.query_name,
+        matrix=contrast.query_matrix,
+        labels=contrast.query_labels,
+        units=contrast.query_units,
+        metadata=contrast.query_metadata,
+    )
+
+
+def build_interventional_contrast_readout_correlation_sensitivity(
+    branch_a: PhysicalPosterior,
+    branch_b: PhysicalPosterior,
+    contrast: InterventionalContrastPosteriorV1,
+    *,
+    correlations: Sequence[float] = (-1.0, -0.5, 0.0, 0.5, 1.0),
+    metadata: Mapping[str, Any] | None = None,
+) -> InterventionalContrastReadoutCorrelationSensitivityV1:
+    """Evaluate marginal contrast summaries over assumed branch correlations.
+
+    The source contrast fixes the finite-support coupling and component means.
+    For every paired component and query output, the declared correlation ``rho``
+    gives marginal conditional variance
+
+    ``v_a + v_b - 2 * rho * sqrt(v_a * v_b)``.
+
+    The calculation is a sensitivity analysis. It does not infer ``rho``, create
+    one joint cross-output covariance, modify either branch, or establish
+    empirical calibration.
+    """
+
+    query = _validate_sources(branch_a, branch_b, contrast)
+    grid = _validated_correlation_grid(correlations)
+    if metadata is None:
+        user_metadata: Mapping[str, Any] = {}
+    else:
+        user_metadata = _require_mapping(metadata, name="metadata")
+
+    covariance_a = _query_component_covariance(branch_a, query)
+    covariance_b = _query_component_covariance(branch_b, query)
+    pairs = np.asarray(contrast.pair_indices, dtype=np.int64)
+    weights = np.asarray(contrast.weights, dtype=float)
+    means = np.asarray(contrast.contrast_values, dtype=float)
+    branch_a_variance = np.diagonal(
+        covariance_a[pairs[:, 0]],
+        axis1=-2,
+        axis2=-1,
+    )
+    branch_b_variance = np.diagonal(
+        covariance_b[pairs[:, 1]],
+        axis1=-2,
+        axis2=-1,
+    )
+    independent_component_variance = branch_a_variance + branch_b_variance
+    source_component_variance = np.diagonal(
+        contrast.conditional_covariance,
+        axis1=-2,
+        axis2=-1,
+    )
+    if not np.allclose(
+        source_component_variance,
+        independent_component_variance,
+        atol=1e-12,
+        rtol=1e-10,
+    ):
+        raise ValueError(
+            "source contrast conditional variance is not the declared independent "
+            "branch sum"
+        )
+
+    correlation_scale = np.sqrt(branch_a_variance * branch_b_variance)
+    mean = np.einsum("k,kq->q", weights, means)
+    centered = means - mean[None]
+    between = np.einsum("k,kq->q", weights, np.square(centered))
+    conditional = np.empty((len(grid), query.output_count), dtype=float)
+    total = np.empty_like(conditional)
+    probability_positive = np.empty_like(conditional)
+    for index, correlation in enumerate(grid):
+        component_variance = np.maximum(
+            independent_component_variance
+            - 2.0 * float(correlation) * correlation_scale,
+            0.0,
+        )
+        conditional[index] = np.einsum("k,kq->q", weights, component_variance)
+        total[index] = between + conditional[index]
+        component_probability = _component_probability_positive(
+            means,
+            component_variance,
+        )
+        probability_positive[index] = np.einsum(
+            "k,kq->q",
+            weights,
+            component_probability,
+        )
+
+    zero_index = int(np.flatnonzero(grid == 0.0)[0])
+    independent_total = np.diag(contrast.covariance)
+    independent_positive = np.asarray(contrast.probability_positive, dtype=float)
+    if not np.allclose(
+        total[zero_index],
+        independent_total,
+        atol=1e-12,
+        rtol=1e-10,
+    ):
+        raise RuntimeError(
+            "zero-correlation sensitivity does not reproduce source variance"
+        )
+    if not np.allclose(
+        probability_positive[zero_index],
+        independent_positive,
+        atol=1e-12,
+        rtol=1e-10,
+    ):
+        raise RuntimeError(
+            "zero-correlation sensitivity does not reproduce source probability"
+        )
+
+    result_metadata = {
+        "claim_boundary": _READOUT_CORRELATION_CLAIM_BOUNDARY,
+        "correlation_semantics": (
+            "pairwise marginal conditional readout-error correlation"
+        ),
+        "correlation_applied_per_query_output": True,
+        "source_conditional_variance_policy": (
+            contrast.conditional_variance_policy
+        ),
+        "source_pair_count": len(pairs),
+        "user": plain_json(user_metadata),
+    }
+    return InterventionalContrastReadoutCorrelationSensitivityV1(
+        source_contrast_id=contrast.artifact_id,
+        source_branch_a_posterior_id=branch_a.artifact_id,
+        source_branch_b_posterior_id=branch_b.artifact_id,
+        source_query_id=contrast.query_id,
+        branch_a_label=contrast.branch_a_label,
+        branch_b_label=contrast.branch_b_label,
+        coupling_policy=contrast.coupling_policy,
+        shared_kappa_names=contrast.shared_kappa_names,
+        query_name=contrast.query_name,
+        query_labels=contrast.query_labels,
+        query_units=contrast.query_units,
+        correlation_grid=grid,
+        mean=mean,
+        between_component_variance=between,
+        conditional_variance=conditional,
+        total_variance=total,
+        probability_positive=probability_positive,
+        independent_total_variance=independent_total,
+        independent_probability_positive=independent_positive,
+        metadata=result_metadata,
+    )

--- a/src/causal4d/_interventional_contrast_readout_correlation_io.py
+++ b/src/causal4d/_interventional_contrast_readout_correlation_io.py
@@ -1,0 +1,185 @@
+"""Strict archive I/O for interventional readout-correlation sensitivity."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import BinaryIO
+
+import numpy as np
+
+from causal4d.atomic_io import atomic_write_binary
+from causal4d.numpy_archive import load_numpy_archive
+from causal4d._interventional_contrast_common import (
+    _reject_duplicate_json_keys,
+    _reject_nonfinite_json_constant,
+    _require_exact_fields,
+    _require_mapping,
+    _require_nonempty_string,
+    _require_positive_integer,
+    _require_sha256,
+    _validated_string_tuple,
+)
+from causal4d._interventional_contrast_readout_correlation import (
+    INTERVENTIONAL_CONTRAST_READOUT_CORRELATION_SCHEMA_VERSION,
+    InterventionalContrastReadoutCorrelationSensitivityV1,
+    _READOUT_CORRELATION_ARRAY_DTYPES,
+    _READOUT_CORRELATION_ARRAY_FIELDS,
+    _READOUT_CORRELATION_ARTIFACT_KIND,
+    _READOUT_CORRELATION_DESCRIPTOR_FIELDS,
+)
+
+
+def save_interventional_contrast_readout_correlation_sensitivity(
+    path: str | Path,
+    sensitivity: InterventionalContrastReadoutCorrelationSensitivityV1,
+    *,
+    overwrite: bool = True,
+) -> None:
+    """Atomically publish a strict non-pickled sensitivity archive."""
+
+    if not isinstance(
+        sensitivity,
+        InterventionalContrastReadoutCorrelationSensitivityV1,
+    ):
+        raise TypeError(
+            "sensitivity must be "
+            "InterventionalContrastReadoutCorrelationSensitivityV1"
+        )
+    descriptor = {
+        **sensitivity._scalar_payload(),
+        "artifact_id": sensitivity.artifact_id,
+    }
+
+    def write_archive(handle: BinaryIO) -> None:
+        np.savez_compressed(
+            handle,
+            descriptor_json=np.asarray(
+                json.dumps(descriptor, sort_keys=True, separators=(",", ":"))
+            ),
+            **sensitivity._array_payload(),
+        )
+
+    def validate_archive(temporary: Path) -> None:
+        restored = load_interventional_contrast_readout_correlation_sensitivity(
+            temporary
+        )
+        if restored.artifact_id != sensitivity.artifact_id:
+            raise ValueError(
+                "written readout-correlation sensitivity failed validation"
+            )
+
+    atomic_write_binary(
+        path,
+        write_archive,
+        overwrite=overwrite,
+        validate=validate_archive,
+    )
+
+
+def load_interventional_contrast_readout_correlation_sensitivity(
+    path: str | Path,
+    *,
+    expected_sha256: str | None = None,
+) -> InterventionalContrastReadoutCorrelationSensitivityV1:
+    """Load and revalidate one exact readout-correlation sensitivity archive."""
+
+    archive = load_numpy_archive(
+        path,
+        expected_sha256=expected_sha256,
+        name="interventional contrast readout-correlation sensitivity archive",
+    )
+    archive_arrays = archive.arrays
+    if "descriptor_json" not in archive_arrays:
+        raise ValueError("sensitivity archive is missing descriptor_json")
+    descriptor_array = np.asarray(archive_arrays["descriptor_json"])
+    if descriptor_array.shape != () or type(descriptor_array.item()) is not str:
+        raise ValueError("descriptor_json must be a scalar string")
+    descriptor = json.loads(
+        descriptor_array.item(),
+        object_pairs_hook=_reject_duplicate_json_keys,
+        parse_constant=_reject_nonfinite_json_constant,
+    )
+    fields = _require_exact_fields(
+        descriptor,
+        name="interventional readout-correlation sensitivity descriptor",
+        required=_READOUT_CORRELATION_DESCRIPTOR_FIELDS,
+    )
+    schema_version = _require_positive_integer(
+        fields["schema_version"],
+        name="schema_version",
+    )
+    if schema_version != INTERVENTIONAL_CONTRAST_READOUT_CORRELATION_SCHEMA_VERSION:
+        raise ValueError(
+            "unsupported interventional readout-correlation schema version"
+        )
+    artifact_kind = _require_nonempty_string(
+        fields["artifact_kind"],
+        name="artifact_kind",
+    )
+    if artifact_kind != _READOUT_CORRELATION_ARTIFACT_KIND:
+        raise ValueError("unexpected readout-correlation sensitivity artifact kind")
+    declared_id = _require_sha256(fields["artifact_id"], name="artifact_id")
+
+    array_names = set(archive_arrays) - {"descriptor_json"}
+    if array_names != _READOUT_CORRELATION_ARRAY_FIELDS:
+        raise ValueError(
+            "readout-correlation sensitivity array fields do not match schema; "
+            f"missing={sorted(_READOUT_CORRELATION_ARRAY_FIELDS - array_names)}, "
+            f"unexpected={sorted(array_names - _READOUT_CORRELATION_ARRAY_FIELDS)}"
+        )
+    arrays: dict[str, np.ndarray] = {}
+    for name in sorted(array_names):
+        values = np.asarray(archive_arrays[name])
+        if values.dtype != _READOUT_CORRELATION_ARRAY_DTYPES[name]:
+            raise ValueError(
+                f"readout-correlation sensitivity array {name!r} must use dtype "
+                f"{_READOUT_CORRELATION_ARRAY_DTYPES[name]}; got {values.dtype}"
+            )
+        arrays[name] = values
+
+    restored = InterventionalContrastReadoutCorrelationSensitivityV1(
+        source_contrast_id=_require_sha256(
+            fields["source_contrast_id"],
+            name="source_contrast_id",
+        ),
+        source_branch_a_posterior_id=_require_sha256(
+            fields["source_branch_a_posterior_id"],
+            name="source_branch_a_posterior_id",
+        ),
+        source_branch_b_posterior_id=_require_sha256(
+            fields["source_branch_b_posterior_id"],
+            name="source_branch_b_posterior_id",
+        ),
+        source_query_id=_require_sha256(
+            fields["source_query_id"],
+            name="source_query_id",
+        ),
+        branch_a_label=fields["branch_a_label"],
+        branch_b_label=fields["branch_b_label"],
+        coupling_policy=fields["coupling_policy"],
+        shared_kappa_names=_validated_string_tuple(
+            fields["shared_kappa_names"],
+            name="shared_kappa_names",
+            unique=True,
+            allow_empty=True,
+        ),
+        query_name=fields["query_name"],
+        query_labels=_validated_string_tuple(
+            fields["query_labels"],
+            name="query_labels",
+            unique=True,
+        ),
+        query_units=_validated_string_tuple(
+            fields["query_units"],
+            name="query_units",
+            unique=False,
+        ),
+        metadata=_require_mapping(fields["metadata"], name="metadata"),
+        **arrays,
+    )
+    if restored.artifact_id != declared_id:
+        raise ValueError(
+            "readout-correlation sensitivity digest does not match its payload"
+        )
+    return restored

--- a/src/causal4d/_interventional_contrast_readout_correlation_io.py
+++ b/src/causal4d/_interventional_contrast_readout_correlation_io.py
@@ -43,8 +43,7 @@ def save_interventional_contrast_readout_correlation_sensitivity(
         InterventionalContrastReadoutCorrelationSensitivityV1,
     ):
         raise TypeError(
-            "sensitivity must be "
-            "InterventionalContrastReadoutCorrelationSensitivityV1"
+            "sensitivity must be InterventionalContrastReadoutCorrelationSensitivityV1"
         )
     descriptor = {
         **sensitivity._scalar_payload(),

--- a/src/causal4d/interventional_contrast.py
+++ b/src/causal4d/interventional_contrast.py
@@ -27,20 +27,36 @@ from causal4d._interventional_contrast_posterior import (
 from causal4d._interventional_contrast_query import (
     InterventionalContrastQueryV1,
 )
+from causal4d._interventional_contrast_readout_correlation import (
+    INTERVENTIONAL_CONTRAST_READOUT_CORRELATION_SCHEMA_VERSION,
+    InterventionalContrastReadoutCorrelationSensitivityV1,
+)
+from causal4d._interventional_contrast_readout_correlation_build import (
+    build_interventional_contrast_readout_correlation_sensitivity,
+)
+from causal4d._interventional_contrast_readout_correlation_io import (
+    load_interventional_contrast_readout_correlation_sensitivity,
+    save_interventional_contrast_readout_correlation_sensitivity,
+)
 
 
 __all__ = [
     "INTERVENTIONAL_CONTRAST_BOUNDS_SCHEMA_VERSION",
+    "INTERVENTIONAL_CONTRAST_READOUT_CORRELATION_SCHEMA_VERSION",
     "INTERVENTIONAL_CONTRAST_SCHEMA_VERSION",
     "ContrastConditionalVariancePolicy",
     "ContrastCouplingPolicy",
     "InterventionalContrastBoundsV1",
     "InterventionalContrastPosteriorV1",
     "InterventionalContrastQueryV1",
+    "InterventionalContrastReadoutCorrelationSensitivityV1",
     "build_interventional_contrast",
     "build_interventional_contrast_bounds",
+    "build_interventional_contrast_readout_correlation_sensitivity",
     "load_interventional_contrast",
     "load_interventional_contrast_bounds",
+    "load_interventional_contrast_readout_correlation_sensitivity",
     "save_interventional_contrast",
     "save_interventional_contrast_bounds",
+    "save_interventional_contrast_readout_correlation_sensitivity",
 ]

--- a/tests/test_interventional_contrast_readout_correlation.py
+++ b/tests/test_interventional_contrast_readout_correlation.py
@@ -208,12 +208,10 @@ def test_probability_curve_uses_declared_conditional_variance() -> None:
     )
 
     assert (
-        sensitivity.probability_positive[0, 0]
-        < sensitivity.probability_positive[1, 0]
+        sensitivity.probability_positive[0, 0] < sensitivity.probability_positive[1, 0]
     )
     assert (
-        sensitivity.probability_positive[1, 0]
-        < sensitivity.probability_positive[2, 0]
+        sensitivity.probability_positive[1, 0] < sensitivity.probability_positive[2, 0]
     )
     np.testing.assert_allclose(sensitivity.probability_positive[2, 0], 1.0)
 
@@ -233,9 +231,7 @@ def test_builder_rejects_wrong_source_and_missing_independent_variance() -> None
             contrast,
         )
 
-    branch_a, branch_b, means_only = _source_contrast(
-        policy="component_means_only"
-    )
+    branch_a, branch_b, means_only = _source_contrast(policy="component_means_only")
     with pytest.raises(ValueError, match="requires an independent_readout"):
         build_interventional_contrast_readout_correlation_sensitivity(
             branch_a,

--- a/tests/test_interventional_contrast_readout_correlation.py
+++ b/tests/test_interventional_contrast_readout_correlation.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from causal4d.contracts import PhysicalPosterior, build_causal_context
+from causal4d.interventional_contrast import (
+    InterventionalContrastQueryV1,
+    build_interventional_contrast,
+    build_interventional_contrast_readout_correlation_sensitivity,
+    load_interventional_contrast_readout_correlation_sensitivity,
+    save_interventional_contrast_readout_correlation_sensitivity,
+)
+
+
+TWIN_ID = "1" * 64
+FACTUAL_ID = "2" * 64
+
+
+def _context(action_id: str, action_scale: float):
+    observations = np.arange(6 * 1 * 3, dtype=float).reshape(6, 1, 3)
+    observed_actions = np.zeros((6, 1, 3), dtype=float)
+    counterfactual_actions = observed_actions.copy()
+    counterfactual_actions[2:, 0, 0] = action_scale
+    return build_causal_context(
+        protocol_id="readout-correlation-unit-protocol",
+        case_id="readout-correlation-unit-case",
+        observations=observations,
+        observed_actions=observed_actions,
+        counterfactual_actions=counterfactual_actions,
+        intervention_frame=2,
+        counterfactual_action_id=action_id,
+    )
+
+
+def _posterior(
+    action_id: str,
+    final_x_m: tuple[float, ...],
+    *,
+    action_scale: float,
+    weights: tuple[float, ...] = (0.75, 0.25),
+    variance_m2: float = 0.04,
+    factual_id: str = FACTUAL_ID,
+) -> PhysicalPosterior:
+    count = len(final_x_m)
+    trajectories = np.zeros((count, 4, 1, 3), dtype=float)
+    trajectories[:, -1, 0, 0] = final_x_m
+    return PhysicalPosterior(
+        context=_context(action_id, action_scale),
+        component_ids=tuple(f"component-{index}" for index in range(count)),
+        state_trajectories_m=trajectories,
+        readout_trajectories_m=trajectories,
+        readout_variance_m2=np.full((count, 1, 3), variance_m2),
+        weights=np.asarray(weights, dtype=float),
+        phi=np.ones((count, 1), dtype=float),
+        kappa_cf=np.column_stack(
+            (
+                np.arange(count, dtype=float),
+                np.zeros(count, dtype=float),
+            )
+        ),
+        hypothesis_indices=np.arange(count, dtype=np.int64),
+        twin_particle_indices=np.zeros(count, dtype=np.int64),
+        phi_names=("gain",),
+        kappa_names=("contact_patch", "slip"),
+        source_twin_belief_id=TWIN_ID,
+        source_factual_intervention_id=factual_id,
+        source_query_id=hashlib.sha256(action_id.encode("utf-8")).hexdigest(),
+        metadata={},
+    )
+
+
+def _query() -> InterventionalContrastQueryV1:
+    matrix = np.zeros((1, 4 * 1 * 3), dtype=float)
+    matrix[0, 3 * 1 * 3] = 1.0
+    return InterventionalContrastQueryV1(
+        name="final-node-0-x",
+        matrix=matrix,
+        labels=("final-node-0-x",),
+        units=("m",),
+        metadata={"registered": True},
+    )
+
+
+def _source_contrast(
+    *,
+    branch_a_variance_m2: float = 0.04,
+    branch_b_variance_m2: float = 0.04,
+    final_a: tuple[float, ...] = (2.0, 4.0),
+    final_b: tuple[float, ...] = (1.0, 1.0),
+    policy: str = "independent_readout",
+):
+    branch_a = _posterior(
+        "action-a",
+        final_a,
+        action_scale=1.0,
+        variance_m2=branch_a_variance_m2,
+    )
+    branch_b = _posterior(
+        "action-b",
+        final_b,
+        action_scale=-1.0,
+        variance_m2=branch_b_variance_m2,
+    )
+    contrast = build_interventional_contrast(
+        branch_a,
+        branch_b,
+        _query(),
+        branch_a_label="do(action-a)",
+        branch_b_label="do(action-b)",
+        conditional_variance_policy=policy,
+    )
+    return branch_a, branch_b, contrast
+
+
+def _build(**kwargs: Any):
+    branch_a, branch_b, contrast = _source_contrast()
+    return build_interventional_contrast_readout_correlation_sensitivity(
+        branch_a,
+        branch_b,
+        contrast,
+        **kwargs,
+    )
+
+
+def test_zero_correlation_reproduces_independent_source_exactly() -> None:
+    branch_a, branch_b, contrast = _source_contrast()
+    sensitivity = build_interventional_contrast_readout_correlation_sensitivity(
+        branch_a,
+        branch_b,
+        contrast,
+        correlations=(-1.0, 0.0, 1.0),
+    )
+
+    zero = sensitivity.zero_correlation_index
+    np.testing.assert_allclose(
+        sensitivity.total_variance[zero],
+        np.diag(contrast.covariance),
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        sensitivity.probability_positive[zero],
+        contrast.probability_positive,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(sensitivity.mean, contrast.mean)
+    assert sensitivity.source_contrast_id == contrast.artifact_id
+    assert sensitivity.metadata["claim_boundary"]["changes_estimator"] is False
+    assert (
+        sensitivity.metadata["claim_boundary"][
+            "cross_branch_conditional_covariance_identified"
+        ]
+        is False
+    )
+
+
+def test_perfect_correlation_limits_equal_variance_readout_uncertainty() -> None:
+    sensitivity = _build(correlations=(-1.0, 0.0, 1.0))
+
+    np.testing.assert_allclose(
+        sensitivity.conditional_variance[:, 0],
+        [0.16, 0.08, 0.0],
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        sensitivity.total_variance[:, 0],
+        sensitivity.between_component_variance[0] + np.asarray([0.16, 0.08, 0.0]),
+        atol=1e-12,
+    )
+    lower, upper = sensitivity.total_variance_envelope
+    np.testing.assert_allclose(lower, sensitivity.total_variance[-1])
+    np.testing.assert_allclose(upper, sensitivity.total_variance[0])
+
+
+def test_unequal_variance_positive_correlation_retains_scale_difference() -> None:
+    branch_a, branch_b, contrast = _source_contrast(
+        branch_a_variance_m2=0.04,
+        branch_b_variance_m2=0.01,
+    )
+    sensitivity = build_interventional_contrast_readout_correlation_sensitivity(
+        branch_a,
+        branch_b,
+        contrast,
+        correlations=(-1.0, 0.0, 1.0),
+    )
+
+    np.testing.assert_allclose(
+        sensitivity.conditional_variance[:, 0],
+        [0.09, 0.05, 0.01],
+        atol=1e-12,
+    )
+
+
+def test_probability_curve_uses_declared_conditional_variance() -> None:
+    branch_a, branch_b, contrast = _source_contrast(
+        final_a=(0.1, 0.1),
+        final_b=(0.0, 0.0),
+    )
+    sensitivity = build_interventional_contrast_readout_correlation_sensitivity(
+        branch_a,
+        branch_b,
+        contrast,
+        correlations=(-1.0, 0.0, 1.0),
+    )
+
+    assert (
+        sensitivity.probability_positive[0, 0]
+        < sensitivity.probability_positive[1, 0]
+    )
+    assert (
+        sensitivity.probability_positive[1, 0]
+        < sensitivity.probability_positive[2, 0]
+    )
+    np.testing.assert_allclose(sensitivity.probability_positive[2, 0], 1.0)
+
+
+def test_builder_rejects_wrong_source_and_missing_independent_variance() -> None:
+    branch_a, branch_b, contrast = _source_contrast()
+    replacement = _posterior(
+        "action-a",
+        (2.0, 5.0),
+        action_scale=1.0,
+        variance_m2=0.04,
+    )
+    with pytest.raises(ValueError, match="branch A does not match"):
+        build_interventional_contrast_readout_correlation_sensitivity(
+            replacement,
+            branch_b,
+            contrast,
+        )
+
+    branch_a, branch_b, means_only = _source_contrast(
+        policy="component_means_only"
+    )
+    with pytest.raises(ValueError, match="requires an independent_readout"):
+        build_interventional_contrast_readout_correlation_sensitivity(
+            branch_a,
+            branch_b,
+            means_only,
+        )
+
+
+def test_correlation_grid_is_strict_and_contains_independent_baseline() -> None:
+    with pytest.raises(ValueError, match="Booleans"):
+        _build(correlations=(False, True))
+    with pytest.raises(ValueError, match="strictly increasing"):
+        _build(correlations=(0.0, -0.5, 1.0))
+    with pytest.raises(ValueError, match="contain zero"):
+        _build(correlations=(-1.0, 1.0))
+    with pytest.raises(ValueError, match=r"\[-1, 1\]"):
+        _build(correlations=(-1.1, 0.0, 1.0))
+
+
+def test_sensitivity_is_immutable_and_content_addressed() -> None:
+    sensitivity = _build(
+        correlations=(-1.0, 0.0, 1.0),
+        metadata={"registered_before_target_access": True},
+    )
+    original_id = sensitivity.artifact_id
+
+    with pytest.raises(ValueError, match="read-only"):
+        sensitivity.total_variance[0, 0] = 0.0
+    assert sensitivity.artifact_id == original_id
+
+    changed = _build(
+        correlations=(-1.0, -0.25, 0.0, 1.0),
+        metadata={"registered_before_target_access": True},
+    )
+    assert changed.artifact_id != original_id
+
+
+def test_archive_round_trip_and_expected_digest(tmp_path: Path) -> None:
+    sensitivity = _build(correlations=(-1.0, 0.0, 1.0))
+    archive = tmp_path / "readout-correlation.npz"
+    save_interventional_contrast_readout_correlation_sensitivity(
+        archive,
+        sensitivity,
+        overwrite=False,
+    )
+    archive_sha256 = hashlib.sha256(archive.read_bytes()).hexdigest()
+
+    restored = load_interventional_contrast_readout_correlation_sensitivity(
+        archive,
+        expected_sha256=archive_sha256,
+    )
+    assert restored.artifact_id == sensitivity.artifact_id
+    np.testing.assert_array_equal(
+        restored.correlation_grid,
+        sensitivity.correlation_grid,
+    )
+    np.testing.assert_allclose(restored.total_variance, sensitivity.total_variance)
+
+    with pytest.raises(ValueError, match="SHA-256"):
+        load_interventional_contrast_readout_correlation_sensitivity(
+            archive,
+            expected_sha256="f" * 64,
+        )
+
+
+def test_archive_rejects_unexpected_array(tmp_path: Path) -> None:
+    sensitivity = _build(correlations=(-1.0, 0.0, 1.0))
+    source = tmp_path / "source.npz"
+    save_interventional_contrast_readout_correlation_sensitivity(source, sensitivity)
+    with np.load(source, allow_pickle=False) as archive:
+        payload = {name: archive[name] for name in archive.files}
+    payload["unexpected"] = np.asarray([1.0])
+    tampered = tmp_path / "tampered.npz"
+    np.savez_compressed(tampered, **payload)
+
+    with pytest.raises(ValueError, match="array fields do not match"):
+        load_interventional_contrast_readout_correlation_sensitivity(tampered)


### PR DESCRIPTION
## Summary

- add a typed, content-addressed analysis artifact for marginal sensitivity to assumed cross-branch conditional readout-error correlation;
- preserve the source interventional contrast coupling, weights, component means, query, and branch identities;
- require the zero-correlation row to reproduce the existing `independent_readout` variance and sign probability exactly;
- report marginal conditional variance, total mixture variance, sign probability, and grid envelopes;
- add strict non-pickled atomic archive I/O, adversarial validation, documentation, and changelog coverage.

## Why

`PhysicalPosterior` provides branch-marginal readout variance but does not identify conditional cross-branch discrepancy covariance. The existing contrast therefore assumes zero cross-branch covariance. This change makes that assumption visible and quantifies its marginal effect without inventing a covariance model or changing either physical posterior.

For each paired component and scalar query output, the sensitivity uses

```text
v_delta(rho) = v_a + v_b - 2 rho sqrt(v_a v_b),  -1 <= rho <= 1.
```

The grid is strictly ordered, must contain zero exactly once, and remains a declared assumption or source-frozen sensitivity range.

## Scientific boundary

This is analysis-only infrastructure. It does not change the frozen 36-execution estimator, registered protocol, source posterior, evidence count, target boundary, or physical fallback. It does not estimate correlation, construct one simultaneous cross-output covariance, establish calibration, or authorize target-side selection.

## Validation

Validated locally against the repository's own source distribution:

- `24 passed` across existing interventional contrasts, coupling-robust bounds, and the new readout-correlation tests;
- strict archive round-trip and expected-SHA validation;
- exact zero-correlation parity with the source contrast;
- equal- and unequal-variance analytic controls;
- immutable arrays, content-identity changes, invalid-grid rejection, source-binding rejection, and unexpected-array rejection;
- Python syntax compilation and a separate standalone numerical parity check.

Repository CI is pending on this draft head.