### PR TITLE
Streamline onboarding and enforce API/workflow hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Causal4D is a research framework for **Bayesian abduction of realized
 interventions and held-out interventional prediction for deformable-object
 dynamics**.
 
-The central distinction is:
-
 ```text
 commanded action u
         |
@@ -16,70 +14,63 @@ realized intervention z = (actuation realization phi, contact state kappa)
 uncertain physical rollout and observable future
 ```
 
-The software implements explicit abduction, intervention, and prediction:
+The software makes the causal sequence explicit:
 
-1. begin from an uncertain physical-twin belief;
+1. start from an uncertain physical-twin belief;
 2. infer how an observed command was physically realized from an allowed
    response prefix;
 3. branch at the prefix endpoint under a held-out action;
-4. propagate physical, intervention, and unresolved discrepancy uncertainty;
-5. optionally reweight safe rollouts with a separately gated semantic prior.
+4. propagate physical, intervention, and unresolved-discrepancy uncertainty;
+5. optionally reweight safe rollouts through a separately gated semantic prior.
 
 This repository is the canonical home of Causal4D. It was extracted with
 history from
-[Bayesian-PhysTwin](https://github.com/IPS-Stuttgart/BayesianPhysTwin);
-the migration boundary is recorded in
+[BayesianPhysTwin](https://github.com/IPS-Stuttgart/BayesianPhysTwin); the
+migration boundary is recorded in
 [docs/migration_from_bayesian_phystwin.md](docs/migration_from_bayesian_phystwin.md).
 
-## Project Map
+## Five-minute start
 
-### Causal4D core
+Install the core package and run the deterministic CPU-only
+abduction-intervention-prediction demonstration:
 
-`src/causal4d/` owns the typed posterior contracts, controlled benchmark,
-latent-contact inference, intervention abduction, counterfactual operators,
-discrepancy transfer, semantic trust gates, physical validation, and
-prospective mechanism gates.
+```bash
+python -m pip install -e .
+python -m causal4d.demo.aip --output-dir build/aip-demo
+```
 
-The structural model, causal timing, transport assumptions, and real-data
-identification boundary are formalized in
-[docs/causal_model_and_identification.md](docs/causal_model_and_identification.md).
-Analysis-only action comparisons use the typed, content-addressed
-`InterventionalContrastPosteriorV1` API documented in
-[docs/interventional_contrast.md](docs/interventional_contrast.md); they do not
-change a source posterior or the frozen physical protocol.
+The demonstration writes non-pickled, content-addressed contracts for a
+`TwinBelief`, factual intervention, counterfactual query, physical posterior,
+and projected posterior. It reloads every artifact and verifies that replacing
+the held-out suffix cannot change factual abduction.
 
-### Bayesian-PhysTwin integration
+The output is a controlled software demonstration, not physical evidence or a
+scientific result. See
+[the end-to-end AIP guide](docs/aip_end_to_end_demo.md).
 
-[Bayesian-PhysTwin](https://github.com/IPS-Stuttgart/BayesianPhysTwin) supplies
-the uncertain deformable-object twin: state and parameter particles, graph
-geometry, PhysTwin/Warp replay, and perception/discrepancy artifacts. Causal4D
-consumes those artifacts and owns the intervention and counterfactual
-inference. Frozen scientific operations use the versioned
-`causal4d_provider_v1` facade, while production replay uses
-`causal4d_provider_v2` through the `PhysTwinReplayProvider` protocol. Graph and
-released visual artifacts use separately versioned provider facades; production
-source does not import Bayesian-PhysTwin internals.
+### Recommended public imports
 
-Install the `phystwin` extra for these adapters. Core controlled benchmarks do
-not require Warp or the PhysTwin checkout. See
-[docs/bayesian_phystwin_provider.md](docs/bayesian_phystwin_provider.md) for
-the compatibility and frozen-lock policies.
+New artifact consumers should use the artifact-only namespace:
 
-### Public-data studies
+```python
+from causal4d.artifacts.v1 import TwinBelief, load_contract, save_contract
+```
 
-`src/causal4d_public/` contains source-locked Deform360 and PokeFlex adapters,
-preflight checks, technical-failure accounting, shared-physics controls, and
-the frozen public-data protocols. These studies are evidence about specific
-model classes and information boundaries; they are not all positive
-confirmations.
+Estimator consumers should import AIP operations separately:
 
-### Prob4D
+```python
+from causal4d.inference.v1 import (
+    abduct_factual_intervention,
+    apply_counterfactual_operator,
+    project_physical_posterior,
+)
+```
 
-[Prob4D](https://github.com/IPS-Stuttgart/Prob4D) is a separate, newly developed
-probabilistic 4D observation and calibration feeder. It is not assumed prior
-literature and is not part of Causal4D's core causal claim. Causal4D may consume
-versioned Prob4D observation artifacts through a narrow interface, but camera
-evidence is admitted only through source-calibrated gates with exact fallback.
+`causal4d.api.v1` remains supported for the existing controlled-benchmark API,
+and historical package-root exports remain available for compatibility. New AIP
+integrations should prefer the split namespaces so artifact-only code does not
+implicitly depend on estimator implementations. The stability policy is
+specified in [docs/public_api.md](docs/public_api.md).
 
 ## Installation
 
@@ -95,22 +86,21 @@ Development tools:
 python -m pip install -e ".[dev]"
 ```
 
-Bayesian-PhysTwin adapters:
+BayesianPhysTwin adapters:
 
 ```bash
 python -m pip install -e ".[phystwin]"
 ```
 
-The `phystwin` extra accepts Bayesian-PhysTwin `>=0.4,<0.5` and validates the
+The `phystwin` extra accepts BayesianPhysTwin `>=0.4,<0.5` and validates the
 provider manifest at runtime. Frozen experiments instead lock both repositories
-with `requirements/frozen/causal4d-0.3.0.txt`. Visual, Warp-runtime, and
+through the corresponding frozen requirements file. Visual, Warp-runtime, and
 actuator-calibration dependencies remain separate so the controlled benchmark
 stays lightweight.
 
 ## Command-line interface
 
-Causal4D 0.5 installs exactly one executable. All stable, diagnostic,
-experimental, public-study, and archived operations are typed grouped routes:
+Causal4D 0.5 installs one executable with typed grouped routes:
 
 ```bash
 causal4d --help
@@ -122,12 +112,14 @@ causal4d commands validate --require-installed
 
 The 67 historical `causal4d-*` console scripts are no longer installed. Their
 successor routes remain available, while frozen tags and milestone environments
-retain the original executables. See [the command-line interface](docs/command_line.md)
-and [the complete 0.5 migration table](docs/command_migration_0_5.md).
+retain the original executables. See
+[the command-line guide](docs/command_line.md) and
+[the 0.5 migration table](docs/command_migration_0_5.md).
 
-## Quick Start
+### Controlled benchmark construction
 
-Build and inspect the controlled protocol through the supported Python API:
+The aggregate compatibility API remains useful for controlled protocol
+construction:
 
 ```python
 from causal4d.api.v1 import CounterfactualBenchmarkConfig, build_protocol
@@ -147,210 +139,116 @@ for object_protocol in protocol:
     )
 ```
 
-The runnable version is
-[`examples/python_api_quickstart.py`](examples/python_api_quickstart.py). New
-downstream code should prefer `causal4d.api.v1`; research and registered-protocol
-internals remain available from their owning modules without entering the v1
-compatibility promise.
+The runnable example is
+[`examples/python_api_quickstart.py`](examples/python_api_quickstart.py).
 
-Run the controlled counterfactual benchmark:
+Run the controlled benchmarks with:
 
 ```bash
 causal4d benchmark counterfactual \
   --output-dir runs/causal4d-counterfactual-v1
-```
 
-Run the latent-contact benchmark:
-
-```bash
 causal4d benchmark latent-contact \
   --output-dir runs/causal4d-latent-contact-v1
 ```
 
-Generate the controlled collaborator video through the
-[`Controlled collaborator demo video`](.github/workflows/controlled-demo-video.yml)
-workflow. The uploaded bundle contains an MP4, GIF, poster, summary, and
-checksums. Its presentation and claim boundary are documented in
-[docs/controlled_collaborator_demo.md](docs/controlled_collaborator_demo.md).
+## Project map
 
-Validate the locked same-object real protocol:
+### Causal4D core
 
-```bash
-causal4d protocol real validate-protocol \
-  configs/causal4d/sloth_multi_action_v1.json
-```
+`src/causal4d/` owns typed posterior contracts, intervention abduction,
+counterfactual operators, discrepancy transfer, semantic trust gates, physical
+validation, and prospective mechanism gates. The structural model, causal
+timing, transport assumptions, and real-data identification boundary are
+formalized in
+[docs/causal_model_and_identification.md](docs/causal_model_and_identification.md).
 
-The full PhysTwin abduction chain is documented in
-[docs/causal4d_abduction_intervention_prediction.md](docs/causal4d_abduction_intervention_prediction.md).
+Analysis-only action comparisons use the typed, content-addressed
+`InterventionalContrastPosteriorV1` contract documented in
+[docs/interventional_contrast.md](docs/interventional_contrast.md). They do not
+change a source posterior or the frozen physical protocol.
 
-## Reviewer-facing paper reproduction
+### BayesianPhysTwin integration
 
-Create an immutable target-free bundle from the exact registered protocol,
-method freeze, and analysis manifest:
+[BayesianPhysTwin](https://github.com/IPS-Stuttgart/BayesianPhysTwin) supplies
+the uncertain deformable-object twin: state and parameter particles, graph
+geometry, PhysTwin/Warp replay, and perception/discrepancy artifacts. Causal4D
+consumes those artifacts and owns intervention and counterfactual inference.
+Production source uses versioned provider facades rather than importing
+BayesianPhysTwin internals. See
+[docs/bayesian_phystwin_provider.md](docs/bayesian_phystwin_provider.md).
 
-```bash
-causal4d paper reproduce \
-  --protocol configs/causal4d/sloth_multi_action_v1.json \
-  --analysis-manifest /data/causal4d-sloth-multi-action-v1/registered-analysis.json \
-  --method-freeze /data/causal4d-sloth-multi-action-v1/method_freeze.json \
-  --output-dir /data/causal4d-sloth-multi-action-v1/paper-reproduction-plan
-```
+### Public-data studies
 
-The bundle copies no raw sensor data and changes no method. It regenerates the
-registered report shell, source-verifies supplied effect tables and gate
-decisions, records exact hashes and byte counts, and can be independently
-reopened with `causal4d paper reproduce --verify <bundle-dir>`. See
-[the paper reproduction guide](docs/paper_reproduction.md).
+`src/causal4d_public/` contains source-locked Deform360 and PokeFlex adapters,
+preflight checks, technical-failure accounting, shared-physics controls, and
+frozen public-data protocols. These studies are evidence about specific model
+classes and information boundaries; they are not all positive confirmations.
 
-## Query-space uncertainty attribution
+### Prob4D
 
-Attribute one fixed finite-posterior query covariance to declared physical
-particle, actuation, contact, slip, or other support labels while retaining any
-unexplained component variation explicitly:
+[Prob4D](https://github.com/IPS-Stuttgart/Prob4D) is a separate probabilistic 4D
+observation and calibration feeder. It is not assumed prior literature and is
+not part of Causal4D's core causal claim. Causal4D consumes versioned Prob4D
+observation artifacts only through narrow, source-calibrated gates with exact
+fallback.
 
-```bash
-causal4d diagnostic uncertainty decompose-query build \
-  posterior-query-input.npz \
-  examples/query_variance_decomposition_spec.json \
-  query-variance-decomposition.json
+## Reproduction and diagnostics
 
-causal4d diagnostic uncertainty decompose-query validate \
-  query-variance-decomposition.json
-```
+Create and independently verify an immutable, target-free paper reproduction
+bundle with the `causal4d paper reproduce` route. It regenerates the registered
+report shell, source-verifies supplied tables and gate decisions, and records
+exact hashes without copying raw sensor data. See
+[docs/paper_reproduction.md](docs/paper_reproduction.md).
 
-The output uses exact Shapley attribution over the declared finite factor set,
-adds caller-declared conditional covariance sources, and verifies numerical
-additivity and content identity. It is diagnostic-only and cannot select or
-change the frozen physical method. See
-[the variance-decomposition guide](docs/query_variance_decomposition.md).
+Query-space uncertainty attribution is available through
+`causal4d diagnostic uncertainty decompose-query`. It uses exact Shapley
+attribution over declared finite factors and verifies numerical additivity and
+content identity. It is diagnostic-only and cannot select or change the frozen
+physical method. See
+[docs/query_variance_decomposition.md](docs/query_variance_decomposition.md).
 
-## Next Scientific Milestone
+## Next scientific milestone
 
-The controlled result has passed. The next first-paper milestone is the locked
-same-object physical experiment: 18 grasp sessions, 36 command executions, and
-independent-execution calibration. Primary-method development is frozen for
-this result; another discrepancy mechanism, semantic component, planner, or
-public-data branch cannot replace it.
-
-The v4 amendment itself remains immutable. After scaffolding the acquisition
-dataset, create its separate operational evidence records:
-
-```bash
-causal4d protocol readiness scaffold \
-  /opt/causal4d-frozen \
-  /data/causal4d-sloth-multi-action-v1
-```
-
-Drive the required 12-execution physical source panel through its registered
-order and exactly-once evidence boundary:
-
-```bash
-causal4d protocol readiness source-panel-status \
-  /opt/causal4d-frozen \
-  /data/causal4d-sloth-multi-action-v1 \
-  --verify-file-hashes
-
-causal4d protocol readiness source-panel-publish \
-  /opt/causal4d-frozen \
-  /data/causal4d-sloth-multi-action-v1 \
-  /data/causal4d-sloth-multi-action-v1/staging/<execution-id>.json
-```
-
-The status identifies the next execution and its exact command profile. The
-publisher admits only that execution, verifies every bound artifact, and never
-overwrites a final manifest. See
-[docs/causal4d_source_panel_acquisition.md](docs/causal4d_source_panel_acquisition.md)
-for the operator workflow and evidence boundary.
-
-Complete and seal the source-panel, actuator, support/gravity, and
-nonconfirmatory dry-run gates. Then seal the exact clean Causal4D commit,
-Bayesian-PhysTwin pin, protocol files, analysis boundary, and reporting contract:
-
-```bash
-causal4d protocol freeze seal \
-  /opt/causal4d-frozen \
-  /data/causal4d-sloth-multi-action-v1/method_freeze.json \
-  --frozen-by "<operator-or-principal-investigator>"
-```
-
-Independently validate and attest that exact freeze before collection:
-
-```bash
-causal4d protocol freeze attest \
-  /data/causal4d-sloth-multi-action-v1/method_freeze.json \
-  configs/causal4d/sloth_multi_action_v1.json \
-  /opt/causal4d-frozen \
-  /data/causal4d-sloth-multi-action-v1/method_freeze_validation.json \
-  --verified-by "<independent-verifier>"
-```
-
-Seal the software-environment gate after that attestation, then require a
-hash-verified readiness decision before confirmatory execution 1:
-
-```bash
-causal4d protocol readiness status \
-  /opt/causal4d-frozen \
-  /data/causal4d-sloth-multi-action-v1 \
-  --verify-file-hashes \
-  --require-ready \
-  --output-json \
-  /data/causal4d-sloth-multi-action-v1/preacquisition-readiness.json
-```
-
-The readiness gate binds the 12-run source panel, actuator synchronization,
-support/gravity registration, the nonconfirmatory end-to-end dry run, the
-method freeze, exact Causal4D/Bayesian-PhysTwin package artifacts, and an
-explicit Prob4D used-or-unused declaration. It refuses readiness when any
-confirmatory manifest already exists. See
-[docs/causal4d_preacquisition_readiness.md](docs/causal4d_preacquisition_readiness.md)
-for its evidence and exit-code contracts.
-
-Track acquisition progress without counting templates as evidence:
-
-```bash
-causal4d protocol real status \
-  configs/causal4d/sloth_multi_action_v1.json \
-  /data/causal4d-sloth-multi-action-v1 \
-  --output-json \
-  /data/causal4d-sloth-multi-action-v1/evidence-status.json
-```
-
-Before analysis, add
-`--repository-root <frozen-checkout> --verify-file-hashes --require-complete`.
-The version-2 gate remains closed until the approved timebase, schema-3 physical
-contact registration, sealed and independently attested method freeze, all 18
-same-grasp session manifests, all 36 execution manifests, and every registered
-artifact hash validate. The gate also proves that the timebase, contact
-approval, method freeze, and independent attestation do not postdate the first
-valid execution. See
-[docs/causal4d_real_evidence_status.md](docs/causal4d_real_evidence_status.md)
-for the exact accounting and exit-code contract.
+The controlled result has passed. The decisive first-paper milestone is the
+locked same-object physical experiment: 18 grasp sessions, 36 command
+executions, and independent-execution calibration. Primary-method development
+is frozen for this result; another discrepancy mechanism, semantic component,
+planner, or public-data branch cannot replace it.
 
 The experiment must report either successful transfer/calibration or a
-well-powered negative result without target-informed method selection. See
-[docs/causal4d_real_experiment_milestone.md](docs/causal4d_real_experiment_milestone.md)
-for the freeze, acquisition, and reporting workflow.
+well-powered negative result without target-informed method selection. Operator
+instructions and exact evidence boundaries live in:
 
-## Evidence Boundary
+- [source-panel acquisition](docs/causal4d_source_panel_acquisition.md);
+- [pre-acquisition readiness](docs/causal4d_preacquisition_readiness.md);
+- [real-evidence accounting](docs/causal4d_real_evidence_status.md); and
+- [the physical-experiment milestone](docs/causal4d_real_experiment_milestone.md).
 
-- `milestones/v0.3.0-causal4d-aip/` is the frozen controlled and first real
-  abduction-intervention-prediction milestone.
-- The released PhysTwin interactions are diagnostic-only after their recorded
-  audits; they must not be reused for further model selection.
-- Deform360 and PokeFlex artifacts preserve source/target access boundaries,
-  retained technical failures, and unsealable cases separately.
+Keeping the operational command sequence in those versioned runbooks avoids
+turning the repository landing page into a second, potentially divergent copy
+of the registered protocol.
+
+## Evidence boundary
+
+- `milestones/v0.3.0-causal4d-aip/` is the frozen controlled and first real AIP
+  milestone.
+- Released PhysTwin interactions are diagnostic-only after their recorded
+  audits and must not be reused for further model selection.
+- Deform360 and PokeFlex preserve source/target access boundaries, retained
+  technical failures, and unsealable cases separately.
 - Graph persistence remains the unresolved-discrepancy fallback unless a
-  physical mechanism passes the prospective held-out shrinkage, prediction,
-  plausibility, transfer, and calibration gates.
-- MolmoMotion or another semantic prior has zero influence unless its locked
-  trust gate passes; rejection gives exact physical-posterior fallback.
-- The 36-execution same-object real protocol is now the decisive pending
-  milestone; optional branches cannot alter or rescue its primary result.
+  physical mechanism passes prospective held-out gates.
+- A semantic prior has zero influence unless its locked trust gate passes;
+  rejection gives exact physical-posterior fallback.
+- The 36-execution same-object protocol is the decisive pending milestone;
+  optional branches cannot alter or rescue its primary result.
 
 See [docs/causal4d_paper_scope.md](docs/causal4d_paper_scope.md) for the narrow
-paper claim and the other documents in `docs/` for protocol-specific details.
+paper claim and [the documentation map](docs/README.md) for the full set of
+conceptual, integration, diagnostic, and operator guides.
 
-## Repository Layout
+## Repository layout
 
 ```text
 src/causal4d/          core inference, contracts, and PhysTwin adapters
@@ -363,10 +261,10 @@ scripts/remote/        reproducible remote execution wrappers
 tests/                 unit, protocol, parity, and artifact-boundary tests
 ```
 
-## License
+## License and citation
 
-Causal4D software and its associated project documentation are available under the
+Causal4D software and project documentation are available under the
 [MIT License](LICENSE). Third-party datasets, model checkpoints, provider
-repositories, and externally sourced artifacts retain their own terms and are not
-relicensed by this repository. See [docs/licensing.md](docs/licensing.md) for the
-scope, historical-version policy, contribution terms, and citation boundary.
+repositories, and externally sourced artifacts retain their own terms and are
+not relicensed by this repository. See [docs/licensing.md](docs/licensing.md)
+and [`CITATION.cff`](CITATION.cff).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,61 @@
+# Causal4D documentation map
+
+This directory contains conceptual references, integration contracts,
+diagnostics, registered protocols, and operator runbooks. The shortest path for
+a new software user is:
+
+1. [End-to-end AIP demonstration](aip_end_to_end_demo.md)
+2. [Public API and compatibility policy](public_api.md)
+3. [Causal model and identification boundary](causal_model_and_identification.md)
+4. [Abduction, intervention, and prediction](causal4d_abduction_intervention_prediction.md)
+5. [Command-line interface](command_line.md)
+
+## Concepts and contracts
+
+- [Causal model and identification](causal_model_and_identification.md)
+- [Abduction, intervention, and prediction](causal4d_abduction_intervention_prediction.md)
+- [Action-conditioned counterfactuals](action_conditioned_counterfactual.md)
+- [Action-conditioned discrepancy](action_conditioned_discrepancy.md)
+- [Interventional contrasts](interventional_contrast.md)
+- [Query-space variance decomposition](query_variance_decomposition.md)
+
+## Integration
+
+- [BayesianPhysTwin provider contract](bayesian_phystwin_provider.md)
+- [BayesianPhysTwin recursive provider contract](bayesian_phystwin_recursive_provider_contract.md)
+- [Belief handoff](bpt_belief_handoff.md)
+- [Camera geometry contract](camera_geometry_contract.md)
+- [Migration from BayesianPhysTwin](migration_from_bayesian_phystwin.md)
+
+## Reproduction and diagnostics
+
+- [Paper reproduction](paper_reproduction.md)
+- [Controlled collaborator demonstration](controlled_collaborator_demo.md)
+- [Automation integrity](automation_integrity.md)
+- [Branch hygiene](branch_hygiene.md)
+- [Exact-head validation](exact_head_validation.md)
+
+## Registered physical experiment
+
+The files in this section are operational and evidence-bearing. Use the exact
+version associated with the frozen experiment rather than copying commands into
+another document.
+
+- [Physical-experiment milestone](causal4d_real_experiment_milestone.md)
+- [Source-panel acquisition](causal4d_source_panel_acquisition.md)
+- [Pre-acquisition readiness](causal4d_preacquisition_readiness.md)
+- [Real-evidence status and accounting](causal4d_real_evidence_status.md)
+- [Acquisition environment capsule](causal4d_acquisition_environment_capsule.md)
+- [Acquisition flight recorder](causal4d_acquisition_flight_recorder.md)
+
+## Governance and scope
+
+- [Paper scope](causal4d_paper_scope.md)
+- [Licensing](licensing.md)
+- [Automation integrity](automation_integrity.md)
+- [Branch hygiene](branch_hygiene.md)
+
+The documentation distinguishes controlled software evidence, diagnostic public
+data, and registered physical evidence. A successful software demonstration or
+workflow run never increments the physical evidence count unless the registered
+protocol explicitly admits it.

--- a/docs/automation_integrity.md
+++ b/docs/automation_integrity.md
@@ -1,7 +1,7 @@
 # Automation integrity
 
-This document separates three automation concerns that have different trust and
-reproducibility requirements.
+This document separates automation concerns that have different trust,
+reproducibility, and lifecycle requirements.
 
 ## Authenticated issue commands
 
@@ -14,13 +14,39 @@ whole. GitHub Actions permits at most one pending run in a concurrency group. If
 all opened issues enter a workflow-level group before the job guard is evaluated,
 an unrelated issue can replace a pending authorized command. Job-scoped
 concurrency means an unrelated issue produces only skipped jobs and never enters
-the command's serialization group. The execution-job groups also use `queue: max`, so
-multiple authenticated commands wait instead of replacing an earlier pending
-command.
+the command's serialization group. The execution-job groups also use
+`queue: max`, so multiple authenticated commands wait instead of replacing an
+earlier pending command.
 
 The policy test in `tests/test_issue_command_concurrency.py` inventories every
 opened-issue workflow. Adding another issue command therefore requires an
 explicit job name and concurrency group in the registry.
+
+## Workflow lifecycle
+
+A mergeable branch must not introduce one-shot workflow files whose names use
+`temporary-*`, `publish-reviewed-*`, `*one-shot*`, `*one_shot*`,
+`agent-apply-*`, or `branch-advance-*` conventions. The equivalent underscore
+forms are also blocked. `tests/test_no_temporary_workflows.py` enforces this
+boundary for both `.yml` and `.yaml` files.
+
+A temporary action should instead use one of these paths:
+
+- invoke an existing reusable workflow with immutable repository, commit,
+  configuration, and dataset inputs;
+- retain the run receipt or evidence bundle as an artifact, issue comment, tag,
+  or checked contract; or
+- keep the temporary workflow off every mergeable head and delete it before
+  review.
+
+The workflow file is an execution mechanism, not the scientific evidence. A
+completed one-shot workflow therefore should not remain active merely to retain
+provenance; the immutable inputs, exact head, logs, receipt, and result bundle
+carry that provenance.
+
+Long-lived branch cleanup remains a separate, fail-closed process. The stale
+agent-branch workflow is read-only and only proposes exact-tip candidates for
+manual review. See [branch_hygiene.md](branch_hygiene.md).
 
 ## Frozen and rolling compatibility lanes
 
@@ -31,8 +57,8 @@ claim-bearing release checks.
 
 `three-repository-rolling-canary.yml` is intentionally different. It follows the
 current `main` branches of Prob4D, BayesianPhysTwin, and Causal4D, records their
-exact revisions, builds all three wheels, verifies installed-only imports, creates
-an ephemeral stack lock, and runs the shared compatibility and provider-v2
+exact revisions, builds all three wheels, verifies installed-only imports,
+creates an ephemeral stack lock, and runs the shared compatibility and provider-v2
 contracts. Its artifacts always declare:
 
 - `claim_bearing = false`;
@@ -41,9 +67,9 @@ contracts. Its artifacts always declare:
 
 A successful rolling canary detects compatibility at those moving revisions. It
 does not update immutable pins and does not establish physical accuracy,
-calibration, counterfactual validity, deployment safety, or any scientific claim.
-A failure is an integration signal; frozen revisions remain unchanged until a
-reviewed pin update passes the frozen lane.
+calibration, counterfactual validity, deployment safety, or any scientific
+claim. A failure is an integration signal; frozen revisions remain unchanged
+until a reviewed pin update passes the frozen lane.
 
 ## Release metadata integrity
 
@@ -60,15 +86,16 @@ source distribution and requires agreement among:
 
 For a tag, the tag must be exactly `v<package-version>`, the package must not be a
 development or prerelease version, the `Unreleased` section must contain no
-pending changes, and the project-status required version must match. The workflow
-is read-only: it validates release inputs and uploads evidence but does not create
-a tag or publish a release.
+pending changes, and the project-status required version must match. The
+workflow is read-only: it validates release inputs and uploads evidence but does
+not create a tag or publish a release.
 
 ## Change procedure
 
 For an issue-command workflow, keep the authorization guard on the execution job
-and place its concurrency block below that guard. For compatibility changes, run
-both the moving-head canary and the immutable installed-wheel lane before updating
-any frozen pin. For a software release, first move all pending changelog entries
-into the release section, synchronize package, citation, and project-status
-versions, and only then create the exact matching tag.
+and place its concurrency block below that guard. For temporary automation, use
+a reusable workflow or remove the one-shot file before review. For compatibility
+changes, run both the moving-head canary and the immutable installed-wheel lane
+before updating any frozen pin. For a software release, first move all pending
+changelog entries into the release section, synchronize package, citation, and
+project-status versions, and only then create the exact matching tag.

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -1,33 +1,74 @@
-# Versioned Python API
+# Public API and compatibility policy
 
-Causal4D contains stable contracts, registered evidence machinery, diagnostics, and
-fast-moving research prototypes. Importing every convenient top-level name made it
-unclear which interfaces downstream projects could rely on and forced even a simple
-package import to initialize unrelated research modules.
+Causal4D contains portable contracts, supported estimator operations, registered
+evidence machinery, diagnostics, and fast-moving research prototypes. The public
+API is split so artifact-only consumers do not need to import estimator
+implementations and so new symbols do not enter a broad compatibility promise by
+accident.
 
-The supported version-1 surface is explicit:
+## Recommended versioned namespaces
+
+### `causal4d.artifacts.v1`
+
+This is the artifact-only surface. It exports the content-addressed AIP contracts
+and the safe non-pickled codec:
 
 ```python
-from causal4d.api.v1 import (
+from causal4d.artifacts.v1 import (
     CounterfactualQuery,
+    FactualIntervention,
     PhysicalPosterior,
-    PrefixLikelihoodConfig,
+    TwinBelief,
+    load_contract,
+    save_contract,
+)
+```
+
+Use it in storage, transport, inspection, and provider-boundary code.
+
+### `causal4d.inference.v1`
+
+This is the estimator surface for the AIP pipeline:
+
+```python
+from causal4d.inference.v1 import (
+    abduct_factual_intervention,
     apply_counterfactual_operator,
     project_physical_posterior,
 )
 ```
 
-Only names listed in `causal4d.api.v1.__all__` are covered by the v1 compatibility
-promise. Existing imports such as `from causal4d import PhysicalPosterior` remain
-compatible, but new downstream code should prefer the versioned path.
+Use it when code performs factual abduction, applies a counterfactual action, or
+projects a physical posterior into a registered query.
 
-## Import behavior
+### `causal4d.api.v1`
 
-The unversioned package root retains its historical export inventory through lazy
-attribute loading. `import causal4d` now defines the version, export table, and lazy
-resolver without importing every experimental, protocol, semantic, or provider
-module. Accessing a historical export loads its owning module once and caches the
-exact object at the package root:
+The aggregate v1 surface remains supported for existing controlled-benchmark and
+integration code:
+
+```python
+from causal4d.api.v1 import (
+    CounterfactualBenchmarkConfig,
+    CounterfactualQuery,
+    PhysicalPosterior,
+    build_protocol,
+)
+```
+
+It is not removed or silently redirected. New AIP integrations should prefer the
+split artifact and inference namespaces because they make dependency direction
+and ownership explicit.
+
+Only names listed in the relevant namespace's `__all__` are covered by that
+version's compatibility promise.
+
+## Package-root compatibility
+
+Historical imports such as `from causal4d import PhysicalPosterior` remain
+compatible through lazy attribute loading. `import causal4d` defines the version,
+export table, and lazy resolver without importing every experimental, protocol,
+semantic, or provider module. Accessing a historical export loads its owning
+module once and caches the exact object at the package root:
 
 ```python
 import causal4d
@@ -36,35 +77,35 @@ posterior_type = causal4d.PhysicalPosterior
 ```
 
 This changes import cost, not object identity or public names. A wildcard import
-still resolves every name in `causal4d.__all__` and therefore deliberately loads the
-complete historical surface. Importing `causal4d.api.v1` loads the modules required
-by the supported API but not unrelated research families such as action-support,
-latent-contact-v2, semantic-freshness, or decision-trace machinery.
+still resolves every name in `causal4d.__all__` and therefore deliberately loads
+the complete historical surface. New public symbols must enter an owning module
+and a reviewed versioned namespace rather than being added to the package root by
+default.
 
-## What v1 contains
+## What the aggregate v1 surface contains
 
-The surface is deliberately conservative:
+`causal4d.api.v1` is deliberately conservative:
 
 - controlled benchmark protocol construction;
 - causal query and posterior contracts;
 - rollout-bank and prefix-likelihood interfaces;
-- the counterfactual operator and explicit physical-posterior query projection;
+- the counterfactual operator and explicit posterior projection;
 - hierarchical intervention abduction;
 - full-joint Gaussian observation contracts and updates;
-- explicit interventional-contrast query and posterior contracts; and
+- interventional-contrast query and posterior contracts; and
 - the versioned BayesianPhysTwin provider boundary.
 
 Registered acquisition internals, CLI implementations, paper-specific report
 builders, prospective promotion machinery, semantic branches, and experimental
-contact models remain in their owning modules. They can evolve without expanding a
-stable compatibility promise accidentally.
+contact models remain in their owning modules. They can evolve without expanding
+a stable compatibility promise accidentally.
 
 ## Counterfactual query projection
 
-A counterfactual rollout bank contains one factual intervention-endpoint frame and
-then exactly `query.horizon_frames` future frames. The dense counterfactual operator
-retains that endpoint for compatibility. Use the explicit projection helper for a
-query-facing artifact:
+A counterfactual rollout bank contains one factual intervention-endpoint frame
+and then exactly `query.horizon_frames` future frames. The dense counterfactual
+operator retains that endpoint for compatibility. Use the explicit projection
+helper for a query-facing artifact:
 
 ```python
 dense = apply_counterfactual_operator(
@@ -80,8 +121,8 @@ future = project_physical_posterior(dense, query)
 The default projection removes the endpoint and preserves the registered
 `query_node_indices` order. Set `include_endpoint=True` only when the endpoint is
 part of the intended output. The projected artifact retains component weights,
-causal ancestry, the source posterior identity, and the complete frame/node policy
-in its content-addressed metadata.
+causal ancestry, source-posterior identity, and the complete frame/node policy in
+its content-addressed metadata.
 
 ## Execution-only grouped batching
 
@@ -101,51 +142,41 @@ factual = abduct_factual_intervention(
 )
 ```
 
-`grouped_component_batch_size` is an execution-only memory bound. It is not written
-to scientific metadata, and the batched path is required to reproduce the dense
-posterior weights, diagnostics, and artifact identity exactly. The dense path
-remains the default. This research entry point is documented here for resource
-control but is not thereby added to the v1 compatibility surface.
+`grouped_component_batch_size` is an execution-only memory bound. It is not
+written to scientific metadata, and the batched path must reproduce dense
+posterior weights, diagnostics, and artifact identity exactly. This research
+entry point remains in its owning module rather than entering a versioned public
+namespace merely because it is documented.
 
-When the complete component-by-group responsibility matrix is unnecessary, the
-standalone streaming update keeps only per-group responsibility means and minima:
+## Compatibility rules
 
-```python
-from causal4d.grouped_likelihood_streaming import (
-    posterior_weights_from_grouped_evidence_batched,
-)
+Within one numbered namespace:
 
-posterior, summary = posterior_weights_from_grouped_evidence_batched(
-    prior_weights,
-    predicted_components_m,
-    evidence,
-    prefix_frame_count=prefix_frame_count,
-    component_batch_size=64,
-)
+- existing exported names retain their import path, meaning, and owning object;
+- signatures do not change incompatibly;
+- serialized contracts retain their schema and content-identity rules;
+- additions require explicit API review and regression coverage;
+- provider schemas remain governed by their own versioned contracts; and
+- removals or incompatible semantics require a new numbered namespace.
+
+The exact split-namespace `__all__` inventories are regression-tested. Re-exported
+functions and classes must be the same objects as those in their owning modules,
+not wrappers with subtly different behavior. A future v2 namespace may coexist
+with v1.
+
+Versioned Python compatibility does not override a frozen scientific protocol. A
+software-compatible implementation can still be inadmissible for a registered
+experiment when its commit, provider lock, configuration, or evidence boundary
+differs from the frozen method.
+
+## Executable example
+
+Run:
+
+```bash
+python -m causal4d.demo.aip --output-dir build/aip-demo
 ```
 
-The function traverses components in their existing row-major support order and
-reproduces the ordinary grouped posterior exactly. Its memory is bounded by one
-component batch plus the posterior-score vector and per-group accumulators. This
-research utility remains in its owning module rather than entering API v1.
-
-## Compatibility policy
-
-Within `causal4d.api.v1`:
-
-- existing names retain their import path and meaning;
-- additive names may be introduced when they are mature;
-- incompatible semantics require a new contract or API version;
-- provider schema changes remain governed by their own versioned contracts; and
-- deprecations should include a documented migration path before removal.
-
-A future `causal4d.api.v2` may coexist with v1. The unversioned top-level package is
-kept for backward compatibility and discovery, not as an automatic promise that
-every re-export is stable.
-
-## Checking the surface
-
-The repository locks the exact v1 inventory and verifies that each versioned symbol
-is the same object as its historical top-level counterpart. Subprocess import probes
-also lock the lazy root boundary and prevent unrelated research modules from
-silently re-entering the stable import path.
+The demonstration exercises both split namespaces, writes and reloads every
+contract, and checks the held-out-suffix causal cutoff. See
+[aip_end_to_end_demo.md](aip_end_to_end_demo.md).

--- a/tests/test_aip_public_api_demo.py
+++ b/tests/test_aip_public_api_demo.py
@@ -11,7 +11,38 @@ from causal4d.demo.aip import run_demo
 from causal4d.inference import v1 as inference_v1
 
 
-def test_artifact_api_v1_reexports_contract_identity() -> None:
+ARTIFACTS_V1_EXPORTS = (
+    "CONTRACT_VERSION",
+    "PUBLIC_API_NAME",
+    "PUBLIC_API_VERSION",
+    "ActionWindow",
+    "CausalContext",
+    "CounterfactualQuery",
+    "FactualIntervention",
+    "ObservationWindow",
+    "PhysicalPosterior",
+    "TaskPosterior",
+    "TwinBelief",
+    "array_sha256",
+    "build_causal_context",
+    "load_contract",
+    "save_contract",
+)
+INFERENCE_V1_EXPORTS = (
+    "PUBLIC_API_NAME",
+    "PUBLIC_API_VERSION",
+    "FactualAbductionConfig",
+    "HierarchicalAbductionResult",
+    "abduct_factual_intervention",
+    "abduct_hierarchical_interventions",
+    "apply_counterfactual_operator",
+    "factual_joint_weights",
+    "project_physical_posterior",
+)
+
+
+def test_artifact_api_v1_has_reviewed_exact_surface() -> None:
+    assert tuple(artifacts_v1.__all__) == ARTIFACTS_V1_EXPORTS
     assert artifacts_v1.PUBLIC_API_NAME == "causal4d.artifacts.v1"
     assert artifacts_v1.PUBLIC_API_VERSION == 1
     assert artifacts_v1.TwinBelief is contracts.TwinBelief
@@ -20,7 +51,8 @@ def test_artifact_api_v1_reexports_contract_identity() -> None:
     assert artifacts_v1.load_contract is contracts.load_contract
 
 
-def test_inference_api_v1_reexports_aip_operations() -> None:
+def test_inference_api_v1_has_reviewed_exact_surface() -> None:
+    assert tuple(inference_v1.__all__) == INFERENCE_V1_EXPORTS
     assert inference_v1.PUBLIC_API_NAME == "causal4d.inference.v1"
     assert inference_v1.PUBLIC_API_VERSION == 1
     assert (

--- a/tests/test_no_temporary_workflows.py
+++ b/tests/test_no_temporary_workflows.py
@@ -5,19 +5,28 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_DIRECTORY = ROOT / ".github" / "workflows"
+TEMPORARY_WORKFLOW_STEMS = (
+    "temporary-*",
+    "publish-reviewed-*",
+    "*one-shot*",
+    "*one_shot*",
+    "agent-apply-*",
+    "agent_apply_*",
+    "branch-advance-*",
+    "branch_advance_*",
+)
 
 
 def test_no_one_shot_workflow_can_reach_a_mergeable_head() -> None:
     one_shot = sorted(
-        path.relative_to(ROOT).as_posix()
-        for pattern in (
-            "temporary-*.yml",
-            "temporary-*.yaml",
-            "publish-reviewed-*.yml",
-            "publish-reviewed-*.yaml",
-        )
-        for path in WORKFLOW_DIRECTORY.glob(pattern)
+        {
+            path.relative_to(ROOT).as_posix()
+            for stem in TEMPORARY_WORKFLOW_STEMS
+            for suffix in (".yml", ".yaml")
+            for path in WORKFLOW_DIRECTORY.glob(f"{stem}{suffix}")
+        }
     )
     assert one_shot == [], (
-        f"one-shot workflows must delete themselves before review and merge: {one_shot}"
+        "temporary workflows must be removed before review and merge; "
+        f"use a reusable workflow plus immutable run inputs instead: {one_shot}"
     )


### PR DESCRIPTION
## Summary

- make the deterministic CPU-only AIP demonstration the primary README onboarding path
- document `causal4d.artifacts.v1` and `causal4d.inference.v1` as the preferred split integration namespaces while preserving `causal4d.api.v1` and package-root compatibility
- add a browsable documentation map and move the detailed physical-operator sequence out of the repository landing page into its existing versioned runbooks
- lock the exact split-namespace `__all__` inventories in regression tests
- broaden the existing temporary-workflow guard to reject one-shot, agent-apply, and branch-advance workflow naming families
- document why immutable inputs and receipts, rather than permanent one-shot YAML files, carry execution provenance

## Why

The repository already has a complete executable AIP path, but the landing page still led new users through the older aggregate API and duplicated a long evidence-bearing operator sequence. The repository also had a useful temporary-workflow guard whose filename coverage was narrower than the workflow conventions used during recent development.

This change makes the supported software path obvious without weakening any compatibility promise or registered scientific boundary.

## Impact

- no estimator, serialized contract, provider schema, registered protocol, target-access boundary, or scientific claim changes
- existing `causal4d.api.v1` and historical package-root imports remain supported
- new AIP integrations receive a clearer artifact/inference dependency split
- mergeable heads cannot accumulate additional one-shot workflow families under the covered conventions

## Validation

- modified Python tests compile locally
- exact API inventories are taken directly from the current `artifacts.v1` and `inference.v1` implementations
- all documentation links reuse existing repository paths except the new `docs/README.md`
- full repository validation is delegated to the exact-head PR workflows
