### PR TITLE
Fail fast on invalid simulator and contact inputs

### DIFF
--- a/src/causal4d/simulator.py
+++ b/src/causal4d/simulator.py
@@ -13,6 +13,33 @@ from causal4d.immutable_array import readonly_array
 PARAMETER_NAMES = ("stiffness", "damping", "contact_gain")
 
 
+def _require_nonempty_string(value: object, *, name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+
+
+def _require_finite_scalar(value: object, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a finite scalar")
+    try:
+        scalar = float(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{name} must be a finite scalar") from error
+    if not np.isfinite(scalar):
+        raise ValueError(f"{name} must be finite")
+    return scalar
+
+
+def _require_integer(value: object, *, name: str, minimum: int) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f"{name} must be an integer")
+    integer = int(value)
+    if integer < minimum:
+        qualifier = "positive" if minimum == 1 else "non-negative"
+        raise ValueError(f"{name} must be {qualifier}")
+    return integer
+
+
 @dataclass(frozen=True)
 class PhysicalParameters:
     """Unknown object and contact parameters exposed to inference."""
@@ -20,6 +47,16 @@ class PhysicalParameters:
     stiffness: float
     damping: float
     contact_gain: float
+
+    def __post_init__(self) -> None:
+        values = {
+            "stiffness": self.stiffness,
+            "damping": self.damping,
+            "contact_gain": self.contact_gain,
+        }
+        for name, value in values.items():
+            if _require_finite_scalar(value, name=name) <= 0.0:
+                raise ValueError(f"{name} must be positive")
 
     def as_array(self) -> np.ndarray:
         return np.asarray(
@@ -50,27 +87,60 @@ class GraphObject:
     sensor_nodes: tuple[int, ...]
 
     def __post_init__(self) -> None:
+        _require_nonempty_string(self.name, name="name")
         positions = np.asarray(self.rest_positions, dtype=float)
         if positions.ndim != 2 or positions.shape[1] != 2:
             raise ValueError("rest_positions must have shape (node, 2)")
         if not np.all(np.isfinite(positions)):
             raise ValueError("rest_positions must be finite")
-        if self.mass <= 0.0:
+        if _require_finite_scalar(self.mass, name="mass") <= 0.0:
             raise ValueError("mass must be positive")
-        if self.support_stiffness < 0.0:
+        if (
+            _require_finite_scalar(
+                self.support_stiffness,
+                name="support_stiffness",
+            )
+            < 0.0
+        ):
             raise ValueError("support_stiffness must be non-negative")
+        if not isinstance(self.true_parameters, PhysicalParameters):
+            raise ValueError("true_parameters must be PhysicalParameters")
         node_count = positions.shape[0]
         if not self.edges:
             raise ValueError("at least one graph edge is required")
-        for first, second in self.edges:
+        seen_edges: set[tuple[int, int]] = set()
+        for edge in self.edges:
+            if len(edge) != 2:
+                raise ValueError("each graph edge must contain two node indices")
+            first, second = edge
+            if any(
+                isinstance(node, (bool, np.bool_))
+                or not isinstance(node, (int, np.integer))
+                for node in edge
+            ):
+                raise ValueError("edge node indices must be integers")
+            first = int(first)
+            second = int(second)
             if first == second or not (
                 0 <= first < node_count and 0 <= second < node_count
             ):
                 raise ValueError("edges must connect distinct valid nodes")
-        if not self.sensor_nodes or any(
-            node < 0 or node >= node_count for node in self.sensor_nodes
-        ):
+            canonical_edge = (min(first, second), max(first, second))
+            if canonical_edge in seen_edges:
+                raise ValueError("edges must not contain duplicates")
+            seen_edges.add(canonical_edge)
+        if not self.sensor_nodes:
             raise ValueError("sensor_nodes must contain valid node indices")
+        if any(
+            isinstance(node, (bool, np.bool_))
+            or not isinstance(node, (int, np.integer))
+            for node in self.sensor_nodes
+        ):
+            raise ValueError("sensor node indices must be integers")
+        if any(node < 0 or node >= node_count for node in self.sensor_nodes):
+            raise ValueError("sensor_nodes must contain valid node indices")
+        if len(set(map(int, self.sensor_nodes))) != len(self.sensor_nodes):
+            raise ValueError("sensor_nodes must not contain duplicates")
         object.__setattr__(
             self, "rest_positions", readonly_array(positions, dtype=float)
         )
@@ -109,9 +179,21 @@ class Action:
     commanded_forces: np.ndarray
 
     def __post_init__(self) -> None:
+        _require_nonempty_string(self.action_id, name="action_id")
         forces = np.asarray(self.commanded_forces, dtype=float)
         if self.split not in {"train", "validation", "test"}:
             raise ValueError("split must be train, validation, or test")
+        if not self.contact_nodes:
+            raise ValueError("contact_nodes must be non-empty")
+        if any(
+            isinstance(node, (bool, np.bool_))
+            or not isinstance(node, (int, np.integer))
+            or node < 0
+            for node in self.contact_nodes
+        ):
+            raise ValueError("contact_nodes must contain non-negative integers")
+        if len(set(map(int, self.contact_nodes))) != len(self.contact_nodes):
+            raise ValueError("contact_nodes must not contain duplicates")
         if forces.ndim != 3 or forces.shape[1:] != (len(self.contact_nodes), 2):
             raise ValueError(
                 "commanded_forces must have shape (transition, contact, 2)"
@@ -148,15 +230,39 @@ class WorldCondition:
     nonlinear_stiffening: float = 0.0
 
     def __post_init__(self) -> None:
-        if self.contact_gain_multiplier <= 0.0:
+        _require_nonempty_string(self.name, name="name")
+        if (
+            _require_finite_scalar(
+                self.contact_gain_multiplier,
+                name="contact_gain_multiplier",
+            )
+            <= 0.0
+        ):
             raise ValueError("contact_gain_multiplier must be positive")
-        if self.contact_delay_steps < 0:
-            raise ValueError("contact_delay_steps must be non-negative")
-        if not 0.0 <= self.contact_spread < 1.0:
+        _require_integer(
+            self.contact_delay_steps,
+            name="contact_delay_steps",
+            minimum=0,
+        )
+        if not isinstance(self.shift_contact_nodes, (bool, np.bool_)):
+            raise ValueError("shift_contact_nodes must be boolean")
+        contact_spread = _require_finite_scalar(
+            self.contact_spread,
+            name="contact_spread",
+        )
+        if not 0.0 <= contact_spread < 1.0:
             raise ValueError("contact_spread must be in [0, 1)")
-        if not np.isfinite(self.control_rotation_radians):
-            raise ValueError("control_rotation_radians must be finite")
-        if self.nonlinear_stiffening < 0.0:
+        _require_finite_scalar(
+            self.control_rotation_radians,
+            name="control_rotation_radians",
+        )
+        if (
+            _require_finite_scalar(
+                self.nonlinear_stiffening,
+                name="nonlinear_stiffening",
+            )
+            < 0.0
+        ):
             raise ValueError("nonlinear_stiffening must be non-negative")
 
     def plan_model(self) -> WorldCondition:
@@ -188,11 +294,22 @@ class SimulatorConfig:
     velocity_drag: float = 0.18
 
     def __post_init__(self) -> None:
-        if self.frame_count < 4:
+        frame_count = _require_integer(
+            self.frame_count,
+            name="frame_count",
+            minimum=1,
+        )
+        if frame_count < 4:
             raise ValueError("frame_count must be at least four")
-        if self.dt <= 0.0:
+        if _require_finite_scalar(self.dt, name="dt") <= 0.0:
             raise ValueError("dt must be positive")
-        if self.velocity_drag < 0.0:
+        if (
+            _require_finite_scalar(
+                self.velocity_drag,
+                name="velocity_drag",
+            )
+            < 0.0
+        ):
             raise ValueError("velocity_drag must be non-negative")
 
 
@@ -354,6 +471,10 @@ def simulate_particles(
     particles = np.asarray(particles, dtype=float)
     if particles.ndim != 2 or particles.shape[1] != len(PARAMETER_NAMES):
         raise ValueError("particles must have shape (particle, 3)")
+    if particles.shape[0] == 0:
+        raise ValueError("particles must be non-empty")
+    if not np.all(np.isfinite(particles)):
+        raise ValueError("particles must be finite")
     return np.stack(
         [
             simulate(

--- a/tests/test_simulator_validation.py
+++ b/tests/test_simulator_validation.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from causal4d.simulator import (
+    Action,
+    GraphObject,
+    PhysicalParameters,
+    SimulatorConfig,
+    WorldCondition,
+    simulate,
+)
+
+
+def _parameters() -> PhysicalParameters:
+    return PhysicalParameters(stiffness=2.0, damping=0.4, contact_gain=1.1)
+
+
+def _graph(**overrides: object) -> GraphObject:
+    values: dict[str, object] = {
+        "name": "line",
+        "rest_positions": np.asarray([[0.0, 0.0], [1.0, 0.0]]),
+        "edges": ((0, 1),),
+        "mass": 1.0,
+        "support_stiffness": 0.2,
+        "true_parameters": _parameters(),
+        "sensor_nodes": (0, 1),
+    }
+    values.update(overrides)
+    return GraphObject(**values)
+
+
+def _action(**overrides: object) -> Action:
+    values: dict[str, object] = {
+        "action_id": "push",
+        "split": "test",
+        "contact_nodes": (0,),
+        "commanded_forces": np.ones((4, 1, 2), dtype=float),
+    }
+    values.update(overrides)
+    return Action(**values)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("stiffness", 0.0),
+        ("stiffness", -1.0),
+        ("stiffness", np.nan),
+        ("damping", np.inf),
+        ("contact_gain", True),
+    ],
+)
+def test_physical_parameters_reject_invalid_scalars(
+    field: str,
+    value: object,
+) -> None:
+    values: dict[str, object] = {
+        "stiffness": 2.0,
+        "damping": 0.4,
+        "contact_gain": 1.1,
+    }
+    values[field] = value
+
+    with pytest.raises(ValueError, match=field):
+        PhysicalParameters(**values)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"name": "  "}, "name must be a non-empty string"),
+        ({"mass": np.nan}, "mass must be finite"),
+        ({"mass": 0.0}, "mass must be positive"),
+        ({"support_stiffness": np.inf}, "support_stiffness must be finite"),
+        ({"support_stiffness": -1.0}, "support_stiffness must be non-negative"),
+        ({"edges": ((0, 1), (1, 0))}, "edges must not contain duplicates"),
+        ({"edges": ((False, 1),)}, "edge node indices must be integers"),
+        ({"sensor_nodes": (0, 0)}, "sensor_nodes must not contain duplicates"),
+        ({"sensor_nodes": (False, 1)}, "sensor node indices must be integers"),
+    ],
+)
+def test_graph_object_rejects_ambiguous_or_nonfinite_inputs(
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        _graph(**overrides)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"action_id": ""}, "action_id must be a non-empty string"),
+        (
+            {
+                "contact_nodes": (),
+                "commanded_forces": np.ones((4, 0, 2), dtype=float),
+            },
+            "contact_nodes must be non-empty",
+        ),
+        (
+            {
+                "contact_nodes": (0, 0),
+                "commanded_forces": np.ones((4, 2, 2), dtype=float),
+            },
+            "contact_nodes must not contain duplicates",
+        ),
+        ({"contact_nodes": (-1,)}, "contact_nodes must contain non-negative integers"),
+        (
+            {"contact_nodes": (True,)},
+            "contact_nodes must contain non-negative integers",
+        ),
+    ],
+)
+def test_action_rejects_invalid_identity_and_contact_support(
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        _action(**overrides)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"name": ""}, "name must be a non-empty string"),
+        ({"contact_gain_multiplier": np.nan}, "contact_gain_multiplier must be finite"),
+        ({"contact_delay_steps": 1.5}, "contact_delay_steps must be an integer"),
+        ({"contact_delay_steps": True}, "contact_delay_steps must be an integer"),
+        ({"shift_contact_nodes": 1}, "shift_contact_nodes must be boolean"),
+        ({"contact_spread": np.nan}, "contact_spread must be finite"),
+        ({"nonlinear_stiffening": np.inf}, "nonlinear_stiffening must be finite"),
+    ],
+)
+def test_world_condition_rejects_nonfinite_or_ambiguous_values(
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    values: dict[str, object] = {"name": "condition"}
+    values.update(overrides)
+    with pytest.raises(ValueError, match=message):
+        WorldCondition(**values)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"frame_count": True}, "frame_count must be an integer"),
+        ({"dt": np.nan}, "dt must be finite"),
+        ({"velocity_drag": np.inf}, "velocity_drag must be finite"),
+    ],
+)
+def test_simulator_config_rejects_nonfinite_or_boolean_values(
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        SimulatorConfig(**overrides)
+
+
+def test_action_contact_nodes_are_checked_against_graph_at_binding_time() -> None:
+    graph = _graph()
+    action = _action(contact_nodes=(2,))
+
+    with pytest.raises(ValueError, match="invalid contact node"):
+        simulate(
+            graph,
+            action,
+            _parameters(),
+            WorldCondition(name="condition"),
+            SimulatorConfig(frame_count=5),
+        )
+
+
+def test_validation_does_not_change_valid_simulation_or_serialization() -> None:
+    graph = _graph()
+    action = _action()
+    condition = WorldCondition(name="condition", contact_spread=0.2)
+    config = SimulatorConfig(frame_count=5, dt=0.03, velocity_drag=0.18)
+    trajectory = simulate(graph, action, _parameters(), condition, config)
+
+    assert trajectory.shape == (5, 2, 2)
+    assert np.all(np.isfinite(trajectory))
+    assert graph.as_dict()["edges"] == [[0, 1]]
+    assert action.as_dict()["contact_nodes"] == [0]
+    assert replace(condition, contact_spread=0.0).contact_spread == 0.0


### PR DESCRIPTION
## Summary

- validate physical parameters at construction time, including NaN/∞ and boolean-as-scalar cases
- reject ambiguous graph topology such as duplicate undirected edges, duplicate sensors, and non-integer node indices
- validate action identity and contact support before numerical simulation
- validate world-condition and simulator scalars for finiteness and semantic type
- reject empty or non-finite particle banks before `np.stack`
- add 31 focused regression cases plus a valid-path simulation/serialization guard

## Scientific-scope guard

This changes input rejection only. It does **not** alter the simulator equations, valid parameter values, benchmark defaults, protocol identities, evidence records, target-access boundaries, or registered claims.

## Verification

Locally exercised against an isolated package copy:

```text
31 passed
```

The full hosted matrix remains authoritative for repository-wide compatibility.