### PR TITLE
Add split public APIs and end-to-end AIP demo

### DIFF
--- a/docs/aip_end_to_end_demo.md
+++ b/docs/aip_end_to_end_demo.md
@@ -1,0 +1,62 @@
+# End-to-end AIP demonstration
+
+The deterministic CPU-only demonstration exercises the supported Causal4D
+information flow without BayesianPhysTwin, Warp, a GPU, or external data:
+
+```text
+TwinBelief
+    -> factual prefix likelihood
+    -> FactualIntervention
+    -> do(counterfactual action)
+    -> PhysicalPosterior
+    -> registered horizon/node projection
+```
+
+Run it from an installed package or checkout:
+
+```bash
+python -m causal4d.demo.aip --output-dir build/aip-demo
+```
+
+The output directory contains:
+
+- `twin_belief.npz`;
+- `factual_intervention.npz`;
+- `counterfactual_query.npz`;
+- `physical_posterior.npz`;
+- `projected_posterior.npz`; and
+- `summary.json` with the verified artifact identities and compact diagnostics.
+
+Every NPZ is written by the non-pickled contract codec and reloaded before the
+summary is emitted. The demonstration also reruns factual abduction after
+replacing every held-out suffix coordinate by a large offset. The factual
+artifact identity must remain unchanged, making the causal-cutoff invariant
+visible in an executable workflow.
+
+## Versioned integration namespaces
+
+New artifact-only consumers should import from:
+
+```python
+from causal4d.artifacts.v1 import TwinBelief, load_contract, save_contract
+```
+
+Estimator consumers should import the AIP operations separately:
+
+```python
+from causal4d.inference.v1 import (
+    abduct_factual_intervention,
+    apply_counterfactual_operator,
+    project_physical_posterior,
+)
+```
+
+`causal4d.api.v1` and the historical lazy package-root exports remain unchanged.
+The split namespaces are additive and do not alter frozen artifacts, registered
+methods, provider compatibility, or scientific claims.
+
+## Evidence boundary
+
+This is a controlled software and contract demonstration only. Its synthetic
+arrays, posterior concentration, and output trajectories must not be counted as
+physical evidence or used to promote a Causal4D claim.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,29 @@
+# Examples
+
+## Controlled protocol construction
+
+```bash
+python examples/python_api_quickstart.py
+```
+
+This prints the objects and held-out actions in the small controlled benchmark.
+
+## End-to-end abduction, intervention, and prediction
+
+```bash
+python -m causal4d.demo.aip --output-dir build/aip-demo
+```
+
+The module runs with the core NumPy/SciPy installation and writes verified,
+non-pickled Causal4D contracts for a `TwinBelief`, factual intervention,
+counterfactual query, dense physical posterior, and projected posterior. It also
+checks that changing held-out suffix frames cannot change factual abduction.
+
+The equivalent repository wrapper is:
+
+```bash
+python examples/aip_end_to_end.py --output-dir build/aip-demo
+```
+
+The output is a controlled software demonstration. It is not physical evidence,
+a provider-competence result, or a scientific claim.

--- a/examples/aip_end_to_end.py
+++ b/examples/aip_end_to_end.py
@@ -1,0 +1,7 @@
+"""Run the installed-package Causal4D AIP demonstration."""
+
+from causal4d.demo.aip import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d/artifacts/__init__.py
+++ b/src/causal4d/artifacts/__init__.py
@@ -1,0 +1,1 @@
+"""Versioned public artifact namespaces for Causal4D."""

--- a/src/causal4d/artifacts/v1.py
+++ b/src/causal4d/artifacts/v1.py
@@ -1,0 +1,49 @@
+"""Version 1 of Causal4D's portable artifact API.
+
+This namespace contains the content-addressed data contracts and their safe
+non-pickled archive codec. Inference functions intentionally live in
+``causal4d.inference.v1`` so downstream integrations can depend on artifacts
+without importing estimator implementations.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from causal4d.contracts import (
+    CONTRACT_VERSION,
+    ActionWindow,
+    CausalContext,
+    CounterfactualQuery,
+    FactualIntervention,
+    ObservationWindow,
+    PhysicalPosterior,
+    TaskPosterior,
+    TwinBelief,
+    array_sha256,
+    build_causal_context,
+    load_contract,
+    save_contract,
+)
+
+
+PUBLIC_API_NAME: Final = "causal4d.artifacts.v1"
+PUBLIC_API_VERSION: Final = 1
+
+__all__ = [
+    "CONTRACT_VERSION",
+    "PUBLIC_API_NAME",
+    "PUBLIC_API_VERSION",
+    "ActionWindow",
+    "CausalContext",
+    "CounterfactualQuery",
+    "FactualIntervention",
+    "ObservationWindow",
+    "PhysicalPosterior",
+    "TaskPosterior",
+    "TwinBelief",
+    "array_sha256",
+    "build_causal_context",
+    "load_contract",
+    "save_contract",
+]

--- a/src/causal4d/demo/__init__.py
+++ b/src/causal4d/demo/__init__.py
@@ -1,0 +1,1 @@
+"""Small deterministic demonstrations of supported Causal4D workflows."""

--- a/src/causal4d/demo/aip.py
+++ b/src/causal4d/demo/aip.py
@@ -164,9 +164,7 @@ def _build_inputs() -> tuple[
         endpoint_frame=context.o_minus.frame_stop - 1,
         particle_ids=("theta-low", "theta-high"),
         theta_names=("stiffness_scale",),
-        endpoint_position_m=np.asarray(
-            factual_bank.trajectories[0, :, 0], dtype=float
-        ),
+        endpoint_position_m=np.asarray(factual_bank.trajectories[0, :, 0], dtype=float),
         endpoint_velocity_mps=np.zeros((2, 2, 3), dtype=float),
         theta=factual_bank.parameter_particles,
         discrepancy_mean_m=np.zeros((2, 2, 3), dtype=float),

--- a/src/causal4d/demo/aip.py
+++ b/src/causal4d/demo/aip.py
@@ -11,7 +11,6 @@ import numpy as np
 
 from causal4d.artifacts.v1 import (
     CounterfactualQuery,
-    PhysicalPosterior,
     TwinBelief,
     build_causal_context,
     load_contract,

--- a/src/causal4d/demo/aip.py
+++ b/src/causal4d/demo/aip.py
@@ -1,0 +1,332 @@
+"""Deterministic CPU-only abduction-intervention-prediction demonstration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from causal4d.artifacts.v1 import (
+    CounterfactualQuery,
+    PhysicalPosterior,
+    TwinBelief,
+    build_causal_context,
+    load_contract,
+    save_contract,
+)
+from causal4d.inference.v1 import (
+    FactualAbductionConfig,
+    abduct_factual_intervention,
+    apply_counterfactual_operator,
+    project_physical_posterior,
+)
+from causal4d.rollout_bank import JointRolloutBank
+
+
+SUMMARY_SCHEMA_NAME = "causal4d.aip-demo-summary"
+SUMMARY_SCHEMA_VERSION = 1
+
+
+def _contact_metadata(
+    *,
+    action_id: str,
+    future_action_observed: bool,
+    gain: float,
+    delay_steps: int,
+    rotation_degrees: float,
+    attachment_shift: int,
+    slip_fraction: float,
+) -> dict[str, Any]:
+    return {
+        "action": {
+            "proposal_id": action_id,
+            "future_action_observed": future_action_observed,
+        },
+        "contact": {
+            "gain_multiplier": gain,
+            "delay_steps": delay_steps,
+            "rotation_degrees": rotation_degrees,
+            "attachment_shifts": [attachment_shift],
+            "slip_fraction": slip_fraction,
+        },
+    }
+
+
+def _rollout_bank(
+    *,
+    action_id: str,
+    future_action_observed: bool,
+    axis: int,
+) -> JointRolloutBank:
+    parameter_particles = np.asarray([[0.9], [1.1]], dtype=float)
+    parameter_weights = np.asarray([0.55, 0.45], dtype=float)
+    endpoint = np.asarray(
+        [
+            [[0.00, 0.000, 0.00], [0.10, 0.000, 0.00]],
+            [[0.00, 0.002, 0.00], [0.10, 0.002, 0.00]],
+        ],
+        dtype=float,
+    )
+    trajectories = np.empty((2, 2, 4, 2, 3), dtype=np.float32)
+    for hypothesis in range(2):
+        for particle in range(2):
+            trajectories[hypothesis, particle, 0] = endpoint[particle]
+            speed = 0.008 + 0.004 * hypothesis + 0.001 * particle
+            for frame in range(1, 4):
+                displacement = np.zeros(3, dtype=float)
+                displacement[axis] = frame * speed
+                trajectories[hypothesis, particle, frame] = (
+                    endpoint[particle] + displacement
+                )
+    metadata = (
+        _contact_metadata(
+            action_id=action_id,
+            future_action_observed=future_action_observed,
+            gain=1.0,
+            delay_steps=0,
+            rotation_degrees=0.0,
+            attachment_shift=0,
+            slip_fraction=0.0,
+        ),
+        _contact_metadata(
+            action_id=action_id,
+            future_action_observed=future_action_observed,
+            gain=1.2,
+            delay_steps=1,
+            rotation_degrees=5.0,
+            attachment_shift=1,
+            slip_fraction=0.1,
+        ),
+    )
+    return JointRolloutBank(
+        hypothesis_ids=("nominal-contact", "shifted-contact"),
+        hypothesis_metadata=metadata,
+        hypothesis_prior_weights=np.asarray([0.5, 0.5], dtype=float),
+        parameter_particles=parameter_particles,
+        parameter_weights=parameter_weights,
+        trajectories=trajectories,
+        variance_floor_m2=1.0e-8,
+        confidence_level=0.90,
+    )
+
+
+def _build_inputs() -> tuple[
+    TwinBelief,
+    JointRolloutBank,
+    JointRolloutBank,
+    np.ndarray,
+    CounterfactualQuery,
+    dict[str, Any],
+]:
+    observed_action_id = "observed-pull"
+    counterfactual_action_id = "counterfactual-lift"
+    factual_bank = _rollout_bank(
+        action_id=observed_action_id,
+        future_action_observed=True,
+        axis=0,
+    )
+    counterfactual_bank = _rollout_bank(
+        action_id=counterfactual_action_id,
+        future_action_observed=False,
+        axis=2,
+    )
+    selected_hypothesis = 1
+    selected_particle = 1
+    factual_observations = np.asarray(
+        factual_bank.trajectories[selected_hypothesis, selected_particle],
+        dtype=float,
+    )
+    complete_observations = np.empty((5, 2, 3), dtype=float)
+    complete_observations[0] = factual_observations[0]
+    complete_observations[0, :, 0] -= 0.004
+    complete_observations[1] = factual_observations[0]
+    complete_observations[2:] = factual_observations[1:]
+    observed_actions = np.zeros((5, 1, 3), dtype=float)
+    counterfactual_actions = np.zeros((5, 1, 3), dtype=float)
+    observed_actions[:, 0, 0] = np.linspace(0.0, 0.04, 5)
+    counterfactual_actions[2:, 0, 2] = np.asarray([0.01, 0.02, 0.03])
+    context = build_causal_context(
+        protocol_id="aip-demo-v1",
+        case_id="controlled-demo",
+        observations=complete_observations,
+        observed_actions=observed_actions,
+        counterfactual_actions=counterfactual_actions,
+        intervention_frame=2,
+        observed_action_id=observed_action_id,
+        counterfactual_action_id=counterfactual_action_id,
+        observed_action_provenance="deterministic demo command",
+        counterfactual_action_provenance="deterministic demo intervention",
+    )
+    belief = TwinBelief(
+        context=context,
+        endpoint_frame=context.o_minus.frame_stop - 1,
+        particle_ids=("theta-low", "theta-high"),
+        theta_names=("stiffness_scale",),
+        endpoint_position_m=np.asarray(
+            factual_bank.trajectories[0, :, 0], dtype=float
+        ),
+        endpoint_velocity_mps=np.zeros((2, 2, 3), dtype=float),
+        theta=factual_bank.parameter_particles,
+        discrepancy_mean_m=np.zeros((2, 2, 3), dtype=float),
+        discrepancy_variance_m2=np.full((2, 2, 3), 1.0e-8, dtype=float),
+        weights=factual_bank.parameter_weights,
+        metadata={
+            "source": "deterministic CPU-only demo",
+            "scientific_evidence": False,
+        },
+    )
+    query = CounterfactualQuery(
+        context=context,
+        controller_points_m=counterfactual_actions[2:],
+        horizon_frames=3,
+        contact_policy="same_grasp",
+        source_factual_intervention_id="0" * 64,
+        query_node_indices=np.asarray([0, 1], dtype=np.int64),
+        metadata={"same_grasp_semantics": "fixed_kappa"},
+    )
+    manifest = {"causal_context": context.as_dict()}
+    return (
+        belief,
+        factual_bank,
+        counterfactual_bank,
+        factual_observations,
+        query,
+        manifest,
+    )
+
+
+def _verified_artifact_id(path: Path, expected: str) -> str:
+    restored = load_contract(path)
+    if restored.artifact_id != expected:
+        raise RuntimeError(f"reloaded artifact identity mismatch for {path.name}")
+    return restored.artifact_id
+
+
+def run_demo(output_dir: str | Path) -> dict[str, Any]:
+    """Run the complete deterministic AIP path and write a verified bundle."""
+
+    target = Path(output_dir)
+    target.mkdir(parents=True, exist_ok=True)
+    (
+        belief,
+        factual_bank,
+        counterfactual_bank,
+        observations,
+        query_template,
+        manifest,
+    ) = _build_inputs()
+    prefix_frame_count = 2
+    config = FactualAbductionConfig(
+        observation_scale_m=0.002,
+        likelihood_power=8.0,
+        dynamic_likelihood_weight=0.25,
+        degrees_of_freedom=4.0,
+    )
+    factual = abduct_factual_intervention(
+        factual_bank,
+        belief,
+        observations,
+        prefix_frame_count=prefix_frame_count,
+        config=config,
+    )
+
+    changed_future = observations.copy()
+    changed_future[prefix_frame_count:] += 10.0
+    future_variant = abduct_factual_intervention(
+        factual_bank,
+        belief,
+        changed_future,
+        prefix_frame_count=prefix_frame_count,
+        config=config,
+    )
+    if future_variant.artifact_id != factual.artifact_id:
+        raise RuntimeError("factual abduction changed after modifying held-out frames")
+
+    query = CounterfactualQuery(
+        context=query_template.context,
+        controller_points_m=query_template.controller_points_m,
+        horizon_frames=query_template.horizon_frames,
+        contact_policy=query_template.contact_policy,
+        source_factual_intervention_id=factual.artifact_id,
+        language=query_template.language,
+        query_node_indices=query_template.query_node_indices,
+        metadata=query_template.metadata,
+    )
+    posterior = apply_counterfactual_operator(
+        counterfactual_bank,
+        manifest,
+        belief,
+        factual,
+        query,
+    )
+    projected = project_physical_posterior(posterior, query)
+
+    artifacts = {
+        "twin_belief": ("twin_belief.npz", belief),
+        "factual_intervention": ("factual_intervention.npz", factual),
+        "counterfactual_query": ("counterfactual_query.npz", query),
+        "physical_posterior": ("physical_posterior.npz", posterior),
+        "projected_posterior": ("projected_posterior.npz", projected),
+    }
+    artifact_ids: dict[str, str] = {}
+    artifact_files: dict[str, str] = {}
+    for name, (filename, artifact) in artifacts.items():
+        path = target / filename
+        save_contract(path, artifact)
+        artifact_ids[name] = _verified_artifact_id(path, artifact.artifact_id)
+        artifact_files[name] = filename
+
+    mean_readout = np.tensordot(
+        projected.weights,
+        projected.readout_trajectories_m,
+        axes=(0, 0),
+    )
+    top_index = int(np.argmax(factual.weights))
+    summary: dict[str, Any] = {
+        "schema_name": SUMMARY_SCHEMA_NAME,
+        "schema_version": SUMMARY_SCHEMA_VERSION,
+        "scientific_evidence": False,
+        "future_suffix_invariant": True,
+        "future_frames_read_by_abduction": int(
+            factual.metadata["future_frames_read_by_abduction"]
+        ),
+        "artifact_ids": artifact_ids,
+        "artifact_files": artifact_files,
+        "factual_top_component": factual.component_ids[top_index],
+        "factual_top_weight": float(factual.weights[top_index]),
+        "projected_frame_count": int(projected.state_trajectories_m.shape[1]),
+        "projected_node_count": int(projected.state_trajectories_m.shape[2]),
+        "counterfactual_final_mean_m": mean_readout[-1].tolist(),
+    }
+    summary_path = target / "summary.json"
+    summary_path.write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a deterministic CPU-only Causal4D "
+            "abduction-intervention-prediction demo."
+        )
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("build/aip-demo"),
+        help="Directory for verified NPZ contracts and summary.json.",
+    )
+    arguments = parser.parse_args(argv)
+    summary = run_demo(arguments.output_dir)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d/inference/__init__.py
+++ b/src/causal4d/inference/__init__.py
@@ -1,0 +1,1 @@
+"""Versioned public inference namespaces for Causal4D."""

--- a/src/causal4d/inference/v1.py
+++ b/src/causal4d/inference/v1.py
@@ -1,0 +1,40 @@
+"""Version 1 of Causal4D's supported inference API.
+
+The surface follows the scientific pipeline directly: factual intervention
+abduction, explicit counterfactual action, and physical-posterior projection.
+Portable contracts and archive I/O live in ``causal4d.artifacts.v1``.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from causal4d.counterfactual import (
+    apply_counterfactual_operator,
+    project_physical_posterior,
+)
+from causal4d.hierarchical_abduction import (
+    HierarchicalAbductionResult,
+    abduct_hierarchical_interventions,
+)
+from causal4d.intervention_abduction import (
+    FactualAbductionConfig,
+    abduct_factual_intervention,
+    factual_joint_weights,
+)
+
+
+PUBLIC_API_NAME: Final = "causal4d.inference.v1"
+PUBLIC_API_VERSION: Final = 1
+
+__all__ = [
+    "PUBLIC_API_NAME",
+    "PUBLIC_API_VERSION",
+    "FactualAbductionConfig",
+    "HierarchicalAbductionResult",
+    "abduct_factual_intervention",
+    "abduct_hierarchical_interventions",
+    "apply_counterfactual_operator",
+    "factual_joint_weights",
+    "project_physical_posterior",
+]

--- a/tests/test_aip_public_api_demo.py
+++ b/tests/test_aip_public_api_demo.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import causal4d.contracts as contracts
+import causal4d.counterfactual as counterfactual
+import causal4d.intervention_abduction as intervention_abduction
+from causal4d.artifacts import v1 as artifacts_v1
+from causal4d.artifacts.v1 import load_contract
+from causal4d.demo.aip import run_demo
+from causal4d.inference import v1 as inference_v1
+
+
+def test_artifact_api_v1_reexports_contract_identity() -> None:
+    assert artifacts_v1.PUBLIC_API_NAME == "causal4d.artifacts.v1"
+    assert artifacts_v1.PUBLIC_API_VERSION == 1
+    assert artifacts_v1.TwinBelief is contracts.TwinBelief
+    assert artifacts_v1.FactualIntervention is contracts.FactualIntervention
+    assert artifacts_v1.save_contract is contracts.save_contract
+    assert artifacts_v1.load_contract is contracts.load_contract
+
+
+def test_inference_api_v1_reexports_aip_operations() -> None:
+    assert inference_v1.PUBLIC_API_NAME == "causal4d.inference.v1"
+    assert inference_v1.PUBLIC_API_VERSION == 1
+    assert (
+        inference_v1.abduct_factual_intervention
+        is intervention_abduction.abduct_factual_intervention
+    )
+    assert (
+        inference_v1.apply_counterfactual_operator
+        is counterfactual.apply_counterfactual_operator
+    )
+    assert (
+        inference_v1.project_physical_posterior
+        is counterfactual.project_physical_posterior
+    )
+
+
+def _validate_bundle(root: Path, summary: dict[str, object]) -> None:
+    artifact_ids = summary["artifact_ids"]
+    artifact_files = summary["artifact_files"]
+    assert isinstance(artifact_ids, dict)
+    assert isinstance(artifact_files, dict)
+    for name, expected_id in artifact_ids.items():
+        filename = artifact_files[name]
+        restored = load_contract(root / str(filename))
+        assert restored.artifact_id == expected_id
+
+
+def test_aip_demo_is_deterministic_and_causally_bounded(tmp_path: Path) -> None:
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+    first = run_demo(first_root)
+    second = run_demo(second_root)
+
+    assert first == second
+    assert first["scientific_evidence"] is False
+    assert first["future_suffix_invariant"] is True
+    assert first["future_frames_read_by_abduction"] == 0
+    assert first["projected_frame_count"] == 3
+    assert first["projected_node_count"] == 2
+    assert float(first["factual_top_weight"]) > 0.5
+    assert (first_root / "summary.json").is_file()
+    _validate_bundle(first_root, first)
+    _validate_bundle(second_root, second)


### PR DESCRIPTION
## Summary

Add two additive versioned integration surfaces and a deterministic CPU-only abduction–intervention–prediction demonstration:

- `causal4d.artifacts.v1` exposes the portable content-addressed contracts and safe NPZ codec without estimator functions;
- `causal4d.inference.v1` exposes factual abduction, hierarchical abduction, explicit counterfactual action, and posterior projection without changing `causal4d.api.v1` or the historical lazy root;
- `python -m causal4d.demo.aip --output-dir build/aip-demo` creates and reload-verifies a complete five-artifact AIP bundle;
- the demo perturbs every held-out suffix coordinate and requires the factual artifact identity to remain unchanged; and
- tests cover public identity re-exports, deterministic replay, contract reload identity, output dimensions, and causal-cutoff isolation.

This makes the central workflow inspectable from an installed core package while preserving all frozen semantics.

## Change classification

- [ ] Frozen or registered method/analysis change requiring a new version
- [ ] Future or experimental method
- [ ] BayesianPhysTwin, Prob4D, or other provider/artifact contract
- [ ] Acquisition, calibration, readiness, or evidence tooling
- [ ] Diagnostic, source-only, retrospective, or controlled study
- [x] Maintenance, documentation, packaging, CI, or security

Evidence status:

- [x] Software or contract evidence only
- [ ] Controlled synthetic evidence
- [ ] Source/calibration-only evidence
- [ ] Retrospective or already-open diagnostic evidence
- [ ] Confirmatory physical evidence
- [ ] No scientific evidence produced

## Scientific and information boundary

- Frozen estimator or registered analysis changed: `no`
- Target or held-out outcomes accessed: `no`; the suffix perturbation uses generated demo arrays only
- Registered physical-acquisition dataset modified: `no`
- Physical evidence increment: `0`
- Existing scientific claim changed or promoted: `no`
- Independent statistical unit: `not applicable`
- Source, calibration, and target split: `not applicable; generated controlled software demonstration only`
- Exact fallback preserved for rejected optional evidence: `not applicable; existing inference and fallback implementations are unchanged`

The demo is explicitly labelled non-evidence in its contracts, summary, examples index, and documentation.

## Provenance and compatibility

- Base revision: `ed1fc6f1d617fb8315a61ae510a980ac8a40df4e`
- Contract/schema versions: existing Causal4D contract version 1; new Python namespace versions are both 1
- Frozen artifacts or milestones affected: none
- Compatibility: additive only. `causal4d.api.v1`, package-root lazy exports, archive bytes, artifact IDs, command routes, provider pins, and frozen protocols are unchanged.

## Validation

- [x] A regression fails on the unpatched implementation, when applicable
- [x] Valid inputs and expected behavior are covered
- [x] Malformed, mutable, or provenance-inconsistent inputs are covered by the existing contract suite; this change adds causal-suffix isolation
- [x] Serialization, distribution, or installed-artifact behavior is covered
- [ ] Cross-repository compatibility is covered when a provider boundary changes

Commands and results:

```text
python -m py_compile <all added Python files>  # passed locally
pytest/ruff/mypy/build/installed-artifact matrices  # delegated to repository CI
```

## Merge disposition

- [x] Product change intended for review and merge
- [ ] Execution/bootstrap helper that must be closed without merge
- [ ] Diagnostic result that cannot promote a method or scientific claim

No post-merge physical execution, target access, or claim update is authorized by this PR.