### PR TITLE
Enforce the one-way BayesianPhysTwin production path

### DIFF
--- a/docs/production_belief_path_v1.md
+++ b/docs/production_belief_path_v1.md
@@ -1,0 +1,74 @@
+# One-way production belief path v1
+
+## Canonical claim-bearing path
+
+The production scientific path is fixed as
+
+```text
+Prob4D observation artifact
+  -> BayesianPhysTwin candidate inference and guard
+  -> selected complete BayesianPhysTwin belief or exact baseline fallback
+  -> Causal4D factual abduction
+  -> explicit intervention
+  -> counterfactual prediction.
+```
+
+Prob4D owns observation means, identities, gauge/dependence structure,
+conditional and shared covariance, reliability, and causal source lineage.
+BayesianPhysTwin owns whether those observations change the physical belief.
+Causal4D consumes only the selected complete belief and the content-bound handoff
+receipt for claim-bearing inference.
+
+## Prohibited production shortcuts
+
+The supported `causal4d.inference.v1` path and the BayesianPhysTwin handoff
+modules must not import the external `prob4d` package or Causal4D's historical
+`causal4d.prob4d_*` adapters. Those modules remain available for artifact
+validation, compatibility studies, diagnostics, and frozen historical
+reproduction, but they are not an alternate claim-bearing inference route.
+
+In particular, Causal4D must not:
+
+- recover raw Prob4D factors after BayesianPhysTwin rejected the update;
+- independently recalibrate or reinterpret provider covariance to rescue a
+  rejected belief;
+- count a rejected observation as consumed evidence;
+- let a downstream counterfactual result retroactively establish provider
+  competence; or
+- combine fields from the candidate with fields from the exact fallback belief.
+
+## Exact fallback consequence
+
+For an all-fallback handoff, Causal4D retains the exact caller-owned baseline
+`TwinBelief` object and the prior evidence ledger. The receipt records zero
+accepted observation-evidence consumption and
+`raw_prob4d_reinterpreted=false`.
+
+For a mixed recursive stream, only accepted BayesianPhysTwin steps enter the
+Causal4D evidence ledger. Rejected steps remain explicit fallback events and do
+not contribute state-update evidence.
+
+## Executable policy
+
+`tests/test_bpt_belief_handoff_production_path_policy.py` parses the supported
+inference and handoff modules and fails if they import raw Prob4D packages or
+provider-specific adapters. It also locks the provider-neutral export surface
+of `causal4d.inference.v1` and the explicit no-reinterpretation receipt field.
+
+Existing behavioral tests remain authoritative for exact object identity,
+causal-prefix intervals, provider-manifest binding, duplicate-evidence
+rejection, recursive accepted-step accounting, and covariance-query handoff.
+
+Run the focused policy with:
+
+```bash
+pytest -q tests/test_bpt_belief_handoff_production_path_policy.py
+```
+
+## Scope boundary
+
+This policy establishes ownership and software routing only. It does not prove
+Prob4D provider competence, BayesianPhysTwin physical benefit, Causal4D
+counterfactual benefit, uncertainty calibration, deployment safety, or state of
+the art. Those remain separate empirical decisions on independently grouped
+physical evidence.

--- a/docs/stack_lock.md
+++ b/docs/stack_lock.md
@@ -6,6 +6,20 @@ portable release and CI artifact: it binds the three wheel contents to their
 reported package versions, exact tested source revisions, required provider
 modules, and the fixed `Prob4D -> BayesianPhysTwin -> Causal4D` pipeline.
 
+## Production-path ownership
+
+The arrow order is an ownership rule, not only an installation order. Prob4D
+publishes uncertainty-bearing observation artifacts; BayesianPhysTwin decides
+whether they change the complete physical belief; and Causal4D consumes only the
+selected BayesianPhysTwin belief and its handoff receipt for claim-bearing
+inference. Causal4D must not reopen raw Prob4D factors after a BayesianPhysTwin
+rejection or use a downstream result to rescue an upstream provider decision.
+
+The executable import and export policy is documented in
+[`production_belief_path_v1.md`](production_belief_path_v1.md). Historical
+Prob4D readers and adapters remain available for validation and frozen
+reproduction, but they are not a second supported production inference path.
+
 ## Create a lock
 
 Build all three wheels first, then provide one wheel and one exact 40-character

--- a/tests/test_bpt_belief_handoff_production_path_policy.py
+++ b/tests/test_bpt_belief_handoff_production_path_policy.py
@@ -77,13 +77,14 @@ def test_supported_inference_api_remains_provider_neutral() -> None:
 
 
 def test_handoff_contract_records_no_raw_prob4d_reinterpretation() -> None:
-    source = (
-        ROOT / "src/causal4d/bpt_belief_handoff.py"
-    ).read_text(encoding="utf-8")
+    source = (ROOT / "src/causal4d/bpt_belief_handoff.py").read_text(
+        encoding="utf-8"
+    )
     recursive_source = (
         ROOT / "src/causal4d/recursive_bpt_belief_handoff.py"
     ).read_text(encoding="utf-8")
+    normalized_source = " ".join(source.split())
 
     assert '"raw_prob4d_reinterpreted"' in source
     assert '"raw_prob4d_reinterpreted"' in recursive_source
-    assert "Raw Prob4D factors remain owned by BayesianPhysTwin" in source
+    assert "Raw Prob4D factors remain owned by BayesianPhysTwin" in normalized_source

--- a/tests/test_bpt_belief_handoff_production_path_policy.py
+++ b/tests/test_bpt_belief_handoff_production_path_policy.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PRODUCTION_MODULES = (
+    Path("src/causal4d/inference/v1.py"),
+    Path("src/causal4d/bpt_belief_handoff.py"),
+    Path("src/causal4d/recursive_bpt_belief_handoff.py"),
+    Path("src/causal4d/recursive_bpt_handoff_contract.py"),
+)
+
+
+def _imported_modules(path: Path) -> tuple[str, ...]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            imported.append(node.module)
+    return tuple(imported)
+
+
+def _exported_names(path: Path) -> tuple[str, ...]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "__all__"
+            for target in node.targets
+        ):
+            continue
+        if not isinstance(node.value, (ast.List, ast.Tuple)):
+            raise AssertionError("stable inference __all__ must be a literal sequence")
+        result: list[str] = []
+        for value in node.value.elts:
+            if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+                raise AssertionError("stable inference __all__ must contain strings")
+            result.append(value.value)
+        return tuple(result)
+    raise AssertionError("stable inference module has no literal __all__")
+
+
+def test_claim_bearing_production_modules_do_not_import_raw_prob4d() -> None:
+    violations: dict[str, list[str]] = {}
+    for relative in PRODUCTION_MODULES:
+        path = ROOT / relative
+        assert path.is_file(), f"missing production module: {relative}"
+        disallowed = [
+            module
+            for module in _imported_modules(path)
+            if module == "prob4d"
+            or module.startswith("prob4d.")
+            or module.startswith("causal4d.prob4d_")
+        ]
+        if disallowed:
+            violations[relative.as_posix()] = sorted(set(disallowed))
+
+    assert not violations, (
+        "claim-bearing Causal4D must consume the selected BayesianPhysTwin "
+        f"belief rather than raw Prob4D modules: {violations}"
+    )
+
+
+def test_supported_inference_api_remains_provider_neutral() -> None:
+    exports = _exported_names(ROOT / "src/causal4d/inference/v1.py")
+
+    assert "abduct_factual_intervention" in exports
+    assert "apply_counterfactual_operator" in exports
+    assert "project_physical_posterior" in exports
+    assert all("prob4d" not in name.lower() for name in exports)
+    assert all("provider" not in name.lower() for name in exports)
+
+
+def test_handoff_contract_records_no_raw_prob4d_reinterpretation() -> None:
+    source = (
+        ROOT / "src/causal4d/bpt_belief_handoff.py"
+    ).read_text(encoding="utf-8")
+    recursive_source = (
+        ROOT / "src/causal4d/recursive_bpt_belief_handoff.py"
+    ).read_text(encoding="utf-8")
+
+    assert '"raw_prob4d_reinterpreted"' in source
+    assert '"raw_prob4d_reinterpreted"' in recursive_source
+    assert "Raw Prob4D factors remain owned by BayesianPhysTwin" in source

--- a/tests/test_bpt_belief_handoff_production_path_policy.py
+++ b/tests/test_bpt_belief_handoff_production_path_policy.py
@@ -77,9 +77,7 @@ def test_supported_inference_api_remains_provider_neutral() -> None:
 
 
 def test_handoff_contract_records_no_raw_prob4d_reinterpretation() -> None:
-    source = (ROOT / "src/causal4d/bpt_belief_handoff.py").read_text(
-        encoding="utf-8"
-    )
+    source = (ROOT / "src/causal4d/bpt_belief_handoff.py").read_text(encoding="utf-8")
     recursive_source = (
         ROOT / "src/causal4d/recursive_bpt_belief_handoff.py"
     ).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- document the canonical `Prob4D -> BayesianPhysTwin -> Causal4D` ownership path
- clarify that claim-bearing Causal4D consumes only the selected complete BayesianPhysTwin belief and handoff receipt
- add an AST-based policy test that rejects direct external Prob4D or historical `causal4d.prob4d_*` imports from supported inference and handoff modules
- lock the provider-neutral export surface of `causal4d.inference.v1`
- require the explicit `raw_prob4d_reinterpreted` receipt field to remain present

## Why

The behavioral handoff already preserves exact fallback and accepted-step evidence accounting. This change makes that architecture harder to bypass accidentally by adding a repository-level import and export invariant rather than another inference implementation.

## Validation

GitHub Actions should run the focused policy test, existing BayesianPhysTwin handoff and recursive-handoff suites, full Python matrix, typing and lint checks, distribution tests, and the three-repository installed-wheel workflows on the exact branch head.

## Scientific boundary

This is an ownership and software-routing invariant. It does not establish Prob4D provider competence, BayesianPhysTwin physical benefit, Causal4D counterfactual benefit, uncertainty calibration, deployment safety, or state of the art.