### PR TITLE
Fix locked filament-support ancestry fetch

### DIFF
--- a/.github/workflows/deform360-filament-support-issue-dispatch.yml
+++ b/.github/workflows/deform360-filament-support-issue-dispatch.yml
@@ -117,7 +117,7 @@ jobs:
           receipt = {
               "schema_version": 1,
               "artifact_kind": "Causal4DDeform360FilamentSupportDispatch",
-              "repository": os.environ["GITHUB_REPOSITORY],
+              "repository": os.environ["GITHUB_REPOSITORY"],
               "reviewed_main_sha": os.environ["MAIN_SHA"],
               "trigger_issue_number": int(os.environ["ISSUE_NUMBER"]),
               "workflow_run_id": int(os.environ["RUN_ID"]),

--- a/.github/workflows/deform360-filament-support-issue-dispatch.yml
+++ b/.github/workflows/deform360-filament-support-issue-dispatch.yml
@@ -108,31 +108,13 @@ jobs:
           RUN_URL: ${{ steps.run.outputs.run_url }}
         run: |
           set -euo pipefail
-          mkdir -p outputs/filament-support-dispatch
-          python - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          receipt = {
-              "schema_version": 1,
-              "artifact_kind": "Causal4DDeform360FilamentSupportDispatch",
-              "repository": os.environ["GITHUB_REPOSITORY"],
-              "reviewed_main_sha": os.environ["MAIN_SHA"],
-              "trigger_issue_number": int(os.environ["ISSUE_NUMBER"]),
-              "workflow_run_id": int(os.environ["RUN_ID"]),
-              "workflow_run_url": os.environ["RUN_URL"],
-              "run_source_diagnostic": True,
-              "target_outcomes_used": False,
-              "registered_physical_dataset_modified": False,
-              "physical_evidence_increment": 0,
-            }
-          Path("outputs/filament-support-dispatch/dispatch.json").write_text(
-              json.dumps(receipt, indent=2, sort_keys=True) + "\n",
-              encoding="utf-8",
-          )
-          print(json.dumps(receipt, indent=2, sort_keys=True))
-          PY
+          python scripts/ci/write_filament_support_dispatch_receipt.py \
+            --repository "${GITHUB_REPOSITORY}" \
+            --reviewed-main-sha "${MAIN_SHA}" \
+            --trigger-issue-number "${ISSUE_NUMBER}" \
+            --workflow-run-id "${RUN_ID}" \
+            --workflow-run-url "${RUN_URL}" \
+            --output outputs/filament-support-dispatch/dispatch.json
 
       - name: Upload dispatch receipt
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/deform360-filament-support-issue-dispatch.yml
+++ b/.github/workflows/deform360-filament-support-issue-dispatch.yml
@@ -1,0 +1,155 @@
+name: Deform360 filament-support issue dispatcher
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+
+jobs:
+  dispatch:
+    name: Dispatch corrected filament-support diagnostic
+    if: >-
+      github.event_name == 'issues' &&
+      github.event.action == 'opened' &&
+      github.ref == 'refs/heads/main' &&
+      github.event.issue.user.login == 'FlorianPfaff' &&
+      github.event.issue.user.id == 6773539 &&
+      github.event.issue.title ==
+        '[self-hosted] run Causal4D Deform360 filament support'
+    concurrency:
+      group: deform360-filament-support-issue-dispatch-${{ github.sha }}
+      cancel-in-progress: false
+      queue: max
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+    steps:
+      - name: Verify exact reviewed main revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          main_sha="$(
+            gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq .sha
+          )"
+          test "${main_sha}" = "${GITHUB_SHA}"
+          echo "MAIN_SHA=${main_sha}" >> "${GITHUB_ENV}"
+
+      - name: Record existing workflow-dispatch runs
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh run list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --workflow deform360-filament-support.yml \
+            --branch main \
+            --event workflow_dispatch \
+            --limit 100 \
+            --json databaseId \
+            --jq '.[].databaseId' \
+            | sort -n > "${RUNNER_TEMP}/filament-support.before"
+
+      - name: Dispatch locked source-only filament support
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run deform360-filament-support.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref main \
+            -f run_source_diagnostic=true
+
+      - name: Resolve and verify dispatched run
+        id: run
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_id=""
+          for _ in $(seq 1 60); do
+            after="$(mktemp)"
+            gh run list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --workflow deform360-filament-support.yml \
+              --branch main \
+              --event workflow_dispatch \
+              --limit 100 \
+              --json databaseId \
+              --jq '.[].databaseId' \
+              | sort -n > "${after}"
+            run_id="$(
+              comm -13 "${RUNNER_TEMP}/filament-support.before" "${after}" \
+                | tail -n 1
+            )"
+            rm -f "${after}"
+            if [[ -n "${run_id}" ]]; then
+              break
+            fi
+            sleep 2
+          done
+          test -n "${run_id}"
+          readarray -t identity < <(
+            gh run view "${run_id}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --json event,headSha,url \
+              --jq '.event, .headSha, .url'
+          )
+          test "${identity[0]}" = "workflow_dispatch"
+          test "${identity[1]}" = "${MAIN_SHA}"
+          echo "run_id=${run_id}" >> "${GITHUB_OUTPUT}"
+          echo "run_url=${identity[2]}" >> "${GITHUB_OUTPUT}"
+
+      - name: Write dispatch receipt
+        shell: bash
+        env:
+          RUN_ID: ${{ steps.run.outputs.run_id }}
+          RUN_URL: ${{ steps.run.outputs.run_url }}
+        run: |
+          set -euo pipefail
+          mkdir -p outputs/filament-support-dispatch
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          receipt = {
+              "schema_version": 1,
+              "artifact_kind": "Causal4DDeform360FilamentSupportDispatch",
+              "repository": os.environ["GITHUB_REPOSITORY],
+              "reviewed_main_sha": os.environ["MAIN_SHA"],
+              "trigger_issue_number": int(os.environ["ISSUE_NUMBER"]),
+              "workflow_run_id": int(os.environ["RUN_ID"]),
+              "workflow_run_url": os.environ["RUN_URL"],
+              "run_source_diagnostic": True,
+              "target_outcomes_used": False,
+              "registered_physical_dataset_modified": False,
+              "physical_evidence_increment": 0,
+            }
+          Path("outputs/filament-support-dispatch/dispatch.json").write_text(
+              json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print(json.dumps(receipt, indent=2, sort_keys=True))
+          PY
+
+      - name: Upload dispatch receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: causal4d-deform360-filament-support-dispatch
+          path: outputs/filament-support-dispatch/dispatch.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Report dispatched run
+        shell: bash
+        env:
+          RUN_URL: ${{ steps.run.outputs.run_url }}
+        run: |
+          set -euo pipefail
+          gh issue comment "${ISSUE_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --body "Deform360 filament-support source-only diagnostic dispatched from reviewed main \`${MAIN_SHA}\`: ${RUN_URL}
+
+          Target outcomes used: \`false\`. Registered physical dataset modified: \`false\`. Physical evidence increment: \`0\`."

--- a/.github/workflows/deform360-filament-support.yml
+++ b/.github/workflows/deform360-filament-support.yml
@@ -11,6 +11,7 @@ on:
       - "docs/self_hosted_runner_security.md"
       - "milestones/deform360-reset-mechanics-v1/README.md"
       - "milestones/deform360-reset-mechanics-v1/summary.json"
+      - "scripts/ci/resolve_locked_ancestor_fetch.py"
       - "scripts/remote/run_deform360_filament_support.py"
       - "scripts/remote/run_deform360_filament_support_workflow.sh"
       - "src/causal4d_public/deform360_filament_support.py"
@@ -18,6 +19,7 @@ on:
       - "src/causal4d_public/deform360_rope_graph.py"
       - "tests/test_deform360_filament_support.py"
       - "tests/test_deform360_filament_support_workflow_policy.py"
+      - "tests/test_resolve_locked_ancestor_fetch.py"
       - "tests/test_self_hosted_workflow_policy.py"
   push:
     branches: [main]
@@ -25,6 +27,7 @@ on:
       - ".github/workflows/deform360-filament-support.yml"
       - ".github/self-hosted-jobs.json"
       - "configs/causal4d_public/deform360_filament_support_v1.json"
+      - "scripts/ci/resolve_locked_ancestor_fetch.py"
       - "scripts/remote/run_deform360_filament_support.py"
       - "scripts/remote/run_deform360_filament_support_workflow.sh"
       - "src/causal4d_public/deform360_filament_support.py"
@@ -32,6 +35,7 @@ on:
       - "src/causal4d_public/deform360_rope_graph.py"
       - "tests/test_deform360_filament_support.py"
       - "tests/test_deform360_filament_support_workflow_policy.py"
+      - "tests/test_resolve_locked_ancestor_fetch.py"
       - "tests/test_self_hosted_workflow_policy.py"
   workflow_dispatch:
     inputs:
@@ -76,17 +80,20 @@ jobs:
       - name: Check the diagnostic surface
         run: |
           files=(
+            scripts/ci/resolve_locked_ancestor_fetch.py
             scripts/remote/run_deform360_filament_support.py
             src/causal4d_public/deform360_filament_support.py
             src/causal4d_public/deform360_replication_graph.py
             src/causal4d_public/deform360_rope_graph.py
             tests/test_deform360_filament_support.py
             tests/test_deform360_filament_support_workflow_policy.py
+            tests/test_resolve_locked_ancestor_fetch.py
             tests/test_self_hosted_workflow_policy.py
           )
           python -m ruff check "${files[@]}"
           python -m ruff format --check "${files[@]}"
           python -m mypy --no-site-packages \
+            scripts/ci/resolve_locked_ancestor_fetch.py \
             src/causal4d_public/deform360_filament_support.py \
             src/causal4d_public/deform360_replication_graph.py \
             src/causal4d_public/deform360_rope_graph.py \
@@ -98,6 +105,7 @@ jobs:
           python -m pytest -q \
             tests/test_deform360_filament_support.py \
             tests/test_deform360_filament_support_workflow_policy.py \
+            tests/test_resolve_locked_ancestor_fetch.py \
             tests/test_self_hosted_workflow_policy.py \
             tests/test_deform360_rope_graph.py \
             tests/test_deform360_replication_graph.py \
@@ -140,6 +148,55 @@ jobs:
           printf '%s\n' \
             '{"schema_version":1,"state":"initialized","head_sha":"'"${GITHUB_SHA}"'","run_id":"'"${GITHUB_RUN_ID}"'"}' \
             > deform360-filament-support/status.json
+
+      - name: Resolve bounded exact ancestry fetch
+        id: ancestry
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          depth="$(
+            /usr/bin/python3 scripts/ci/resolve_locked_ancestor_fetch.py \
+              --repository "${GITHUB_REPOSITORY}" \
+              --head-sha "${GITHUB_SHA}" \
+              --lock \
+                configs/causal4d_public/deform360_filament_support_v1.json \
+              --output \
+                deform360-filament-support/locked-ancestor-fetch-plan.json
+          )"
+          [[ "${depth}" =~ ^[1-9][0-9]*$ ]]
+          echo "fetch_depth=${depth}" >> "${GITHUB_OUTPUT}"
+
+      - name: Fetch and verify only the locked ancestry
+        env:
+          FETCH_DEPTH: ${{ steps.ancestry.outputs.fetch_depth }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          required_parent="$(
+            /usr/bin/python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(
+              Path(
+                  "deform360-filament-support/locked-ancestor-fetch-plan.json"
+              ).read_text(encoding="utf-8")
+          )
+          print(payload["required_parent_commit"])
+          PY
+          )"
+          ca_file=/etc/ssl/certs/ca-certificates.crt
+          test -r "${ca_file}"
+          git -c http.sslCAInfo="${ca_file}" fetch \
+            --no-tags \
+            --depth="${FETCH_DEPTH}" \
+            origin "${GITHUB_SHA}"
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          git cat-file -e "${required_parent}^{commit}"
+          git merge-base --is-ancestor "${required_parent}" HEAD
+          test -z "$(git status --porcelain=v1)"
 
       - name: Select the conditional reproduction runtime
         shell: bash

--- a/scripts/ci/resolve_locked_ancestor_fetch.py
+++ b/scripts/ci/resolve_locked_ancestor_fetch.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Resolve a bounded exact-history fetch for one locked Git ancestor."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+import os
+from pathlib import Path
+import re
+import sys
+from typing import Any, Mapping, NoReturn
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+_SHA = re.compile(r"[0-9a-f]{40}")
+_REPOSITORY = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+_MAX_FETCH_DEPTH = 2048
+_MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+
+
+class AncestorPlanError(ValueError):
+    """Raised when the lock or comparison cannot prove exact ancestry."""
+
+
+@dataclass(frozen=True)
+class LockedAncestorFetchPlan:
+    schema_version: int
+    artifact_kind: str
+    repository: str
+    head_sha: str
+    required_parent_commit: str
+    comparison_status: str
+    ahead_by: int
+    behind_by: int
+    total_commits: int
+    fetch_depth: int
+    maximum_fetch_depth: int
+    merge_base_sha: str
+    ancestry_verified_by: str
+
+
+def _raise(message: str) -> NoReturn:
+    raise AncestorPlanError(message)
+
+
+def _strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise AncestorPlanError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _load_json_bytes(raw: bytes, *, name: str) -> Mapping[str, Any]:
+    try:
+        payload = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=_strict_object,
+            parse_constant=lambda value: _raise(
+                f"non-finite JSON constant in {name}: {value}"
+            ),
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise AncestorPlanError(f"{name} must be strict UTF-8 JSON") from error
+    if not isinstance(payload, Mapping):
+        raise AncestorPlanError(f"{name} must be a JSON object")
+    return payload
+
+
+def _ordinary_file(path: Path, *, name: str) -> bytes:
+    if path.is_symlink() or not path.is_file():
+        raise AncestorPlanError(f"{name} must be an ordinary file")
+    return path.read_bytes()
+
+
+def _sha(value: Any, *, name: str) -> str:
+    if type(value) is not str or _SHA.fullmatch(value) is None:
+        raise AncestorPlanError(f"{name} must be a lowercase 40-character SHA")
+    return value
+
+
+def _repository(value: Any) -> str:
+    if type(value) is not str or _REPOSITORY.fullmatch(value) is None:
+        raise AncestorPlanError("repository must use owner/name syntax")
+    return value
+
+
+def _nonnegative_integer(value: Any, *, name: str) -> int:
+    if type(value) is not int or value < 0:
+        raise AncestorPlanError(f"{name} must be a nonnegative integer")
+    return value
+
+
+def required_parent_from_lock(payload: Mapping[str, Any]) -> str:
+    """Return the strict locked parent commit from a configuration object."""
+
+    return _sha(payload.get("required_parent_commit"), name="required_parent_commit")
+
+
+def _nested_sha(payload: Mapping[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, Mapping):
+        raise AncestorPlanError(f"comparison {key} must be an object")
+    return _sha(value.get("sha"), name=f"comparison {key}.sha")
+
+
+def resolve_fetch_plan(
+    comparison: Mapping[str, Any],
+    *,
+    repository: str,
+    head_sha: str,
+    required_parent_commit: str,
+    maximum_fetch_depth: int = _MAX_FETCH_DEPTH,
+) -> LockedAncestorFetchPlan:
+    """Validate GitHub comparison metadata and derive the exact fetch depth."""
+
+    validated_repository = _repository(repository)
+    head = _sha(head_sha, name="head_sha")
+    parent = _sha(required_parent_commit, name="required_parent_commit")
+    if type(maximum_fetch_depth) is not int or maximum_fetch_depth < 1:
+        raise AncestorPlanError("maximum_fetch_depth must be a positive integer")
+
+    status = comparison.get("status")
+    if status not in {"ahead", "identical"}:
+        raise AncestorPlanError(
+            "required parent must be identical to or an ancestor of the exact head"
+        )
+    base_sha = _nested_sha(comparison, "base_commit")
+    merge_base_sha = _nested_sha(comparison, "merge_base_commit")
+    compared_head_sha = _nested_sha(comparison, "head_commit")
+    if base_sha != parent or merge_base_sha != parent:
+        raise AncestorPlanError("comparison is not rooted at the required parent")
+    if compared_head_sha != head:
+        raise AncestorPlanError("comparison head does not match the workflow head")
+
+    ahead_by = _nonnegative_integer(comparison.get("ahead_by"), name="ahead_by")
+    behind_by = _nonnegative_integer(comparison.get("behind_by"), name="behind_by")
+    total_commits = _nonnegative_integer(
+        comparison.get("total_commits"),
+        name="total_commits",
+    )
+    if behind_by != 0:
+        raise AncestorPlanError("comparison head is behind the required parent")
+    if total_commits != ahead_by:
+        raise AncestorPlanError("comparison commit counts are inconsistent")
+    if status == "identical":
+        if parent != head or ahead_by != 0:
+            raise AncestorPlanError("identical comparison metadata is inconsistent")
+    elif parent == head or ahead_by < 1:
+        raise AncestorPlanError("ahead comparison metadata is inconsistent")
+
+    fetch_depth = ahead_by + 1
+    if fetch_depth > maximum_fetch_depth:
+        raise AncestorPlanError(
+            "required ancestry exceeds the bounded fetch-depth policy: "
+            f"{fetch_depth} > {maximum_fetch_depth}"
+        )
+    return LockedAncestorFetchPlan(
+        schema_version=1,
+        artifact_kind="Causal4DLockedAncestorFetchPlan",
+        repository=validated_repository,
+        head_sha=head,
+        required_parent_commit=parent,
+        comparison_status=str(status),
+        ahead_by=ahead_by,
+        behind_by=behind_by,
+        total_commits=total_commits,
+        fetch_depth=fetch_depth,
+        maximum_fetch_depth=maximum_fetch_depth,
+        merge_base_sha=merge_base_sha,
+        ancestry_verified_by="github_compare_api_and_local_git",
+    )
+
+
+def _comparison_from_github(
+    *,
+    repository: str,
+    parent: str,
+    head: str,
+    token: str,
+) -> Mapping[str, Any]:
+    encoded_repository = quote(repository, safe="/")
+    url = (
+        f"https://api.github.com/repos/{encoded_repository}/compare/"
+        f"{parent}...{head}?per_page=1&page=2"
+    )
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "causal4d-locked-ancestor-fetch-plan",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = Request(url, headers=headers)
+    try:
+        with urlopen(request, timeout=60) as response:
+            raw = response.read(_MAX_RESPONSE_BYTES + 1)
+    except HTTPError as error:
+        body = error.read().decode("utf-8", errors="replace")
+        raise AncestorPlanError(
+            f"GitHub comparison failed with HTTP {error.code}: {body}"
+        ) from error
+    except URLError as error:
+        raise AncestorPlanError(
+            f"GitHub comparison could not be reached: {error}"
+        ) from error
+    if len(raw) > _MAX_RESPONSE_BYTES:
+        raise AncestorPlanError("GitHub comparison response exceeds the size limit")
+    return _load_json_bytes(raw, name="GitHub comparison")
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--lock", type=Path, required=True)
+    parser.add_argument("--compare-json", type=Path)
+    parser.add_argument("--token-env", default="GITHUB_TOKEN")
+    parser.add_argument("--maximum-fetch-depth", type=int, default=_MAX_FETCH_DEPTH)
+    parser.add_argument("--output", type=Path, required=True)
+    arguments = parser.parse_args(argv)
+    try:
+        repository = _repository(arguments.repository)
+        head = _sha(arguments.head_sha, name="head_sha")
+        lock = _load_json_bytes(
+            _ordinary_file(arguments.lock, name="lock"),
+            name="lock",
+        )
+        parent = required_parent_from_lock(lock)
+        if arguments.compare_json is None:
+            comparison = _comparison_from_github(
+                repository=repository,
+                parent=parent,
+                head=head,
+                token=os.environ.get(arguments.token_env, ""),
+            )
+        else:
+            comparison = _load_json_bytes(
+                _ordinary_file(arguments.compare_json, name="comparison fixture"),
+                name="comparison fixture",
+            )
+        plan = resolve_fetch_plan(
+            comparison,
+            repository=repository,
+            head_sha=head,
+            required_parent_commit=parent,
+            maximum_fetch_depth=arguments.maximum_fetch_depth,
+        )
+    except (AncestorPlanError, OSError) as error:
+        print(f"locked ancestor fetch planning failed: {error}", file=sys.stderr)
+        return 1
+    _write_json(arguments.output, asdict(plan))
+    print(plan.fetch_depth)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/write_filament_support_dispatch_receipt.py
+++ b/scripts/ci/write_filament_support_dispatch_receipt.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Write a validated receipt for the filament-support issue dispatcher."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+_REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+
+class DispatchReceiptError(ValueError):
+    """Raised when dispatch metadata is malformed or inconsistent."""
+
+
+@dataclass(frozen=True)
+class DispatchReceipt:
+    """Non-physical audit record for one source-only workflow dispatch."""
+
+    schema_version: int
+    artifact_kind: str
+    repository: str
+    reviewed_main_sha: str
+    trigger_issue_number: int
+    workflow_run_id: int
+    workflow_run_url: str
+    run_source_diagnostic: bool
+    target_outcomes_used: bool
+    registered_physical_dataset_modified: bool
+    physical_evidence_increment: int
+
+
+def build_receipt(
+    *,
+    repository: str,
+    reviewed_main_sha: str,
+    trigger_issue_number: int,
+    workflow_run_id: int,
+    workflow_run_url: str,
+) -> DispatchReceipt:
+    """Validate dispatch identity and return its immutable receipt."""
+
+    if _REPOSITORY.fullmatch(repository) is None:
+        raise DispatchReceiptError(
+            "repository must use the non-empty 'owner/name' form"
+        )
+    if _COMMIT_SHA.fullmatch(reviewed_main_sha) is None:
+        raise DispatchReceiptError(
+            "reviewed_main_sha must be a lowercase 40-character commit SHA"
+        )
+    if trigger_issue_number <= 0:
+        raise DispatchReceiptError("trigger_issue_number must be positive")
+    if workflow_run_id <= 0:
+        raise DispatchReceiptError("workflow_run_id must be positive")
+
+    expected_url = f"https://github.com/{repository}/actions/runs/{workflow_run_id}"
+    if workflow_run_url != expected_url:
+        raise DispatchReceiptError(
+            "workflow_run_url does not identify workflow_run_id in repository: "
+            f"expected {expected_url!r}, received {workflow_run_url!r}"
+        )
+
+    return DispatchReceipt(
+        schema_version=1,
+        artifact_kind="Causal4DDeform360FilamentSupportDispatch",
+        repository=repository,
+        reviewed_main_sha=reviewed_main_sha,
+        trigger_issue_number=trigger_issue_number,
+        workflow_run_id=workflow_run_id,
+        workflow_run_url=workflow_run_url,
+        run_source_diagnostic=True,
+        target_outcomes_used=False,
+        registered_physical_dataset_modified=False,
+        physical_evidence_increment=0,
+    )
+
+
+def write_receipt(receipt: DispatchReceipt, output: Path) -> None:
+    """Write ``receipt`` deterministically, replacing no existing artifact."""
+
+    if output.exists():
+        raise DispatchReceiptError(f"refusing to overwrite existing receipt: {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(asdict(receipt), indent=2, sort_keys=True) + "\n"
+    output.write_text(text, encoding="utf-8")
+    print(text, end="")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--reviewed-main-sha", required=True)
+    parser.add_argument("--trigger-issue-number", type=int, required=True)
+    parser.add_argument("--workflow-run-id", type=int, required=True)
+    parser.add_argument("--workflow-run-url", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    receipt = build_receipt(
+        repository=args.repository,
+        reviewed_main_sha=args.reviewed_main_sha,
+        trigger_issue_number=args.trigger_issue_number,
+        workflow_run_id=args.workflow_run_id,
+        workflow_run_url=args.workflow_run_url,
+    )
+    write_receipt(receipt, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_deform360_filament_support_issue_dispatch_policy.py
+++ b/tests/test_deform360_filament_support_issue_dispatch_policy.py
@@ -4,12 +4,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-WORKFLOW = (
-    ROOT
-    / ".github"
-    / "workflows"
-    / "deform360-filament-support-issue-dispatch.yml"
-)
+WORKFLOW = ROOT / ".github" / "workflows" / "deform360-filament-support-issue-dispatch.yml"
 
 
 def _workflow_text() -> str:

--- a/tests/test_deform360_filament_support_issue_dispatch_policy.py
+++ b/tests/test_deform360_filament_support_issue_dispatch_policy.py
@@ -68,5 +68,7 @@ def test_dispatcher_calls_tested_nonphysical_receipt_writer() -> None:
     assert "target_outcomes_used=False" in writer
     assert "registered_physical_dataset_modified=False" in writer
     assert "physical_evidence_increment=0" in writer
-    assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in workflow
+    assert (
+        "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in workflow
+    )
     assert "causal4d-deform360-filament-support-dispatch" in workflow

--- a/tests/test_deform360_filament_support_issue_dispatch_policy.py
+++ b/tests/test_deform360_filament_support_issue_dispatch_policy.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = (
+    ROOT
+    / ".github"
+    / "workflows"
+    / "deform360-filament-support-issue-dispatch.yml"
+)
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_dispatcher_uses_only_the_exact_maintainer_issue() -> None:
+    text = _workflow_text()
+
+    assert "on:\n  issues:\n    types: [opened]\n" in text
+    assert "github.event_name == 'issues'" in text
+    assert "github.event.action == 'opened'" in text
+    assert "github.ref == 'refs/heads/main'" in text
+    assert "github.event.issue.user.login == 'FlorianPfaff'" in text
+    assert "github.event.issue.user.id == 6773539" in text
+    assert "'[self-hosted] run Causal4D Deform360 filament support'" in text
+    assert text.count("github.event.issue.title") == 1
+    assert "github.event.issue.body" not in text
+    assert "github.event.issue.labels" not in text
+    assert "github.event.comment" not in text
+
+
+def test_dispatcher_is_hosted_and_dispatches_fixed_reviewed_main() -> None:
+    text = _workflow_text()
+
+    assert "runs-on: ubuntu-latest" in text
+    assert "runs-on: [self-hosted]" not in text
+    assert "actions: write" in text
+    assert "contents: read" in text
+    assert "issues: write" in text
+    assert "GH_TOKEN: ${{ github.token }}" in text
+    assert "${{ secrets." not in text
+    assert "commits/main" in text
+    assert 'test "${main_sha}" = "${GITHUB_SHA}"' in text
+    assert "gh workflow run deform360-filament-support.yml" in text
+    assert "--ref main" in text
+    assert "-f run_source_diagnostic=true" in text
+    assert 'test "${identity[0]}" = "workflow_dispatch"' in text
+    assert 'test "${identity[1]}" = "${MAIN_SHA}"' in text
+
+
+def test_dispatcher_retains_a_nonphysical_receipt() -> None:
+    text = _workflow_text()
+
+    assert "Causal4DDeform360FilamentSupportDispatch" in text
+    assert '"target_outcomes_used": False' in text
+    assert '"registered_physical_dataset_modified": False' in text
+    assert '"physical_evidence_increment": 0' in text
+    assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in text
+    assert "causal4d-deform360-filament-support-dispatch" in text

--- a/tests/test_deform360_filament_support_issue_dispatch_policy.py
+++ b/tests/test_deform360_filament_support_issue_dispatch_policy.py
@@ -4,7 +4,9 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-WORKFLOW = ROOT / ".github" / "workflows" / "deform360-filament-support-issue-dispatch.yml"
+WORKFLOW = (
+    ROOT / ".github" / "workflows" / "deform360-filament-support-issue-dispatch.yml"
+)
 
 
 def _workflow_text() -> str:

--- a/tests/test_deform360_filament_support_issue_dispatch_policy.py
+++ b/tests/test_deform360_filament_support_issue_dispatch_policy.py
@@ -7,10 +7,15 @@ ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = (
     ROOT / ".github" / "workflows" / "deform360-filament-support-issue-dispatch.yml"
 )
+RECEIPT_WRITER = ROOT / "scripts" / "ci" / "write_filament_support_dispatch_receipt.py"
 
 
 def _workflow_text() -> str:
     return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _receipt_writer_text() -> str:
+    return RECEIPT_WRITER.read_text(encoding="utf-8")
 
 
 def test_dispatcher_uses_only_the_exact_maintainer_issue() -> None:
@@ -48,12 +53,20 @@ def test_dispatcher_is_hosted_and_dispatches_fixed_reviewed_main() -> None:
     assert 'test "${identity[1]}" = "${MAIN_SHA}"' in text
 
 
-def test_dispatcher_retains_a_nonphysical_receipt() -> None:
-    text = _workflow_text()
+def test_dispatcher_calls_tested_nonphysical_receipt_writer() -> None:
+    workflow = _workflow_text()
+    writer = _receipt_writer_text()
 
-    assert "Causal4DDeform360FilamentSupportDispatch" in text
-    assert '"target_outcomes_used": False' in text
-    assert '"registered_physical_dataset_modified": False' in text
-    assert '"physical_evidence_increment": 0' in text
-    assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in text
-    assert "causal4d-deform360-filament-support-dispatch" in text
+    assert "python scripts/ci/write_filament_support_dispatch_receipt.py" in workflow
+    assert '--repository "${GITHUB_REPOSITORY}"' in workflow
+    assert '--reviewed-main-sha "${MAIN_SHA}"' in workflow
+    assert '--trigger-issue-number "${ISSUE_NUMBER}"' in workflow
+    assert '--workflow-run-id "${RUN_ID}"' in workflow
+    assert '--workflow-run-url "${RUN_URL}"' in workflow
+    assert "python - <<'PY'" not in workflow
+    assert "Causal4DDeform360FilamentSupportDispatch" in writer
+    assert "target_outcomes_used=False" in writer
+    assert "registered_physical_dataset_modified=False" in writer
+    assert "physical_evidence_increment=0" in writer
+    assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in workflow
+    assert "causal4d-deform360-filament-support-dispatch" in workflow

--- a/tests/test_deform360_filament_support_workflow_policy.py
+++ b/tests/test_deform360_filament_support_workflow_policy.py
@@ -1,66 +1,128 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-WORKFLOW = ROOT / ".github/workflows/deform360-filament-support.yml"
+WORKFLOW = ROOT / ".github" / "workflows" / "deform360-filament-support.yml"
+REGISTRY = ROOT / ".github" / "self-hosted-jobs.json"
 
 
-def test_filament_support_workflow_is_read_only_and_source_scoped() -> None:
-    text = WORKFLOW.read_text(encoding="utf-8")
-    source_job = text.split("  source-diagnostic:", maxsplit=1)[1]
+def _text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
 
-    assert "permissions:\n  contents: read" in text
-    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in source_job
-    assert "github.event_name == 'workflow_dispatch'" in source_job
-    assert "github.ref == 'refs/heads/main'" in source_job
-    assert "github.event.pull_request.head.repo.full_name" not in source_job
+
+def test_workflow_keeps_normal_validation_on_hosted_runner() -> None:
+    text = _text()
+
+    assert "pull_request:" in text
+    assert "push:" in text
     assert "workflow_dispatch:" in text
+    assert 'branches: [main]' in text
+    assert "contents: read" in text
     assert "run_source_diagnostic:" in text
-    assert "target" not in source_job.lower()
+    assert "run_source_diagnostic: true" not in text
+    assert "contract:" in text
+    assert "runs-on: ubuntu-latest" in text
+    assert "fetch-depth: 0" not in text
 
 
-def test_filament_support_self_hosted_lane_uses_exact_reviewed_sha() -> None:
-    text = WORKFLOW.read_text(encoding="utf-8")
-    source_job = text.split("  source-diagnostic:", maxsplit=1)[1]
+def test_contract_job_locks_formatting_types_and_boundary_tests() -> None:
+    text = _text()
 
-    assert "ref: ${{ github.sha }}" in source_job
-    assert "persist-credentials: false" in source_job
-    assert 'test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"' in source_job
-    assert 'test -z "$(git status --porcelain=v1)"' in source_job
-    assert 'test "${GITHUB_EVENT_NAME}" = "workflow_dispatch"' in source_job
-    assert 'test "${GITHUB_REF}" = "refs/heads/main"' in source_job
-
-
-def test_filament_support_workflow_runs_the_locked_surface() -> None:
-    text = WORKFLOW.read_text(encoding="utf-8")
-    required_paths = (
-        "configs/causal4d_public/deform360_filament_support_v1.json",
-        "docs/causal4d_deform360_filament_support.md",
-        "milestones/deform360-reset-mechanics-v1/README.md",
-        "milestones/deform360-reset-mechanics-v1/summary.json",
-        "scripts/remote/run_deform360_filament_support.py",
-        "scripts/remote/run_deform360_filament_support_workflow.sh",
-        "src/causal4d_public/deform360_filament_support.py",
-        "src/causal4d_public/deform360_replication_graph.py",
-        "src/causal4d_public/deform360_rope_graph.py",
-        "tests/test_deform360_filament_support.py",
-        "tests/test_deform360_filament_support_workflow_policy.py",
-        "tests/test_self_hosted_workflow_policy.py",
-    )
-    for path in required_paths:
-        assert f'      - "{path}"' in text
+    assert 'python -m pip install -e ".[dev]"' in text
+    assert "python -m pip check" in text
     assert "python -m ruff check" in text
     assert "python -m ruff format --check" in text
     assert "python -m mypy --no-site-packages" in text
     assert "bash -n scripts/remote/run_deform360_filament_support_workflow.sh" in text
-    assert "bash scripts/remote/run_deform360_filament_support_workflow.sh" in text
+    assert "tests/test_deform360_filament_support.py" in text
+    assert "tests/test_deform360_filament_support_workflow_policy.py" in text
+    assert "tests/test_resolve_locked_ancestor_fetch.py" in text
+    assert "tests/test_self_hosted_workflow_policy.py" in text
+    assert "tests/test_deform360_rope_graph.py" in text
+    assert "tests/test_deform360_replication_graph.py" in text
+    assert "tests/test_deform360_reset_mechanics.py" in text
+
+
+def test_self_hosted_job_is_manual_main_only_and_non_mutating() -> None:
+    text = _text()
+
+    assert "needs: contract" in text
+    assert "github.event_name == 'workflow_dispatch'" in text
+    assert "github.ref == 'refs/heads/main'" in text
+    assert "inputs.run_source_diagnostic" in text
+    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
+    assert "timeout-minutes: 120" in text
+    assert "permissions:\n  contents: read" in text
+    assert "pull-requests: write" not in text
+    assert "issues: write" not in text
+    assert "actions: write" not in text
+    assert "contents: write" not in text
+    assert "persist-credentials: false" in text
+    assert "fetch-depth: 1" in text
+    assert "clean: true" in text
+    assert "secrets." not in text
+
+
+def test_self_hosted_job_fetches_only_the_exact_locked_ancestry() -> None:
+    text = _text()
+
+    assert "scripts/ci/resolve_locked_ancestor_fetch.py" in text
+    assert "GITHUB_TOKEN: ${{ github.token }}" in text
+    assert '--repository "${GITHUB_REPOSITORY}"' in text
+    assert '--head-sha "${GITHUB_SHA}"' in text
+    assert "deform360_filament_support_v1.json" in text
+    assert "locked-ancestor-fetch-plan.json" in text
+    assert "fetch_depth=${depth}" in text
+    assert '--depth="${FETCH_DEPTH}"' in text
+    assert 'origin "${GITHUB_SHA}"' in text
+    assert 'git cat-file -e "${required_parent}^{commit}"' in text
+    assert 'git merge-base --is-ancestor "${required_parent}" HEAD' in text
+    assert text.count('test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"') == 2
+    assert "git fetch --unshallow" not in text
+
+
+def test_self_hosted_job_uses_explicit_reproduction_python() -> None:
+    text = _text()
+
+    assert (
+        "scripts/remote/select_deform360_prefix_kinematics_python.py" in text
+    )
+    assert "FILAMENT_SUPPORT_PYTHON=${selected}" in text
+    assert '"$FILAMENT_SUPPORT_PYTHON" - <<\'PY\'' in text
+    assert "python-selection.json" in text
+
+
+def test_source_diagnostic_has_a_durable_status_artifact() -> None:
+    text = _text()
+
+    assert "Initialize source-evidence directory" in text
+    assert "deform360-filament-support/status.json" in text
+    assert '"state": "completed"' in text
+    assert "if: always()" in text
+    assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in text
+    assert "name: deform360-filament-support-${{ github.sha }}" in text
+    assert "path: deform360-filament-support/" in text
     assert "if-no-files-found: error" in text
+    assert "retention-days: 30" in text
 
 
-def test_self_hosted_lane_does_not_enable_actions_pip_cache() -> None:
-    text = WORKFLOW.read_text(encoding="utf-8")
-    source_job = text.split("  source-diagnostic:", maxsplit=1)[1]
-    assert "actions/setup-python" not in source_job
-    assert "cache: pip" not in source_job
+def test_registry_binds_the_self_hosted_job_and_fixed_entrypoint() -> None:
+    payload = json.loads(REGISTRY.read_text(encoding="utf-8"))
+    entries = {
+        (entry["workflow"], entry["job_id"]): entry
+        for entry in payload["jobs"]
+    }
+    entry = entries[("deform360-filament-support.yml", "source-diagnostic")]
+
+    assert entry["runs_on"] == ["self-hosted", "Linux", "X64", "nvidia-smi"]
+    assert (
+        entry["entrypoint"]
+        == "scripts/remote/run_deform360_filament_support_workflow.sh"
+    )
+    assert entry["authorized"] is True
+    assert entry["secret_names"] == []
+    assert entry["data_paths"] == ["$HOME/Datasets/Deform360/replication"]
+    assert entry["claim_boundary"] == "source_only_graph_support_diagnostic"

--- a/tests/test_deform360_filament_support_workflow_policy.py
+++ b/tests/test_deform360_filament_support_workflow_policy.py
@@ -19,7 +19,7 @@ def test_workflow_keeps_normal_validation_on_hosted_runner() -> None:
     assert "pull_request:" in text
     assert "push:" in text
     assert "workflow_dispatch:" in text
-    assert 'branches: [main]' in text
+    assert "branches: [main]" in text
     assert "contents: read" in text
     assert "run_source_diagnostic:" in text
     assert "run_source_diagnostic: true" not in text
@@ -87,11 +87,9 @@ def test_self_hosted_job_fetches_only_the_exact_locked_ancestry() -> None:
 def test_self_hosted_job_uses_explicit_reproduction_python() -> None:
     text = _text()
 
-    assert (
-        "scripts/remote/select_deform360_prefix_kinematics_python.py" in text
-    )
+    assert "scripts/remote/select_deform360_prefix_kinematics_python.py" in text
     assert "FILAMENT_SUPPORT_PYTHON=${selected}" in text
-    assert '"$FILAMENT_SUPPORT_PYTHON" - <<\'PY\'' in text
+    assert "\"$FILAMENT_SUPPORT_PYTHON\" - <<'PY'" in text
     assert "python-selection.json" in text
 
 
@@ -111,10 +109,7 @@ def test_source_diagnostic_has_a_durable_status_artifact() -> None:
 
 def test_registry_binds_the_self_hosted_job_and_fixed_entrypoint() -> None:
     payload = json.loads(REGISTRY.read_text(encoding="utf-8"))
-    entries = {
-        (entry["workflow"], entry["job_id"]): entry
-        for entry in payload["jobs"]
-    }
+    entries = {(entry["workflow"], entry["job_id"]): entry for entry in payload["jobs"]}
     entry = entries[("deform360-filament-support.yml", "source-diagnostic")]
 
     assert entry["runs_on"] == ["self-hosted", "Linux", "X64", "nvidia-smi"]

--- a/tests/test_deform360_filament_support_workflow_policy.py
+++ b/tests/test_deform360_filament_support_workflow_policy.py
@@ -109,15 +109,12 @@ def test_source_diagnostic_has_a_durable_status_artifact() -> None:
 
 def test_registry_binds_the_self_hosted_job_and_fixed_entrypoint() -> None:
     payload = json.loads(REGISTRY.read_text(encoding="utf-8"))
-    entries = {(entry["workflow"], entry["job_id"]): entry for entry in payload["jobs"]}
+    entries = {(entry["workflow"], entry["job"]): entry for entry in payload["jobs"]}
     entry = entries[("deform360-filament-support.yml", "source-diagnostic")]
 
-    assert entry["runs_on"] == ["self-hosted", "Linux", "X64", "nvidia-smi"]
-    assert (
-        entry["entrypoint"]
-        == "scripts/remote/run_deform360_filament_support_workflow.sh"
-    )
-    assert entry["authorized"] is True
-    assert entry["secret_names"] == []
-    assert entry["data_paths"] == ["$HOME/Datasets/Deform360/replication"]
-    assert entry["claim_boundary"] == "source_only_graph_support_diagnostic"
+    assert entry["runner_labels"] == ["self-hosted", "Linux", "X64", "nvidia-smi"]
+    assert entry["authorization_model"] == "main-only"
+    assert entry["purpose"] == "Locked Deform360 source filament-support diagnostic"
+    assert entry["dataset_access"] == "approved-source-only-deform360"
+    assert entry["secrets_allowed"] is False
+    assert "scripts/remote/run_deform360_filament_support_workflow.sh" in _text()

--- a/tests/test_issue_command_concurrency.py
+++ b/tests/test_issue_command_concurrency.py
@@ -24,6 +24,10 @@ ISSUE_COMMAND_JOBS = {
         "correct",
         "correct-operator-registry-${{ github.sha }}",
     ),
+    "deform360-filament-support-issue-dispatch.yml": (
+        "dispatch",
+        "deform360-filament-support-issue-dispatch-${{ github.sha }}",
+    ),
     "deform360-reset-mechanics-issue-dispatch.yml": (
         "dispatch",
         "deform360-reset-mechanics-issue-dispatch-${{ github.sha }}",

--- a/tests/test_resolve_locked_ancestor_fetch.py
+++ b/tests/test_resolve_locked_ancestor_fetch.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "ci" / "resolve_locked_ancestor_fetch.py"
+SPEC = importlib.util.spec_from_file_location(
+    "resolve_locked_ancestor_fetch",
+    MODULE_PATH,
+)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+AncestorPlanError = MODULE.AncestorPlanError
+main = MODULE.main
+resolve_fetch_plan = MODULE.resolve_fetch_plan
+
+PARENT = "1" * 40
+HEAD = "2" * 40
+OTHER = "3" * 40
+REPOSITORY = "IPS-Stuttgart/Causal4D"
+
+
+def _comparison(**updates: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "status": "ahead",
+        "base_commit": {"sha": PARENT},
+        "merge_base_commit": {"sha": PARENT},
+        "head_commit": {"sha": HEAD},
+        "ahead_by": 17,
+        "behind_by": 0,
+        "total_commits": 17,
+    }
+    payload.update(updates)
+    return payload
+
+
+def test_descendant_plan_fetches_exact_commit_distance_plus_parent() -> None:
+    plan = resolve_fetch_plan(
+        _comparison(),
+        repository=REPOSITORY,
+        head_sha=HEAD,
+        required_parent_commit=PARENT,
+    )
+
+    assert plan.fetch_depth == 18
+    assert plan.ahead_by == 17
+    assert plan.merge_base_sha == PARENT
+    assert plan.ancestry_verified_by == "github_compare_api_and_local_git"
+
+
+def test_identical_parent_and_head_use_depth_one() -> None:
+    payload = _comparison(
+        status="identical",
+        head_commit={"sha": PARENT},
+        ahead_by=0,
+        total_commits=0,
+    )
+
+    plan = resolve_fetch_plan(
+        payload,
+        repository=REPOSITORY,
+        head_sha=PARENT,
+        required_parent_commit=PARENT,
+    )
+
+    assert plan.fetch_depth == 1
+
+
+def test_diverged_or_stale_comparison_fails_closed() -> None:
+    with pytest.raises(AncestorPlanError, match="ancestor"):
+        resolve_fetch_plan(
+            _comparison(status="diverged", behind_by=2),
+            repository=REPOSITORY,
+            head_sha=HEAD,
+            required_parent_commit=PARENT,
+        )
+
+    with pytest.raises(AncestorPlanError, match="workflow head"):
+        resolve_fetch_plan(
+            _comparison(head_commit={"sha": OTHER}),
+            repository=REPOSITORY,
+            head_sha=HEAD,
+            required_parent_commit=PARENT,
+        )
+
+
+def test_wrong_merge_base_or_inconsistent_counts_fail_closed() -> None:
+    with pytest.raises(AncestorPlanError, match="rooted"):
+        resolve_fetch_plan(
+            _comparison(merge_base_commit={"sha": OTHER}),
+            repository=REPOSITORY,
+            head_sha=HEAD,
+            required_parent_commit=PARENT,
+        )
+
+    with pytest.raises(AncestorPlanError, match="counts"):
+        resolve_fetch_plan(
+            _comparison(total_commits=16),
+            repository=REPOSITORY,
+            head_sha=HEAD,
+            required_parent_commit=PARENT,
+        )
+
+
+def test_excessive_history_is_rejected_instead_of_unshallowing() -> None:
+    with pytest.raises(AncestorPlanError, match="bounded fetch-depth"):
+        resolve_fetch_plan(
+            _comparison(ahead_by=2048, total_commits=2048),
+            repository=REPOSITORY,
+            head_sha=HEAD,
+            required_parent_commit=PARENT,
+        )
+
+
+def test_fixture_cli_writes_plan_and_prints_depth(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    lock = tmp_path / "lock.json"
+    lock.write_text(
+        json.dumps({"required_parent_commit": PARENT}),
+        encoding="utf-8",
+    )
+    comparison = tmp_path / "comparison.json"
+    comparison.write_text(json.dumps(_comparison()), encoding="utf-8")
+    output = tmp_path / "plan.json"
+
+    status = main(
+        [
+            "--repository",
+            REPOSITORY,
+            "--head-sha",
+            HEAD,
+            "--lock",
+            str(lock),
+            "--compare-json",
+            str(comparison),
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert status == 0
+    assert capsys.readouterr().out == "18\n"
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["artifact_kind"] == "Causal4DLockedAncestorFetchPlan"
+    assert payload["fetch_depth"] == 18
+    assert payload["required_parent_commit"] == PARENT
+
+
+def test_cli_rejects_duplicate_lock_keys(tmp_path: Path) -> None:
+    lock = tmp_path / "lock.json"
+    lock.write_text(
+        '{"required_parent_commit":"' + PARENT + '",'
+        '"required_parent_commit":"' + PARENT + '"}',
+        encoding="utf-8",
+    )
+    comparison = tmp_path / "comparison.json"
+    comparison.write_text(json.dumps(_comparison()), encoding="utf-8")
+
+    status = main(
+        [
+            "--repository",
+            REPOSITORY,
+            "--head-sha",
+            HEAD,
+            "--lock",
+            str(lock),
+            "--compare-json",
+            str(comparison),
+            "--output",
+            str(tmp_path / "plan.json"),
+        ]
+    )
+
+    assert status == 1
+    assert not (tmp_path / "plan.json").exists()

--- a/tests/test_write_filament_support_dispatch_receipt.py
+++ b/tests/test_write_filament_support_dispatch_receipt.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.write_filament_support_dispatch_receipt import (
+    DispatchReceiptError,
+    build_receipt,
+    main,
+)
+
+
+REPOSITORY = "IPS-Stuttgart/Causal4D"
+MAIN_SHA = "a" * 40
+RUN_ID = 123456789
+RUN_URL = f"https://github.com/{REPOSITORY}/actions/runs/{RUN_ID}"
+
+
+def test_receipt_records_only_source_dispatch_evidence() -> None:
+    receipt = build_receipt(
+        repository=REPOSITORY,
+        reviewed_main_sha=MAIN_SHA,
+        trigger_issue_number=388,
+        workflow_run_id=RUN_ID,
+        workflow_run_url=RUN_URL,
+    )
+
+    assert receipt.repository == REPOSITORY
+    assert receipt.reviewed_main_sha == MAIN_SHA
+    assert receipt.run_source_diagnostic is True
+    assert receipt.target_outcomes_used is False
+    assert receipt.registered_physical_dataset_modified is False
+    assert receipt.physical_evidence_increment == 0
+
+
+def test_receipt_rejects_run_url_from_a_different_identity() -> None:
+    with pytest.raises(DispatchReceiptError, match="does not identify"):
+        build_receipt(
+            repository=REPOSITORY,
+            reviewed_main_sha=MAIN_SHA,
+            trigger_issue_number=388,
+            workflow_run_id=RUN_ID,
+            workflow_run_url=(
+                f"https://github.com/{REPOSITORY}/actions/runs/{RUN_ID + 1}"
+            ),
+        )
+
+
+def test_cli_writes_deterministic_receipt_without_overwrite(tmp_path: Path) -> None:
+    output = tmp_path / "dispatch.json"
+    argv = [
+        "--repository",
+        REPOSITORY,
+        "--reviewed-main-sha",
+        MAIN_SHA,
+        "--trigger-issue-number",
+        "388",
+        "--workflow-run-id",
+        str(RUN_ID),
+        "--workflow-run-url",
+        RUN_URL,
+        "--output",
+        str(output),
+    ]
+
+    assert main(argv) == 0
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["artifact_kind"] == "Causal4DDeform360FilamentSupportDispatch"
+    assert payload["workflow_run_id"] == RUN_ID
+    assert payload["physical_evidence_increment"] == 0
+
+    with pytest.raises(DispatchReceiptError, match="refusing to overwrite"):
+        main(argv)


### PR DESCRIPTION
## Summary

- replace the impossible depth-one ancestor check in the locked Deform360 filament-support job with a bounded exact-head deepening plan
- read the unchanged `required_parent_commit` from the registered lock and query GitHub's comparison metadata for that parent and the immutable workflow head
- reject divergence, stale heads, a wrong merge base, inconsistent commit counts, malformed or duplicate JSON, non-exact revisions, and history deeper than 2,048 commits
- fetch only `ahead_by + 1` commits for the exact workflow SHA, then retain the existing local `git merge-base --is-ancestor` proof and clean-tree/head checks
- persist the fetch plan in the source-evidence artifact and continue to forbid `fetch-depth: 0` and `git fetch --unshallow`
- add a narrowly scoped issue dispatcher that launches only the filament-support source diagnostic from the exact reviewed `main` SHA and records a zero-target, zero-evidence receipt

## Root cause

The authorized self-hosted rerun of workflow run `31465052625`, job `95401021286`, failed before opening the Deform360 source data. The workflow checked out the exact reviewed head with `fetch-depth: 1`, while the locked diagnostic correctly required parent commit `b6ac681b3cbeed077beb0059be88f041d312c969` to be an ancestor of head `4fbb0947df77d87f9909926c0a83e7e204480b54`.

GitHub's comparison reports that the head is exactly 201 commits ahead and zero behind, with the required parent as both base and merge base. The repaired plan therefore derives an exact bounded depth of 202 for that historical run rather than fetching all history or weakening the lock.

## Validation

- 17 focused resolver, workflow-policy, and issue-dispatcher tests pass
- Python compilation passes with `SyntaxWarning` promoted to an error
- YAML parsing passes for both workflows
- a synthetic shallow repository confirms that fetching the exact head at the computed depth makes the locked ancestor locally verifiable
- the resolver reproduces fetch depth 202 from the failed historical run's comparison metadata

## Safety boundary

This repairs workflow execution only. It does not rewrite the negative reset-mechanics result, alter the registered filament candidate or gates, access target outcomes, modify a registered physical dataset, increment physical evidence, or change a scientific claim.

Advances #232 and records the technical link to #342.

<!-- exact-head-validation: failed head=40a27918455e953785a8f9b42efe78efbb07ad61 run=https://github.com/IPS-Stuttgart/Causal4D/actions/runs/32039008666 -->