### PR TITLE
Harden public API typing and document lifecycle

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,13 @@ a new software user is:
 4. [Abduction, intervention, and prediction](causal4d_abduction_intervention_prediction.md)
 5. [Command-line interface](command_line.md)
 
+Operational document status is declared in the machine-readable
+[lifecycle registry](lifecycle_registry.json) and checked in CI. `current`
+documents are the mutable operator references, `frozen` documents are
+byte-locked protocol records, and `superseded` documents remain available only
+for provenance and identify their successor. Do not infer operational status
+from a filename or search result alone.
+
 ## Concepts and contracts
 
 - [Causal model and identification](causal_model_and_identification.md)
@@ -41,12 +48,32 @@ The files in this section are operational and evidence-bearing. Use the exact
 version associated with the frozen experiment rather than copying commands into
 another document.
 
+### Active operator references
+
 - [Physical-experiment milestone](causal4d_real_experiment_milestone.md)
 - [Source-panel acquisition](causal4d_source_panel_acquisition.md)
 - [Pre-acquisition readiness](causal4d_preacquisition_readiness.md)
 - [Real-evidence status and accounting](causal4d_real_evidence_status.md)
 - [Acquisition environment capsule](causal4d_acquisition_environment_capsule.md)
 - [Acquisition flight recorder](causal4d_acquisition_flight_recorder.md)
+- [Pre-acquisition next-action derivation](causal4d_preacquisition_next_action.md)
+- [Next-action packet](causal4d_preacquisition_next_action_packet.md)
+- [Next-action validation](causal4d_preacquisition_next_action_validation.md)
+- [Self-hosted pre-acquisition automation](self_hosted_preacquisition_automation.md)
+
+### Frozen amendment lineage
+
+- [Pre-acquisition amendment v4](causal4d_preacquisition_v4.md) is the active,
+  byte-locked amendment.
+- [Pre-acquisition amendment v3](causal4d_preacquisition_v3.md) is superseded by
+  v4 and retained unchanged for provenance.
+- [Pre-acquisition amendment v2](causal4d_preacquisition_v2.md) is superseded by
+  v3 and retained unchanged for provenance.
+
+The lifecycle validator requires every active operational role to be unique and
+linked here. It also verifies the Git blob identities of frozen and superseded
+amendments and rejects an unregistered future `causal4d_preacquisition_v*.md`
+document.
 
 ## Governance and scope
 

--- a/docs/lifecycle_registry.json
+++ b/docs/lifecycle_registry.json
@@ -1,0 +1,151 @@
+{
+  "schema_version": 1,
+  "required_active_roles": [
+    "acquisition-environment",
+    "acquisition-flight-recorder",
+    "next-action",
+    "next-action-packet",
+    "next-action-validation",
+    "preacquisition-amendment",
+    "preacquisition-readiness",
+    "real-evidence-accounting",
+    "real-experiment-milestone",
+    "self-hosted-preacquisition-automation",
+    "source-panel-acquisition"
+  ],
+  "covered_path_patterns": [
+    "docs/causal4d_preacquisition_v*.md"
+  ],
+  "documents": [
+    {
+      "path": "docs/causal4d_acquisition_environment_capsule.md",
+      "title": "Acquisition environment capsule",
+      "kind": "runbook",
+      "status": "current",
+      "claim_bearing": true,
+      "operational_role": "acquisition-environment",
+      "successor": null,
+      "git_blob_sha1": null
+    },
+    {
+      "path": "docs/causal4d_acquisition_flight_recorder.md",
+      "title": "Acquisition flight recorder",
+      "kind": "runbook",
+      "status": "current",
+      "claim_bearing": true,
+      "operational_role": "acquisition-flight-recorder",
+      "successor": null,
+      "git_blob_sha1": null
+    },
+    {
+      "path": "docs/causal4d_preacquisition_next_action.md",
+      "title": "Pre-acquisition next-action derivation",
+      "kind": "contract",
+      "status": "current",
+      "claim_bearing": true,
+      "operational_role": "next-action",
+      "successor": null,
+      "git_blob_sha1": null
+    },
+    {
+      "path": "docs/causal4d_preacquisition_next_action_packet.md",
+      "title": "Pre-acquisition next-action packet",
+      "kind": "contract",
+      "status": "current",
+      "claim_bearing": true,
+      "operational_role": "next-action-packet",
+      "successor": null,
+      "git_blob_sha1": null
+    },
+    {
+      "path": "docs/causal4d_preacquisition_next_action_validation.md",
+      "title": "Pre-acquisition next-action validation",
+      "kind": "contract",
+      "status": "current",
+      "claim_bearing": true,
+      "operational_role": "next-action-validation",
+      "successor": null,
+      "git_blob_sha1": null
+    },
+    {
+      "path": "docs/causal4d_preacquisition_readiness.md",
+      "title": "Pre-acquisition readiness",
+      "kind": "runbook",
+      "status": "current",
+      "claim_bearing": true,
+      "operational_role": "preacquisition-readiness",
+      "successor": null,
+      "git_blob_sha1": null
+    },
+    {
+      "path": "docs/causal4d_preacquisition_v2.md",
+      "title": "Pre-acquisition amendment v2",
+      "kind": "protocol",
+      "status": "superseded",
+      "claim_bearing": true,
+      "operational_role": null,
+      "successor": "docs/causal4d_preacquisition_v3.md",
+      "git_blob_sha1": "193c08f9d86ccdb600d3b43ff93101faaeef36ed"
+    },
+    {
+      "path": "docs/causal4d_preacquisition_v3.md",
+      "title": "Pre-acquisition amendment v3",
+      "kind": "protocol",
+      "status": "superseded",
+      "claim_bearing": true,
+      "operational_role": null,
+      "successor": "docs/causal4d_preacquisition_v4.md",
+      "git_blob_sha1": "f7842c0dd99eb0c628e509f9f30afffaca697c92"
+    },
+    {
+      "path": "docs/causal4d_preacquisition_v4.md",
+      "title": "Pre-acquisition amendment v4",
+      "kind": "protocol",
+      "status": "frozen",
+      "claim_bearing": true,
+      "operational_role": "preacquisition-amendment",
+      "successor": null,
+      "git_blob_sha1": "9c35910925cf49c456e2a848ac8528792689472d"
+    },
+    {
+      "path": "docs/causal4d_real_evidence_status.md",
+      "title": "Real-evidence status and accounting",
+      "kind": "runbook",
+      "status": "current",
+      "claim_bearing": true,
+      "operational_role": "real-evidence-accounting",
+      "successor": null,
+      "git_blob_sha1": null
+    },
+    {
+      "path": "docs/causal4d_real_experiment_milestone.md",
+      "title": "Physical-experiment milestone",
+      "kind": "runbook",
+      "status": "current",
+      "claim_bearing": true,
+      "operational_role": "real-experiment-milestone",
+      "successor": null,
+      "git_blob_sha1": null
+    },
+    {
+      "path": "docs/causal4d_source_panel_acquisition.md",
+      "title": "Source-panel acquisition",
+      "kind": "runbook",
+      "status": "current",
+      "claim_bearing": true,
+      "operational_role": "source-panel-acquisition",
+      "successor": null,
+      "git_blob_sha1": null
+    },
+    {
+      "path": "docs/self_hosted_preacquisition_automation.md",
+      "title": "Self-hosted pre-acquisition automation",
+      "kind": "runbook",
+      "status": "current",
+      "claim_bearing": false,
+      "operational_role": "self-hosted-preacquisition-automation",
+      "successor": null,
+      "git_blob_sha1": null
+    }
+  ]
+}

--- a/docs/stable_core_typing.md
+++ b/docs/stable_core_typing.md
@@ -2,11 +2,12 @@
 
 ## Scope
 
-Causal4D applies an additive strict MyPy ratchet to the small reusable core that
+Causal4D applies an additive strict MyPy ratchet to the reusable surface that
 owns versioned artifacts, factual intervention abduction, grouped likelihoods,
-and the counterfactual operator. Historical diagnostics, acquisition tooling,
-and fast-moving research modules remain on the repository's incremental typing
-policy until they are promoted in separate reviewed tranches.
+counterfactual operators, atomic publication, provider admission, replay
+validation, and result-bundle verification. Historical diagnostics,
+acquisition tooling, and fast-moving research modules remain on the repository's
+incremental typing policy until they are promoted in separate reviewed tranches.
 
 The single source of truth is:
 
@@ -27,16 +28,30 @@ against exactly:
 
 ```text
 src/causal4d/api/v1.py
+src/causal4d/artifacts/v1.py
+src/causal4d/inference/v1.py
 src/causal4d/contracts.py
 src/causal4d/counterfactual.py
 src/causal4d/grouped_likelihood.py
 src/causal4d/intervention_abduction.py
 src/causal4d/observation_evidence.py
+src/causal4d/atomic_io.py
+src/causal4d/result_bundle_verification.py
+src/causal4d/result_bundle_publication.py
+src/causal4d/provider_contract.py
+src/causal4d/replay_provider_contract.py
 ```
 
 Both ordinary CI and the required merge gate invoke that same runner. The policy
 test locks the exact options, target inventory, command construction, and one
 workflow invocation per required workflow.
+
+The split `causal4d.artifacts.v1` and `causal4d.inference.v1` namespaces are part
+of the strict inventory so their deliberately narrow public exports cannot drift
+away from the typed implementations they expose. The publication and provider
+modules are included because they are fail-closed boundaries: an untyped change
+there can invalidate archive identity, exact fallback, provider admission, or
+installed-wheel provenance even when the numerical estimator is unchanged.
 
 ## Repair boundary
 

--- a/scripts/ci/run_stable_core_mypy.py
+++ b/scripts/ci/run_stable_core_mypy.py
@@ -17,11 +17,18 @@ STRICT_MYPY_OPTIONS: Final = (
 
 STABLE_CORE_TARGETS: Final = (
     "src/causal4d/api/v1.py",
+    "src/causal4d/artifacts/v1.py",
+    "src/causal4d/inference/v1.py",
     "src/causal4d/contracts.py",
     "src/causal4d/counterfactual.py",
     "src/causal4d/grouped_likelihood.py",
     "src/causal4d/intervention_abduction.py",
     "src/causal4d/observation_evidence.py",
+    "src/causal4d/atomic_io.py",
+    "src/causal4d/result_bundle_verification.py",
+    "src/causal4d/result_bundle_publication.py",
+    "src/causal4d/provider_contract.py",
+    "src/causal4d/replay_provider_contract.py",
 )
 
 

--- a/scripts/ci/validate_document_lifecycle.py
+++ b/scripts/ci/validate_document_lifecycle.py
@@ -15,9 +15,7 @@ from typing import Any, Final, cast
 ROOT: Final = Path(__file__).resolve().parents[2]
 DEFAULT_REGISTRY: Final = ROOT / "docs" / "lifecycle_registry.json"
 DEFAULT_INDEX: Final = ROOT / "docs" / "README.md"
-ALLOWED_STATUSES: Final = frozenset(
-    {"current", "frozen", "historical", "superseded"}
-)
+ALLOWED_STATUSES: Final = frozenset({"current", "frozen", "historical", "superseded"})
 ALLOWED_KINDS: Final = frozenset(
     {"archive", "concept", "contract", "protocol", "result", "runbook"}
 )
@@ -58,9 +56,7 @@ def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
 
 
 def _reject_nonfinite_constant(value: str) -> None:
-    raise ValueError(
-        f"document lifecycle registry contains non-finite value {value!r}"
-    )
+    raise ValueError(f"document lifecycle registry contains non-finite value {value!r}")
 
 
 def _load_registry(path: Path) -> Mapping[str, Any]:
@@ -133,8 +129,7 @@ def _resolve_document(root: Path, raw_path: str) -> Path:
     relative = Path(raw_path)
     if relative.is_absolute() or relative.as_posix() != raw_path:
         raise ValueError(
-            "document path must be a normalized relative POSIX path: "
-            f"{raw_path}"
+            f"document path must be a normalized relative POSIX path: {raw_path}"
         )
     if not relative.parts or relative.parts[0] != "docs" or ".." in relative.parts:
         raise ValueError(f"document path must stay below docs/: {raw_path}")
@@ -242,9 +237,7 @@ def validate_document_lifecycle(
         )
 
         path = _require_string(document["path"], label=f"documents[{position}].path")
-        title = _require_string(
-            document["title"], label=f"documents[{position}].title"
-        )
+        title = _require_string(document["title"], label=f"documents[{position}].title")
         kind = _require_string(document["kind"], label=f"documents[{position}].kind")
         status = _require_string(
             document["status"], label=f"documents[{position}].status"

--- a/scripts/ci/validate_document_lifecycle.py
+++ b/scripts/ci/validate_document_lifecycle.py
@@ -1,0 +1,424 @@
+"""Validate the lifecycle registry for operational Causal4D documentation."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final, cast
+
+
+ROOT: Final = Path(__file__).resolve().parents[2]
+DEFAULT_REGISTRY: Final = ROOT / "docs" / "lifecycle_registry.json"
+DEFAULT_INDEX: Final = ROOT / "docs" / "README.md"
+ALLOWED_STATUSES: Final = frozenset(
+    {"current", "frozen", "historical", "superseded"}
+)
+ALLOWED_KINDS: Final = frozenset(
+    {"archive", "concept", "contract", "protocol", "result", "runbook"}
+)
+ACTIVE_STATUSES: Final = frozenset({"current", "frozen"})
+IMMUTABLE_STATUSES: Final = frozenset({"frozen", "superseded"})
+HEX_40: Final = re.compile(r"[0-9a-f]{40}")
+TOP_LEVEL_FIELDS: Final = frozenset(
+    {
+        "schema_version",
+        "required_active_roles",
+        "covered_path_patterns",
+        "documents",
+    }
+)
+DOCUMENT_FIELDS: Final = frozenset(
+    {
+        "path",
+        "title",
+        "kind",
+        "status",
+        "claim_bearing",
+        "operational_role",
+        "successor",
+        "git_blob_sha1",
+    }
+)
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(
+                f"document lifecycle registry contains duplicate key {key!r}"
+            )
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_constant(value: str) -> None:
+    raise ValueError(
+        f"document lifecycle registry contains non-finite value {value!r}"
+    )
+
+
+def _load_registry(path: Path) -> Mapping[str, Any]:
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_nonfinite_constant,
+        )
+    except json.JSONDecodeError as error:
+        raise ValueError(
+            f"document lifecycle registry is not valid JSON: {path}"
+        ) from error
+    if not isinstance(payload, Mapping):
+        raise ValueError("document lifecycle registry must be a JSON object")
+    return cast(Mapping[str, Any], payload)
+
+
+def _require_exact_fields(
+    values: Mapping[str, Any],
+    *,
+    expected: frozenset[str],
+    label: str,
+) -> None:
+    actual = set(values)
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+    if missing or unexpected:
+        raise ValueError(
+            f"{label} fields do not match schema; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+
+
+def _require_string(value: Any, *, label: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{label} must be a nonempty string")
+    return value
+
+
+def _require_optional_string(value: Any, *, label: str) -> str | None:
+    if value is None:
+        return None
+    return _require_string(value, label=label)
+
+
+def _require_string_sequence(value: Any, *, label: str) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValueError(f"{label} must be a sequence of strings")
+    result = tuple(
+        _require_string(item, label=f"{label}[{index}]")
+        for index, item in enumerate(value)
+    )
+    if len(result) != len(set(result)):
+        raise ValueError(f"{label} must contain unique values")
+    if result != tuple(sorted(result)):
+        raise ValueError(f"{label} must be sorted")
+    return result
+
+
+def git_blob_sha1(path: Path) -> str:
+    """Return the Git blob identity of one ordinary file."""
+
+    data = path.read_bytes()
+    header = f"blob {len(data)}\0".encode("ascii")
+    return hashlib.sha1(header + data, usedforsecurity=False).hexdigest()
+
+
+def _resolve_document(root: Path, raw_path: str) -> Path:
+    relative = Path(raw_path)
+    if relative.is_absolute() or relative.as_posix() != raw_path:
+        raise ValueError(
+            "document path must be a normalized relative POSIX path: "
+            f"{raw_path}"
+        )
+    if not relative.parts or relative.parts[0] != "docs" or ".." in relative.parts:
+        raise ValueError(f"document path must stay below docs/: {raw_path}")
+    candidate = (root / relative).resolve()
+    if not candidate.is_relative_to(root):
+        raise ValueError(f"document path escapes repository root: {raw_path}")
+    if candidate.suffix != ".md" or not candidate.is_file():
+        raise ValueError(f"registered document does not exist as Markdown: {raw_path}")
+    return candidate
+
+
+def _validate_successor_chains(
+    documents: Mapping[str, Mapping[str, Any]],
+) -> None:
+    for start_path, start in documents.items():
+        if start["status"] != "superseded":
+            continue
+        seen: set[str] = set()
+        chain: list[str] = []
+        current_path = start_path
+        while documents[current_path]["status"] == "superseded":
+            if current_path in seen:
+                cycle = " -> ".join((*chain, current_path))
+                raise ValueError(
+                    f"superseded document successor cycle detected: {cycle}"
+                )
+            seen.add(current_path)
+            chain.append(current_path)
+            successor = documents[current_path]["successor"]
+            if successor not in documents:
+                raise ValueError(
+                    f"superseded document successor is not registered: "
+                    f"{current_path} -> {successor}"
+                )
+            current_path = cast(str, successor)
+        if documents[current_path]["status"] not in ACTIVE_STATUSES:
+            raise ValueError(
+                f"superseded document chain must terminate at an active document: "
+                f"{start_path} -> {current_path}"
+            )
+
+
+def validate_document_lifecycle(
+    *,
+    root: Path = ROOT,
+    registry_path: Path | None = None,
+    index_path: Path | None = None,
+) -> dict[str, int]:
+    """Validate lifecycle metadata, immutable identities, and index coverage."""
+
+    repository_root = root.resolve()
+    registry = (
+        registry_path.resolve()
+        if registry_path is not None
+        else repository_root / "docs" / "lifecycle_registry.json"
+    )
+    index = (
+        index_path.resolve()
+        if index_path is not None
+        else repository_root / "docs" / "README.md"
+    )
+    if not registry.is_file():
+        raise ValueError(f"document lifecycle registry does not exist: {registry}")
+    if not index.is_file():
+        raise ValueError(f"documentation index does not exist: {index}")
+
+    payload = _load_registry(registry)
+    if any(type(key) is not str for key in payload):
+        raise ValueError("document lifecycle registry keys must be strings")
+    _require_exact_fields(payload, expected=TOP_LEVEL_FIELDS, label="registry")
+    if payload["schema_version"] != 1:
+        raise ValueError("document lifecycle registry schema_version must equal 1")
+
+    required_roles = _require_string_sequence(
+        payload["required_active_roles"],
+        label="required_active_roles",
+    )
+    covered_patterns = _require_string_sequence(
+        payload["covered_path_patterns"],
+        label="covered_path_patterns",
+    )
+    raw_documents = payload["documents"]
+    if isinstance(raw_documents, (str, bytes)) or not isinstance(
+        raw_documents, Sequence
+    ):
+        raise ValueError("documents must be a sequence of objects")
+
+    normalized: dict[str, Mapping[str, Any]] = {}
+    paths: list[str] = []
+    active_roles: dict[str, str] = {}
+    index_text = index.read_text(encoding="utf-8")
+    if "(lifecycle_registry.json)" not in index_text:
+        raise ValueError("docs/README.md must link lifecycle_registry.json")
+
+    for position, raw_document in enumerate(raw_documents):
+        if not isinstance(raw_document, Mapping):
+            raise ValueError(f"documents[{position}] must be an object")
+        if any(type(key) is not str for key in raw_document):
+            raise ValueError(f"documents[{position}] keys must be strings")
+        document = cast(Mapping[str, Any], raw_document)
+        _require_exact_fields(
+            document,
+            expected=DOCUMENT_FIELDS,
+            label=f"documents[{position}]",
+        )
+
+        path = _require_string(document["path"], label=f"documents[{position}].path")
+        title = _require_string(
+            document["title"], label=f"documents[{position}].title"
+        )
+        kind = _require_string(document["kind"], label=f"documents[{position}].kind")
+        status = _require_string(
+            document["status"], label=f"documents[{position}].status"
+        )
+        role = _require_optional_string(
+            document["operational_role"],
+            label=f"documents[{position}].operational_role",
+        )
+        successor = _require_optional_string(
+            document["successor"],
+            label=f"documents[{position}].successor",
+        )
+        blob_sha = _require_optional_string(
+            document["git_blob_sha1"],
+            label=f"documents[{position}].git_blob_sha1",
+        )
+        if type(document["claim_bearing"]) is not bool:
+            raise ValueError(f"documents[{position}].claim_bearing must be boolean")
+        if kind not in ALLOWED_KINDS:
+            raise ValueError(f"unsupported document kind {kind!r}: {path}")
+        if status not in ALLOWED_STATUSES:
+            raise ValueError(f"unsupported document status {status!r}: {path}")
+        if path in normalized:
+            raise ValueError(f"document path is registered more than once: {path}")
+
+        file_path = _resolve_document(repository_root, path)
+        if status in IMMUTABLE_STATUSES:
+            if blob_sha is None or HEX_40.fullmatch(blob_sha) is None:
+                raise ValueError(
+                    f"immutable document requires a lowercase Git blob SHA-1: {path}"
+                )
+            actual_blob_sha = git_blob_sha1(file_path)
+            if actual_blob_sha != blob_sha:
+                raise ValueError(
+                    f"immutable document Git blob SHA-1 changed: "
+                    f"{path}; expected={blob_sha}, actual={actual_blob_sha}"
+                )
+        elif blob_sha is not None:
+            raise ValueError(
+                f"mutable document must not carry a frozen Git blob SHA-1: {path}"
+            )
+
+        if status == "superseded":
+            if successor is None:
+                raise ValueError(f"superseded document requires a successor: {path}")
+            if role is not None:
+                raise ValueError(
+                    f"superseded document must not retain an operational role: {path}"
+                )
+        elif successor is not None:
+            raise ValueError(
+                f"only superseded documents may declare a successor: {path}"
+            )
+
+        if status in ACTIVE_STATUSES:
+            if role is None:
+                raise ValueError(
+                    f"active document requires an operational role: {path}"
+                )
+            if role in active_roles:
+                raise ValueError(
+                    f"active operational role is ambiguous: {role!r}; "
+                    f"{active_roles[role]} and {path}"
+                )
+            active_roles[role] = path
+            relative_link = Path(path).relative_to("docs").as_posix()
+            if f"({relative_link})" not in index_text:
+                raise ValueError(
+                    f"active document is not linked from docs/README.md: {path}"
+                )
+        elif role is not None:
+            raise ValueError(
+                f"inactive document must not declare an operational role: {path}"
+            )
+
+        normalized[path] = {
+            "path": path,
+            "title": title,
+            "kind": kind,
+            "status": status,
+            "claim_bearing": document["claim_bearing"],
+            "operational_role": role,
+            "successor": successor,
+            "git_blob_sha1": blob_sha,
+        }
+        paths.append(path)
+
+    if paths != sorted(paths):
+        raise ValueError("documents must be sorted by path")
+    if set(required_roles) != set(active_roles):
+        missing = sorted(set(required_roles) - set(active_roles))
+        unexpected = sorted(set(active_roles) - set(required_roles))
+        raise ValueError(
+            "active operational roles do not match the registry contract; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+
+    _validate_successor_chains(normalized)
+
+    registered_paths = set(normalized)
+    for pattern in covered_patterns:
+        matches = sorted(
+            path.relative_to(repository_root).as_posix()
+            for path in repository_root.glob(pattern)
+            if path.is_file()
+        )
+        if not matches:
+            raise ValueError(f"covered_path_patterns entry matches no files: {pattern}")
+        unregistered = sorted(set(matches) - registered_paths)
+        if unregistered:
+            raise ValueError(
+                f"covered lifecycle documents are not registered for {pattern!r}: "
+                f"{unregistered}"
+            )
+
+    status_counts = {
+        status: sum(
+            1 for document in normalized.values() if document["status"] == status
+        )
+        for status in sorted(ALLOWED_STATUSES)
+    }
+    return {
+        "active_documents": sum(
+            count
+            for status, count in status_counts.items()
+            if status in ACTIVE_STATUSES
+        ),
+        "current_documents": status_counts["current"],
+        "frozen_documents": status_counts["frozen"],
+        "historical_documents": status_counts["historical"],
+        "registered_documents": len(normalized),
+        "superseded_documents": status_counts["superseded"],
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate the operational-document lifecycle registry."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=ROOT,
+        help="Repository root (default: detected checkout root).",
+    )
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        help="Registry path (default: <root>/docs/lifecycle_registry.json).",
+    )
+    parser.add_argument(
+        "--index",
+        type=Path,
+        help="Documentation index path (default: <root>/docs/README.md).",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Validate the registry and print a deterministic JSON summary."""
+
+    arguments = _build_parser().parse_args(argv)
+    try:
+        summary = validate_document_lifecycle(
+            root=arguments.root,
+            registry_path=arguments.registry,
+            index_path=arguments.index,
+        )
+    except (OSError, ValueError) as error:
+        print(f"document lifecycle validation failed: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_document_lifecycle_registry.py
+++ b/tests/test_document_lifecycle_registry.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.ci.validate_document_lifecycle import (
+    git_blob_sha1,
+    validate_document_lifecycle,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "docs" / "lifecycle_registry.json"
+
+
+def _write_registry(
+    root: Path,
+    *,
+    documents: list[dict[str, Any]],
+    required_active_roles: list[str] | None = None,
+    covered_path_patterns: list[str] | None = None,
+) -> Path:
+    registry = root / "docs" / "lifecycle_registry.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "required_active_roles": sorted(required_active_roles or []),
+                "covered_path_patterns": sorted(covered_path_patterns or []),
+                "documents": sorted(documents, key=lambda entry: entry["path"]),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry
+
+
+def _document(
+    path: str,
+    *,
+    title: str,
+    kind: str,
+    status: str,
+    operational_role: str | None,
+    successor: str | None = None,
+    git_blob_sha1_value: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "path": path,
+        "title": title,
+        "kind": kind,
+        "status": status,
+        "claim_bearing": True,
+        "operational_role": operational_role,
+        "successor": successor,
+        "git_blob_sha1": git_blob_sha1_value,
+    }
+
+
+def test_repository_document_lifecycle_registry_is_valid() -> None:
+    assert validate_document_lifecycle(root=ROOT, registry_path=REGISTRY) == {
+        "active_documents": 11,
+        "current_documents": 10,
+        "frozen_documents": 1,
+        "historical_documents": 0,
+        "registered_documents": 13,
+        "superseded_documents": 2,
+    }
+
+
+def test_unregistered_versioned_document_is_rejected(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "README.md").write_text(
+        "[registry](lifecycle_registry.json)\n[current](current.md)\n",
+        encoding="utf-8",
+    )
+    (docs / "current.md").write_text("current\n", encoding="utf-8")
+    (docs / "protocol_v2.md").write_text("unregistered\n", encoding="utf-8")
+    registry = _write_registry(
+        tmp_path,
+        documents=[
+            _document(
+                "docs/current.md",
+                title="Current",
+                kind="runbook",
+                status="current",
+                operational_role="current-runbook",
+            )
+        ],
+        required_active_roles=["current-runbook"],
+        covered_path_patterns=["docs/protocol_v*.md"],
+    )
+
+    with pytest.raises(ValueError, match="not registered"):
+        validate_document_lifecycle(root=tmp_path, registry_path=registry)
+
+
+def test_superseded_successor_cycle_is_rejected(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "README.md").write_text(
+        "[registry](lifecycle_registry.json)\n",
+        encoding="utf-8",
+    )
+    first = docs / "first.md"
+    second = docs / "second.md"
+    first.write_text("first\n", encoding="utf-8")
+    second.write_text("second\n", encoding="utf-8")
+    registry = _write_registry(
+        tmp_path,
+        documents=[
+            _document(
+                "docs/first.md",
+                title="First",
+                kind="protocol",
+                status="superseded",
+                operational_role=None,
+                successor="docs/second.md",
+                git_blob_sha1_value=git_blob_sha1(first),
+            ),
+            _document(
+                "docs/second.md",
+                title="Second",
+                kind="protocol",
+                status="superseded",
+                operational_role=None,
+                successor="docs/first.md",
+                git_blob_sha1_value=git_blob_sha1(second),
+            ),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="successor cycle"):
+        validate_document_lifecycle(root=tmp_path, registry_path=registry)
+
+
+def test_frozen_document_drift_is_rejected(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    frozen = docs / "frozen.md"
+    frozen.write_text("frozen\n", encoding="utf-8")
+    (docs / "README.md").write_text(
+        "[registry](lifecycle_registry.json)\n[frozen](frozen.md)\n",
+        encoding="utf-8",
+    )
+    registry = _write_registry(
+        tmp_path,
+        documents=[
+            _document(
+                "docs/frozen.md",
+                title="Frozen",
+                kind="protocol",
+                status="frozen",
+                operational_role="frozen-protocol",
+                git_blob_sha1_value=git_blob_sha1(frozen),
+            )
+        ],
+        required_active_roles=["frozen-protocol"],
+    )
+    frozen.write_text("changed\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Git blob SHA-1 changed"):
+        validate_document_lifecycle(root=tmp_path, registry_path=registry)
+
+
+def test_active_document_must_be_linked_from_index(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "README.md").write_text(
+        "[registry](lifecycle_registry.json)\n",
+        encoding="utf-8",
+    )
+    (docs / "current.md").write_text("current\n", encoding="utf-8")
+    registry = _write_registry(
+        tmp_path,
+        documents=[
+            _document(
+                "docs/current.md",
+                title="Current",
+                kind="runbook",
+                status="current",
+                operational_role="current-runbook",
+            )
+        ],
+        required_active_roles=["current-runbook"],
+    )
+
+    with pytest.raises(ValueError, match="not linked"):
+        validate_document_lifecycle(root=tmp_path, registry_path=registry)

--- a/tests/test_stable_core_typing_policy.py
+++ b/tests/test_stable_core_typing_policy.py
@@ -9,11 +9,18 @@ from scripts.ci.run_stable_core_mypy import (
 
 EXPECTED_TARGETS = (
     "src/causal4d/api/v1.py",
+    "src/causal4d/artifacts/v1.py",
+    "src/causal4d/inference/v1.py",
     "src/causal4d/contracts.py",
     "src/causal4d/counterfactual.py",
     "src/causal4d/grouped_likelihood.py",
     "src/causal4d/intervention_abduction.py",
     "src/causal4d/observation_evidence.py",
+    "src/causal4d/atomic_io.py",
+    "src/causal4d/result_bundle_verification.py",
+    "src/causal4d/result_bundle_publication.py",
+    "src/causal4d/provider_contract.py",
+    "src/causal4d/replay_provider_contract.py",
 )
 
 EXPECTED_OPTIONS = (


### PR DESCRIPTION
## Summary

- expand the existing strict MyPy ratchet to the split `causal4d.artifacts.v1` and `causal4d.inference.v1` public APIs plus atomic I/O, result-bundle verification/publication, and provider/replay admission boundaries;
- add `docs/lifecycle_registry.json` as the machine-readable source of truth for current, frozen, and superseded physical-experiment documents;
- add a fail-closed lifecycle validator that checks exact schema, sorted/unique identities, active-role uniqueness, documentation-index coverage, successor-chain termination, registered versioned documents, and Git blob identities for frozen/superseded amendments;
- document the active operator references and immutable v2 -> v3 -> v4 amendment lineage;
- add positive and adversarial tests for unregistered versioned documents, successor cycles, frozen-document drift, and missing active index links.

## Scientific and operational boundary

This PR changes no estimator, likelihood, physical support, protocol content, acquisition decision, target access, evidence count, or scientific claim. The existing v2, v3, and v4 amendment bytes are not modified; their current Git blob identities are recorded and enforced.

## Validation

Exact head: `c3b3389395ceabd41adfe1f2ff17d2f8c3116d29`

- **CI and release:** passed, including Ruff lint, changed-file Ruff formatting, the expanded strict MyPy boundary, Python 3.10/3.12/3.14 core suites, frozen milestone validation, deterministic bundle round trips, distribution builds, installed wheel/sdist CLI checks, and the pinned BayesianPhysTwin installed-wheel integration.
- **Extended compatibility:** passed, including Python 3.11/3.13 and exact declared dependency floors on Python 3.10.
- **Causal4D merge gate:** passed on the GitHub-generated merge result, including the complete default suite, distributions, and pinned BayesianPhysTwin integration.
- **Security scanning:** passed for CodeQL Python, CodeQL Actions, and the resolved-runtime dependency audit.

The only initial-head failure was Ruff line wrapping in the new lifecycle validator; commit `c3b3389` applies exactly those formatter changes without changing validation behavior.