### PR TITLE
Add target-free design sensitivity and exact factual-action binding

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,12 +31,14 @@ from a filename or search result alone.
 - [BayesianPhysTwin provider contract](bayesian_phystwin_provider.md)
 - [BayesianPhysTwin recursive provider contract](bayesian_phystwin_recursive_provider_contract.md)
 - [Belief handoff](bpt_belief_handoff.md)
+- [Action-bound factual abduction](bound_factual_abduction.md)
 - [Camera geometry contract](camera_geometry_contract.md)
 - [Migration from BayesianPhysTwin](migration_from_bayesian_phystwin.md)
 
 ## Reproduction and diagnostics
 
 - [Paper reproduction](paper_reproduction.md)
+- [Target-free real design sensitivity](causal4d_real_design_sensitivity.md)
 - [Controlled collaborator demonstration](controlled_collaborator_demo.md)
 - [Automation integrity](automation_integrity.md)
 - [Branch hygiene](branch_hygiene.md)

--- a/docs/bound_factual_abduction.md
+++ b/docs/bound_factual_abduction.md
@@ -1,0 +1,60 @@
+# Action-bound factual abduction
+
+## Motivation
+
+A factual rollout bank is meaningful only when every finite-support hypothesis
+represents the exact observed action `u_obs` recorded by the source
+`TwinBelief`. The historical factual-abduction implementation checks that each
+hypothesis is marked as factual, but its frozen compatibility surface does not
+add a new action-identity field to existing artifacts.
+
+`causal4d.bound_factual_abduction` provides an additive path for future
+claim-bearing studies. It validates the bank before scoring and records the
+binding in the resulting `FactualIntervention` metadata.
+
+## Validation
+
+`validate_factual_rollout_action_binding` requires every hypothesis to contain:
+
+- an action metadata mapping;
+- a nonempty `proposal_id` equal to `belief.context.u_obs.action_id`; and
+- the boolean `future_action_observed=true`.
+
+The returned binding records:
+
+- the complete rollout-bank content identity;
+- the source TwinBelief identity;
+- protocol and case identities;
+- the observed action ID, interval, and trajectory digest; and
+- the ordered action identity for every hypothesis.
+
+A relabelled bank, a counterfactual bank, malformed action metadata, or mixed
+action support fails before any likelihood is evaluated.
+
+## Usage
+
+```python
+from causal4d.bound_factual_abduction import (
+    abduct_factual_intervention_bound,
+)
+
+factual = abduct_factual_intervention_bound(
+    factual_bank,
+    twin_belief,
+    observations,
+    prefix_frame_count=6,
+)
+```
+
+For valid input, the wrapper calls the existing estimator with the supplied
+settings. Posterior weights and intervention support therefore match ordinary
+factual abduction; the artifact identity changes because the exact action and
+rollout-bank binding is now part of the metadata.
+
+## Compatibility and scientific boundary
+
+The historical path remains unchanged for frozen evidence and compatibility.
+This module does not modify the registered 36-execution estimator, open target
+outcomes, establish action correctness, or create physical evidence. New studies
+that use this path must still bind the actual action trajectory and rollout
+producer through their protocol and environment artifacts.

--- a/docs/causal4d_real_design_sensitivity.md
+++ b/docs/causal4d_real_design_sensitivity.md
@@ -1,0 +1,82 @@
+# Target-free real-experiment design sensitivity
+
+## Purpose
+
+`causal4d.real_design_sensitivity` evaluates the operating characteristics of
+the already registered real-effect interval rule before target outcomes are
+opened. The independent unit is one complete physical session. Frames, nodes,
+coordinates, camera views, and posterior components are never counted as
+independent replicates.
+
+The audit calls the exact production functions from
+`causal4d.real_analysis_intervals`:
+
+1. the session bootstrap-t interval is primary;
+2. the Student-t mean interval is the required robustness interval;
+3. both lower bounds must be strictly positive for a positive claim;
+4. the Student-t interval may veto but cannot rescue the primary interval; and
+5. a degenerate or non-estimable panel fails closed.
+
+It does not read physical data, choose a new threshold, change the frozen
+36-execution method, or authorize target access.
+
+## Default sensitivity panel
+
+The default run evaluates sample counts 18, 15, and 12 to expose precision loss
+from smaller endpoints or preregistered exclusions. Mean effects are expressed
+in assumed between-session standard-deviation units. Five zero-mean session
+models are included:
+
+- Gaussian effects;
+- variance-standardized Student-t effects with five degrees of freedom;
+- a variance-standardized 10% contaminated Gaussian mixture;
+- a centered, variance-standardized skewed lognormal distribution; and
+- one adverse session per panel, with a mean-preserving offset.
+
+For every scenario and sample count, the report records:
+
+- the null positive-gate rate;
+- the rate of estimable, nondegenerate panels;
+- median and 90th-percentile primary interval width;
+- positive-gate probability across the fixed effect grid;
+- Monte Carlo standard errors;
+- the probability that at least one session is nonpositive; and
+- the first tested effect reaching the declared target power, when any does.
+
+The final quantity is a grid result, not an interpolated minimum detectable
+effect.
+
+## Running the audit
+
+Run the deterministic default audit from an installed package or checkout:
+
+```bash
+python -m causal4d.real_design_sensitivity \
+  --output-json build/causal4d-real-design-sensitivity.json
+```
+
+A smaller smoke run can reduce only the Monte Carlo budgets:
+
+```bash
+python -m causal4d.real_design_sensitivity \
+  --simulation-replicates 100 \
+  --bootstrap-replicates 500 \
+  --output-json build/causal4d-real-design-sensitivity-smoke.json
+```
+
+Custom sample counts, scenarios, effect grids, and target power are available
+through `RealDesignSensitivityConfig` in Python. The JSON output is finite,
+key-sorted, content-addressed, and published without overwrite unless
+`--overwrite` is supplied.
+
+## Interpretation boundary
+
+The report supports statements about expected precision under declared
+session-level distributions. It cannot establish the real effect, empirical
+coverage, physical benefit, or an admissible new threshold. A low predicted
+probability of passing the positive gate does not authorize inspecting target
+outcomes early or changing the registered method.
+
+For the frozen experiment, archive the chosen target-free report with the final
+method freeze and software environment. Do not rerun it with target-informed
+assumptions after acquisition begins.

--- a/src/causal4d/bound_factual_abduction.py
+++ b/src/causal4d/bound_factual_abduction.py
@@ -1,0 +1,141 @@
+"""Action-bound factual abduction for future claim-bearing integrations.
+
+The historical factual-abduction path is preserved for frozen compatibility.
+This additive wrapper binds the finite rollout bank to the exact observed action
+identity before evaluating evidence and records that binding in the resulting
+artifact metadata.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Literal
+
+import numpy as np
+
+from causal4d.contracts import FactualIntervention, TwinBelief
+from causal4d.factual_abduction_uncertainty import FactualAbductionUncertaintyV1
+from causal4d.identifiability import InterventionIdentifiabilityResult
+from causal4d.intervention_abduction import (
+    FactualAbductionConfig,
+    abduct_factual_intervention,
+)
+from causal4d.observation_evidence import GroupedObservationEvidence
+from causal4d.rollout_bank import JointRolloutBank
+
+
+IdentifiabilityPolicy = Literal["full_parameter", "registered_query"]
+ACTION_BINDING_SCHEMA_NAME = "causal4d.factual-rollout-action-binding"
+ACTION_BINDING_SCHEMA_VERSION = 1
+
+
+def validate_factual_rollout_action_binding(
+    bank: JointRolloutBank,
+    belief: TwinBelief,
+) -> dict[str, Any]:
+    """Require every factual hypothesis to represent the exact observed action."""
+
+    expected_action_id = belief.context.u_obs.action_id
+    observed_ids: list[str] = []
+    for index, metadata in enumerate(bank.hypothesis_metadata):
+        action = metadata.get("action")
+        if not isinstance(action, Mapping):
+            raise ValueError(f"hypothesis {index} has no action metadata mapping")
+        proposal_id = action.get("proposal_id")
+        if type(proposal_id) is not str or not proposal_id:
+            raise ValueError(
+                f"hypothesis {index} action proposal_id must be a nonempty string"
+            )
+        future_action_observed = action.get("future_action_observed")
+        if type(future_action_observed) is not bool:
+            raise ValueError(
+                f"hypothesis {index} future_action_observed must be boolean"
+            )
+        if not future_action_observed:
+            raise ValueError(
+                f"hypothesis {index} does not represent the factual observed action"
+            )
+        if proposal_id != expected_action_id:
+            raise ValueError(
+                "factual rollout action identity differs from TwinBelief u_obs: "
+                f"expected {expected_action_id!r}, observed {proposal_id!r}"
+            )
+        observed_ids.append(proposal_id)
+
+    return {
+        "schema_name": ACTION_BINDING_SCHEMA_NAME,
+        "schema_version": ACTION_BINDING_SCHEMA_VERSION,
+        "rollout_bank_id": bank.artifact_id,
+        "source_twin_belief_id": belief.artifact_id,
+        "protocol_id": belief.context.protocol_id,
+        "case_id": belief.context.case_id,
+        "observed_action_id": expected_action_id,
+        "observed_action_trajectory_sha256": (
+            belief.context.u_obs.trajectory_sha256
+        ),
+        "observed_action_frame_start": belief.context.u_obs.frame_start,
+        "observed_action_frame_stop": belief.context.u_obs.frame_stop,
+        "hypothesis_count": len(bank.hypothesis_ids),
+        "hypothesis_action_ids": observed_ids,
+        "all_hypotheses_marked_factual": True,
+    }
+
+
+def abduct_factual_intervention_bound(
+    bank: JointRolloutBank,
+    belief: TwinBelief,
+    observations_from_endpoint_m: np.ndarray,
+    *,
+    prefix_frame_count: int,
+    observation_mask: np.ndarray | None = None,
+    config: FactualAbductionConfig | None = None,
+    grouped_evidence: GroupedObservationEvidence | None = None,
+    identifiability: InterventionIdentifiabilityResult | None = None,
+    abstain_when_unidentifiable: bool = False,
+    identifiability_policy: IdentifiabilityPolicy = "full_parameter",
+    abduction_uncertainty: FactualAbductionUncertaintyV1 | None = None,
+    dense_component_batch_size: int | None = None,
+    grouped_component_batch_size: int | None = None,
+) -> FactualIntervention:
+    """Run factual abduction after exact observed-action identity validation."""
+
+    binding = validate_factual_rollout_action_binding(bank, belief)
+    factual = abduct_factual_intervention(
+        bank,
+        belief,
+        observations_from_endpoint_m,
+        prefix_frame_count=prefix_frame_count,
+        observation_mask=observation_mask,
+        config=config,
+        grouped_evidence=grouped_evidence,
+        identifiability=identifiability,
+        abstain_when_unidentifiable=abstain_when_unidentifiable,
+        identifiability_policy=identifiability_policy,
+        abduction_uncertainty=abduction_uncertainty,
+        dense_component_batch_size=dense_component_batch_size,
+        grouped_component_batch_size=grouped_component_batch_size,
+    )
+    metadata = dict(factual.metadata)
+    metadata["factual_rollout_action_binding"] = binding
+    return FactualIntervention(
+        context=factual.context,
+        component_ids=factual.component_ids,
+        phi_names=factual.phi_names,
+        kappa_names=factual.kappa_names,
+        phi=factual.phi,
+        kappa_obs=factual.kappa_obs,
+        hypothesis_indices=factual.hypothesis_indices,
+        twin_particle_indices=factual.twin_particle_indices,
+        weights=factual.weights,
+        evidence_frame_stop=factual.evidence_frame_stop,
+        source_twin_belief_id=factual.source_twin_belief_id,
+        metadata=metadata,
+    )
+
+
+__all__ = [
+    "ACTION_BINDING_SCHEMA_NAME",
+    "ACTION_BINDING_SCHEMA_VERSION",
+    "abduct_factual_intervention_bound",
+    "validate_factual_rollout_action_binding",
+]

--- a/src/causal4d/bound_factual_abduction.py
+++ b/src/causal4d/bound_factual_abduction.py
@@ -70,9 +70,7 @@ def validate_factual_rollout_action_binding(
         "protocol_id": belief.context.protocol_id,
         "case_id": belief.context.case_id,
         "observed_action_id": expected_action_id,
-        "observed_action_trajectory_sha256": (
-            belief.context.u_obs.trajectory_sha256
-        ),
+        "observed_action_trajectory_sha256": (belief.context.u_obs.trajectory_sha256),
         "observed_action_frame_start": belief.context.u_obs.frame_start,
         "observed_action_frame_stop": belief.context.u_obs.frame_stop,
         "hypothesis_count": len(bank.hypothesis_ids),

--- a/src/causal4d/real_design_sensitivity.py
+++ b/src/causal4d/real_design_sensitivity.py
@@ -268,9 +268,7 @@ def _one_result(
         "sample_count": sample_count,
         "scenario_definition": definition,
         "eligible_panel_rate": float(np.mean(eligible)),
-        "null_positive_gate_rate": effect_rows[0][
-            "registered_positive_gate_pass_rate"
-        ],
+        "null_positive_gate_rate": effect_rows[0]["registered_positive_gate_pass_rate"],
         "primary_interval_width_sd": width_summary,
         "effect_grid": effect_rows,
         "minimum_detectable_grid_effect_at_target_power": detectable,

--- a/src/causal4d/real_design_sensitivity.py
+++ b/src/causal4d/real_design_sensitivity.py
@@ -1,0 +1,378 @@
+"""Target-free sensitivity analysis for the registered real-effect interval gate."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Literal, cast
+
+import numpy as np
+
+from causal4d.atomic_io import atomic_write_json
+from causal4d.real_analysis_intervals import (
+    REAL_EFFECT_CONFIDENCE_LEVEL,
+    bootstrap_t_mean_interval,
+    registered_positive_effect_interval_decision,
+    student_t_mean_interval,
+)
+
+SCHEMA_NAME = "causal4d.real-design-sensitivity"
+SCHEMA_VERSION = 1
+DEFAULT_SEED = 20_260_819
+Scenario = Literal[
+    "normal",
+    "student_t_5",
+    "contaminated_normal",
+    "centered_lognormal",
+    "one_adverse_session",
+]
+SCENARIOS: tuple[Scenario, ...] = (
+    "normal",
+    "student_t_5",
+    "contaminated_normal",
+    "centered_lognormal",
+    "one_adverse_session",
+)
+
+
+@dataclass(frozen=True)
+class RealDesignSensitivityConfig:
+    """Settings for one deterministic, target-free operating-characteristic run."""
+
+    sample_counts: tuple[int, ...] = (18, 15, 12)
+    standardized_effects: tuple[float, ...] = (0.0, 0.25, 0.5, 0.75, 1.0, 1.25)
+    scenarios: tuple[Scenario, ...] = SCENARIOS
+    simulation_replicates: int = 500
+    bootstrap_replicates: int = 1_000
+    seed: int = DEFAULT_SEED
+    target_power: float = 0.80
+    adverse_session_shift_sd: float = 3.0
+
+    def __post_init__(self) -> None:
+        if not self.sample_counts or any(
+            type(value) is not int or value < 2 for value in self.sample_counts
+        ):
+            raise ValueError("sample_counts must contain integers >= 2")
+        if len(set(self.sample_counts)) != len(self.sample_counts):
+            raise ValueError("sample_counts must not contain duplicates")
+        effects = tuple(float(value) for value in self.standardized_effects)
+        if (
+            not effects
+            or not np.all(np.isfinite(effects))
+            or effects[0] != 0.0
+            or any(right <= left for left, right in zip(effects, effects[1:]))
+        ):
+            raise ValueError(
+                "standardized_effects must start at zero and be strictly increasing"
+            )
+        if any(value < 0.0 for value in effects):
+            raise ValueError("standardized_effects must be nonnegative")
+        if not self.scenarios:
+            raise ValueError("scenarios must be nonempty")
+        if any(value not in SCENARIOS for value in self.scenarios):
+            raise ValueError("unsupported design-sensitivity scenario")
+        if len(set(self.scenarios)) != len(self.scenarios):
+            raise ValueError("scenarios must not contain duplicates")
+        for name in ("simulation_replicates", "bootstrap_replicates"):
+            value = getattr(self, name)
+            if type(value) is not int or value < 1:
+                raise ValueError(f"{name} must be a positive integer")
+        if type(self.seed) is not int:
+            raise ValueError("seed must be an integer")
+        if not np.isfinite(self.target_power) or not 0.0 < self.target_power < 1.0:
+            raise ValueError("target_power must lie in (0, 1)")
+        if (
+            not np.isfinite(self.adverse_session_shift_sd)
+            or self.adverse_session_shift_sd <= 0.0
+        ):
+            raise ValueError("adverse_session_shift_sd must be finite and positive")
+        object.__setattr__(self, "standardized_effects", effects)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "sample_counts": list(self.sample_counts),
+            "standardized_effects": list(self.standardized_effects),
+            "scenarios": list(self.scenarios),
+            "simulation_replicates": self.simulation_replicates,
+            "bootstrap_replicates": self.bootstrap_replicates,
+            "confidence_level": REAL_EFFECT_CONFIDENCE_LEVEL,
+            "seed": self.seed,
+            "target_power": self.target_power,
+            "adverse_session_shift_sd": self.adverse_session_shift_sd,
+        }
+
+
+def _seed(*parts: object) -> int:
+    payload = json.dumps(parts, separators=(",", ":"), allow_nan=False).encode()
+    return int.from_bytes(hashlib.sha256(payload).digest()[:8], "big")
+
+
+def _panels(
+    scenario: Scenario,
+    sample_count: int,
+    config: RealDesignSensitivityConfig,
+) -> tuple[np.ndarray, dict[str, Any]]:
+    rng = np.random.default_rng(_seed(config.seed, scenario, sample_count, "panels"))
+    shape = (config.simulation_replicates, sample_count)
+    if scenario == "normal":
+        return rng.normal(size=shape), {"distribution": "normal"}
+    if scenario == "student_t_5":
+        scale = np.sqrt(3.0 / 5.0)
+        return rng.standard_t(5.0, size=shape) * scale, {
+            "distribution": "student_t",
+            "degrees_of_freedom": 5,
+            "variance_standardized": True,
+        }
+    if scenario == "contaminated_normal":
+        contaminated = rng.random(size=shape) < 0.10
+        raw = rng.normal(size=shape) * np.where(contaminated, 4.0, 1.0)
+        return raw / np.sqrt(2.5), {
+            "distribution": "contaminated_normal",
+            "contamination_probability": 0.10,
+            "contamination_scale": 4.0,
+            "variance_standardized": True,
+        }
+    if scenario == "centered_lognormal":
+        sigma = 0.75
+        raw = np.exp(rng.normal(scale=sigma, size=shape))
+        mean = np.exp(0.5 * sigma**2)
+        variance = (np.exp(sigma**2) - 1.0) * np.exp(sigma**2)
+        return (raw - mean) / np.sqrt(variance), {
+            "distribution": "centered_lognormal",
+            "log_sigma": sigma,
+            "variance_standardized": True,
+        }
+    panels = rng.normal(size=shape)
+    rows = np.arange(config.simulation_replicates)
+    columns = rng.integers(0, sample_count, size=config.simulation_replicates)
+    panels += config.adverse_session_shift_sd / sample_count
+    panels[rows, columns] -= config.adverse_session_shift_sd
+    return panels, {
+        "distribution": "one_adverse_session",
+        "adverse_session_shift_sd": config.adverse_session_shift_sd,
+        "panel_mean_preserved": True,
+    }
+
+
+def evaluate_registered_interval_panel(
+    values: Sequence[float],
+    *,
+    bootstrap_replicates: int,
+    seed: int,
+) -> dict[str, Any]:
+    """Evaluate one session panel with the unchanged registered interval rule."""
+
+    primary = bootstrap_t_mean_interval(
+        values,
+        confidence_level=REAL_EFFECT_CONFIDENCE_LEVEL,
+        replicates=bootstrap_replicates,
+        seed=seed,
+    )
+    robustness = student_t_mean_interval(
+        values,
+        confidence_level=REAL_EFFECT_CONFIDENCE_LEVEL,
+    )
+    return {
+        "primary": primary,
+        "robustness": robustness,
+        "decision": registered_positive_effect_interval_decision(
+            primary,
+            robustness,
+        ),
+    }
+
+
+def _finite(interval: Mapping[str, Any], key: str) -> float | None:
+    value = interval.get(key)
+    if type(value) not in {int, float} or not np.isfinite(float(value)):
+        return None
+    return float(value)
+
+
+def _one_result(
+    scenario: Scenario,
+    sample_count: int,
+    config: RealDesignSensitivityConfig,
+) -> dict[str, Any]:
+    panels, definition = _panels(scenario, sample_count, config)
+    lower_primary = np.full(config.simulation_replicates, np.nan)
+    lower_robustness = np.full(config.simulation_replicates, np.nan)
+    widths = np.full(config.simulation_replicates, np.nan)
+    eligible = np.zeros(config.simulation_replicates, dtype=bool)
+    for index, panel in enumerate(panels):
+        evaluated = evaluate_registered_interval_panel(
+            panel,
+            bootstrap_replicates=config.bootstrap_replicates,
+            seed=_seed(config.seed, scenario, sample_count, index),
+        )
+        primary = cast(Mapping[str, Any], evaluated["primary"])
+        robustness = cast(Mapping[str, Any], evaluated["robustness"])
+        decision = cast(Mapping[str, Any], evaluated["decision"])
+        p_lower = _finite(primary, "lower")
+        r_lower = _finite(robustness, "lower")
+        p_upper = _finite(primary, "upper")
+        if p_lower is not None:
+            lower_primary[index] = p_lower
+        if r_lower is not None:
+            lower_robustness[index] = r_lower
+        if p_lower is not None and p_upper is not None:
+            widths[index] = p_upper - p_lower
+        eligible[index] = (
+            primary.get("estimable") is True
+            and robustness.get("estimable") is True
+            and decision.get("degenerate_session_panel") is not True
+        )
+    effect_rows = []
+    for effect in config.standardized_effects:
+        passed = (
+            eligible
+            & (lower_primary + effect > 0.0)
+            & (lower_robustness + effect > 0.0)
+        )
+        rate = float(np.mean(passed))
+        effect_rows.append(
+            {
+                "standardized_effect": effect,
+                "registered_positive_gate_pass_rate": rate,
+                "monte_carlo_standard_error": float(
+                    np.sqrt(rate * (1.0 - rate) / len(passed))
+                ),
+                "probability_any_session_nonpositive": float(
+                    np.mean(np.any(panels + effect <= 0.0, axis=1))
+                ),
+            }
+        )
+    detectable = next(
+        (
+            row["standardized_effect"]
+            for row in effect_rows
+            if row["registered_positive_gate_pass_rate"] >= config.target_power
+        ),
+        None,
+    )
+    finite_widths = widths[np.isfinite(widths)]
+    width_summary: dict[str, float | None]
+    if len(finite_widths):
+        width_summary = {
+            "median": float(np.median(finite_widths)),
+            "p90": float(np.quantile(finite_widths, 0.90)),
+        }
+    else:
+        width_summary = {"median": None, "p90": None}
+    return {
+        "scenario": scenario,
+        "sample_count": sample_count,
+        "scenario_definition": definition,
+        "eligible_panel_rate": float(np.mean(eligible)),
+        "null_positive_gate_rate": effect_rows[0][
+            "registered_positive_gate_pass_rate"
+        ],
+        "primary_interval_width_sd": width_summary,
+        "effect_grid": effect_rows,
+        "minimum_detectable_grid_effect_at_target_power": detectable,
+    }
+
+
+def _artifact_id(payload: Mapping[str, Any]) -> str:
+    data = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode()
+    return hashlib.sha256(data).hexdigest()
+
+
+def build_real_design_sensitivity_report(
+    config: RealDesignSensitivityConfig | None = None,
+) -> dict[str, Any]:
+    """Build a content-addressed target-free operating-characteristic report."""
+
+    settings = config or RealDesignSensitivityConfig()
+    payload: dict[str, Any] = {
+        "schema_name": SCHEMA_NAME,
+        "schema_version": SCHEMA_VERSION,
+        "config": settings.as_dict(),
+        "independent_unit": "complete physical session",
+        "registered_interval_rule": {
+            "primary": "target_session_bootstrap_t",
+            "required_veto": "student_t_mean",
+            "confidence_level": REAL_EFFECT_CONFIDENCE_LEVEL,
+        },
+        "results": [
+            _one_result(scenario, sample_count, settings)
+            for scenario in settings.scenarios
+            for sample_count in settings.sample_counts
+        ],
+        "scientific_boundary": {
+            "target_outcomes_accessed": False,
+            "physical_data_accessed": False,
+            "changes_registered_protocol": False,
+            "changes_estimator": False,
+            "changes_thresholds": False,
+            "physical_evidence_increment": 0,
+            "scientific_claim_established": False,
+        },
+    }
+    return {**payload, "artifact_id": _artifact_id(payload)}
+
+
+def save_real_design_sensitivity_report(
+    path: str | Path,
+    report: Mapping[str, Any],
+    *,
+    overwrite: bool = False,
+) -> None:
+    payload = dict(report)
+    supplied = payload.pop("artifact_id", None)
+    if type(supplied) is not str or supplied != _artifact_id(payload):
+        raise ValueError("real design-sensitivity artifact_id is missing or stale")
+    atomic_write_json(path, dict(report), overwrite=overwrite)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=Path("build/causal4d-real-design-sensitivity.json"),
+    )
+    parser.add_argument("--simulation-replicates", type=int, default=500)
+    parser.add_argument("--bootstrap-replicates", type=int, default=1_000)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--overwrite", action="store_true")
+    arguments = parser.parse_args(argv)
+    report = build_real_design_sensitivity_report(
+        RealDesignSensitivityConfig(
+            simulation_replicates=arguments.simulation_replicates,
+            bootstrap_replicates=arguments.bootstrap_replicates,
+            seed=arguments.seed,
+        )
+    )
+    save_real_design_sensitivity_report(
+        arguments.output_json,
+        report,
+        overwrite=arguments.overwrite,
+    )
+    print(json.dumps({"artifact_id": report["artifact_id"]}, sort_keys=True))
+    return 0
+
+
+__all__ = [
+    "DEFAULT_SEED",
+    "SCENARIOS",
+    "SCHEMA_NAME",
+    "SCHEMA_VERSION",
+    "RealDesignSensitivityConfig",
+    "build_real_design_sensitivity_report",
+    "evaluate_registered_interval_panel",
+    "save_real_design_sensitivity_report",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bound_factual_abduction.py
+++ b/tests/test_bound_factual_abduction.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from causal4d.bound_factual_abduction import (
+    abduct_factual_intervention_bound,
+    validate_factual_rollout_action_binding,
+)
+from causal4d.contracts import TwinBelief, build_causal_context
+from causal4d.intervention_abduction import abduct_factual_intervention
+from causal4d.rollout_bank import JointRolloutBank
+
+
+def _problem(*, proposal_id: str = "observed-pull", factual: bool = True):
+    frame_count = 6
+    trajectories = np.zeros((2, 1, frame_count, 1, 3), dtype=float)
+    trajectories[1, 0, :, 0, 0] = np.arange(frame_count) * 0.01
+
+    def metadata(identifier: str, gain: float) -> dict[str, object]:
+        return {
+            "hypothesis_id": identifier,
+            "action": {
+                "proposal_id": proposal_id,
+                "future_action_observed": factual,
+                "provenance": "unit factual action",
+            },
+            "contact": {
+                "attachment_shifts": [0],
+                "gain_multiplier": gain,
+                "delay_steps": 0,
+                "slip_fraction": 0.0,
+                "rotation_degrees": 0.0,
+            },
+        }
+
+    bank = JointRolloutBank(
+        hypothesis_ids=("nominal", "high-gain"),
+        hypothesis_metadata=(
+            metadata("nominal", 1.0),
+            metadata("high-gain", 1.2),
+        ),
+        hypothesis_prior_weights=np.asarray([0.5, 0.5]),
+        parameter_particles=np.asarray([[1.0]]),
+        parameter_weights=np.asarray([1.0]),
+        trajectories=trajectories,
+        variance_floor_m2=1.0e-8,
+    )
+    intervention_frame = 2
+    complete_observations = np.zeros((7, 1, 3), dtype=float)
+    actions = np.zeros((7, 1, 3), dtype=float)
+    context = build_causal_context(
+        protocol_id="bound-abduction-v1",
+        case_id="synthetic",
+        observations=complete_observations,
+        observed_actions=actions,
+        counterfactual_actions=actions,
+        intervention_frame=intervention_frame,
+        observed_action_id="observed-pull",
+    )
+    belief = TwinBelief(
+        context=context,
+        endpoint_frame=intervention_frame - 1,
+        particle_ids=("p0",),
+        theta_names=("stiffness",),
+        endpoint_position_m=np.zeros((1, 1, 3)),
+        endpoint_velocity_mps=np.zeros((1, 1, 3)),
+        theta=np.asarray([[1.0]]),
+        discrepancy_mean_m=np.zeros((1, 1, 3)),
+        discrepancy_variance_m2=np.zeros((1, 1, 3)),
+        weights=np.asarray([1.0]),
+    )
+    observations = trajectories[1, 0].copy()
+    return bank, belief, observations
+
+
+def test_bound_abduction_preserves_posterior_and_adds_exact_binding() -> None:
+    bank, belief, observations = _problem()
+    ordinary = abduct_factual_intervention(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=3,
+    )
+    bound = abduct_factual_intervention_bound(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=3,
+    )
+
+    assert np.array_equal(bound.weights, ordinary.weights)
+    assert np.array_equal(bound.phi, ordinary.phi)
+    assert np.array_equal(bound.kappa_obs, ordinary.kappa_obs)
+    assert bound.artifact_id != ordinary.artifact_id
+    binding = bound.metadata["factual_rollout_action_binding"]
+    assert binding["rollout_bank_id"] == bank.artifact_id
+    assert binding["source_twin_belief_id"] == belief.artifact_id
+    assert binding["observed_action_id"] == belief.context.u_obs.action_id
+    assert binding["hypothesis_action_ids"] == ["observed-pull", "observed-pull"]
+
+
+def test_action_binding_rejects_relabelled_factual_bank() -> None:
+    bank, belief, observations = _problem(proposal_id="different-action")
+    with pytest.raises(ValueError, match="action identity"):
+        abduct_factual_intervention_bound(
+            bank,
+            belief,
+            observations,
+            prefix_frame_count=3,
+        )
+
+
+def test_action_binding_rejects_counterfactual_bank() -> None:
+    bank, belief, _ = _problem(factual=False)
+    with pytest.raises(ValueError, match="factual observed action"):
+        validate_factual_rollout_action_binding(bank, belief)
+
+
+def test_bound_abduction_remains_future_suffix_invariant() -> None:
+    bank, belief, observations = _problem()
+    first = abduct_factual_intervention_bound(
+        bank,
+        belief,
+        observations,
+        prefix_frame_count=3,
+    )
+    changed = observations.copy()
+    changed[3:] += 100.0
+    second = abduct_factual_intervention_bound(
+        bank,
+        belief,
+        changed,
+        prefix_frame_count=3,
+    )
+    assert first.artifact_id == second.artifact_id

--- a/tests/test_real_design_sensitivity.py
+++ b/tests/test_real_design_sensitivity.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from causal4d.real_design_sensitivity import (
+    RealDesignSensitivityConfig,
+    build_real_design_sensitivity_report,
+    evaluate_registered_interval_panel,
+    save_real_design_sensitivity_report,
+)
+
+
+def _small_config() -> RealDesignSensitivityConfig:
+    return RealDesignSensitivityConfig(
+        sample_counts=(8,),
+        standardized_effects=(0.0, 0.5, 1.0),
+        scenarios=("normal", "one_adverse_session"),
+        simulation_replicates=12,
+        bootstrap_replicates=96,
+        seed=1234,
+        target_power=0.75,
+    )
+
+
+def test_report_is_deterministic_target_free_and_content_addressed() -> None:
+    config = _small_config()
+    first = build_real_design_sensitivity_report(config)
+    second = build_real_design_sensitivity_report(config)
+
+    assert first == second
+    assert len(first["artifact_id"]) == 64
+    boundary = first["scientific_boundary"]
+    assert boundary["target_outcomes_accessed"] is False
+    assert boundary["physical_data_accessed"] is False
+    assert boundary["changes_registered_protocol"] is False
+    assert boundary["physical_evidence_increment"] == 0
+
+
+def test_additive_effect_power_is_monotone_for_every_scenario() -> None:
+    report = build_real_design_sensitivity_report(_small_config())
+    for result in report["results"]:
+        rates = [
+            row["registered_positive_gate_pass_rate"]
+            for row in result["effect_grid"]
+        ]
+        assert rates == sorted(rates)
+
+
+def test_registered_interval_gate_is_unit_scale_invariant() -> None:
+    panel = np.asarray([-0.8, -0.1, 0.2, 0.4, 0.7, 1.0, 1.3, 1.7])
+    base = evaluate_registered_interval_panel(
+        panel,
+        bootstrap_replicates=512,
+        seed=88,
+    )
+    scaled = evaluate_registered_interval_panel(
+        panel * 1_000.0,
+        bootstrap_replicates=512,
+        seed=88,
+    )
+
+    assert base["decision"]["positive_claim_interval_gate_passed"] == (
+        scaled["decision"]["positive_claim_interval_gate_passed"]
+    )
+    for name in ("primary", "robustness"):
+        assert scaled[name]["point_estimate"] == pytest.approx(
+            1_000.0 * base[name]["point_estimate"]
+        )
+        assert scaled[name]["lower"] == pytest.approx(
+            1_000.0 * base[name]["lower"]
+        )
+        assert scaled[name]["upper"] == pytest.approx(
+            1_000.0 * base[name]["upper"]
+        )
+
+
+def test_report_publication_rejects_stale_identity_and_overwrite(
+    tmp_path: Path,
+) -> None:
+    report = build_real_design_sensitivity_report(_small_config())
+    target = tmp_path / "design-sensitivity.json"
+    save_real_design_sensitivity_report(target, report)
+    assert target.is_file()
+    with pytest.raises(FileExistsError):
+        save_real_design_sensitivity_report(target, report)
+
+    changed = dict(report)
+    changed["independent_unit"] = "frame"
+    with pytest.raises(ValueError, match="artifact_id"):
+        save_real_design_sensitivity_report(tmp_path / "stale.json", changed)
+
+
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        ({"sample_counts": (1,)}, "sample_counts"),
+        ({"sample_counts": (8, 8)}, "duplicates"),
+        ({"standardized_effects": (0.1, 0.5)}, "start at zero"),
+        ({"standardized_effects": (0.0, 0.5, 0.5)}, "strictly increasing"),
+        ({"scenarios": ("unknown",)}, "unsupported"),
+        ({"simulation_replicates": 0}, "simulation_replicates"),
+        ({"bootstrap_replicates": True}, "bootstrap_replicates"),
+        ({"target_power": 1.0}, "target_power"),
+    ],
+)
+def test_config_rejects_malformed_designs(
+    kwargs: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        RealDesignSensitivityConfig(**kwargs)

--- a/tests/test_real_design_sensitivity.py
+++ b/tests/test_real_design_sensitivity.py
@@ -43,8 +43,7 @@ def test_additive_effect_power_is_monotone_for_every_scenario() -> None:
     report = build_real_design_sensitivity_report(_small_config())
     for result in report["results"]:
         rates = [
-            row["registered_positive_gate_pass_rate"]
-            for row in result["effect_grid"]
+            row["registered_positive_gate_pass_rate"] for row in result["effect_grid"]
         ]
         assert rates == sorted(rates)
 
@@ -62,19 +61,16 @@ def test_registered_interval_gate_is_unit_scale_invariant() -> None:
         seed=88,
     )
 
-    assert base["decision"]["positive_claim_interval_gate_passed"] == (
-        scaled["decision"]["positive_claim_interval_gate_passed"]
+    assert (
+        base["decision"]["positive_claim_interval_gate_passed"]
+        == (scaled["decision"]["positive_claim_interval_gate_passed"])
     )
     for name in ("primary", "robustness"):
         assert scaled[name]["point_estimate"] == pytest.approx(
             1_000.0 * base[name]["point_estimate"]
         )
-        assert scaled[name]["lower"] == pytest.approx(
-            1_000.0 * base[name]["lower"]
-        )
-        assert scaled[name]["upper"] == pytest.approx(
-            1_000.0 * base[name]["upper"]
-        )
+        assert scaled[name]["lower"] == pytest.approx(1_000.0 * base[name]["lower"])
+        assert scaled[name]["upper"] == pytest.approx(1_000.0 * base[name]["upper"])
 
 
 def test_report_publication_rejects_stale_identity_and_overwrite(


### PR DESCRIPTION
## Summary

- add deterministic, content-addressed target-free operating-characteristic simulation for the registered session bootstrap-t interval and required Student-t veto;
- evaluate the frozen rule at 18, 15, and 12 independent sessions under Gaussian, heavy-tail, contaminated, skewed, and one-adverse-session panels;
- report null gate rate, interval width, effect-grid power, Monte Carlo uncertainty, and the first tested effect reaching the declared target power;
- add an opt-in factual-abduction wrapper that requires every rollout hypothesis to match the exact `TwinBelief.context.u_obs.action_id` before likelihood evaluation;
- bind the complete rollout-bank identity, observed action interval, trajectory digest, and ordered hypothesis action identities into the resulting factual artifact metadata; and
- add deterministic, scale-invariance, future-suffix, relabelling, malformed-input, content-identity, and no-overwrite tests.

## Why

The frozen 36-execution study is no longer improved by another estimator branch. The highest-value software additions before acquisition are a target-free precision audit and a fail-closed exact action identity check for future claim-bearing integrations.

The historical factual-abduction function remains byte- and behavior-compatible. The stricter wrapper is additive and is not inserted into the frozen physical method.

## Validation

Exact head: `aff7c3a412069af40547c2df622c0ee7f429f9f4`

All authoritative workflows pass:

- **CI and release**, run `32178206401`: Ruff lint and formatting, strict stable-boundary typing, complete core suites on Python 3.10/3.12/3.14, frozen milestone validation, deterministic result-bundle round trips, wheel/sdist builds, every installed CLI help surface, and pinned BayesianPhysTwin installed-wheel integration;
- **Extended compatibility**, run `32178206147`: Python 3.11/3.13 and exact declared NumPy/SciPy/packaging dependency floors;
- **Causal4D merge gate**, run `32178206075`: repository quality checks, complete default suite on the GitHub-generated merge result, distributions, and isolated pinned-provider wheel integration; and
- **Security scanning**, run `32178206261`: CodeQL for Python and Actions plus resolved-runtime dependency audit.

The initial head exposed only canonical Ruff formatting differences; commit `aff7c3a` applies the formatter output without changing behavior.

## Scientific and information boundary

- frozen estimator changed: `no`;
- registered 36-execution protocol changed: `no`;
- target outcomes accessed: `no`;
- physical data accessed: `no`;
- thresholds changed: `no`;
- physical evidence increment: `0`;
- scientific claim promoted: `no`.

The design-sensitivity result describes operating characteristics only. It cannot establish the physical effect or authorize target-informed changes. The action-bound path establishes software lineage only; it does not prove that the real actuator followed the declared command.