### PR TITLE
Require contact approval before the slip pilot

### DIFF
--- a/docs/causal4d_preacquisition_next_action.md
+++ b/docs/causal4d_preacquisition_next_action.md
@@ -47,17 +47,18 @@ action from this sequence:
 3. scaffold and seal the operator identity registry;
 4. stop on malformed evidence, chronology violations, unexpected source-panel
    entries, or confirmatory collection that began before readiness;
-5. complete the fixed object registration, slip pilot, shared timebase, and
-   two-pass self-reviewed contact registration;
-6. acquire, safely stage, verify, self-review, and publish exactly the next
+5. complete the fixed object registration, then the authoritative two-pass
+   self-reviewed contact registration;
+6. complete the slip pilot and shared timebase calibration;
+7. acquire, safely stage, verify, self-review, and publish exactly the next
    registered source-panel execution;
-7. seal source-panel completion, actuator synchronization, support/gravity, and
+8. seal source-panel completion, actuator synchronization, support/gravity, and
    nonconfirmatory end-to-end dry-run gates;
-8. seal the exact clean method freeze;
-9. self-attest the freeze with the registered freezer;
-10. seal the deployed software environment;
-11. run the final hash-verified readiness gate; and
-12. validate the freeze and begin only the first registered confirmatory session.
+9. seal the exact clean method freeze;
+10. self-attest the freeze with the registered freezer;
+11. seal the deployed software environment;
+12. run the final hash-verified readiness gate; and
+13. validate the freeze and begin only the first registered confirmatory session.
 
 Operator-registry scaffolding is proposed only when both the sealed registry and its
 registered draft template are absent. When the sealed registry is missing but a

--- a/docs/object_registration_operator.md
+++ b/docs/object_registration_operator.md
@@ -41,3 +41,24 @@ prescribe a serialization format for canonical node sets.
 After sealing, recompute the registered next action with file-hash verification.
 Do not select or revise node sets using source-panel or confirmatory outcome
 quality.
+
+## Contact approval remains separate
+
+`object_registration.json` is the compact fixed-object and canonical-node-set
+index. It is not the authoritative physical contact approval. Before the slip
+pilot, complete `contact_registration.json` as a schema-4
+`PhysicalContactRegistration` with the registered weighted patches, multiview
+overlays, rejected alternatives, frame and support geometry, and two strictly
+chronological review passes by the registered v5 self-attesting operator.
+
+The registered next-action decision must therefore advance in this order:
+
+```text
+object_registration.json
+-> contact_registration.json
+-> slip_pilot.json
+```
+
+Under v5, this is disclosed single-operator self-review; it is not an
+independent-attestation claim. The slip pilot must not start while the
+authoritative contact registration is absent, invalid, or unapproved.

--- a/src/causal4d/preacquisition_next_action.py
+++ b/src/causal4d/preacquisition_next_action.py
@@ -38,6 +38,12 @@ _MANUAL = {
         "object_registration.json",
         False,
     ),
+    "contact_registration": (
+        "Publish the independently reviewed contact registration",
+        "contact_registration.staging.json",
+        "contact_registration.json",
+        False,
+    ),
     "slip_pilot": (
         "Complete the preregistered slip go/no-go pilot",
         "slip_pilot.template.json",
@@ -49,12 +55,6 @@ _MANUAL = {
         "timebase_calibration.template.json",
         "timebase_calibration.json",
         True,
-    ),
-    "contact_registration": (
-        "Publish the independently reviewed contact registration",
-        "contact_registration.staging.json",
-        "contact_registration.json",
-        False,
     ),
 }
 _GATE = {

--- a/tests/test_preacquisition_next_action.py
+++ b/tests/test_preacquisition_next_action.py
@@ -266,9 +266,7 @@ def test_contact_registration_precedes_slip_pilot() -> None:
     readiness["prerequisites"]["contact_registration"] = _prerequisite(
         present=False, valid=False
     )
-    readiness["prerequisites"]["slip_pilot"] = _prerequisite(
-        present=False, valid=False
-    )
+    readiness["prerequisites"]["slip_pilot"] = _prerequisite(present=False, valid=False)
     readiness["missing_prerequisites"] = ["slip_pilot", "contact_registration"]
 
     decision = _derive(readiness, _source_panel())

--- a/tests/test_preacquisition_next_action.py
+++ b/tests/test_preacquisition_next_action.py
@@ -260,6 +260,26 @@ def test_manual_prerequisite_names_exact_paths() -> None:
     assert "protocol real status" in action["completion_check_text"]
 
 
+def test_contact_registration_precedes_slip_pilot() -> None:
+    readiness = _readiness()
+    _enable_single_operator_v5(readiness)
+    readiness["prerequisites"]["contact_registration"] = _prerequisite(
+        present=False, valid=False
+    )
+    readiness["prerequisites"]["slip_pilot"] = _prerequisite(
+        present=False, valid=False
+    )
+    readiness["missing_prerequisites"] = ["slip_pilot", "contact_registration"]
+
+    decision = _derive(readiness, _source_panel())
+
+    action = decision["action"]
+    assert action["action_id"] == "complete_contact_registration"
+    assert action["operator_role"] == "self_attesting_operator"
+    assert action["physical_acquisition_required"] is False
+    assert action["target_outcomes_permitted"] is False
+
+
 def test_source_panel_action_binds_exact_registered_execution() -> None:
     readiness = _readiness()
     source = _source_panel(complete=False)


### PR DESCRIPTION
## Summary
- make the registered next-action sequence require schema-4 contact registration before the slip pilot
- add a v5 regression test for the fail-closed ordering
- clarify the distinction between the compact object index and authoritative contact approval

## Verification
- 109 broader pre-acquisition/real-evidence tests passed
- 35 focused next-action/operator-flow/contact-registration tests passed
- Ruff passed on changed Python files
- synthetic rehearsal now emits complete_contact_registration before complete_slip_pilot

This changes no frozen protocol, thresholds, split, or target boundary.