### PR TITLE
feat: add cross-branch covariance and prefix stability routing

### DIFF
--- a/docs/interventional_cross_covariance.md
+++ b/docs/interventional_cross_covariance.md
@@ -1,0 +1,75 @@
+# Explicit cross-branch covariance for interventional contrasts
+
+## Scope
+
+`causal4d.interventional_cross_covariance` is an additive analysis layer for an
+existing `InterventionalContrastPosteriorV1` whose conditional-variance policy is
+`independent_readout`. It leaves both physical branch posteriors and the historical
+contrast estimator unchanged.
+
+The historical policy uses
+
+```text
+Cov(Q(R^a) - Q(R^b) | pair) = C_a + C_b.
+```
+
+A separately registered source-only or controlled-data model may instead supply
+one query-space cross covariance `C_ab` for every coupled component pair. The
+adjusted conditional contrast covariance is
+
+```text
+C_delta = C_a + C_b - C_ab - C_ab^T.
+```
+
+Every declared joint block must be positive semidefinite:
+
+```text
+[ C_a     C_ab  ]
+[ C_ab^T  C_b   ] >= 0.
+```
+
+The implementation fails closed when a joint block or the resulting contrast
+covariance is invalid.
+
+## Exact fallback
+
+Omitting `cross_branch_conditional_covariance` returns the exact source contrast
+object, including object identity and artifact identity. Supplying a covariance
+requires a lowercase SHA-256 `cross_covariance_model_id` and exact source branch
+identities.
+
+```python
+from causal4d.interventional_contrast import (
+    build_interventional_cross_covariance,
+)
+
+adjusted = build_interventional_cross_covariance(
+    source_contrast,
+    branch_a,
+    branch_b,
+    cross_branch_conditional_covariance=source_frozen_cross_covariance,
+    cross_covariance_model_id=source_frozen_model_id,
+)
+```
+
+The returned `InterventionalCrossCovarianceV1` binds the source contrast, model,
+pair support, branch covariances, cross covariance, adjusted covariance, query
+labels and units, and finite metadata into one content identity. It exposes the
+same finite-mixture mean, covariance, positive-effect probability, and marginal
+quantile summaries as the source contrast.
+
+## Relationship to correlation sensitivity
+
+The existing readout-correlation sensitivity artifact varies scalar marginal
+correlations over a declared grid. This module is complementary: it consumes one
+complete pair-specific, potentially cross-output covariance tensor whose identity
+and source are already frozen. It does not estimate a covariance or select one
+from target outcomes.
+
+## Scientific boundary
+
+This is query-space uncertainty analysis, not a new physical estimator. It does
+not establish empirical calibration, identify a physical discrepancy mechanism,
+provide individual-level real counterfactual ground truth, or change the frozen
+36-execution protocol. A nonzero covariance must be fitted or preregistered using
+source or controlled data before confirmatory target access.

--- a/docs/prequential_stability_certificate.md
+++ b/docs/prequential_stability_certificate.md
@@ -1,0 +1,82 @@
+# Source-frozen prequential stability routing
+
+## Scope
+
+`causal4d.prequential_stability_certificate` turns an existing leakage-safe
+`PrequentialAbductionPathV1` and registered-query stability diagnostic into a
+deterministic routing certificate for a separately versioned future protocol.
+It does not alter the registered 36-execution estimator.
+
+The rule is frozen from source or controlled sessions and binds:
+
+- the threshold-source artifact;
+- one exact fallback artifact;
+- limits on previous-step standardized mean movement;
+- limits on previous-step Gaussian Wasserstein movement;
+- a minimum credible-interval overlap fraction;
+- limits on posterior KL divergence and total variation;
+- a minimum posterior effective sample size;
+- the required number of consecutive passing transitions; and
+- the latest causal prefix that may be admitted.
+
+## Chronological decision
+
+Only previous-step quantities enter the decision. The certificate scans causal
+prefixes in chronological order and selects the earliest prefix that completes
+the required run of passing transitions. Later prefixes cannot alter an already
+accepted earlier decision.
+
+When no prefix qualifies, the certificate selects the source-frozen fallback
+artifact exactly:
+
+```text
+accept_stable_prefix
+    -> selected_posterior_id = factual_intervention_ids[accepted_step]
+
+exact_fallback_no_stable_prefix
+    -> selected_posterior_id = fallback_artifact_id
+```
+
+The fallback must be distinct from every prefix posterior. The supplied query
+stability artifact must bind the exact prequential path, prefix inventory, and
+posterior weights. Both sources must declare `future_frames_read=0`.
+
+```python
+from causal4d.prequential_stability_certificate import (
+    PrequentialStabilityRuleV1,
+    build_prequential_stability_certificate,
+)
+
+rule = PrequentialStabilityRuleV1(
+    threshold_source_id=source_threshold_report_id,
+    fallback_artifact_id=nominal_factual_posterior_id,
+    maximum_previous_mean_shift_standardized_l2=0.10,
+    maximum_previous_gaussian_wasserstein_standardized=0.10,
+    minimum_previous_interval_overlap_fraction=0.85,
+    maximum_previous_posterior_kl=0.10,
+    maximum_previous_posterior_total_variation=0.10,
+    minimum_effective_sample_size=8.0,
+    required_consecutive_steps=2,
+    maximum_prefix_frame_count=6,
+)
+
+certificate = build_prequential_stability_certificate(
+    query_stability,
+    prequential_path,
+    rule,
+)
+```
+
+`PrequentialStabilityRuleV1` and `PrequentialStabilityCertificateV1` are immutable,
+content-addressed values. The certificate records every step decision, accepted
+step and prefix, selected posterior identity, fallback identity, source artifact
+identities, and the explicit claim boundary.
+
+## Scientific boundary
+
+Passing the rule is a source-frozen stability decision, not evidence of physical
+correctness or calibration. Thresholds, query scales, fallback identity,
+consecutive-step policy, and maximum prefix must be selected before target access.
+A future promotion study must still report held-out trajectory accuracy, proper
+scores, coverage, interval width, worst-session regret, and exact fallback
+frequency. A stable but inaccurate posterior remains a failed scientific result.

--- a/src/causal4d/interventional_contrast.py
+++ b/src/causal4d/interventional_contrast.py
@@ -38,21 +38,31 @@ from causal4d._interventional_contrast_readout_correlation_io import (
     load_interventional_contrast_readout_correlation_sensitivity,
     save_interventional_contrast_readout_correlation_sensitivity,
 )
+from causal4d.interventional_cross_covariance import (
+    INTERVENTIONAL_CROSS_COVARIANCE_CLAIM_BOUNDARY,
+    INTERVENTIONAL_CROSS_COVARIANCE_SCHEMA_VERSION,
+    InterventionalCrossCovarianceV1,
+    build_interventional_cross_covariance,
+)
 
 
 __all__ = [
     "INTERVENTIONAL_CONTRAST_BOUNDS_SCHEMA_VERSION",
     "INTERVENTIONAL_CONTRAST_READOUT_CORRELATION_SCHEMA_VERSION",
     "INTERVENTIONAL_CONTRAST_SCHEMA_VERSION",
+    "INTERVENTIONAL_CROSS_COVARIANCE_CLAIM_BOUNDARY",
+    "INTERVENTIONAL_CROSS_COVARIANCE_SCHEMA_VERSION",
     "ContrastConditionalVariancePolicy",
     "ContrastCouplingPolicy",
     "InterventionalContrastBoundsV1",
     "InterventionalContrastPosteriorV1",
     "InterventionalContrastQueryV1",
     "InterventionalContrastReadoutCorrelationSensitivityV1",
+    "InterventionalCrossCovarianceV1",
     "build_interventional_contrast",
     "build_interventional_contrast_bounds",
     "build_interventional_contrast_readout_correlation_sensitivity",
+    "build_interventional_cross_covariance",
     "load_interventional_contrast",
     "load_interventional_contrast_bounds",
     "load_interventional_contrast_readout_correlation_sensitivity",

--- a/src/causal4d/interventional_cross_covariance.py
+++ b/src/causal4d/interventional_cross_covariance.py
@@ -1,0 +1,339 @@
+"""Explicit query-space cross-branch covariance for contrast posteriors.
+
+This module is additive.  It never changes either source posterior or the
+historical interventional-contrast estimator.  Omitting the cross covariance
+returns the exact source contrast object.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+import hashlib
+import json
+import re
+from typing import Any
+
+import numpy as np
+from scipy.special import ndtr
+
+from causal4d.contracts import PhysicalPosterior, array_sha256
+from causal4d.immutable_array import readonly_array, readonly_integer_array
+from causal4d.immutable_json import plain_json, validated_json_mapping
+from causal4d._interventional_contrast_common import (
+    _mixture_marginal_quantiles,
+    _validated_probabilities,
+    _validated_weights,
+)
+from causal4d._interventional_contrast_posterior import (
+    InterventionalContrastPosteriorV1,
+)
+
+
+INTERVENTIONAL_CROSS_COVARIANCE_SCHEMA_VERSION = 1
+INTERVENTIONAL_CROSS_COVARIANCE_CLAIM_BOUNDARY = (
+    "Analysis-only query-space covariance adjustment. It does not change source "
+    "posteriors, estimate covariance from target outcomes, establish calibration, "
+    "or identify an individual-level real counterfactual effect."
+)
+_KIND = "Causal4DInterventionalCrossCovarianceV1"
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _require_sha256(value: object, *, name: str) -> str:
+    if type(value) is not str or _SHA256.fullmatch(value) is None:
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _query_component_covariance(
+    posterior: PhysicalPosterior,
+    source: InterventionalContrastPosteriorV1,
+) -> np.ndarray:
+    trajectories = np.asarray(posterior.readout_trajectories_m, dtype=float)
+    variance = np.asarray(posterior.readout_variance_m2, dtype=float)
+    if trajectories.ndim != 4 or trajectories.shape[-1] != 3:
+        raise ValueError("source readout trajectories have the wrong shape")
+    expected = (len(trajectories), trajectories.shape[2], trajectories.shape[3])
+    if variance.shape != expected:
+        raise ValueError("source readout variance has the wrong shape")
+    if not np.all(np.isfinite(variance)) or np.any(variance < 0.0):
+        raise ValueError("source readout variance must be finite and nonnegative")
+    diagonal = np.broadcast_to(variance[:, None], trajectories.shape).reshape(
+        len(trajectories), -1
+    )
+    matrix = np.asarray(source.query_matrix, dtype=float)
+    return np.einsum("qi,ki,ri->kqr", matrix, diagonal, matrix)
+
+
+def _validate_joint_blocks(
+    branch_a: np.ndarray,
+    branch_b: np.ndarray,
+    cross: np.ndarray,
+) -> None:
+    output_count = branch_a.shape[-1]
+    for index in range(len(cross)):
+        joint = np.block(
+            [
+                [branch_a[index], cross[index]],
+                [cross[index].T, branch_b[index]],
+            ]
+        )
+        scale = max(1.0, float(np.max(np.abs(joint), initial=0.0)))
+        if float(np.min(np.linalg.eigvalsh(joint), initial=0.0)) < -1.0e-10 * scale:
+            raise ValueError(
+                f"joint branch covariance for pair {index} is not positive "
+                "semidefinite"
+            )
+        if joint.shape != (2 * output_count, 2 * output_count):
+            raise RuntimeError("internal joint covariance shape changed")
+
+
+def _contrast_covariance(
+    branch_a: np.ndarray,
+    branch_b: np.ndarray,
+    cross: np.ndarray,
+) -> np.ndarray:
+    result = branch_a + branch_b - cross - cross.swapaxes(-1, -2)
+    result = 0.5 * (result + result.swapaxes(-1, -2))
+    scale = np.maximum(1.0, np.max(np.abs(result), axis=(-2, -1)))
+    minimum = np.min(np.linalg.eigvalsh(result), axis=-1)
+    if np.any(minimum < -1.0e-10 * scale):
+        raise ValueError("derived contrast covariance is not positive semidefinite")
+    return np.asarray(result, dtype=float)
+
+
+@dataclass(frozen=True)
+class InterventionalCrossCovarianceV1:
+    """Finite contrast posterior with an explicit conditional branch coupling."""
+
+    source_contrast_id: str
+    cross_covariance_model_id: str
+    query_labels: tuple[str, ...]
+    query_units: tuple[str, ...]
+    pair_indices: np.ndarray
+    weights: np.ndarray
+    contrast_values: np.ndarray
+    branch_a_conditional_covariance: np.ndarray
+    branch_b_conditional_covariance: np.ndarray
+    cross_branch_conditional_covariance: np.ndarray
+    conditional_covariance: np.ndarray
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        source_id = _require_sha256(self.source_contrast_id, name="source_contrast_id")
+        model_id = _require_sha256(
+            self.cross_covariance_model_id,
+            name="cross_covariance_model_id",
+        )
+        labels = tuple(self.query_labels)
+        units = tuple(self.query_units)
+        if not labels or len(labels) != len(units):
+            raise ValueError("query labels and units must be nonempty and aligned")
+        if (
+            len(set(labels)) != len(labels)
+            or any(not value for value in labels + units)
+        ):
+            raise ValueError("query labels must be unique and labels/units nonempty")
+        pairs = readonly_integer_array(self.pair_indices, name="pair_indices")
+        if pairs.ndim != 2 or pairs.shape[1:] != (2,) or len(pairs) == 0:
+            raise ValueError("pair_indices must have nonempty shape (pair, 2)")
+        weights = _validated_weights(self.weights, expected_count=len(pairs))
+        values = readonly_array(self.contrast_values, dtype=float)
+        dimension = len(labels)
+        if values.shape != (len(pairs), dimension) or not np.all(np.isfinite(values)):
+            raise ValueError("contrast_values must have finite shape (pair, query)")
+        expected = (len(pairs), dimension, dimension)
+        covariances = []
+        for raw, name in (
+            (self.branch_a_conditional_covariance, "branch_a_conditional_covariance"),
+            (self.branch_b_conditional_covariance, "branch_b_conditional_covariance"),
+            (
+                self.cross_branch_conditional_covariance,
+                "cross_branch_conditional_covariance",
+            ),
+            (self.conditional_covariance, "conditional_covariance"),
+        ):
+            covariance = readonly_array(raw, dtype=float)
+            if covariance.shape != expected or not np.all(np.isfinite(covariance)):
+                raise ValueError(f"{name} must have finite shape {expected}")
+            covariances.append(covariance)
+        branch_a, branch_b, cross, conditional = covariances
+        _validate_joint_blocks(branch_a, branch_b, cross)
+        wanted = _contrast_covariance(branch_a, branch_b, cross)
+        if not np.allclose(conditional, wanted, atol=1.0e-12, rtol=1.0e-10):
+            raise ValueError("conditional_covariance does not match branch coupling")
+        metadata = validated_json_mapping(
+            self.metadata,
+            error_message="cross-covariance metadata must contain finite JSON data",
+        )
+        object.__setattr__(self, "source_contrast_id", source_id)
+        object.__setattr__(self, "cross_covariance_model_id", model_id)
+        object.__setattr__(self, "query_labels", labels)
+        object.__setattr__(self, "query_units", units)
+        object.__setattr__(self, "pair_indices", pairs)
+        object.__setattr__(self, "weights", weights)
+        object.__setattr__(self, "contrast_values", values)
+        object.__setattr__(self, "branch_a_conditional_covariance", branch_a)
+        object.__setattr__(self, "branch_b_conditional_covariance", branch_b)
+        object.__setattr__(self, "cross_branch_conditional_covariance", cross)
+        object.__setattr__(self, "conditional_covariance", conditional)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def mean(self) -> np.ndarray:
+        return readonly_array(np.einsum("k,kq->q", self.weights, self.contrast_values))
+
+    @property
+    def covariance(self) -> np.ndarray:
+        centered = self.contrast_values - np.asarray(self.mean)[None]
+        between = np.einsum("k,ki,kj->ij", self.weights, centered, centered)
+        within = np.einsum("k,kij->ij", self.weights, self.conditional_covariance)
+        return readonly_array(0.5 * (between + within + (between + within).T))
+
+    @property
+    def probability_positive(self) -> np.ndarray:
+        variance = np.diagonal(self.conditional_covariance, axis1=-2, axis2=-1)
+        probabilities = np.zeros_like(self.contrast_values)
+        positive = variance > 0.0
+        probabilities[positive] = ndtr(
+            self.contrast_values[positive] / np.sqrt(variance[positive])
+        )
+        probabilities[~positive] = self.contrast_values[~positive] > 0.0
+        return readonly_array(np.einsum("k,kq->q", self.weights, probabilities))
+
+    def marginal_quantiles(
+        self,
+        probabilities: Sequence[float] = (0.05, 0.5, 0.95),
+    ) -> np.ndarray:
+        levels = _validated_probabilities(probabilities)
+        variance = np.diagonal(self.conditional_covariance, axis1=-2, axis2=-1)
+        return readonly_array(
+            _mixture_marginal_quantiles(
+                self.contrast_values,
+                variance,
+                self.weights,
+                levels,
+            )
+        )
+
+    @property
+    def artifact_id(self) -> str:
+        descriptor = {
+            "schema_version": INTERVENTIONAL_CROSS_COVARIANCE_SCHEMA_VERSION,
+            "artifact_kind": _KIND,
+            "source_contrast_id": self.source_contrast_id,
+            "cross_covariance_model_id": self.cross_covariance_model_id,
+            "query_labels": list(self.query_labels),
+            "query_units": list(self.query_units),
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": INTERVENTIONAL_CROSS_COVARIANCE_CLAIM_BOUNDARY,
+            "arrays": {
+                name: array_sha256(getattr(self, name))
+                for name in (
+                    "pair_indices",
+                    "weights",
+                    "contrast_values",
+                    "branch_a_conditional_covariance",
+                    "branch_b_conditional_covariance",
+                    "cross_branch_conditional_covariance",
+                    "conditional_covariance",
+                )
+            },
+        }
+        encoded = json.dumps(
+            descriptor,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": INTERVENTIONAL_CROSS_COVARIANCE_SCHEMA_VERSION,
+            "artifact_kind": _KIND,
+            "artifact_id": self.artifact_id,
+            "source_contrast_id": self.source_contrast_id,
+            "cross_covariance_model_id": self.cross_covariance_model_id,
+            "query_labels": list(self.query_labels),
+            "query_units": list(self.query_units),
+            "mean": self.mean.tolist(),
+            "covariance": self.covariance.tolist(),
+            "probability_positive": self.probability_positive.tolist(),
+            "effective_component_count": float(1.0 / np.sum(np.square(self.weights))),
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": INTERVENTIONAL_CROSS_COVARIANCE_CLAIM_BOUNDARY,
+        }
+
+
+def build_interventional_cross_covariance(
+    source: InterventionalContrastPosteriorV1,
+    branch_a: PhysicalPosterior,
+    branch_b: PhysicalPosterior,
+    *,
+    cross_branch_conditional_covariance: np.ndarray | None = None,
+    cross_covariance_model_id: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> InterventionalContrastPosteriorV1 | InterventionalCrossCovarianceV1:
+    """Apply a source-frozen cross covariance, or return ``source`` exactly."""
+
+    if cross_branch_conditional_covariance is None:
+        if cross_covariance_model_id is not None:
+            raise ValueError("cross_covariance_model_id requires a covariance array")
+        return source
+    if source.conditional_variance_policy != "independent_readout":
+        raise ValueError("cross covariance requires an independent_readout source")
+    if source.source_branch_a_posterior_id != branch_a.artifact_id:
+        raise ValueError("branch_a does not match the source contrast")
+    if source.source_branch_b_posterior_id != branch_b.artifact_id:
+        raise ValueError("branch_b does not match the source contrast")
+    model_id = _require_sha256(
+        cross_covariance_model_id,
+        name="cross_covariance_model_id",
+    )
+    branch_a_all = _query_component_covariance(branch_a, source)
+    branch_b_all = _query_component_covariance(branch_b, source)
+    pairs = np.asarray(source.pair_indices, dtype=np.int64)
+    branch_a_covariance = branch_a_all[pairs[:, 0]]
+    branch_b_covariance = branch_b_all[pairs[:, 1]]
+    cross = np.asarray(cross_branch_conditional_covariance, dtype=float)
+    expected = branch_a_covariance.shape
+    if cross.shape != expected or not np.all(np.isfinite(cross)):
+        raise ValueError(f"cross covariance must have finite shape {expected}")
+    _validate_joint_blocks(branch_a_covariance, branch_b_covariance, cross)
+    conditional = _contrast_covariance(
+        branch_a_covariance,
+        branch_b_covariance,
+        cross,
+    )
+    user_metadata = dict(metadata or {})
+    user_metadata.update(
+        {
+            "future_observations_read": 0,
+            "source_conditional_variance_policy": "independent_readout",
+            "target_outcomes_used_for_covariance": False,
+        }
+    )
+    return InterventionalCrossCovarianceV1(
+        source_contrast_id=source.artifact_id,
+        cross_covariance_model_id=model_id,
+        query_labels=source.query_labels,
+        query_units=source.query_units,
+        pair_indices=source.pair_indices,
+        weights=source.weights,
+        contrast_values=source.contrast_values,
+        branch_a_conditional_covariance=branch_a_covariance,
+        branch_b_conditional_covariance=branch_b_covariance,
+        cross_branch_conditional_covariance=cross,
+        conditional_covariance=conditional,
+        metadata=user_metadata,
+    )
+
+
+__all__ = [
+    "INTERVENTIONAL_CROSS_COVARIANCE_CLAIM_BOUNDARY",
+    "INTERVENTIONAL_CROSS_COVARIANCE_SCHEMA_VERSION",
+    "InterventionalCrossCovarianceV1",
+    "build_interventional_cross_covariance",
+]

--- a/src/causal4d/interventional_cross_covariance.py
+++ b/src/causal4d/interventional_cross_covariance.py
@@ -82,8 +82,7 @@ def _validate_joint_blocks(
         scale = max(1.0, float(np.max(np.abs(joint), initial=0.0)))
         if float(np.min(np.linalg.eigvalsh(joint), initial=0.0)) < -1.0e-10 * scale:
             raise ValueError(
-                f"joint branch covariance for pair {index} is not positive "
-                "semidefinite"
+                f"joint branch covariance for pair {index} is not positive semidefinite"
             )
         if joint.shape != (2 * output_count, 2 * output_count):
             raise RuntimeError("internal joint covariance shape changed")
@@ -130,9 +129,8 @@ class InterventionalCrossCovarianceV1:
         units = tuple(self.query_units)
         if not labels or len(labels) != len(units):
             raise ValueError("query labels and units must be nonempty and aligned")
-        if (
-            len(set(labels)) != len(labels)
-            or any(not value for value in labels + units)
+        if len(set(labels)) != len(labels) or any(
+            not value for value in labels + units
         ):
             raise ValueError("query labels must be unique and labels/units nonempty")
         pairs = readonly_integer_array(self.pair_indices, name="pair_indices")

--- a/src/causal4d/prequential_stability_certificate.py
+++ b/src/causal4d/prequential_stability_certificate.py
@@ -1,0 +1,384 @@
+"""Source-frozen routing from prequential stability or exact fallback."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+import hashlib
+import json
+import re
+from typing import Any
+
+import numpy as np
+
+from causal4d.contracts import array_sha256
+from causal4d.immutable_array import readonly_array, readonly_integer_array
+from causal4d.immutable_json import plain_json, validated_json_mapping
+from causal4d.prequential_abduction import PrequentialAbductionPathV1
+from causal4d.prequential_query_stability import PrequentialQueryStabilityV1
+
+
+PREQUENTIAL_STABILITY_CERTIFICATE_SCHEMA_VERSION = 1
+PREQUENTIAL_STABILITY_CERTIFICATE_CLAIM_BOUNDARY = (
+    "Future-protocol routing under source-frozen thresholds. It does not alter the "
+    "registered 36-execution estimator, establish calibration, or authorize target-"
+    "informed prefix or threshold selection."
+)
+_KIND = "Causal4DPrequentialStabilityCertificateV1"
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _sha256(value: object, *, name: str) -> str:
+    if type(value) is not str or _SHA256.fullmatch(value) is None:
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _finite_nonnegative(value: object, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(
+        value,
+        (int, float, np.integer, np.floating),
+    ):
+        raise ValueError(f"{name} must be a real number")
+    result = float(value)
+    if not np.isfinite(result) or result < 0.0:
+        raise ValueError(f"{name} must be finite and nonnegative")
+    return result
+
+
+def _positive_integer(value: object, *, name: str) -> int:
+    if type(value) is not int or value < 1:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def _future_frames_read(metadata: Mapping[str, Any], *, name: str) -> int:
+    value = metadata.get("future_frames_read", 0)
+    if type(value) is not int or value != 0:
+        raise ValueError(f"{name} must declare future_frames_read=0")
+    return value
+
+
+@dataclass(frozen=True)
+class PrequentialStabilityRuleV1:
+    """Source-frozen thresholds for chronological prefix admission."""
+
+    threshold_source_id: str
+    fallback_artifact_id: str
+    maximum_previous_mean_shift_standardized_l2: float
+    maximum_previous_gaussian_wasserstein_standardized: float
+    minimum_previous_interval_overlap_fraction: float
+    maximum_previous_posterior_kl: float
+    maximum_previous_posterior_total_variation: float
+    minimum_effective_sample_size: float
+    required_consecutive_steps: int
+    maximum_prefix_frame_count: int
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "threshold_source_id",
+            _sha256(self.threshold_source_id, name="threshold_source_id"),
+        )
+        object.__setattr__(
+            self,
+            "fallback_artifact_id",
+            _sha256(self.fallback_artifact_id, name="fallback_artifact_id"),
+        )
+        for name in (
+            "maximum_previous_mean_shift_standardized_l2",
+            "maximum_previous_gaussian_wasserstein_standardized",
+            "maximum_previous_posterior_kl",
+            "maximum_previous_posterior_total_variation",
+            "minimum_effective_sample_size",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _finite_nonnegative(getattr(self, name), name=name),
+            )
+        overlap = _finite_nonnegative(
+            self.minimum_previous_interval_overlap_fraction,
+            name="minimum_previous_interval_overlap_fraction",
+        )
+        if overlap > 1.0:
+            raise ValueError(
+                "minimum_previous_interval_overlap_fraction must not exceed one"
+            )
+        object.__setattr__(
+            self,
+            "minimum_previous_interval_overlap_fraction",
+            overlap,
+        )
+        object.__setattr__(
+            self,
+            "required_consecutive_steps",
+            _positive_integer(
+                self.required_consecutive_steps,
+                name="required_consecutive_steps",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "maximum_prefix_frame_count",
+            _positive_integer(
+                self.maximum_prefix_frame_count,
+                name="maximum_prefix_frame_count",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "metadata",
+            validated_json_mapping(
+                self.metadata,
+                error_message="stability-rule metadata must contain finite JSON data",
+            ),
+        )
+
+    @property
+    def artifact_id(self) -> str:
+        payload = {
+            "threshold_source_id": self.threshold_source_id,
+            "fallback_artifact_id": self.fallback_artifact_id,
+            "maximum_previous_mean_shift_standardized_l2": (
+                self.maximum_previous_mean_shift_standardized_l2
+            ),
+            "maximum_previous_gaussian_wasserstein_standardized": (
+                self.maximum_previous_gaussian_wasserstein_standardized
+            ),
+            "minimum_previous_interval_overlap_fraction": (
+                self.minimum_previous_interval_overlap_fraction
+            ),
+            "maximum_previous_posterior_kl": self.maximum_previous_posterior_kl,
+            "maximum_previous_posterior_total_variation": (
+                self.maximum_previous_posterior_total_variation
+            ),
+            "minimum_effective_sample_size": self.minimum_effective_sample_size,
+            "required_consecutive_steps": self.required_consecutive_steps,
+            "maximum_prefix_frame_count": self.maximum_prefix_frame_count,
+            "metadata": plain_json(self.metadata),
+        }
+        encoded = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            **json.loads(json.dumps(plain_json(self.__dict__))),
+            "artifact_id": self.artifact_id,
+        }
+
+
+@dataclass(frozen=True)
+class PrequentialStabilityCertificateV1:
+    """Deterministic earliest-prefix acceptance or exact-fallback decision."""
+
+    source_prequential_path_id: str
+    source_query_stability_id: str
+    rule_id: str
+    prefix_frame_counts: np.ndarray
+    step_passes: np.ndarray
+    accepted_step_index: int | None
+    selected_posterior_id: str
+    fallback_artifact_id: str
+    decision: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for name in (
+            "source_prequential_path_id",
+            "source_query_stability_id",
+            "rule_id",
+            "selected_posterior_id",
+            "fallback_artifact_id",
+        ):
+            object.__setattr__(self, name, _sha256(getattr(self, name), name=name))
+        prefixes = readonly_integer_array(
+            self.prefix_frame_counts,
+            name="prefix_frame_counts",
+        )
+        passes = np.asarray(self.step_passes)
+        if passes.dtype.kind != "b" or passes.shape != prefixes.shape:
+            raise ValueError("step_passes must be a Boolean vector aligned to prefixes")
+        passes = readonly_array(passes, dtype=bool)
+        if self.accepted_step_index is not None and (
+            type(self.accepted_step_index) is not int
+            or not 0 <= self.accepted_step_index < len(prefixes)
+        ):
+            raise ValueError("accepted_step_index is invalid")
+        if self.decision not in {
+            "accept_stable_prefix",
+            "exact_fallback_no_stable_prefix",
+        }:
+            raise ValueError("unsupported stability decision")
+        stable = self.decision == "accept_stable_prefix"
+        if stable != (self.accepted_step_index is not None):
+            raise ValueError("decision and accepted_step_index disagree")
+        if stable and self.selected_posterior_id == self.fallback_artifact_id:
+            raise ValueError("accepted prefix cannot select the fallback artifact")
+        if not stable and self.selected_posterior_id != self.fallback_artifact_id:
+            raise ValueError(
+                "fallback decision must select fallback_artifact_id exactly"
+            )
+        object.__setattr__(self, "prefix_frame_counts", prefixes)
+        object.__setattr__(self, "step_passes", passes)
+        object.__setattr__(
+            self,
+            "metadata",
+            validated_json_mapping(
+                self.metadata,
+                error_message=(
+                    "stability-certificate metadata must contain finite JSON data"
+                ),
+            ),
+        )
+
+    @property
+    def stable(self) -> bool:
+        return self.accepted_step_index is not None
+
+    @property
+    def accepted_prefix_frame_count(self) -> int | None:
+        if self.accepted_step_index is None:
+            return None
+        return int(self.prefix_frame_counts[self.accepted_step_index])
+
+    @property
+    def exact_fallback_required(self) -> bool:
+        return not self.stable
+
+    @property
+    def artifact_id(self) -> str:
+        payload = {
+            "schema_version": PREQUENTIAL_STABILITY_CERTIFICATE_SCHEMA_VERSION,
+            "artifact_kind": _KIND,
+            "source_prequential_path_id": self.source_prequential_path_id,
+            "source_query_stability_id": self.source_query_stability_id,
+            "rule_id": self.rule_id,
+            "accepted_step_index": self.accepted_step_index,
+            "selected_posterior_id": self.selected_posterior_id,
+            "fallback_artifact_id": self.fallback_artifact_id,
+            "decision": self.decision,
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": PREQUENTIAL_STABILITY_CERTIFICATE_CLAIM_BOUNDARY,
+            "arrays": {
+                "prefix_frame_counts": array_sha256(self.prefix_frame_counts),
+                "step_passes": array_sha256(self.step_passes),
+            },
+        }
+        encoded = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": PREQUENTIAL_STABILITY_CERTIFICATE_SCHEMA_VERSION,
+            "artifact_kind": _KIND,
+            "artifact_id": self.artifact_id,
+            "source_prequential_path_id": self.source_prequential_path_id,
+            "source_query_stability_id": self.source_query_stability_id,
+            "rule_id": self.rule_id,
+            "prefix_frame_counts": self.prefix_frame_counts.tolist(),
+            "step_passes": self.step_passes.tolist(),
+            "accepted_step_index": self.accepted_step_index,
+            "accepted_prefix_frame_count": self.accepted_prefix_frame_count,
+            "selected_posterior_id": self.selected_posterior_id,
+            "fallback_artifact_id": self.fallback_artifact_id,
+            "decision": self.decision,
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": PREQUENTIAL_STABILITY_CERTIFICATE_CLAIM_BOUNDARY,
+        }
+
+
+def build_prequential_stability_certificate(
+    stability: PrequentialQueryStabilityV1,
+    path: PrequentialAbductionPathV1,
+    rule: PrequentialStabilityRuleV1,
+    *,
+    metadata: Mapping[str, Any] | None = None,
+) -> PrequentialStabilityCertificateV1:
+    """Select the earliest stable causal prefix, otherwise exact fallback."""
+
+    if stability.source_prequential_path_id != path.artifact_id:
+        raise ValueError("query stability does not match the supplied path")
+    if not np.array_equal(stability.prefix_frame_counts, path.prefix_frame_counts):
+        raise ValueError("query stability and path prefix inventories differ")
+    if not np.array_equal(stability.posterior_weights, path.posterior_weights):
+        raise ValueError("query stability and path posterior weights differ")
+    _future_frames_read(path.metadata, name="prequential path")
+    _future_frames_read(stability.metadata, name="query-stability source")
+    if rule.fallback_artifact_id in path.factual_intervention_ids:
+        raise ValueError(
+            "fallback artifact must be distinct from every prefix posterior"
+        )
+
+    summaries = stability.summary_arrays()
+    prefixes = np.asarray(path.prefix_frame_counts, dtype=np.int64)
+    passes = np.zeros(len(prefixes), dtype=bool)
+    for index in range(1, len(prefixes)):
+        passes[index] = bool(
+            prefixes[index] <= rule.maximum_prefix_frame_count
+            and summaries["previous_mean_shift_standardized_l2"][index]
+            <= rule.maximum_previous_mean_shift_standardized_l2
+            and summaries["previous_gaussian_wasserstein_standardized"][index]
+            <= rule.maximum_previous_gaussian_wasserstein_standardized
+            and summaries["previous_interval_overlap_fraction"][index]
+            >= rule.minimum_previous_interval_overlap_fraction
+            and path.previous_step_kl[index] <= rule.maximum_previous_posterior_kl
+            and path.previous_step_total_variation[index]
+            <= rule.maximum_previous_posterior_total_variation
+            and path.posterior_effective_sample_size[index]
+            >= rule.minimum_effective_sample_size
+        )
+
+    accepted: int | None = None
+    run = 0
+    for index, passed in enumerate(passes):
+        run = run + 1 if passed else 0
+        if run >= rule.required_consecutive_steps:
+            accepted = index
+            break
+    if accepted is None:
+        selected = rule.fallback_artifact_id
+        decision = "exact_fallback_no_stable_prefix"
+    else:
+        selected = path.factual_intervention_ids[accepted]
+        decision = "accept_stable_prefix"
+    user_metadata = dict(metadata or {})
+    user_metadata.update(
+        {
+            "future_frames_read": 0,
+            "source_thresholds_frozen": True,
+            "target_outcomes_used_for_thresholds": False,
+        }
+    )
+    return PrequentialStabilityCertificateV1(
+        source_prequential_path_id=path.artifact_id,
+        source_query_stability_id=stability.artifact_id,
+        rule_id=rule.artifact_id,
+        prefix_frame_counts=prefixes,
+        step_passes=passes,
+        accepted_step_index=accepted,
+        selected_posterior_id=selected,
+        fallback_artifact_id=rule.fallback_artifact_id,
+        decision=decision,
+        metadata=user_metadata,
+    )
+
+
+__all__ = [
+    "PREQUENTIAL_STABILITY_CERTIFICATE_CLAIM_BOUNDARY",
+    "PREQUENTIAL_STABILITY_CERTIFICATE_SCHEMA_VERSION",
+    "PrequentialStabilityCertificateV1",
+    "PrequentialStabilityRuleV1",
+    "build_prequential_stability_certificate",
+]

--- a/tests/test_interventional_cross_covariance.py
+++ b/tests/test_interventional_cross_covariance.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import numpy as np
+import pytest
+
+from causal4d.contracts import PhysicalPosterior, build_causal_context
+from causal4d.interventional_contrast import (
+    InterventionalContrastQueryV1,
+    build_interventional_contrast,
+)
+from causal4d.interventional_cross_covariance import (
+    InterventionalCrossCovarianceV1,
+    build_interventional_cross_covariance,
+)
+
+
+TWIN_ID = "1" * 64
+FACTUAL_ID = "2" * 64
+
+
+def _context(action_id: str, action_scale: float):
+    observations = np.arange(18, dtype=float).reshape(6, 1, 3)
+    observed_actions = np.zeros((6, 1, 3), dtype=float)
+    counterfactual_actions = observed_actions.copy()
+    counterfactual_actions[2:, 0, 0] = action_scale
+    return build_causal_context(
+        protocol_id="cross-covariance-unit-protocol",
+        case_id="cross-covariance-unit-case",
+        observations=observations,
+        observed_actions=observed_actions,
+        counterfactual_actions=counterfactual_actions,
+        intervention_frame=2,
+        counterfactual_action_id=action_id,
+    )
+
+
+def _posterior(
+    action_id: str,
+    final_x_m: tuple[float, ...],
+    *,
+    action_scale: float,
+    variance_m2: float,
+    metadata: dict[str, Any] | None = None,
+) -> PhysicalPosterior:
+    count = len(final_x_m)
+    trajectories = np.zeros((count, 4, 1, 3), dtype=float)
+    trajectories[:, -1, 0, 0] = final_x_m
+    return PhysicalPosterior(
+        context=_context(action_id, action_scale),
+        component_ids=tuple(f"component-{index}" for index in range(count)),
+        state_trajectories_m=trajectories,
+        readout_trajectories_m=trajectories,
+        readout_variance_m2=np.full((count, 1, 3), variance_m2),
+        weights=np.asarray([0.75, 0.25]),
+        phi=np.ones((count, 1), dtype=float),
+        kappa_cf=np.column_stack((np.arange(count), np.zeros(count))),
+        hypothesis_indices=np.arange(count, dtype=np.int64),
+        twin_particle_indices=np.zeros(count, dtype=np.int64),
+        phi_names=("gain",),
+        kappa_names=("contact_patch", "slip"),
+        source_twin_belief_id=TWIN_ID,
+        source_factual_intervention_id=FACTUAL_ID,
+        source_query_id=hashlib.sha256(action_id.encode()).hexdigest(),
+        metadata=metadata or {},
+    )
+
+
+def _query() -> InterventionalContrastQueryV1:
+    matrix = np.zeros((1, 12), dtype=float)
+    matrix[0, 9] = 1.0
+    return InterventionalContrastQueryV1(
+        name="final-node-0-x",
+        matrix=matrix,
+        labels=("final-node-0-x",),
+        units=("m",),
+        metadata={"registered": True},
+    )
+
+
+def _inputs():
+    branch_a = _posterior(
+        "action-a",
+        (2.0, 4.0),
+        action_scale=1.0,
+        variance_m2=0.04,
+    )
+    branch_b = _posterior(
+        "action-b",
+        (1.0, 1.0),
+        action_scale=-1.0,
+        variance_m2=0.01,
+    )
+    source = build_interventional_contrast(
+        branch_a,
+        branch_b,
+        _query(),
+        branch_a_label="do(action-a)",
+        branch_b_label="do(action-b)",
+        conditional_variance_policy="independent_readout",
+    )
+    return branch_a, branch_b, source
+
+
+def test_omitted_covariance_returns_exact_source_object() -> None:
+    branch_a, branch_b, source = _inputs()
+    result = build_interventional_cross_covariance(source, branch_a, branch_b)
+    assert result is source
+
+
+def test_positive_cross_covariance_reduces_uncertainty() -> None:
+    branch_a, branch_b, source = _inputs()
+    result = build_interventional_cross_covariance(
+        source,
+        branch_a,
+        branch_b,
+        cross_branch_conditional_covariance=np.full((2, 1, 1), 0.015),
+        cross_covariance_model_id=hashlib.sha256(b"source-fit-v1").hexdigest(),
+    )
+    assert isinstance(result, InterventionalCrossCovarianceV1)
+    np.testing.assert_allclose(result.conditional_covariance[:, 0, 0], 0.02)
+    np.testing.assert_allclose(result.covariance, [[0.77]])
+    assert result.metadata["future_observations_read"] == 0
+    assert result.metadata["target_outcomes_used_for_covariance"] is False
+
+
+def test_invalid_joint_covariance_fails_closed() -> None:
+    branch_a, branch_b, source = _inputs()
+    with pytest.raises(ValueError, match="joint branch covariance"):
+        build_interventional_cross_covariance(
+            source,
+            branch_a,
+            branch_b,
+            cross_branch_conditional_covariance=np.full((2, 1, 1), 0.03),
+            cross_covariance_model_id=hashlib.sha256(b"invalid-v1").hexdigest(),
+        )
+
+
+def test_covariance_requires_content_addressed_model_and_source_identity() -> None:
+    branch_a, branch_b, source = _inputs()
+    with pytest.raises(ValueError, match="lowercase SHA-256"):
+        build_interventional_cross_covariance(
+            source,
+            branch_a,
+            branch_b,
+            cross_branch_conditional_covariance=np.zeros((2, 1, 1)),
+        )
+    wrong_branch = _posterior(
+        "action-other",
+        (2.0, 4.0),
+        action_scale=1.0,
+        variance_m2=0.04,
+    )
+    with pytest.raises(ValueError, match="branch_a"):
+        build_interventional_cross_covariance(
+            source,
+            wrong_branch,
+            branch_b,
+            cross_branch_conditional_covariance=np.zeros((2, 1, 1)),
+            cross_covariance_model_id="a" * 64,
+        )

--- a/tests/test_prequential_stability_certificate.py
+++ b/tests/test_prequential_stability_certificate.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from causal4d.prequential_abduction import PrequentialAbductionPathV1
+from causal4d.prequential_query_stability import PrequentialQueryStabilityV1
+from causal4d.prequential_stability_certificate import (
+    PrequentialStabilityRuleV1,
+    build_prequential_stability_certificate,
+)
+
+
+PREFIXES = np.asarray([2, 3, 4, 5], dtype=np.int64)
+FACTUAL_IDS = tuple(character * 64 for character in "3456")
+FALLBACK_ID = "f" * 64
+
+
+def _summaries(weights: np.ndarray):
+    positive = weights > 0.0
+    terms = np.zeros_like(weights)
+    terms[positive] = weights[positive] * np.log(weights[positive])
+    entropy = -np.sum(terms, axis=1)
+    ess = 1.0 / np.sum(np.square(weights), axis=1)
+    maximum = np.max(weights, axis=1)
+    maps = np.argmax(weights, axis=1).astype(np.int64)
+    kl = np.zeros(len(weights))
+    tv = np.zeros(len(weights))
+    for index in range(1, len(weights)):
+        current = weights[index]
+        previous = np.maximum(weights[index - 1], np.finfo(float).tiny)
+        kl[index] = float(np.sum(current * np.log(current / previous)))
+        tv[index] = float(0.5 * np.sum(np.abs(current - weights[index - 1])))
+    return entropy, ess, maximum, maps, kl, tv
+
+
+def _path(*, unstable_last: bool = False, suffix: str = ""):
+    weights = np.asarray(
+        [
+            [0.50, 0.50],
+            [0.55, 0.45],
+            [0.56, 0.44],
+            [0.90, 0.10] if unstable_last else [0.565, 0.435],
+        ]
+    )
+    values = _summaries(weights)
+    return PrequentialAbductionPathV1(
+        source_rollout_bank_id="1" * 64,
+        source_twin_belief_id="2" * 64,
+        component_ids=("component-0", "component-1"),
+        factual_intervention_ids=FACTUAL_IDS,
+        step_evidence_ids=tuple(character * 64 for character in "789a"),
+        prefix_frame_counts=PREFIXES,
+        evidence_frame_stops=np.asarray([3, 4, 5, 6], dtype=np.int64),
+        posterior_weights=weights,
+        posterior_entropy=values[0],
+        posterior_effective_sample_size=values[1],
+        posterior_maximum_weight=values[2],
+        map_component_indices=values[3],
+        previous_step_kl=values[4],
+        previous_step_total_variation=values[5],
+        metadata={"future_frames_read": 0, "suffix": suffix},
+    )
+
+
+def _stability(path: PrequentialAbductionPathV1):
+    return PrequentialQueryStabilityV1(
+        source_prequential_path_id=path.artifact_id,
+        query_id="registered-query",
+        query_labels=("query-output",),
+        query_units=("m",),
+        query_scales=np.asarray([1.0]),
+        confidence_level=0.90,
+        prefix_frame_counts=path.prefix_frame_counts,
+        posterior_weights=path.posterior_weights,
+        component_query_values=np.asarray([[0.0], [1.0]]),
+        metadata={"future_frames_read": 0},
+    )
+
+
+def _rule(**changes):
+    values = {
+        "threshold_source_id": "b" * 64,
+        "fallback_artifact_id": FALLBACK_ID,
+        "maximum_previous_mean_shift_standardized_l2": 0.10,
+        "maximum_previous_gaussian_wasserstein_standardized": 0.10,
+        "minimum_previous_interval_overlap_fraction": 0.85,
+        "maximum_previous_posterior_kl": 0.10,
+        "maximum_previous_posterior_total_variation": 0.10,
+        "minimum_effective_sample_size": 1.5,
+        "required_consecutive_steps": 2,
+        "maximum_prefix_frame_count": 5,
+    }
+    values.update(changes)
+    return PrequentialStabilityRuleV1(**values)
+
+
+def test_selects_earliest_consecutive_stable_prefix() -> None:
+    path = _path()
+    result = build_prequential_stability_certificate(_stability(path), path, _rule())
+    assert result.stable
+    assert result.accepted_step_index == 2
+    assert result.accepted_prefix_frame_count == 4
+    assert result.selected_posterior_id == FACTUAL_IDS[2]
+    np.testing.assert_array_equal(result.step_passes, [False, True, True, True])
+
+
+def test_unstable_path_routes_exact_fallback() -> None:
+    path = _path(unstable_last=True)
+    result = build_prequential_stability_certificate(
+        _stability(path),
+        path,
+        _rule(required_consecutive_steps=3),
+    )
+    assert result.exact_fallback_required
+    assert result.selected_posterior_id == FALLBACK_ID
+    assert result.decision == "exact_fallback_no_stable_prefix"
+
+
+def test_later_prefix_change_cannot_change_accepted_earlier_prefix() -> None:
+    first = _path()
+    second = _path(unstable_last=True)
+    result_a = build_prequential_stability_certificate(
+        _stability(first), first, _rule()
+    )
+    result_b = build_prequential_stability_certificate(
+        _stability(second), second, _rule()
+    )
+    assert result_a.accepted_step_index == result_b.accepted_step_index == 2
+    assert result_a.selected_posterior_id == result_b.selected_posterior_id
+
+
+def test_path_ancestry_and_fallback_identity_fail_closed() -> None:
+    path = _path()
+    other = _path(suffix="different")
+    with pytest.raises(ValueError, match="does not match"):
+        build_prequential_stability_certificate(_stability(path), other, _rule())
+    with pytest.raises(ValueError, match="distinct from every prefix"):
+        build_prequential_stability_certificate(
+            _stability(path),
+            path,
+            _rule(fallback_artifact_id=FACTUAL_IDS[0]),
+        )


### PR DESCRIPTION
## Summary

- add an analysis-only, content-addressed query-space cross-branch covariance artifact for existing `independent_readout` interventional contrasts;
- validate every component pair's complete joint covariance block and preserve exact source-object fallback when no cross covariance is supplied;
- add source-frozen prequential stability rules and certificates that select the earliest consecutively stable causal prefix or route to an exact declared fallback; and
- expose the covariance path through `causal4d.interventional_contrast` with focused tests and claim-boundary documentation.

## Scientific invariants

- no change to either physical posterior, the factual estimator, the registered 36-execution protocol, evidence count, target boundary, or claim status;
- no target-outcome use; nonzero cross covariance and stability thresholds must be fitted on source/controlled data or preregistered before target access;
- omitting cross covariance returns the exact source contrast object;
- absence of a qualifying stable prefix selects the exact source-frozen fallback identity; and
- later prefixes cannot change an already admitted earlier prefix.

## Validation

At exact head `0902f689b5225059832315148264ec11e51aa9ca`:

- focused reconstructed-dependency suite: **8 passed**;
- `CI and release`: **success**;
- `Extended compatibility`: **success**;
- `Causal4D merge gate`: **success**; and
- `Security scanning`: **success**.

The formatting defect exposed by the first workflow run was corrected without changing estimator or protocol semantics.