### PR TITLE
Inspect the authoritative v5 acquisition dataset

### DIFF
--- a/.github/workflows/acquisition-readiness-self-hosted.yml
+++ b/.github/workflows/acquisition-readiness-self-hosted.yml
@@ -101,11 +101,11 @@ jobs:
             --root-candidate \
               canonical \
               /opt/causal4d-frozen \
-              /data/causal4d-sloth-multi-action-v1 \
+              /data/causal4d-sloth-multi-action-v1-v5 \
             --root-candidate \
               workstation2-persistent \
               /mnt/lexar4tb/causal4d-physical/causal4d-frozen \
-              /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1 \
+              /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5 \
             --output outputs/acquisition-readiness/report.json \
             | tee outputs/acquisition-readiness/report.txt
 

--- a/docs/self_hosted_acquisition_readiness.md
+++ b/docs/self_hosted_acquisition_readiness.md
@@ -23,13 +23,14 @@ read-only repository token and no GitHub secrets.
 
 ## Registered root-pair selection
 
-The workflow currently inspects these complete pairs rather than testing or
-combining individual paths independently:
+The workflow inspects the authoritative v5 acquisition roots created by the
+source-independent single-operator bootstrap. The historical non-v5 dataset is
+not an admissible readiness candidate for the current protocol.
 
 | Candidate | Frozen checkout | Dataset root |
 | --- | --- | --- |
-| `canonical` | `/opt/causal4d-frozen` | `/data/causal4d-sloth-multi-action-v1` |
-| `workstation2-persistent` | `/mnt/lexar4tb/causal4d-physical/causal4d-frozen` | `/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1` |
+| `canonical` | `/opt/causal4d-frozen` | `/data/causal4d-sloth-multi-action-v1-v5` |
+| `workstation2-persistent` | `/mnt/lexar4tb/causal4d-physical/causal4d-frozen` | `/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5` |
 
 Selection is fail-closed:
 

--- a/tests/test_v5_acquisition_readiness_workflow.py
+++ b/tests/test_v5_acquisition_readiness_workflow.py
@@ -45,7 +45,7 @@ def test_readiness_trigger_and_read_only_boundary_are_unchanged() -> None:
     assert "github.event.issue.user.id == 6773539" in text
     assert "permissions:\n  contents: read" in text
     assert "scripts/ci/probe_self_hosted_acquisition.py" in text
-    assert "physical_evidence_increment: \\`0\\`" in text
+    assert "- Physical evidence increment: \\`0\\`" in text
 
 
 def test_readiness_documentation_matches_v5_root_binding() -> None:

--- a/tests/test_v5_acquisition_readiness_workflow.py
+++ b/tests/test_v5_acquisition_readiness_workflow.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "acquisition-readiness-self-hosted.yml"
+DOCUMENTATION = ROOT / "docs" / "self_hosted_acquisition_readiness.md"
+
+CANONICAL_V5 = "/data/causal4d-sloth-multi-action-v1-v5"
+PERSISTENT_V5 = (
+    "/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5"
+)
+CANONICAL_HISTORICAL = "/data/causal4d-sloth-multi-action-v1"
+PERSISTENT_HISTORICAL = (
+    "/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1"
+)
+
+
+def _workflow_paths() -> set[str]:
+    paths: set[str] = set()
+    for line in WORKFLOW.read_text(encoding="utf-8").splitlines():
+        value = line.strip()
+        if value.endswith("\\"):
+            value = value[:-1].strip()
+        if value.startswith("/"):
+            paths.add(value)
+    return paths
+
+
+def test_readiness_inspects_only_authoritative_v5_dataset_roots() -> None:
+    paths = _workflow_paths()
+
+    assert CANONICAL_V5 in paths
+    assert PERSISTENT_V5 in paths
+    assert CANONICAL_HISTORICAL not in paths
+    assert PERSISTENT_HISTORICAL not in paths
+
+
+def test_readiness_trigger_and_read_only_boundary_are_unchanged() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "[self-hosted] inspect Causal4D acquisition readiness" in text
+    assert "github.event.issue.user.login == 'FlorianPfaff'" in text
+    assert "github.event.issue.user.id == 6773539" in text
+    assert "permissions:\n  contents: read" in text
+    assert "scripts/ci/probe_self_hosted_acquisition.py" in text
+    assert "physical_evidence_increment: \\`0\\`" in text
+
+
+def test_readiness_documentation_matches_v5_root_binding() -> None:
+    text = DOCUMENTATION.read_text(encoding="utf-8")
+
+    assert f"`{CANONICAL_V5}`" in text
+    assert f"`{PERSISTENT_V5}`" in text
+    assert f"`{CANONICAL_HISTORICAL}` |" not in text
+    assert f"`{PERSISTENT_HISTORICAL}` |" not in text
+    assert "historical non-v5 dataset is" in text
+    assert "not an admissible readiness candidate" in text

--- a/tests/test_v5_acquisition_readiness_workflow.py
+++ b/tests/test_v5_acquisition_readiness_workflow.py
@@ -8,13 +8,9 @@ WORKFLOW = ROOT / ".github" / "workflows" / "acquisition-readiness-self-hosted.y
 DOCUMENTATION = ROOT / "docs" / "self_hosted_acquisition_readiness.md"
 
 CANONICAL_V5 = "/data/causal4d-sloth-multi-action-v1-v5"
-PERSISTENT_V5 = (
-    "/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5"
-)
+PERSISTENT_V5 = "/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5"
 CANONICAL_HISTORICAL = "/data/causal4d-sloth-multi-action-v1"
-PERSISTENT_HISTORICAL = (
-    "/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1"
-)
+PERSISTENT_HISTORICAL = "/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1"
 
 
 def _workflow_paths() -> set[str]:


### PR DESCRIPTION
## Summary

- update the read-only self-hosted acquisition-readiness workflow to inspect the authoritative v5 dataset created by the single-operator bootstrap;
- stop treating the historical non-v5 dataset root as a readiness candidate;
- synchronize the operator documentation; and
- add regression tests for exact v5 root binding and preservation of the read-only/no-physical-evidence boundary.

## Reproduced execution defect

Issue #419 triggered workflow run `33084293005` after the v5 transition, but the workflow at current `main` still names:

```text
/data/causal4d-sloth-multi-action-v1
/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1
```

The authoritative fresh governance tree was created at:

```text
/data/causal4d-sloth-multi-action-v1-v5
/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5
```

Without this correction, a future runner could inspect stale pre-v5 identity/governance material and produce a non-authoritative next-action report.

## Boundary

This changes only which registered dataset root is inspected. The workflow remains read-only, uses no secrets, opens no device node, sends no robot or sensor command, reads no source or target outcome, changes no method or protocol, and increments physical evidence by zero. It does not authorize object registration or confirmatory execution 1.

The retained v5 decision remains `complete_object_registration`; the real sloth inventory serial and subsequent physical readiness evidence are still required before acquisition.

Refs #25, #377, #413, #419.