### PR TITLE
Enforce the preregistered reset mode-zero audit

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,7 @@ another document.
 - [Pre-acquisition next-action derivation](causal4d_preacquisition_next_action.md)
 - [Next-action packet](causal4d_preacquisition_next_action_packet.md)
 - [Next-action validation](causal4d_preacquisition_next_action_validation.md)
+- [Fresh-reset mode-0 cross-check](causal4d_reset_mode0_pilot.md)
 - [Self-hosted pre-acquisition automation](self_hosted_preacquisition_automation.md)
 
 ### Frozen amendment lineage

--- a/docs/causal4d_reset_mode0_pilot.md
+++ b/docs/causal4d_reset_mode0_pilot.md
@@ -1,0 +1,86 @@
+# Fresh-reset mode-0 cross-check
+
+The v5 pre-acquisition amendment preregisters a scale check for the released
+`single_lift` state result. This check is descriptive and target-blind. It asks
+whether fresh-reset variation in graph mode zero is commensurate with the
+released 13.736 mm per-node vector RMS correction. It does not select a model,
+change the slip gate, or establish that reset error caused the released result.
+
+Run the check only on fresh-reset pilot sessions, before any confirmatory
+execution. Positions must remain in the locked world frame; do not align each
+reset independently before supplying the input.
+
+## Input contract
+
+The input NPZ contains:
+
+```text
+session_ids                       (reset,) string
+reference_positions_world_m       (node, 3) float
+reset_positions_world_m           (reset, node, 3) float
+graph_mode0                        (node,) float
+registration_uncertainty_95_m      scalar float
+world_frame_id                     scalar string
+units                              scalar string, exactly "m"
+positions_are_pre_alignment        scalar bool, true
+fresh_reset_mask                   (reset,) bool, all true
+data_role                          scalar string,
+                                   "preacquisition_fresh_reset_pilot"
+target_outcomes_used               scalar bool, false
+object_registration_sha256         scalar SHA-256
+contact_registration_sha256        scalar SHA-256
+```
+
+At least five unique fresh-reset sessions are required, matching the minimum
+slip-pilot execution count. The node count must equal the registered 6,895-node
+released reference. The supplied mode must match the released basis's constant
+mode-zero direction up to scale and sign; an arbitrary or nonconstant vector is
+rejected. The tool also verifies that the frozen initial mode energy divided by
+6,895 yields the frozen per-node RMS exactly. Projection uses the unweighted
+Euclidean node inner product.
+
+## Frozen estimator
+
+For each reset, the tool projects the locked-frame displacement onto mode zero
+and computes per-node vector RMS. It takes the empirical 95th percentile using
+NumPy's conservative `higher` order-statistic rule, then adds the preregistered
+95% registration uncertainty:
+
+```text
+pilot statistic
+= higher-quantile-0.95(fresh-reset mode-0 RMS)
++ registration uncertainty 95% bound
+```
+
+The reset-scale explanation is weakened when the released 13.736 mm reference
+is greater than twice this statistic. Otherwise the result is only
+`scale_compatible`; compatibility never confirms reset error as the cause.
+
+The report also records, per session, locked-frame translation, the best-fit
+SE(3) component, the post-SE(3) residual, and its remaining mode-0 component.
+These are secondary decompositions and cannot revise the registered decision.
+
+## Command
+
+```bash
+causal4d protocol reset-mode0-crosscheck \
+  /opt/causal4d-frozen \
+  /data/causal4d-sloth-multi-action-v1 \
+  /data/causal4d-sloth-multi-action-v1/preacquisition/reset-pilot.npz \
+  /data/causal4d-sloth-multi-action-v1/preacquisition/reset-mode0-crosscheck.json
+```
+
+The command validates the complete canonical protocol-v2-v3-v4-v5 chain,
+then validates approved schema-4 `object_registration.json` and
+`contact_registration.json`, including their source-file hashes and registered
+two-pass review. The NPZ must name those exact artifact digests. The command
+hashes the NPZ and its principal arrays and publishes the JSON exactly once. It
+rejects target use, post-alignment positions, non-fresh resets, duplicate
+session IDs, nonfinite arrays, a wrong node count, registration mismatch, or
+replacement of an existing result.
+
+For v5 readiness this report is a required component of pilot completion. The
+operator flow cannot advance to the 12-run source panel until it has replayed
+the registered NPZ and reproduced the report exactly. A missing report remains
+an incomplete prerequisite; a report, registration, or NPZ mismatch is invalid
+evidence and stops the workflow.

--- a/src/causal4d/cli/command_registry.py
+++ b/src/causal4d/cli/command_registry.py
@@ -430,6 +430,13 @@ COMMANDS = (
         removed_in=REMOVED_EXECUTABLE_VERSION,
     ),
     CommandSpec(
+        route=("protocol", "reset-mode0-crosscheck"),
+        target="causal4d.cli.reset_mode0_crosscheck:main",
+        summary="Evaluate the preregistered fresh-reset mode-zero scale check.",
+        lifecycle="stable",
+        claim_bearing=True,
+    ),
+    CommandSpec(
         route=("protocol", "contact-registration"),
         target="causal4d.cli.contact_registration:main",
         summary="Create or validate registered physical contact geometry.",

--- a/src/causal4d/cli/reset_mode0_crosscheck.py
+++ b/src/causal4d/cli/reset_mode0_crosscheck.py
@@ -1,0 +1,70 @@
+"""Evaluate the preregistered fresh-reset graph-mode-zero scale cross-check."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+from causal4d.acquisition_flight_common import _assert_no_symlink_components
+from causal4d.preacquisition_readiness_contracts import (
+    load_registered_preacquisition_chain,
+)
+from causal4d.reset_mode0_crosscheck import (
+    RESET_MODE0_ARTIFACT_PATH,
+    RESET_MODE0_INPUT_PATH,
+    evaluate_reset_mode0_npz,
+    load_reset_registration_binding,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("repository_root")
+    parser.add_argument("dataset_root")
+    parser.add_argument("input_npz")
+    parser.add_argument("output_json")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        dataset_root = Path(args.dataset_root).resolve()
+        _assert_no_symlink_components(Path(args.dataset_root), name="dataset root")
+        _assert_no_symlink_components(Path(args.input_npz), name="reset pilot NPZ")
+        _assert_no_symlink_components(Path(args.output_json), name="mode-0 output")
+        if not dataset_root.is_dir():
+            raise ValueError("dataset root is invalid")
+        input_path = Path(args.input_npz).resolve()
+        output_path = Path(args.output_json).resolve()
+        if input_path != (dataset_root / RESET_MODE0_INPUT_PATH).resolve():
+            raise ValueError("input NPZ differs from the registered reset-pilot path")
+        if output_path != (dataset_root / RESET_MODE0_ARTIFACT_PATH).resolve():
+            raise ValueError("output JSON differs from the registered mode-0 path")
+        protocol, _, _, preacquisition_v5 = load_registered_preacquisition_chain(
+            args.repository_root
+        )
+        registration_binding = load_reset_registration_binding(
+            protocol,
+            preacquisition_v5,
+            args.dataset_root,
+        )
+        result = evaluate_reset_mode0_npz(
+            protocol,
+            preacquisition_v5,
+            args.input_npz,
+            args.output_json,
+            registration_binding=registration_binding,
+            source_path_label=RESET_MODE0_INPUT_PATH,
+        )
+    except (FileExistsError, OSError, KeyError, TypeError, ValueError) as error:
+        print(json.dumps({"passed": False, "error": str(error)}, indent=2))
+        return 2
+    print(json.dumps({"passed": True, **result}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d/preacquisition_next_action.py
+++ b/src/causal4d/preacquisition_next_action.py
@@ -442,9 +442,8 @@ def _derive_action(
                     )
             return action
 
-    if (
-        "reset_mode0_crosscheck" in readiness.get("prerequisites", {})
-        and _pending(readiness, "prerequisites", "reset_mode0_crosscheck")
+    if "reset_mode0_crosscheck" in readiness.get("prerequisites", {}) and _pending(
+        readiness, "prerequisites", "reset_mode0_crosscheck"
     ):
         input_path = str(root / RESET_MODE0_INPUT_PATH)
         output_path = str(root / RESET_MODE0_ARTIFACT_PATH)
@@ -675,9 +674,7 @@ def derive_preacquisition_next_action(
         ),
     }
     for name, value in identity.items():
-        _require(
-            isinstance(value, str) and bool(value), f"readiness {name} is missing"
-        )
+        _require(isinstance(value, str) and bool(value), f"readiness {name} is missing")
         _require(value == source_panel.get(name), f"status {name} values differ")
     _require(
         source_panel.get("target_outcomes_used") is False,

--- a/src/causal4d/preacquisition_next_action.py
+++ b/src/causal4d/preacquisition_next_action.py
@@ -22,6 +22,10 @@ from causal4d.preacquisition_readiness_contracts import (
     load_registered_preacquisition_chain,
 )
 from causal4d.preacquisition_source_panel_control import build_source_panel_status
+from causal4d.reset_mode0_crosscheck import (
+    RESET_MODE0_ARTIFACT_PATH,
+    RESET_MODE0_INPUT_PATH,
+)
 
 NEXT_ACTION_SCHEMA_VERSION = 1
 NEXT_ACTION_ARTIFACT_KIND = "Causal4DPreacquisitionNextAction"
@@ -427,7 +431,7 @@ def _derive_action(
             automatable=True,
         )
 
-    for name in _MANUAL:
+    for name in ("object_registration", "contact_registration", "slip_pilot"):
         if _pending(readiness, "prerequisites", name):
             action = _manual_action(name, repository, dataset)
             if single_operator:
@@ -438,9 +442,48 @@ def _derive_action(
                     )
             return action
 
+    if (
+        "reset_mode0_crosscheck" in readiness.get("prerequisites", {})
+        and _pending(readiness, "prerequisites", "reset_mode0_crosscheck")
+    ):
+        input_path = str(root / RESET_MODE0_INPUT_PATH)
+        output_path = str(root / RESET_MODE0_ARTIFACT_PATH)
+        input_present = Path(input_path).is_file()
+        return _action(
+            "run_reset_mode0_crosscheck",
+            (
+                "Run the preregistered fresh-reset mode-0 cross-check"
+                if input_present
+                else "Prepare the fresh-reset NPZ and run the mode-0 cross-check"
+            ),
+            "acquisition_operator",
+            category="preacquisition_analysis",
+            command=_cmd(
+                "protocol",
+                "reset-mode0-crosscheck",
+                repository,
+                dataset,
+                input_path,
+                output_path,
+            ),
+            completion=next_check,
+            inputs=[
+                input_path,
+                str(root / "object_registration.json"),
+                str(root / "contact_registration.json"),
+            ],
+            outputs=[output_path],
+            blockers=[] if input_present else ["fresh_reset_pilot_npz_missing"],
+            automatable=input_present,
+        )
+
+    if _pending(readiness, "prerequisites", "timebase_calibration"):
+        return _manual_action("timebase_calibration", repository, dataset)
+
     if source.get("complete") is not True:
         execution = source.get("next_execution")
-        _require(isinstance(execution, Mapping), "next source execution is missing")
+        if not isinstance(execution, Mapping):
+            raise ValueError("next source execution is missing")
         execution_id = str(execution["execution_id"])
         staging = str(root / "staging" / f"{execution_id}.json")
         return _action(
@@ -632,7 +675,9 @@ def derive_preacquisition_next_action(
         ),
     }
     for name, value in identity.items():
-        _require(isinstance(value, str) and value, f"readiness {name} is missing")
+        _require(
+            isinstance(value, str) and bool(value), f"readiness {name} is missing"
+        )
         _require(value == source_panel.get(name), f"status {name} values differ")
     _require(
         source_panel.get("target_outcomes_used") is False,

--- a/src/causal4d/preacquisition_readiness.py
+++ b/src/causal4d/preacquisition_readiness.py
@@ -25,6 +25,7 @@ from causal4d.preacquisition_readiness_contracts import (
     SOURCE_PANEL_MANIFEST_PATH as SOURCE_PANEL_MANIFEST_PATH,
     SOURCE_PANEL_MANIFEST_TEMPLATE_PATH,
     _parse_utc_timestamp,
+    _require,
     gate_evidence_sha256 as gate_evidence_sha256,
     gate_evidence_template,
     load_registered_preacquisition_chain,
@@ -36,6 +37,7 @@ from causal4d.real_evidence_contract_v2 import build_real_evidence_status
 from causal4d.registered_real_analysis_prerequisite import (
     validate_registered_real_analysis_prerequisite,
 )
+from causal4d.reset_mode0_crosscheck import load_reset_mode0_crosscheck_prerequisite
 
 
 def _publish_template(
@@ -169,6 +171,12 @@ def evaluate_preacquisition_readiness(
     prerequisites = {
         str(name): dict(value) for name, value in real_status["prerequisites"].items()
     }
+    require_reset_mode0_crosscheck = "prospective_mode0_reset_crosscheck" in v4
+    if require_reset_mode0_crosscheck:
+        _require(
+            "reset_mode0_crosscheck" in prerequisites,
+            "v5 readiness is missing the reset mode-0 prerequisite",
+        )
     if require_registered_analysis:
         prerequisites["registered_analysis"] = (
             validate_registered_real_analysis_prerequisite(
@@ -211,6 +219,7 @@ def evaluate_preacquisition_readiness(
         "acquisition_schedule",
         "object_registration",
         "slip_pilot",
+        *(() if not require_reset_mode0_crosscheck else ("reset_mode0_crosscheck",)),
         "timebase_calibration",
         "contact_registration",
         "operator_registry",
@@ -375,6 +384,10 @@ def evaluate_preacquisition_readiness(
         flags["primary_analysis_registered"] = prerequisites["registered_analysis"].get(
             "valid", False
         )
+    if require_reset_mode0_crosscheck:
+        flags["reset_mode0_crosscheck_completed"] = prerequisites[
+            "reset_mode0_crosscheck"
+        ].get("valid", False)
     ready = not blockers and all(flags.values())
     flags["first_confirmatory_execution_allowed"] = ready
     valid = (
@@ -447,6 +460,14 @@ def build_preacquisition_readiness(
         dataset_root,
         repository_root=repository_root,
         verify_file_hashes=verify_file_hashes,
+    )
+    real_status["prerequisites"]["reset_mode0_crosscheck"] = (
+        load_reset_mode0_crosscheck_prerequisite(
+            protocol,
+            v4,
+            dataset_root,
+            verify_file_hashes=verify_file_hashes,
+        )
     )
     return evaluate_preacquisition_readiness(
         protocol,

--- a/src/causal4d/preacquisition_source_panel_control.py
+++ b/src/causal4d/preacquisition_source_panel_control.py
@@ -28,6 +28,9 @@ from causal4d.preacquisition_readiness_contracts import (
 from causal4d.preacquisition_source_validation import (
     _validate_source_execution_manifest,
 )
+from causal4d.reset_mode0_crosscheck import (
+    load_reset_mode0_crosscheck_prerequisite,
+)
 
 SOURCE_PANEL_STATUS_SCHEMA_VERSION = 1
 SOURCE_PANEL_STATUS_ARTIFACT_KIND = "Causal4DSourcePanelStatus"
@@ -60,9 +63,11 @@ def _registered_source_executions(
 ) -> list[dict[str, Any]]:
     expected_ids, expected_sessions = _expected_source_panel(v2)
     panel = v2.get("preacquisition_signature_panel")
-    _require(isinstance(panel, Mapping), "source-panel registration is missing")
+    if not isinstance(panel, Mapping):
+        raise ValueError("source-panel registration is missing")
     raw_executions = panel.get("executions")
-    _require(isinstance(raw_executions, list), "source-panel executions are missing")
+    if not isinstance(raw_executions, list):
+        raise ValueError("source-panel executions are missing")
     executions = [dict(value) for value in raw_executions]
     _require(
         [str(value.get("execution_id")) for value in executions] == expected_ids,
@@ -77,21 +82,19 @@ def _registered_source_executions(
 
 def _registered_profiles(v2: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
     panel = v2.get("preacquisition_signature_panel")
-    _require(isinstance(panel, Mapping), "source-panel registration is missing")
+    if not isinstance(panel, Mapping):
+        raise ValueError("source-panel registration is missing")
     raw_profiles = panel.get("profiles")
-    _require(isinstance(raw_profiles, list), "source-panel profiles are missing")
+    if not isinstance(raw_profiles, list):
+        raise ValueError("source-panel profiles are missing")
     profiles: dict[str, dict[str, Any]] = {}
     for index, value in enumerate(raw_profiles):
-        _require(
-            isinstance(value, Mapping),
-            f"source-panel profile {index} is invalid",
-        )
+        if not isinstance(value, Mapping):
+            raise ValueError(f"source-panel profile {index} is invalid")
         profile = dict(value)
         identifier = profile.get("id")
-        _require(
-            isinstance(identifier, str) and bool(identifier),
-            f"source-panel profile {index} lacks an id",
-        )
+        if not isinstance(identifier, str) or not identifier:
+            raise ValueError(f"source-panel profile {index} lacks an id")
         _require(
             identifier not in profiles,
             f"duplicate source-panel profile: {identifier}",
@@ -375,6 +378,18 @@ def publish_source_panel_manifest(
 
     protocol, _, _, v4 = load_registered_preacquisition_chain(repository_root)
     root = _resolved_dataset_root(dataset_root)
+    if "prospective_mode0_reset_crosscheck" in v4:
+        reset_crosscheck = load_reset_mode0_crosscheck_prerequisite(
+            protocol,
+            v4,
+            root,
+            verify_file_hashes=True,
+        )
+        _require(
+            reset_crosscheck.get("valid") is True,
+            "source-panel publication requires the valid reset mode-0 cross-check: "
+            f"{reset_crosscheck.get('error')}",
+        )
     status_before = build_source_panel_status(
         repository_root,
         root,
@@ -383,7 +398,8 @@ def publish_source_panel_manifest(
     _require(status_before["valid"] is True, "source-panel status is invalid")
     _require(status_before["complete"] is False, "source panel is already complete")
     next_execution = status_before.get("next_execution")
-    _require(isinstance(next_execution, Mapping), "source panel has no next execution")
+    if not isinstance(next_execution, Mapping):
+        raise ValueError("source panel has no next execution")
     _require(
         next_execution.get("template_present") is True
         and next_execution.get("template_valid") is True,

--- a/src/causal4d/reset_mode0_crosscheck.py
+++ b/src/causal4d/reset_mode0_crosscheck.py
@@ -1,0 +1,624 @@
+"""Prospective reset-scale cross-check for the registered graph mode zero."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+
+from causal4d import real_evidence_common
+from causal4d.acquisition_flight_common import _assert_no_symlink_components
+from causal4d.atomic_io import atomic_write_json
+from causal4d.contact_registration import (
+    SINGLE_OPERATOR_CONTACT_REGISTRATION_SCHEMA_VERSION,
+    SINGLE_OPERATOR_REVIEW_POLICY,
+)
+from causal4d.preacquisition_protocol_v5 import (
+    governance_allows_single_operator,
+)
+
+
+RESET_MODE0_CROSSCHECK_SCHEMA_VERSION = 1
+RESET_MODE0_CROSSCHECK_ARTIFACT_KIND = "Causal4DResetMode0Crosscheck"
+RESET_MODE0_INPUT_ROLE = "preacquisition_fresh_reset_pilot"
+RESET_MODE0_QUANTILE_METHOD: Literal["higher"] = "higher"
+RESET_MODE0_INPUT_PATH = "preacquisition/reset-pilot.npz"
+RESET_MODE0_ARTIFACT_PATH = "preacquisition/reset-mode0-crosscheck.json"
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _is_sha256(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _scalar_text(values: Any, name: str) -> str:
+    array = np.asarray(values)
+    _require(array.shape == (), f"{name} must be a scalar string")
+    value = array.item()
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+    _require(isinstance(value, str) and bool(value.strip()), f"{name} is invalid")
+    return str(value).strip()
+
+
+def _validated_registration_binding(binding: Mapping[str, Any]) -> dict[str, Any]:
+    required = {
+        "object_registration_sha256",
+        "contact_registration_sha256",
+        "physical_instance_serial",
+        "twin_geometry_sha256",
+        "contact_registration_schema_version",
+        "review_policy",
+        "source_file_hashes_verified",
+    }
+    _require(set(binding) == required, "registration binding fields are invalid")
+    _require(
+        _is_sha256(binding["object_registration_sha256"]),
+        "object registration digest is invalid",
+    )
+    _require(
+        _is_sha256(binding["contact_registration_sha256"]),
+        "contact registration digest is invalid",
+    )
+    _require(
+        _is_sha256(binding["twin_geometry_sha256"]),
+        "twin geometry digest is invalid",
+    )
+    serial = binding["physical_instance_serial"]
+    _require(
+        isinstance(serial, str) and bool(serial.strip()),
+        "physical instance serial is invalid",
+    )
+    _require(
+        binding["contact_registration_schema_version"]
+        == SINGLE_OPERATOR_CONTACT_REGISTRATION_SCHEMA_VERSION,
+        "reset pilot requires approved schema-4 contact registration",
+    )
+    _require(
+        binding["review_policy"] == SINGLE_OPERATOR_REVIEW_POLICY,
+        "reset pilot requires the registered two-pass review policy",
+    )
+    _require(
+        binding["source_file_hashes_verified"] is True,
+        "registration source files were not hash-verified",
+    )
+    return {
+        "object_registration_sha256": str(binding["object_registration_sha256"]),
+        "contact_registration_sha256": str(binding["contact_registration_sha256"]),
+        "physical_instance_serial": serial.strip(),
+        "twin_geometry_sha256": str(binding["twin_geometry_sha256"]),
+        "contact_registration_schema_version": int(
+            binding["contact_registration_schema_version"]
+        ),
+        "review_policy": str(binding["review_policy"]),
+        "source_file_hashes_verified": True,
+    }
+
+
+def load_reset_registration_binding(
+    protocol: Mapping[str, Any],
+    preacquisition_v5: Mapping[str, Any],
+    dataset_root: str | Path,
+) -> dict[str, Any]:
+    """Validate and bind only the approved physical-registration artifacts."""
+
+    root = Path(dataset_root)
+    object_result, simple = (
+        real_evidence_common._validate_object_registration_prerequisite(
+            protocol,
+            root,
+            root / "object_registration.json",
+            verify_file_hashes=True,
+        )
+    )
+    _require(
+        object_result.get("valid") is True and simple is not None,
+        f"object registration prerequisite failed: {object_result.get('error')}",
+    )
+    require_single_operator_review = governance_allows_single_operator(
+        preacquisition_v5
+    )
+    _require(require_single_operator_review, "reset pilot requires v5 governance")
+    contact_result, physical = (
+        real_evidence_common._validate_contact_registration_prerequisite(
+            protocol,
+            root,
+            root / "contact_registration.json",
+            simple_registration=simple,
+            simple_registration_sha256=str(object_result["sha256"]),
+            verify_file_hashes=True,
+            require_single_operator_review=True,
+        )
+    )
+    _require(
+        contact_result.get("valid") is True and physical is not None,
+        f"contact registration prerequisite failed: {contact_result.get('error')}",
+    )
+    return _validated_registration_binding(
+        {
+            "object_registration_sha256": object_result["sha256"],
+            "contact_registration_sha256": contact_result["sha256"],
+            "physical_instance_serial": simple["object_instance_serial"],
+            "twin_geometry_sha256": simple["phystwin_model_sha256"],
+            "contact_registration_schema_version": contact_result["schema_version"],
+            "review_policy": contact_result["review_policy"],
+            "source_file_hashes_verified": True,
+        }
+    )
+
+
+def _sha256_file(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    byte_count = 0
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+            byte_count += len(block)
+    return digest.hexdigest(), byte_count
+
+
+def _artifact_id(payload: Mapping[str, Any]) -> str:
+    canonical = dict(payload)
+    canonical.pop("artifact_id", None)
+    encoded = json.dumps(
+        canonical,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _array_sha256(values: np.ndarray) -> str:
+    array = np.ascontiguousarray(values)
+    descriptor = json.dumps(
+        {"dtype": array.dtype.str, "shape": list(array.shape)},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(descriptor + b"\0" + array.tobytes(order="C")).hexdigest()
+
+
+def _finite_array(values: Any, shape: tuple[int | None, ...], name: str) -> np.ndarray:
+    result = np.asarray(values, dtype=np.float64)
+    _require(result.ndim == len(shape), f"{name} has the wrong rank")
+    for axis, expected in enumerate(shape):
+        if expected is not None:
+            _require(result.shape[axis] == expected, f"{name} has the wrong shape")
+    _require(bool(np.all(np.isfinite(result))), f"{name} must be finite")
+    return result
+
+
+def _session_ids(values: Sequence[object], count: int) -> list[str]:
+    result: list[str] = []
+    for value in values:
+        if isinstance(value, bytes):
+            value = value.decode("utf-8")
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError("session id is invalid")
+        result.append(value.strip())
+    _require(len(result) == count, "session_ids does not match reset count")
+    _require(len(set(result)) == len(result), "session_ids contains duplicates")
+    return result
+
+
+def _vector_rms(values: np.ndarray) -> float:
+    return float(np.sqrt(np.mean(np.sum(np.square(values), axis=-1))))
+
+
+def _mode_component(displacement: np.ndarray, mode: np.ndarray) -> np.ndarray:
+    unit = mode / np.linalg.norm(mode)
+    coefficient = np.einsum("n,snd->sd", unit, displacement)
+    return np.einsum("n,sd->snd", unit, coefficient)
+
+
+def _best_fit_se3(
+    reference: np.ndarray, observed: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    reference_center = np.mean(reference, axis=0)
+    observed_center = np.mean(observed, axis=0)
+    centered_reference = reference - reference_center
+    centered_observed = observed - observed_center
+    left, _, right_t = np.linalg.svd(centered_reference.T @ centered_observed)
+    rotation = right_t.T @ left.T
+    if np.linalg.det(rotation) < 0.0:
+        right_t = right_t.copy()
+        right_t[-1] *= -1.0
+        rotation = right_t.T @ left.T
+    transformed = centered_reference @ rotation.T + observed_center
+    return transformed, rotation
+
+
+def evaluate_reset_mode0_crosscheck(
+    protocol: Mapping[str, Any],
+    preacquisition_v5: Mapping[str, Any],
+    *,
+    session_ids: Sequence[object],
+    reference_positions_world_m: Any,
+    reset_positions_world_m: Any,
+    graph_mode0: Any,
+    registration_uncertainty_95_m: float,
+    world_frame_id: str,
+) -> dict[str, Any]:
+    """Evaluate the locked reset-scale hypothesis without action outcomes."""
+
+    reference = _finite_array(
+        reference_positions_world_m,
+        (None, 3),
+        "reference_positions_world_m",
+    )
+    resets = _finite_array(
+        reset_positions_world_m,
+        (None, reference.shape[0], 3),
+        "reset_positions_world_m",
+    )
+    mode = _finite_array(graph_mode0, (reference.shape[0],), "graph_mode0")
+    mode_norm = float(np.linalg.norm(mode))
+    _require(mode_norm > 0.0, "graph_mode0 has zero norm")
+    constant_mode = np.full(reference.shape[0], 1.0 / np.sqrt(reference.shape[0]))
+    raw_constant_alignment = abs(float(np.dot(mode / mode_norm, constant_mode)))
+    constant_alignment = min(1.0, raw_constant_alignment)
+    _require(
+        bool(np.isclose(raw_constant_alignment, 1.0, atol=1e-10, rtol=0.0)),
+        "graph_mode0 does not match the registered constant mode-zero direction",
+    )
+    _require(
+        isinstance(world_frame_id, str) and bool(world_frame_id.strip()),
+        "world_frame_id is missing",
+    )
+    uncertainty = float(registration_uncertainty_95_m)
+    _require(
+        np.isfinite(uncertainty) and uncertainty >= 0.0,
+        "registration_uncertainty_95_m is invalid",
+    )
+
+    identifiers = _session_ids(session_ids, resets.shape[0])
+    minimum_resets = int(protocol["slip_activation_gate"]["minimum_pilot_executions"])
+    _require(len(identifiers) >= minimum_resets, "too few fresh-reset sessions")
+
+    crosscheck = preacquisition_v5["prospective_mode0_reset_crosscheck"]
+    released = crosscheck["released_reference"]
+    _require(
+        reference.shape[0] == int(released["object_node_count"]),
+        "reset node count differs from the registered mode-0 reference",
+    )
+    released_rms = float(released["per_node_vector_rms_m"])
+    initial_mode_energy = float(released["initial_mode_energy_m2"])
+    _require(
+        bool(np.isfinite(initial_mode_energy)) and initial_mode_energy > 0.0,
+        "released mode-0 energy is invalid",
+    )
+    energy_derived_rms = float(np.sqrt(initial_mode_energy / reference.shape[0]))
+    _require(
+        bool(np.isclose(energy_derived_rms, released_rms, atol=1e-15, rtol=0.0)),
+        "released mode-0 energy and RMS are inconsistent",
+    )
+
+    displacement = resets - reference[None, :, :]
+    mode_component = _mode_component(displacement, mode)
+    mode_rms = np.asarray([_vector_rms(value) for value in mode_component])
+    percentile = float(np.quantile(mode_rms, 0.95, method=RESET_MODE0_QUANTILE_METHOD))
+    pilot_statistic = percentile + uncertainty
+    weakened = released_rms > 2.0 * pilot_statistic
+
+    translation_rms: list[float] = []
+    se3_rms: list[float] = []
+    post_se3_rms: list[float] = []
+    post_se3_mode0_rms: list[float] = []
+    rotation_deg: list[float] = []
+    for observed in resets:
+        translation = np.mean(observed - reference, axis=0)
+        translation_rms.append(float(np.linalg.norm(translation)))
+        transformed, rotation = _best_fit_se3(reference, observed)
+        se3_rms.append(_vector_rms(transformed - reference))
+        residual = observed - transformed
+        post_se3_rms.append(_vector_rms(residual))
+        post_component = _mode_component(residual[None, :, :], mode)[0]
+        post_se3_mode0_rms.append(_vector_rms(post_component))
+        cosine = float(np.clip((np.trace(rotation) - 1.0) / 2.0, -1.0, 1.0))
+        rotation_deg.append(float(np.degrees(np.arccos(cosine))))
+
+    per_session = []
+    for index, session_id in enumerate(identifiers):
+        per_session.append(
+            {
+                "session_id": session_id,
+                "locked_frame_mode0_rms_m": float(mode_rms[index]),
+                "locked_frame_translation_rms_m": translation_rms[index],
+                "best_fit_se3_component_rms_m": se3_rms[index],
+                "best_fit_rotation_deg": rotation_deg[index],
+                "post_se3_residual_rms_m": post_se3_rms[index],
+                "post_se3_mode0_rms_m": post_se3_mode0_rms[index],
+            }
+        )
+
+    result: dict[str, Any] = {
+        "schema_version": RESET_MODE0_CROSSCHECK_SCHEMA_VERSION,
+        "artifact_kind": RESET_MODE0_CROSSCHECK_ARTIFACT_KIND,
+        "protocol_id": protocol["protocol_id"],
+        "protocol_design_sha256": protocol["design_sha256"],
+        "preacquisition_plan_id": preacquisition_v5["plan_id"],
+        "preacquisition_amendment_sha256": preacquisition_v5["amendment_sha256"],
+        "world_frame_id": world_frame_id.strip(),
+        "units": "m",
+        "node_count": int(reference.shape[0]),
+        "session_count": len(identifiers),
+        "array_sha256": {
+            "reference_positions_world_m": _array_sha256(reference),
+            "reset_positions_world_m": _array_sha256(resets),
+            "graph_mode0": _array_sha256(mode),
+        },
+        "estimator": {
+            "projection_inner_product": "unweighted_euclidean_node_inner_product",
+            "mode_scale_invariant": True,
+            "mode_zero_definition": "registered_constant_graph_direction",
+            "constant_mode_absolute_alignment": constant_alignment,
+            "percentile": 0.95,
+            "percentile_method": RESET_MODE0_QUANTILE_METHOD,
+            "positions_evaluated_before_per_reset_alignment": True,
+        },
+        "released_reference": {
+            "mode": int(released["mode"]),
+            "initial_mode_energy_m2": initial_mode_energy,
+            "per_node_vector_rms_m": released_rms,
+            "source": dict(
+                preacquisition_v5["state_propagation_interpretation_lock"][
+                    "released_case_source"
+                ]
+            ),
+        },
+        "pilot": {
+            "per_session": per_session,
+            "mode0_rms_95th_percentile_m": percentile,
+            "registration_uncertainty_95_m": uncertainty,
+            "pilot_statistic_m": pilot_statistic,
+        },
+        "decision": {
+            "classification": (
+                "reset_scale_explanation_weakened" if weakened else "scale_compatible"
+            ),
+            "released_reference_exceeds_twice_pilot_statistic": weakened,
+            "compatibility_confirms_cause": False,
+        },
+        "information_boundary": {
+            "fresh_reset_sessions_only": True,
+            "target_outcomes_used": False,
+            "confirmatory_executions_used": False,
+            "action_outcomes_used": False,
+        },
+    }
+    result["artifact_id"] = _artifact_id(result)
+    return result
+
+
+def _build_reset_mode0_npz_result(
+    protocol: Mapping[str, Any],
+    preacquisition_v5: Mapping[str, Any],
+    input_npz: str | Path,
+    *,
+    registration_binding: Mapping[str, Any],
+    source_path_label: str | None = None,
+) -> dict[str, Any]:
+    """Load the locked NPZ contract and build one deterministic audit."""
+
+    binding = _validated_registration_binding(registration_binding)
+    input_path = Path(input_npz)
+    _require(input_path.is_file(), "reset pilot NPZ is missing")
+    required = {
+        "session_ids",
+        "reference_positions_world_m",
+        "reset_positions_world_m",
+        "graph_mode0",
+        "registration_uncertainty_95_m",
+        "world_frame_id",
+        "units",
+        "positions_are_pre_alignment",
+        "fresh_reset_mask",
+        "data_role",
+        "target_outcomes_used",
+        "object_registration_sha256",
+        "contact_registration_sha256",
+    }
+    with np.load(input_path, allow_pickle=False) as archive:
+        missing = required - set(archive.files)
+        _require(not missing, f"reset pilot NPZ is missing arrays: {sorted(missing)}")
+        session_values = np.asarray(archive["session_ids"]).reshape(-1)
+        reset_values = np.asarray(archive["reset_positions_world_m"])
+        fresh_reset = np.asarray(archive["fresh_reset_mask"])
+        _require(
+            fresh_reset.dtype == np.bool_
+            and fresh_reset.shape == (len(session_values),)
+            and bool(np.all(fresh_reset)),
+            "every reset record must be a fresh-reset session",
+        )
+        _require(str(np.asarray(archive["units"]).item()) == "m", "units must be m")
+        _require(
+            bool(np.asarray(archive["positions_are_pre_alignment"]).item()) is True,
+            "reset positions must be recorded before per-reset alignment",
+        )
+        _require(
+            str(np.asarray(archive["data_role"]).item()) == RESET_MODE0_INPUT_ROLE,
+            "reset pilot data_role is invalid",
+        )
+        _require(
+            bool(np.asarray(archive["target_outcomes_used"]).item()) is False,
+            "target outcomes entered the reset pilot",
+        )
+        _require(
+            _scalar_text(
+                archive["object_registration_sha256"],
+                "object_registration_sha256",
+            )
+            == binding["object_registration_sha256"],
+            "reset pilot object registration digest changed",
+        )
+        _require(
+            _scalar_text(
+                archive["contact_registration_sha256"],
+                "contact_registration_sha256",
+            )
+            == binding["contact_registration_sha256"],
+            "reset pilot contact registration digest changed",
+        )
+        result = evaluate_reset_mode0_crosscheck(
+            protocol,
+            preacquisition_v5,
+            session_ids=session_values.tolist(),
+            reference_positions_world_m=archive["reference_positions_world_m"],
+            reset_positions_world_m=reset_values,
+            graph_mode0=archive["graph_mode0"],
+            registration_uncertainty_95_m=float(
+                np.asarray(archive["registration_uncertainty_95_m"]).item()
+            ),
+            world_frame_id=str(np.asarray(archive["world_frame_id"]).item()),
+        )
+    result["registration_binding"] = binding
+    source_sha256, source_bytes = _sha256_file(input_path)
+    result["source_npz"] = {
+        "path": str(input_path) if source_path_label is None else source_path_label,
+        "sha256": source_sha256,
+        "bytes": source_bytes,
+    }
+    result["artifact_id"] = _artifact_id(result)
+    return result
+
+
+def evaluate_reset_mode0_npz(
+    protocol: Mapping[str, Any],
+    preacquisition_v5: Mapping[str, Any],
+    input_npz: str | Path,
+    output_json: str | Path,
+    *,
+    registration_binding: Mapping[str, Any],
+    source_path_label: str | None = None,
+) -> dict[str, Any]:
+    """Load the locked NPZ contract and atomically publish one audit."""
+
+    result = _build_reset_mode0_npz_result(
+        protocol,
+        preacquisition_v5,
+        input_npz,
+        registration_binding=registration_binding,
+        source_path_label=source_path_label,
+    )
+    atomic_write_json(output_json, result, overwrite=False)
+    return result
+
+
+def _load_json_mapping(path: Path) -> dict[str, Any]:
+    def object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            _require(key not in result, f"duplicate JSON key is forbidden: {key}")
+            result[key] = value
+        return result
+
+    def reject_constant(value: str) -> Any:
+        raise ValueError(f"non-finite JSON constant is forbidden: {value}")
+
+    payload = json.loads(
+        path.read_text(encoding="utf-8"),
+        object_pairs_hook=object_pairs,
+        parse_constant=reject_constant,
+    )
+    _require(isinstance(payload, Mapping), "reset mode-0 artifact must be an object")
+    return dict(payload)
+
+
+def load_reset_mode0_crosscheck_prerequisite(
+    protocol: Mapping[str, Any],
+    preacquisition_v5: Mapping[str, Any],
+    dataset_root: str | Path,
+    *,
+    verify_file_hashes: bool,
+) -> dict[str, Any]:
+    """Recompute and validate the registered reset-scale artifact."""
+
+    root = Path(dataset_root)
+    output_path = root / RESET_MODE0_ARTIFACT_PATH
+    result: dict[str, Any] = {
+        "path": str(output_path),
+        "present": output_path.is_file(),
+        "template": False,
+        "valid": False,
+        "error": None,
+        "file_hashes_verified": False if verify_file_hashes else None,
+    }
+    if not result["present"]:
+        result["error"] = "reset-mode0-crosscheck.json is missing"
+        return result
+    try:
+        source_path = root / RESET_MODE0_INPUT_PATH
+        _assert_no_symlink_components(root, name="dataset root")
+        _require(root.is_dir(), "dataset root is invalid")
+        _assert_no_symlink_components(source_path, name="reset pilot NPZ")
+        _assert_no_symlink_components(output_path, name="reset mode-0 artifact")
+        artifact = _load_json_mapping(output_path)
+        _require(
+            artifact.get("schema_version") == RESET_MODE0_CROSSCHECK_SCHEMA_VERSION,
+            "unsupported reset mode-0 artifact schema",
+        )
+        _require(
+            artifact.get("artifact_kind") == RESET_MODE0_CROSSCHECK_ARTIFACT_KIND,
+            "unexpected reset mode-0 artifact kind",
+        )
+        _require(
+            artifact.get("artifact_id") == _artifact_id(artifact),
+            "reset mode-0 artifact digest mismatch",
+        )
+        binding = load_reset_registration_binding(protocol, preacquisition_v5, root)
+        expected = _build_reset_mode0_npz_result(
+            protocol,
+            preacquisition_v5,
+            source_path,
+            registration_binding=binding,
+            source_path_label=RESET_MODE0_INPUT_PATH,
+        )
+        _require(
+            artifact == expected,
+            "reset mode-0 artifact differs from the registered source replay",
+        )
+        digest, byte_count = _sha256_file(output_path)
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        message = str(error).strip()
+        result["error"] = (
+            f"{type(error).__name__}: {message}" if message else type(error).__name__
+        )
+        return result
+    result.update(
+        valid=True,
+        error=None,
+        file_hashes_verified=True,
+        sha256=digest,
+        bytes=byte_count,
+        artifact_id=artifact["artifact_id"],
+        classification=artifact["decision"]["classification"],
+        source_npz_sha256=artifact["source_npz"]["sha256"],
+    )
+    return result
+
+
+__all__ = [
+    "RESET_MODE0_CROSSCHECK_ARTIFACT_KIND",
+    "RESET_MODE0_CROSSCHECK_SCHEMA_VERSION",
+    "RESET_MODE0_ARTIFACT_PATH",
+    "RESET_MODE0_INPUT_PATH",
+    "RESET_MODE0_INPUT_ROLE",
+    "RESET_MODE0_QUANTILE_METHOD",
+    "evaluate_reset_mode0_crosscheck",
+    "evaluate_reset_mode0_npz",
+    "load_reset_registration_binding",
+    "load_reset_mode0_crosscheck_prerequisite",
+]

--- a/tests/test_preacquisition_next_action.py
+++ b/tests/test_preacquisition_next_action.py
@@ -38,6 +38,7 @@ def _readiness() -> dict:
             "acquisition_schedule",
             "object_registration",
             "slip_pilot",
+            "reset_mode0_crosscheck",
             "timebase_calibration",
             "contact_registration",
             "operator_registry",
@@ -276,6 +277,24 @@ def test_contact_registration_precedes_slip_pilot() -> None:
     assert action["operator_role"] == "self_attesting_operator"
     assert action["physical_acquisition_required"] is False
     assert action["target_outcomes_permitted"] is False
+
+
+def test_mode0_crosscheck_blocks_source_panel_after_slip_pilot() -> None:
+    readiness = _readiness()
+    readiness["prerequisites"]["reset_mode0_crosscheck"] = _prerequisite(
+        present=False,
+        valid=False,
+    )
+    readiness["missing_prerequisites"] = ["reset_mode0_crosscheck"]
+
+    decision = _derive(readiness, _source_panel(complete=False))
+
+    action = decision["action"]
+    assert action["action_id"] == "run_reset_mode0_crosscheck"
+    assert action["physical_acquisition_required"] is False
+    assert action["automatable"] is False
+    assert action["blocking_items"] == ["fresh_reset_pilot_npz_missing"]
+    assert "protocol reset-mode0-crosscheck" in action["command_text"]
 
 
 def test_source_panel_action_binds_exact_registered_execution() -> None:

--- a/tests/test_preacquisition_readiness.py
+++ b/tests/test_preacquisition_readiness.py
@@ -460,6 +460,41 @@ def test_readiness_opens_only_when_every_artifact_gate_passes(
     assert status["status_sha256"] == readiness_status_sha256(status)
 
 
+def test_v5_mode0_crosscheck_is_a_fail_closed_prerequisite(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    protocol, v2, v4 = _registered_values()
+    v4["prospective_mode0_reset_crosscheck"] = {}
+    _patch_gate_results(monkeypatch)
+
+    with pytest.raises(ValueError, match="missing the reset mode-0 prerequisite"):
+        evaluate_preacquisition_readiness(
+            protocol,
+            v2,
+            v4,
+            tmp_path,
+            _real_status(),
+            verify_file_hashes=True,
+        )
+
+    real_status = _real_status()
+    real_status["prerequisites"]["reset_mode0_crosscheck"] = {
+        "path": str(tmp_path / "preacquisition/reset-mode0-crosscheck.json"),
+        "present": False,
+        "template": False,
+        "valid": False,
+        "error": "reset-mode0-crosscheck.json is missing",
+    }
+    status = evaluate_preacquisition_readiness(
+        protocol, v2, v4, tmp_path, real_status, verify_file_hashes=True
+    )
+
+    assert "reset_mode0_crosscheck" in status["missing_prerequisites"]
+    assert status["collection_gate"]["reset_mode0_crosscheck_completed"] is False
+    assert status["ready"] is False
+
+
 def test_template_gate_is_valid_but_not_ready(monkeypatch, tmp_path: Path) -> None:
     protocol, v2, v4 = _registered_values()
     _patch_gate_results(

--- a/tests/test_preacquisition_source_panel_control.py
+++ b/tests/test_preacquisition_source_panel_control.py
@@ -200,6 +200,34 @@ def test_publish_is_exactly_once_and_advances_registered_order(
         source_control.publish_source_panel_manifest(tmp_path, tmp_path, source)
 
 
+def test_v5_publish_rejects_missing_mode0_audit_before_reading_source(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, _, v4 = _patch_chain(monkeypatch)
+    v4["prospective_mode0_reset_crosscheck"] = {}
+    calls = []
+
+    def missing(protocol, preacquisition, root, *, verify_file_hashes):
+        calls.append((protocol, preacquisition, root, verify_file_hashes))
+        return {
+            "present": False,
+            "valid": False,
+            "error": "reset-mode0-crosscheck.json is missing",
+        }
+
+    monkeypatch.setattr(
+        source_control,
+        "load_reset_mode0_crosscheck_prerequisite",
+        missing,
+    )
+    with pytest.raises(ValueError, match="requires the valid reset mode-0"):
+        source_control.publish_source_panel_manifest(
+            tmp_path, tmp_path, tmp_path / "source-must-not-be-read.json"
+        )
+    assert len(calls) == 1
+
+
 def test_publish_rejects_bad_artifact_hash_without_final_manifest(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_preacquisition_source_panel_control.py
+++ b/tests/test_preacquisition_source_panel_control.py
@@ -106,9 +106,7 @@ def _completed_manifest(
     bad_digest: bool = False,
 ) -> dict:
     execution_id = execution["execution_id"]
-    artifact_relative = (
-        f"preacquisition/source_panel/executions/{execution_id}/raw.bin"
-    )
+    artifact_relative = f"preacquisition/source_panel/executions/{execution_id}/raw.bin"
     artifact_path = root / artifact_relative
     artifact_path.parent.mkdir(parents=True, exist_ok=True)
     artifact_path.write_bytes(f"physical-source:{execution_id}".encode())
@@ -134,9 +132,7 @@ def _completed_manifest(
 
 
 def _write_final_manifest(root: Path, execution: dict, manifest: dict) -> Path:
-    relative = SOURCE_PANEL_MANIFEST_PATH.format(
-        execution_id=execution["execution_id"]
-    )
+    relative = SOURCE_PANEL_MANIFEST_PATH.format(execution_id=execution["execution_id"])
     path = root / relative
     _write_json(path, manifest)
     return path
@@ -193,8 +189,9 @@ def test_publish_is_exactly_once_and_advances_registered_order(
 
     assert published["execution_id"] == executions[0]["execution_id"]
     assert published["source_panel_status"]["validated_executions"] == 1
-    assert published["source_panel_status"]["next_execution"]["execution_id"] == (
-        executions[1]["execution_id"]
+    assert (
+        published["source_panel_status"]["next_execution"]["execution_id"]
+        == (executions[1]["execution_id"])
     )
     with pytest.raises(ValueError, match="next registered execution"):
         source_control.publish_source_panel_manifest(tmp_path, tmp_path, source)

--- a/tests/test_reset_mode0_crosscheck.py
+++ b/tests/test_reset_mode0_crosscheck.py
@@ -1,0 +1,436 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from causal4d import reset_mode0_crosscheck as reset_module
+from causal4d.cli import reset_mode0_crosscheck as reset_cli
+from causal4d.cli.command_registry import find_command
+from causal4d.preacquisition_readiness_contracts import (
+    load_registered_preacquisition_chain,
+)
+from causal4d.reset_mode0_crosscheck import (
+    RESET_MODE0_ARTIFACT_PATH,
+    RESET_MODE0_INPUT_PATH,
+    RESET_MODE0_INPUT_ROLE,
+    evaluate_reset_mode0_crosscheck,
+    evaluate_reset_mode0_npz,
+    load_reset_registration_binding,
+    load_reset_mode0_crosscheck_prerequisite,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+OBJECT_REGISTRATION_SHA256 = "d" * 64
+CONTACT_REGISTRATION_SHA256 = "e" * 64
+
+
+def _registration_binding() -> dict:
+    return {
+        "object_registration_sha256": OBJECT_REGISTRATION_SHA256,
+        "contact_registration_sha256": CONTACT_REGISTRATION_SHA256,
+        "physical_instance_serial": "sloth-001",
+        "twin_geometry_sha256": "f" * 64,
+        "contact_registration_schema_version": 4,
+        "review_policy": "two_pass_single_operator_review_v1",
+        "source_file_hashes_verified": True,
+    }
+
+
+def test_registration_loader_composes_hash_verified_v5_prerequisites(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    protocol, _, _, preacquisition = load_registered_preacquisition_chain(ROOT)
+
+    def object_validator(protocol_arg, root, path, *, verify_file_hashes):
+        assert protocol_arg is protocol
+        assert root == tmp_path
+        assert path == tmp_path / "object_registration.json"
+        assert verify_file_hashes is True
+        return (
+            {"valid": True, "sha256": OBJECT_REGISTRATION_SHA256},
+            {
+                "object_instance_serial": "sloth-001",
+                "phystwin_model_sha256": "f" * 64,
+            },
+        )
+
+    def contact_validator(
+        protocol_arg,
+        root,
+        path,
+        *,
+        simple_registration,
+        simple_registration_sha256,
+        verify_file_hashes,
+        require_single_operator_review,
+    ):
+        assert protocol_arg is protocol
+        assert root == tmp_path
+        assert path == tmp_path / "contact_registration.json"
+        assert simple_registration["object_instance_serial"] == "sloth-001"
+        assert simple_registration_sha256 == OBJECT_REGISTRATION_SHA256
+        assert verify_file_hashes is True
+        assert require_single_operator_review is True
+        return (
+            {
+                "valid": True,
+                "sha256": CONTACT_REGISTRATION_SHA256,
+                "schema_version": 4,
+                "review_policy": "two_pass_single_operator_review_v1",
+            },
+            {"status": "approved"},
+        )
+
+    monkeypatch.setattr(
+        reset_module.real_evidence_common,
+        "_validate_object_registration_prerequisite",
+        object_validator,
+    )
+    monkeypatch.setattr(
+        reset_module.real_evidence_common,
+        "_validate_contact_registration_prerequisite",
+        contact_validator,
+    )
+
+    result = load_reset_registration_binding(protocol, preacquisition, tmp_path)
+
+    assert result == _registration_binding()
+
+
+def test_stable_claim_bearing_route_is_registered_without_a_legacy_alias() -> None:
+    command = find_command("protocol/reset-mode0-crosscheck")
+    assert command.target == "causal4d.cli.reset_mode0_crosscheck:main"
+    assert command.lifecycle == "stable"
+    assert command.claim_bearing is True
+    assert command.historical_name is None
+
+
+def _protocol() -> dict:
+    return {
+        "protocol_id": "protocol",
+        "design_sha256": "a" * 64,
+        "slip_activation_gate": {"minimum_pilot_executions": 5},
+    }
+
+
+def _v5(node_count: int, reference_rms_m: float = 0.013736264750447176) -> dict:
+    return {
+        "plan_id": "plan",
+        "amendment_sha256": "b" * 64,
+        "prospective_mode0_reset_crosscheck": {
+            "released_reference": {
+                "mode": 0,
+                "object_node_count": node_count,
+                "initial_mode_energy_m2": reference_rms_m**2 * node_count,
+                "per_node_vector_rms_m": reference_rms_m,
+            }
+        },
+        "state_propagation_interpretation_lock": {
+            "released_case_source": {
+                "aggregate_artifact": "source.json",
+                "aggregate_file_sha256": "c" * 64,
+                "git_tag": "source-tag",
+            }
+        },
+    }
+
+
+def _reference() -> np.ndarray:
+    return np.asarray(
+        [
+            [0.0, 0.0, 0.0],
+            [0.02, 0.0, 0.0],
+            [0.0, 0.03, 0.0],
+            [0.0, 0.0, 0.04],
+        ],
+        dtype=np.float64,
+    )
+
+
+def _translated_resets(translation_m: float, count: int = 5) -> np.ndarray:
+    reference = _reference()
+    translation = np.asarray([translation_m, 0.0, 0.0])
+    return np.repeat((reference + translation)[None, :, :], count, axis=0)
+
+
+def test_locked_frame_mode0_statistic_and_secondary_decomposition() -> None:
+    reference = _reference()
+    result = evaluate_reset_mode0_crosscheck(
+        _protocol(),
+        _v5(len(reference)),
+        session_ids=[f"reset-{index}" for index in range(5)],
+        reference_positions_world_m=reference,
+        reset_positions_world_m=_translated_resets(0.002),
+        graph_mode0=np.ones(len(reference)),
+        registration_uncertainty_95_m=0.001,
+        world_frame_id="world-v1",
+    )
+
+    assert result["pilot"]["mode0_rms_95th_percentile_m"] == pytest.approx(0.002)
+    assert result["pilot"]["pilot_statistic_m"] == pytest.approx(0.003)
+    assert result["decision"] == {
+        "classification": "reset_scale_explanation_weakened",
+        "released_reference_exceeds_twice_pilot_statistic": True,
+        "compatibility_confirms_cause": False,
+    }
+    for record in result["pilot"]["per_session"]:
+        assert record["locked_frame_translation_rms_m"] == pytest.approx(0.002)
+        assert record["best_fit_se3_component_rms_m"] == pytest.approx(0.002)
+        assert record["post_se3_residual_rms_m"] == pytest.approx(0.0, abs=1e-12)
+        assert record["post_se3_mode0_rms_m"] == pytest.approx(0.0, abs=1e-12)
+
+
+def test_scale_compatibility_does_not_claim_causality() -> None:
+    reference = _reference()
+    result = evaluate_reset_mode0_crosscheck(
+        _protocol(),
+        _v5(len(reference)),
+        session_ids=[f"reset-{index}" for index in range(5)],
+        reference_positions_world_m=reference,
+        reset_positions_world_m=_translated_resets(0.008),
+        graph_mode0=np.ones(len(reference)),
+        registration_uncertainty_95_m=0.001,
+        world_frame_id="world-v1",
+    )
+
+    assert result["decision"]["classification"] == "scale_compatible"
+    assert result["decision"]["compatibility_confirms_cause"] is False
+
+
+def test_nonconstant_mode_zero_is_rejected() -> None:
+    reference = _reference()
+    with pytest.raises(ValueError, match="constant mode-zero"):
+        evaluate_reset_mode0_crosscheck(
+            _protocol(),
+            _v5(len(reference)),
+            session_ids=[f"reset-{index}" for index in range(5)],
+            reference_positions_world_m=reference,
+            reset_positions_world_m=_translated_resets(0.002),
+            graph_mode0=np.asarray([1.0, 1.0, 1.0, 2.0]),
+            registration_uncertainty_95_m=0.001,
+            world_frame_id="world-v1",
+        )
+
+
+def test_released_energy_and_rms_must_be_consistent() -> None:
+    reference = _reference()
+    plan = _v5(len(reference))
+    plan["prospective_mode0_reset_crosscheck"]["released_reference"][
+        "initial_mode_energy_m2"
+    ] = 1.0
+    with pytest.raises(ValueError, match="energy and RMS"):
+        evaluate_reset_mode0_crosscheck(
+            _protocol(),
+            plan,
+            session_ids=[f"reset-{index}" for index in range(5)],
+            reference_positions_world_m=reference,
+            reset_positions_world_m=_translated_resets(0.002),
+            graph_mode0=np.ones(len(reference)),
+            registration_uncertainty_95_m=0.001,
+            world_frame_id="world-v1",
+        )
+
+
+def _write_npz(
+    path: Path,
+    *,
+    node_count: int,
+    target_outcomes_used: bool = False,
+    positions_are_pre_alignment: bool = True,
+) -> None:
+    reference: np.ndarray = np.zeros((node_count, 3), dtype=np.float64)
+    resets = np.repeat(reference[None, :, :], 5, axis=0)
+    resets[:, :, 0] = 0.002
+    np.savez_compressed(
+        path,
+        session_ids=np.asarray([f"reset-{index}" for index in range(5)]),
+        reference_positions_world_m=reference,
+        reset_positions_world_m=resets,
+        graph_mode0=np.ones(node_count, dtype=np.float64),
+        registration_uncertainty_95_m=np.asarray(0.001),
+        world_frame_id=np.asarray("world-v1"),
+        units=np.asarray("m"),
+        positions_are_pre_alignment=np.asarray(positions_are_pre_alignment),
+        fresh_reset_mask=np.ones(5, dtype=np.bool_),
+        data_role=np.asarray(RESET_MODE0_INPUT_ROLE),
+        target_outcomes_used=np.asarray(target_outcomes_used),
+        object_registration_sha256=np.asarray(OBJECT_REGISTRATION_SHA256),
+        contact_registration_sha256=np.asarray(CONTACT_REGISTRATION_SHA256),
+    )
+
+
+def test_npz_contract_is_content_bound_and_write_once(tmp_path: Path) -> None:
+    input_path = tmp_path / "reset-pilot.npz"
+    output_path = tmp_path / "reset-mode0.json"
+    _write_npz(input_path, node_count=4)
+
+    result = evaluate_reset_mode0_npz(
+        _protocol(),
+        _v5(4),
+        input_path,
+        output_path,
+        registration_binding=_registration_binding(),
+    )
+
+    written = json.loads(output_path.read_text(encoding="utf-8"))
+    assert written == result
+    assert written["source_npz"]["bytes"] == input_path.stat().st_size
+    assert len(written["source_npz"]["sha256"]) == 64
+    assert written["information_boundary"]["target_outcomes_used"] is False
+    with pytest.raises(FileExistsError):
+        evaluate_reset_mode0_npz(
+            _protocol(),
+            _v5(4),
+            input_path,
+            output_path,
+            registration_binding=_registration_binding(),
+        )
+
+
+def test_prerequisite_replays_source_and_rejects_consistent_tampering(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / RESET_MODE0_INPUT_PATH
+    output_path = tmp_path / RESET_MODE0_ARTIFACT_PATH
+    input_path.parent.mkdir(parents=True)
+    _write_npz(input_path, node_count=4)
+    protocol = _protocol()
+    preacquisition = _v5(4)
+    monkeypatch.setattr(
+        reset_module,
+        "load_reset_registration_binding",
+        lambda protocol_arg, preacquisition_arg, root: _registration_binding(),
+    )
+    evaluate_reset_mode0_npz(
+        protocol,
+        preacquisition,
+        input_path,
+        output_path,
+        registration_binding=_registration_binding(),
+        source_path_label=RESET_MODE0_INPUT_PATH,
+    )
+
+    accepted = load_reset_mode0_crosscheck_prerequisite(
+        protocol,
+        preacquisition,
+        tmp_path,
+        verify_file_hashes=True,
+    )
+    assert accepted["valid"] is True
+    assert accepted["file_hashes_verified"] is True
+
+    artifact = json.loads(output_path.read_text(encoding="utf-8"))
+    artifact["decision"]["compatibility_confirms_cause"] = True
+    artifact["artifact_id"] = reset_module._artifact_id(artifact)
+    output_path.write_text(
+        json.dumps(artifact, sort_keys=True, allow_nan=False),
+        encoding="utf-8",
+    )
+    rejected = load_reset_mode0_crosscheck_prerequisite(
+        protocol,
+        preacquisition,
+        tmp_path,
+        verify_file_hashes=True,
+    )
+    assert rejected["valid"] is False
+    assert "registered source replay" in rejected["error"]
+
+
+def test_prerequisite_rejects_a_symlinked_preacquisition_root(tmp_path: Path) -> None:
+    external = tmp_path / "external"
+    external.mkdir()
+    (external / "reset-mode0-crosscheck.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "preacquisition").symlink_to(external, target_is_directory=True)
+
+    rejected = load_reset_mode0_crosscheck_prerequisite(
+        _protocol(),
+        _v5(4),
+        tmp_path,
+        verify_file_hashes=True,
+    )
+
+    assert rejected["valid"] is False
+    assert "symlink component" in rejected["error"]
+
+
+@pytest.mark.parametrize(
+    ("target_outcomes_used", "positions_are_pre_alignment", "message"),
+    [
+        (True, True, "target outcomes entered"),
+        (False, False, "before per-reset alignment"),
+    ],
+)
+def test_npz_contract_rejects_information_boundary_violations(
+    tmp_path: Path,
+    target_outcomes_used: bool,
+    positions_are_pre_alignment: bool,
+    message: str,
+) -> None:
+    input_path = tmp_path / "reset-pilot.npz"
+    _write_npz(
+        input_path,
+        node_count=4,
+        target_outcomes_used=target_outcomes_used,
+        positions_are_pre_alignment=positions_are_pre_alignment,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        evaluate_reset_mode0_npz(
+            _protocol(),
+            _v5(4),
+            input_path,
+            tmp_path / "result.json",
+            registration_binding=_registration_binding(),
+        )
+
+
+def test_npz_contract_rejects_registration_digest_mismatch(tmp_path: Path) -> None:
+    input_path = tmp_path / "reset-pilot.npz"
+    _write_npz(input_path, node_count=4)
+    binding = _registration_binding()
+    binding["contact_registration_sha256"] = "a" * 64
+
+    with pytest.raises(ValueError, match="contact registration digest changed"):
+        evaluate_reset_mode0_npz(
+            _protocol(),
+            _v5(4),
+            input_path,
+            tmp_path / "result.json",
+            registration_binding=binding,
+        )
+
+
+def test_registered_cli_binds_the_canonical_v5_chain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    input_path = tmp_path / RESET_MODE0_INPUT_PATH
+    output_path = tmp_path / RESET_MODE0_ARTIFACT_PATH
+    input_path.parent.mkdir(parents=True)
+    _write_npz(input_path, node_count=6895)
+    monkeypatch.setattr(
+        reset_cli,
+        "load_reset_registration_binding",
+        lambda protocol, preacquisition, dataset_root: _registration_binding(),
+    )
+
+    exit_code = reset_cli.main(
+        [str(ROOT), str(tmp_path), str(input_path), str(output_path)]
+    )
+
+    assert exit_code == 0
+    result = json.loads(output_path.read_text(encoding="utf-8"))
+    assert result["protocol_id"] == "causal4d-sloth-multi-action-v1"
+    assert result["preacquisition_plan_id"] == (
+        "causal4d-sloth-preacquisition-v5-single-operator"
+    )
+    assert result["node_count"] == 6895
+    assert result["registration_binding"] == _registration_binding()
+    assert result["source_npz"]["path"] == RESET_MODE0_INPUT_PATH
+    assert result["estimator"]["constant_mode_absolute_alignment"] <= 1.0


### PR DESCRIPTION
Adds the preregistered fresh-reset mode-zero audit, binds it to schema-4 registration and the frozen 6,895-node reference, and blocks source-panel publication until deterministic replay passes. No frozen threshold or protocol JSON changed; no action, target, confirmatory, or held-out outcome was accessed. Verification: 63 focused and 207 broad tests passed; full mounted suite reached 2,253 passed/23 skipped with 12 mount-specific POSIX failures, and all affected tests passed 20/20 on native POSIX; Ruff, MyPy, and diff-check pass.