### PR TITLE
Route Causal4D physical-data jobs by runner label

### DIFF
--- a/.github/self-hosted-jobs.json
+++ b/.github/self-hosted-jobs.json
@@ -17,7 +17,8 @@
         "self-hosted",
         "Linux",
         "X64",
-        "nvidia-smi"
+        "nvidia-smi",
+        "data-causal4d-physical-v1"
       ],
       "purpose": "Read-only registered acquisition readiness and interface qualification",
       "dataset_access": "registered-local-preacquisition-read-only",
@@ -31,7 +32,8 @@
         "self-hosted",
         "Linux",
         "X64",
-        "nvidia-smi"
+        "nvidia-smi",
+        "data-causal4d-physical-v1"
       ],
       "purpose": "Execute one exact allowlisted nonphysical registered next action",
       "dataset_access": "registered-local-preacquisition-single-template-write",
@@ -101,7 +103,8 @@
         "self-hosted",
         "Linux",
         "X64",
-        "nvidia-smi"
+        "nvidia-smi",
+        "data-causal4d-physical-v1"
       ],
       "purpose": "Replace the unsupported roster with the single real participant",
       "dataset_access": "registered-local-preacquisition-operator-registry-correction",

--- a/.github/workflows/acquisition-readiness-self-hosted.yml
+++ b/.github/workflows/acquisition-readiness-self-hosted.yml
@@ -28,7 +28,7 @@ jobs:
       group: acquisition-readiness-${{ github.sha }}
       cancel-in-progress: false
       queue: max
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    runs-on: [self-hosted, Linux, X64, nvidia-smi, data-causal4d-physical-v1]
     timeout-minutes: 45
     outputs:
       conclusion: ${{ steps.summary.outputs.conclusion }}

--- a/.github/workflows/automatable-preacquisition-self-hosted.yml
+++ b/.github/workflows/automatable-preacquisition-self-hosted.yml
@@ -28,7 +28,7 @@ jobs:
       group: automatable-preacquisition-${{ github.sha }}
       cancel-in-progress: false
       queue: max
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    runs-on: [self-hosted, Linux, X64, nvidia-smi, data-causal4d-physical-v1]
     timeout-minutes: 45
     outputs:
       selected_root_candidate: ${{ steps.summary.outputs.selected_root_candidate }}

--- a/.github/workflows/correct-operator-registry-self-hosted.yml
+++ b/.github/workflows/correct-operator-registry-self-hosted.yml
@@ -28,7 +28,7 @@ jobs:
       group: correct-operator-registry-${{ github.sha }}
       cancel-in-progress: false
       queue: max
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    runs-on: [self-hosted, Linux, X64, nvidia-smi, data-causal4d-physical-v1]
     timeout-minutes: 45
     outputs:
       already_corrected: ${{ steps.summary.outputs.already_corrected }}


### PR DESCRIPTION
## Summary

- require `data-causal4d-physical-v1` for acquisition readiness
- require the same label for the automatable pre-acquisition action
- require the same label for operator-registry correction
- record the label in `.github/self-hosted-jobs.json`

These jobs read or update immutable/local state under `/mnt/lexar4tb/causal4d-physical`, which is available on the runner carrying this label.

## Verification

- fetched all four updated files back from the branch
- parsed the updated self-hosted-job registry as JSON
- confirmed exactly three registry entries and three workflows carry the label
- confirmed the branch changes only the three target workflows and the registry

This PR changes scheduling only; authorization, experiment logic, and data paths remain unchanged.