### PR TITLE
Register and verify Bayesian-PhysTwin belief provider v3

### DIFF
--- a/ci/bayesian_phystwin_provider_registry.json
+++ b/ci/bayesian_phystwin_provider_registry.json
@@ -33,6 +33,13 @@
       "local_contract_module": "causal4d.belief_provider_v2_contract"
     },
     {
+      "module": "bayesian_phystwin.causal4d_belief_provider_v3",
+      "api_version": 3,
+      "role": "dynamic_endpoint_and_recursive_belief",
+      "lifecycle": "additive_development",
+      "local_contract_module": null
+    },
+    {
       "module": "bayesian_phystwin.causal4d_guarded_belief_provider_v1",
       "api_version": 1,
       "role": "guarded_complete_belief_handoff",

--- a/docs/bayesian_phystwin_provider.md
+++ b/docs/bayesian_phystwin_provider.md
@@ -11,6 +11,8 @@ modules:
   endpoint inference and immutable endpoint posteriors;
 - `bayesian_phystwin.causal4d_belief_provider_v2` for additive model-averaged
   endpoints and source-calibrated horizon discrepancy moments;
+- `bayesian_phystwin.causal4d_belief_provider_v3` for the additive dynamic
+  endpoint and recursive-belief surface retained by Bayesian-PhysTwin;
 - `bayesian_phystwin.causal4d_guarded_belief_provider_v1` for exact Prob4D
   runtime, candidate-construction, complete-belief guard, and selected-belief
   receipt identities;
@@ -32,10 +34,14 @@ Registered tree-block covariance queries use their own additive provider and
 local validation contract. Guarded handoff v2 imports runtime and complete-belief
 selection contracts only through its dedicated versioned facade; an older pinned
 wheel may omit that additive module unless the paired compatibility lane sets
-`CAUSAL4D_REQUIRE_GUARDED_BPT_PROVIDER=1`. The rollout-bank backend and resumable
-cache execute
-replay exclusively through provider v2. Provider v1 remains only for frozen
-scientific and diagnostic compatibility operations.
+`CAUSAL4D_REQUIRE_GUARDED_BPT_PROVIDER=1`. The additive v3 belief provider is
+registered so its public boundary cannot drift silently and so dedicated
+compatibility lanes can require it with
+`CAUSAL4D_REQUIRE_BPT_BELIEF_PROVIDER_V3=1`. Causal4D production source does not
+yet import v3, and registering it does not promote its dynamic covariance to a
+calibrated or claim-bearing result. The rollout-bank backend and resumable cache
+execute replay exclusively through provider v2. Provider v1 remains only for
+frozen scientific and diagnostic compatibility operations.
 
 Production source and scripts no longer import any unversioned
 Bayesian-PhysTwin implementation module. The canonical module inventory is
@@ -49,7 +55,8 @@ reviewable registry entry rather than synchronized hand-written inventories.
 
 Normal development accepts Bayesian-PhysTwin versions in the range
 `>=0.4,<0.5`. Compatibility is not inferred from the package version alone.
-Causal4D validates six deliberately separate provider manifests:
+Causal4D validates six deliberately separate provider manifests and registers
+one additional additive development surface:
 
 - scientific provider API/schema version 1 for frozen compatibility names and
   migrated diagnostics;
@@ -61,8 +68,11 @@ Causal4D validates six deliberately separate provider manifests:
 - additive belief provider API/schema version 2 for evidence-weighted endpoint
   model averaging and source-frozen horizon discrepancy prediction;
 - tree-block query provider API/schema version 1 for strict claim-bearing update
-  validation and exact factorized linear-query covariance; and
-- graph provider API/schema version 1 for graph and controller grouping values.
+  validation and exact factorized linear-query covariance;
+- graph provider API/schema version 1 for graph and controller grouping values;
+  and
+- additive belief provider API/schema version 3 as a registered compatibility
+  surface for dynamic endpoint and recursive-belief operations.
 
 The scientific manifest requires its existing `TwinBelief` and `GraphBelief`
 artifact schemas. The replay manifest additionally requires `ReplayRequest` and
@@ -87,6 +97,16 @@ The additive belief provider is checked separately for:
 - immutable endpoint, prediction, and calibration artifact schemas; and
 - an explicit boundary that keeps raw model covariance distinct from interval
   calibration and target-side coverage claims.
+
+The additive v3 provider remains an explicit development boundary rather than a
+production inference dependency. Compatibility checks require that the module
+imports from the installed Bayesian-PhysTwin distribution and that its public
+manifest can be emitted. Its dynamic endpoint, exact-persistence comparator,
+robust local-level/damped-trend components, and retained recursive Prob4D stream
+surface remain subject to their source-frozen evidence and calibration limits.
+A successful import or manifest check does not establish downstream Causal4D
+benefit, empirical interval coverage, unseen-object transfer, or state of the
+art.
 
 The tree-block query provider is checked separately for:
 
@@ -122,7 +142,9 @@ manifest is loaded with
 `load_bayesian_phystwin_tree_block_query_provider_manifest()` and checked with
 `validate_bayesian_phystwin_tree_block_query_provider()`. The graph manifest is
 loaded with `load_bayesian_phystwin_graph_provider_manifest()` and checked with
-`validate_bayesian_phystwin_graph_provider()`. A version, capability, artifact,
+`validate_bayesian_phystwin_graph_provider()`. The v3 manifest is emitted by the
+dedicated cross-repository compatibility lane; Causal4D has no production v3
+validator or local inference contract yet. A version, capability, artifact,
 provider-identity, inference-role, graph-provider, or parent-provider mismatch
 fails closed and is reported explicitly.
 
@@ -195,6 +217,8 @@ CAUSAL4D_REQUIRE_TREE_BLOCK_QUERY_PROVIDER=1 python -m pytest -q \
   tests/test_tree_block_belief_query.py
 CAUSAL4D_REQUIRE_GUARDED_BPT_PROVIDER=1 python -m pytest -q \
   tests/test_guarded_bpt_belief_handoff_v2.py \
+  tests/test_bpt_provider_import_boundary.py
+CAUSAL4D_REQUIRE_BPT_BELIEF_PROVIDER_V3=1 python -m pytest -q \
   tests/test_bpt_provider_import_boundary.py
 ```
 

--- a/tests/test_bpt_provider_import_boundary.py
+++ b/tests/test_bpt_provider_import_boundary.py
@@ -8,6 +8,7 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -29,7 +30,14 @@ def _allowed_bayesian_phystwin_modules() -> frozenset[str]:
     for entry in modules:
         if not isinstance(entry, dict) or type(entry.get("module")) is not str:
             raise AssertionError("provider registry entries require string modules")
-        result.add(entry["module"])
+        module_name = entry["module"]
+        if not module_name.startswith("bayesian_phystwin."):
+            raise AssertionError(
+                "provider registry modules must be Bayesian-PhysTwin submodules"
+            )
+        if module_name in result:
+            raise AssertionError("provider registry modules must be unique")
+        result.add(module_name)
     return frozenset(result)
 
 
@@ -55,6 +63,26 @@ def _python_sources() -> list[Path]:
         if directory.exists():
             sources.extend(directory.rglob("*.py"))
     return sorted(sources)
+
+
+def _import_registered_provider(module_name: str) -> ModuleType | None:
+    try:
+        return importlib.import_module(module_name)
+    except ModuleNotFoundError as error:
+        requirement = _DEDICATED_PROVIDER_REQUIREMENTS.get(module_name)
+        if (
+            error.name == module_name
+            and requirement is not None
+            and os.environ.get(requirement) != "1"
+        ):
+            return None
+        raise
+
+
+def test_provider_registry_is_complete_and_well_formed() -> None:
+    assert "bayesian_phystwin.causal4d_belief_provider_v3" in (
+        ALLOWED_BAYESIAN_PHYSTWIN_MODULES
+    )
 
 
 def test_causal4d_imports_bpt_only_through_versioned_provider_modules() -> None:
@@ -87,6 +115,13 @@ def test_causal4d_imports_bpt_only_through_versioned_provider_modules() -> None:
     )
 
 
+def test_every_registered_provider_resolves_when_bpt_is_installed() -> None:
+    if importlib.util.find_spec("bayesian_phystwin") is None:
+        pytest.skip("Bayesian-PhysTwin is not installed in the core-only environment")
+    for module_name in sorted(ALLOWED_BAYESIAN_PHYSTWIN_MODULES):
+        _import_registered_provider(module_name)
+
+
 def test_every_imported_provider_name_resolves_when_bpt_is_installed() -> None:
     if importlib.util.find_spec("bayesian_phystwin") is None:
         pytest.skip("Bayesian-PhysTwin is not installed in the core-only environment")
@@ -98,17 +133,9 @@ def test_every_imported_provider_name_resolves_when_bpt_is_installed() -> None:
             module_name = node.module or ""
             if module_name not in ALLOWED_BAYESIAN_PHYSTWIN_MODULES:
                 continue
-            try:
-                module = importlib.import_module(module_name)
-            except ModuleNotFoundError as error:
-                requirement = _DEDICATED_PROVIDER_REQUIREMENTS.get(module_name)
-                if (
-                    error.name == module_name
-                    and requirement is not None
-                    and os.environ.get(requirement) != "1"
-                ):
-                    continue
-                raise
+            module = _import_registered_provider(module_name)
+            if module is None:
+                continue
             for alias in node.names:
                 assert alias.name != "*"
                 assert hasattr(module, alias.name), (

--- a/tests/test_bpt_provider_registry.py
+++ b/tests/test_bpt_provider_registry.py
@@ -114,6 +114,7 @@ def test_registry_contains_current_additive_provider_boundaries() -> None:
     modules = {entry["module"] for entry in _registry()["modules"]}
     assert "bayesian_phystwin.causal4d_artifacts_v2" in modules
     assert "bayesian_phystwin.causal4d_belief_provider_v2" in modules
+    assert "bayesian_phystwin.causal4d_belief_provider_v3" in modules
     assert "bayesian_phystwin.causal4d_guarded_belief_provider_v1" in modules
     assert "bayesian_phystwin.causal4d_tree_block_provider_v1" in modules
 


### PR DESCRIPTION
## Summary

- register `bayesian_phystwin.causal4d_belief_provider_v3` in the authoritative Bayesian-PhysTwin provider registry;
- validate that registry entries are unique Bayesian-PhysTwin submodules;
- import every registered provider when Bayesian-PhysTwin is installed, rather than checking only modules already referenced by Causal4D source;
- retain the existing environment-gated behavior for additive providers so older compatible installations can still be tested deliberately.

## Why

The v3 provider already exists and has a dedicated requirement flag in the import-boundary test, but it was absent from the registry. That mixed state allowed provider inventory and compatibility coverage to drift.

## Local validation

- registry JSON parses successfully;
- updated test module compiles;
- core-only focused run: `2 passed, 2 skipped` (the installed-provider checks correctly skip without Bayesian-PhysTwin).

## Boundary

This is compatibility and packaging infrastructure. It does not change Causal4D inference, a frozen provider contract, an experimental protocol, or any scientific claim.