### PR TITLE
Align acquisition runbooks with single-operator v5 governance

### DIFF
--- a/docs/causal4d_preacquisition_readiness.md
+++ b/docs/causal4d_preacquisition_readiness.md
@@ -1,11 +1,12 @@
 # Pre-acquisition readiness attestation
 
-The registered v4 amendment defines the order of work before the 36-run
-confirmatory experiment, but its Boolean collection gate is intentionally frozen
-at `false`. It is a preregistration artifact, not a mutable checklist.
+The registered v5 amendment defines the order of work before the 36-run
+confirmatory experiment and supersedes v4 only for human-separation governance.
+Its Boolean collection gate is intentionally frozen at `false`; it is a
+preregistration artifact, not a mutable checklist.
 
 `causal4d protocol readiness` adds a separate, evidence-derived decision layer.
-It never rewrites the v2, v3, or v4 protocol files. The first confirmatory
+It never rewrites the v2, v3, v4, or v5 protocol files. The first confirmatory
 execution is permitted only when every prerequisite and operational gate below
 validates from immutable, checksummed evidence.
 
@@ -39,7 +40,7 @@ preacquisition/
 └── source_panel/executions/<execution-id>/manifest.template.json
 ```
 
-Each gate record binds the locked protocol and v4 amendment, its underlying
+Each gate record binds the locked protocol and active v5 amendment, its underlying
 files, completion and approval timestamps, the no-target-outcomes boundary, and
 a canonical SHA-256 digest. The scaffold also writes one source-panel manifest
 template per registered execution. Operators complete a separate staging copy;
@@ -126,7 +127,7 @@ The dry run may not reuse a confirmatory execution ID or use target outcomes.
 
 The software-environment gate is sealed after the method freeze. It binds:
 
-- the exact method-freeze and independent-attestation file hashes;
+- the exact method-freeze and registered self-attestation file hashes;
 - the frozen Causal4D and Bayesian-PhysTwin commits;
 - package versions and SHA-256 descriptors for the installed wheel or equivalent
   immutable distribution artifact;
@@ -171,15 +172,16 @@ causal4d protocol readiness seal-gate \
   --approved-by "<reviewer>"
 ```
 
-Seal the software environment after `method_freeze.json` and its independent
-attestation validate:
+Under v5, seal the software environment after `method_freeze.json` and its
+registered self-attestation validate. The same registered operator may approve
+this gate, and no independent attestation is claimed:
 
 ```bash
 causal4d protocol readiness seal-gate \
   /opt/causal4d-frozen \
   /data/causal4d-sloth-multi-action-v1 \
   software_environment_locked \
-  --approved-by "<independent-verifier>"
+  --approved-by "florianpfaff"
 ```
 
 Finally, require a hash-verified ready decision before execution 1:

--- a/docs/causal4d_real_evidence_status.md
+++ b/docs/causal4d_real_evidence_status.md
@@ -1,7 +1,9 @@
 # Real-Evidence Status and Claim-Readiness Gate
 
 The same-object multi-action protocol contains 18 same-grasp sessions and 36
-preregistered executions. Scaffolded files are acquisition templates, not
+preregistered executions. Active v5 governance permits one registered operator
+to perform and self-attest pre-acquisition checks; no independent attestation is
+claimed. Scaffolded files are acquisition templates, not
 evidence. The version-2 status contract therefore separates acquisition
 progress, evidence completeness, statistical analysability, pre-acquisition
 chronology, and claim readiness.
@@ -11,26 +13,25 @@ chronology, and claim readiness.
 A claim-ready dataset contains the locked protocol and acquisition schedule plus:
 
 - `object_registration.json` and every hashed canonical contact-node set;
-- approved schema-3 `contact_registration.json`, including multiview overlays,
-  rejected attachment candidates, independent reviews, and source checksums that
-  bind the simple registration and each canonical node set;
+- approved schema-4 `contact_registration.json`, including multiview overlays,
+  rejected attachment candidates, two chronological self-review passes, and
+  source checksums that bind the simple registration and each canonical node set;
 - `slip_pilot.json` with the preregistered bounded-slip decision;
 - approved `timebase_calibration.json` for the exact timestamped-stream set and
   one common `clock_domain_id`;
 - sealed `method_freeze.json`, verified against a clean checkout at the frozen
   Causal4D commit and its Bayesian-PhysTwin pin;
-- independent `method_freeze_validation.json`, signed by someone other than the
+- self-attested `method_freeze_validation.json`, signed by the registered
   freezer and bound to the exact freeze-file SHA-256;
 - one completed `sessions/<session-id>/session.json` for each of the 18 sessions;
 - one completed and hash-verified execution manifest for each of the 36 locked
   executions.
 
 The calibrated and approved timebase, physical contact approval, method freeze,
-and independent freeze attestation must not postdate the first validated
+and registered freeze self-attestation must not postdate the first validated
 execution.
 
-Create the independent freeze attestation from a second operator account or
-review step after sealing:
+Create the v5 self-attestation after sealing:
 
 ```bash
 causal4d protocol freeze attest \
@@ -38,21 +39,21 @@ causal4d protocol freeze attest \
   configs/causal4d/sloth_multi_action_v1.json \
   /opt/causal4d-frozen \
   /data/causal4d-sloth-multi-action-v1/method_freeze_validation.json \
-  --verified-by "<independent-verifier>"
+  --verified-by "florianpfaff"
 ```
 
 The command revalidates the clean checkout, every locked file hash, and the
-Bayesian-PhysTwin pin before writing the attestation. It rejects a verifier ID
-that matches the original freezer.
+Bayesian-PhysTwin pin before writing the attestation. Under v5 it requires the
+attester to resolve to the same registered person as the freezer and records
+that independence is not claimed.
 
-The physical registration uses `PhysicalContactRegistration` schema 3 as the
+The physical registration uses `PhysicalContactRegistration` schema 4 as the
 authoritative contact record. Its `source_checksums` mapping must include
 `object_registration.json` and `contact_node_set:<region-id>` entries. The
 simpler registration remains as a compact acquisition index and is checked
-against the authoritative artifact. Every region must have case-insensitively
-distinct independent reviewer identities, every review and approval timestamp
-must be valid UTC, and the registration approval must not predate any
-independent review.
+against the authoritative artifact. Every region must contain two strictly
+chronological review passes by the registered operator; all review and approval
+timestamps must be valid UTC, and approval must not predate either pass.
 
 ## Scaffold
 
@@ -128,7 +129,7 @@ uses separate decisions:
   fit, calibration, and target execution and at least one same-grasp pair remains;
 - `full_registered_power`: no execution was excluded;
 - `preacquisition_chronology`: the calibrated and approved timebase, contact
-  approval, method freeze, and independent attestation do not postdate the
+  approval, method freeze, and registered self-attestation do not postdate the
   earliest validated execution; before any execution validates, the report has
   no earliest execution timestamp;
 - `claim_ready`: the evidence tree is complete, hash verified, and passes the
@@ -160,9 +161,9 @@ The command returns:
 - `2` when an input or locked contract cannot be interpreted;
 - `3` when `--require-complete` is requested but any evidence blocker remains.
 
-The gate rejects timebase approval before calibration, duplicate contact
-reviewers, contact approval before an independent review, and any timestamped
-method prerequisite after the first validated execution.
+The gate rejects timebase approval before calibration, malformed or
+nonchronological contact self-review passes, contact approval before review, and
+any timestamped method prerequisite after the first validated execution.
 
 `validate-dataset` applies the same version-2 contract. Without
 `--skip-file-hashes`, it fails unless the complete evidence tree is claim-ready.

--- a/docs/causal4d_real_experiment_milestone.md
+++ b/docs/causal4d_real_experiment_milestone.md
@@ -32,8 +32,8 @@ The following rules apply to the primary real-experiment analysis:
   mechanism may enter the primary comparison before the 36-execution result is
   reported.
 - The exact Causal4D commit, clean-worktree state, protocol, acquisition
-  schedule, exact locked Bayesian-PhysTwin revision, final v4 pre-acquisition
-  amendment, mechanism-gate control evidence, scope document, and protocol
+  schedule, exact locked Bayesian-PhysTwin revision, final v5 pre-acquisition
+  governance amendment, mechanism-gate control evidence, scope document, and protocol
   document are sealed before the first confirmatory execution.
 - The confirmatory uncertainty path is
   `causal4d calibration execution-block`: one preregistered execution per
@@ -56,6 +56,10 @@ Every such change must be logged with its commit and reason.
 
 ## Freeze and acquisition workflow
 
+V5 permits Florian Pfaff to perform these checks as the single registered
+self-attesting operator. Every report must state that no independent
+pre-acquisition attestation is claimed.
+
 Start from a clean checkout of the commit intended for acquisition. Scaffold the
 non-overwriting dataset and readiness evidence first:
 
@@ -71,24 +75,24 @@ causal4d protocol readiness scaffold \
 
 Complete and seal the source-panel, actuator, support/gravity, and
 nonconfirmatory dry-run gates. These operational approvals must predate the
-method freeze. Then write and independently attest the freeze manifest:
+method freeze. Then write and self-attest the freeze manifest under v5:
 
 ```bash
 causal4d protocol freeze seal \
   /opt/causal4d-frozen \
   /data/causal4d-sloth-multi-action-v1/method_freeze.json \
-  --frozen-by "<operator-or-principal-investigator>"
+  --frozen-by "florianpfaff"
 
 causal4d protocol freeze attest \
   /data/causal4d-sloth-multi-action-v1/method_freeze.json \
   configs/causal4d/sloth_multi_action_v1.json \
   /opt/causal4d-frozen \
   /data/causal4d-sloth-multi-action-v1/method_freeze_validation.json \
-  --verified-by "<independent-verifier>"
+  --verified-by "florianpfaff"
 ```
 
-After the attestation, seal the software-environment gate. It binds the exact
-freeze and attestation hashes, Causal4D and Bayesian-PhysTwin package artifacts,
+After the self-attestation, seal the software-environment gate. It binds the
+exact freeze and attestation hashes, Causal4D and Bayesian-PhysTwin package artifacts,
 the observation producer, and an explicit Prob4D used-or-unused declaration.
 Finally, require the hash-verified readiness decision:
 
@@ -114,14 +118,14 @@ causal4d protocol freeze validate \
 
 The seal command refuses a dirty Git worktree. Freeze schema v2 records file
 checksums, the protocol design digest, the exact Bayesian-PhysTwin commit from
-`requirements/ci/bayesian-phystwin-provider-v1.sha`, the final v4 amendment
+`requirements/ci/bayesian-phystwin-provider-v1.sha`, the final v5 amendment
 digest, its mechanism-gate control digest, the six-frame observation boundary,
 and the registered analysis entrypoints. It also freezes the confirmatory
 execution-block score, calibration unit, fold count, finite rank, and
 non-claims. A manifest that substitutes the older coordinate-pooled calibration
 command fails validation.
 
-The separate readiness status does not mutate that freeze or the v4 amendment.
+The separate readiness status does not mutate that freeze or the v5 amendment.
 It derives the collection decision from the registered prerequisite validators,
 checksummed operational records, software lineage, chronology, and zero
 confirmatory manifests. See
@@ -140,7 +144,7 @@ Before confirmatory execution 1:
 - validate commanded versus measured actuation;
 - validate support, gravity, camera/controller, and shared-clock registration;
 - pass one nonconfirmatory end-to-end dry run;
-- seal and independently validate `method_freeze.json`;
+- seal and self-attest `method_freeze.json` with the registered operator;
 - bind the exact software distributions and observation producer;
 - confirm that no confirmatory manifest or target outcome exists; and
 - obtain `first_confirmatory_execution_allowed=true` from

--- a/docs/causal4d_source_panel_review_receipt.md
+++ b/docs/causal4d_source_panel_review_receipt.md
@@ -1,70 +1,57 @@
-# Two-person source-panel publication receipt
+# Governance-bound source-panel publication receipt
 
 A successful staged preflight proves that the next source manifest and all
-referenced artifacts are valid at one instant. It does not prove that a second
-person inspected the result, and it must not allow the same person to approve
-and publish claim-bearing evidence under two operator aliases.
+referenced artifacts are valid at one instant. The review-receipt flow adds a
+registered human review before the existing exactly-once publisher.
 
-The review-receipt flow adds a registered two-person boundary before the
-existing exactly-once publisher.
+Under active v5 governance, the same registered operator may review and publish.
+The receipt records that fact and must not claim independent review. Historical
+v4 evidence retains its two-person requirement.
 
-## Operator sequence
+## V5 operator sequence
 
 ```text
 acquire registered source execution
         ↓
 hash-verify staged manifest and artifacts
         ↓
-registered reviewer seals a content-addressed receipt
+registered operator seals a content-addressed review receipt
         ↓
-distinct registered publisher reruns validation and publishes exactly once
+the same registered operator reruns validation and publishes exactly once
         ↓
 recompute readiness and the next action
 ```
 
 The reviewer must be active in the sealed operator registry with either the
-`gate_approver` or `independent_verifier` role. The publisher must be another
-active registered person. Distinct operator IDs are insufficient: the two
-records must have different `person_identity_sha256` values.
+`gate_approver` or `independent_verifier` role. A one-person v5 project uses
+the registered `gate_approver`; it does not assign or claim an independent role.
 
 ## Review command
 
-After the staged preflight succeeds, a reviewer runs:
+After staged preflight succeeds:
 
 ```bash
 causal4d protocol readiness source-panel-review-staged \
   /opt/causal4d-frozen \
   /data/causal4d-sloth-multi-action-v1 \
   /data/causal4d-sloth-multi-action-v1/staging/<execution-id>.json \
-  --reviewed-by <registered-reviewer-id>
+  --reviewed-by florianpfaff
 ```
 
-The command reruns the complete preflight. It writes the receipt exactly once to:
+The command reruns the complete preflight and writes exactly once to:
 
 ```text
 staging/reviews/<execution-id>.json
 ```
 
-The review timestamp must follow execution completion, and the sealed operator
-registry must predate the review. The receipt binds:
-
-- protocol and pre-acquisition amendment identities;
-- execution and independent-session identities;
-- staged manifest path, SHA-256, and byte count;
-- source execution completion timestamp;
-- portable and host-local staged-preflight identities;
-- the source-panel evidence identity before publication;
-- the exact operator-registry identity;
-- reviewer operator ID, person identity, and active roles;
-- review timestamp; and
-- the explicit no-target-outcomes and no-method-change boundary.
-
-The receipt carries its own canonical `artifact_sha256`. Publication refuses a
-modified or relocated receipt.
+The review must follow execution completion, and the operator registry must
+predate it. The receipt binds protocol and amendment identities, execution and
+session identities, staged manifest bytes and digest, source completion time,
+preflight identities, source-panel state before publication, registry identity,
+operator identity and roles, review time, and the no-target/no-method-change
+boundary.
 
 ## Publication command
-
-A distinct registered publisher runs:
 
 ```bash
 causal4d protocol readiness source-panel-publish \
@@ -73,40 +60,37 @@ causal4d protocol readiness source-panel-publish \
   /data/causal4d-sloth-multi-action-v1/staging/<execution-id>.json \
   --review-receipt \
   /data/causal4d-sloth-multi-action-v1/staging/reviews/<execution-id>.json \
-  --published-by <registered-publisher-id>
+  --published-by florianpfaff
 ```
 
-The claim-bearing CLI has no receipt-free route. Before publication it:
+Before publication the CLI reruns preflight, validates the canonical receipt,
+revalidates the operator and roles, checks receipt stability, and invokes the
+exactly-once publisher. Under v5 the result records:
 
-1. reruns the complete staged preflight;
-2. verifies the receipt path and canonical digest;
-3. verifies every receipt field against the current preflight;
-4. revalidates the sealed operator registry;
-5. resolves reviewer and publisher as active operators;
-6. proves person-level independence;
-7. checks receipt stability while validation runs; and
-8. invokes the existing exactly-once publisher, which validates all source
-   artifacts again immediately before the final write.
+```text
+governance_mode=single_operator_self_attested
+independent_people=false
+independent_preacquisition_attestation_claimed=false
+```
 
-The publication result includes both operator identities, the review-receipt
-file descriptor, the bound preflight evidence identity, and
-`independent_people=true`.
+Under historical v4 governance, reviewer and publisher must still resolve to
+different person digests and `independent_people=true`.
 
 ## Failure handling
 
-A receipt becomes stale if the staged manifest, any referenced artifact, the
-source-panel prefix, or the operator registry changes. Generate a fresh
-preflight and a new receipt. A receipt path is non-overwriting; do not edit or
-replace an existing receipt to rescue a failed publication.
+A receipt becomes stale if the staged manifest, a referenced artifact, the
+source-panel prefix, or the operator registry changes. Review receipts are
+non-overwriting; preserve a failed receipt and create a newly versioned
+pre-acquisition process rather than editing it in place.
 
-Self-review, duplicate person identities under different operator IDs, inactive
-operators, unsupported reviewer roles, review before execution completion,
-receipt-field drift, target-outcome fields, symlinks, and noncanonical receipt
-paths fail closed before the final manifest can be created.
+Unknown or inactive operators, unsupported roles, review before execution
+completion, field drift, target-outcome fields, symlinks, and noncanonical paths
+fail closed. V5 permits same-person review and publication only when the exact
+validated v5 governance policy is active.
 
 ## Scientific boundary
 
 The receipt does not make an execution valid, increment evidence count, reserve
 the next source slot, alter the estimator, or authorize confirmatory collection.
-It records only that a registered second person reviewed the current source
-preflight before a distinct registered person invoked exactly-once publication.
+It records a checksummed self-review before publication. It is not independent
+reproduction or independent attestation.

--- a/docs/independent_verifier_invitation_template.md
+++ b/docs/independent_verifier_invitation_template.md
@@ -1,5 +1,7 @@
 # Independent-verifier invitation template
 
+> **V5 status:** This invitation is optional under active v5 and must not be presented as a readiness requirement.
+
 > Copy this text into a private message to a prospective verifier. Replace only
 > the bracketed contact fields. Do not commit the completed message, the
 > recipient's identity, or private principal material to the repository or

--- a/docs/independent_verifier_onboarding.md
+++ b/docs/independent_verifier_onboarding.md
@@ -1,5 +1,7 @@
 # Independent verifier onboarding
 
+> **V5 status:** A distinct verifier is optional under active v5. Use this guide only for a genuine additional independent review; it is not required for acquisition readiness.
+
 ## Purpose and current boundary
 
 The registered Causal4D same-object physical protocol requires a genuinely

--- a/docs/independent_verifier_self_declaration_template.md
+++ b/docs/independent_verifier_self_declaration_template.md
@@ -1,5 +1,7 @@
 # Independent-verifier self-declaration template
 
+> **V5 status:** This declaration is used only when a genuinely distinct verifier volunteers; active v5 does not require it.
+
 > This is a private onboarding aid, not a repository artifact and not an
 > attestation. The prospective verifier completes it in their own words and
 > returns it through an institutionally appropriate private channel. Do not

--- a/docs/operator_identity_registry.md
+++ b/docs/operator_identity_registry.md
@@ -1,31 +1,50 @@
 # Operator identity registry
 
-The confirmatory acquisition workflow uses a sealed operator roster so that approval independence is checked at the **person** level rather than by comparing free-form display strings.
+The acquisition workflow uses a sealed operator roster so approvals are bound to
+a real person rather than free-form display strings. Under the active
+pre-acquisition v5 policy, one registered person may perform every
+pre-acquisition role. The resulting evidence is self-attested; it is not
+independently attested.
 
-This is an operational-provenance control. It does not change the estimator, the 36-execution schedule, the registered analysis, the exclusion policy, or any scientific threshold.
+This governance change does not alter the estimator, 18-session/36-execution
+schedule, source/target split, registered analysis, exclusion policy, or any
+scientific threshold.
+
+## Active v5 policy
+
+The active policy is
+`causal4d-sloth-preacquisition-v5-single-operator`. It permits the same
+registered person to:
+
+- seal and self-attest the method freeze;
+- approve operational and software-environment gates;
+- review and publish source-panel evidence; and
+- perform the two chronological contact-registration review passes.
+
+Every report using this study must disclose:
+
+> One registered operator performed the pre-acquisition checks and
+> self-attested the freeze; no independent pre-acquisition attestation is
+> claimed.
+
+A genuinely distinct verifier can still be added later, but is not required for
+v5 readiness. Do not create aliases or duplicate identities to simulate
+independence.
 
 ## Identity model
 
-The canonical artifact is stored at:
+The canonical artifact is:
 
 ```text
 preacquisition/operator_registry.json
 ```
 
-Each entry contains only:
+Each entry contains a stable project-local `operator_id`, an `active` flag,
+registered roles, and `person_identity_sha256`. Raw email addresses, account
+names, personnel numbers, and the HMAC key must stay outside the repository and
+dataset.
 
-- a stable project-local `operator_id`;
-- an `active` flag;
-- registered roles; and
-- `person_identity_sha256`, a privacy-preserving stable person digest.
-
-Raw email addresses, account names, personnel numbers, and the HMAC key must not be written to the dataset. The registered digest method is:
-
-```text
-hmac-sha256-domain-separated-v1
-```
-
-A suitable institutional procedure is:
+The registered digest method is:
 
 ```text
 HMAC-SHA256(
@@ -34,24 +53,26 @@ HMAC-SHA256(
 )
 ```
 
-The secret and the stable institutional principal remain outside the repository and acquisition dataset. The same person must always produce the same digest, even when that person uses a different display name or project-local alias. Two registry entries may never share a person digest.
+The same person must always produce the same digest. Two registry entries may
+not share a person digest.
 
 ## Roles
 
-The supported roles are:
+Supported roles are:
 
-- `freezer`: may seal the method freeze;
-- `independent_verifier`: may attest the method freeze and counts as an independent software-lock approver;
-- `gate_approver`: may approve operational readiness gates; and
-- `software_environment_approver`: may independently approve the software-environment lock.
+- `freezer`;
+- `gate_approver`;
+- `software_environment_approver`; and
+- `independent_verifier`, retained for genuinely independent future review.
 
-Every gate approver must have `gate_approver`. The software-environment approver must additionally have either `independent_verifier` or `software_environment_approver`, and must have a different person digest from the method freezer.
-
-The method freezer and independent verifier must resolve to distinct person digests. Different `operator_id` strings do not establish independence.
+For a one-person v5 registry, one active operator needs at least
+`freezer`, `gate_approver`, and `software_environment_approver`.
+The `independent_verifier` role must not be assigned unless a distinct person
+actually performs that role.
 
 ## Lifecycle
 
-Scaffold the registered template after creating the dataset:
+Create the v5-bound template in a fresh, non-overwriting dataset scaffold:
 
 ```bash
 causal4d protocol readiness scaffold-operator-registry \
@@ -59,13 +80,22 @@ causal4d protocol readiness scaffold-operator-registry \
   /data/causal4d-sloth-multi-action-v1
 ```
 
-Edit only the `operators` array in:
+Edit only the `operators` array in
+`preacquisition/operator_registry.template.json`. A valid one-person entry has
+this shape, with roles sorted canonically:
 
-```text
-preacquisition/operator_registry.template.json
+```json
+{
+  "operator_id": "florianpfaff",
+  "person_identity_sha256": "<64 lowercase hex>",
+  "active": true,
+  "roles": [
+    "freezer",
+    "gate_approver",
+    "software_environment_approver"
+  ]
+}
 ```
-
-Keep the template artifact kind, `status: "template"`, registered protocol and amendment digests, `target_outcomes_used: false`, and all seal fields unchanged. Roles and operators are canonicalized during sealing.
 
 Seal the roster exactly once:
 
@@ -74,63 +104,44 @@ causal4d protocol readiness seal-operator-registry \
   /opt/causal4d-frozen \
   /data/causal4d-sloth-multi-action-v1 \
   /data/causal4d-sloth-multi-action-v1/preacquisition/operator_registry.template.json \
-  --sealed-by freezer.primary
+  --sealed-by florianpfaff
 ```
 
-The seal fails closed when:
-
-- the canonical registry already exists;
-- method-freeze or freeze-attestation evidence already exists;
-- an operational gate has already been approved;
-- confirmatory execution or session manifests already exist;
-- a person digest or operator ID is duplicated;
-- an operator is unknown, inactive, or missing a required role;
-- an unsupported or noncanonical field is present; or
-- target outcomes entered the identity artifact.
-
-The canonical registry is published atomically and cannot be replaced or resealed.
+The seal fails closed if evidence already exists, identities or roles are
+invalid, the template is not bound to v5, or target outcomes entered the
+artifact. An old v4-bound registry must not be edited in place; start a fresh
+v5-bound scaffold and retain the old tree as historical provenance.
 
 ## Governed approvals
 
-Use registered operator IDs, not names:
+Use the same registered operator ID honestly:
 
 ```bash
 causal4d protocol freeze seal \
   /opt/causal4d-frozen \
   /data/causal4d-sloth-multi-action-v1/method_freeze.json \
-  --frozen-by freezer.primary
+  --frozen-by florianpfaff
 
 causal4d protocol freeze attest \
   /data/causal4d-sloth-multi-action-v1/method_freeze.json \
   configs/causal4d/sloth_multi_action_v1.json \
   /opt/causal4d-frozen \
   /data/causal4d-sloth-multi-action-v1/method_freeze_validation.json \
-  --verified-by verifier.independent
+  --verified-by florianpfaff
 
 causal4d protocol readiness seal-gate \
   /opt/causal4d-frozen \
   /data/causal4d-sloth-multi-action-v1 \
   support_registration_passed \
-  --approved-by verifier.independent
+  --approved-by florianpfaff
 ```
 
-The registry must predate every governed approval. A postdated registry, role change, alias collision, unknown identity, or person-level independence failure blocks readiness and claim status.
+The registry must predate every governed approval. Readiness revalidates the
+complete identity chain, all roles, chronology, source hashes, and the explicit
+self-attestation policy at status time.
 
-## Status-time revalidation
+## Legacy v4 boundary
 
-Approval checks are not limited to the commands that create an artifact. Every readiness and claim-status evaluation reopens and validates the complete governed chain:
-
-- method freezer and independent freeze verifier;
-- timebase-calibration approver;
-- contact-registration approver; and
-- every operational readiness-gate approver.
-
-The derived `operator_identity_bindings` prerequisite records the canonical registry digest, the resolved person digests, approval-role bindings, and SHA-256 digests of all governed source artifacts. Missing or template evidence remains valid-but-incomplete. A completed artifact with an unknown, inactive, role-incompatible, postdated, aliased, or non-independent identity fails closed.
-
-This status-time validation prevents manually edited artifacts or legacy free-form identifiers from bypassing the creation-time checks.
-
-## Evidence identity
-
-The registry carries a canonical `artifact_sha256`. Pre-acquisition readiness and real-evidence status include that digest as a prerequisite. Portable readiness identity removes workstation-local paths but retains the registry digest and the governed source digests, so relocating an unchanged dataset preserves evidence identity while changing the roster or any approval artifact does not.
-
-Registry templates, dry runs, or scaffold output never count as physical executions and never change the valid evidence boundary from `0/36 acquired` until genuine acquisition begins.
+Artifacts created under v4 remain immutable and retain their original
+two-person requirement. V5 does not reinterpret them. Only evidence bound to the
+v5 plan and amendment digest may use the single-operator policy.

--- a/docs/single_operator_registry_correction.md
+++ b/docs/single_operator_registry_correction.md
@@ -1,5 +1,7 @@
 # Single-operator registry correction
 
+> **V5 status:** This records the superseded v4 governance blocker. Active v5 permits disclosed single-operator self-attestation and does not require a second person.
+
 The workstation2 operator registry created in August 2026 contained unsupported
 person assignments. Those assignments were not provided or authorized by the
 project owner and must not be used as evidence of participation, consent,


### PR DESCRIPTION
## Summary

- replace stale two-person instructions in current acquisition runbooks
- document the one-person operator registry, self-attested freeze, source self-review, and two-pass contact review
- mark independent-verifier materials and the v4 blocker note as optional/historical under v5
- preserve the explicit statement that no independent pre-acquisition attestation is claimed

This is documentation-only. It does not change the v5 implementation, the 18-session/36-execution design, source/target boundaries, thresholds, or evidence state.