### PR TITLE
Replace lost-source v5 owner bootstrap

### DIFF
--- a/.github/self-hosted-jobs.json
+++ b/.github/self-hosted-jobs.json
@@ -8,7 +8,7 @@
       "description": "Exact registered-maintainer issue trigger on reviewed refs/heads/main, exact GITHUB_SHA checkout, clean-tree verification, read-only self-hosted token, no issue text execution, and no secrets."
     },
     "single-operator-v5-issue-main": {
-      "description": "Exact registered-owner issue trigger on reviewed refs/heads/main for the nonphysical v5 scaffold bootstrap, exact GITHUB_SHA checkout, read-only self-hosted token, no issue text execution, and no secrets."
+      "description": "Exact registered-owner issue trigger on reviewed refs/heads/main for the nonphysical source-independent v5 owner-identity bootstrap, exact GITHUB_SHA checkout, read-only self-hosted token, no issue text execution, and no secrets."
     }
   },
   "jobs": [
@@ -54,7 +54,7 @@
         "data-causal4d-physical-v1"
       ],
       "purpose": "Create or revalidate the fresh v5 single-operator acquisition scaffold",
-      "dataset_access": "registered-local-preacquisition-v5-scaffold-bootstrap",
+      "dataset_access": "registered-local-preacquisition-v5-owner-identity-bootstrap",
       "secrets_allowed": false
     },
     {

--- a/.github/workflows/bootstrap-single-operator-v5-self-hosted.yml
+++ b/.github/workflows/bootstrap-single-operator-v5-self-hosted.yml
@@ -1,4 +1,4 @@
-name: Bootstrap single-operator v5 scaffold
+name: Bootstrap source-independent single-operator v5 scaffold
 
 on:
   issues:
@@ -17,9 +17,9 @@ jobs:
       github.event.issue.user.login == 'FlorianPfaff' &&
       github.event.issue.user.id == 6773539 &&
       github.event.issue.title ==
-        '[self-hosted] bootstrap Causal4D v5 operator scaffold'
+        '[self-hosted] bootstrap Causal4D v5 owner identity scaffold v2'
     concurrency:
-      group: causal4d-single-operator-v5-bootstrap-${{ github.sha }}
+      group: causal4d-single-operator-v5-bootstrap-v2-${{ github.sha }}
       cancel-in-progress: false
       queue: max
     runs-on: [self-hosted, Linux, X64, nvidia-smi, data-causal4d-physical-v1]
@@ -27,6 +27,16 @@ jobs:
     outputs:
       created: ${{ steps.summary.outputs.created }}
       dataset_modified: ${{ steps.summary.outputs.dataset_modified }}
+      private_identity_material_created: >-
+        ${{ steps.summary.outputs.private_identity_material_created }}
+      identity_initialization_mode: >-
+        ${{ steps.summary.outputs.identity_initialization_mode }}
+      historical_registry_available: >-
+        ${{ steps.summary.outputs.historical_registry_available }}
+      historical_registry_reused: >-
+        ${{ steps.summary.outputs.historical_registry_reused }}
+      identity_digest_continuity_claimed: >-
+        ${{ steps.summary.outputs.identity_digest_continuity_claimed }}
       plan_id: ${{ steps.summary.outputs.plan_id }}
       registry_artifact_sha256: >-
         ${{ steps.summary.outputs.registry_artifact_sha256 }}
@@ -93,15 +103,15 @@ jobs:
               )
           PY
 
-      - name: Create or revalidate the fresh v5 scaffold
+      - name: Create or revalidate the source-independent v5 scaffold
         shell: bash
         run: |
           set -euo pipefail
           PYTHONPATH="" .single-operator-v5-bootstrap-venv/bin/python \
             scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py \
             --repository-root "${GITHUB_WORKSPACE}" \
-            --source-dataset-root \
-              /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1 \
+            --private-identity-root \
+              /mnt/lexar4tb/causal4d-physical/private/operator-registry-v5 \
             --target-dataset-root \
               /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5 \
             --output outputs/single-operator-v5-bootstrap/report.json \
@@ -126,6 +136,8 @@ jobs:
               "Causal4DSingleOperatorV5BootstrapReport"
           ):
               raise SystemExit("unexpected bootstrap report")
+          if report["schema_version"] != 2:
+              raise SystemExit("unexpected bootstrap report schema")
           if report["reviewed_main_commit"] != os.environ["GITHUB_SHA"]:
               raise SystemExit("bootstrap report commit mismatch")
           if report["target_preacquisition_plan_id"] != (
@@ -136,6 +148,19 @@ jobs:
               raise SystemExit("bootstrap report operator mismatch")
           if report["independent_verifier_available"] is not False:
               raise SystemExit("bootstrap report claims independent verification")
+          if report["independent_preacquisition_attestation_claimed"] is not False:
+              raise SystemExit("bootstrap report claims independent attestation")
+          if report["identity_initialization_mode"] != "fresh_owner_hmac_v1":
+              raise SystemExit("bootstrap identity initialization mode mismatch")
+          for field in (
+              "historical_registry_available",
+              "historical_registry_reused",
+              "identity_digest_continuity_claimed",
+          ):
+              if report[field] is not False:
+                  raise SystemExit(f"bootstrap makes a false identity claim: {field}")
+          if "person_identity_sha256" in json.dumps(report, sort_keys=True):
+              raise SystemExit("bootstrap report exposes the private person digest")
           action = report["next_action"]
           if action["action_id"] != "complete_object_registration":
               raise SystemExit("fresh v5 scaffold did not reach registration")
@@ -157,6 +182,26 @@ jobs:
           print(f"created={str(report['created']).lower()}")
           print(
               f"dataset_modified={str(report['dataset_modified']).lower()}"
+          )
+          print(
+              "private_identity_material_created="
+              f"{str(report['private_identity_material_created']).lower()}"
+          )
+          print(
+              "identity_initialization_mode="
+              f"{report['identity_initialization_mode']}"
+          )
+          print(
+              "historical_registry_available="
+              f"{str(report['historical_registry_available']).lower()}"
+          )
+          print(
+              "historical_registry_reused="
+              f"{str(report['historical_registry_reused']).lower()}"
+          )
+          print(
+              "identity_digest_continuity_claimed="
+              f"{str(report['identity_digest_continuity_claimed']).lower()}"
           )
           print(f"plan_id={report['target_preacquisition_plan_id']}")
           print(
@@ -203,7 +248,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: causal4d-single-operator-v5-bootstrap
+          name: causal4d-single-operator-v5-owner-bootstrap-v2
           path: |
             outputs/single-operator-v5-bootstrap/report.json
             outputs/single-operator-v5-bootstrap/report.txt
@@ -231,7 +276,7 @@ jobs:
       github.event.issue.user.login == 'FlorianPfaff' &&
       github.event.issue.user.id == 6773539 &&
       github.event.issue.title ==
-        '[self-hosted] bootstrap Causal4D v5 operator scaffold'
+        '[self-hosted] bootstrap Causal4D v5 owner identity scaffold v2'
     needs: bootstrap
     runs-on: ubuntu-latest
     permissions:
@@ -243,6 +288,16 @@ jobs:
       BOOTSTRAP_RESULT: ${{ needs.bootstrap.result }}
       CREATED: ${{ needs.bootstrap.outputs.created }}
       DATASET_MODIFIED: ${{ needs.bootstrap.outputs.dataset_modified }}
+      PRIVATE_IDENTITY_MATERIAL_CREATED: >-
+        ${{ needs.bootstrap.outputs.private_identity_material_created }}
+      IDENTITY_INITIALIZATION_MODE: >-
+        ${{ needs.bootstrap.outputs.identity_initialization_mode }}
+      HISTORICAL_REGISTRY_AVAILABLE: >-
+        ${{ needs.bootstrap.outputs.historical_registry_available }}
+      HISTORICAL_REGISTRY_REUSED: >-
+        ${{ needs.bootstrap.outputs.historical_registry_reused }}
+      IDENTITY_DIGEST_CONTINUITY_CLAIMED: >-
+        ${{ needs.bootstrap.outputs.identity_digest_continuity_claimed }}
       PLAN_ID: ${{ needs.bootstrap.outputs.plan_id }}
       REGISTRY_ARTIFACT_SHA256: >-
         ${{ needs.bootstrap.outputs.registry_artifact_sha256 }}
@@ -269,6 +324,11 @@ jobs:
           - Registered plan: `${PLAN_ID:-unavailable}`
           - Fresh scaffold created: `${CREATED:-unknown}`
           - Dataset modified: `${DATASET_MODIFIED:-unknown}`
+          - Fresh private owner identity created: `${PRIVATE_IDENTITY_MATERIAL_CREATED:-unknown}`
+          - Identity initialization mode: `${IDENTITY_INITIALIZATION_MODE:-unavailable}`
+          - Historical registry available: `${HISTORICAL_REGISTRY_AVAILABLE:-unknown}`
+          - Historical registry reused: `${HISTORICAL_REGISTRY_REUSED:-unknown}`
+          - Historical identity-digest continuity claimed: `${IDENTITY_DIGEST_CONTINUITY_CLAIMED:-unknown}`
           - Registered operator count: `${OPERATOR_COUNT:-unknown}`
           - Independent verifier available: `${INDEPENDENT_VERIFIER_AVAILABLE:-unknown}`
           - Registry artifact: `${REGISTRY_ARTIFACT_SHA256:-unavailable}`
@@ -277,9 +337,9 @@ jobs:
           - Physical acquisition required by next action: `${PHYSICAL_REQUIRED:-unknown}`
           - Physical evidence increment from this run: `${PHYSICAL_EVIDENCE_INCREMENT:-unknown}`
           - Workflow run: ${run_url}
-          - Artifact: `causal4d-single-operator-v5-bootstrap`
+          - Artifact: `causal4d-single-operator-v5-owner-bootstrap-v2`
 
-          This run claims no independent pre-acquisition attestation and does not authorize target access.
+          This run initializes a fresh owner-only HMAC identity. It claims neither historical identity-digest continuity nor independent pre-acquisition attestation, and it does not authorize target access.
           EOF
           )"
           gh issue comment "${ISSUE_NUMBER}" \

--- a/docs/source_independent_v5_owner_bootstrap.md
+++ b/docs/source_independent_v5_owner_bootstrap.md
@@ -1,0 +1,92 @@
+# Source-independent v5 owner-identity bootstrap
+
+Status: **locked before the replacement bootstrap execution**
+
+This is an operational provenance amendment to the v5 single-operator policy. It
+does not change the registered scientific design, source/target split, mechanism
+gates, acquisition roster, or analysis.
+
+## Why a replacement is required
+
+The first v5 bootstrap workflow copied the public operator record from an
+ephemeral v4 dataset tree. That tree and its private HMAC material are no longer
+available on `workstation2`, so the workflow cannot start. The canceled legacy
+run reached no job steps and created no scaffold, physical evidence, or target
+access.
+
+The surviving public correction receipt proves what the old registry claimed,
+but it does not contain the private key needed to reproduce its person digest.
+The old digest must therefore not be guessed, reconstructed from public
+metadata, or claimed as continuous.
+
+## Replacement identity semantics
+
+The v2 bootstrap initializes a new owner-only identity exactly once:
+
+- canonical principal: `github-login-v1:FlorianPfaff`;
+- digest method: `hmac-sha256-domain-separated-v1`;
+- HMAC domain: `causal4d-operator-v1` followed by a NUL byte;
+- one 32-byte random private key;
+- active roles: `freezer`, `gate_approver`, and
+  `software_environment_approver`;
+- no `independent_verifier` role.
+
+The private key and principal roster live only below the fixed owner-only root:
+
+```text
+/mnt/lexar4tb/causal4d-physical/private/operator-registry-v5
+```
+
+The directory must have mode `0700`; its two files must have mode `0600`.
+Neither file, the canonical principal, nor the person digest is uploaded as a
+workflow artifact. The public registry necessarily contains the HMAC-derived
+person digest required by the registered Causal4D identity contract.
+
+Every v2 receipt and sanitized report states:
+
+```text
+identity_initialization_mode=fresh_owner_hmac_v1
+historical_registry_available=false
+historical_registry_reused=false
+identity_digest_continuity_claimed=false
+independent_preacquisition_attestation_claimed=false
+```
+
+## Transaction and rerun behavior
+
+Private material is published from an owner-only staging directory by atomic
+rename. The acquisition scaffold is separately built in a sibling staging tree
+and atomically renamed to the fixed v5 dataset root. If scaffold creation fails
+after the private identity is initialized, a later run must reuse and revalidate
+that same private identity; it may not generate another one.
+
+An idempotent rerun verifies the private material, operator registry, bootstrap
+receipt, protocol, v5 amendment, and registered next action byte-for-value. It
+also binds the receipt to the exact bootstrap implementation SHA-256 and byte
+count. It does not reseal or modify the dataset. Partial private roots,
+unexpected files, wrong permissions, symlinks, changed private material,
+changed registry bytes, or any already-created governed evidence fail closed.
+
+## Trigger and evidence boundary
+
+Only an issue opened by the registered repository owner on reviewed `main` with
+this exact title may allocate the self-hosted job:
+
+```text
+[self-hosted] bootstrap Causal4D v5 owner identity scaffold v2
+```
+
+The older title is revoked on current `main`. The replacement job receives no
+GitHub secrets, builds and imports the exact reviewed wheel, and uploads only a
+sanitized report, runner identity, GPU inventory, and wheel digest.
+
+Successful bootstrap advances only to:
+
+```text
+complete_object_registration
+```
+
+It sends no physical command, opens no device node, uses no target outcome,
+changes no registered method, and adds zero physical executions. The standing
+paper disclosure remains: one registered operator self-attests the checks and
+no independent pre-acquisition attestation is claimed.

--- a/scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py
+++ b/scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py
@@ -1,22 +1,26 @@
 #!/usr/bin/env python3
-"""Bootstrap the fresh v5 single-operator evidence tree without physical work."""
+"""Bootstrap the fresh v5 single-operator tree without historical identity data."""
 
 from __future__ import annotations
 
 import argparse
 import hashlib
+import hmac
 import json
 import os
+import secrets
 import shutil
+import stat
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 
-from causal4d.atomic_io import atomic_write_json
+from causal4d.atomic_io import atomic_write_binary, atomic_write_json
 from causal4d.operator_registry import (
     OPERATOR_REGISTRY_PATH,
     OPERATOR_REGISTRY_TEMPLATE_PATH,
+    PERSON_IDENTITY_DIGEST_METHOD,
     ROLE_FREEZER,
     ROLE_GATE_APPROVER,
     ROLE_INDEPENDENT_VERIFIER,
@@ -28,32 +32,40 @@ from causal4d.operator_registry import (
 from causal4d.preacquisition_operator_flow import (
     build_preacquisition_operator_next_action,
 )
-from causal4d.preacquisition_protocol_v4 import load_v4_chain
 from causal4d.preacquisition_readiness import scaffold_preacquisition_readiness
 from causal4d.preacquisition_readiness_contracts import (
-    MECHANISM_GATE_EVIDENCE_PATH,
-    PREACQUISITION_V2_PATH,
-    PREACQUISITION_V3_PATH,
-    PREACQUISITION_V4_PATH,
-    PROTOCOL_PATH,
     load_registered_preacquisition_chain,
 )
 from causal4d.real_evidence_contract_v2 import scaffold_real_evidence_v2_templates
 from causal4d.real_protocol import load_protocol, scaffold_dataset
 
 
-REPORT_SCHEMA_VERSION = 1
+REPORT_SCHEMA_VERSION = 2
 REPORT_ARTIFACT_KIND = "Causal4DSingleOperatorV5BootstrapReport"
-RECEIPT_SCHEMA_VERSION = 1
+RECEIPT_SCHEMA_VERSION = 2
 RECEIPT_ARTIFACT_KIND = "Causal4DSingleOperatorV5BootstrapReceipt"
 RECEIPT_PATH = "preacquisition/single_operator_v5_bootstrap.json"
+PRIVATE_ROSTER_SCHEMA_VERSION = 2
+PRIVATE_ROSTER_ARTIFACT_KIND = "Causal4DPrivateOperatorPrincipalRoster"
+KEY_FILENAME = "operator-identity-hmac-v1.key"
+PRIVATE_ROSTER_FILENAME = "operator-principals-v1.json"
+PERSON_DOMAIN = b"causal4d-operator-v1\0"
+KEY_BYTES = 32
+IDENTITY_INITIALIZATION_MODE = "fresh_owner_hmac_v1"
+IMPLEMENTATION_PATH = "scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py"
 OPERATOR_ID = "florianpfaff"
-OPERATOR_ROLES = (
-    ROLE_FREEZER,
-    ROLE_GATE_APPROVER,
-    ROLE_SOFTWARE_ENVIRONMENT_APPROVER,
+CANONICAL_PRINCIPAL = "github-login-v1:FlorianPfaff"
+OPERATOR_ROLES = tuple(
+    sorted(
+        (
+            ROLE_FREEZER,
+            ROLE_GATE_APPROVER,
+            ROLE_SOFTWARE_ENVIRONMENT_APPROVER,
+        )
+    )
 )
-_GOVERNED_SOURCE_PATHS = (
+_EXPECTED_PRIVATE_FILES = frozenset({KEY_FILENAME, PRIVATE_ROSTER_FILENAME})
+_GOVERNED_PATHS = (
     "object_registration.json",
     "slip_pilot.json",
     "timebase_calibration.json",
@@ -62,10 +74,37 @@ _GOVERNED_SOURCE_PATHS = (
     "method_freeze_validation.json",
     "registered-analysis.json",
 )
-_GOVERNED_SOURCE_PATTERNS = (
+_GOVERNED_PATTERNS = (
     "preacquisition/source_panel/executions/*/manifest.json",
     "executions/*/manifest.json",
     "sessions/*/session.json",
+)
+_RECEIPT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "artifact_kind",
+        "target_preacquisition_plan_id",
+        "target_preacquisition_amendment_sha256",
+        "identity_initialization_mode",
+        "person_identity_digest_method",
+        "private_roster_artifact_sha256",
+        "bootstrap_implementation_sha256",
+        "bootstrap_implementation_bytes",
+        "historical_registry_available",
+        "historical_registry_reused",
+        "identity_digest_continuity_claimed",
+        "target_registry_artifact_sha256",
+        "target_registry_file_sha256",
+        "target_registry_file_bytes",
+        "operator_id",
+        "operator_roles",
+        "sealed_at_utc",
+        "independent_preacquisition_attestation_claimed",
+        "target_outcomes_used",
+        "physical_command_sent",
+        "physical_evidence_increment",
+        "artifact_sha256",
+    }
 )
 
 
@@ -74,15 +113,28 @@ def _require(condition: bool, message: str) -> None:
         raise ValueError(message)
 
 
+def _reject_json_constant(value: str) -> Any:
+    raise ValueError(f"non-finite JSON constant is forbidden: {value}")
+
+
 def _contains_symlink_component(path: Path) -> bool:
     candidate = path.absolute()
     return any(component.is_symlink() for component in (candidate, *candidate.parents))
 
 
+def _require_ordinary_directory(path: Path, *, name: str) -> Path:
+    _require(not _contains_symlink_component(path), f"{name} contains a symlink")
+    _require(path.is_dir(), f"{name} must be an ordinary directory")
+    return path.resolve()
+
+
 def _read_json_mapping(path: Path, *, name: str) -> dict[str, Any]:
     _require(not _contains_symlink_component(path), f"{name} contains a symlink")
     _require(path.is_file(), f"{name} is missing")
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload = json.loads(
+        path.read_text(encoding="utf-8"),
+        parse_constant=_reject_json_constant,
+    )
     _require(isinstance(payload, Mapping), f"{name} must be a JSON object")
     return dict(payload)
 
@@ -109,69 +161,159 @@ def _canonical_sha256(payload: Mapping[str, Any], *, field: str) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _load_v4(repository: Path) -> tuple[dict[str, Any], dict[str, Any]]:
-    protocol, _, _, v4 = load_v4_chain(
-        repository / PROTOCOL_PATH,
-        repository / PREACQUISITION_V2_PATH,
-        repository / PREACQUISITION_V3_PATH,
-        repository / MECHANISM_GATE_EVIDENCE_PATH,
-        repository / PREACQUISITION_V4_PATH,
-    )
-    return protocol, v4
+def _fsync_directory(path: Path) -> None:
+    if os.name != "posix":
+        return
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
 
 
-def _source_operator(
-    repository: Path, source_dataset: Path
-) -> tuple[dict[str, Any], str]:
-    protocol, v4 = _load_v4(repository)
-    registry_path = source_dataset / OPERATOR_REGISTRY_PATH
-    registry = _read_json_mapping(registry_path, name="historical v4 operator registry")
-    summary = validate_operator_registry(protocol, v4, registry)
-    _require(
-        summary.get("independent_verifier_available") is False,
-        "source registry claims an independent verifier",
+def _require_mode(path: Path, *, name: str, expected: int) -> None:
+    actual = stat.S_IMODE(path.stat().st_mode)
+    _require(actual == expected, f"{name} mode is {actual:o}, expected {expected:o}")
+
+
+def _private_roster_payload() -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": PRIVATE_ROSTER_SCHEMA_VERSION,
+        "artifact_kind": PRIVATE_ROSTER_ARTIFACT_KIND,
+        "person_identity_digest_method": PERSON_IDENTITY_DIGEST_METHOD,
+        "assignments": [
+            {
+                "operator_id": OPERATOR_ID,
+                "canonical_principal": CANONICAL_PRINCIPAL,
+                "roles": list(OPERATOR_ROLES),
+            }
+        ],
+        "target_outcomes_used": False,
+    }
+    payload["artifact_sha256"] = _canonical_sha256(
+        payload,
+        field="artifact_sha256",
     )
-    operators = registry.get("operators")
+    return payload
+
+
+def _person_digest(secret: bytes) -> str:
+    return hmac.new(
+        secret,
+        PERSON_DOMAIN + CANONICAL_PRINCIPAL.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def _operator_record(secret: bytes) -> dict[str, Any]:
+    return {
+        "operator_id": OPERATOR_ID,
+        "person_identity_sha256": _person_digest(secret),
+        "active": True,
+        "roles": list(OPERATOR_ROLES),
+    }
+
+
+def _read_private_material(private_root: Path) -> tuple[bytes, dict[str, Any]]:
+    root = _require_ordinary_directory(private_root, name="private identity root")
+    _require_mode(root, name="private identity root", expected=0o700)
+    members = list(root.iterdir())
     _require(
-        isinstance(operators, list) and len(operators) == 1,
-        "source registry must contain exactly one person",
-    )
-    operator_values = cast(list[Any], operators)
-    operator = dict(cast(Mapping[str, Any], operator_values[0]))
-    _require(
-        operator.get("operator_id") == OPERATOR_ID,
-        "source registry operator is not florianpfaff",
-    )
-    _require(operator.get("active") is True, "source registry operator is inactive")
-    roles = tuple(operator.get("roles", ()))
-    _require(
-        roles == OPERATOR_ROLES,
-        "source registry roles differ from the v5 one-person lock",
+        {member.name for member in members} == _EXPECTED_PRIVATE_FILES,
+        "private identity root members differ from the registered schema",
     )
     _require(
-        ROLE_INDEPENDENT_VERIFIER not in roles,
-        "source registry assigns a false independent role",
+        all(member.is_file() and not member.is_symlink() for member in members),
+        "private identity root contains a non-regular member",
     )
+    key_path = root / KEY_FILENAME
+    roster_path = root / PRIVATE_ROSTER_FILENAME
+    _require_mode(key_path, name="operator identity key", expected=0o600)
+    _require_mode(roster_path, name="private operator roster", expected=0o600)
+    secret = key_path.read_bytes()
+    _require(len(secret) == KEY_BYTES, "operator identity key length is invalid")
+    roster = _read_json_mapping(roster_path, name="private operator roster")
     _require(
-        registry.get("target_outcomes_used") is False,
-        "target outcomes entered source identity evidence",
+        roster == _private_roster_payload(),
+        "private operator roster differs from the fresh-owner lock",
     )
-    for relative in _GOVERNED_SOURCE_PATHS:
-        _require(
-            not os.path.lexists(source_dataset / relative),
-            f"historical source tree contains governed evidence: {relative}",
+    return secret, roster
+
+
+def _create_or_read_private_material(
+    private_root: Path,
+) -> tuple[bytes, dict[str, Any], bool]:
+    root = private_root.absolute()
+    _require(
+        not _contains_symlink_component(root),
+        "private identity root contains a symlink component",
+    )
+    if os.path.lexists(root):
+        secret, roster = _read_private_material(root)
+        return secret, roster, False
+
+    parent = root.parent
+    _require(
+        not _contains_symlink_component(parent),
+        "private identity parent contains a symlink component",
+    )
+    if not os.path.lexists(parent):
+        grandparent = _require_ordinary_directory(
+            parent.parent,
+            name="private identity grandparent",
         )
-    for pattern in _GOVERNED_SOURCE_PATTERNS:
+        parent.mkdir(mode=0o700)
+        _fsync_directory(grandparent)
+    parent = _require_ordinary_directory(parent, name="private identity parent")
+    _require_mode(parent, name="private identity parent", expected=0o700)
+    staging = parent / f".{root.name}.bootstrap-v5.tmp"
+    _require(
+        not os.path.lexists(staging),
+        "private identity staging path already exists",
+    )
+    try:
+        staging.mkdir(mode=0o700)
+        secret = secrets.token_bytes(KEY_BYTES)
+
+        def write_key(handle: Any) -> None:
+            handle.write(secret)
+
+        key_path = staging / KEY_FILENAME
+        roster_path = staging / PRIVATE_ROSTER_FILENAME
+        atomic_write_binary(key_path, write_key, overwrite=False)
+        os.chmod(key_path, 0o600)
+        atomic_write_json(roster_path, _private_roster_payload(), overwrite=False)
+        os.chmod(roster_path, 0o600)
+        _fsync_directory(staging)
+        staging.rename(root)
+        _fsync_directory(parent)
+    except BaseException:
+        if staging.exists():
+            shutil.rmtree(staging)
+        raise
+    loaded_secret, roster = _read_private_material(root)
+    _require(loaded_secret == secret, "private identity publication changed")
+    return loaded_secret, roster, True
+
+
+def _require_no_governed_evidence(dataset: Path) -> None:
+    for relative in _GOVERNED_PATHS:
         _require(
-            not any(source_dataset.glob(pattern)),
-            f"historical source tree contains governed evidence matching: {pattern}",
+            not os.path.lexists(dataset / relative),
+            f"v5 bootstrap is too late; governed evidence exists: {relative}",
         )
-    return operator, str(registry["artifact_sha256"])
+    for pattern in _GOVERNED_PATTERNS:
+        _require(
+            not any(dataset.glob(pattern)),
+            f"v5 bootstrap is too late; governed evidence matches: {pattern}",
+        )
 
 
 def _receipt(
     *,
-    source_registry_artifact_sha256: str,
+    private_roster_artifact_sha256: str,
+    bootstrap_implementation_sha256: str,
+    bootstrap_implementation_bytes: int,
     target_registry_artifact_sha256: str,
     target_registry_file_sha256: str,
     target_registry_file_bytes: int,
@@ -182,10 +324,16 @@ def _receipt(
     payload: dict[str, Any] = {
         "schema_version": RECEIPT_SCHEMA_VERSION,
         "artifact_kind": RECEIPT_ARTIFACT_KIND,
-        "source_preacquisition_plan_id": "causal4d-sloth-preacquisition-v4",
-        "source_registry_artifact_sha256": source_registry_artifact_sha256,
         "target_preacquisition_plan_id": plan_id,
         "target_preacquisition_amendment_sha256": amendment_sha256,
+        "identity_initialization_mode": IDENTITY_INITIALIZATION_MODE,
+        "person_identity_digest_method": PERSON_IDENTITY_DIGEST_METHOD,
+        "private_roster_artifact_sha256": private_roster_artifact_sha256,
+        "bootstrap_implementation_sha256": bootstrap_implementation_sha256,
+        "bootstrap_implementation_bytes": bootstrap_implementation_bytes,
+        "historical_registry_available": False,
+        "historical_registry_reused": False,
+        "identity_digest_continuity_claimed": False,
         "target_registry_artifact_sha256": target_registry_artifact_sha256,
         "target_registry_file_sha256": target_registry_file_sha256,
         "target_registry_file_bytes": target_registry_file_bytes,
@@ -204,30 +352,45 @@ def _receipt(
 def _verify_target(
     repository: Path,
     target_dataset: Path,
-    source_operator: Mapping[str, Any],
-    source_registry_artifact_sha256: str,
+    operator: Mapping[str, Any],
+    private_roster_artifact_sha256: str,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
+    target = _require_ordinary_directory(target_dataset, name="v5 target dataset")
+    _require_no_governed_evidence(target)
     protocol, _, _, v5 = load_registered_preacquisition_chain(repository)
     _require(
-        load_protocol(target_dataset / "protocol.json") == protocol,
+        load_protocol(target / "protocol.json") == protocol,
         "target protocol changed",
     )
-    registry_path = target_dataset / OPERATOR_REGISTRY_PATH
+    registry_path = target / OPERATOR_REGISTRY_PATH
     registry = _read_json_mapping(registry_path, name="v5 operator registry")
     summary = validate_operator_registry(protocol, v5, registry)
     operators = registry.get("operators")
     _require(
-        isinstance(operators, list) and operators == [dict(source_operator)],
-        "v5 registry changed the registered person",
+        isinstance(operators, list) and operators == [dict(operator)],
+        "v5 registry differs from the owner-only private identity",
     )
     _require(
         summary.get("independent_verifier_available") is False,
         "v5 registry claims independent verification",
     )
-    receipt_path = target_dataset / RECEIPT_PATH
-    receipt = _read_json_mapping(receipt_path, name="v5 bootstrap receipt")
     _require(
-        receipt.get("artifact_kind") == RECEIPT_ARTIFACT_KIND,
+        ROLE_INDEPENDENT_VERIFIER
+        not in cast(list[dict[str, Any]], operators)[0]["roles"],
+        "v5 registry assigns a false independent role",
+    )
+
+    receipt = _read_json_mapping(
+        target / RECEIPT_PATH,
+        name="v5 bootstrap receipt",
+    )
+    _require(
+        set(receipt) == _RECEIPT_FIELDS,
+        "v5 bootstrap receipt fields differ from schema v2",
+    )
+    _require(
+        receipt.get("schema_version") == RECEIPT_SCHEMA_VERSION
+        and receipt.get("artifact_kind") == RECEIPT_ARTIFACT_KIND,
         "unexpected v5 bootstrap receipt",
     )
     _require(
@@ -236,15 +399,26 @@ def _verify_target(
         "v5 bootstrap receipt digest mismatch",
     )
     file_sha256, file_bytes = _sha256_file(registry_path)
+    implementation_sha256, implementation_bytes = _sha256_file(
+        repository / IMPLEMENTATION_PATH
+    )
     expected = {
-        "source_registry_artifact_sha256": source_registry_artifact_sha256,
         "target_preacquisition_plan_id": v5["plan_id"],
         "target_preacquisition_amendment_sha256": v5["amendment_sha256"],
+        "identity_initialization_mode": IDENTITY_INITIALIZATION_MODE,
+        "person_identity_digest_method": PERSON_IDENTITY_DIGEST_METHOD,
+        "private_roster_artifact_sha256": private_roster_artifact_sha256,
+        "bootstrap_implementation_sha256": implementation_sha256,
+        "bootstrap_implementation_bytes": implementation_bytes,
+        "historical_registry_available": False,
+        "historical_registry_reused": False,
+        "identity_digest_continuity_claimed": False,
         "target_registry_artifact_sha256": registry["artifact_sha256"],
         "target_registry_file_sha256": file_sha256,
         "target_registry_file_bytes": file_bytes,
         "operator_id": OPERATOR_ID,
         "operator_roles": list(OPERATOR_ROLES),
+        "sealed_at_utc": registry["sealed_at_utc"],
         "independent_preacquisition_attestation_claimed": False,
         "target_outcomes_used": False,
         "physical_command_sent": False,
@@ -255,13 +429,15 @@ def _verify_target(
             receipt.get(field) == expected_value,
             f"v5 bootstrap receipt {field} mismatch",
         )
+
     decision = build_preacquisition_operator_next_action(
         repository,
-        target_dataset,
+        target,
         verify_file_hashes=True,
     )
-    action = decision.get("action")
-    _require(isinstance(action, Mapping), "v5 next action is missing")
+    action_value = decision.get("action")
+    _require(isinstance(action_value, Mapping), "v5 next action is missing")
+    action = dict(cast(Mapping[str, Any], action_value))
     _require(
         action.get("action_id") == "complete_object_registration",
         "v5 bootstrap did not advance to object registration",
@@ -278,45 +454,39 @@ def _verify_target(
         action.get("target_outcomes_permitted") is False,
         "v5 next action permits target outcomes",
     )
-    return receipt, dict(action)
+    return receipt, action
 
 
 def bootstrap_single_operator_v5(
     *,
     repository_root: Path,
-    source_dataset_root: Path,
+    private_identity_root: Path,
     target_dataset_root: Path,
     sealed_at_utc: str | None = None,
 ) -> dict[str, Any]:
-    repository = repository_root.resolve(strict=True)
-    source = source_dataset_root.resolve(strict=True)
+    repository = _require_ordinary_directory(repository_root, name="repository root")
     target = target_dataset_root.absolute()
-    _require(
-        repository.is_dir() and source.is_dir(),
-        "repository and source dataset must be directories",
-    )
-    _require(
-        not _contains_symlink_component(repository),
-        "repository contains a symlink component",
-    )
-    _require(
-        not _contains_symlink_component(source),
-        "source dataset contains a symlink component",
-    )
     _require(
         not _contains_symlink_component(target),
         "target dataset contains a symlink component",
     )
-    source_operator, source_registry_artifact_sha256 = _source_operator(
-        repository, source
+    implementation_sha256, implementation_bytes = _sha256_file(
+        repository / IMPLEMENTATION_PATH
     )
+    secret, private_roster, private_created = _create_or_read_private_material(
+        private_identity_root,
+    )
+    operator = _operator_record(secret)
+    private_roster_artifact_sha256 = str(private_roster["artifact_sha256"])
 
     created = False
-    if not target.exists():
+    if not os.path.lexists(target):
         target.parent.mkdir(parents=True, exist_ok=True)
+        _require_ordinary_directory(target.parent, name="target dataset parent")
         staging = target.parent / f".{target.name}.bootstrap-v5.tmp"
         _require(
-            not os.path.lexists(staging), "v5 bootstrap staging path already exists"
+            not os.path.lexists(staging),
+            "v5 bootstrap staging path already exists",
         )
         try:
             protocol, _, _, v5 = load_registered_preacquisition_chain(repository)
@@ -326,9 +496,10 @@ def bootstrap_single_operator_v5(
             scaffold_operator_registry(repository, staging)
             template_path = staging / OPERATOR_REGISTRY_TEMPLATE_PATH
             template = _read_json_mapping(
-                template_path, name="v5 operator registry template"
+                template_path,
+                name="v5 operator registry template",
             )
-            template["operators"] = [dict(source_operator)]
+            template["operators"] = [operator]
             atomic_write_json(template_path, template, overwrite=True)
             timestamp = sealed_at_utc or datetime.now(timezone.utc).isoformat()
             sealed = seal_operator_registry(
@@ -339,7 +510,9 @@ def bootstrap_single_operator_v5(
                 sealed_at_utc=timestamp,
             )
             receipt = _receipt(
-                source_registry_artifact_sha256=source_registry_artifact_sha256,
+                private_roster_artifact_sha256=private_roster_artifact_sha256,
+                bootstrap_implementation_sha256=implementation_sha256,
+                bootstrap_implementation_bytes=implementation_bytes,
                 target_registry_artifact_sha256=str(sealed["artifact_sha256"]),
                 target_registry_file_sha256=str(sealed["sha256"]),
                 target_registry_file_bytes=int(sealed["bytes"]),
@@ -349,17 +522,17 @@ def bootstrap_single_operator_v5(
             )
             atomic_write_json(staging / RECEIPT_PATH, receipt, overwrite=False)
             staging.rename(target)
+            _fsync_directory(target.parent)
             created = True
         except BaseException:
             if staging.exists():
                 shutil.rmtree(staging)
             raise
-    _require(target.is_dir(), "v5 target dataset is not an ordinary directory")
     receipt, action = _verify_target(
         repository,
         target,
-        source_operator,
-        source_registry_artifact_sha256,
+        operator,
+        private_roster_artifact_sha256,
     )
     report: dict[str, Any] = {
         "schema_version": REPORT_SCHEMA_VERSION,
@@ -367,7 +540,13 @@ def bootstrap_single_operator_v5(
         "reviewed_main_commit": os.environ.get("GITHUB_SHA"),
         "created": created,
         "dataset_modified": created,
-        "source_registry_artifact_sha256": source_registry_artifact_sha256,
+        "private_identity_material_created": private_created,
+        "identity_initialization_mode": IDENTITY_INITIALIZATION_MODE,
+        "historical_registry_available": False,
+        "historical_registry_reused": False,
+        "identity_digest_continuity_claimed": False,
+        "bootstrap_implementation_sha256": receipt["bootstrap_implementation_sha256"],
+        "bootstrap_implementation_bytes": receipt["bootstrap_implementation_bytes"],
         "target_preacquisition_plan_id": receipt["target_preacquisition_plan_id"],
         "target_preacquisition_amendment_sha256": receipt[
             "target_preacquisition_amendment_sha256"
@@ -377,6 +556,7 @@ def bootstrap_single_operator_v5(
         "operator_ids": [OPERATOR_ID],
         "operator_roles": list(OPERATOR_ROLES),
         "independent_verifier_available": False,
+        "independent_preacquisition_attestation_claimed": False,
         "next_action": {
             "action_id": action["action_id"],
             "operator_role": action["operator_role"],
@@ -389,6 +569,11 @@ def bootstrap_single_operator_v5(
         "physical_command_sent": False,
         "registered_method_changed": False,
         "physical_evidence_increment": 0,
+        "claim_boundary": (
+            "A fresh owner-only HMAC identity was initialized for v5 because the "
+            "historical private identity material was unavailable. No historical "
+            "identity-digest continuity or independent attestation is claimed."
+        ),
     }
     report["report_sha256"] = _canonical_sha256(report, field="report_sha256")
     return report
@@ -397,7 +582,7 @@ def bootstrap_single_operator_v5(
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repository-root", type=Path, required=True)
-    parser.add_argument("--source-dataset-root", type=Path, required=True)
+    parser.add_argument("--private-identity-root", type=Path, required=True)
     parser.add_argument("--target-dataset-root", type=Path, required=True)
     parser.add_argument("--sealed-at-utc")
     parser.add_argument("--output", type=Path, required=True)
@@ -408,14 +593,13 @@ def main() -> int:
     arguments = _parser().parse_args()
     report = bootstrap_single_operator_v5(
         repository_root=arguments.repository_root,
-        source_dataset_root=arguments.source_dataset_root,
+        private_identity_root=arguments.private_identity_root,
         target_dataset_root=arguments.target_dataset_root,
         sealed_at_utc=arguments.sealed_at_utc,
     )
     arguments.output.parent.mkdir(parents=True, exist_ok=True)
-    encoded = json.dumps(report, indent=2, sort_keys=True, allow_nan=False)
-    arguments.output.write_text(encoded + "\n", encoding="utf-8")
-    print(encoded)
+    atomic_write_json(arguments.output, report, overwrite=True)
+    print(json.dumps(report, indent=2, sort_keys=True, allow_nan=False))
     return 0
 
 

--- a/tests/test_issue_command_concurrency.py
+++ b/tests/test_issue_command_concurrency.py
@@ -18,7 +18,7 @@ ISSUE_COMMAND_JOBS = {
     ),
     "bootstrap-single-operator-v5-self-hosted.yml": (
         "bootstrap",
-        "causal4d-single-operator-v5-bootstrap-${{ github.sha }}",
+        "causal4d-single-operator-v5-bootstrap-v2-${{ github.sha }}",
     ),
     "controlled-execution-campaign.yml": (
         "dispatch",

--- a/tests/test_self_hosted_v5_operator_scaffold.py
+++ b/tests/test_self_hosted_v5_operator_scaffold.py
@@ -203,9 +203,10 @@ def test_bootstrap_refuses_changed_private_roster(tmp_path: Path) -> None:
 def test_bootstrap_refuses_public_private_material(tmp_path: Path) -> None:
     _run(tmp_path)
     key = _private_root(tmp_path) / bootstrap.KEY_FILENAME
-    os.chmod(key, 0o644)
+    owner_mode = stat.S_IMODE(key.stat().st_mode)
+    key.chmod(owner_mode | stat.S_IRGRP)
 
-    with pytest.raises(ValueError, match="mode is 644, expected 600"):
+    with pytest.raises(ValueError, match="mode is 640, expected 600"):
         _run(tmp_path)
 
 

--- a/tests/test_self_hosted_v5_operator_scaffold.py
+++ b/tests/test_self_hosted_v5_operator_scaffold.py
@@ -2,17 +2,14 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
+import stat
 from pathlib import Path
 from types import ModuleType
 
 import pytest
 
-from causal4d.operator_registry import (
-    OPERATOR_REGISTRY_ARTIFACT_KIND,
-    OPERATOR_REGISTRY_PATH,
-    operator_registry_sha256,
-    operator_registry_template,
-)
+from causal4d.operator_registry import OPERATOR_REGISTRY_PATH
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -34,34 +31,8 @@ def _load_bootstrap() -> ModuleType:
 bootstrap = _load_bootstrap()
 
 
-def _source_dataset(tmp_path: Path) -> Path:
-    source = tmp_path / "source-v4"
-    registry_path = source / OPERATOR_REGISTRY_PATH
-    registry_path.parent.mkdir(parents=True)
-    protocol, v4 = bootstrap._load_v4(ROOT)
-    registry = operator_registry_template(protocol, v4)
-    registry.update(
-        {
-            "artifact_kind": OPERATOR_REGISTRY_ARTIFACT_KIND,
-            "status": "sealed",
-            "sealed_at_utc": "2026-08-11T10:00:00+00:00",
-            "sealed_by_operator_id": bootstrap.OPERATOR_ID,
-            "operators": [
-                {
-                    "operator_id": bootstrap.OPERATOR_ID,
-                    "person_identity_sha256": "1" * 64,
-                    "active": True,
-                    "roles": list(bootstrap.OPERATOR_ROLES),
-                }
-            ],
-        }
-    )
-    registry["artifact_sha256"] = operator_registry_sha256(registry)
-    registry_path.write_text(
-        json.dumps(registry, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
-    return source
+def _private_root(tmp_path: Path) -> Path:
+    return tmp_path / "private" / "operator-registry-v5"
 
 
 def _tree_snapshot(root: Path) -> dict[str, bytes]:
@@ -72,27 +43,44 @@ def _tree_snapshot(root: Path) -> dict[str, bytes]:
     }
 
 
-def test_bootstrap_creates_fresh_v5_tree_and_advances_to_registration(
-    tmp_path: Path,
-) -> None:
-    source = _source_dataset(tmp_path)
-    target = tmp_path / "fresh-v5"
-
-    report = bootstrap.bootstrap_single_operator_v5(
+def _run(tmp_path: Path, *, sealed_at_utc: str = "2026-08-26T01:00:00+00:00"):
+    return bootstrap.bootstrap_single_operator_v5(
         repository_root=ROOT,
-        source_dataset_root=source,
-        target_dataset_root=target,
-        sealed_at_utc="2026-08-26T01:00:00+00:00",
+        private_identity_root=_private_root(tmp_path),
+        target_dataset_root=tmp_path / "fresh-v5",
+        sealed_at_utc=sealed_at_utc,
     )
 
+
+def test_bootstrap_creates_fresh_owner_identity_and_advances_to_registration(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "fresh-v5"
+    private = _private_root(tmp_path)
+
+    report = _run(tmp_path)
+
+    assert report["schema_version"] == 2
     assert report["created"] is True
     assert report["dataset_modified"] is True
+    assert report["private_identity_material_created"] is True
+    assert report["identity_initialization_mode"] == "fresh_owner_hmac_v1"
+    assert report["historical_registry_available"] is False
+    assert report["historical_registry_reused"] is False
+    assert report["identity_digest_continuity_claimed"] is False
+    implementation = ROOT / bootstrap.IMPLEMENTATION_PATH
+    assert (
+        report["bootstrap_implementation_sha256"]
+        == bootstrap._sha256_file(implementation)[0]
+    )
+    assert report["bootstrap_implementation_bytes"] == implementation.stat().st_size
     assert report["target_preacquisition_plan_id"] == (
         "causal4d-sloth-preacquisition-v5-single-operator"
     )
     assert report["operator_ids"] == [bootstrap.OPERATOR_ID]
     assert report["operator_roles"] == list(bootstrap.OPERATOR_ROLES)
     assert report["independent_verifier_available"] is False
+    assert report["independent_preacquisition_attestation_claimed"] is False
     assert report["next_action"] == {
         "action_id": "complete_object_registration",
         "operator_role": "self_attesting_operator",
@@ -106,77 +94,150 @@ def test_bootstrap_creates_fresh_v5_tree_and_advances_to_registration(
     assert report["physical_evidence_increment"] == 0
 
     registry = json.loads((target / OPERATOR_REGISTRY_PATH).read_text(encoding="utf-8"))
-    assert registry["operators"][0]["operator_id"] == bootstrap.OPERATOR_ID
-    assert registry["operators"][0]["person_identity_sha256"] == "1" * 64
-    assert registry["operators"][0]["roles"] == list(bootstrap.OPERATOR_ROLES)
-    assert "independent_verifier" not in registry["operators"][0]["roles"]
+    operator = registry["operators"][0]
+    assert operator["operator_id"] == bootstrap.OPERATOR_ID
+    assert len(operator["person_identity_sha256"]) == 64
+    assert operator["roles"] == list(bootstrap.OPERATOR_ROLES)
+    assert "independent_verifier" not in operator["roles"]
 
     receipt = json.loads((target / bootstrap.RECEIPT_PATH).read_text(encoding="utf-8"))
+    assert receipt["schema_version"] == 2
+    assert receipt["identity_initialization_mode"] == "fresh_owner_hmac_v1"
+    assert receipt["historical_registry_available"] is False
+    assert receipt["historical_registry_reused"] is False
+    assert receipt["identity_digest_continuity_claimed"] is False
+    assert (
+        receipt["bootstrap_implementation_sha256"]
+        == report["bootstrap_implementation_sha256"]
+    )
+    assert receipt["bootstrap_implementation_bytes"] == implementation.stat().st_size
     assert receipt["independent_preacquisition_attestation_claimed"] is False
     assert receipt["physical_evidence_increment"] == 0
 
+    assert stat.S_IMODE(private.stat().st_mode) == 0o700
+    assert stat.S_IMODE((private / bootstrap.KEY_FILENAME).stat().st_mode) == 0o600
+    assert (
+        stat.S_IMODE((private / bootstrap.PRIVATE_ROSTER_FILENAME).stat().st_mode)
+        == 0o600
+    )
+    assert len((private / bootstrap.KEY_FILENAME).read_bytes()) == 32
+
+    serialized_report = json.dumps(report, sort_keys=True)
+    assert bootstrap.CANONICAL_PRINCIPAL not in serialized_report
+    assert "person_identity_sha256" not in serialized_report
+    assert str(private) not in serialized_report
+
 
 def test_bootstrap_is_idempotent_and_does_not_reseal(tmp_path: Path) -> None:
-    source = _source_dataset(tmp_path)
+    private = _private_root(tmp_path)
     target = tmp_path / "fresh-v5"
-    first = bootstrap.bootstrap_single_operator_v5(
-        repository_root=ROOT,
-        source_dataset_root=source,
-        target_dataset_root=target,
-        sealed_at_utc="2026-08-26T01:00:00+00:00",
-    )
-    snapshot = _tree_snapshot(target)
+    first = _run(tmp_path)
+    private_snapshot = _tree_snapshot(private)
+    target_snapshot = _tree_snapshot(target)
 
-    repeated = bootstrap.bootstrap_single_operator_v5(
-        repository_root=ROOT,
-        source_dataset_root=source,
-        target_dataset_root=target,
-        sealed_at_utc="2026-08-26T02:00:00+00:00",
-    )
+    repeated = _run(tmp_path, sealed_at_utc="2026-08-26T02:00:00+00:00")
 
     assert first["created"] is True
     assert repeated["created"] is False
     assert repeated["dataset_modified"] is False
-    assert _tree_snapshot(target) == snapshot
+    assert repeated["private_identity_material_created"] is False
+    assert _tree_snapshot(private) == private_snapshot
+    assert _tree_snapshot(target) == target_snapshot
     assert (
         repeated["target_registry_artifact_sha256"]
-        == (first["target_registry_artifact_sha256"])
+        == first["target_registry_artifact_sha256"]
     )
     assert (
         repeated["bootstrap_receipt_artifact_sha256"]
-        == (first["bootstrap_receipt_artifact_sha256"])
+        == first["bootstrap_receipt_artifact_sha256"]
     )
 
 
-def test_bootstrap_refuses_historical_tree_after_governed_work(
-    tmp_path: Path,
-) -> None:
-    source = _source_dataset(tmp_path)
-    (source / "object_registration.json").write_text("{}\n", encoding="utf-8")
+def test_bootstrap_refuses_partial_private_identity_root(tmp_path: Path) -> None:
+    private = _private_root(tmp_path)
+    private.mkdir(parents=True, mode=0o700)
+    key = private / bootstrap.KEY_FILENAME
+    key.write_bytes(b"1" * 32)
+    os.chmod(key, 0o600)
 
-    with pytest.raises(ValueError, match="contains governed evidence"):
-        bootstrap.bootstrap_single_operator_v5(
-            repository_root=ROOT,
-            source_dataset_root=source,
-            target_dataset_root=tmp_path / "fresh-v5",
-        )
+    with pytest.raises(ValueError, match="members differ"):
+        _run(tmp_path)
 
 
-def test_bootstrap_refuses_false_independent_role(tmp_path: Path) -> None:
-    source = _source_dataset(tmp_path)
-    registry_path = source / OPERATOR_REGISTRY_PATH
-    registry = json.loads(registry_path.read_text(encoding="utf-8"))
-    registry["operators"][0]["roles"].append("independent_verifier")
-    registry["operators"][0]["roles"].sort()
-    registry["artifact_sha256"] = operator_registry_sha256(registry)
-    registry_path.write_text(
-        json.dumps(registry, indent=2, sort_keys=True) + "\n",
+def test_bootstrap_refuses_invalid_private_key_length(tmp_path: Path) -> None:
+    _run(tmp_path)
+    target = tmp_path / "fresh-v5"
+    for path in sorted(target.rglob("*"), reverse=True):
+        if path.is_file():
+            path.unlink()
+        elif path.is_dir():
+            path.rmdir()
+    target.rmdir()
+    key = _private_root(tmp_path) / bootstrap.KEY_FILENAME
+    key.write_bytes(b"too-short")
+    os.chmod(key, 0o600)
+
+    with pytest.raises(ValueError, match="key length is invalid"):
+        _run(tmp_path)
+
+
+def test_bootstrap_refuses_changed_private_roster(tmp_path: Path) -> None:
+    _run(tmp_path)
+    target = tmp_path / "fresh-v5"
+    for path in sorted(target.rglob("*"), reverse=True):
+        if path.is_file():
+            path.unlink()
+        elif path.is_dir():
+            path.rmdir()
+    target.rmdir()
+    roster_path = _private_root(tmp_path) / bootstrap.PRIVATE_ROSTER_FILENAME
+    roster = json.loads(roster_path.read_text(encoding="utf-8"))
+    roster["assignments"][0]["roles"].append("independent_verifier")
+    roster_path.write_text(json.dumps(roster), encoding="utf-8")
+    os.chmod(roster_path, 0o600)
+
+    with pytest.raises(ValueError, match="differs from the fresh-owner lock"):
+        _run(tmp_path)
+
+
+def test_bootstrap_refuses_public_private_material(tmp_path: Path) -> None:
+    _run(tmp_path)
+    key = _private_root(tmp_path) / bootstrap.KEY_FILENAME
+    os.chmod(key, 0o644)
+
+    with pytest.raises(ValueError, match="mode is 644, expected 600"):
+        _run(tmp_path)
+
+
+def test_bootstrap_refuses_private_identity_symlink(tmp_path: Path) -> None:
+    private = _private_root(tmp_path)
+    private.parent.mkdir(mode=0o700)
+    key_target = tmp_path / "key-target"
+    key_target.write_bytes(b"1" * 32)
+    private.symlink_to(key_target)
+
+    with pytest.raises(ValueError, match="symlink"):
+        _run(tmp_path)
+
+
+def test_bootstrap_refuses_registry_private_identity_mismatch(tmp_path: Path) -> None:
+    _run(tmp_path)
+    key = _private_root(tmp_path) / bootstrap.KEY_FILENAME
+    key.write_bytes(b"2" * 32)
+    os.chmod(key, 0o600)
+
+    with pytest.raises(
+        ValueError, match="differs from the owner-only private identity"
+    ):
+        _run(tmp_path)
+
+
+def test_bootstrap_refuses_rerun_after_governed_work(tmp_path: Path) -> None:
+    _run(tmp_path)
+    (tmp_path / "fresh-v5" / "object_registration.json").write_text(
+        "{}\n",
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError, match="roles differ from the v5 one-person lock"):
-        bootstrap.bootstrap_single_operator_v5(
-            repository_root=ROOT,
-            source_dataset_root=source,
-            target_dataset_root=tmp_path / "fresh-v5",
-        )
+    with pytest.raises(ValueError, match="bootstrap is too late"):
+        _run(tmp_path)

--- a/tests/test_self_hosted_workflow_policy.py
+++ b/tests/test_self_hosted_workflow_policy.py
@@ -195,7 +195,7 @@ def _single_operator_v5_issue_main_errors(
             "github.event.issue.user.id == 6773539"
         ): "missing exact maintainer-ID authorization",
         (
-            "'[self-hosted] bootstrap Causal4D v5 operator scaffold'"
+            "'[self-hosted] bootstrap Causal4D v5 owner identity scaffold v2'"
         ): "missing exact trigger-title authorization",
     }
     for fragment, message in required.items():

--- a/tests/test_single_operator_v5_bootstrap_workflow.py
+++ b/tests/test_single_operator_v5_bootstrap_workflow.py
@@ -10,7 +10,8 @@ WORKFLOW = (
 )
 SCRIPT = ROOT / "scripts" / "ci" / "bootstrap_self_hosted_v5_operator_scaffold.py"
 SELF_HOSTED_REGISTRY = ROOT / ".github" / "self-hosted-jobs.json"
-TRIGGER = "[self-hosted] bootstrap Causal4D v5 operator scaffold"
+TRIGGER = "[self-hosted] bootstrap Causal4D v5 owner identity scaffold v2"
+REVOKED_TRIGGER = "[self-hosted] bootstrap Causal4D v5 operator scaffold"
 
 
 def _workflow_text() -> str:
@@ -26,6 +27,7 @@ def test_v5_bootstrap_has_one_exact_maintainer_issue_trigger() -> None:
     assert "github.event.issue.user.login == 'FlorianPfaff'" in text
     assert "github.event.issue.user.id == 6773539" in text
     assert f"'{TRIGGER}'" in text
+    assert REVOKED_TRIGGER not in text
     for forbidden in (
         "github.event.issue.body",
         "github.event.issue.labels",
@@ -35,17 +37,39 @@ def test_v5_bootstrap_has_one_exact_maintainer_issue_trigger() -> None:
         assert forbidden not in text
 
 
-def test_v5_bootstrap_uses_fresh_fixed_root_and_exact_wheel() -> None:
+def test_v5_bootstrap_uses_fixed_private_and_target_roots_and_exact_wheel() -> None:
     text = _workflow_text()
+    script = SCRIPT.read_text(encoding="utf-8")
 
-    assert ("/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1") in text
-    assert ("/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5") in text
+    assert "/mnt/lexar4tb/causal4d-physical/private/operator-registry-v5" in text
+    assert "/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5" in text
+    assert "--private-identity-root" in text
+    assert "--source-dataset-root" not in text
+    assert "source_dataset_root" not in script
     assert "scripts/ci/bootstrap_self_hosted_v5_operator_scaffold.py" in text
     assert '--repository-root "${GITHUB_WORKSPACE}"' in text
     assert "ref: ${{ github.sha }}" in text
     assert "persist-credentials: false" in text
     assert 'PYTHONPATH=""' in text
     assert "installed import" in text
+
+
+def test_v5_bootstrap_verifies_fresh_identity_claim_boundary() -> None:
+    text = _workflow_text()
+    script = SCRIPT.read_text(encoding="utf-8")
+
+    for field in (
+        "identity_initialization_mode",
+        "historical_registry_available",
+        "historical_registry_reused",
+        "identity_digest_continuity_claimed",
+        "independent_preacquisition_attestation_claimed",
+    ):
+        assert field in text
+        assert field in script
+    assert "fresh_owner_hmac_v1" in text
+    assert "historical identity-digest continuity" in text
+    assert "identity-digest continuity" in script
 
 
 def test_v5_bootstrap_upload_is_sanitized_and_nonphysical() -> None:
@@ -69,6 +93,8 @@ def test_v5_bootstrap_upload_is_sanitized_and_nonphysical() -> None:
         "operator_registry.json",
         "operator_registry.template.json",
         "single_operator_v5_bootstrap.json",
+        "operator-identity-hmac-v1.key",
+        "operator-principals-v1.json",
         "person_identity_sha256",
         "object_registration",
         "executions/",
@@ -109,5 +135,5 @@ def test_v5_bootstrap_is_registered_as_self_hosted() -> None:
     assert entry["authorization_model"] == "single-operator-v5-issue-main"
     assert entry["secrets_allowed"] is False
     assert entry["dataset_access"] == (
-        "registered-local-preacquisition-v5-scaffold-bootstrap"
+        "registered-local-preacquisition-v5-owner-identity-bootstrap"
     )


### PR DESCRIPTION
## Summary
- replace the vanished v4 source-tree dependency with an exactly-once owner-only HMAC identity bootstrap
- state explicitly that no historical identity-digest continuity or independent attestation is claimed
- bind the durable receipt to the v5 plan, registry, private-roster contract, and exact bootstrap implementation bytes
- revoke the legacy issue title and retain exact fallback to the physical object-registration boundary

## Verification
- focused bootstrap and workflow policy: 26 passed
- broader identity/readiness/registration suite: 87 passed
- full suite: 2,247 passed, 23 skipped; sole nested-pytest failure was the known Windows-temp capture error
- exact failed packaging test rerun with native POSIX temp: 1 passed
- Ruff, Ruff format, MyPy, and git diff checks pass

## Boundaries
- no target outcomes, device nodes, physical commands, or held-v8 artifacts accessed
- no scientific design, acquisition roster, split, mechanism gate, or registered method changed