### PR TITLE
Route Deform360 and workstation2 jobs by capability

### DIFF
--- a/.github/self-hosted-jobs.json
+++ b/.github/self-hosted-jobs.json
@@ -118,7 +118,8 @@
         "self-hosted",
         "Linux",
         "X64",
-        "nvidia-smi"
+        "nvidia-smi",
+        "data-deform360-v1"
       ],
       "purpose": "Locked Deform360 source contact/support diagnostic",
       "dataset_access": "approved-source-only-deform360",
@@ -132,7 +133,8 @@
         "self-hosted",
         "Linux",
         "X64",
-        "nvidia-smi"
+        "nvidia-smi",
+        "data-deform360-v1"
       ],
       "purpose": "Locked Deform360 source filament-support diagnostic",
       "dataset_access": "approved-source-only-deform360",
@@ -146,7 +148,8 @@
         "self-hosted",
         "Linux",
         "X64",
-        "nvidia-smi"
+        "nvidia-smi",
+        "data-deform360-v1"
       ],
       "purpose": "Locked Deform360 source prefix-kinematics diagnostic",
       "dataset_access": "approved-source-only-deform360",
@@ -160,7 +163,8 @@
         "self-hosted",
         "Linux",
         "X64",
-        "nvidia-smi"
+        "nvidia-smi",
+        "data-deform360-v1"
       ],
       "purpose": "Locked Deform360 source reset-mechanics diagnostic",
       "dataset_access": "approved-source-only-deform360",
@@ -216,7 +220,8 @@
         "self-hosted",
         "Linux",
         "X64",
-        "nvidia-smi"
+        "nvidia-smi",
+        "host-workstation2"
       ],
       "purpose": "CUDA qualification and controlled replication",
       "dataset_access": "none",

--- a/.github/workflows/deform360-contact-support.yml
+++ b/.github/workflows/deform360-contact-support.yml
@@ -103,7 +103,7 @@ jobs:
       github.ref == 'refs/heads/main' &&
       inputs.run_source_diagnostic
     needs: contract
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]
     timeout-minutes: 360
     env:
       DEFORM360_REPLICATION_ROOT: ${{ inputs.data_root }}

--- a/.github/workflows/deform360-filament-support.yml
+++ b/.github/workflows/deform360-filament-support.yml
@@ -118,7 +118,7 @@ jobs:
       github.ref == 'refs/heads/main' &&
       inputs.run_source_diagnostic
     needs: contract
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]
     timeout-minutes: 120
     env:
       DEFORM360_REPLICATION_ROOT: ${{ inputs.data_root }}

--- a/.github/workflows/deform360-prefix-kinematics.yml
+++ b/.github/workflows/deform360-prefix-kinematics.yml
@@ -118,7 +118,7 @@ jobs:
       github.ref == 'refs/heads/main' &&
       inputs.run_source_diagnostic
     needs: contract
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]
     timeout-minutes: 360
     env:
       DEFORM360_REPLICATION_ROOT: ${{ inputs.data_root }}

--- a/.github/workflows/deform360-reset-mechanics.yml
+++ b/.github/workflows/deform360-reset-mechanics.yml
@@ -93,7 +93,7 @@ jobs:
       github.ref == 'refs/heads/main' &&
       inputs.run_source_diagnostic
     needs: contract
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]
     timeout-minutes: 480
     env:
       DEFORM360_REPLICATION_ROOT: ${{ inputs.data_root }}

--- a/.github/workflows/workstation2-evaluation.yml
+++ b/.github/workflows/workstation2-evaluation.yml
@@ -47,7 +47,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/main'
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    runs-on: [self-hosted, Linux, X64, nvidia-smi, host-workstation2]
     timeout-minutes: 180
     steps:
       - name: Check out exact reviewed Causal4D revision

--- a/tests/test_deform360_contact_support_workflow_policy.py
+++ b/tests/test_deform360_contact_support_workflow_policy.py
@@ -19,10 +19,7 @@ def test_permanent_gpu_evidence_requires_explicit_dispatch() -> None:
     assert "github.event_name == 'workflow_dispatch'" in text
     assert "inputs.run_source_diagnostic" in text
     assert "needs: contract" in text
-    assert (
-        "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]"
-        in text
-    )
+    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]" in text
     assert "permissions:\n  contents: read" in text
     assert "contents: write" not in text
     assert "continue-on-error: true" not in text

--- a/tests/test_deform360_contact_support_workflow_policy.py
+++ b/tests/test_deform360_contact_support_workflow_policy.py
@@ -19,7 +19,7 @@ def test_permanent_gpu_evidence_requires_explicit_dispatch() -> None:
     assert "github.event_name == 'workflow_dispatch'" in text
     assert "inputs.run_source_diagnostic" in text
     assert "needs: contract" in text
-    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
+    assert (\n        "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]"\n        in text\n    )
     assert "permissions:\n  contents: read" in text
     assert "contents: write" not in text
     assert "continue-on-error: true" not in text

--- a/tests/test_deform360_contact_support_workflow_policy.py
+++ b/tests/test_deform360_contact_support_workflow_policy.py
@@ -19,7 +19,10 @@ def test_permanent_gpu_evidence_requires_explicit_dispatch() -> None:
     assert "github.event_name == 'workflow_dispatch'" in text
     assert "inputs.run_source_diagnostic" in text
     assert "needs: contract" in text
-    assert (\n        "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]"\n        in text\n    )
+    assert (
+        "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]"
+        in text
+    )
     assert "permissions:\n  contents: read" in text
     assert "contents: write" not in text
     assert "continue-on-error: true" not in text

--- a/tests/test_deform360_filament_support_workflow_policy.py
+++ b/tests/test_deform360_filament_support_workflow_policy.py
@@ -53,7 +53,7 @@ def test_self_hosted_job_is_manual_main_only_and_non_mutating() -> None:
     assert "github.event_name == 'workflow_dispatch'" in text
     assert "github.ref == 'refs/heads/main'" in text
     assert "inputs.run_source_diagnostic" in text
-    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
+    assert (\n        "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]"\n        in text\n    )
     assert "timeout-minutes: 120" in text
     assert "permissions:\n  contents: read" in text
     assert "pull-requests: write" not in text
@@ -112,7 +112,7 @@ def test_registry_binds_the_self_hosted_job_and_fixed_entrypoint() -> None:
     entries = {(entry["workflow"], entry["job"]): entry for entry in payload["jobs"]}
     entry = entries[("deform360-filament-support.yml", "source-diagnostic")]
 
-    assert entry["runner_labels"] == ["self-hosted", "Linux", "X64", "nvidia-smi"]
+    assert entry["runner_labels"] == [\n        "self-hosted",\n        "Linux",\n        "X64",\n        "nvidia-smi",\n        "data-deform360-v1",\n    ]
     assert entry["authorization_model"] == "main-only"
     assert entry["purpose"] == "Locked Deform360 source filament-support diagnostic"
     assert entry["dataset_access"] == "approved-source-only-deform360"

--- a/tests/test_deform360_filament_support_workflow_policy.py
+++ b/tests/test_deform360_filament_support_workflow_policy.py
@@ -53,10 +53,7 @@ def test_self_hosted_job_is_manual_main_only_and_non_mutating() -> None:
     assert "github.event_name == 'workflow_dispatch'" in text
     assert "github.ref == 'refs/heads/main'" in text
     assert "inputs.run_source_diagnostic" in text
-    assert (
-        "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]"
-        in text
-    )
+    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]" in text
     assert "timeout-minutes: 120" in text
     assert "permissions:\n  contents: read" in text
     assert "pull-requests: write" not in text

--- a/tests/test_deform360_filament_support_workflow_policy.py
+++ b/tests/test_deform360_filament_support_workflow_policy.py
@@ -53,7 +53,10 @@ def test_self_hosted_job_is_manual_main_only_and_non_mutating() -> None:
     assert "github.event_name == 'workflow_dispatch'" in text
     assert "github.ref == 'refs/heads/main'" in text
     assert "inputs.run_source_diagnostic" in text
-    assert (\n        "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]"\n        in text\n    )
+    assert (
+        "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]"
+        in text
+    )
     assert "timeout-minutes: 120" in text
     assert "permissions:\n  contents: read" in text
     assert "pull-requests: write" not in text
@@ -112,7 +115,13 @@ def test_registry_binds_the_self_hosted_job_and_fixed_entrypoint() -> None:
     entries = {(entry["workflow"], entry["job"]): entry for entry in payload["jobs"]}
     entry = entries[("deform360-filament-support.yml", "source-diagnostic")]
 
-    assert entry["runner_labels"] == [\n        "self-hosted",\n        "Linux",\n        "X64",\n        "nvidia-smi",\n        "data-deform360-v1",\n    ]
+    assert entry["runner_labels"] == [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "nvidia-smi",
+        "data-deform360-v1",
+    ]
     assert entry["authorization_model"] == "main-only"
     assert entry["purpose"] == "Locked Deform360 source filament-support diagnostic"
     assert entry["dataset_access"] == "approved-source-only-deform360"

--- a/tests/test_deform360_prefix_kinematics_workflow_policy.py
+++ b/tests/test_deform360_prefix_kinematics_workflow_policy.py
@@ -41,7 +41,10 @@ def test_prefix_kinematics_gpu_evidence_requires_explicit_dispatch() -> None:
     assert "workflow_dispatch:" in text
     assert "github.event_name == 'workflow_dispatch'" in text
     assert "inputs.run_source_diagnostic" in text
-    assert (\n        "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]"\n        in text\n    )
+    assert (
+        "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]"
+        in text
+    )
     assert "Check out pinned public BayesianPhysTwin" in text
     assert "BPT_READ_SSH_KEY" not in text
     assert "ssh-key:" not in text

--- a/tests/test_deform360_prefix_kinematics_workflow_policy.py
+++ b/tests/test_deform360_prefix_kinematics_workflow_policy.py
@@ -41,7 +41,7 @@ def test_prefix_kinematics_gpu_evidence_requires_explicit_dispatch() -> None:
     assert "workflow_dispatch:" in text
     assert "github.event_name == 'workflow_dispatch'" in text
     assert "inputs.run_source_diagnostic" in text
-    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
+    assert (\n        "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]"\n        in text\n    )
     assert "Check out pinned public BayesianPhysTwin" in text
     assert "BPT_READ_SSH_KEY" not in text
     assert "ssh-key:" not in text

--- a/tests/test_deform360_prefix_kinematics_workflow_policy.py
+++ b/tests/test_deform360_prefix_kinematics_workflow_policy.py
@@ -41,10 +41,7 @@ def test_prefix_kinematics_gpu_evidence_requires_explicit_dispatch() -> None:
     assert "workflow_dispatch:" in text
     assert "github.event_name == 'workflow_dispatch'" in text
     assert "inputs.run_source_diagnostic" in text
-    assert (
-        "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]"
-        in text
-    )
+    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]" in text
     assert "Check out pinned public BayesianPhysTwin" in text
     assert "BPT_READ_SSH_KEY" not in text
     assert "ssh-key:" not in text

--- a/tests/test_deform360_reset_mechanics_workflow_policy.py
+++ b/tests/test_deform360_reset_mechanics_workflow_policy.py
@@ -10,7 +10,10 @@ WORKFLOW = ROOT / ".github/workflows/deform360-reset-mechanics.yml"
 def test_reset_mechanics_workflow_is_read_only_and_source_scoped() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
     assert "permissions:\n  contents: read" in text
-    assert (\n        "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]"\n        in text\n    )
+    assert (
+        "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]"
+        in text
+    )
     assert "github.ref == 'refs/heads/main'" in text
     assert (
         "github.event.pull_request.head.repo.full_name == github.repository" not in text

--- a/tests/test_deform360_reset_mechanics_workflow_policy.py
+++ b/tests/test_deform360_reset_mechanics_workflow_policy.py
@@ -10,10 +10,7 @@ WORKFLOW = ROOT / ".github/workflows/deform360-reset-mechanics.yml"
 def test_reset_mechanics_workflow_is_read_only_and_source_scoped() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
     assert "permissions:\n  contents: read" in text
-    assert (
-        "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]"
-        in text
-    )
+    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]" in text
     assert "github.ref == 'refs/heads/main'" in text
     assert (
         "github.event.pull_request.head.repo.full_name == github.repository" not in text

--- a/tests/test_deform360_reset_mechanics_workflow_policy.py
+++ b/tests/test_deform360_reset_mechanics_workflow_policy.py
@@ -10,7 +10,7 @@ WORKFLOW = ROOT / ".github/workflows/deform360-reset-mechanics.yml"
 def test_reset_mechanics_workflow_is_read_only_and_source_scoped() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
     assert "permissions:\n  contents: read" in text
-    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
+    assert (\n        "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-deform360-v1]"\n        in text\n    )
     assert "github.ref == 'refs/heads/main'" in text
     assert (
         "github.event.pull_request.head.repo.full_name == github.repository" not in text

--- a/tests/test_workstation2_cache_policy.py
+++ b/tests/test_workstation2_cache_policy.py
@@ -12,7 +12,10 @@ def test_workstation2_uses_isolated_grouped_reproduction_path() -> None:
 
     text = WORKFLOW.read_text(encoding="utf-8")
 
-    assert (\n        "runs-on: [self-hosted, Linux, X64, nvidia-smi, host-workstation2]"\n        in text\n    )
+    assert (
+        "runs-on: [self-hosted, Linux, X64, nvidia-smi, host-workstation2]"
+        in text
+    )
     assert "github.ref == 'refs/heads/main'" in text
     assert "cache: pip" not in text
     assert ".workstation2-venv/bin/causal4d benchmark latent-contact" in text

--- a/tests/test_workstation2_cache_policy.py
+++ b/tests/test_workstation2_cache_policy.py
@@ -12,10 +12,7 @@ def test_workstation2_uses_isolated_grouped_reproduction_path() -> None:
 
     text = WORKFLOW.read_text(encoding="utf-8")
 
-    assert (
-        "runs-on: [self-hosted, Linux, X64, nvidia-smi, host-workstation2]"
-        in text
-    )
+    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi, host-workstation2]" in text
     assert "github.ref == 'refs/heads/main'" in text
     assert "cache: pip" not in text
     assert ".workstation2-venv/bin/causal4d benchmark latent-contact" in text

--- a/tests/test_workstation2_cache_policy.py
+++ b/tests/test_workstation2_cache_policy.py
@@ -12,7 +12,7 @@ def test_workstation2_uses_isolated_grouped_reproduction_path() -> None:
 
     text = WORKFLOW.read_text(encoding="utf-8")
 
-    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
+    assert (\n        "runs-on: [self-hosted, Linux, X64, nvidia-smi, host-workstation2]"\n        in text\n    )
     assert "github.ref == 'refs/heads/main'" in text
     assert "cache: pip" not in text
     assert ".workstation2-venv/bin/causal4d benchmark latent-contact" in text


### PR DESCRIPTION
## Summary

- require `data-deform360-v1` for the four source-only Deform360 diagnostics: contact support, filament support, prefix kinematics, and reset mechanics
- require `host-workstation2` for the explicitly workstation2-specific CUDA qualification workflow
- record the same selectors in `.github/self-hosted-jobs.json`
- update the exact workflow-policy assertions

The Deform360 entrypoints auto-discover their locked derived dataset under the runner-local dataset cache. Workstation2 contains the required `002-rope-silk` and `170-spider` files and already carries `data-deform360-v1`. The workstation2 evaluation records and publishes a workstation2-specific qualification, so it now requires the existing `host-workstation2` label.

Portable GPU-only jobs remain on the generic `self-hosted`, `Linux`, `X64`, and `nvidia-smi` selector.

## Verification

- `git diff --check`
- all 33 fixture-free tests in the seven affected/general self-hosted policy modules passed by direct function execution
- `.github/self-hosted-jobs.json` is loaded and checked by those tests

The locally installed pytest is older than this repository's `conftest.py` hook signature, so the same fixture-free test functions were executed directly instead. Hosted CI remains authoritative.

This PR changes scheduling only. It does not change scientific logic, frozen protocols, prediction seals, milestone artifacts, or data.