### PR TITLE
Permit disclosed single-operator pre-acquisition governance

### DIFF
--- a/configs/causal4d/sloth_preacquisition_v5.json
+++ b/configs/causal4d/sloth_preacquisition_v5.json
@@ -1,0 +1,354 @@
+{
+  "schema_version": 1,
+  "plan_id": "causal4d-sloth-preacquisition-v5-single-operator",
+  "status": "supersedes_v4_before_any_physical_execution",
+  "supersedes": {
+    "plan_id": "causal4d-sloth-preacquisition-v4",
+    "amendment_sha256": "0e167538a7824e5ec053031d8359d4e9b4ff89ad61a85666400a86c2a88ac42f",
+    "git_commit": "998b9adfd17ed9b2e98ed9bac18366f62ec1ba18",
+    "physical_executions_completed_before_supersession": 0
+  },
+  "base_protocol": {
+    "action_contact_grid_unchanged": true,
+    "confirmatory_execution_count": 36,
+    "design_sha256": "6d61f2bea96af0ba04faaf3476990b58cd87e0a9c826420c254a012dec647968",
+    "protocol_id": "causal4d-sloth-multi-action-v1",
+    "target_execution_ids_unchanged": true
+  },
+  "unchanged_acquisition_design": {
+    "confirmatory_execution_count": 36,
+    "confirmatory_target_ids_unchanged": true,
+    "new_physical_executions_added_by_v3": 0,
+    "source_panel_execution_count": 12,
+    "source_panel_execution_ids": [
+      "sloth-pre-v2-lift_high-r1",
+      "sloth-pre-v2-lift_high-r2",
+      "sloth-pre-v2-lift_high-r3",
+      "sloth-pre-v2-lower_high-r1",
+      "sloth-pre-v2-lower_high-r2",
+      "sloth-pre-v2-lower_high-r3",
+      "sloth-pre-v2-lift_high_slow-r1",
+      "sloth-pre-v2-lift_high_slow-r2",
+      "sloth-pre-v2-lift_high_slow-r3",
+      "sloth-pre-v2-lift_high_long_hold-r1",
+      "sloth-pre-v2-lift_high_long_hold-r2",
+      "sloth-pre-v2-lift_high_long_hold-r3"
+    ]
+  },
+  "unchanged_v3_analysis": {
+    "calibration_resolution": {
+      "achievable_nominal_grid": [
+        0.1,
+        0.2,
+        0.3,
+        0.4,
+        0.5,
+        0.6,
+        0.7,
+        0.8,
+        0.9
+      ],
+      "calibration_unit": "one preregistered execution per independent session",
+      "calibration_units_per_outer_fold": 9,
+      "claim": "Finite marginal execution-block split-conformal coverage under session exchangeability; coarse rank-9-of-9 calibration.",
+      "fragility_diagnostics": [
+        "maximum_to_median_score_ratio",
+        "largest_and_second_largest_scores",
+        "leave_one_calibration_session_out_thresholds",
+        "interval_width_by_outer_fold"
+      ],
+      "fragility_diagnostics_may_select_threshold": false,
+      "pooled_coordinate_conformal_claim_allowed": false,
+      "resolution": 0.1,
+      "selected_nominal_coverage": 0.9,
+      "selected_order_statistic_rank_one_based": 9,
+      "selected_threshold_is_maximum_calibration_score": true,
+      "worst_group_coverage_guarantee_claimed": false
+    },
+    "signature_eligibility_gates": {
+      "camera_observation": {
+        "magnitude_threshold": "at least 1.5 times camera-specific repeatability floor",
+        "minimum_view_count": 3,
+        "required_direction": "held-view transfer worse than object-frame transfer",
+        "statistic": "leave-one-view-out correction transfer ratio"
+      },
+      "common": {
+        "effect_below_threshold_interpretation": "not_eligible_for_confirmatory_mechanism",
+        "minimum_consistent_repetitions": 2,
+        "p_values_or_null_rejection_allowed": false,
+        "repetition_count": 3
+      },
+      "hold_relaxation": {
+        "amplitude_definition": "difference between the first-three and last-three hold-frame object-frame residual means",
+        "minimum_exponential_log_r_squared": 0.8,
+        "minimum_relaxation_amplitude_over_sigma_repeat": 1.5,
+        "observable_time_constant_s": [
+          0.0667,
+          0.5
+        ],
+        "profiles": [
+          "lift_high",
+          "lift_high_long_hold"
+        ]
+      },
+      "reset_state": {
+        "minimum_crossfit_effect_over_sigma_repeat": 1.5,
+        "statistic": "residual covariance explained by measured reset deviation"
+      },
+      "speed": {
+        "matched": [
+          "direction",
+          "amplitude",
+          "hold_duration",
+          "contact"
+        ],
+        "minimum_effect_rms_over_sigma_repeat": 1.5,
+        "profiles": [
+          "lift_high",
+          "lift_high_slow"
+        ],
+        "required_measured_slow_to_fast_peak_speed_ratio": [
+          0.35,
+          0.65
+        ]
+      }
+    },
+    "source_panel_crossfit": {
+      "all_12_sessions_held_out_exactly_once": true,
+      "folds": [
+        {
+          "fold_id": "source-panel-hold-replicate-1",
+          "heldout_future_used_for_coefficient_fit": false,
+          "heldout_session_count": 4,
+          "heldout_shrinkage_execution_ids": [
+            "sloth-pre-v2-lift_high-r1",
+            "sloth-pre-v2-lower_high-r1",
+            "sloth-pre-v2-lift_high_slow-r1",
+            "sloth-pre-v2-lift_high_long_hold-r1"
+          ],
+          "mechanism_fit_execution_ids": [
+            "sloth-pre-v2-lift_high-r2",
+            "sloth-pre-v2-lift_high-r3",
+            "sloth-pre-v2-lower_high-r2",
+            "sloth-pre-v2-lower_high-r3",
+            "sloth-pre-v2-lift_high_slow-r2",
+            "sloth-pre-v2-lift_high_slow-r3",
+            "sloth-pre-v2-lift_high_long_hold-r2",
+            "sloth-pre-v2-lift_high_long_hold-r3"
+          ],
+          "mechanism_fit_session_count": 8,
+          "readout_coefficients_refit_on_heldout_prefix": true
+        },
+        {
+          "fold_id": "source-panel-hold-replicate-2",
+          "heldout_future_used_for_coefficient_fit": false,
+          "heldout_session_count": 4,
+          "heldout_shrinkage_execution_ids": [
+            "sloth-pre-v2-lift_high-r2",
+            "sloth-pre-v2-lower_high-r2",
+            "sloth-pre-v2-lift_high_slow-r2",
+            "sloth-pre-v2-lift_high_long_hold-r2"
+          ],
+          "mechanism_fit_execution_ids": [
+            "sloth-pre-v2-lift_high-r1",
+            "sloth-pre-v2-lift_high-r3",
+            "sloth-pre-v2-lower_high-r1",
+            "sloth-pre-v2-lower_high-r3",
+            "sloth-pre-v2-lift_high_slow-r1",
+            "sloth-pre-v2-lift_high_slow-r3",
+            "sloth-pre-v2-lift_high_long_hold-r1",
+            "sloth-pre-v2-lift_high_long_hold-r3"
+          ],
+          "mechanism_fit_session_count": 8,
+          "readout_coefficients_refit_on_heldout_prefix": true
+        },
+        {
+          "fold_id": "source-panel-hold-replicate-3",
+          "heldout_future_used_for_coefficient_fit": false,
+          "heldout_session_count": 4,
+          "heldout_shrinkage_execution_ids": [
+            "sloth-pre-v2-lift_high-r3",
+            "sloth-pre-v2-lower_high-r3",
+            "sloth-pre-v2-lift_high_slow-r3",
+            "sloth-pre-v2-lift_high_long_hold-r3"
+          ],
+          "mechanism_fit_execution_ids": [
+            "sloth-pre-v2-lift_high-r1",
+            "sloth-pre-v2-lift_high-r2",
+            "sloth-pre-v2-lower_high-r1",
+            "sloth-pre-v2-lower_high-r2",
+            "sloth-pre-v2-lift_high_slow-r1",
+            "sloth-pre-v2-lift_high_slow-r2",
+            "sloth-pre-v2-lift_high_long_hold-r1",
+            "sloth-pre-v2-lift_high_long_hold-r2"
+          ],
+          "mechanism_fit_session_count": 8,
+          "readout_coefficients_refit_on_heldout_prefix": true
+        }
+      ],
+      "graph_correction_refit_boundary": "Refit c_base and c_M independently from the permitted prefix of each held-out source execution, after mechanism parameters are frozen.",
+      "heldout_shrinkage_sessions_per_fold": 4,
+      "mechanism_fit_sessions_per_fold": 8,
+      "mechanism_may_not_fit_heldout_session": true
+    },
+    "source_panel_role": {
+      "confirmatory_claim_allowed": false,
+      "decision_rule": "predeclared_effect_direction_and_noise_scaled_magnitude",
+      "exact_repetitions_per_profile": 3,
+      "replication_unit": "fresh_reset_session",
+      "role": "discovery_and_model_family_eligibility_only",
+      "significance_test_allowed": false
+    }
+  },
+  "mechanism_gate_control_lock": {
+    "claim_boundary": "Controlled operating-point evidence only; no released or prospective physical outcome is used, and no real-world false-positive guarantee is claimed.",
+    "evidence_artifact": "runs/causal4d_preacquisition_v4/mechanism_gate_controls.json",
+    "evidence_sha256": "f48e1fbc650daf7b81a317085e3bf038087dda3d459299a4e34c61777e4a5761",
+    "frozen_threshold": {
+      "minimum_geometric_mean_shrinkage_fraction": 0.1,
+      "minimum_sessions_with_positive_shrinkage": 8,
+      "session_count": 12
+    },
+    "placebo": {
+      "definition": "the exact scalar actuation-response bank rotated 90 degrees, preserving candidate norms and the identical nine-value grid",
+      "full_gate_pass_count": 0,
+      "full_gate_pass_rate": 0.0,
+      "wilson_95": [
+        0.0,
+        0.007447247372
+      ]
+    },
+    "positive_control": {
+      "definition": "known 10 percent actuation-gain loss, fitted on a scalar grid",
+      "full_gate_pass_count": 478,
+      "full_gate_pass_rate": 0.93359375,
+      "wilson_95": [
+        0.908636119037,
+        0.952093221132
+      ]
+    },
+    "real_world_false_positive_rate_claimed": false,
+    "simulation_count_per_arm": 512,
+    "threshold_changed_after_controls": false
+  },
+  "state_propagation_interpretation_lock": {
+    "attachment_correlations_inferential": false,
+    "cross_case_claim": "A prefix state error may matter interaction by interaction, but one generic state reset is not a transferable persistent-discrepancy model.",
+    "double_lift": {
+      "final_outside_injected_rank4_fraction": 0.7356,
+      "interpretation": "contraction_and_basis_leakage"
+    },
+    "double_stretch": {
+      "interpretation": "spatial redistribution or cancellation; contact switching remains an alternative to a smooth rotation interpretation",
+      "near_middle_far_aligned_retention": [
+        0.0555,
+        -0.3638,
+        0.4798
+      ]
+    },
+    "empirical_description": "delta_x_T approximately Phi_a(T,t_p) delta_x_t_p",
+    "linearization_boundary": "Phi_a is an empirical secant or local linearization at the injected magnitude, not a globally valid state-transition matrix. Contact-mode switching can make propagation nonsmooth.",
+    "released_case_source": {
+      "aggregate_artifact": "data/paper_evidence/phystwin_discrepancy_localization_v1/state_correction_modes_aggregate.json",
+      "aggregate_file_sha256": "97eafb9a64a51faac4fd92d8aff9fffb89b28143b4e5f1e91189ff6572b91df7",
+      "git_tag": "phystwin-discrepancy-localization-v1"
+    },
+    "single_lift": {
+      "dominant_retained_mode": 0,
+      "readout_cd_gain_captured_fraction": 0.8267,
+      "readout_track_gain_captured_fraction": 0.8738,
+      "state_error_interpretation": "plausible_for_this_interaction"
+    }
+  },
+  "prospective_mode0_reset_crosscheck": {
+    "action_outcomes_may_revise_mapping": false,
+    "decision_rule": {
+      "compatibility_confirms_cause": false,
+      "reset_scale_explanation_weakened": "released mode-0 RMS exceeds twice the pilot statistic",
+      "scale_compatible": "released mode-0 RMS is no more than twice the pilot statistic"
+    },
+    "hypothesis": "If the single-lift mode-0 component is primarily initial pose, reset, or registration error, independently measured reset mode-0 variation should be commensurate with the released inferred correction.",
+    "pilot_statistic": "95th percentile across fresh-reset sessions of per-node vector RMS in mode 0, expressed in the locked world frame before any per-reset best-fit alignment, plus the preregistered 95 percent registration uncertainty.",
+    "released_reference": {
+      "initial_mode_energy_m2": 1.3009828632847338,
+      "mode": 0,
+      "object_node_count": 6895,
+      "per_node_vector_rms_m": 0.013736264750447176
+    },
+    "secondary_decomposition": [
+      "locked-frame rigid translation",
+      "best-fit SE3 registration component",
+      "post-SE3 low-rank nonrigid component"
+    ],
+    "status": "preregistered_before_slip_reset_pilot"
+  },
+  "mechanism_ladder_addition": {
+    "definition": "Infer a prefix state update, propagate its basis through the frozen action/contact-conditioned simulator, and cross-fit every mechanism parameter on 8 source sessions before evaluation on 4 held-out sessions.",
+    "implementation_may_use_target_sessions": false,
+    "name": "action_dependent_propagated_state_correction",
+    "promoted_before_source_panel": false,
+    "role": "source_panel_candidate_not_released_case_model_selection",
+    "same_v3_shrinkage_and_prediction_gates_required": true
+  },
+  "contact_registration_contract": {
+    "approval_required_before_slip_pilot": true,
+    "artifact_kind": "PhysicalContactRegistration",
+    "minimum_calibrated_camera_views": 3,
+    "minimum_independent_reviews": 2,
+    "minimum_rejected_candidates_per_region": 1,
+    "schema_version": 3,
+    "se3_covariance_and_closure_required": true,
+    "selected_and_rejected_candidates_required": true,
+    "support_geometry_required": true,
+    "target_outcomes_may_revise_registration": false,
+    "weighted_node_patch_required": true
+  },
+  "collection_sequence": [
+    "approve_contact_registration",
+    "run_preregistered_slip_pilot",
+    "collect_12_execution_signature_and_repeatability_panel",
+    "validate_commanded_vs_measured_actuation",
+    "validate_support_and_gravity_registration",
+    "run_one_nonconfirmatory_end_to_end_dry_run",
+    "seal_analysis_implementation_and_environment",
+    "collect_36_unchanged_confirmatory_executions"
+  ],
+  "collection_gate": {
+    "actuator_sync_passed": false,
+    "analysis_code_frozen": false,
+    "contact_registration_approved": false,
+    "end_to_end_dry_run_passed": false,
+    "first_confirmatory_execution_allowed": false,
+    "signature_panel_complete": false,
+    "slip_pilot_passed_or_versioned_out": false,
+    "support_registration_passed": false,
+    "v3_analysis_code_frozen": false,
+    "v4_analysis_code_frozen": false
+  },
+  "governance": {
+    "policy_id": "single-operator-self-attestation-v1",
+    "mode": "single_operator_self_attested",
+    "single_operator_allowed": true,
+    "independent_verifier_required": false,
+    "independent_preacquisition_attestation_claimed": false,
+    "self_attestation_required": true,
+    "same_person_method_freeze_attestation_allowed": true,
+    "same_person_software_environment_approval_allowed": true,
+    "same_person_source_review_and_publication_allowed": true,
+    "contact_registration_review_policy": "two_pass_single_operator_review_v1",
+    "minimum_contact_registration_review_passes": 2,
+    "contact_review_passes_must_be_chronologically_ordered": true,
+    "registered_person_identity_required": true,
+    "cryptographic_freeze_required": true,
+    "complete_failure_and_negative_result_reporting_required": true,
+    "target_outcomes_used_for_amendment": false,
+    "scientific_method_changed": false,
+    "acquisition_design_changed": false,
+    "split_changed": false,
+    "threshold_changed": false,
+    "reporting_boundary_changed": false,
+    "paper_disclosure": "One registered operator performed the pre-acquisition checks and self-attested the freeze; no independent pre-acquisition attestation is claimed.",
+    "single_operator_contact_registration_schema_version": 4
+  },
+  "amendment_sha256": "c0128865c7b527304dc7a6177d7f935d753bfdbc1e4469243f1acaeae6ce8e93"
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,8 +66,11 @@ another document.
 
 ### Frozen amendment lineage
 
-- [Pre-acquisition amendment v4](causal4d_preacquisition_v4.md) is the active,
-  byte-locked amendment.
+- [Pre-acquisition governance amendment v5](causal4d_preacquisition_v5.md)
+  is the active, byte-locked amendment. It permits disclosed single-operator
+  self-attestation and makes no independent-attestation claim.
+- [Pre-acquisition amendment v4](causal4d_preacquisition_v4.md) is superseded by
+  v5 and retained unchanged for provenance.
 - [Pre-acquisition amendment v3](causal4d_preacquisition_v3.md) is superseded by
   v4 and retained unchanged for provenance.
 - [Pre-acquisition amendment v2](causal4d_preacquisition_v2.md) is superseded by

--- a/docs/causal4d_preacquisition_v5.md
+++ b/docs/causal4d_preacquisition_v5.md
@@ -4,7 +4,7 @@ Status: **locked before any physical execution**
 
 Plan ID: `causal4d-sloth-preacquisition-v5-single-operator`
 
-Canonical amendment SHA-256: `680371b7a05f72ee13270d509275b396f9d0de9cff19b810af23034f260dec31`
+Canonical amendment SHA-256: `c0128865c7b527304dc7a6177d7f935d753bfdbc1e4469243f1acaeae6ce8e93`
 
 ## Decision
 

--- a/docs/causal4d_preacquisition_v5.md
+++ b/docs/causal4d_preacquisition_v5.md
@@ -1,0 +1,80 @@
+# Causal4D pre-acquisition governance amendment v5
+
+Status: **locked before any physical execution**
+
+Plan ID: `causal4d-sloth-preacquisition-v5-single-operator`
+
+Canonical amendment SHA-256: `680371b7a05f72ee13270d509275b396f9d0de9cff19b810af23034f260dec31`
+
+## Decision
+
+Causal4D is currently operated by one person. Version 4 required a second,
+person-level independent verifier and therefore made the registered physical
+study impossible without inventing an identity or recruiting someone who does
+not exist. Neither is acceptable.
+
+Version 5 uses the alternative governance path recorded before acquisition:
+one registered operator may perform and attest the pre-acquisition checks.
+Every artifact must name that operator honestly. The project makes **no claim
+of independent pre-acquisition attestation**.
+
+## What changed
+
+Only human-separation governance changed:
+
+- the method freezer may self-attest the immutable freeze;
+- the software-environment approver may be the same registered person;
+- source-panel review and publication may be performed by the same registered
+  person, with the review receipt and byte checks still required;
+- contact registration uses schema 4 with two chronological review passes by the registered
+  operator rather than two purportedly independent people;
+- reports must state that these are self-attested checks.
+
+The operator registry, chronology checks, cryptographic hashes, write-once
+artifacts, exact fallback behavior, complete failure accounting, and target
+boundary remain mandatory.
+
+## What did not change
+
+The complete v4 scientific and acquisition state is copied byte-for-value into
+v5 and validated at load time. In particular, v5 does not change:
+
+- the 18-session, 36-execution acquisition design;
+- the 12-execution source panel or its three 8-fit/4-held-out folds;
+- contact regions, commands, reversal/speed/hold contrasts, or calibration
+  sessions;
+- graph basis, rank, mechanism ladder, shrinkage threshold, transfer gates, or
+  calibration arithmetic;
+- the target split, target-outcome prohibition, no-replacement rule, or
+  execution-level reporting;
+- the controlled mechanism-gate evidence or any released-case result.
+
+The old v4 artifact remains immutable in the evidence chain. Version 5
+supersedes it only for governance and has a new plan identity.
+
+## Required disclosure
+
+Every paper, report, and evidence summary using this study must say:
+
+> One registered operator performed the pre-acquisition checks and
+> self-attested the freeze; no independent pre-acquisition attestation is
+> claimed.
+
+“Independent verifier,” “independent review,” and equivalent wording must not
+be used for evidence produced under this policy unless a genuinely distinct
+person later performs a separately registered review.
+
+## Review semantics
+
+Self-attestation is not a waiver of checks. The same operator must still:
+
+1. seal the operator registry before governed evidence;
+2. complete each review after the underlying artifact is finalized;
+3. preserve the review receipt and all source hashes;
+4. perform two chronological contact-registration review passes;
+5. run the final hash-verified readiness command;
+6. retain every failed or aborted execution with an explicit disposition;
+7. keep all target outcomes closed until the registered barrier opens.
+
+This amendment permits the study to proceed honestly. It does not make the
+result independently reproduced.

--- a/docs/lifecycle_registry.json
+++ b/docs/lifecycle_registry.json
@@ -101,11 +101,21 @@
       "path": "docs/causal4d_preacquisition_v4.md",
       "title": "Pre-acquisition amendment v4",
       "kind": "protocol",
+      "status": "superseded",
+      "claim_bearing": true,
+      "operational_role": null,
+      "successor": "docs/causal4d_preacquisition_v5.md",
+      "git_blob_sha1": "9c35910925cf49c456e2a848ac8528792689472d"
+    },
+    {
+      "path": "docs/causal4d_preacquisition_v5.md",
+      "title": "Pre-acquisition governance amendment v5",
+      "kind": "protocol",
       "status": "frozen",
       "claim_bearing": true,
       "operational_role": "preacquisition-amendment",
       "successor": null,
-      "git_blob_sha1": "9c35910925cf49c456e2a848ac8528792689472d"
+      "git_blob_sha1": "951716665c64e37eee0784b5c8fed9289e4222f4"
     },
     {
       "path": "docs/causal4d_real_evidence_status.md",

--- a/docs/lifecycle_registry.json
+++ b/docs/lifecycle_registry.json
@@ -115,7 +115,7 @@
       "claim_bearing": true,
       "operational_role": "preacquisition-amendment",
       "successor": null,
-      "git_blob_sha1": "951716665c64e37eee0784b5c8fed9289e4222f4"
+      "git_blob_sha1": "f8df1d56673338bda661bb6a1b3fed4b8ca217b9"
     },
     {
       "path": "docs/causal4d_real_evidence_status.md",

--- a/src/causal4d/cli/contact_registration.py
+++ b/src/causal4d/cli/contact_registration.py
@@ -7,6 +7,8 @@ import json
 from collections.abc import Sequence
 
 from causal4d.contact_registration import (
+    INDEPENDENT_REVIEW_POLICY,
+    SINGLE_OPERATOR_REVIEW_POLICY,
     build_contact_registration_template,
     validate_contact_registration,
     write_contact_registration,
@@ -22,6 +24,11 @@ def build_parser() -> argparse.ArgumentParser:
     template.add_argument("output_json")
     template.add_argument("--camera-id", action="append", required=True)
     template.add_argument("--object-node-count", type=int, required=True)
+    template.add_argument(
+        "--review-policy",
+        choices=(INDEPENDENT_REVIEW_POLICY, SINGLE_OPERATOR_REVIEW_POLICY),
+        default=INDEPENDENT_REVIEW_POLICY,
+    )
     validate = subparsers.add_parser("validate")
     validate.add_argument("protocol_json")
     validate.add_argument("registration_json")
@@ -37,6 +44,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 protocol,
                 camera_ids=args.camera_id,
                 object_node_count=args.object_node_count,
+                review_policy=args.review_policy,
             )
             output = write_contact_registration(args.output_json, artifact)
             result = {

--- a/src/causal4d/contact_registration.py
+++ b/src/causal4d/contact_registration.py
@@ -14,6 +14,9 @@ from causal4d.real_protocol import validate_protocol
 
 
 CONTACT_REGISTRATION_SCHEMA_VERSION = 3
+SINGLE_OPERATOR_CONTACT_REGISTRATION_SCHEMA_VERSION = 4
+INDEPENDENT_REVIEW_POLICY = "independent_two_person_v1"
+SINGLE_OPERATOR_REVIEW_POLICY = "two_pass_single_operator_review_v1"
 
 
 def _require(condition: bool, message: str) -> None:
@@ -100,8 +103,9 @@ def build_contact_registration_template(
     *,
     camera_ids: Sequence[str],
     object_node_count: int,
+    review_policy: str = INDEPENDENT_REVIEW_POLICY,
 ) -> dict[str, Any]:
-    """Build an explicitly incomplete version-3 registration template."""
+    """Build an explicitly incomplete registration template."""
 
     validate_protocol(protocol)
     cameras = [str(value) for value in camera_ids]
@@ -113,10 +117,20 @@ def build_contact_registration_template(
         raise ValueError("at least three unique camera ids are required")
     if object_node_count < 1:
         raise ValueError("object_node_count must be positive")
+    if review_policy not in {
+        INDEPENDENT_REVIEW_POLICY,
+        SINGLE_OPERATOR_REVIEW_POLICY,
+    }:
+        raise ValueError("unsupported contact-registration review policy")
+    schema_version = (
+        SINGLE_OPERATOR_CONTACT_REGISTRATION_SCHEMA_VERSION
+        if review_policy == SINGLE_OPERATOR_REVIEW_POLICY
+        else CONTACT_REGISTRATION_SCHEMA_VERSION
+    )
     transform = {"matrix": None, "covariance_se3": None}
     descriptor = {"path": None, "sha256": None, "bytes": None}
     return {
-        "schema_version": CONTACT_REGISTRATION_SCHEMA_VERSION,
+        "schema_version": schema_version,
         "artifact_kind": "PhysicalContactRegistration",
         "protocol_id": protocol["protocol_id"],
         "protocol_design_sha256": protocol["design_sha256"],
@@ -179,7 +193,14 @@ def build_contact_registration_template(
                     }
                     for camera_id in cameras
                 },
-                "independent_reviews": [],
+                **(
+                    {
+                        "review_policy": SINGLE_OPERATOR_REVIEW_POLICY,
+                        "review_passes": [],
+                    }
+                    if review_policy == SINGLE_OPERATOR_REVIEW_POLICY
+                    else {"independent_reviews": []}
+                ),
                 "interreview_rms_m": None,
                 "multiview_reprojection_rmse_px": None,
             }
@@ -187,7 +208,11 @@ def build_contact_registration_template(
         },
         "acceptance": {
             "multiview_agreement_passed": None,
-            "independent_review_passed": None,
+            **(
+                {"review_policy_passed": None}
+                if review_policy == SINGLE_OPERATOR_REVIEW_POLICY
+                else {"independent_review_passed": None}
+            ),
             "attachment_uncertainty_separates_regions": None,
             "frame_closure_recorded": None,
             "target_outcomes_used": False,
@@ -208,7 +233,8 @@ def validate_contact_registration(
 
     validate_protocol(protocol)
     _require(
-        artifact.get("schema_version") in {2, 3},
+        artifact.get("schema_version")
+        in {2, 3, SINGLE_OPERATOR_CONTACT_REGISTRATION_SCHEMA_VERSION},
         "unsupported contact registration schema",
     )
     _require(
@@ -224,6 +250,10 @@ def validate_contact_registration(
     )
     _require(
         artifact.get("status") == "approved", "contact registration is not approved"
+    )
+    single_operator_review = (
+        artifact["schema_version"]
+        == SINGLE_OPERATOR_CONTACT_REGISTRATION_SCHEMA_VERSION
     )
     object_record = artifact["object"]
     _require(
@@ -484,8 +514,15 @@ def validate_contact_registration(
             _validate_descriptor(
                 overlay["artifact"], f"{region_id} {camera_id} overlay"
             )
-        reviews = list(region["independent_reviews"])
-        _require(len(reviews) >= 2, f"{region_id} needs two independent reviews")
+        if single_operator_review:
+            _require(
+                region.get("review_policy") == SINGLE_OPERATOR_REVIEW_POLICY,
+                f"{region_id} has the wrong self-review policy",
+            )
+            reviews = list(region["review_passes"])
+        else:
+            reviews = list(region["independent_reviews"])
+        _require(len(reviews) >= 2, f"{region_id} needs two review passes")
         reviewer_ids: list[str] = []
         review_times: list[datetime] = []
         for review in reviews:
@@ -502,11 +539,24 @@ def validate_contact_registration(
                 )
             )
             _vector(review["centroid_world_m"], 3, f"{region_id} review centroid")
-        _require(
-            len({reviewer_id.casefold() for reviewer_id in reviewer_ids})
-            == len(reviewer_ids),
-            f"{region_id} independent reviewers must be distinct",
-        )
+        if single_operator_review:
+            _require(
+                len({reviewer_id.casefold() for reviewer_id in reviewer_ids}) == 1,
+                f"{region_id} self-review passes must use one registered operator",
+            )
+            _require(
+                all(
+                    review_times[index] < review_times[index + 1]
+                    for index in range(len(review_times) - 1)
+                ),
+                f"{region_id} self-review passes must be chronologically ordered",
+            )
+        else:
+            _require(
+                len({reviewer_id.casefold() for reviewer_id in reviewer_ids})
+                == len(reviewer_ids),
+                f"{region_id} independent reviewers must be distinct",
+            )
         all_review_times.extend(review_times)
         for key in ("interreview_rms_m", "multiview_reprojection_rmse_px"):
             value = float(region[key])
@@ -530,9 +580,14 @@ def validate_contact_registration(
         )
 
     acceptance = artifact["acceptance"]
+    review_acceptance_key = (
+        "review_policy_passed"
+        if single_operator_review
+        else "independent_review_passed"
+    )
     for key in (
         "multiview_agreement_passed",
-        "independent_review_passed",
+        review_acceptance_key,
         "attachment_uncertainty_separates_regions",
         "frame_closure_recorded",
     ):
@@ -554,7 +609,11 @@ def validate_contact_registration(
     )
     _require(
         all(reviewed_at <= approved_at for reviewed_at in all_review_times),
-        "contact registration approval predates an independent review",
+        (
+            "contact registration approval predates a review pass"
+            if single_operator_review
+            else "contact registration approval predates an independent review"
+        ),
     )
     checksums = artifact.get("source_checksums", {})
     _require(
@@ -570,6 +629,12 @@ def validate_contact_registration(
         "object_node_count": node_count,
         "approved": True,
         "approved_at_utc": approval["approved_at_utc"],
+        "review_policy": (
+            SINGLE_OPERATOR_REVIEW_POLICY
+            if single_operator_review
+            else INDEPENDENT_REVIEW_POLICY
+        ),
+        "independent_review_claimed": not single_operator_review,
     }
 
 

--- a/src/causal4d/operator_bound_real_evidence.py
+++ b/src/causal4d/operator_bound_real_evidence.py
@@ -87,8 +87,7 @@ def build_operator_bound_real_evidence_status(
         registry = None
     else:
         if (
-            Path(repository_root)
-            / "configs/causal4d/sloth_preacquisition_v5.json"
+            Path(repository_root) / "configs/causal4d/sloth_preacquisition_v5.json"
         ).is_file():
             _, _, _, preacquisition = load_registered_preacquisition_chain(
                 repository_root

--- a/src/causal4d/operator_bound_real_evidence.py
+++ b/src/causal4d/operator_bound_real_evidence.py
@@ -16,6 +16,9 @@ from causal4d.operator_registry import (
     OPERATOR_REGISTRY_PATH,
     load_registered_operator_registry,
 )
+from causal4d.preacquisition_readiness_contracts import (
+    load_registered_preacquisition_chain,
+)
 from causal4d.real_evidence_contract_v2 import build_real_evidence_status
 
 
@@ -72,6 +75,7 @@ def build_operator_bound_real_evidence_status(
         str(name): dict(result) for name, result in status["prerequisites"].items()
     }
 
+    preacquisition: Mapping[str, Any] | None = None
     if repository_root is None:
         registry_path = root / OPERATOR_REGISTRY_PATH
         registry_result: dict[str, Any] = {
@@ -82,13 +86,24 @@ def build_operator_bound_real_evidence_status(
         }
         registry = None
     else:
+        if (
+            Path(repository_root)
+            / "configs/causal4d/sloth_preacquisition_v5.json"
+        ).is_file():
+            _, _, _, preacquisition = load_registered_preacquisition_chain(
+                repository_root
+            )
         registry_result, registry = load_registered_operator_registry(
             repository_root,
             root,
         )
     prerequisites["operator_registry"] = registry_result
     prerequisites["operator_identity_bindings"] = (
-        validate_preacquisition_identity_bindings(root, registry)
+        validate_preacquisition_identity_bindings(
+            root,
+            registry,
+            preacquisition=preacquisition,
+        )
     )
 
     freeze_result = prerequisites["method_freeze"]
@@ -116,6 +131,7 @@ def build_operator_bound_real_evidence_status(
                     method_freeze,
                     None,
                     registry,
+                    preacquisition=preacquisition,
                 )
                 freeze_result.update(identity)
                 freeze_result["operator_registry_artifact_sha256"] = registry_result[
@@ -140,6 +156,7 @@ def build_operator_bound_real_evidence_status(
                     method_freeze,
                     attestation,
                     registry,
+                    preacquisition=preacquisition,
                 )
                 freeze_result.update(
                     {

--- a/src/causal4d/operator_identity_integration.py
+++ b/src/causal4d/operator_identity_integration.py
@@ -16,6 +16,7 @@ from causal4d.operator_registry import (
     validate_gate_approver_identity,
     validate_method_freeze_operator_identity,
 )
+from causal4d.preacquisition_protocol_v5 import governance_allows_single_operator
 
 
 def _require(condition: bool, message: str) -> None:
@@ -63,6 +64,8 @@ def validate_gate_file_operator_identity(
     path: str | Path,
     registry: Mapping[str, Any],
     prerequisites: Mapping[str, Mapping[str, Any]],
+    *,
+    preacquisition: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Validate the identity behind one otherwise-valid operational gate."""
 
@@ -87,6 +90,10 @@ def validate_gate_file_operator_identity(
         freezer_person_identity_sha256=(
             str(freezer_digest) if freezer_digest is not None else None
         ),
+        allow_software_environment_self_approval=(
+            preacquisition is not None
+            and governance_allows_single_operator(preacquisition)
+        ),
     )
     return {
         "approver_operator_id": str(approver["operator_id"]),
@@ -98,8 +105,10 @@ def validate_method_freeze_identity_evidence(
     method_freeze: Mapping[str, Any],
     attestation: Mapping[str, Any] | None,
     registry: Mapping[str, Any],
+    *,
+    preacquisition: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Resolve the freezer and, when present, the independent verifier."""
+    """Resolve the freezer and the policy-compatible registered attester."""
 
     freezer = validate_method_freeze_operator_identity(method_freeze, registry)
     result = {
@@ -111,12 +120,20 @@ def validate_method_freeze_identity_evidence(
             method_freeze,
             attestation,
             registry,
+            allow_self_attestation=(
+                preacquisition is not None
+                and governance_allows_single_operator(preacquisition)
+            ),
         )
         result.update(
             {
                 "verifier_operator_id": str(verifier["operator_id"]),
                 "verifier_person_identity_sha256": str(
                     verifier["person_identity_sha256"]
+                ),
+                "attestation_independent": (
+                    verifier["person_identity_sha256"]
+                    != freezer["person_identity_sha256"]
                 ),
             }
         )
@@ -126,14 +143,16 @@ def validate_method_freeze_identity_evidence(
 def validate_preacquisition_identity_bindings(
     dataset_root: str | Path,
     registry: Mapping[str, Any] | None,
+    *,
+    preacquisition: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Validate every person identity that governs acquisition evidence.
 
-    This derived prerequisite covers the method freezer, independent freeze
-    verifier, timebase and contact-registration approvers, and all operational
+    This derived prerequisite covers the method freezer, the registered freeze
+    attester, timebase and contact-registration approvers, and all operational
     readiness-gate approvers. Missing or still-template evidence is reported as
     incomplete; completed evidence with an unknown, inactive, role-incompatible,
-    postdated, or non-independent identity fails closed.
+    postdated, or policy-incompatible identity fails closed.
     """
 
     from causal4d.preacquisition_readiness_contracts import GATE_PATHS
@@ -217,6 +236,7 @@ def validate_preacquisition_identity_bindings(
             method_freeze,
             attestation,
             registry,
+            preacquisition=preacquisition,
         )
         freezer_digest = identity["freezer_person_identity_sha256"]
         approvals: dict[str, dict[str, str]] = {}
@@ -247,6 +267,11 @@ def validate_preacquisition_identity_bindings(
                     if gate_id == "software_environment_locked"
                     else None
                 ),
+                allow_software_environment_self_approval=(
+                    gate_id == "software_environment_locked"
+                    and preacquisition is not None
+                    and governance_allows_single_operator(preacquisition)
+                ),
             )
             approvals[f"operational_gate:{gate_id}"] = {
                 "operator_id": str(approver["operator_id"]),
@@ -263,7 +288,14 @@ def validate_preacquisition_identity_bindings(
                 "approval_bindings": approvals,
                 "source_sha256": source_sha256,
                 "software_environment_approval_policy": (
-                    "independent_registered_person_distinct_from_method_freezer"
+                    "registered_self_approval_disclosed"
+                    if preacquisition is not None
+                    and governance_allows_single_operator(preacquisition)
+                    else "independent_registered_person_distinct_from_method_freezer"
+                ),
+                "independent_preacquisition_attestation_claimed": not (
+                    preacquisition is not None
+                    and governance_allows_single_operator(preacquisition)
                 ),
                 "template": False,
                 "valid": True,
@@ -295,7 +327,10 @@ def seal_registered_preacquisition_gate(
     """Require a registered, role-compatible approver before sealing a gate."""
 
     from causal4d.preacquisition_gate_validation import seal_preacquisition_gate
-    from causal4d.preacquisition_readiness_contracts import GATE_PATHS
+    from causal4d.preacquisition_readiness_contracts import (
+        GATE_PATHS,
+        load_registered_preacquisition_chain,
+    )
 
     _require(gate_id in GATE_PATHS, f"unknown pre-acquisition gate: {gate_id}")
     gate_path = Path(dataset_root) / GATE_PATHS[gate_id]
@@ -311,6 +346,7 @@ def seal_registered_preacquisition_gate(
         registry_result.get("valid") is True and registry is not None,
         str(registry_result.get("error") or "operator registry is invalid"),
     )
+    _, _, _, preacquisition = load_registered_preacquisition_chain(repository_root)
     approved_at = approved_at_utc or datetime.now(timezone.utc).isoformat()
     freezer_digest: str | None = None
     if gate_id == "software_environment_locked":
@@ -326,6 +362,9 @@ def seal_registered_preacquisition_gate(
         approved_at,
         registry,
         freezer_person_identity_sha256=freezer_digest,
+        allow_software_environment_self_approval=(
+            governance_allows_single_operator(preacquisition)
+        ),
     )
     result = seal_preacquisition_gate(
         repository_root,

--- a/src/causal4d/operator_registry.py
+++ b/src/causal4d/operator_registry.py
@@ -545,8 +545,7 @@ def validate_attestation_operator_identities(
     if allow_self_attestation:
         _require(
             verifier["operator_id"] == freezer["operator_id"]
-            and verifier["person_identity_sha256"]
-            == freezer["person_identity_sha256"],
+            and verifier["person_identity_sha256"] == freezer["person_identity_sha256"],
             "single-operator method freeze must be self-attested by its freezer",
         )
     else:

--- a/src/causal4d/operator_registry.py
+++ b/src/causal4d/operator_registry.py
@@ -519,26 +519,44 @@ def validate_attestation_operator_identities(
     method_freeze: Mapping[str, Any],
     attestation: Mapping[str, Any],
     registry: Mapping[str, Any],
+    *,
+    allow_self_attestation: bool = False,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Resolve freezer and verifier and prove person-level independence."""
+    """Resolve the freezer and enforce the registered attestation policy."""
 
     freezer = validate_method_freeze_operator_identity(method_freeze, registry)
     verifier = resolve_operator(
         registry,
         attestation.get("verifier_id"),
-        required_role=ROLE_INDEPENDENT_VERIFIER,
-        name="method freeze verifier",
+        required_role=(
+            ROLE_FREEZER if allow_self_attestation else ROLE_INDEPENDENT_VERIFIER
+        ),
+        name=(
+            "method freeze self-attester"
+            if allow_self_attestation
+            else "method freeze verifier"
+        ),
     )
     require_registry_precedes_event(
         registry,
         attestation.get("verified_at_utc"),
         event_name="method freeze attestation",
     )
-    require_distinct_operator_people(
-        freezer,
-        verifier,
-        relationship="method freeze must be verified by a distinct registered person",
-    )
+    if allow_self_attestation:
+        _require(
+            verifier["operator_id"] == freezer["operator_id"]
+            and verifier["person_identity_sha256"]
+            == freezer["person_identity_sha256"],
+            "single-operator method freeze must be self-attested by its freezer",
+        )
+    else:
+        require_distinct_operator_people(
+            freezer,
+            verifier,
+            relationship=(
+                "method freeze must be verified by a distinct registered person"
+            ),
+        )
     return freezer, verifier
 
 
@@ -549,6 +567,7 @@ def validate_gate_approver_identity(
     registry: Mapping[str, Any],
     *,
     freezer_person_identity_sha256: str | None = None,
+    allow_software_environment_self_approval: bool = False,
 ) -> dict[str, Any]:
     """Resolve a gate approver and enforce the software-lock independence policy."""
 
@@ -564,25 +583,32 @@ def validate_gate_approver_identity(
         event_name=f"{gate_id} approval",
     )
     if gate_id == "software_environment_locked":
+        permitted_roles = (
+            {ROLE_SOFTWARE_ENVIRONMENT_APPROVER}
+            if allow_software_environment_self_approval
+            else {
+                ROLE_INDEPENDENT_VERIFIER,
+                ROLE_SOFTWARE_ENVIRONMENT_APPROVER,
+            }
+        )
         _require(
-            bool(
-                set(approver["roles"])
-                & {
-                    ROLE_INDEPENDENT_VERIFIER,
-                    ROLE_SOFTWARE_ENVIRONMENT_APPROVER,
-                }
+            bool(set(approver["roles"]) & permitted_roles),
+            (
+                "software environment approver lacks the registered self-approval role"
+                if allow_software_environment_self_approval
+                else "software environment approver lacks an independent approval role"
             ),
-            "software environment approver lacks an independent approval role",
         )
         _require(
             isinstance(freezer_person_identity_sha256, str)
             and bool(_SHA64.fullmatch(freezer_person_identity_sha256)),
             "software environment approval cannot resolve the method freezer identity",
         )
-        _require(
-            approver["person_identity_sha256"] != freezer_person_identity_sha256,
-            "software environment approval is not independent of the method freezer",
-        )
+        if not allow_software_environment_self_approval:
+            _require(
+                approver["person_identity_sha256"] != freezer_person_identity_sha256,
+                "software environment approval is not independent of the method freezer",
+            )
     return approver
 
 

--- a/src/causal4d/preacquisition_next_action.py
+++ b/src/causal4d/preacquisition_next_action.py
@@ -281,6 +281,17 @@ def _derive_action(
     protocol = Path(repository) / PROTOCOL_PATH
     next_check = _readiness("next-action", repository, dataset)
     gates = readiness.get("operational_gates", {})
+    governance = readiness.get("governance", {})
+    single_operator = bool(
+        isinstance(governance, Mapping)
+        and governance.get("mode") == "single_operator_self_attested"
+        and governance.get("single_operator_allowed") is True
+        and governance.get("independent_verifier_required") is False
+        and governance.get("independent_preacquisition_attestation_claimed") is False
+    )
+    verification_role = (
+        "self_attesting_operator" if single_operator else "independent_verifier"
+    )
     if (
         bool(gates)
         and all(not value.get("present") for value in gates.values())
@@ -302,7 +313,11 @@ def _derive_action(
         return _action(
             "stop_and_repair_invalid_evidence",
             "Stop and repair the first invalid evidence boundary",
-            "principal_investigator_and_independent_verifier",
+            (
+                "principal_investigator_and_self_attester"
+                if single_operator
+                else "principal_investigator_and_independent_verifier"
+            ),
             category="invalid_evidence",
             command=_readiness("status", repository, dataset, "--verify-file-hashes"),
             completion=next_check,
@@ -363,7 +378,10 @@ def _derive_action(
             automatable=operation.startswith("scaffold"),
         )
 
-    if registry.get("independent_verifier_available") is not True:
+    if (
+        registry.get("independent_verifier_available") is not True
+        and not single_operator
+    ):
         return _action(
             "stop_independent_verifier_unavailable",
             "Stop: independent verification is unavailable in a single-person project",
@@ -383,7 +401,11 @@ def _derive_action(
         return _action(
             "stop_and_repair_invalid_evidence",
             "Stop and repair the first invalid evidence boundary",
-            "principal_investigator_and_independent_verifier",
+            (
+                "principal_investigator_and_self_attester"
+                if single_operator
+                else "principal_investigator_and_independent_verifier"
+            ),
             category="invalid_evidence",
             command=_readiness("status", repository, dataset, "--verify-file-hashes"),
             completion=next_check,
@@ -407,7 +429,14 @@ def _derive_action(
 
     for name in _MANUAL:
         if _pending(readiness, "prerequisites", name):
-            return _manual_action(name, repository, dataset)
+            action = _manual_action(name, repository, dataset)
+            if single_operator:
+                action["operator_role"] = "self_attesting_operator"
+                if name == "contact_registration":
+                    action["title"] = (
+                        "Complete the two-pass self-reviewed contact registration"
+                    )
+            return action
 
     if source.get("complete") is not True:
         execution = source.get("next_execution")
@@ -464,8 +493,12 @@ def _derive_action(
         attestation = str(root / "method_freeze_validation.json")
         return _action(
             "attest_method_freeze",
-            "Independently attest the sealed method freeze",
-            "independent_verifier",
+            (
+                "Self-attest the sealed method freeze under v5 governance"
+                if single_operator
+                else "Independently attest the sealed method freeze"
+            ),
+            verification_role,
             category="attest",
             command=_freeze(
                 "attest",
@@ -474,7 +507,11 @@ def _derive_action(
                 repository,
                 attestation,
                 "--verified-by",
-                "<registered-independent-verifier-id>",
+                (
+                    "<registered-freezer-id>"
+                    if single_operator
+                    else "<registered-independent-verifier-id>"
+                ),
             ),
             completion=next_check,
             inputs=[freeze],
@@ -488,7 +525,7 @@ def _derive_action(
         return _action(
             "run_final_hash_verified_readiness_gate",
             "Run the final hash-verified readiness gate",
-            "independent_verifier",
+            verification_role,
             category="final_verification",
             command=_readiness(
                 "status",
@@ -523,7 +560,7 @@ def _derive_action(
     return _action(
         "rerun_readiness_diagnostics",
         "Rerun the complete readiness diagnostics",
-        "independent_verifier",
+        verification_role,
         category="final_verification",
         command=_readiness("status", repository, dataset, "--verify-file-hashes"),
         completion=next_check,
@@ -554,6 +591,11 @@ def _decision(
         "readiness_status_sha256": value(readiness, "status_sha256"),
         "source_panel_evidence_sha256": value(source, "evidence_sha256"),
         "source_panel_status_sha256": value(source, "status_sha256"),
+        "governance": (
+            None
+            if readiness is None
+            else deepcopy(dict(readiness.get("governance", {})))
+        ),
         "readiness_valid": (
             None if readiness is None else readiness.get("valid") is True
         ),

--- a/src/causal4d/preacquisition_operator_flow.py
+++ b/src/causal4d/preacquisition_operator_flow.py
@@ -43,13 +43,20 @@ def _expected_publication_command(
 def enrich_preacquisition_next_action(
     decision: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Insert safe staging, verification, and two-person publication."""
+    """Insert safe staging, verification, and governed publication."""
 
     result = deepcopy(dict(decision))
     action_value = result.get("action")
     if not isinstance(action_value, Mapping):
         raise ValueError("next-action decision has no action object")
     action = deepcopy(dict(action_value))
+    governance = result.get("governance", {})
+    single_operator = bool(
+        isinstance(governance, Mapping)
+        and governance.get("mode") == "single_operator_self_attested"
+        and governance.get("single_operator_allowed") is True
+        and governance.get("independent_verifier_required") is False
+    )
     result["schema_version"] = NEXT_ACTION_SCHEMA_VERSION
     result["operator_flow_schema_version"] = OPERATOR_FLOW_SCHEMA_VERSION
 
@@ -121,7 +128,11 @@ def enrich_preacquisition_next_action(
                 dataset,
                 staging,
                 "--reviewed-by",
-                "<registered-reviewer-id>",
+                (
+                    "<registered-self-attesting-operator-id>"
+                    if single_operator
+                    else "<registered-reviewer-id>"
+                ),
             ]
         )
         publication_argv, publication_text = _command_pair(
@@ -130,7 +141,11 @@ def enrich_preacquisition_next_action(
                 "--review-receipt",
                 receipt,
                 "--published-by",
-                "<registered-publisher-id>",
+                (
+                    "<registered-self-attesting-operator-id>"
+                    if single_operator
+                    else "<registered-publisher-id>"
+                ),
             ]
         )
         action["after_completion_argv"] = None
@@ -148,17 +163,32 @@ def enrich_preacquisition_next_action(
         action["staged_review_argv"] = review_argv
         action["staged_review_text"] = review_text
         action["review_receipt_path"] = receipt
-        action["two_person_publication_required"] = True
-        action["reviewer_identity_placeholder"] = "<registered-reviewer-id>"
-        action["publisher_identity_placeholder"] = "<registered-publisher-id>"
-        action["independent_review_required_before_publication"] = True
+        action["two_person_publication_required"] = not single_operator
+        action["reviewer_identity_placeholder"] = (
+            "<registered-self-attesting-operator-id>"
+            if single_operator
+            else "<registered-reviewer-id>"
+        )
+        action["publisher_identity_placeholder"] = (
+            "<registered-self-attesting-operator-id>"
+            if single_operator
+            else "<registered-publisher-id>"
+        )
+        action["independent_review_required_before_publication"] = (
+            not single_operator
+        )
+        action["self_review_required_before_publication"] = single_operator
         action["claim_bearing_publication_argv"] = publication_argv
         action["claim_bearing_publication_text"] = publication_text
         action["operator_sequence"] = [
             "acquire_registered_source_execution",
             "build_staged_manifest_from_registered_template_and_artifact_bytes",
             "verify_staged_manifest_and_artifacts",
-            "independent_review_of_preflight_report",
+            (
+                "self_review_of_preflight_report"
+                if single_operator
+                else "independent_review_of_preflight_report"
+            ),
             "publish_exactly_once",
             "recompute_next_action",
         ]
@@ -183,6 +213,7 @@ def enrich_preacquisition_next_action(
         action.setdefault("reviewer_identity_placeholder", None)
         action.setdefault("publisher_identity_placeholder", None)
         action.setdefault("independent_review_required_before_publication", False)
+        action.setdefault("self_review_required_before_publication", False)
         action.setdefault("claim_bearing_publication_argv", None)
         action.setdefault("claim_bearing_publication_text", None)
         action.setdefault("operator_sequence", [])
@@ -239,6 +270,7 @@ def render_preacquisition_operator_next_action_markdown(
     action = decision.get("action")
     if not isinstance(action, Mapping):
         raise ValueError("next-action decision has no action object")
+    self_review = action.get("self_review_required_before_publication") is True
     lines = [
         "# Causal4D pre-acquisition next action",
         "",
@@ -264,7 +296,11 @@ def render_preacquisition_operator_next_action_markdown(
         ("Verify staged evidence", "post_acquisition_verification_text", None),
         ("Review and seal receipt", "staged_review_text", None),
         (
-            "Publish after independent review",
+            (
+                "Publish after registered self-review"
+                if self_review
+                else "Publish after independent review"
+            ),
             "claim_bearing_publication_text",
             None,
         ),
@@ -276,7 +312,16 @@ def render_preacquisition_operator_next_action_markdown(
             lines += ["", f"### {heading}", "", "```bash", str(value), "```"]
             if note_field and action.get(note_field):
                 lines += ["", str(action[note_field])]
-    if action.get("independent_review_required_before_publication") is True:
+    if self_review:
+        lines += [
+            "",
+            (
+                "Publication is claim-bearing and requires a registered self-review "
+                "receipt. Review and publication are performed by the same disclosed "
+                "operator; no independent review is claimed."
+            ),
+        ]
+    elif action.get("independent_review_required_before_publication") is True:
         lines += [
             "",
             "Publication is claim-bearing and requires independent review by a ",

--- a/src/causal4d/preacquisition_operator_flow.py
+++ b/src/causal4d/preacquisition_operator_flow.py
@@ -174,9 +174,7 @@ def enrich_preacquisition_next_action(
             if single_operator
             else "<registered-publisher-id>"
         )
-        action["independent_review_required_before_publication"] = (
-            not single_operator
-        )
+        action["independent_review_required_before_publication"] = not single_operator
         action["self_review_required_before_publication"] = single_operator
         action["claim_bearing_publication_argv"] = publication_argv
         action["claim_bearing_publication_text"] = publication_text

--- a/src/causal4d/preacquisition_protocol_v5.py
+++ b/src/causal4d/preacquisition_protocol_v5.py
@@ -1,0 +1,233 @@
+"""Single-operator governance amendment for prospective physical acquisition."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Mapping
+
+from causal4d.preacquisition_protocol_v4 import load_v4_chain
+
+
+PREACQUISITION_V5_SCHEMA_VERSION = 1
+PREACQUISITION_V5_PLAN_ID = "causal4d-sloth-preacquisition-v5-single-operator"
+SINGLE_OPERATOR_GOVERNANCE_MODE = "single_operator_self_attested"
+_CANONICAL_V5_SHA256 = "c0128865c7b527304dc7a6177d7f935d753bfdbc1e4469243f1acaeae6ce8e93"
+_INHERITED_V4_FIELDS = (
+    "base_protocol",
+    "unchanged_acquisition_design",
+    "unchanged_v3_analysis",
+    "mechanism_gate_control_lock",
+    "state_propagation_interpretation_lock",
+    "prospective_mode0_reset_crosscheck",
+    "mechanism_ladder_addition",
+    "contact_registration_contract",
+    "collection_sequence",
+    "collection_gate",
+)
+_CANONICAL_GOVERNANCE = {
+    "policy_id": "single-operator-self-attestation-v1",
+    "mode": SINGLE_OPERATOR_GOVERNANCE_MODE,
+    "single_operator_allowed": True,
+    "independent_verifier_required": False,
+    "independent_preacquisition_attestation_claimed": False,
+    "self_attestation_required": True,
+    "same_person_method_freeze_attestation_allowed": True,
+    "same_person_software_environment_approval_allowed": True,
+    "same_person_source_review_and_publication_allowed": True,
+    "contact_registration_review_policy": "two_pass_single_operator_review_v1",
+    "single_operator_contact_registration_schema_version": 4,
+    "minimum_contact_registration_review_passes": 2,
+    "contact_review_passes_must_be_chronologically_ordered": True,
+    "registered_person_identity_required": True,
+    "cryptographic_freeze_required": True,
+    "complete_failure_and_negative_result_reporting_required": True,
+    "target_outcomes_used_for_amendment": False,
+    "scientific_method_changed": False,
+    "acquisition_design_changed": False,
+    "split_changed": False,
+    "threshold_changed": False,
+    "reporting_boundary_changed": False,
+    "paper_disclosure": (
+        "One registered operator performed the pre-acquisition checks and "
+        "self-attested the freeze; no independent pre-acquisition attestation "
+        "is claimed."
+    ),
+}
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def preacquisition_v5_sha256(amendment: Mapping[str, Any]) -> str:
+    payload = deepcopy(dict(amendment))
+    payload.pop("amendment_sha256", None)
+    return hashlib.sha256(_canonical_bytes(payload)).hexdigest()
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def single_operator_governance_policy() -> dict[str, Any]:
+    """Return a copy of the registered v5 governance policy."""
+
+    return deepcopy(_CANONICAL_GOVERNANCE)
+
+
+def governance_allows_single_operator(
+    preacquisition: Mapping[str, Any],
+) -> bool:
+    """Return true only for the exact validated v5 self-attestation policy."""
+
+    governance = preacquisition.get("governance")
+    return bool(
+        isinstance(governance, Mapping)
+        and dict(governance) == _CANONICAL_GOVERNANCE
+        and governance.get("single_operator_allowed") is True
+        and governance.get("independent_verifier_required") is False
+        and governance.get("independent_preacquisition_attestation_claimed") is False
+    )
+
+
+def build_preacquisition_v5(v4: Mapping[str, Any]) -> dict[str, Any]:
+    """Build v5 while preserving every v4 scientific and acquisition field."""
+
+    amendment: dict[str, Any] = {
+        "schema_version": PREACQUISITION_V5_SCHEMA_VERSION,
+        "plan_id": PREACQUISITION_V5_PLAN_ID,
+        "status": "supersedes_v4_before_any_physical_execution",
+        "supersedes": {
+            "plan_id": v4["plan_id"],
+            "amendment_sha256": v4["amendment_sha256"],
+            "git_commit": "998b9adfd17ed9b2e98ed9bac18366f62ec1ba18",
+            "physical_executions_completed_before_supersession": 0,
+        },
+    }
+    amendment.update(
+        {field: deepcopy(v4[field]) for field in _INHERITED_V4_FIELDS}
+    )
+    amendment["governance"] = deepcopy(_CANONICAL_GOVERNANCE)
+    amendment["amendment_sha256"] = preacquisition_v5_sha256(amendment)
+    validate_preacquisition_v5(amendment, v4)
+    return amendment
+
+
+def validate_preacquisition_v5(
+    amendment: Mapping[str, Any],
+    v4: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate the immutable governance-only supersession of v4."""
+
+    _require(
+        amendment.get("schema_version") == PREACQUISITION_V5_SCHEMA_VERSION,
+        "unsupported v5 schema",
+    )
+    _require(
+        amendment.get("plan_id") == PREACQUISITION_V5_PLAN_ID,
+        "unexpected v5 id",
+    )
+    _require(
+        amendment.get("status") == "supersedes_v4_before_any_physical_execution",
+        "v5 was not locked before physical execution",
+    )
+    _require(
+        amendment.get("amendment_sha256") == preacquisition_v5_sha256(amendment),
+        "v5 SHA-256 does not match its contents",
+    )
+    _require(
+        amendment["amendment_sha256"] == _CANONICAL_V5_SHA256,
+        "v5 differs from the locked canonical design",
+    )
+    supersedes = amendment.get("supersedes", {})
+    _require(
+        supersedes.get("plan_id") == v4["plan_id"]
+        and supersedes.get("amendment_sha256") == v4["amendment_sha256"]
+        and supersedes.get("physical_executions_completed_before_supersession") == 0,
+        "v5 does not supersede locked v4 before physical execution",
+    )
+    for field in _INHERITED_V4_FIELDS:
+        _require(
+            amendment.get(field) == v4[field],
+            f"v5 changed frozen v4 field: {field}",
+        )
+    _require(
+        amendment.get("governance") == _CANONICAL_GOVERNANCE,
+        "v5 governance policy differs from the registered single-operator policy",
+    )
+    _require(
+        governance_allows_single_operator(amendment),
+        "v5 does not transparently disable the independent-attestation claim",
+    )
+    return {
+        "passed": True,
+        "plan_id": amendment["plan_id"],
+        "amendment_sha256": amendment["amendment_sha256"],
+        "superseded_v4_sha256": v4["amendment_sha256"],
+        "governance_mode": SINGLE_OPERATOR_GOVERNANCE_MODE,
+        "independent_preacquisition_attestation_claimed": False,
+        "scientific_method_changed": False,
+        "physical_execution_count_changed": False,
+    }
+
+
+def write_preacquisition_v5(path: str | Path, amendment: Mapping[str, Any]) -> Path:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(dict(amendment), indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    return output
+
+
+def load_preacquisition_v5(
+    path: str | Path,
+    v4: Mapping[str, Any],
+) -> dict[str, Any]:
+    amendment = json.loads(Path(path).read_text(encoding="utf-8"))
+    validate_preacquisition_v5(amendment, v4)
+    return amendment
+
+
+def load_v5_chain(
+    protocol_path: str | Path,
+    v2_path: str | Path,
+    v3_path: str | Path,
+    gate_control_path: str | Path,
+    v4_path: str | Path,
+    v5_path: str | Path,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+    protocol, v2, v3, v4 = load_v4_chain(
+        protocol_path,
+        v2_path,
+        v3_path,
+        gate_control_path,
+        v4_path,
+    )
+    v5 = load_preacquisition_v5(v5_path, v4)
+    return protocol, v2, v3, v5
+
+
+__all__ = [
+    "PREACQUISITION_V5_PLAN_ID",
+    "PREACQUISITION_V5_SCHEMA_VERSION",
+    "SINGLE_OPERATOR_GOVERNANCE_MODE",
+    "build_preacquisition_v5",
+    "governance_allows_single_operator",
+    "load_preacquisition_v5",
+    "load_v5_chain",
+    "preacquisition_v5_sha256",
+    "single_operator_governance_policy",
+    "validate_preacquisition_v5",
+    "write_preacquisition_v5",
+]

--- a/src/causal4d/preacquisition_protocol_v5.py
+++ b/src/causal4d/preacquisition_protocol_v5.py
@@ -14,7 +14,9 @@ from causal4d.preacquisition_protocol_v4 import load_v4_chain
 PREACQUISITION_V5_SCHEMA_VERSION = 1
 PREACQUISITION_V5_PLAN_ID = "causal4d-sloth-preacquisition-v5-single-operator"
 SINGLE_OPERATOR_GOVERNANCE_MODE = "single_operator_self_attested"
-_CANONICAL_V5_SHA256 = "c0128865c7b527304dc7a6177d7f935d753bfdbc1e4469243f1acaeae6ce8e93"
+_CANONICAL_V5_SHA256 = (
+    "c0128865c7b527304dc7a6177d7f935d753bfdbc1e4469243f1acaeae6ce8e93"
+)
 _INHERITED_V4_FIELDS = (
     "base_protocol",
     "unchanged_acquisition_design",
@@ -113,9 +115,7 @@ def build_preacquisition_v5(v4: Mapping[str, Any]) -> dict[str, Any]:
             "physical_executions_completed_before_supersession": 0,
         },
     }
-    amendment.update(
-        {field: deepcopy(v4[field]) for field in _INHERITED_V4_FIELDS}
-    )
+    amendment.update({field: deepcopy(v4[field]) for field in _INHERITED_V4_FIELDS})
     amendment["governance"] = deepcopy(_CANONICAL_GOVERNANCE)
     amendment["amendment_sha256"] = preacquisition_v5_sha256(amendment)
     validate_preacquisition_v5(amendment, v4)

--- a/src/causal4d/preacquisition_readiness.py
+++ b/src/causal4d/preacquisition_readiness.py
@@ -125,15 +125,22 @@ def _identity_bound_gate_results(
                 result["error"] = "operator registry is unavailable"
             else:
                 try:
-                    result.update(
-                        validate_gate_file_operator_identity(
+                    if governance_allows_single_operator(v4):
+                        identity = validate_gate_file_operator_identity(
                             gate_id,
                             path,
                             registry,
                             prerequisites,
                             preacquisition=v4,
                         )
-                    )
+                    else:
+                        identity = validate_gate_file_operator_identity(
+                            gate_id,
+                            path,
+                            registry,
+                            prerequisites,
+                        )
+                    result.update(identity)
                 except (OSError, KeyError, TypeError, ValueError) as error:
                     message = str(error).strip()
                     result["valid"] = False
@@ -383,9 +390,7 @@ def evaluate_preacquisition_readiness(
         "preacquisition_plan_id": v4["plan_id"],
         "preacquisition_amendment_sha256": v4["amendment_sha256"],
         "governance": {
-            "mode": v4.get("governance", {}).get(
-                "mode", "independent_two_person_v4"
-            ),
+            "mode": v4.get("governance", {}).get("mode", "independent_two_person_v4"),
             "single_operator_allowed": v4.get("governance", {}).get(
                 "single_operator_allowed", False
             ),

--- a/src/causal4d/preacquisition_readiness.py
+++ b/src/causal4d/preacquisition_readiness.py
@@ -130,6 +130,7 @@ def _identity_bound_gate_results(
                             path,
                             registry,
                             prerequisites,
+                            preacquisition=v4,
                         )
                     )
                 except (OSError, KeyError, TypeError, ValueError) as error:
@@ -173,7 +174,11 @@ def evaluate_preacquisition_readiness(
     )
     prerequisites["operator_registry"] = operator_registry_result
     prerequisites["operator_identity_bindings"] = (
-        validate_preacquisition_identity_bindings(root, operator_registry)
+        validate_preacquisition_identity_bindings(
+            root,
+            operator_registry,
+            preacquisition=v4,
+        )
     )
     gate_results = _identity_bound_gate_results(
         protocol,
@@ -368,6 +373,23 @@ def evaluate_preacquisition_readiness(
         "protocol_design_sha256": protocol["design_sha256"],
         "preacquisition_plan_id": v4["plan_id"],
         "preacquisition_amendment_sha256": v4["amendment_sha256"],
+        "governance": {
+            "mode": v4.get("governance", {}).get(
+                "mode", "independent_two_person_v4"
+            ),
+            "single_operator_allowed": v4.get("governance", {}).get(
+                "single_operator_allowed", False
+            ),
+            "independent_verifier_required": v4.get("governance", {}).get(
+                "independent_verifier_required", True
+            ),
+            "independent_preacquisition_attestation_claimed": v4.get(
+                "governance", {}
+            ).get("independent_preacquisition_attestation_claimed", True),
+            "self_attestation_required": v4.get("governance", {}).get(
+                "self_attestation_required", False
+            ),
+        },
         "dataset_root": str(root.resolve()),
         "verify_file_hashes": verify_file_hashes,
         "registered_analysis_required": require_registered_analysis,

--- a/src/causal4d/preacquisition_readiness.py
+++ b/src/causal4d/preacquisition_readiness.py
@@ -14,6 +14,7 @@ from causal4d.operator_identity_integration import (
 )
 from causal4d.operator_registry import load_operator_registry_prerequisite
 from causal4d.preacquisition_gate_validation import _validate_gate_file
+from causal4d.preacquisition_protocol_v5 import governance_allows_single_operator
 from causal4d.preacquisition_readiness_contracts import (
     GATE_EVIDENCE_ARTIFACT_KIND as GATE_EVIDENCE_ARTIFACT_KIND,
     GATE_EVIDENCE_SCHEMA_VERSION as GATE_EVIDENCE_SCHEMA_VERSION,
@@ -173,13 +174,21 @@ def evaluate_preacquisition_readiness(
         protocol, v4, root
     )
     prerequisites["operator_registry"] = operator_registry_result
-    prerequisites["operator_identity_bindings"] = (
-        validate_preacquisition_identity_bindings(
-            root,
-            operator_registry,
-            preacquisition=v4,
+    if governance_allows_single_operator(v4):
+        prerequisites["operator_identity_bindings"] = (
+            validate_preacquisition_identity_bindings(
+                root,
+                operator_registry,
+                preacquisition=v4,
+            )
         )
-    )
+    else:
+        prerequisites["operator_identity_bindings"] = (
+            validate_preacquisition_identity_bindings(
+                root,
+                operator_registry,
+            )
+        )
     gate_results = _identity_bound_gate_results(
         protocol,
         v2,

--- a/src/causal4d/preacquisition_readiness_contracts.py
+++ b/src/causal4d/preacquisition_readiness_contracts.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from causal4d.preacquisition_protocol_v4 import load_v4_chain
+from causal4d.preacquisition_protocol_v5 import load_v5_chain
 
 READINESS_SCHEMA_VERSION = 2
 GATE_EVIDENCE_SCHEMA_VERSION = 2
@@ -22,6 +22,7 @@ PROTOCOL_PATH = "configs/causal4d/sloth_multi_action_v1.json"
 PREACQUISITION_V2_PATH = "configs/causal4d/sloth_preacquisition_v2.json"
 PREACQUISITION_V3_PATH = "configs/causal4d/sloth_preacquisition_v3.json"
 PREACQUISITION_V4_PATH = "configs/causal4d/sloth_preacquisition_v4.json"
+PREACQUISITION_V5_PATH = "configs/causal4d/sloth_preacquisition_v5.json"
 MECHANISM_GATE_EVIDENCE_PATH = (
     "runs/causal4d_preacquisition_v4/mechanism_gate_controls.json"
 )
@@ -468,15 +469,16 @@ def gate_evidence_template(
 def load_registered_preacquisition_chain(
     repository_root: str | Path,
 ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
-    """Load and validate the immutable protocol-v2-v3-v4 chain."""
+    """Load and validate the immutable protocol-v2-v3-v4-v5 chain."""
 
     root = Path(repository_root)
-    return load_v4_chain(
+    return load_v5_chain(
         root / PROTOCOL_PATH,
         root / PREACQUISITION_V2_PATH,
         root / PREACQUISITION_V3_PATH,
         root / MECHANISM_GATE_EVIDENCE_PATH,
         root / PREACQUISITION_V4_PATH,
+        root / PREACQUISITION_V5_PATH,
     )
 
 
@@ -489,6 +491,7 @@ __all__ = [
     "PREACQUISITION_V2_PATH",
     "PREACQUISITION_V3_PATH",
     "PREACQUISITION_V4_PATH",
+    "PREACQUISITION_V5_PATH",
     "PROTOCOL_PATH",
     "READINESS_ARTIFACT_KIND",
     "READINESS_SCHEMA_VERSION",

--- a/src/causal4d/preacquisition_source_panel_review.py
+++ b/src/causal4d/preacquisition_source_panel_review.py
@@ -1,4 +1,4 @@
-"""Two-person review receipts for staged source-panel publication."""
+"""Governance-bound review receipts for staged source-panel publication."""
 
 from __future__ import annotations
 
@@ -22,6 +22,7 @@ from causal4d.operator_registry import (
     require_registry_precedes_event,
     resolve_operator,
 )
+from causal4d.preacquisition_protocol_v5 import governance_allows_single_operator
 from causal4d.preacquisition_readiness_contracts import (
     _canonical_sha256,
     _read_json_mapping,
@@ -120,6 +121,8 @@ def build_source_panel_review_receipt(
         dataset_root,
         source_json,
     )
+    _, _, _, preacquisition = load_registered_preacquisition_chain(repository_root)
+    single_operator = governance_allows_single_operator(preacquisition)
     registry_result, registry = _registry(repository_root, dataset_root)
     reviewer = resolve_operator(
         registry,
@@ -278,7 +281,7 @@ def validate_source_panel_review_receipt(
     *,
     published_by: str | None,
 ) -> dict[str, Any]:
-    """Require a current review and a distinct registered publisher."""
+    """Require a current review and the registered publication policy."""
 
     _require(receipt_json is not None, "source-panel review receipt is required")
     _require(
@@ -320,13 +323,14 @@ def validate_source_panel_review_receipt(
         published_by,
         name="source-panel publisher",
     )
-    require_distinct_operator_people(
-        reviewer,
-        publisher,
-        relationship=(
-            "source-panel staging review and publication require distinct people"
-        ),
-    )
+    if not single_operator:
+        require_distinct_operator_people(
+            reviewer,
+            publisher,
+            relationship=(
+                "source-panel staging review and publication require distinct people"
+            ),
+        )
     require_registry_precedes_event(
         registry,
         receipt.get("reviewed_at_utc"),
@@ -388,7 +392,12 @@ def validate_source_panel_review_receipt(
         "reviewer_person_identity_sha256": reviewer["person_identity_sha256"],
         "publisher_operator_id": publisher["operator_id"],
         "publisher_person_identity_sha256": publisher["person_identity_sha256"],
-        "independent_people": True,
+        "independent_people": (
+            reviewer["person_identity_sha256"]
+            != publisher["person_identity_sha256"]
+        ),
+        "governance_mode": preacquisition["governance"]["mode"],
+        "independent_preacquisition_attestation_claimed": not single_operator,
         "preflight_evidence_sha256": preflight["evidence_sha256"],
         "target_outcomes_used": False,
     }

--- a/src/causal4d/preacquisition_source_panel_review.py
+++ b/src/causal4d/preacquisition_source_panel_review.py
@@ -393,10 +393,11 @@ def validate_source_panel_review_receipt(
         "publisher_operator_id": publisher["operator_id"],
         "publisher_person_identity_sha256": publisher["person_identity_sha256"],
         "independent_people": (
-            reviewer["person_identity_sha256"]
-            != publisher["person_identity_sha256"]
+            reviewer["person_identity_sha256"] != publisher["person_identity_sha256"]
         ),
-        "governance_mode": preacquisition["governance"]["mode"],
+        "governance_mode": preacquisition.get("governance", {}).get(
+            "mode", "independent_two_person_v4"
+        ),
         "independent_preacquisition_attestation_claimed": not single_operator,
         "preflight_evidence_sha256": preflight["evidence_sha256"],
         "target_outcomes_used": False,

--- a/src/causal4d/preacquisition_source_panel_review.py
+++ b/src/causal4d/preacquisition_source_panel_review.py
@@ -121,8 +121,6 @@ def build_source_panel_review_receipt(
         dataset_root,
         source_json,
     )
-    _, _, _, preacquisition = load_registered_preacquisition_chain(repository_root)
-    single_operator = governance_allows_single_operator(preacquisition)
     registry_result, registry = _registry(repository_root, dataset_root)
     reviewer = resolve_operator(
         registry,
@@ -283,6 +281,8 @@ def validate_source_panel_review_receipt(
 ) -> dict[str, Any]:
     """Require a current review and the registered publication policy."""
 
+    _, _, _, preacquisition = load_registered_preacquisition_chain(repository_root)
+    single_operator = governance_allows_single_operator(preacquisition)
     _require(receipt_json is not None, "source-panel review receipt is required")
     _require(
         isinstance(published_by, str) and bool(published_by),

--- a/src/causal4d/preacquisition_source_panel_review_publication.py
+++ b/src/causal4d/preacquisition_source_panel_review_publication.py
@@ -193,7 +193,7 @@ def publish_reviewed_source_panel_manifest(
     review_receipt_json: str | Path,
     published_by: str,
 ) -> dict[str, Any]:
-    """Require a current independent receipt, then publish exactly once."""
+    """Require a current governance-bound receipt, then publish exactly once."""
 
     review = validate_source_panel_review_receipt(
         repository_root,

--- a/src/causal4d/real_evidence_common.py
+++ b/src/causal4d/real_evidence_common.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from causal4d.contact_registration import (
     CONTACT_REGISTRATION_SCHEMA_VERSION,
+    SINGLE_OPERATOR_CONTACT_REGISTRATION_SCHEMA_VERSION,
     validate_contact_registration,
 )
 from causal4d.real_protocol import (
@@ -421,8 +422,12 @@ def _cross_check_contact_registration(
     simple_sha256: str,
 ) -> None:
     _require(
-        physical.get("schema_version") == CONTACT_REGISTRATION_SCHEMA_VERSION,
-        "physical contact registration must use schema 3",
+        physical.get("schema_version")
+        in {
+            CONTACT_REGISTRATION_SCHEMA_VERSION,
+            SINGLE_OPERATOR_CONTACT_REGISTRATION_SCHEMA_VERSION,
+        },
+        "physical contact registration must use schema 3 or 4",
     )
     object_record = physical["object"]
     _require(
@@ -459,6 +464,7 @@ def _validate_contact_registration_prerequisite(
     simple_registration: Mapping[str, Any] | None,
     simple_registration_sha256: str | None,
     verify_file_hashes: bool,
+    require_single_operator_review: bool = False,
 ) -> tuple[dict[str, Any], dict[str, Any] | None]:
     result = _prerequisite_result(path)
     result["file_hashes_verified"] = None if not verify_file_hashes else False
@@ -475,6 +481,12 @@ def _validate_contact_registration_prerequisite(
             "object registration digest is unavailable",
         )
         physical = _load_json_mapping(path)
+        if require_single_operator_review:
+            _require(
+                physical.get("schema_version")
+                == SINGLE_OPERATOR_CONTACT_REGISTRATION_SCHEMA_VERSION,
+                "single-operator governance requires contact registration schema 4",
+            )
         validation = validate_contact_registration(physical, protocol)
         _cross_check_contact_registration(
             physical,

--- a/src/causal4d/real_evidence_contract_v2.py
+++ b/src/causal4d/real_evidence_contract_v2.py
@@ -132,13 +132,10 @@ def build_real_evidence_status(
     if (
         repository_root is not None
         and (
-            Path(repository_root)
-            / "configs/causal4d/sloth_preacquisition_v5.json"
+            Path(repository_root) / "configs/causal4d/sloth_preacquisition_v5.json"
         ).is_file()
     ):
-        _, _, _, preacquisition = load_registered_preacquisition_chain(
-            repository_root
-        )
+        _, _, _, preacquisition = load_registered_preacquisition_chain(repository_root)
         require_single_operator_review = governance_allows_single_operator(
             preacquisition
         )

--- a/src/causal4d/real_evidence_contract_v2.py
+++ b/src/causal4d/real_evidence_contract_v2.py
@@ -9,6 +9,10 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from causal4d.preacquisition_protocol_v5 import governance_allows_single_operator
+from causal4d.preacquisition_readiness_contracts import (
+    load_registered_preacquisition_chain,
+)
 from causal4d.real_evidence_common import (
     EVIDENCE_STATUS_SCHEMA_VERSION,
     METHOD_FREEZE_ATTESTATION_SCHEMA_VERSION,
@@ -124,6 +128,20 @@ def build_real_evidence_status(
         root / "timebase_calibration.json",
         verify_file_hashes=verify_file_hashes,
     )
+    require_single_operator_review = False
+    if (
+        repository_root is not None
+        and (
+            Path(repository_root)
+            / "configs/causal4d/sloth_preacquisition_v5.json"
+        ).is_file()
+    ):
+        _, _, _, preacquisition = load_registered_preacquisition_chain(
+            repository_root
+        )
+        require_single_operator_review = governance_allows_single_operator(
+            preacquisition
+        )
     contact_registration, _ = _validate_contact_registration_prerequisite(
         protocol,
         root,
@@ -131,6 +149,7 @@ def build_real_evidence_status(
         simple_registration=simple_registration,
         simple_registration_sha256=object_registration.get("sha256"),
         verify_file_hashes=verify_file_hashes,
+        require_single_operator_review=require_single_operator_review,
     )
     method_freeze, method_freeze_attestation, _ = _validate_method_freeze_prerequisites(
         protocol,

--- a/src/causal4d/real_experiment_freeze.py
+++ b/src/causal4d/real_experiment_freeze.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from causal4d.atomic_io import atomic_write_json
+from causal4d.preacquisition_protocol_v5 import governance_allows_single_operator
 from causal4d.real_analysis_interval_amendment import (
     REAL_ANALYSIS_INTERVAL_AMENDMENT_REPOSITORY_PATH,
     REAL_ANALYSIS_INTERVAL_EVIDENCE_REPOSITORY_PATH,
@@ -24,8 +25,8 @@ MILESTONE_ID = "causal4d-same-object-real-v1"
 BPT_PIN_PATH = "requirements/ci/bayesian-phystwin-provider-v1.sha"
 PROTOCOL_PATH = "configs/causal4d/sloth_multi_action_v1.json"
 ACQUISITION_CANDIDATE_PATH = "configs/causal4d/sloth_acquisition_candidate_v1.json"
-PREACQUISITION_PATH = "configs/causal4d/sloth_preacquisition_v4.json"
-PREACQUISITION_PLAN_ID = "causal4d-sloth-preacquisition-v4"
+PREACQUISITION_PATH = "configs/causal4d/sloth_preacquisition_v5.json"
+PREACQUISITION_PLAN_ID = "causal4d-sloth-preacquisition-v5-single-operator"
 MECHANISM_GATE_EVIDENCE_PATH = (
     "runs/causal4d_preacquisition_v4/mechanism_gate_controls.json"
 )
@@ -33,6 +34,7 @@ REQUIRED_LOCKED_PATHS = (
     PROTOCOL_PATH,
     ACQUISITION_CANDIDATE_PATH,
     "configs/causal4d/sloth_multi_action_v1_schedule.csv",
+    "configs/causal4d/sloth_preacquisition_v4.json",
     PREACQUISITION_PATH,
     MECHANISM_GATE_EVIDENCE_PATH,
     REAL_ANALYSIS_INTERVAL_AMENDMENT_REPOSITORY_PATH,
@@ -41,6 +43,7 @@ REQUIRED_LOCKED_PATHS = (
     "docs/causal4d_same_object_multi_action_protocol.md",
     "docs/causal4d_real_experiment_milestone.md",
     "docs/causal4d_preacquisition_v4.md",
+    "docs/causal4d_preacquisition_v5.md",
     "docs/execution_block_conformal_calibration.md",
     "src/causal4d/execution_block_calibration.py",
     "src/causal4d/cli/execution_block_calibration.py",
@@ -141,8 +144,8 @@ def _preacquisition_contract(
         "wrong pre-acquisition plan id",
     )
     _require(
-        plan.get("status") == "supersedes_v3_before_any_physical_execution",
-        "pre-acquisition v4 was not locked before physical execution",
+        plan.get("status") == "supersedes_v4_before_any_physical_execution",
+        "pre-acquisition v5 was not locked before physical execution",
     )
     amendment_sha256 = plan.get("amendment_sha256")
     _require(
@@ -159,7 +162,17 @@ def _preacquisition_contract(
             "physical_executions_completed_before_supersession"
         )
         == 0,
-        "pre-acquisition v4 was introduced after physical execution began",
+        "pre-acquisition v5 was introduced after physical execution began",
+    )
+
+    _require(
+        governance_allows_single_operator(plan),
+        "pre-acquisition v5 does not bind the registered single-operator policy",
+    )
+    _require(
+        plan["governance"]["independent_preacquisition_attestation_claimed"]
+        is False,
+        "pre-acquisition v5 falsely claims independent attestation",
     )
 
     base_protocol = plan.get("base_protocol", {})
@@ -218,6 +231,8 @@ def _preacquisition_contract(
         "amendment_sha256": amendment_sha256,
         "base_protocol_design_sha256": protocol_design_sha256,
         "confirmatory_execution_count": 36,
+        "governance_mode": plan["governance"]["mode"],
+        "independent_preacquisition_attestation_claimed": False,
         "mechanism_gate_control": {
             "path": MECHANISM_GATE_EVIDENCE_PATH,
             "result_sha256": evidence_sha256,

--- a/src/causal4d/real_experiment_freeze.py
+++ b/src/causal4d/real_experiment_freeze.py
@@ -170,8 +170,7 @@ def _preacquisition_contract(
         "pre-acquisition v5 does not bind the registered single-operator policy",
     )
     _require(
-        plan["governance"]["independent_preacquisition_attestation_claimed"]
-        is False,
+        plan["governance"]["independent_preacquisition_attestation_claimed"] is False,
         "pre-acquisition v5 falsely claims independent attestation",
     )
 

--- a/tests/test_contact_registration.py
+++ b/tests/test_contact_registration.py
@@ -6,6 +6,8 @@ import numpy as np
 import pytest
 
 from causal4d.contact_registration import (
+    SINGLE_OPERATOR_CONTACT_REGISTRATION_SCHEMA_VERSION,
+    SINGLE_OPERATOR_REVIEW_POLICY,
     build_contact_registration_template,
     validate_contact_registration,
 )
@@ -200,3 +202,41 @@ def test_contact_registration_keeps_approved_schema2_artifacts_readable() -> Non
     result = validate_contact_registration(legacy, protocol)
     assert result["passed"] is True
     assert result["schema_version"] == 2
+
+
+def test_schema4_accepts_two_chronological_self_review_passes() -> None:
+    protocol, artifact = _approved_artifact()
+    artifact["schema_version"] = SINGLE_OPERATOR_CONTACT_REGISTRATION_SCHEMA_VERSION
+    for region in artifact["contact_regions"].values():
+        reviews = region.pop("independent_reviews")
+        reviews[0]["reviewer_id"] = "florianpfaff"
+        reviews[1]["reviewer_id"] = "florianpfaff"
+        region["review_policy"] = SINGLE_OPERATOR_REVIEW_POLICY
+        region["review_passes"] = reviews
+    artifact["acceptance"].pop("independent_review_passed")
+    artifact["acceptance"]["review_policy_passed"] = True
+
+    result = validate_contact_registration(artifact, protocol)
+
+    assert result["passed"] is True
+    assert result["review_policy"] == SINGLE_OPERATOR_REVIEW_POLICY
+    assert result["independent_review_claimed"] is False
+
+
+def test_schema4_rejects_nonchronological_self_review_passes() -> None:
+    protocol, artifact = _approved_artifact()
+    artifact["schema_version"] = SINGLE_OPERATOR_CONTACT_REGISTRATION_SCHEMA_VERSION
+    for region in artifact["contact_regions"].values():
+        reviews = region.pop("independent_reviews")
+        reviews[0]["reviewer_id"] = "florianpfaff"
+        reviews[1]["reviewer_id"] = "florianpfaff"
+        region["review_policy"] = SINGLE_OPERATOR_REVIEW_POLICY
+        region["review_passes"] = reviews
+    artifact["acceptance"].pop("independent_review_passed")
+    artifact["acceptance"]["review_policy_passed"] = True
+    artifact["contact_regions"]["left_forepaw"]["review_passes"][1][
+        "reviewed_at_utc"
+    ] = "2026-07-12T11:59:00Z"
+
+    with pytest.raises(ValueError, match="chronologically ordered"):
+        validate_contact_registration(artifact, protocol)

--- a/tests/test_document_lifecycle_registry.py
+++ b/tests/test_document_lifecycle_registry.py
@@ -70,8 +70,8 @@ def test_repository_document_lifecycle_registry_is_valid() -> None:
         "current_documents": 10,
         "frozen_documents": 1,
         "historical_documents": 0,
-        "registered_documents": 13,
-        "superseded_documents": 2,
+        "registered_documents": 14,
+        "superseded_documents": 3,
     }
 
 

--- a/tests/test_operator_registry.py
+++ b/tests/test_operator_registry.py
@@ -489,3 +489,40 @@ def test_identity_bindings_reject_nonindependent_freeze_verifier(
 
     assert result["valid"] is False
     assert "lacks required role" in result["error"]
+
+
+def test_v5_allows_truthful_freezer_self_attestation() -> None:
+    registry = _single_operator_registry()
+    method_freeze = {
+        "frozen_by": "florianpfaff",
+        "frozen_at_utc": "2026-07-30T09:00:00Z",
+    }
+    attestation = {
+        "verifier_id": "florianpfaff",
+        "verified_at_utc": "2026-07-30T09:05:00Z",
+    }
+
+    freezer, attester = validate_attestation_operator_identities(
+        method_freeze,
+        attestation,
+        registry,
+        allow_self_attestation=True,
+    )
+
+    assert freezer["operator_id"] == "florianpfaff"
+    assert attester["operator_id"] == freezer["operator_id"]
+
+
+def test_v5_allows_registered_software_environment_self_approval() -> None:
+    registry = _single_operator_registry()
+
+    approver = validate_gate_approver_identity(
+        "software_environment_locked",
+        "florianpfaff",
+        "2026-07-30T09:10:00Z",
+        registry,
+        freezer_person_identity_sha256="3" * 64,
+        allow_software_environment_self_approval=True,
+    )
+
+    assert approver["operator_id"] == "florianpfaff"

--- a/tests/test_preacquisition_next_action.py
+++ b/tests/test_preacquisition_next_action.py
@@ -424,3 +424,51 @@ def test_cli_returns_incomplete_exit_code_and_writes_reports(
 
     assert exit_code == 3
     assert written == [("json", output_json), ("markdown", output_markdown)]
+
+
+def _enable_single_operator_v5(readiness: dict) -> None:
+    readiness["governance"] = {
+        "mode": "single_operator_self_attested",
+        "single_operator_allowed": True,
+        "independent_verifier_required": False,
+        "independent_preacquisition_attestation_claimed": False,
+        "self_attestation_required": True,
+    }
+    readiness["prerequisites"]["operator_registry"][
+        "independent_verifier_available"
+    ] = False
+
+
+def test_v5_single_operator_advances_past_independent_verifier_block() -> None:
+    readiness = _readiness()
+    _enable_single_operator_v5(readiness)
+    readiness["prerequisites"]["object_registration"] = _prerequisite(
+        present=False,
+        valid=False,
+    )
+    readiness["missing_prerequisites"] = ["object_registration"]
+
+    decision = _derive(readiness, _source_panel())
+
+    action = decision["action"]
+    assert action["action_id"] == "complete_object_registration"
+    assert action["operator_role"] == "self_attesting_operator"
+    assert action["target_outcomes_permitted"] is False
+
+
+def test_v5_method_freeze_action_is_disclosed_self_attestation() -> None:
+    readiness = _readiness()
+    _enable_single_operator_v5(readiness)
+    readiness["prerequisites"]["method_freeze_validation"] = _prerequisite(
+        present=False,
+        valid=False,
+    )
+    readiness["missing_prerequisites"] = ["method_freeze_validation"]
+
+    decision = _derive(readiness, _source_panel())
+
+    action = decision["action"]
+    assert action["action_id"] == "attest_method_freeze"
+    assert action["operator_role"] == "self_attesting_operator"
+    assert "Self-attest" in action["title"]
+    assert "<registered-freezer-id>" in action["command_argv"]

--- a/tests/test_preacquisition_operator_flow.py
+++ b/tests/test_preacquisition_operator_flow.py
@@ -284,3 +284,31 @@ def test_json_and_markdown_writers_are_atomic(tmp_path: Path) -> None:
     markdown = markdown_path.read_text(encoding="utf-8")
     assert "Build staged manifest" in markdown
     assert "Verify staged evidence" in markdown
+
+
+def test_v5_source_action_uses_disclosed_self_review_publication() -> None:
+    decision = _source_decision()
+    decision["governance"] = {
+        "mode": "single_operator_self_attested",
+        "single_operator_allowed": True,
+        "independent_verifier_required": False,
+        "independent_preacquisition_attestation_claimed": False,
+    }
+
+    result = operator_flow.enrich_preacquisition_next_action(decision)
+
+    action = result["action"]
+    assert action["two_person_publication_required"] is False
+    assert action["independent_review_required_before_publication"] is False
+    assert action["self_review_required_before_publication"] is True
+    assert action["reviewer_identity_placeholder"] == (
+        "<registered-self-attesting-operator-id>"
+    )
+    assert action["publisher_identity_placeholder"] == (
+        "<registered-self-attesting-operator-id>"
+    )
+    assert "self_review_of_preflight_report" in action["operator_sequence"]
+    markdown = operator_flow.render_preacquisition_operator_next_action_markdown(
+        result
+    )
+    assert "no independent review is claimed" in markdown

--- a/tests/test_preacquisition_operator_flow.py
+++ b/tests/test_preacquisition_operator_flow.py
@@ -308,7 +308,5 @@ def test_v5_source_action_uses_disclosed_self_review_publication() -> None:
         "<registered-self-attesting-operator-id>"
     )
     assert "self_review_of_preflight_report" in action["operator_sequence"]
-    markdown = operator_flow.render_preacquisition_operator_next_action_markdown(
-        result
-    )
+    markdown = operator_flow.render_preacquisition_operator_next_action_markdown(result)
     assert "no independent review is claimed" in markdown

--- a/tests/test_preacquisition_protocol_v5.py
+++ b/tests/test_preacquisition_protocol_v5.py
@@ -44,12 +44,12 @@ def test_registered_v5_chain_is_canonical_and_single_operator() -> None:
     assert v2["plan_id"]
     assert v3["plan_id"]
     assert v5["plan_id"] == PREACQUISITION_V5_PLAN_ID
-    assert v5["amendment_sha256"] == "c0128865c7b527304dc7a6177d7f935d753bfdbc1e4469243f1acaeae6ce8e93"
-    assert governance_allows_single_operator(v5) is True
     assert (
-        v5["governance"]["independent_preacquisition_attestation_claimed"]
-        is False
+        v5["amendment_sha256"]
+        == "c0128865c7b527304dc7a6177d7f935d753bfdbc1e4469243f1acaeae6ce8e93"
     )
+    assert governance_allows_single_operator(v5) is True
+    assert v5["governance"]["independent_preacquisition_attestation_claimed"] is False
 
 
 def test_v5_builder_matches_registered_artifact_and_preserves_v4() -> None:
@@ -98,9 +98,7 @@ def test_v5_records_zero_physical_execution_at_supersession() -> None:
     registered = load_preacquisition_v5(V5, _v4())
 
     assert (
-        registered["supersedes"][
-            "physical_executions_completed_before_supersession"
-        ]
+        registered["supersedes"]["physical_executions_completed_before_supersession"]
         == 0
     )
     assert registered["governance"]["scientific_method_changed"] is False

--- a/tests/test_preacquisition_protocol_v5.py
+++ b/tests/test_preacquisition_protocol_v5.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from causal4d.preacquisition_protocol_v4 import load_v4_chain
+from causal4d.preacquisition_protocol_v5 import (
+    PREACQUISITION_V5_PLAN_ID,
+    build_preacquisition_v5,
+    governance_allows_single_operator,
+    load_preacquisition_v5,
+    load_v5_chain,
+    preacquisition_v5_sha256,
+    validate_preacquisition_v5,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL = ROOT / "configs/causal4d/sloth_multi_action_v1.json"
+V2 = ROOT / "configs/causal4d/sloth_preacquisition_v2.json"
+V3 = ROOT / "configs/causal4d/sloth_preacquisition_v3.json"
+V4 = ROOT / "configs/causal4d/sloth_preacquisition_v4.json"
+V5 = ROOT / "configs/causal4d/sloth_preacquisition_v5.json"
+CONTROLS = ROOT / "runs/causal4d_preacquisition_v4/mechanism_gate_controls.json"
+
+
+def _v4() -> dict:
+    return load_v4_chain(PROTOCOL, V2, V3, CONTROLS, V4)[3]
+
+
+def test_registered_v5_chain_is_canonical_and_single_operator() -> None:
+    protocol, v2, v3, v5 = load_v5_chain(
+        PROTOCOL,
+        V2,
+        V3,
+        CONTROLS,
+        V4,
+        V5,
+    )
+
+    assert protocol["protocol_id"]
+    assert v2["plan_id"]
+    assert v3["plan_id"]
+    assert v5["plan_id"] == PREACQUISITION_V5_PLAN_ID
+    assert v5["amendment_sha256"] == "c0128865c7b527304dc7a6177d7f935d753bfdbc1e4469243f1acaeae6ce8e93"
+    assert governance_allows_single_operator(v5) is True
+    assert (
+        v5["governance"]["independent_preacquisition_attestation_claimed"]
+        is False
+    )
+
+
+def test_v5_builder_matches_registered_artifact_and_preserves_v4() -> None:
+    v4 = _v4()
+    registered = load_preacquisition_v5(V5, v4)
+    built = build_preacquisition_v5(v4)
+
+    assert built == registered
+    for field in (
+        "base_protocol",
+        "unchanged_acquisition_design",
+        "unchanged_v3_analysis",
+        "mechanism_gate_control_lock",
+        "state_propagation_interpretation_lock",
+        "prospective_mode0_reset_crosscheck",
+        "mechanism_ladder_addition",
+        "contact_registration_contract",
+        "collection_sequence",
+        "collection_gate",
+    ):
+        assert registered[field] == v4[field]
+
+
+def test_v5_rejects_scientific_or_governance_drift() -> None:
+    v4 = _v4()
+    registered = load_preacquisition_v5(V5, v4)
+
+    changed_method = deepcopy(registered)
+    changed_method["unchanged_acquisition_design"]["source_panel_execution_count"] = 11
+    changed_method["amendment_sha256"] = preacquisition_v5_sha256(changed_method)
+    with pytest.raises(ValueError, match="canonical|changed frozen"):
+        validate_preacquisition_v5(changed_method, v4)
+
+    false_independence = deepcopy(registered)
+    false_independence["governance"][
+        "independent_preacquisition_attestation_claimed"
+    ] = True
+    false_independence["amendment_sha256"] = preacquisition_v5_sha256(
+        false_independence
+    )
+    with pytest.raises(ValueError, match="canonical|governance"):
+        validate_preacquisition_v5(false_independence, v4)
+
+
+def test_v5_records_zero_physical_execution_at_supersession() -> None:
+    registered = load_preacquisition_v5(V5, _v4())
+
+    assert (
+        registered["supersedes"][
+            "physical_executions_completed_before_supersession"
+        ]
+        == 0
+    )
+    assert registered["governance"]["scientific_method_changed"] is False
+    assert registered["governance"]["threshold_changed"] is False
+    assert registered["governance"]["target_outcomes_used_for_amendment"] is False

--- a/tests/test_preacquisition_source_panel_review.py
+++ b/tests/test_preacquisition_source_panel_review.py
@@ -9,6 +9,7 @@ import pytest
 
 import causal4d.preacquisition_source_panel_review as review
 import causal4d.preacquisition_source_panel_review_publication as publication
+from causal4d.preacquisition_protocol_v5 import single_operator_governance_policy
 from causal4d.cli import preacquisition_readiness as readiness_cli
 
 
@@ -407,3 +408,67 @@ def test_cli_review_and_publication_routes(
         == 0
     )
     assert calls == ["review", "publish"]
+
+
+def test_v5_allows_disclosed_same_operator_review_and_publication(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "staging" / "source-01.json"
+    _write_source(source)
+    preflight = _preflight(source)
+    operator = _operator(
+        "florianpfaff",
+        "4" * 64,
+        ["freezer", "gate_approver"],
+    )
+    monkeypatch.setattr(
+        review,
+        "load_registered_preacquisition_chain",
+        lambda root: (
+            {"protocol_id": "protocol", "design_sha256": "a" * 64},
+            {},
+            {},
+            {
+                "plan_id": "plan",
+                "amendment_sha256": "b" * 64,
+                "governance": single_operator_governance_policy(),
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        review,
+        "verify_source_panel_manifest_staging",
+        lambda *args: deepcopy(preflight),
+    )
+    monkeypatch.setattr(
+        review,
+        "_registry",
+        lambda *args: (
+            {"valid": True, "artifact_sha256": "5" * 64, "error": None},
+            {
+                "sealed_at_utc": "2026-08-04T07:00:00Z",
+                "operators": [operator],
+            },
+        ),
+    )
+    receipt = review.build_source_panel_review_receipt(
+        tmp_path,
+        tmp_path,
+        source,
+        reviewed_by="florianpfaff",
+        reviewed_at_utc="2026-08-04T08:02:00Z",
+    )
+    receipt_path = review.write_source_panel_review_receipt(tmp_path, receipt)
+
+    result = review.validate_source_panel_review_receipt(
+        tmp_path,
+        tmp_path,
+        source,
+        receipt_path,
+        published_by="florianpfaff",
+    )
+
+    assert result["independent_people"] is False
+    assert result["independent_preacquisition_attestation_claimed"] is False
+    assert result["governance_mode"] == "single_operator_self_attested"

--- a/tests/test_real_experiment_freeze.py
+++ b/tests/test_real_experiment_freeze.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from causal4d.preacquisition_protocol_v5 import single_operator_governance_policy
 from causal4d.real_analysis_interval_amendment import (
     REAL_ANALYSIS_INTERVAL_AMENDMENT_REPOSITORY_PATH,
     REAL_ANALYSIS_INTERVAL_EVIDENCE_REPOSITORY_PATH,
@@ -88,10 +89,11 @@ def _repository(tmp_path: Path) -> Path:
     amendment: dict[str, object] = {
         "schema_version": 1,
         "plan_id": PREACQUISITION_PLAN_ID,
-        "status": "supersedes_v3_before_any_physical_execution",
+        "status": "supersedes_v4_before_any_physical_execution",
         "supersedes": {
             "physical_executions_completed_before_supersession": 0,
         },
+        "governance": single_operator_governance_policy(),
         "base_protocol": {
             "design_sha256": PROTOCOL_SHA,
             "confirmatory_execution_count": 36,


### PR DESCRIPTION
## Summary

- add immutable pre-acquisition v5 with a new plan identity
- permit Florian Pfaff to act as the registered self-attesting operator
- remove person-separation requirements from freeze, environment, source publication, and contact review only under v5
- preserve every v4 scientific design, split, threshold, target boundary, and failure-reporting requirement
- require explicit disclosure that no independent pre-acquisition attestation is claimed

## Scientific boundary

This is a governance-only supersession made at 0/36 physical executions. It does not authorize target access, change the estimator, alter the source/target split, relax mechanism gates, or claim independent verification.

Closes the single-operator branch of #377.
