### PR TITLE
Preserve the single-operator v5 bootstrap receipt

### DIFF
--- a/evidence/single-operator-v5-bootstrap-20260826/README.md
+++ b/evidence/single-operator-v5-bootstrap-20260826/README.md
@@ -1,0 +1,46 @@
+# Single-operator v5 bootstrap evidence - 2026-08-26
+
+This directory preserves the sanitized result of the owner-only v5 identity
+bootstrap. It is operational evidence, not physical evidence, and it does not
+advance the source-panel or confirmatory execution counts.
+
+## Execution identity
+
+- Workflow run: `32925318021` (success)
+- Reviewed main commit: `c4abf3ebe599ba6d2c009d242cab493d95da88af`
+- GitHub artifact: `causal4d-single-operator-v5-owner-bootstrap-v2`
+- GitHub artifact ID: `9597158446`
+- GitHub archive digest: `sha256:15cd19a517f75582984c41a5d0e8b64397ff3dd6325d9aa15c382cbbe2d482ab`
+- Report SHA-256: `8cd6f2d66d954b49f2f021ea936b3485e70420defa0816b60898f22098092c1b`
+- Built wheel SHA-256: `0833d7e27efae963c28c186e697595ea20811b703f7756611db3b14c50ed9f6a`
+
+The committed `report.json` is byte-identical to the workflow's `report.txt`.
+Its canonical digest, computed with `report_sha256` omitted, recomputes to the
+recorded value.
+
+## Result
+
+The run created a fresh private owner HMAC identity because the historical
+private identity material was unavailable. It intentionally claims neither
+historical identity-digest continuity nor independent attestation.
+
+`dataset_modified = true` records creation of the target dataset scaffold and
+registry binding. It does not mean that an experimental observation or outcome
+was collected. The report also records:
+
+- `physical_evidence_increment = 0`
+- `target_outcomes_used = false`
+- `device_nodes_opened = false`
+- `physical_command_sent = false`
+- `registered_method_changed = false`
+
+The registered next action is `complete_object_registration`. The contact
+registration must still pass anatomical review before the slip/reset pilot is
+eligible to run.
+
+## Current registration boundary
+
+The first generated contact proposal was rejected during anatomical review:
+its red region was a backpaw, and its yellow torso region was too low. This
+bootstrap result does not approve that proposal and cannot be used to bypass
+the schema-4 object/contact registration gate.

--- a/evidence/single-operator-v5-bootstrap-20260826/report.json
+++ b/evidence/single-operator-v5-bootstrap-20260826/report.json
@@ -1,0 +1,42 @@
+{
+  "artifact_kind": "Causal4DSingleOperatorV5BootstrapReport",
+  "bootstrap_implementation_bytes": 22724,
+  "bootstrap_implementation_sha256": "eb3e0436abcc555cc25b5240b61d92b868d85427ec5585b337fd811adb244e9d",
+  "bootstrap_receipt_artifact_sha256": "c4c9299dc51b168e910c704efd6e25558c65f9838a4385827e491bb30de6536e",
+  "claim_boundary": "A fresh owner-only HMAC identity was initialized for v5 because the historical private identity material was unavailable. No historical identity-digest continuity or independent attestation is claimed.",
+  "created": true,
+  "dataset_modified": true,
+  "device_nodes_opened": false,
+  "historical_registry_available": false,
+  "historical_registry_reused": false,
+  "identity_digest_continuity_claimed": false,
+  "identity_initialization_mode": "fresh_owner_hmac_v1",
+  "independent_preacquisition_attestation_claimed": false,
+  "independent_verifier_available": false,
+  "next_action": {
+    "action_id": "complete_object_registration",
+    "automatable": false,
+    "operator_role": "self_attesting_operator",
+    "physical_acquisition_required": false,
+    "target_outcomes_permitted": false
+  },
+  "operator_ids": [
+    "florianpfaff"
+  ],
+  "operator_roles": [
+    "freezer",
+    "gate_approver",
+    "software_environment_approver"
+  ],
+  "physical_command_sent": false,
+  "physical_evidence_increment": 0,
+  "private_identity_material_created": true,
+  "registered_method_changed": false,
+  "report_sha256": "8cd6f2d66d954b49f2f021ea936b3485e70420defa0816b60898f22098092c1b",
+  "reviewed_main_commit": "c4abf3ebe599ba6d2c009d242cab493d95da88af",
+  "schema_version": 2,
+  "target_outcomes_used": false,
+  "target_preacquisition_amendment_sha256": "c0128865c7b527304dc7a6177d7f935d753bfdbc1e4469243f1acaeae6ce8e93",
+  "target_preacquisition_plan_id": "causal4d-sloth-preacquisition-v5-single-operator",
+  "target_registry_artifact_sha256": "4f15d24fc03502d641fc78de269dfa7ffaba75c4419e894a92b9cf24ea5100ab"
+}

--- a/tests/test_single_operator_v5_bootstrap_evidence.py
+++ b/tests/test_single_operator_v5_bootstrap_evidence.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+
+EVIDENCE_PATH = (
+    Path(__file__).parents[1]
+    / "evidence"
+    / "single-operator-v5-bootstrap-20260826"
+    / "report.json"
+)
+
+
+def test_single_operator_v5_bootstrap_evidence_is_content_bound() -> None:
+    report = json.loads(EVIDENCE_PATH.read_text(encoding="utf-8"))
+    expected = report.pop("report_sha256")
+    canonical = json.dumps(report, sort_keys=True, separators=(",", ":")).encode()
+
+    assert hashlib.sha256(canonical).hexdigest() == expected
+
+
+def test_single_operator_v5_bootstrap_preserves_information_boundary() -> None:
+    report = json.loads(EVIDENCE_PATH.read_text(encoding="utf-8"))
+
+    assert report["artifact_kind"] == "Causal4DSingleOperatorV5BootstrapReport"
+    assert report["schema_version"] == 2
+    assert report["identity_initialization_mode"] == "fresh_owner_hmac_v1"
+    assert report["independent_verifier_available"] is False
+    assert report["independent_preacquisition_attestation_claimed"] is False
+    assert report["historical_registry_available"] is False
+    assert report["historical_registry_reused"] is False
+    assert report["identity_digest_continuity_claimed"] is False
+    assert report["physical_evidence_increment"] == 0
+    assert report["target_outcomes_used"] is False
+    assert report["device_nodes_opened"] is False
+    assert report["physical_command_sent"] is False
+    assert report["registered_method_changed"] is False
+    assert report["next_action"] == {
+        "action_id": "complete_object_registration",
+        "automatable": False,
+        "operator_role": "self_attesting_operator",
+        "physical_acquisition_required": False,
+        "target_outcomes_permitted": False,
+    }


### PR DESCRIPTION
Preserves the sanitized successful bootstrap report before the Actions artifact expires. The report remains explicit that this is owner-only operational evidence with zero physical evidence increment, no target outcomes, and object registration as the next action. Adds focused hash and information-boundary tests.\n\nVerification: 2 focused tests passed; Ruff and format checks passed; git diff --check passed.