### PR TITLE
Make independent-verifier recruitment actionable without relaxing the gate

### DIFF
--- a/docs/independent_verifier_invitation_template.md
+++ b/docs/independent_verifier_invitation_template.md
@@ -1,0 +1,78 @@
+# Independent-verifier invitation template
+
+> Copy this text into a private message to a prospective verifier. Replace only
+> the bracketed contact fields. Do not commit the completed message, the
+> recipient's identity, or private principal material to the repository or
+> acquisition dataset.
+
+## Suggested subject
+
+Independent reproducibility verification for a frozen deformable-robotics study
+
+## Suggested invitation
+
+Dear [recipient],
+
+I am preparing a preregistered same-object physical experiment for Causal4D, a
+Bayesian abduction--intervention--prediction method for deformable-object
+forecasting. The protocol requires one real person, distinct from the method
+freezer, to independently attest the final scientific and software freeze before
+any confirmatory physical acquisition begins.
+
+I am asking whether you would be willing to consider this bounded verifier role.
+The role does **not** involve developing or tuning the method, operating the
+robot, selecting thresholds or exclusions, inspecting confirmatory outcomes, or
+performing the final analysis. Its claim-bearing scope is limited to checking the
+registered protocol and analysis manifest, the exact source and built-package
+identities, the deployed checkout, the chronology and target-access boundary,
+and the resulting immutable freeze attestation.
+
+Before deciding, please review:
+
+- `docs/independent_verifier_onboarding.md`;
+- `docs/independent_verifier_self_declaration_template.md`; and
+- `docs/operator_identity_registry.md`.
+
+Eligibility requires that you are a real, distinct person and can truthfully
+declare that you did not select or tune the frozen method using confirmatory
+target outcomes. A second account, alias, service identity, bot, or unattended
+workflow cannot satisfy the role. You may decline or refuse attestation at any
+point when an identity, artifact, chronology, or independence check fails.
+
+No raw personal identifier is published in the study artifacts. The public
+registry contains a project-local operator ID and a privacy-preserving
+person-level commitment; the stable principal and institutional secret remain
+outside the repository and dataset.
+
+The current evidence state is `0/36` acquired. Your review or acceptance would
+not authorize acquisition by itself. Acquisition remains blocked until the real
+operator registry is sealed, all source-only readiness checks pass, the exact
+method freeze is sealed and independently attested, and the final readiness
+record explicitly permits the first confirmatory execution.
+
+Please reply only after reviewing the two role documents. A suitable response is
+one of:
+
+- “I decline.”
+- “I am interested, but need clarification about [question].”
+- “I am willing to be assessed for the bounded independent-verifier role and
+  will complete the self-declaration privately.”
+
+Kind regards,
+
+[sender]
+
+## Sender checklist
+
+Before sending, verify that:
+
+- no target outcome or confirmatory execution has been opened;
+- the prospective verifier has not been entered into any registry without their
+  knowledge and consent;
+- no claim is made that accepting the invitation proves eligibility or completes
+  attestation;
+- no raw identity, email address, personnel number, or HMAC secret will be
+  committed to Git or stored in the acquisition dataset; and
+- the current readiness action remains
+  `stop_independent_verifier_unavailable` until a truthful sealed registry
+  validates.

--- a/docs/independent_verifier_onboarding.md
+++ b/docs/independent_verifier_onboarding.md
@@ -14,6 +14,23 @@ require transferring model-development, robot-operation, or data-analysis work.
 It does not register a person, infer an identity, relax independence, or
 authorize physical acquisition.
 
+## Recruitment materials
+
+Two copy-ready aids reduce the administrative burden without changing the
+protocol:
+
+- [`independent_verifier_invitation_template.md`](independent_verifier_invitation_template.md)
+  is a private invitation that explains the bounded role and current `0/36`
+  evidence state; and
+- [`independent_verifier_self_declaration_template.md`](independent_verifier_self_declaration_template.md)
+  is a private, candidate-completed consent and independence declaration.
+
+Only the blank templates belong in Git. A completed invitation, declaration,
+signature, stable principal, raw email address, personnel number, or HMAC secret
+must remain outside the repository and acquisition dataset. Receiving a private
+declaration does not itself register the candidate, authorize physical work, or
+constitute the final attestation.
+
 ## Bounded verifier role
 
 The independent verifier is responsible only for checking and attesting the
@@ -80,8 +97,9 @@ status.
 ## Onboarding and attestation sequence
 
 All commands must run from the exact deployed checkout and dataset selected for
-the physical study. Placeholder identities below must be replaced only by the
-real participants themselves.
+the physical study. Placeholder identities below must be replaced only after the
+real participants themselves have supplied and reviewed the required private
+material.
 
 1. Recompute the current decision and preserve the hash-verified result:
 
@@ -91,17 +109,55 @@ real participants themselves.
      /data/causal4d-sloth-multi-action-v1
    ```
 
-2. Scaffold or update the operator-registry template through the registered
-   readiness route. Do not edit the sealed registry in place.
+   Until a truthful sealed registry validates, the action must remain
+   `stop_independent_verifier_unavailable` and must not authorize physical work.
 
-3. Have the verifier supply and review their own identity and independence
-   declaration. Seal the corrected registry with the real principal
-   investigator identity.
+2. Send the bounded invitation privately. The candidate reviews this guide and
+   the blank self-declaration, then replies and completes the declaration in
+   their own words. Do not enter a candidate into the registry before their
+   informed consent.
 
-4. Recompute the next action. The governance blocker must disappear before any
-   physical or claim-bearing operation is attempted.
+3. Scaffold the protocol-bound registry template through the registered CLI:
 
-5. After all source-only readiness gates pass, seal the exact method freeze:
+   ```bash
+   causal4d protocol readiness scaffold-operator-registry \
+     /opt/causal4d-frozen \
+     /data/causal4d-sloth-multi-action-v1
+   ```
+
+4. The authorized identity custodian derives the person-level commitment using
+   the registered institution-held, domain-separated HMAC procedure. Edit only
+   the `operators` array in:
+
+   ```text
+   /data/causal4d-sloth-multi-action-v1/preacquisition/operator_registry.template.json
+   ```
+
+   The real verifier entry must use the consented project-local operator ID,
+   role `independent_verifier`, and the derived person-level commitment. Do not
+   copy raw identity or the completed declaration into the template.
+
+5. Seal the roster exactly once with the registered freezer identity:
+
+   ```bash
+   causal4d protocol readiness seal-operator-registry \
+     /opt/causal4d-frozen \
+     /data/causal4d-sloth-multi-action-v1 \
+     /data/causal4d-sloth-multi-action-v1/preacquisition/operator_registry.template.json \
+     --sealed-by "<registered-freezer-id>"
+   ```
+
+6. Recompute the next action. The governance blocker must disappear before any
+   object registration, source-panel acquisition, gate approval, freeze
+   attestation, or confirmatory physical operation is attempted:
+
+   ```bash
+   causal4d protocol readiness next-action \
+     /opt/causal4d-frozen \
+     /data/causal4d-sloth-multi-action-v1
+   ```
+
+7. After all source-only readiness gates pass, seal the exact method freeze:
 
    ```bash
    causal4d protocol freeze seal \
@@ -110,7 +166,7 @@ real participants themselves.
      --frozen-by "<registered-freezer-id>"
    ```
 
-6. The distinct verifier independently validates and attests that freeze:
+8. The distinct verifier independently validates and attests that freeze:
 
    ```bash
    causal4d protocol freeze attest \
@@ -121,7 +177,7 @@ real participants themselves.
      --verified-by "<registered-independent-verifier-id>"
    ```
 
-7. Obtain the final hash-verified readiness decision. Confirmatory execution 1
+9. Obtain the final hash-verified readiness decision. Confirmatory execution 1
    remains forbidden unless both `ready=true` and
    `first_confirmatory_execution_allowed=true` are present.
 
@@ -161,7 +217,9 @@ negative or bounded result.
 
 See also:
 
+- [`operator_identity_registry.md`](operator_identity_registry.md)
 - [`single_operator_registry_correction.md`](single_operator_registry_correction.md)
 - [`causal4d_real_experiment_milestone.md`](causal4d_real_experiment_milestone.md)
 - [`causal4d_paper_scope.md`](causal4d_paper_scope.md)
+- [governance blocker issue #377](https://github.com/IPS-Stuttgart/Causal4D/issues/377)
 - [primary milestone issue #25](https://github.com/IPS-Stuttgart/Causal4D/issues/25)

--- a/docs/independent_verifier_self_declaration_template.md
+++ b/docs/independent_verifier_self_declaration_template.md
@@ -1,0 +1,121 @@
+# Independent-verifier self-declaration template
+
+> This is a private onboarding aid, not a repository artifact and not an
+> attestation. The prospective verifier completes it in their own words and
+> returns it through an institutionally appropriate private channel. Do not
+> commit a completed declaration, raw identity material, or signature to Git or
+> store it in the acquisition dataset.
+
+## Candidate-supplied identity
+
+- Full name: [candidate completes privately]
+- Institutional affiliation or independent professional context: [candidate
+  completes privately]
+- Stable institutional principal or other approved identity input: [candidate
+  supplies privately to the authorized identity custodian]
+- Project-local operator ID requested: [candidate and principal investigator
+  agree; for example, `verifier.independent`]
+
+The stable principal is used only to derive the registered person-level identity
+commitment through the institution-held, domain-separated HMAC procedure. It is
+not written to the public operator registry.
+
+## Consent and person-level identity
+
+I confirm that:
+
+- I am a real person and I knowingly consent to being considered for the bounded
+  Causal4D independent-verifier role;
+- the identity information above is mine and was supplied by me;
+- I am not FlorianPfaff, and I am not acting through an alias, duplicate account,
+  service account, bot, language model, or unattended workflow for the method
+  freezer;
+- I understand that different usernames or operator IDs do not establish
+  person-level independence; and
+- I understand that this declaration does not itself register me, authorize
+  acquisition, or constitute the final method-freeze attestation.
+
+## Independence from target-informed method development
+
+I confirm that, to the best of my knowledge:
+
+- I did not use confirmatory target outcomes to select or tune the frozen
+  Causal4D estimator, intervention hypotheses, thresholds, exclusions, command
+  profiles, contact regions, analysis rules, or reporting policy;
+- I have not been shown confirmatory target outcomes from the registered
+  18-session, 36-execution physical study;
+- I will not inspect such outcomes before the method freeze and its independent
+  attestation are complete;
+- I will disclose any prior contribution or relationship that could make the
+  independence statement misleading; and
+- I will refuse or withdraw from the role if these statements cease to be true.
+
+Relevant prior involvement or potential conflict, including “none”: [candidate
+completes privately]
+
+## Bounded role acceptance
+
+I have reviewed:
+
+- `docs/independent_verifier_onboarding.md`;
+- `docs/operator_identity_registry.md`; and
+- the registered protocol and analysis materials supplied for review.
+
+I understand that my claim-bearing duties are limited to independently checking:
+
+1. the exact registered protocol and acquisition schedule;
+2. the registered analysis manifest and reporting boundary;
+3. the source revision, built distributions, dependencies, and deployed
+   checkout;
+4. the method-freeze identity and chronology;
+5. the distinct person-level identity of freezer and verifier; and
+6. the final fail-closed readiness result before confirmatory acquisition.
+
+I am not being asked to develop the method, operate the robot, choose scientific
+settings, inspect target outcomes, or perform the confirmatory analysis. I may
+refuse attestation whenever any required identity, artifact, chronology, or
+independence check fails.
+
+## Target-access and publication boundary
+
+I understand that:
+
+- the current evidence state is `0/36` acquired;
+- object registration, source-panel work, freeze attestation, and confirmatory
+  acquisition remain governed by the generated next-action sequence;
+- accepting this role does not by itself authorize physical work;
+- only the sealed project-local operator ID, roles, person-level commitment, and
+  immutable artifact identities may appear in published study records; and
+- raw personal identifiers, the institutional secret, and this completed private
+  declaration must remain outside the repository and acquisition dataset.
+
+## Candidate decision
+
+Select exactly one:
+
+- [ ] I decline the role.
+- [ ] I need clarification before deciding: [candidate completes privately]
+- [ ] I consent to registration for the bounded `independent_verifier` role,
+  subject to successful identity processing and all fail-closed validation.
+
+Candidate signature or institutionally accepted equivalent: [private]
+
+Date and time with timezone: [private]
+
+## Identity-custodian receipt
+
+The authorized custodian records privately, without copying raw identity into the
+dataset:
+
+- declaration received: [yes/no]
+- consent selection: [decline/clarification/consent]
+- approved identity derivation procedure: `hmac-sha256-domain-separated-v1`
+- person-level commitment derived: [64-character digest, inserted only into the
+  operator-registry template]
+- duplicate-person check passed: [yes/no]
+- incompatible-role check passed: [yes/no]
+- candidate notified of the resulting project-local operator ID: [yes/no]
+
+A “yes” receipt is still not a scientific attestation. The canonical registry
+must be sealed and validated, and the verifier must later execute or independently
+witness the registered freeze-attestation procedure.

--- a/src/causal4d/preacquisition_next_action.py
+++ b/src/causal4d/preacquisition_next_action.py
@@ -26,6 +26,11 @@ from causal4d.preacquisition_source_panel_control import build_source_panel_stat
 NEXT_ACTION_SCHEMA_VERSION = 1
 NEXT_ACTION_ARTIFACT_KIND = "Causal4DPreacquisitionNextAction"
 
+_INDEPENDENT_VERIFIER_MATERIALS = (
+    "docs/independent_verifier_onboarding.md",
+    "docs/independent_verifier_invitation_template.md",
+    "docs/independent_verifier_self_declaration_template.md",
+)
 _MANUAL = {
     "object_registration": (
         "Complete the fixed-object registration",
@@ -365,6 +370,10 @@ def _derive_action(
             "principal_investigator",
             category="governance_blocker",
             completion=next_check,
+            inputs=[
+                str(Path(repository) / relative)
+                for relative in _INDEPENDENT_VERIFIER_MATERIALS
+            ],
             blockers=[
                 "single_operator_project_cannot_satisfy_independent_verification"
             ],
@@ -679,6 +688,9 @@ def render_preacquisition_next_action_markdown(
     ):
         if action.get(field):
             lines += ["", f"### {heading}", "", "```bash", str(action[field]), "```"]
+    if action.get("input_paths"):
+        lines += ["", "### Input materials", ""]
+        lines += [f"- `{path}`" for path in action["input_paths"]]
     if action.get("blocking_items"):
         lines += ["", "### Blocking items", ""]
         lines += [f"- `{item}`" for item in action["blocking_items"]]

--- a/tests/test_independent_verifier_recruitment_packet.py
+++ b/tests/test_independent_verifier_recruitment_packet.py
@@ -117,7 +117,8 @@ def _decision(repository: str, dataset: str) -> dict[str, Any]:
 
 
 def _normalized(relative: str) -> str:
-    return " ".join((ROOT / relative).read_text(encoding="utf-8").split())
+    text = (ROOT / relative).read_text(encoding="utf-8").replace("\n> ", "\n")
+    return " ".join(text.split())
 
 
 def test_verifier_stop_packet_surfaces_only_blank_recruitment_materials() -> None:

--- a/tests/test_independent_verifier_recruitment_packet.py
+++ b/tests/test_independent_verifier_recruitment_packet.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from causal4d.preacquisition_next_action import (
     derive_preacquisition_next_action,
@@ -35,7 +36,7 @@ def _gate() -> dict[str, object]:
     }
 
 
-def _readiness() -> dict[str, object]:
+def _readiness() -> dict[str, Any]:
     prerequisites = {
         name: _prerequisite()
         for name in (
@@ -89,7 +90,7 @@ def _readiness() -> dict[str, object]:
     }
 
 
-def _source_panel() -> dict[str, object]:
+def _source_panel() -> dict[str, Any]:
     return {
         "protocol_id": "protocol",
         "protocol_design_sha256": "a" * 64,
@@ -106,13 +107,17 @@ def _source_panel() -> dict[str, object]:
     }
 
 
-def _decision(repository: str, dataset: str) -> dict[str, object]:
+def _decision(repository: str, dataset: str) -> dict[str, Any]:
     return derive_preacquisition_next_action(
         _readiness(),
         _source_panel(),
         repository_root=repository,
         dataset_root=dataset,
     )
+
+
+def _normalized(relative: str) -> str:
+    return " ".join((ROOT / relative).read_text(encoding="utf-8").split())
 
 
 def test_verifier_stop_packet_surfaces_only_blank_recruitment_materials() -> None:
@@ -157,15 +162,11 @@ def test_recruitment_documents_preserve_the_governance_boundary() -> None:
         assert path.is_file()
         assert not path.is_symlink()
 
-    invitation = (
-        ROOT / "docs/independent_verifier_invitation_template.md"
-    ).read_text(encoding="utf-8")
-    declaration = (
-        ROOT / "docs/independent_verifier_self_declaration_template.md"
-    ).read_text(encoding="utf-8")
-    onboarding = (ROOT / "docs/independent_verifier_onboarding.md").read_text(
-        encoding="utf-8"
+    invitation = _normalized("docs/independent_verifier_invitation_template.md")
+    declaration = _normalized(
+        "docs/independent_verifier_self_declaration_template.md"
     )
+    onboarding = _normalized("docs/independent_verifier_onboarding.md")
 
     for marker in (
         "current evidence state is `0/36` acquired",
@@ -176,7 +177,10 @@ def test_recruitment_documents_preserve_the_governance_boundary() -> None:
         assert marker in invitation
 
     for marker in (
-        "This is a private onboarding aid, not a repository artifact and not an attestation",
+        (
+            "This is a private onboarding aid, not a repository artifact and "
+            "not an attestation"
+        ),
         "I am a real person",
         "I am not FlorianPfaff",
         "did not use confirmatory target outcomes",

--- a/tests/test_independent_verifier_recruitment_packet.py
+++ b/tests/test_independent_verifier_recruitment_packet.py
@@ -163,9 +163,7 @@ def test_recruitment_documents_preserve_the_governance_boundary() -> None:
         assert not path.is_symlink()
 
     invitation = _normalized("docs/independent_verifier_invitation_template.md")
-    declaration = _normalized(
-        "docs/independent_verifier_self_declaration_template.md"
-    )
+    declaration = _normalized("docs/independent_verifier_self_declaration_template.md")
     onboarding = _normalized("docs/independent_verifier_onboarding.md")
 
     for marker in (

--- a/tests/test_independent_verifier_recruitment_packet.py
+++ b/tests/test_independent_verifier_recruitment_packet.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from causal4d.preacquisition_next_action import (
+    derive_preacquisition_next_action,
+    render_preacquisition_next_action_markdown,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+MATERIALS = (
+    "docs/independent_verifier_onboarding.md",
+    "docs/independent_verifier_invitation_template.md",
+    "docs/independent_verifier_self_declaration_template.md",
+)
+
+
+def _prerequisite() -> dict[str, object]:
+    return {
+        "present": True,
+        "valid": True,
+        "template": False,
+        "identity_pending": False,
+        "error": None,
+    }
+
+
+def _gate() -> dict[str, object]:
+    return {
+        "present": True,
+        "valid": True,
+        "template": False,
+        "identity_pending": False,
+        "error": None,
+    }
+
+
+def _readiness() -> dict[str, object]:
+    prerequisites = {
+        name: _prerequisite()
+        for name in (
+            "dataset_protocol",
+            "acquisition_schedule",
+            "object_registration",
+            "slip_pilot",
+            "timebase_calibration",
+            "contact_registration",
+            "operator_registry",
+            "operator_identity_bindings",
+            "method_freeze",
+            "method_freeze_validation",
+        )
+    }
+    prerequisites["operator_registry"]["independent_verifier_available"] = False
+    gates = {
+        name: _gate()
+        for name in (
+            "signature_panel_complete",
+            "actuator_sync_passed",
+            "support_registration_passed",
+            "end_to_end_dry_run_passed",
+            "software_environment_locked",
+        )
+    }
+    return {
+        "protocol_id": "protocol",
+        "protocol_design_sha256": "a" * 64,
+        "preacquisition_plan_id": "plan",
+        "preacquisition_amendment_sha256": "b" * 64,
+        "verify_file_hashes": True,
+        "prerequisites": prerequisites,
+        "operational_gates": gates,
+        "missing_prerequisites": [],
+        "malformed_prerequisites": [],
+        "missing_or_template_gates": [],
+        "malformed_gates": [],
+        "chronology_blockers": [],
+        "blockers": [],
+        "confirmatory_collection": {
+            "manifest_executions": 0,
+            "acquired_executions": 0,
+            "validated_executions": 0,
+            "not_started": True,
+        },
+        "evidence_sha256": "c" * 64,
+        "status_sha256": "d" * 64,
+        "valid": True,
+        "ready": False,
+    }
+
+
+def _source_panel() -> dict[str, object]:
+    return {
+        "protocol_id": "protocol",
+        "protocol_design_sha256": "a" * 64,
+        "preacquisition_plan_id": "plan",
+        "preacquisition_amendment_sha256": "b" * 64,
+        "missing_template_ids": [],
+        "blockers": [],
+        "next_execution": None,
+        "evidence_sha256": "e" * 64,
+        "status_sha256": "f" * 64,
+        "valid": True,
+        "complete": True,
+        "target_outcomes_used": False,
+    }
+
+
+def _decision(repository: str, dataset: str) -> dict[str, object]:
+    return derive_preacquisition_next_action(
+        _readiness(),
+        _source_panel(),
+        repository_root=repository,
+        dataset_root=dataset,
+    )
+
+
+def test_verifier_stop_packet_surfaces_only_blank_recruitment_materials() -> None:
+    decision = _decision("/repo", "/data/run")
+    action = decision["action"]
+
+    assert action["action_id"] == "stop_independent_verifier_unavailable"
+    assert action["category"] == "governance_blocker"
+    assert action["automatable"] is False
+    assert action["physical_acquisition_required"] is False
+    assert action["target_outcomes_permitted"] is False
+    assert action["changes_registered_method"] is False
+    assert action["command_argv"] is None
+    assert action["command_text"] is None
+    assert action["after_completion_argv"] is None
+    assert action["output_paths"] == []
+    assert action["input_paths"] == [f"/repo/{path}" for path in MATERIALS]
+    assert action["blocking_items"] == [
+        "single_operator_project_cannot_satisfy_independent_verification"
+    ]
+    assert decision["ready"] is False
+    assert decision["target_outcomes_used"] is False
+
+    markdown = render_preacquisition_next_action_markdown(decision)
+    assert "### Input materials" in markdown
+    for path in action["input_paths"]:
+        assert f"`{path}`" in markdown
+    assert "Physical acquisition required: `false`" in markdown
+
+
+def test_verifier_stop_packet_identity_is_mount_invariant() -> None:
+    first = _decision("/repo", "/data/run")
+    second = _decision("/different/repo", "/different/data")
+
+    assert first["evidence_sha256"] == second["evidence_sha256"]
+    assert first["status_sha256"] != second["status_sha256"]
+
+
+def test_recruitment_documents_preserve_the_governance_boundary() -> None:
+    for relative in MATERIALS:
+        path = ROOT / relative
+        assert path.is_file()
+        assert not path.is_symlink()
+
+    invitation = (
+        ROOT / "docs/independent_verifier_invitation_template.md"
+    ).read_text(encoding="utf-8")
+    declaration = (
+        ROOT / "docs/independent_verifier_self_declaration_template.md"
+    ).read_text(encoding="utf-8")
+    onboarding = (ROOT / "docs/independent_verifier_onboarding.md").read_text(
+        encoding="utf-8"
+    )
+
+    for marker in (
+        "current evidence state is `0/36` acquired",
+        "would not authorize acquisition by itself",
+        "A second account, alias, service identity, bot, or unattended workflow",
+        "Do not commit the completed message",
+    ):
+        assert marker in invitation
+
+    for marker in (
+        "This is a private onboarding aid, not a repository artifact and not an attestation",
+        "I am a real person",
+        "I am not FlorianPfaff",
+        "did not use confirmatory target outcomes",
+        "does not by itself authorize physical work",
+        "must remain outside the repository and acquisition dataset",
+    ):
+        assert marker in declaration
+
+    for marker in (
+        "independent_verifier_invitation_template.md",
+        "independent_verifier_self_declaration_template.md",
+        "Receiving a private declaration does not itself register the candidate",
+        "stop_independent_verifier_unavailable",
+        "Confirmatory execution 1 remains forbidden",
+    ):
+        assert marker in onboarding


### PR DESCRIPTION
## Summary

- add a copy-ready private invitation for a prospective independent verifier;
- add a private self-declaration covering consent, person-level distinctness, target-access independence, bounded duties, and identity-custodian handling;
- make the onboarding guide an exact end-to-end sequence from invitation through sealed registry, method-freeze attestation, and final readiness;
- surface the three blank recruitment materials in the generated `stop_independent_verifier_unavailable` decision and its Markdown report;
- add regressions for the fail-closed action, absent execution command/output, mount-independent evidence identity, and privacy/governance wording.

## Boundary retained

This patch does **not** register or infer a person, create an alias, authorize physical work, change the frozen scientific method, open target outcomes, or weaken the independent-attestation requirement. The stop action remains non-automatable, has no execution command, and keeps the blocker `single_operator_project_cannot_satisfy_independent_verification`.

The real evidence state remains `0/36`. Confirmatory execution remains forbidden until a truthful sealed registry names a real distinct verifier and all later readiness gates pass.

## Expected decision change

Only `action.input_paths` and the human-readable input-material list change for the single-person governance stop. Repository-root paths remain normalized in the logical evidence digest, so the decision identity is mount independent.