### PR TITLE
Add fail-closed physical object registration

### DIFF
--- a/docs/object_registration_operator.md
+++ b/docs/object_registration_operator.md
@@ -1,0 +1,43 @@
+# Fixed-object registration
+
+The first physical prerequisite after the v5 single-operator scaffold is
+`object_registration.json`. It binds the physical sloth instance, the exact
+PhysTwin model artifact, and the three preregistered canonical contact-node sets.
+It does not inspect outcomes, operate hardware, or count as an execution.
+
+Place each canonical node-set file below the fresh dataset root, then seal the
+registration once:
+
+```bash
+causal4d protocol real object-registration-seal \
+  /opt/causal4d-frozen/configs/causal4d/sloth_multi_action_v1.json \
+  /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5 \
+  --object-instance-serial '<physical serial>' \
+  --phystwin-model-id '<model identifier>' \
+  --phystwin-model-file /absolute/path/to/exact/model/artifact \
+  --left-forepaw-node-set contact_node_sets/left_forepaw.json \
+  --left-forepaw-node-count '<count>' \
+  --right-forepaw-node-set contact_node_sets/right_forepaw.json \
+  --right-forepaw-node-count '<count>' \
+  --upper-torso-node-set contact_node_sets/upper_torso.json \
+  --upper-torso-node-count '<count>'
+```
+
+The command:
+
+- requires the exact scaffolded `protocol.json` and unchanged registration
+  template;
+- computes the model and node-set SHA-256 values from ordinary files;
+- rejects symlinks and node-set files outside the dataset root;
+- validates all registered fields before publication;
+- writes `object_registration.json` atomically; and
+- refuses replacement of any existing registration.
+
+Use `--phystwin-model-sha256` instead of `--phystwin-model-file` only when the
+precomputed digest has already been obtained from the exact immutable model
+artifact. The node counts remain operator-supplied because the protocol does not
+prescribe a serialization format for canonical node sets.
+
+After sealing, recompute the registered next action with file-hash verification.
+Do not select or revise node sets using source-panel or confirmatory outcome
+quality.

--- a/src/causal4d/cli/real_protocol.py
+++ b/src/causal4d/cli/real_protocol.py
@@ -6,6 +6,10 @@ import argparse
 import json
 from collections.abc import Sequence
 
+from causal4d.object_registration import (
+    seal_object_registration,
+    sha256_ordinary_file,
+)
 from causal4d.operator_bound_real_evidence import (
     build_operator_bound_real_evidence_status as build_real_evidence_status,
     validate_operator_bound_real_dataset as validate_real_dataset_v2,
@@ -56,6 +60,36 @@ def build_parser() -> argparse.ArgumentParser:
     )
     scaffold.add_argument("protocol_json")
     scaffold.add_argument("output_root")
+
+    object_registration = subparsers.add_parser(
+        "object-registration-seal",
+        help="hash and atomically seal the fixed object and contact-node registration",
+    )
+    object_registration.add_argument("protocol_json")
+    object_registration.add_argument("dataset_root")
+    object_registration.add_argument("--object-instance-serial", required=True)
+    object_registration.add_argument("--phystwin-model-id", required=True)
+    model_source = object_registration.add_mutually_exclusive_group(required=True)
+    model_source.add_argument(
+        "--phystwin-model-file",
+        help="ordinary model artifact whose SHA-256 is registered",
+    )
+    model_source.add_argument(
+        "--phystwin-model-sha256",
+        help="precomputed SHA-256 when the exact model artifact is unavailable locally",
+    )
+    for region_id in ("left_forepaw", "right_forepaw", "upper_torso"):
+        option = region_id.replace("_", "-")
+        object_registration.add_argument(
+            f"--{option}-node-set",
+            required=True,
+            help="ordinary canonical node-set file below the dataset root",
+        )
+        object_registration.add_argument(
+            f"--{option}-node-count",
+            required=True,
+            type=int,
+        )
 
     analysis_seal = subparsers.add_parser(
         "analysis-manifest-seal",
@@ -146,6 +180,31 @@ def main(argv: Sequence[str] | None = None) -> int:
                 **result,
                 **scaffold_real_evidence_v2_templates(protocol, args.output_root),
             }
+        elif args.command == "object-registration-seal":
+            if args.phystwin_model_file:
+                model_sha256, _ = sha256_ordinary_file(
+                    args.phystwin_model_file,
+                    name="PhysTwin model artifact",
+                )
+            else:
+                model_sha256 = args.phystwin_model_sha256
+            result = seal_object_registration(
+                load_protocol(args.protocol_json),
+                args.dataset_root,
+                object_instance_serial=args.object_instance_serial,
+                phystwin_model_id=args.phystwin_model_id,
+                phystwin_model_sha256=model_sha256,
+                contact_node_set_paths={
+                    "left_forepaw": args.left_forepaw_node_set,
+                    "right_forepaw": args.right_forepaw_node_set,
+                    "upper_torso": args.upper_torso_node_set,
+                },
+                contact_node_counts={
+                    "left_forepaw": args.left_forepaw_node_count,
+                    "right_forepaw": args.right_forepaw_node_count,
+                    "upper_torso": args.upper_torso_node_count,
+                },
+            )
         elif args.command == "analysis-manifest-seal":
             result = seal_registered_real_analysis_manifest(
                 args.repository_root,

--- a/src/causal4d/object_registration.py
+++ b/src/causal4d/object_registration.py
@@ -1,0 +1,175 @@
+"""Exactly-once construction of the fixed-object registration artifact."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from causal4d.atomic_io import atomic_write_json
+from causal4d.real_protocol import (
+    object_registration_template,
+    validate_object_registration,
+    validate_protocol,
+)
+
+
+OBJECT_REGISTRATION_PATH = "object_registration.json"
+OBJECT_REGISTRATION_TEMPLATE_PATH = "object_registration.template.json"
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _contains_symlink_component(path: Path) -> bool:
+    candidate = path.absolute()
+    return any(component.is_symlink() for component in (candidate, *candidate.parents))
+
+
+def _ordinary_file(path: Path, *, name: str) -> Path:
+    candidate = path.absolute()
+    _require(
+        not _contains_symlink_component(candidate),
+        f"{name} contains a symlink component",
+    )
+    _require(candidate.is_file(), f"{name} is not an ordinary file")
+    return candidate.resolve(strict=True)
+
+
+def _sha256_file(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    byte_count = 0
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+            byte_count += len(block)
+    return digest.hexdigest(), byte_count
+
+
+def sha256_ordinary_file(path: str | Path, *, name: str) -> tuple[str, int]:
+    """Hash one ordinary, non-symlinked file for operator input binding."""
+
+    return _sha256_file(_ordinary_file(Path(path), name=name))
+
+
+def _dataset_file(
+    value: str | Path,
+    *,
+    dataset_root: Path,
+    name: str,
+) -> tuple[Path, str]:
+    supplied = Path(value)
+    candidate = supplied if supplied.is_absolute() else dataset_root / supplied
+    ordinary = _ordinary_file(candidate, name=name)
+    try:
+        relative = ordinary.relative_to(dataset_root)
+    except ValueError as error:
+        raise ValueError(f"{name} must be below the dataset root") from error
+    _require(bool(relative.parts), f"{name} path is empty")
+    return ordinary, relative.as_posix()
+
+
+def seal_object_registration(
+    protocol: Mapping[str, Any],
+    dataset_root: str | Path,
+    *,
+    object_instance_serial: str,
+    phystwin_model_id: str,
+    phystwin_model_sha256: str,
+    contact_node_set_paths: Mapping[str, str | Path],
+    contact_node_counts: Mapping[str, int],
+) -> dict[str, Any]:
+    """Validate inputs and atomically publish ``object_registration.json`` once."""
+
+    validate_protocol(protocol)
+    root_supplied = Path(dataset_root).absolute()
+    _require(
+        not _contains_symlink_component(root_supplied),
+        "dataset root contains a symlink component",
+    )
+    _require(root_supplied.is_dir(), "dataset root is not an ordinary directory")
+    root = root_supplied.resolve(strict=True)
+
+    protocol_path = _ordinary_file(root / "protocol.json", name="dataset protocol")
+    dataset_protocol = json.loads(protocol_path.read_text(encoding="utf-8"))
+    _require(dataset_protocol == dict(protocol), "dataset protocol differs from input")
+
+    expected_template = object_registration_template(protocol)
+    template_path = _ordinary_file(
+        root / OBJECT_REGISTRATION_TEMPLATE_PATH,
+        name="object registration template",
+    )
+    template = json.loads(template_path.read_text(encoding="utf-8"))
+    _require(template == expected_template, "object registration template changed")
+
+    output = root / OBJECT_REGISTRATION_PATH
+    _require(
+        not os.path.lexists(output),
+        "object_registration.json already exists",
+    )
+
+    region_ids = tuple(region["id"] for region in protocol["contact_regions"])
+    _require(
+        set(contact_node_set_paths) == set(region_ids),
+        "contact node-set paths do not match the registered regions",
+    )
+    _require(
+        set(contact_node_counts) == set(region_ids),
+        "contact node counts do not match the registered regions",
+    )
+
+    registration = object_registration_template(protocol)
+    registration["object_instance_serial"] = object_instance_serial
+    registration["phystwin_model_id"] = phystwin_model_id
+    registration["phystwin_model_sha256"] = phystwin_model_sha256
+
+    node_files: dict[str, dict[str, Any]] = {}
+    for region_id in region_ids:
+        node_file, relative = _dataset_file(
+            contact_node_set_paths[region_id],
+            dataset_root=root,
+            name=f"{region_id} canonical node set",
+        )
+        node_sha256, node_bytes = _sha256_file(node_file)
+        node_count = contact_node_counts[region_id]
+        descriptor = registration["contact_regions"][region_id]
+        descriptor["canonical_node_set_path"] = relative
+        descriptor["canonical_node_set_sha256"] = node_sha256
+        descriptor["node_count"] = node_count
+        node_files[region_id] = {
+            "path": relative,
+            "sha256": node_sha256,
+            "bytes": node_bytes,
+            "node_count": node_count,
+        }
+
+    validate_object_registration(protocol, registration)
+    atomic_write_json(output, registration, overwrite=False)
+    output_sha256, output_bytes = _sha256_file(output)
+    return {
+        "passed": True,
+        "output": str(output),
+        "sha256": output_sha256,
+        "bytes": output_bytes,
+        "protocol_id": protocol["protocol_id"],
+        "protocol_design_sha256": protocol["design_sha256"],
+        "object_instance_serial": object_instance_serial,
+        "phystwin_model_id": phystwin_model_id,
+        "phystwin_model_sha256": phystwin_model_sha256,
+        "contact_node_sets": node_files,
+        "target_outcomes_used": False,
+        "physical_command_sent": False,
+    }
+
+
+__all__ = [
+    "OBJECT_REGISTRATION_PATH",
+    "OBJECT_REGISTRATION_TEMPLATE_PATH",
+    "seal_object_registration",
+    "sha256_ordinary_file",
+]

--- a/src/causal4d/real_protocol.py
+++ b/src/causal4d/real_protocol.py
@@ -1414,6 +1414,7 @@ def validate_object_registration(
         )
         _require(
             isinstance(descriptor.get("node_count"), int)
+            and not isinstance(descriptor["node_count"], bool)
             and descriptor["node_count"] > 0,
             f"contact node count is invalid: {region_id}",
         )

--- a/tests/test_object_registration.py
+++ b/tests/test_object_registration.py
@@ -61,9 +61,10 @@ def test_seal_object_registration_hashes_inputs_and_refuses_replacement(
         assert descriptor["canonical_node_set_path"] == (
             f"contact_node_sets/{region_id}.json"
         )
-        assert descriptor["canonical_node_set_sha256"] == hashlib.sha256(
-            path.read_bytes()
-        ).hexdigest()
+        assert (
+            descriptor["canonical_node_set_sha256"]
+            == hashlib.sha256(path.read_bytes()).hexdigest()
+        )
         assert descriptor["node_count"] == 2
 
     with pytest.raises(ValueError, match="already exists"):

--- a/tests/test_object_registration.py
+++ b/tests/test_object_registration.py
@@ -1,0 +1,162 @@
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from causal4d.cli.real_protocol import main as real_protocol_main
+from causal4d.object_registration import seal_object_registration
+from causal4d.real_protocol import (
+    build_same_object_real_protocol,
+    scaffold_dataset,
+    validate_object_registration,
+)
+
+
+REGIONS = ("left_forepaw", "right_forepaw", "upper_torso")
+
+
+def _scaffold(tmp_path: Path) -> tuple[dict, Path, dict[str, Path]]:
+    protocol = build_same_object_real_protocol()
+    dataset = tmp_path / "dataset"
+    scaffold_dataset(protocol, dataset)
+    node_root = dataset / "contact_node_sets"
+    node_root.mkdir()
+    node_sets: dict[str, Path] = {}
+    for index, region_id in enumerate(REGIONS):
+        path = node_root / f"{region_id}.json"
+        path.write_text(json.dumps([index, index + 10]) + "\n", encoding="utf-8")
+        node_sets[region_id] = path
+    return protocol, dataset, node_sets
+
+
+def _seal(protocol: dict, dataset: Path, node_sets: dict[str, Path]) -> dict:
+    return seal_object_registration(
+        protocol,
+        dataset,
+        object_instance_serial="physical-sloth-001",
+        phystwin_model_id="sloth-twin-v1",
+        phystwin_model_sha256="a" * 64,
+        contact_node_set_paths=node_sets,
+        contact_node_counts={region_id: 2 for region_id in REGIONS},
+    )
+
+
+def test_seal_object_registration_hashes_inputs_and_refuses_replacement(
+    tmp_path: Path,
+) -> None:
+    protocol, dataset, node_sets = _scaffold(tmp_path)
+
+    result = _seal(protocol, dataset, node_sets)
+
+    output = dataset / "object_registration.json"
+    registration = json.loads(output.read_text(encoding="utf-8"))
+    validate_object_registration(protocol, registration)
+    assert result["passed"] is True
+    assert result["target_outcomes_used"] is False
+    assert result["physical_command_sent"] is False
+    assert result["sha256"] == hashlib.sha256(output.read_bytes()).hexdigest()
+    for region_id, path in node_sets.items():
+        descriptor = registration["contact_regions"][region_id]
+        assert descriptor["canonical_node_set_path"] == (
+            f"contact_node_sets/{region_id}.json"
+        )
+        assert descriptor["canonical_node_set_sha256"] == hashlib.sha256(
+            path.read_bytes()
+        ).hexdigest()
+        assert descriptor["node_count"] == 2
+
+    with pytest.raises(ValueError, match="already exists"):
+        _seal(protocol, dataset, node_sets)
+
+
+def test_seal_object_registration_rejects_out_of_root_and_modified_template(
+    tmp_path: Path,
+) -> None:
+    protocol, dataset, node_sets = _scaffold(tmp_path)
+    outside = tmp_path / "outside.json"
+    outside.write_text("[1]\n", encoding="utf-8")
+    node_sets["left_forepaw"] = outside
+    with pytest.raises(ValueError, match="below the dataset root"):
+        _seal(protocol, dataset, node_sets)
+    assert not (dataset / "object_registration.json").exists()
+
+    protocol, dataset, node_sets = _scaffold(tmp_path / "second")
+    template = dataset / "object_registration.template.json"
+    payload = json.loads(template.read_text(encoding="utf-8"))
+    payload["object_id"] = "changed"
+    template.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="template changed"):
+        _seal(protocol, dataset, node_sets)
+    assert not (dataset / "object_registration.json").exists()
+
+
+def test_registration_rejects_boolean_node_count(tmp_path: Path) -> None:
+    protocol, dataset, node_sets = _scaffold(tmp_path)
+    with pytest.raises(ValueError, match="node count is invalid"):
+        seal_object_registration(
+            protocol,
+            dataset,
+            object_instance_serial="physical-sloth-001",
+            phystwin_model_id="sloth-twin-v1",
+            phystwin_model_sha256="a" * 64,
+            contact_node_set_paths=node_sets,
+            contact_node_counts={
+                "left_forepaw": True,
+                "right_forepaw": 2,
+                "upper_torso": 2,
+            },
+        )
+    assert not (dataset / "object_registration.json").exists()
+
+
+def test_object_registration_cli_hashes_exact_model_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    protocol, dataset, node_sets = _scaffold(tmp_path)
+    model = tmp_path / "sloth-model.pth"
+    model.write_bytes(b"exact-twin-model\n")
+    arguments = [
+        "object-registration-seal",
+        str(dataset / "protocol.json"),
+        str(dataset),
+        "--object-instance-serial",
+        "physical-sloth-001",
+        "--phystwin-model-id",
+        "sloth-twin-v1",
+        "--phystwin-model-file",
+        str(model),
+    ]
+    for region_id in REGIONS:
+        option = region_id.replace("_", "-")
+        arguments.extend(
+            [
+                f"--{option}-node-set",
+                str(node_sets[region_id]),
+                f"--{option}-node-count",
+                "2",
+            ]
+        )
+
+    assert real_protocol_main(arguments) == 0
+    result = json.loads(capsys.readouterr().out)
+    expected_model_sha256 = hashlib.sha256(model.read_bytes()).hexdigest()
+    registration = json.loads(
+        (dataset / "object_registration.json").read_text(encoding="utf-8")
+    )
+    assert result["phystwin_model_sha256"] == expected_model_sha256
+    assert registration["phystwin_model_sha256"] == expected_model_sha256
+
+
+def test_object_registration_rejects_symlinked_node_set(tmp_path: Path) -> None:
+    protocol, dataset, node_sets = _scaffold(tmp_path)
+    link = dataset / "contact_node_sets" / "left-link.json"
+    try:
+        link.symlink_to(node_sets["left_forepaw"])
+    except OSError as error:
+        pytest.skip(f"symlinks unavailable: {error}")
+    node_sets["left_forepaw"] = link
+
+    with pytest.raises(ValueError, match="symlink component"):
+        _seal(protocol, dataset, node_sets)
+    assert not (dataset / "object_registration.json").exists()


### PR DESCRIPTION
## Summary\n- add an atomic, exactly-once sealer for the fixed physical object registration\n- hash-bind the exact twin model and all three canonical contact-node sets\n- reject changed scaffolds, symlinks, out-of-root files, invalid node counts, and replacement writes\n- document the operator command and preserve the no-outcome/no-command boundary\n\n## Verification\n- 75 registration/readiness/CLI tests passed\n- full suite: 2238 passed, 23 skipped; four DrvFS mode/temp failures each passed on native POSIX\n- Ruff, focused MyPy, and git diff check passed\n- wheel and sdist built successfully and passed twine check\n