### PR TITLE
Bootstrap the fresh single-operator v5 scaffold

### DIFF
--- a/.github/self-hosted-jobs.json
+++ b/.github/self-hosted-jobs.json
@@ -40,6 +40,21 @@
       "secrets_allowed": false
     },
     {
+      "workflow": "bootstrap-single-operator-v5-self-hosted.yml",
+      "job": "bootstrap",
+      "authorization_model": "maintainer-issue-main",
+      "runner_labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "nvidia-smi",
+        "data-causal4d-physical-v1"
+      ],
+      "purpose": "Create or revalidate the fresh v5 single-operator acquisition scaffold",
+      "dataset_access": "registered-local-preacquisition-v5-scaffold-bootstrap",
+      "secrets_allowed": false
+    },
+    {
       "workflow": "contact-posterior-concentration.yml",
       "job": "evaluate",
       "authorization_model": "main-only",

--- a/.github/self-hosted-jobs.json
+++ b/.github/self-hosted-jobs.json
@@ -6,6 +6,9 @@
     },
     "maintainer-issue-main": {
       "description": "Exact registered-maintainer issue trigger on reviewed refs/heads/main, exact GITHUB_SHA checkout, clean-tree verification, read-only self-hosted token, no issue text execution, and no secrets."
+    },
+    "single-operator-v5-issue-main": {
+      "description": "Exact registered-owner issue trigger on reviewed refs/heads/main for the nonphysical v5 scaffold bootstrap, exact GITHUB_SHA checkout, read-only self-hosted token, no issue text execution, and no secrets."
     }
   },
   "jobs": [
@@ -42,7 +45,7 @@
     {
       "workflow": "bootstrap-single-operator-v5-self-hosted.yml",
       "job": "bootstrap",
-      "authorization_model": "maintainer-issue-main",
+      "authorization_model": "single-operator-v5-issue-main",
       "runner_labels": [
         "self-hosted",
         "Linux",

--- a/.github/workflows/bootstrap-single-operator-v5-self-hosted.yml
+++ b/.github/workflows/bootstrap-single-operator-v5-self-hosted.yml
@@ -1,0 +1,267 @@
+name: Bootstrap single-operator v5 scaffold
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  bootstrap:
+    name: Bootstrap the fresh v5 acquisition scaffold on workstation2
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      github.event_name == 'issues' &&
+      github.event.action == 'opened' &&
+      github.event.issue.user.login == 'FlorianPfaff' &&
+      github.event.issue.user.id == 6773539 &&
+      github.event.issue.title ==
+        '[self-hosted] bootstrap Causal4D v5 operator scaffold'
+    concurrency:
+      group: causal4d-single-operator-v5-bootstrap
+      cancel-in-progress: false
+    runs-on: [self-hosted, Linux, X64, nvidia-smi, data-causal4d-physical-v1]
+    timeout-minutes: 45
+    outputs:
+      created: ${{ steps.summary.outputs.created }}
+      dataset_modified: ${{ steps.summary.outputs.dataset_modified }}
+      plan_id: ${{ steps.summary.outputs.plan_id }}
+      registry_artifact_sha256: >-
+        ${{ steps.summary.outputs.registry_artifact_sha256 }}
+      receipt_artifact_sha256: >-
+        ${{ steps.summary.outputs.receipt_artifact_sha256 }}
+      operator_count: ${{ steps.summary.outputs.operator_count }}
+      independent_verifier_available: >-
+        ${{ steps.summary.outputs.independent_verifier_available }}
+      next_action: ${{ steps.summary.outputs.next_action }}
+      physical_required: ${{ steps.summary.outputs.physical_required }}
+      physical_evidence_increment: >-
+        ${{ steps.summary.outputs.physical_evidence_increment }}
+    steps:
+      - name: Check out exact reviewed main revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          clean: true
+
+      - name: Verify reviewed main revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Build and install the exact Causal4D wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p outputs/single-operator-v5-bootstrap/wheels
+          python -m venv .single-operator-v5-bootstrap-venv
+          .single-operator-v5-bootstrap-venv/bin/python -m pip install             --upgrade pip "build>=1.2"
+          .single-operator-v5-bootstrap-venv/bin/python -m build --wheel             --outdir outputs/single-operator-v5-bootstrap/wheels .
+          wheel="$(
+            find outputs/single-operator-v5-bootstrap/wheels -maxdepth 1               -name 'causal4d-*.whl' -print -quit
+          )"
+          test -n "${wheel}"
+          sha256sum "${wheel}"             | tee outputs/single-operator-v5-bootstrap/wheel-sha256.txt
+          .single-operator-v5-bootstrap-venv/bin/python -m pip install "${wheel}"
+          .single-operator-v5-bootstrap-venv/bin/python -m pip check
+          .single-operator-v5-bootstrap-venv/bin/python - <<'PY'
+          from pathlib import Path
+
+          import causal4d
+
+          source_root = (Path.cwd() / "src").resolve()
+          origin = Path(causal4d.__file__).resolve()
+          print("installed import", origin)
+          if origin.is_relative_to(source_root):
+              raise SystemExit(
+                  "Causal4D resolved from the checkout instead of the wheel"
+              )
+          PY
+
+      - name: Create or revalidate the fresh v5 scaffold
+        shell: bash
+        run: |
+          set -euo pipefail
+          PYTHONPATH="" .single-operator-v5-bootstrap-venv/bin/python             scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py             --repository-root "${GITHUB_WORKSPACE}"             --source-dataset-root               /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1             --target-dataset-root               /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5             --output outputs/single-operator-v5-bootstrap/report.json             | tee outputs/single-operator-v5-bootstrap/report.txt
+
+      - name: Verify and export sanitized result fields
+        id: summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          .single-operator-v5-bootstrap-venv/bin/python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads(
+              Path(
+                  "outputs/single-operator-v5-bootstrap/report.json"
+              ).read_text(encoding="utf-8")
+          )
+          if report["artifact_kind"] != (
+              "Causal4DSingleOperatorV5BootstrapReport"
+          ):
+              raise SystemExit("unexpected bootstrap report")
+          if report["reviewed_main_commit"] != os.environ["GITHUB_SHA"]:
+              raise SystemExit("bootstrap report commit mismatch")
+          if report["target_preacquisition_plan_id"] != (
+              "causal4d-sloth-preacquisition-v5-single-operator"
+          ):
+              raise SystemExit("bootstrap report plan mismatch")
+          if report["operator_ids"] != ["florianpfaff"]:
+              raise SystemExit("bootstrap report operator mismatch")
+          if report["independent_verifier_available"] is not False:
+              raise SystemExit("bootstrap report claims independent verification")
+          action = report["next_action"]
+          if action["action_id"] != "complete_object_registration":
+              raise SystemExit("fresh v5 scaffold did not reach registration")
+          if action["operator_role"] != "self_attesting_operator":
+              raise SystemExit("fresh v5 scaffold has the wrong operator role")
+          for field in (
+              "target_outcomes_used",
+              "device_nodes_opened",
+              "physical_command_sent",
+              "registered_method_changed",
+          ):
+              if report[field] is not False:
+                  raise SystemExit(f"bootstrap crossed forbidden boundary: {field}")
+          if report["physical_evidence_increment"] != 0:
+              raise SystemExit("bootstrap changed physical evidence")
+
+          print(f"created={str(report['created']).lower()}")
+          print(
+              f"dataset_modified={str(report['dataset_modified']).lower()}"
+          )
+          print(f"plan_id={report['target_preacquisition_plan_id']}")
+          print(
+              "registry_artifact_sha256="
+              f"{report['target_registry_artifact_sha256']}"
+          )
+          print(
+              "receipt_artifact_sha256="
+              f"{report['bootstrap_receipt_artifact_sha256']}"
+          )
+          print(f"operator_count={len(report['operator_ids'])}")
+          print(
+              "independent_verifier_available="
+              f"{str(report['independent_verifier_available']).lower()}"
+          )
+          print(f"next_action={action['action_id']}")
+          print(
+              "physical_required="
+              f"{str(action['physical_acquisition_required']).lower()}"
+          )
+          print(
+              "physical_evidence_increment="
+              f"{report['physical_evidence_increment']}"
+          )
+          PY
+
+      - name: Record runner identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "runner_name=${RUNNER_NAME}"
+            echo "runner_os=${RUNNER_OS}"
+            echo "runner_arch=${RUNNER_ARCH}"
+            echo "repository=${GITHUB_REPOSITORY}"
+            echo "commit=${GITHUB_SHA}"
+            echo "workflow_run_id=${GITHUB_RUN_ID}"
+            uname -a
+          } | tee outputs/single-operator-v5-bootstrap/runner.txt
+          nvidia-smi -L             | tee outputs/single-operator-v5-bootstrap/nvidia-smi-L.txt
+
+      - name: Upload sanitized bootstrap evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: causal4d-single-operator-v5-bootstrap
+          path: |
+            outputs/single-operator-v5-bootstrap/report.json
+            outputs/single-operator-v5-bootstrap/report.txt
+            outputs/single-operator-v5-bootstrap/runner.txt
+            outputs/single-operator-v5-bootstrap/nvidia-smi-L.txt
+            outputs/single-operator-v5-bootstrap/wheel-sha256.txt
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Remove isolated environment and wheel
+        if: always()
+        shell: bash
+        run: |
+          rm -rf             .single-operator-v5-bootstrap-venv             outputs/single-operator-v5-bootstrap/wheels
+
+  report:
+    name: Report the v5 bootstrap to the trigger issue
+    if: >-
+      always() &&
+      github.event_name == 'issues' &&
+      github.event.action == 'opened' &&
+      github.ref == 'refs/heads/main' &&
+      github.event.issue.user.login == 'FlorianPfaff' &&
+      github.event.issue.user.id == 6773539 &&
+      github.event.issue.title ==
+        '[self-hosted] bootstrap Causal4D v5 operator scaffold'
+    needs: bootstrap
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      BOOTSTRAP_RESULT: ${{ needs.bootstrap.result }}
+      CREATED: ${{ needs.bootstrap.outputs.created }}
+      DATASET_MODIFIED: ${{ needs.bootstrap.outputs.dataset_modified }}
+      PLAN_ID: ${{ needs.bootstrap.outputs.plan_id }}
+      REGISTRY_ARTIFACT_SHA256: >-
+        ${{ needs.bootstrap.outputs.registry_artifact_sha256 }}
+      RECEIPT_ARTIFACT_SHA256: >-
+        ${{ needs.bootstrap.outputs.receipt_artifact_sha256 }}
+      OPERATOR_COUNT: ${{ needs.bootstrap.outputs.operator_count }}
+      INDEPENDENT_VERIFIER_AVAILABLE: >-
+        ${{ needs.bootstrap.outputs.independent_verifier_available }}
+      NEXT_ACTION: ${{ needs.bootstrap.outputs.next_action }}
+      PHYSICAL_REQUIRED: ${{ needs.bootstrap.outputs.physical_required }}
+      PHYSICAL_EVIDENCE_INCREMENT: >-
+        ${{ needs.bootstrap.outputs.physical_evidence_increment }}
+    steps:
+      - name: Comment with the sanitized bootstrap result
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/"
+          run_url+="${GITHUB_RUN_ID}"
+          body="$(cat <<EOF
+          Causal4D v5 single-operator scaffold bootstrap: **${BOOTSTRAP_RESULT}**
+
+          - Exact reviewed main commit: `${GITHUB_SHA}`
+          - Registered plan: `${PLAN_ID:-unavailable}`
+          - Fresh scaffold created: `${CREATED:-unknown}`
+          - Dataset modified: `${DATASET_MODIFIED:-unknown}`
+          - Registered operator count: `${OPERATOR_COUNT:-unknown}`
+          - Independent verifier available: `${INDEPENDENT_VERIFIER_AVAILABLE:-unknown}`
+          - Registry artifact: `${REGISTRY_ARTIFACT_SHA256:-unavailable}`
+          - Bootstrap receipt: `${RECEIPT_ARTIFACT_SHA256:-unavailable}`
+          - Derived next action: `${NEXT_ACTION:-unavailable}`
+          - Physical acquisition required by next action: `${PHYSICAL_REQUIRED:-unknown}`
+          - Physical evidence increment from this run: `${PHYSICAL_EVIDENCE_INCREMENT:-unknown}`
+          - Workflow run: ${run_url}
+          - Artifact: `causal4d-single-operator-v5-bootstrap`
+
+          This run claims no independent pre-acquisition attestation and does not authorize target access.
+          EOF
+          )"
+          gh issue comment "${ISSUE_NUMBER}"             --repo "${GITHUB_REPOSITORY}"             --body "${body}"

--- a/.github/workflows/bootstrap-single-operator-v5-self-hosted.yml
+++ b/.github/workflows/bootstrap-single-operator-v5-self-hosted.yml
@@ -19,8 +19,9 @@ jobs:
       github.event.issue.title ==
         '[self-hosted] bootstrap Causal4D v5 operator scaffold'
     concurrency:
-      group: causal4d-single-operator-v5-bootstrap
+      group: causal4d-single-operator-v5-bootstrap-${{ github.sha }}
       cancel-in-progress: false
+      queue: max
     runs-on: [self-hosted, Linux, X64, nvidia-smi, data-causal4d-physical-v1]
     timeout-minutes: 45
     outputs:
@@ -65,13 +66,17 @@ jobs:
           set -euo pipefail
           mkdir -p outputs/single-operator-v5-bootstrap/wheels
           python -m venv .single-operator-v5-bootstrap-venv
-          .single-operator-v5-bootstrap-venv/bin/python -m pip install             --upgrade pip "build>=1.2"
-          .single-operator-v5-bootstrap-venv/bin/python -m build --wheel             --outdir outputs/single-operator-v5-bootstrap/wheels .
+          .single-operator-v5-bootstrap-venv/bin/python -m pip install \
+            --upgrade pip "build>=1.2"
+          .single-operator-v5-bootstrap-venv/bin/python -m build --wheel \
+            --outdir outputs/single-operator-v5-bootstrap/wheels .
           wheel="$(
-            find outputs/single-operator-v5-bootstrap/wheels -maxdepth 1               -name 'causal4d-*.whl' -print -quit
+            find outputs/single-operator-v5-bootstrap/wheels -maxdepth 1 \
+              -name 'causal4d-*.whl' -print -quit
           )"
           test -n "${wheel}"
-          sha256sum "${wheel}"             | tee outputs/single-operator-v5-bootstrap/wheel-sha256.txt
+          sha256sum "${wheel}" \
+            | tee outputs/single-operator-v5-bootstrap/wheel-sha256.txt
           .single-operator-v5-bootstrap-venv/bin/python -m pip install "${wheel}"
           .single-operator-v5-bootstrap-venv/bin/python -m pip check
           .single-operator-v5-bootstrap-venv/bin/python - <<'PY'
@@ -92,7 +97,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          PYTHONPATH="" .single-operator-v5-bootstrap-venv/bin/python             scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py             --repository-root "${GITHUB_WORKSPACE}"             --source-dataset-root               /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1             --target-dataset-root               /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5             --output outputs/single-operator-v5-bootstrap/report.json             | tee outputs/single-operator-v5-bootstrap/report.txt
+          PYTHONPATH="" .single-operator-v5-bootstrap-venv/bin/python \
+            scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py \
+            --repository-root "${GITHUB_WORKSPACE}" \
+            --source-dataset-root \
+              /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1 \
+            --target-dataset-root \
+              /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5 \
+            --output outputs/single-operator-v5-bootstrap/report.json \
+            | tee outputs/single-operator-v5-bootstrap/report.txt
 
       - name: Verify and export sanitized result fields
         id: summary
@@ -128,6 +141,8 @@ jobs:
               raise SystemExit("fresh v5 scaffold did not reach registration")
           if action["operator_role"] != "self_attesting_operator":
               raise SystemExit("fresh v5 scaffold has the wrong operator role")
+          if action["target_outcomes_permitted"] is not False:
+              raise SystemExit("fresh v5 scaffold permits target outcomes")
           for field in (
               "target_outcomes_used",
               "device_nodes_opened",
@@ -181,7 +196,8 @@ jobs:
             echo "workflow_run_id=${GITHUB_RUN_ID}"
             uname -a
           } | tee outputs/single-operator-v5-bootstrap/runner.txt
-          nvidia-smi -L             | tee outputs/single-operator-v5-bootstrap/nvidia-smi-L.txt
+          nvidia-smi -L \
+            | tee outputs/single-operator-v5-bootstrap/nvidia-smi-L.txt
 
       - name: Upload sanitized bootstrap evidence
         if: always()
@@ -201,7 +217,9 @@ jobs:
         if: always()
         shell: bash
         run: |
-          rm -rf             .single-operator-v5-bootstrap-venv             outputs/single-operator-v5-bootstrap/wheels
+          rm -rf \
+            .single-operator-v5-bootstrap-venv \
+            outputs/single-operator-v5-bootstrap/wheels
 
   report:
     name: Report the v5 bootstrap to the trigger issue
@@ -264,4 +282,6 @@ jobs:
           This run claims no independent pre-acquisition attestation and does not authorize target access.
           EOF
           )"
-          gh issue comment "${ISSUE_NUMBER}"             --repo "${GITHUB_REPOSITORY}"             --body "${body}"
+          gh issue comment "${ISSUE_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --body "${body}"

--- a/scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py
+++ b/scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py
@@ -11,7 +11,7 @@ import shutil
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from causal4d.atomic_io import atomic_write_json
 from causal4d.operator_registry import (
@@ -136,7 +136,7 @@ def _source_operator(
         isinstance(operators, list) and len(operators) == 1,
         "source registry must contain exactly one person",
     )
-    operator = dict(operators[0])
+    operator = dict(cast(Mapping[str, Any], operators[0]))
     _require(
         operator.get("operator_id") == OPERATOR_ID,
         "source registry operator is not florianpfaff",

--- a/scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py
+++ b/scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py
@@ -120,21 +120,41 @@ def _load_v4(repository: Path) -> tuple[dict[str, Any], dict[str, Any]]:
     return protocol, v4
 
 
-def _source_operator(repository: Path, source_dataset: Path) -> tuple[dict[str, Any], str]:
+def _source_operator(
+    repository: Path, source_dataset: Path
+) -> tuple[dict[str, Any], str]:
     protocol, v4 = _load_v4(repository)
     registry_path = source_dataset / OPERATOR_REGISTRY_PATH
     registry = _read_json_mapping(registry_path, name="historical v4 operator registry")
     summary = validate_operator_registry(protocol, v4, registry)
-    _require(summary.get("independent_verifier_available") is False, "source registry claims an independent verifier")
+    _require(
+        summary.get("independent_verifier_available") is False,
+        "source registry claims an independent verifier",
+    )
     operators = registry.get("operators")
-    _require(isinstance(operators, list) and len(operators) == 1, "source registry must contain exactly one person")
+    _require(
+        isinstance(operators, list) and len(operators) == 1,
+        "source registry must contain exactly one person",
+    )
     operator = dict(operators[0])
-    _require(operator.get("operator_id") == OPERATOR_ID, "source registry operator is not florianpfaff")
+    _require(
+        operator.get("operator_id") == OPERATOR_ID,
+        "source registry operator is not florianpfaff",
+    )
     _require(operator.get("active") is True, "source registry operator is inactive")
     roles = tuple(operator.get("roles", ()))
-    _require(roles == OPERATOR_ROLES, "source registry roles differ from the v5 one-person lock")
-    _require(ROLE_INDEPENDENT_VERIFIER not in roles, "source registry assigns a false independent role")
-    _require(registry.get("target_outcomes_used") is False, "target outcomes entered source identity evidence")
+    _require(
+        roles == OPERATOR_ROLES,
+        "source registry roles differ from the v5 one-person lock",
+    )
+    _require(
+        ROLE_INDEPENDENT_VERIFIER not in roles,
+        "source registry assigns a false independent role",
+    )
+    _require(
+        registry.get("target_outcomes_used") is False,
+        "target outcomes entered source identity evidence",
+    )
     for relative in _GOVERNED_SOURCE_PATHS:
         _require(
             not os.path.lexists(source_dataset / relative),
@@ -187,18 +207,31 @@ def _verify_target(
     source_registry_artifact_sha256: str,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     protocol, _, _, v5 = load_registered_preacquisition_chain(repository)
-    _require(load_protocol(target_dataset / "protocol.json") == protocol, "target protocol changed")
+    _require(
+        load_protocol(target_dataset / "protocol.json") == protocol,
+        "target protocol changed",
+    )
     registry_path = target_dataset / OPERATOR_REGISTRY_PATH
     registry = _read_json_mapping(registry_path, name="v5 operator registry")
     summary = validate_operator_registry(protocol, v5, registry)
     operators = registry.get("operators")
-    _require(isinstance(operators, list) and operators == [dict(source_operator)], "v5 registry changed the registered person")
-    _require(summary.get("independent_verifier_available") is False, "v5 registry claims independent verification")
+    _require(
+        isinstance(operators, list) and operators == [dict(source_operator)],
+        "v5 registry changed the registered person",
+    )
+    _require(
+        summary.get("independent_verifier_available") is False,
+        "v5 registry claims independent verification",
+    )
     receipt_path = target_dataset / RECEIPT_PATH
     receipt = _read_json_mapping(receipt_path, name="v5 bootstrap receipt")
-    _require(receipt.get("artifact_kind") == RECEIPT_ARTIFACT_KIND, "unexpected v5 bootstrap receipt")
     _require(
-        receipt.get("artifact_sha256") == _canonical_sha256(receipt, field="artifact_sha256"),
+        receipt.get("artifact_kind") == RECEIPT_ARTIFACT_KIND,
+        "unexpected v5 bootstrap receipt",
+    )
+    _require(
+        receipt.get("artifact_sha256")
+        == _canonical_sha256(receipt, field="artifact_sha256"),
         "v5 bootstrap receipt digest mismatch",
     )
     file_sha256, file_bytes = _sha256_file(registry_path)
@@ -217,7 +250,10 @@ def _verify_target(
         "physical_evidence_increment": 0,
     }
     for field, expected_value in expected.items():
-        _require(receipt.get(field) == expected_value, f"v5 bootstrap receipt {field} mismatch")
+        _require(
+            receipt.get(field) == expected_value,
+            f"v5 bootstrap receipt {field} mismatch",
+        )
     decision = build_preacquisition_operator_next_action(
         repository,
         target_dataset,
@@ -225,10 +261,22 @@ def _verify_target(
     )
     action = decision.get("action")
     _require(isinstance(action, Mapping), "v5 next action is missing")
-    _require(action.get("action_id") == "complete_object_registration", "v5 bootstrap did not advance to object registration")
-    _require(action.get("operator_role") == "self_attesting_operator", "v5 next action has the wrong operator role")
-    _require(action.get("automatable") is False, "object registration unexpectedly became automatable")
-    _require(action.get("target_outcomes_permitted") is False, "v5 next action permits target outcomes")
+    _require(
+        action.get("action_id") == "complete_object_registration",
+        "v5 bootstrap did not advance to object registration",
+    )
+    _require(
+        action.get("operator_role") == "self_attesting_operator",
+        "v5 next action has the wrong operator role",
+    )
+    _require(
+        action.get("automatable") is False,
+        "object registration unexpectedly became automatable",
+    )
+    _require(
+        action.get("target_outcomes_permitted") is False,
+        "v5 next action permits target outcomes",
+    )
     return receipt, dict(action)
 
 
@@ -242,17 +290,33 @@ def bootstrap_single_operator_v5(
     repository = repository_root.resolve(strict=True)
     source = source_dataset_root.resolve(strict=True)
     target = target_dataset_root.absolute()
-    _require(repository.is_dir() and source.is_dir(), "repository and source dataset must be directories")
-    _require(not _contains_symlink_component(repository), "repository contains a symlink component")
-    _require(not _contains_symlink_component(source), "source dataset contains a symlink component")
-    _require(not _contains_symlink_component(target), "target dataset contains a symlink component")
-    source_operator, source_registry_artifact_sha256 = _source_operator(repository, source)
+    _require(
+        repository.is_dir() and source.is_dir(),
+        "repository and source dataset must be directories",
+    )
+    _require(
+        not _contains_symlink_component(repository),
+        "repository contains a symlink component",
+    )
+    _require(
+        not _contains_symlink_component(source),
+        "source dataset contains a symlink component",
+    )
+    _require(
+        not _contains_symlink_component(target),
+        "target dataset contains a symlink component",
+    )
+    source_operator, source_registry_artifact_sha256 = _source_operator(
+        repository, source
+    )
 
     created = False
     if not target.exists():
         target.parent.mkdir(parents=True, exist_ok=True)
         staging = target.parent / f".{target.name}.bootstrap-v5.tmp"
-        _require(not os.path.lexists(staging), "v5 bootstrap staging path already exists")
+        _require(
+            not os.path.lexists(staging), "v5 bootstrap staging path already exists"
+        )
         try:
             protocol, _, _, v5 = load_registered_preacquisition_chain(repository)
             scaffold_dataset(protocol, staging)
@@ -260,7 +324,9 @@ def bootstrap_single_operator_v5(
             scaffold_preacquisition_readiness(repository, staging)
             scaffold_operator_registry(repository, staging)
             template_path = staging / OPERATOR_REGISTRY_TEMPLATE_PATH
-            template = _read_json_mapping(template_path, name="v5 operator registry template")
+            template = _read_json_mapping(
+                template_path, name="v5 operator registry template"
+            )
             template["operators"] = [dict(source_operator)]
             atomic_write_json(template_path, template, overwrite=True)
             timestamp = sealed_at_utc or datetime.now(timezone.utc).isoformat()
@@ -305,9 +371,7 @@ def bootstrap_single_operator_v5(
         "target_preacquisition_amendment_sha256": receipt[
             "target_preacquisition_amendment_sha256"
         ],
-        "target_registry_artifact_sha256": receipt[
-            "target_registry_artifact_sha256"
-        ],
+        "target_registry_artifact_sha256": receipt["target_registry_artifact_sha256"],
         "bootstrap_receipt_artifact_sha256": receipt["artifact_sha256"],
         "operator_ids": [OPERATOR_ID],
         "operator_roles": list(OPERATOR_ROLES),
@@ -316,9 +380,7 @@ def bootstrap_single_operator_v5(
             "action_id": action["action_id"],
             "operator_role": action["operator_role"],
             "automatable": action["automatable"],
-            "physical_acquisition_required": action[
-                "physical_acquisition_required"
-            ],
+            "physical_acquisition_required": action["physical_acquisition_required"],
             "target_outcomes_permitted": action["target_outcomes_permitted"],
         },
         "target_outcomes_used": False,

--- a/scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py
+++ b/scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py
@@ -136,7 +136,8 @@ def _source_operator(
         isinstance(operators, list) and len(operators) == 1,
         "source registry must contain exactly one person",
     )
-    operator = dict(cast(Mapping[str, Any], operators[0]))
+    operator_values = cast(list[Any], operators)
+    operator = dict(cast(Mapping[str, Any], operator_values[0]))
     _require(
         operator.get("operator_id") == OPERATOR_ID,
         "source registry operator is not florianpfaff",

--- a/scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py
+++ b/scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Bootstrap the fresh v5 single-operator evidence tree without physical work."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from causal4d.atomic_io import atomic_write_json
+from causal4d.operator_registry import (
+    OPERATOR_REGISTRY_PATH,
+    OPERATOR_REGISTRY_TEMPLATE_PATH,
+    ROLE_FREEZER,
+    ROLE_GATE_APPROVER,
+    ROLE_INDEPENDENT_VERIFIER,
+    ROLE_SOFTWARE_ENVIRONMENT_APPROVER,
+    seal_operator_registry,
+    scaffold_operator_registry,
+    validate_operator_registry,
+)
+from causal4d.preacquisition_operator_flow import (
+    build_preacquisition_operator_next_action,
+)
+from causal4d.preacquisition_protocol_v4 import load_v4_chain
+from causal4d.preacquisition_readiness import scaffold_preacquisition_readiness
+from causal4d.preacquisition_readiness_contracts import (
+    MECHANISM_GATE_EVIDENCE_PATH,
+    PREACQUISITION_V2_PATH,
+    PREACQUISITION_V3_PATH,
+    PREACQUISITION_V4_PATH,
+    PROTOCOL_PATH,
+    load_registered_preacquisition_chain,
+)
+from causal4d.real_evidence_contract_v2 import scaffold_real_evidence_v2_templates
+from causal4d.real_protocol import load_protocol, scaffold_dataset
+
+
+REPORT_SCHEMA_VERSION = 1
+REPORT_ARTIFACT_KIND = "Causal4DSingleOperatorV5BootstrapReport"
+RECEIPT_SCHEMA_VERSION = 1
+RECEIPT_ARTIFACT_KIND = "Causal4DSingleOperatorV5BootstrapReceipt"
+RECEIPT_PATH = "preacquisition/single_operator_v5_bootstrap.json"
+OPERATOR_ID = "florianpfaff"
+OPERATOR_ROLES = (
+    ROLE_FREEZER,
+    ROLE_GATE_APPROVER,
+    ROLE_SOFTWARE_ENVIRONMENT_APPROVER,
+)
+_GOVERNED_SOURCE_PATHS = (
+    "object_registration.json",
+    "slip_pilot.json",
+    "timebase_calibration.json",
+    "contact_registration.json",
+    "method_freeze.json",
+    "method_freeze_validation.json",
+    "registered-analysis.json",
+)
+_GOVERNED_SOURCE_PATTERNS = (
+    "preacquisition/source_panel/executions/*/manifest.json",
+    "executions/*/manifest.json",
+    "sessions/*/session.json",
+)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _contains_symlink_component(path: Path) -> bool:
+    candidate = path.absolute()
+    return any(component.is_symlink() for component in (candidate, *candidate.parents))
+
+
+def _read_json_mapping(path: Path, *, name: str) -> dict[str, Any]:
+    _require(not _contains_symlink_component(path), f"{name} contains a symlink")
+    _require(path.is_file(), f"{name} is missing")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    _require(isinstance(payload, Mapping), f"{name} must be a JSON object")
+    return dict(payload)
+
+
+def _sha256_file(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    byte_count = 0
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+            byte_count += len(block)
+    return digest.hexdigest(), byte_count
+
+
+def _canonical_sha256(payload: Mapping[str, Any], *, field: str) -> str:
+    value = dict(payload)
+    value.pop(field, None)
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _load_v4(repository: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    protocol, _, _, v4 = load_v4_chain(
+        repository / PROTOCOL_PATH,
+        repository / PREACQUISITION_V2_PATH,
+        repository / PREACQUISITION_V3_PATH,
+        repository / MECHANISM_GATE_EVIDENCE_PATH,
+        repository / PREACQUISITION_V4_PATH,
+    )
+    return protocol, v4
+
+
+def _source_operator(repository: Path, source_dataset: Path) -> tuple[dict[str, Any], str]:
+    protocol, v4 = _load_v4(repository)
+    registry_path = source_dataset / OPERATOR_REGISTRY_PATH
+    registry = _read_json_mapping(registry_path, name="historical v4 operator registry")
+    summary = validate_operator_registry(protocol, v4, registry)
+    _require(summary.get("independent_verifier_available") is False, "source registry claims an independent verifier")
+    operators = registry.get("operators")
+    _require(isinstance(operators, list) and len(operators) == 1, "source registry must contain exactly one person")
+    operator = dict(operators[0])
+    _require(operator.get("operator_id") == OPERATOR_ID, "source registry operator is not florianpfaff")
+    _require(operator.get("active") is True, "source registry operator is inactive")
+    roles = tuple(operator.get("roles", ()))
+    _require(roles == OPERATOR_ROLES, "source registry roles differ from the v5 one-person lock")
+    _require(ROLE_INDEPENDENT_VERIFIER not in roles, "source registry assigns a false independent role")
+    _require(registry.get("target_outcomes_used") is False, "target outcomes entered source identity evidence")
+    for relative in _GOVERNED_SOURCE_PATHS:
+        _require(
+            not os.path.lexists(source_dataset / relative),
+            f"historical source tree contains governed evidence: {relative}",
+        )
+    for pattern in _GOVERNED_SOURCE_PATTERNS:
+        _require(
+            not any(source_dataset.glob(pattern)),
+            f"historical source tree contains governed evidence matching: {pattern}",
+        )
+    return operator, str(registry["artifact_sha256"])
+
+
+def _receipt(
+    *,
+    source_registry_artifact_sha256: str,
+    target_registry_artifact_sha256: str,
+    target_registry_file_sha256: str,
+    target_registry_file_bytes: int,
+    plan_id: str,
+    amendment_sha256: str,
+    sealed_at_utc: str,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "artifact_kind": RECEIPT_ARTIFACT_KIND,
+        "source_preacquisition_plan_id": "causal4d-sloth-preacquisition-v4",
+        "source_registry_artifact_sha256": source_registry_artifact_sha256,
+        "target_preacquisition_plan_id": plan_id,
+        "target_preacquisition_amendment_sha256": amendment_sha256,
+        "target_registry_artifact_sha256": target_registry_artifact_sha256,
+        "target_registry_file_sha256": target_registry_file_sha256,
+        "target_registry_file_bytes": target_registry_file_bytes,
+        "operator_id": OPERATOR_ID,
+        "operator_roles": list(OPERATOR_ROLES),
+        "sealed_at_utc": sealed_at_utc,
+        "independent_preacquisition_attestation_claimed": False,
+        "target_outcomes_used": False,
+        "physical_command_sent": False,
+        "physical_evidence_increment": 0,
+    }
+    payload["artifact_sha256"] = _canonical_sha256(payload, field="artifact_sha256")
+    return payload
+
+
+def _verify_target(
+    repository: Path,
+    target_dataset: Path,
+    source_operator: Mapping[str, Any],
+    source_registry_artifact_sha256: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    protocol, _, _, v5 = load_registered_preacquisition_chain(repository)
+    _require(load_protocol(target_dataset / "protocol.json") == protocol, "target protocol changed")
+    registry_path = target_dataset / OPERATOR_REGISTRY_PATH
+    registry = _read_json_mapping(registry_path, name="v5 operator registry")
+    summary = validate_operator_registry(protocol, v5, registry)
+    operators = registry.get("operators")
+    _require(isinstance(operators, list) and operators == [dict(source_operator)], "v5 registry changed the registered person")
+    _require(summary.get("independent_verifier_available") is False, "v5 registry claims independent verification")
+    receipt_path = target_dataset / RECEIPT_PATH
+    receipt = _read_json_mapping(receipt_path, name="v5 bootstrap receipt")
+    _require(receipt.get("artifact_kind") == RECEIPT_ARTIFACT_KIND, "unexpected v5 bootstrap receipt")
+    _require(
+        receipt.get("artifact_sha256") == _canonical_sha256(receipt, field="artifact_sha256"),
+        "v5 bootstrap receipt digest mismatch",
+    )
+    file_sha256, file_bytes = _sha256_file(registry_path)
+    expected = {
+        "source_registry_artifact_sha256": source_registry_artifact_sha256,
+        "target_preacquisition_plan_id": v5["plan_id"],
+        "target_preacquisition_amendment_sha256": v5["amendment_sha256"],
+        "target_registry_artifact_sha256": registry["artifact_sha256"],
+        "target_registry_file_sha256": file_sha256,
+        "target_registry_file_bytes": file_bytes,
+        "operator_id": OPERATOR_ID,
+        "operator_roles": list(OPERATOR_ROLES),
+        "independent_preacquisition_attestation_claimed": False,
+        "target_outcomes_used": False,
+        "physical_command_sent": False,
+        "physical_evidence_increment": 0,
+    }
+    for field, expected_value in expected.items():
+        _require(receipt.get(field) == expected_value, f"v5 bootstrap receipt {field} mismatch")
+    decision = build_preacquisition_operator_next_action(
+        repository,
+        target_dataset,
+        verify_file_hashes=True,
+    )
+    action = decision.get("action")
+    _require(isinstance(action, Mapping), "v5 next action is missing")
+    _require(action.get("action_id") == "complete_object_registration", "v5 bootstrap did not advance to object registration")
+    _require(action.get("operator_role") == "self_attesting_operator", "v5 next action has the wrong operator role")
+    _require(action.get("automatable") is False, "object registration unexpectedly became automatable")
+    _require(action.get("target_outcomes_permitted") is False, "v5 next action permits target outcomes")
+    return receipt, dict(action)
+
+
+def bootstrap_single_operator_v5(
+    *,
+    repository_root: Path,
+    source_dataset_root: Path,
+    target_dataset_root: Path,
+    sealed_at_utc: str | None = None,
+) -> dict[str, Any]:
+    repository = repository_root.resolve(strict=True)
+    source = source_dataset_root.resolve(strict=True)
+    target = target_dataset_root.absolute()
+    _require(repository.is_dir() and source.is_dir(), "repository and source dataset must be directories")
+    _require(not _contains_symlink_component(repository), "repository contains a symlink component")
+    _require(not _contains_symlink_component(source), "source dataset contains a symlink component")
+    _require(not _contains_symlink_component(target), "target dataset contains a symlink component")
+    source_operator, source_registry_artifact_sha256 = _source_operator(repository, source)
+
+    created = False
+    if not target.exists():
+        target.parent.mkdir(parents=True, exist_ok=True)
+        staging = target.parent / f".{target.name}.bootstrap-v5.tmp"
+        _require(not os.path.lexists(staging), "v5 bootstrap staging path already exists")
+        try:
+            protocol, _, _, v5 = load_registered_preacquisition_chain(repository)
+            scaffold_dataset(protocol, staging)
+            scaffold_real_evidence_v2_templates(protocol, staging)
+            scaffold_preacquisition_readiness(repository, staging)
+            scaffold_operator_registry(repository, staging)
+            template_path = staging / OPERATOR_REGISTRY_TEMPLATE_PATH
+            template = _read_json_mapping(template_path, name="v5 operator registry template")
+            template["operators"] = [dict(source_operator)]
+            atomic_write_json(template_path, template, overwrite=True)
+            timestamp = sealed_at_utc or datetime.now(timezone.utc).isoformat()
+            sealed = seal_operator_registry(
+                repository,
+                staging,
+                template_path,
+                sealed_by=OPERATOR_ID,
+                sealed_at_utc=timestamp,
+            )
+            receipt = _receipt(
+                source_registry_artifact_sha256=source_registry_artifact_sha256,
+                target_registry_artifact_sha256=str(sealed["artifact_sha256"]),
+                target_registry_file_sha256=str(sealed["sha256"]),
+                target_registry_file_bytes=int(sealed["bytes"]),
+                plan_id=str(v5["plan_id"]),
+                amendment_sha256=str(v5["amendment_sha256"]),
+                sealed_at_utc=timestamp,
+            )
+            atomic_write_json(staging / RECEIPT_PATH, receipt, overwrite=False)
+            staging.rename(target)
+            created = True
+        except BaseException:
+            if staging.exists():
+                shutil.rmtree(staging)
+            raise
+    _require(target.is_dir(), "v5 target dataset is not an ordinary directory")
+    receipt, action = _verify_target(
+        repository,
+        target,
+        source_operator,
+        source_registry_artifact_sha256,
+    )
+    report: dict[str, Any] = {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "artifact_kind": REPORT_ARTIFACT_KIND,
+        "reviewed_main_commit": os.environ.get("GITHUB_SHA"),
+        "created": created,
+        "dataset_modified": created,
+        "source_registry_artifact_sha256": source_registry_artifact_sha256,
+        "target_preacquisition_plan_id": receipt["target_preacquisition_plan_id"],
+        "target_preacquisition_amendment_sha256": receipt[
+            "target_preacquisition_amendment_sha256"
+        ],
+        "target_registry_artifact_sha256": receipt[
+            "target_registry_artifact_sha256"
+        ],
+        "bootstrap_receipt_artifact_sha256": receipt["artifact_sha256"],
+        "operator_ids": [OPERATOR_ID],
+        "operator_roles": list(OPERATOR_ROLES),
+        "independent_verifier_available": False,
+        "next_action": {
+            "action_id": action["action_id"],
+            "operator_role": action["operator_role"],
+            "automatable": action["automatable"],
+            "physical_acquisition_required": action[
+                "physical_acquisition_required"
+            ],
+            "target_outcomes_permitted": action["target_outcomes_permitted"],
+        },
+        "target_outcomes_used": False,
+        "device_nodes_opened": False,
+        "physical_command_sent": False,
+        "registered_method_changed": False,
+        "physical_evidence_increment": 0,
+    }
+    report["report_sha256"] = _canonical_sha256(report, field="report_sha256")
+    return report
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository-root", type=Path, required=True)
+    parser.add_argument("--source-dataset-root", type=Path, required=True)
+    parser.add_argument("--target-dataset-root", type=Path, required=True)
+    parser.add_argument("--sealed-at-utc")
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main() -> int:
+    arguments = _parser().parse_args()
+    report = bootstrap_single_operator_v5(
+        repository_root=arguments.repository_root,
+        source_dataset_root=arguments.source_dataset_root,
+        target_dataset_root=arguments.target_dataset_root,
+        sealed_at_utc=arguments.sealed_at_utc,
+    )
+    arguments.output.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(report, indent=2, sort_keys=True, allow_nan=False)
+    arguments.output.write_text(encoded + "\n", encoding="utf-8")
+    print(encoded)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_issue_command_concurrency.py
+++ b/tests/test_issue_command_concurrency.py
@@ -16,6 +16,10 @@ ISSUE_COMMAND_JOBS = {
         "execute",
         "automatable-preacquisition-${{ github.sha }}",
     ),
+    "bootstrap-single-operator-v5-self-hosted.yml": (
+        "bootstrap",
+        "causal4d-single-operator-v5-bootstrap-${{ github.sha }}",
+    ),
     "controlled-execution-campaign.yml": (
         "dispatch",
         "controlled-execution-campaign-${{ github.sha }}",

--- a/tests/test_self_hosted_v5_operator_scaffold.py
+++ b/tests/test_self_hosted_v5_operator_scaffold.py
@@ -99,7 +99,7 @@ def test_bootstrap_creates_fresh_v5_tree_and_advances_to_registration(
         "action_id": "complete_object_registration",
         "operator_role": "self_attesting_operator",
         "automatable": False,
-        "physical_acquisition_required": True,
+        "physical_acquisition_required": False,
         "target_outcomes_permitted": False,
     }
     assert report["target_outcomes_used"] is False

--- a/tests/test_self_hosted_v5_operator_scaffold.py
+++ b/tests/test_self_hosted_v5_operator_scaffold.py
@@ -174,7 +174,7 @@ def test_bootstrap_refuses_false_independent_role(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError, match="claims an independent verifier"):
+    with pytest.raises(ValueError, match="roles differ from the v5 one-person lock"):
         bootstrap.bootstrap_single_operator_v5(
             repository_root=ROOT,
             source_dataset_root=source,

--- a/tests/test_self_hosted_v5_operator_scaffold.py
+++ b/tests/test_self_hosted_v5_operator_scaffold.py
@@ -16,9 +16,7 @@ from causal4d.operator_registry import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
-SCRIPT_PATH = (
-    ROOT / "scripts" / "ci" / "bootstrap_self_hosted_v5_operator_scaffold.py"
-)
+SCRIPT_PATH = ROOT / "scripts" / "ci" / "bootstrap_self_hosted_v5_operator_scaffold.py"
 
 
 def _load_bootstrap() -> ModuleType:
@@ -107,17 +105,13 @@ def test_bootstrap_creates_fresh_v5_tree_and_advances_to_registration(
     assert report["physical_command_sent"] is False
     assert report["physical_evidence_increment"] == 0
 
-    registry = json.loads(
-        (target / OPERATOR_REGISTRY_PATH).read_text(encoding="utf-8")
-    )
+    registry = json.loads((target / OPERATOR_REGISTRY_PATH).read_text(encoding="utf-8"))
     assert registry["operators"][0]["operator_id"] == bootstrap.OPERATOR_ID
     assert registry["operators"][0]["person_identity_sha256"] == "1" * 64
     assert registry["operators"][0]["roles"] == list(bootstrap.OPERATOR_ROLES)
     assert "independent_verifier" not in registry["operators"][0]["roles"]
 
-    receipt = json.loads(
-        (target / bootstrap.RECEIPT_PATH).read_text(encoding="utf-8")
-    )
+    receipt = json.loads((target / bootstrap.RECEIPT_PATH).read_text(encoding="utf-8"))
     assert receipt["independent_preacquisition_attestation_claimed"] is False
     assert receipt["physical_evidence_increment"] == 0
 
@@ -144,11 +138,13 @@ def test_bootstrap_is_idempotent_and_does_not_reseal(tmp_path: Path) -> None:
     assert repeated["created"] is False
     assert repeated["dataset_modified"] is False
     assert _tree_snapshot(target) == snapshot
-    assert repeated["target_registry_artifact_sha256"] == (
-        first["target_registry_artifact_sha256"]
+    assert (
+        repeated["target_registry_artifact_sha256"]
+        == (first["target_registry_artifact_sha256"])
     )
-    assert repeated["bootstrap_receipt_artifact_sha256"] == (
-        first["bootstrap_receipt_artifact_sha256"]
+    assert (
+        repeated["bootstrap_receipt_artifact_sha256"]
+        == (first["bootstrap_receipt_artifact_sha256"])
     )
 
 

--- a/tests/test_self_hosted_v5_operator_scaffold.py
+++ b/tests/test_self_hosted_v5_operator_scaffold.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from causal4d.operator_registry import (
+    OPERATOR_REGISTRY_ARTIFACT_KIND,
+    OPERATOR_REGISTRY_PATH,
+    operator_registry_sha256,
+    operator_registry_template,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = (
+    ROOT / "scripts" / "ci" / "bootstrap_self_hosted_v5_operator_scaffold.py"
+)
+
+
+def _load_bootstrap() -> ModuleType:
+    specification = importlib.util.spec_from_file_location(
+        "causal4d_self_hosted_v5_operator_scaffold",
+        SCRIPT_PATH,
+    )
+    assert specification is not None
+    assert specification.loader is not None
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+bootstrap = _load_bootstrap()
+
+
+def _source_dataset(tmp_path: Path) -> Path:
+    source = tmp_path / "source-v4"
+    registry_path = source / OPERATOR_REGISTRY_PATH
+    registry_path.parent.mkdir(parents=True)
+    protocol, v4 = bootstrap._load_v4(ROOT)
+    registry = operator_registry_template(protocol, v4)
+    registry.update(
+        {
+            "artifact_kind": OPERATOR_REGISTRY_ARTIFACT_KIND,
+            "status": "sealed",
+            "sealed_at_utc": "2026-08-11T10:00:00+00:00",
+            "sealed_by_operator_id": bootstrap.OPERATOR_ID,
+            "operators": [
+                {
+                    "operator_id": bootstrap.OPERATOR_ID,
+                    "person_identity_sha256": "1" * 64,
+                    "active": True,
+                    "roles": list(bootstrap.OPERATOR_ROLES),
+                }
+            ],
+        }
+    )
+    registry["artifact_sha256"] = operator_registry_sha256(registry)
+    registry_path.write_text(
+        json.dumps(registry, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return source
+
+
+def _tree_snapshot(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def test_bootstrap_creates_fresh_v5_tree_and_advances_to_registration(
+    tmp_path: Path,
+) -> None:
+    source = _source_dataset(tmp_path)
+    target = tmp_path / "fresh-v5"
+
+    report = bootstrap.bootstrap_single_operator_v5(
+        repository_root=ROOT,
+        source_dataset_root=source,
+        target_dataset_root=target,
+        sealed_at_utc="2026-08-26T01:00:00+00:00",
+    )
+
+    assert report["created"] is True
+    assert report["dataset_modified"] is True
+    assert report["target_preacquisition_plan_id"] == (
+        "causal4d-sloth-preacquisition-v5-single-operator"
+    )
+    assert report["operator_ids"] == [bootstrap.OPERATOR_ID]
+    assert report["operator_roles"] == list(bootstrap.OPERATOR_ROLES)
+    assert report["independent_verifier_available"] is False
+    assert report["next_action"] == {
+        "action_id": "complete_object_registration",
+        "operator_role": "self_attesting_operator",
+        "automatable": False,
+        "physical_acquisition_required": True,
+        "target_outcomes_permitted": False,
+    }
+    assert report["target_outcomes_used"] is False
+    assert report["device_nodes_opened"] is False
+    assert report["physical_command_sent"] is False
+    assert report["physical_evidence_increment"] == 0
+
+    registry = json.loads(
+        (target / OPERATOR_REGISTRY_PATH).read_text(encoding="utf-8")
+    )
+    assert registry["operators"][0]["operator_id"] == bootstrap.OPERATOR_ID
+    assert registry["operators"][0]["person_identity_sha256"] == "1" * 64
+    assert registry["operators"][0]["roles"] == list(bootstrap.OPERATOR_ROLES)
+    assert "independent_verifier" not in registry["operators"][0]["roles"]
+
+    receipt = json.loads(
+        (target / bootstrap.RECEIPT_PATH).read_text(encoding="utf-8")
+    )
+    assert receipt["independent_preacquisition_attestation_claimed"] is False
+    assert receipt["physical_evidence_increment"] == 0
+
+
+def test_bootstrap_is_idempotent_and_does_not_reseal(tmp_path: Path) -> None:
+    source = _source_dataset(tmp_path)
+    target = tmp_path / "fresh-v5"
+    first = bootstrap.bootstrap_single_operator_v5(
+        repository_root=ROOT,
+        source_dataset_root=source,
+        target_dataset_root=target,
+        sealed_at_utc="2026-08-26T01:00:00+00:00",
+    )
+    snapshot = _tree_snapshot(target)
+
+    repeated = bootstrap.bootstrap_single_operator_v5(
+        repository_root=ROOT,
+        source_dataset_root=source,
+        target_dataset_root=target,
+        sealed_at_utc="2026-08-26T02:00:00+00:00",
+    )
+
+    assert first["created"] is True
+    assert repeated["created"] is False
+    assert repeated["dataset_modified"] is False
+    assert _tree_snapshot(target) == snapshot
+    assert repeated["target_registry_artifact_sha256"] == (
+        first["target_registry_artifact_sha256"]
+    )
+    assert repeated["bootstrap_receipt_artifact_sha256"] == (
+        first["bootstrap_receipt_artifact_sha256"]
+    )
+
+
+def test_bootstrap_refuses_historical_tree_after_governed_work(
+    tmp_path: Path,
+) -> None:
+    source = _source_dataset(tmp_path)
+    (source / "object_registration.json").write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="contains governed evidence"):
+        bootstrap.bootstrap_single_operator_v5(
+            repository_root=ROOT,
+            source_dataset_root=source,
+            target_dataset_root=tmp_path / "fresh-v5",
+        )
+
+
+def test_bootstrap_refuses_false_independent_role(tmp_path: Path) -> None:
+    source = _source_dataset(tmp_path)
+    registry_path = source / OPERATOR_REGISTRY_PATH
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    registry["operators"][0]["roles"].append("independent_verifier")
+    registry["operators"][0]["roles"].sort()
+    registry["artifact_sha256"] = operator_registry_sha256(registry)
+    registry_path.write_text(
+        json.dumps(registry, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="claims an independent verifier"):
+        bootstrap.bootstrap_single_operator_v5(
+            repository_root=ROOT,
+            source_dataset_root=source,
+            target_dataset_root=tmp_path / "fresh-v5",
+        )

--- a/tests/test_self_hosted_workflow_policy.py
+++ b/tests/test_self_hosted_workflow_policy.py
@@ -180,6 +180,43 @@ def _maintainer_issue_main_errors(workflow_text: str, block: str) -> list[str]:
     return errors
 
 
+def _single_operator_v5_issue_main_errors(
+    workflow_text: str,
+    block: str,
+) -> list[str]:
+    errors = _common_self_hosted_errors(block)
+    required = {
+        "github.event_name == 'issues'": "missing issue-event authorization",
+        "github.event.action == 'opened'": "missing issue-open authorization",
+        (
+            "github.event.issue.user.login == 'FlorianPfaff'"
+        ): "missing exact maintainer-login authorization",
+        (
+            "github.event.issue.user.id == 6773539"
+        ): "missing exact maintainer-ID authorization",
+        (
+            "'[self-hosted] bootstrap Causal4D v5 operator scaffold'"
+        ): "missing exact trigger-title authorization",
+    }
+    for fragment, message in required.items():
+        if fragment not in block:
+            errors.append(message)
+    if block.count("github.event.issue.title") != 1:
+        errors.append("issue title must be used only by the exact guard")
+    for forbidden in (
+        "github.event.issue.body",
+        "github.event.issue.labels",
+        "github.event.comment",
+    ):
+        if forbidden in block:
+            errors.append(
+                f"untrusted issue payload reaches self-hosted job: {forbidden}"
+            )
+    if not _issue_only_workflow(workflow_text):
+        errors.append("workflow is not issue-only")
+    return errors
+
+
 def _authorization_errors(
     authorization_model: str,
     workflow_text: str,
@@ -189,6 +226,8 @@ def _authorization_errors(
         return _main_only_errors(workflow_text, block)
     if authorization_model == "maintainer-issue-main":
         return _maintainer_issue_main_errors(workflow_text, block)
+    if authorization_model == "single-operator-v5-issue-main":
+        return _single_operator_v5_issue_main_errors(workflow_text, block)
     return [f"unsupported authorization model: {authorization_model}"]
 
 
@@ -198,6 +237,7 @@ def test_self_hosted_job_registry_is_complete_and_unique() -> None:
     assert set(payload["authorization_models"]) == {
         "main-only",
         "maintainer-issue-main",
+        "single-operator-v5-issue-main",
     }
 
     entries = payload["jobs"]

--- a/tests/test_single_operator_v5_bootstrap_workflow.py
+++ b/tests/test_single_operator_v5_bootstrap_workflow.py
@@ -38,9 +38,11 @@ def test_v5_bootstrap_has_one_exact_maintainer_issue_trigger() -> None:
 def test_v5_bootstrap_uses_fresh_fixed_root_and_exact_wheel() -> None:
     text = _workflow_text()
 
-    assert ("/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1\n") in text
     assert (
-        "/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5\n"
+        "/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1"
+    ) in text
+    assert (
+        "/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5"
     ) in text
     assert "scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py" in text
     assert '--repository-root "${GITHUB_WORKSPACE}"' in text
@@ -108,7 +110,7 @@ def test_v5_bootstrap_is_registered_as_self_hosted() -> None:
 
     assert len(matches) == 1
     entry = matches[0]
-    assert entry["authorization_model"] == "maintainer-issue-main"
+    assert entry["authorization_model"] == "single-operator-v5-issue-main"
     assert entry["secrets_allowed"] is False
     assert entry["dataset_access"] == (
         "registered-local-preacquisition-v5-scaffold-bootstrap"

--- a/tests/test_single_operator_v5_bootstrap_workflow.py
+++ b/tests/test_single_operator_v5_bootstrap_workflow.py
@@ -38,12 +38,8 @@ def test_v5_bootstrap_has_one_exact_maintainer_issue_trigger() -> None:
 def test_v5_bootstrap_uses_fresh_fixed_root_and_exact_wheel() -> None:
     text = _workflow_text()
 
-    assert (
-        "/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1"
-    ) in text
-    assert (
-        "/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5"
-    ) in text
+    assert ("/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1") in text
+    assert ("/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5") in text
     assert "scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py" in text
     assert '--repository-root "${GITHUB_WORKSPACE}"' in text
     assert "ref: ${{ github.sha }}" in text

--- a/tests/test_single_operator_v5_bootstrap_workflow.py
+++ b/tests/test_single_operator_v5_bootstrap_workflow.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = (
+    ROOT
+    / ".github"
+    / "workflows"
+    / "bootstrap-single-operator-v5-self-hosted.yml"
+)
+SCRIPT = ROOT / "scripts" / "ci" / "bootstrap_self_hosted_v5_operator_scaffold.py"
+SELF_HOSTED_REGISTRY = ROOT / ".github" / "self-hosted-jobs.json"
+TRIGGER = "[self-hosted] bootstrap Causal4D v5 operator scaffold"
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_v5_bootstrap_has_one_exact_maintainer_issue_trigger() -> None:
+    text = _workflow_text()
+
+    assert "issues:\n    types: [opened]" in text
+    assert "workflow_dispatch:" not in text
+    assert "github.ref == 'refs/heads/main'" in text
+    assert "github.event.issue.user.login == 'FlorianPfaff'" in text
+    assert "github.event.issue.user.id == 6773539" in text
+    assert f"'{TRIGGER}'" in text
+    for forbidden in (
+        "github.event.issue.body",
+        "github.event.issue.labels",
+        "github.event.comment",
+        "${{ secrets.",
+    ):
+        assert forbidden not in text
+
+
+def test_v5_bootstrap_uses_fresh_fixed_root_and_exact_wheel() -> None:
+    text = _workflow_text()
+
+    assert (
+        "/mnt/lexar4tb/causal4d-physical/"
+        "causal4d-sloth-multi-action-v1\n"
+    ) in text
+    assert (
+        "/mnt/lexar4tb/causal4d-physical/"
+        "causal4d-sloth-multi-action-v1-v5\n"
+    ) in text
+    assert "scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py" in text
+    assert '--repository-root "${GITHUB_WORKSPACE}"' in text
+    assert "ref: ${{ github.sha }}" in text
+    assert "persist-credentials: false" in text
+    assert "PYTHONPATH=\"\"" in text
+    assert "installed import" in text
+
+
+def test_v5_bootstrap_upload_is_sanitized_and_nonphysical() -> None:
+    text = _workflow_text()
+    script = SCRIPT.read_text(encoding="utf-8")
+
+    upload = text[
+        text.index("- name: Upload sanitized bootstrap evidence") : text.index(
+            "- name: Remove isolated environment and wheel"
+        )
+    ]
+    for allowed in (
+        "report.json",
+        "report.txt",
+        "runner.txt",
+        "nvidia-smi-L.txt",
+        "wheel-sha256.txt",
+    ):
+        assert allowed in upload
+    for forbidden in (
+        "operator_registry.json",
+        "operator_registry.template.json",
+        "single_operator_v5_bootstrap.json",
+        "person_identity_sha256",
+        "object_registration",
+        "executions/",
+        "sessions/",
+    ):
+        assert forbidden not in upload
+
+    assert '"target_outcomes_used": False' in script
+    assert '"device_nodes_opened": False' in script
+    assert '"physical_command_sent": False' in script
+    assert '"registered_method_changed": False' in script
+    assert '"physical_evidence_increment": 0' in script
+    assert "target_outcomes_permitted" in text
+    assert "does not authorize target access" in text
+
+
+def test_v5_bootstrap_pins_all_external_actions() -> None:
+    for line in _workflow_text().splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("uses:"):
+            continue
+        reference = stripped.rsplit("@", 1)[1].split()[0]
+        assert len(reference) == 40
+        assert all(character in "0123456789abcdef" for character in reference)
+
+
+def test_v5_bootstrap_is_registered_as_self_hosted() -> None:
+    payload = json.loads(SELF_HOSTED_REGISTRY.read_text(encoding="utf-8"))
+    matches = [
+        entry
+        for entry in payload["jobs"]
+        if entry["workflow"]
+        == "bootstrap-single-operator-v5-self-hosted.yml"
+        and entry["job"] == "bootstrap"
+    ]
+
+    assert len(matches) == 1
+    entry = matches[0]
+    assert entry["authorization_model"] == "maintainer-issue-main"
+    assert entry["secrets_allowed"] is False
+    assert entry["dataset_access"] == (
+        "registered-local-preacquisition-v5-scaffold-bootstrap"
+    )

--- a/tests/test_single_operator_v5_bootstrap_workflow.py
+++ b/tests/test_single_operator_v5_bootstrap_workflow.py
@@ -6,10 +6,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = (
-    ROOT
-    / ".github"
-    / "workflows"
-    / "bootstrap-single-operator-v5-self-hosted.yml"
+    ROOT / ".github" / "workflows" / "bootstrap-single-operator-v5-self-hosted.yml"
 )
 SCRIPT = ROOT / "scripts" / "ci" / "bootstrap_self_hosted_v5_operator_scaffold.py"
 SELF_HOSTED_REGISTRY = ROOT / ".github" / "self-hosted-jobs.json"
@@ -41,19 +38,15 @@ def test_v5_bootstrap_has_one_exact_maintainer_issue_trigger() -> None:
 def test_v5_bootstrap_uses_fresh_fixed_root_and_exact_wheel() -> None:
     text = _workflow_text()
 
+    assert ("/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1\n") in text
     assert (
-        "/mnt/lexar4tb/causal4d-physical/"
-        "causal4d-sloth-multi-action-v1\n"
-    ) in text
-    assert (
-        "/mnt/lexar4tb/causal4d-physical/"
-        "causal4d-sloth-multi-action-v1-v5\n"
+        "/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5\n"
     ) in text
     assert "scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py" in text
     assert '--repository-root "${GITHUB_WORKSPACE}"' in text
     assert "ref: ${{ github.sha }}" in text
     assert "persist-credentials: false" in text
-    assert "PYTHONPATH=\"\"" in text
+    assert 'PYTHONPATH=""' in text
     assert "installed import" in text
 
 
@@ -109,8 +102,7 @@ def test_v5_bootstrap_is_registered_as_self_hosted() -> None:
     matches = [
         entry
         for entry in payload["jobs"]
-        if entry["workflow"]
-        == "bootstrap-single-operator-v5-self-hosted.yml"
+        if entry["workflow"] == "bootstrap-single-operator-v5-self-hosted.yml"
         and entry["job"] == "bootstrap"
     ]
 


### PR DESCRIPTION
## Summary

- add a fail-closed, idempotent bootstrap for the fresh v5 acquisition tree
- carry forward only the validated one-person identity record from the untouched v4 tree
- seal the v5 registry under the disclosed self-attestation policy
- derive and require `complete_object_registration` as the next action
- add an exact-owner issue-triggered self-hosted workflow with sanitized evidence only

## Boundaries

- no target outcomes
- no device nodes or physical commands
- no physical evidence increment
- no independent-verifier claim
- no modification of the historical v4 tree
- no raw identity material in workflow artifacts

## Verification

The PR CI must pass the new end-to-end temporary-tree tests, workflow contract tests, and the repository's existing protected checks before the workflow may be triggered.