### PR TITLE
Ratchet modern Ruff rules on changed files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,8 @@ repos:
   - repo: local
     hooks:
       - id: ruff-check
-        name: Ruff lint
-        entry: python -m ruff check --fix
+        name: Ruff lint (incremental modern rules)
+        entry: python -m ruff check --fix --select E4,E7,E9,F,I,UP,B
         language: system
         types_or: [python, pyi]
       - id: ruff-format


### PR DESCRIPTION
## Summary

Extend the existing local pre-commit Ruff hook from the repository-wide baseline (`E4`, `E7`, `E9`, `F`) to also enforce import sorting, Python modernization, and bugbear rules (`I`, `UP`, `B`) on staged Python and stub files.

This is intentionally incremental: it does not switch the whole historical repository to stricter rules in one change, alter the global CI baseline, or rewrite frozen scientific code. Future changed files receive the stronger local ratchet and Ruff applies its safe fixes before commit.

## Boundary

This changes developer quality tooling only. It changes no estimator, protocol, artifact, acquisition schedule, evidence count, target-access boundary, physical result, or scientific claim.