### PR TITLE
Reprovision the stale v5 acquisition checkout safely

### DIFF
--- a/.github/self-hosted-jobs.json
+++ b/.github/self-hosted-jobs.json
@@ -9,6 +9,9 @@
     },
     "single-operator-v5-issue-main": {
       "description": "Exact registered-owner issue trigger on reviewed refs/heads/main for the nonphysical source-independent v5 owner-identity bootstrap, exact GITHUB_SHA checkout, read-only self-hosted token, no issue text execution, and no secrets."
+    },
+    "v5-checkout-reprovision-issue-main": {
+      "description": "Exact registered-maintainer issue trigger on reviewed refs/heads/main for the pre-freeze atomic v5 checkout replacement, exact GITHUB_SHA checkout, clean-tree verification, byte-verified dataset noninterference, read-only self-hosted token, no issue text execution, and no secrets."
     }
   },
   "jobs": [
@@ -219,7 +222,7 @@
     {
       "workflow": "reprovision-v5-checkout-self-hosted.yml",
       "job": "reprovision",
-      "authorization_model": "maintainer-issue-main",
+      "authorization_model": "v5-checkout-reprovision-issue-main",
       "runner_labels": [
         "self-hosted",
         "Linux",

--- a/.github/self-hosted-jobs.json
+++ b/.github/self-hosted-jobs.json
@@ -217,6 +217,21 @@
       "secrets_allowed": false
     },
     {
+      "workflow": "reprovision-v5-checkout-self-hosted.yml",
+      "job": "reprovision",
+      "authorization_model": "maintainer-issue-main",
+      "runner_labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "nvidia-smi",
+        "data-causal4d-physical-v1"
+      ],
+      "purpose": "Atomically replace a stale clean pre-freeze v5 acquisition checkout",
+      "dataset_access": "registered-local-preacquisition-v5-checkout-replacement-with-byte-verification",
+      "secrets_allowed": false
+    },
+    {
       "workflow": "self-hosted-evaluation.yml",
       "job": "evaluate",
       "authorization_model": "main-only",

--- a/.github/workflows/reprovision-v5-checkout-self-hosted.yml
+++ b/.github/workflows/reprovision-v5-checkout-self-hosted.yml
@@ -1,0 +1,267 @@
+name: Reprovision v5 acquisition checkout on workstation2
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  reprovision:
+    name: Reprovision the pre-freeze v5 checkout
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      github.event_name == 'issues' &&
+      github.event.action == 'opened' &&
+      github.event.issue.user.login == 'FlorianPfaff' &&
+      github.event.issue.user.id == 6773539 &&
+      github.event.issue.title ==
+        '[self-hosted] reprovision Causal4D v5 acquisition checkout'
+    concurrency:
+      group: causal4d-v5-checkout-reprovision-${{ github.sha }}
+      cancel-in-progress: false
+      queue: max
+    runs-on: [self-hosted, Linux, X64, nvidia-smi, data-causal4d-physical-v1]
+    timeout-minutes: 45
+    outputs:
+      previous_commit: ${{ steps.summary.outputs.previous_commit }}
+      deployed_commit: ${{ steps.summary.outputs.deployed_commit }}
+      backup_repository: ${{ steps.summary.outputs.backup_repository }}
+      next_action: ${{ steps.summary.outputs.next_action }}
+      readiness_conclusion: ${{ steps.summary.outputs.readiness_conclusion }}
+      dataset_modified: ${{ steps.summary.outputs.dataset_modified }}
+      target_outcomes_used: ${{ steps.summary.outputs.target_outcomes_used }}
+      physical_evidence_increment: >-
+        ${{ steps.summary.outputs.physical_evidence_increment }}
+    steps:
+      - name: Check out exact reviewed main revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+
+      - name: Verify reviewed main revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Build and install the exact Causal4D wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p outputs/v5-checkout-reprovision/wheels
+          python -m venv .v5-checkout-reprovision-venv
+          .v5-checkout-reprovision-venv/bin/python -m pip install \
+            --upgrade pip "build>=1.2"
+          .v5-checkout-reprovision-venv/bin/python -m build --wheel \
+            --outdir outputs/v5-checkout-reprovision/wheels .
+          wheel="$(
+            find outputs/v5-checkout-reprovision/wheels -maxdepth 1 \
+              -name 'causal4d-*.whl' -print -quit
+          )"
+          test -n "${wheel}"
+          sha256sum "${wheel}" \
+            | tee outputs/v5-checkout-reprovision/wheel-sha256.txt
+          .v5-checkout-reprovision-venv/bin/python -m pip install "${wheel}"
+          .v5-checkout-reprovision-venv/bin/python -m pip check
+
+      - name: Atomically reprovision the registered checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          PYTHONPATH="" .v5-checkout-reprovision-venv/bin/python \
+            scripts/ci/reprovision_self_hosted_v5_checkout.py \
+            --source-repository "${GITHUB_WORKSPACE}" \
+            --target-repository \
+              /mnt/lexar4tb/causal4d-physical/causal4d-frozen \
+            --dataset-root \
+              /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5 \
+            --expected-source-commit "${GITHUB_SHA}" \
+            --output outputs/v5-checkout-reprovision/report.json \
+            | tee outputs/v5-checkout-reprovision/report.txt
+
+      - name: Recompute hash-verified readiness from the deployed checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          PYTHONPATH="" .v5-checkout-reprovision-venv/bin/python \
+            scripts/ci/probe_self_hosted_acquisition.py \
+            --root-candidate \
+              canonical \
+              /opt/causal4d-frozen \
+              /data/causal4d-sloth-multi-action-v1-v5 \
+            --root-candidate \
+              workstation2-persistent \
+              /mnt/lexar4tb/causal4d-physical/causal4d-frozen \
+              /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5 \
+            --output outputs/v5-checkout-reprovision/readiness.json \
+            | tee outputs/v5-checkout-reprovision/readiness.txt
+
+      - name: Verify and export sanitized result fields
+        id: summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          .v5-checkout-reprovision-venv/bin/python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads(
+              Path("outputs/v5-checkout-reprovision/report.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          readiness = json.loads(
+              Path("outputs/v5-checkout-reprovision/readiness.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          if report["artifact_kind"] != "Causal4DV5CheckoutReprovisionReport":
+              raise SystemExit("unexpected checkout reprovision report")
+          if report["reviewed_source_commit"] != os.environ["GITHUB_SHA"]:
+              raise SystemExit("reprovisioned commit differs from the issue event")
+          if report["deployed_target_commit"] != os.environ["GITHUB_SHA"]:
+              raise SystemExit("deployed checkout commit differs from reviewed main")
+          if report["dataset_modified"] is not False:
+              raise SystemExit("reprovision modified the registered dataset")
+          if report["target_outcomes_used"] is not False:
+              raise SystemExit("reprovision used target outcomes")
+          if report["physical_evidence_increment"] != 0:
+              raise SystemExit("reprovision changed physical evidence")
+          action = readiness.get("next_action") or {}
+          if action.get("action_id") != "complete_object_registration":
+              raise SystemExit("deployed checkout did not recover object registration")
+          if action.get("physical_acquisition_required") is not False:
+              raise SystemExit("recovered next action unexpectedly requires acquisition")
+          if action.get("target_outcomes_permitted") is not False:
+              raise SystemExit("recovered next action permits target outcomes")
+          if readiness["dataset_modified"] is not False:
+              raise SystemExit("readiness probe modified the registered dataset")
+          if readiness["physical_evidence_increment"] != 0:
+              raise SystemExit("readiness probe changed physical evidence")
+
+          print(f"previous_commit={report['previous_target_commit']}")
+          print(f"deployed_commit={report['deployed_target_commit']}")
+          print(f"backup_repository={report['retained_backup_repository']}")
+          print(f"next_action={action['action_id']}")
+          print(f"readiness_conclusion={readiness['conclusion']}")
+          print(f"dataset_modified={str(report['dataset_modified']).lower()}")
+          print(
+              f"target_outcomes_used={str(report['target_outcomes_used']).lower()}"
+          )
+          print(
+              "physical_evidence_increment="
+              f"{report['physical_evidence_increment']}"
+          )
+          PY
+
+      - name: Record runner and GPU identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "runner_name=${RUNNER_NAME}"
+            echo "runner_os=${RUNNER_OS}"
+            echo "runner_arch=${RUNNER_ARCH}"
+            echo "repository=${GITHUB_REPOSITORY}"
+            echo "commit=${GITHUB_SHA}"
+            echo "workflow_run_id=${GITHUB_RUN_ID}"
+            uname -a
+          } | tee outputs/v5-checkout-reprovision/runner.txt
+          nvidia-smi -L \
+            | tee outputs/v5-checkout-reprovision/nvidia-smi-L.txt
+
+      - name: Upload sanitized checkout-reprovision evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: causal4d-v5-checkout-reprovision-self-hosted
+          path: |
+            outputs/v5-checkout-reprovision/report.json
+            outputs/v5-checkout-reprovision/report.txt
+            outputs/v5-checkout-reprovision/readiness.json
+            outputs/v5-checkout-reprovision/readiness.txt
+            outputs/v5-checkout-reprovision/runner.txt
+            outputs/v5-checkout-reprovision/nvidia-smi-L.txt
+            outputs/v5-checkout-reprovision/wheel-sha256.txt
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Remove isolated environment and wheel
+        if: always()
+        shell: bash
+        run: |
+          rm -rf \
+            .v5-checkout-reprovision-venv \
+            outputs/v5-checkout-reprovision/wheels
+
+  report:
+    name: Report the checkout reprovision to the trigger issue
+    if: >-
+      always() &&
+      github.event_name == 'issues' &&
+      github.event.action == 'opened' &&
+      github.ref == 'refs/heads/main' &&
+      github.event.issue.user.login == 'FlorianPfaff' &&
+      github.event.issue.user.id == 6773539 &&
+      github.event.issue.title ==
+        '[self-hosted] reprovision Causal4D v5 acquisition checkout'
+    needs: reprovision
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      REPROVISION_RESULT: ${{ needs.reprovision.result }}
+      PREVIOUS_COMMIT: ${{ needs.reprovision.outputs.previous_commit }}
+      DEPLOYED_COMMIT: ${{ needs.reprovision.outputs.deployed_commit }}
+      BACKUP_REPOSITORY: ${{ needs.reprovision.outputs.backup_repository }}
+      NEXT_ACTION: ${{ needs.reprovision.outputs.next_action }}
+      READINESS_CONCLUSION: ${{ needs.reprovision.outputs.readiness_conclusion }}
+      DATASET_MODIFIED: ${{ needs.reprovision.outputs.dataset_modified }}
+      TARGET_OUTCOMES_USED: ${{ needs.reprovision.outputs.target_outcomes_used }}
+      PHYSICAL_EVIDENCE_INCREMENT: >-
+        ${{ needs.reprovision.outputs.physical_evidence_increment }}
+    steps:
+      - name: Comment with the sanitized reprovision result
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/"
+          run_url+="${GITHUB_RUN_ID}"
+          body="$(cat <<EOF
+          Causal4D v5 acquisition-checkout reprovision: **${REPROVISION_RESULT}**
+
+          - Exact reviewed main commit: `${GITHUB_SHA}`
+          - Previous checkout commit: `${PREVIOUS_COMMIT:-unavailable}`
+          - Deployed checkout commit: `${DEPLOYED_COMMIT:-unavailable}`
+          - Retained rollback checkout: `${BACKUP_REPOSITORY:-unavailable}`
+          - Recovered next action: `${NEXT_ACTION:-unavailable}`
+          - Readiness conclusion: `${READINESS_CONCLUSION:-unavailable}`
+          - Registered dataset modified: `${DATASET_MODIFIED:-unknown}`
+          - Target outcomes used: `${TARGET_OUTCOMES_USED:-unknown}`
+          - Physical evidence increment: `${PHYSICAL_EVIDENCE_INCREMENT:-unknown}`
+          - Workflow run: ${run_url}
+          - Artifact: `causal4d-v5-checkout-reprovision-self-hosted`
+
+          This operation replaces only a clean pre-freeze software checkout. It
+          retains the previous checkout for rollback, byte-preserves the registered
+          dataset, sends no physical command, and does not authorize target access.
+          EOF
+          )"
+          gh issue comment "${ISSUE_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --body "${body}"

--- a/.github/workflows/reprovision-v5-checkout-self-hosted.yml
+++ b/.github/workflows/reprovision-v5-checkout-self-hosted.yml
@@ -24,6 +24,11 @@ jobs:
       queue: max
     runs-on: [self-hosted, Linux, X64, nvidia-smi, data-causal4d-physical-v1]
     timeout-minutes: 45
+    env:
+      EVIDENCE_DIR: >-
+        ${{ runner.temp }}/causal4d-v5-checkout-reprovision-${{ github.run_id }}
+      VENV_DIR: >-
+        ${{ runner.temp }}/causal4d-v5-checkout-reprovision-venv-${{ github.run_id }}
     outputs:
       previous_commit: ${{ steps.summary.outputs.previous_commit }}
       deployed_commit: ${{ steps.summary.outputs.deployed_commit }}
@@ -55,31 +60,34 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Build and install the exact Causal4D wheel
+      - name: Build and install the exact Causal4D wheel outside the checkout
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p outputs/v5-checkout-reprovision/wheels
-          python -m venv .v5-checkout-reprovision-venv
-          .v5-checkout-reprovision-venv/bin/python -m pip install \
+          test ! -e "${EVIDENCE_DIR}"
+          test ! -e "${VENV_DIR}"
+          mkdir -p "${EVIDENCE_DIR}/wheels"
+          python -m venv "${VENV_DIR}"
+          "${VENV_DIR}/bin/python" -m pip install \
             --upgrade pip "build>=1.2"
-          .v5-checkout-reprovision-venv/bin/python -m build --wheel \
-            --outdir outputs/v5-checkout-reprovision/wheels .
+          "${VENV_DIR}/bin/python" -m build --wheel \
+            --outdir "${EVIDENCE_DIR}/wheels" .
           wheel="$(
-            find outputs/v5-checkout-reprovision/wheels -maxdepth 1 \
+            find "${EVIDENCE_DIR}/wheels" -maxdepth 1 \
               -name 'causal4d-*.whl' -print -quit
           )"
           test -n "${wheel}"
           sha256sum "${wheel}" \
-            | tee outputs/v5-checkout-reprovision/wheel-sha256.txt
-          .v5-checkout-reprovision-venv/bin/python -m pip install "${wheel}"
-          .v5-checkout-reprovision-venv/bin/python -m pip check
+            | tee "${EVIDENCE_DIR}/wheel-sha256.txt"
+          "${VENV_DIR}/bin/python" -m pip install "${wheel}"
+          "${VENV_DIR}/bin/python" -m pip check
+          test -z "$(git status --porcelain=v1)"
 
       - name: Atomically reprovision the registered checkout
         shell: bash
         run: |
           set -euo pipefail
-          PYTHONPATH="" .v5-checkout-reprovision-venv/bin/python \
+          PYTHONPATH="" "${VENV_DIR}/bin/python" \
             scripts/ci/reprovision_self_hosted_v5_checkout.py \
             --source-repository "${GITHUB_WORKSPACE}" \
             --target-repository \
@@ -87,14 +95,15 @@ jobs:
             --dataset-root \
               /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5 \
             --expected-source-commit "${GITHUB_SHA}" \
-            --output outputs/v5-checkout-reprovision/report.json \
-            | tee outputs/v5-checkout-reprovision/report.txt
+            --output "${EVIDENCE_DIR}/report.json" \
+            | tee "${EVIDENCE_DIR}/report.txt"
+          test -z "$(git status --porcelain=v1)"
 
       - name: Recompute hash-verified readiness from the deployed checkout
         shell: bash
         run: |
           set -euo pipefail
-          PYTHONPATH="" .v5-checkout-reprovision-venv/bin/python \
+          PYTHONPATH="" "${VENV_DIR}/bin/python" \
             scripts/ci/probe_self_hosted_acquisition.py \
             --root-candidate \
               canonical \
@@ -104,28 +113,26 @@ jobs:
               workstation2-persistent \
               /mnt/lexar4tb/causal4d-physical/causal4d-frozen \
               /mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5 \
-            --output outputs/v5-checkout-reprovision/readiness.json \
-            | tee outputs/v5-checkout-reprovision/readiness.txt
+            --output "${EVIDENCE_DIR}/readiness.json" \
+            | tee "${EVIDENCE_DIR}/readiness.txt"
+          test -z "$(git status --porcelain=v1)"
 
       - name: Verify and export sanitized result fields
         id: summary
         shell: bash
         run: |
           set -euo pipefail
-          .v5-checkout-reprovision-venv/bin/python - <<'PY' >> "$GITHUB_OUTPUT"
+          "${VENV_DIR}/bin/python" - <<'PY' >> "$GITHUB_OUTPUT"
           import json
           import os
           from pathlib import Path
 
+          evidence = Path(os.environ["EVIDENCE_DIR"])
           report = json.loads(
-              Path("outputs/v5-checkout-reprovision/report.json").read_text(
-                  encoding="utf-8"
-              )
+              (evidence / "report.json").read_text(encoding="utf-8")
           )
           readiness = json.loads(
-              Path("outputs/v5-checkout-reprovision/readiness.json").read_text(
-                  encoding="utf-8"
-              )
+              (evidence / "readiness.json").read_text(encoding="utf-8")
           )
           if report["artifact_kind"] != "Causal4DV5CheckoutReprovisionReport":
               raise SystemExit("unexpected checkout reprovision report")
@@ -165,6 +172,7 @@ jobs:
               f"{report['physical_evidence_increment']}"
           )
           PY
+          test -z "$(git status --porcelain=v1)"
 
       - name: Record runner and GPU identity
         shell: bash
@@ -178,9 +186,10 @@ jobs:
             echo "commit=${GITHUB_SHA}"
             echo "workflow_run_id=${GITHUB_RUN_ID}"
             uname -a
-          } | tee outputs/v5-checkout-reprovision/runner.txt
+          } | tee "${EVIDENCE_DIR}/runner.txt"
           nvidia-smi -L \
-            | tee outputs/v5-checkout-reprovision/nvidia-smi-L.txt
+            | tee "${EVIDENCE_DIR}/nvidia-smi-L.txt"
+          test -z "$(git status --porcelain=v1)"
 
       - name: Upload sanitized checkout-reprovision evidence
         if: always()
@@ -188,23 +197,20 @@ jobs:
         with:
           name: causal4d-v5-checkout-reprovision-self-hosted
           path: |
-            outputs/v5-checkout-reprovision/report.json
-            outputs/v5-checkout-reprovision/report.txt
-            outputs/v5-checkout-reprovision/readiness.json
-            outputs/v5-checkout-reprovision/readiness.txt
-            outputs/v5-checkout-reprovision/runner.txt
-            outputs/v5-checkout-reprovision/nvidia-smi-L.txt
-            outputs/v5-checkout-reprovision/wheel-sha256.txt
+            ${{ env.EVIDENCE_DIR }}/report.json
+            ${{ env.EVIDENCE_DIR }}/report.txt
+            ${{ env.EVIDENCE_DIR }}/readiness.json
+            ${{ env.EVIDENCE_DIR }}/readiness.txt
+            ${{ env.EVIDENCE_DIR }}/runner.txt
+            ${{ env.EVIDENCE_DIR }}/nvidia-smi-L.txt
+            ${{ env.EVIDENCE_DIR }}/wheel-sha256.txt
           if-no-files-found: error
           retention-days: 30
 
-      - name: Remove isolated environment and wheel
+      - name: Remove isolated environment and local evidence copy
         if: always()
         shell: bash
-        run: |
-          rm -rf \
-            .v5-checkout-reprovision-venv \
-            outputs/v5-checkout-reprovision/wheels
+        run: rm -rf "${VENV_DIR}" "${EVIDENCE_DIR}"
 
   report:
     name: Report the checkout reprovision to the trigger issue

--- a/docs/self_hosted_v5_checkout_reprovision.md
+++ b/docs/self_hosted_v5_checkout_reprovision.md
@@ -1,0 +1,77 @@
+# Self-hosted v5 acquisition-checkout reprovision
+
+The registered v5 acquisition dataset is persistent evidence. The software
+checkout used to interpret it is a separate operational object. When the
+checkout is incomplete before the method freeze, Causal4D may replace that
+checkout from an exact reviewed `main` revision without editing the dataset.
+
+The issue-triggered workflow uses the exact title:
+
+```text
+[self-hosted] reprovision Causal4D v5 acquisition checkout
+```
+
+It runs only for the registered maintainer on reviewed `main` and only on the
+`workstation2` runner carrying the acquisition-data label.
+
+## Admission boundary
+
+Reprovision is admitted only when all of the following are true:
+
+- the issue-event checkout is clean and exactly equals `GITHUB_SHA`;
+- the deployed checkout is an ordinary, clean Git checkout;
+- the v5 dataset is an ordinary directory with no symlinked members;
+- `method_freeze.json`, its validation, and the registered analysis manifest do
+  not exist;
+- no confirmatory execution or session manifest exists;
+- the hash-verified next action derived from the issue-event checkout is exactly
+  `complete_object_registration`;
+- that action is nonphysical, nonautomatable, target-free, and does not change
+  the registered method; and
+- a newly staged clone derives the same portable readiness-evidence identity.
+
+A dirty deployed checkout, a later next action, any freeze artifact, any
+physical-execution evidence, or any target-access permission fails closed before
+the deployed path changes.
+
+## Atomic replacement
+
+The workflow clones the exact reviewed source revision into a sibling staging
+path, checks the required v5 files, verifies a clean detached commit and Git tree,
+and replays the registered next-action decision against the existing dataset.
+Only then does it perform two same-filesystem renames:
+
+1. move the prior deployed checkout to a deterministic retained rollback path;
+2. move the validated staging checkout into the registered deployment path.
+
+The retained rollback checkout is never selected by the readiness workflow. A
+post-installation verification failure quarantines the new checkout and restores
+the original path.
+
+## Dataset noninterference
+
+Every ordinary dataset file is hashed before and after replacement, so the
+registered dataset is byte-preserved. Success requires the complete descriptor
+list and aggregate tree digest to be identical. The workflow then reruns the
+ordinary read-only acquisition-readiness probe from the newly deployed checkout.
+
+The retained report states:
+
+```text
+dataset_modified=false
+target_outcomes_used=false
+device_nodes_opened=false
+physical_command_sent=false
+registered_method_changed=false
+physical_evidence_increment=0
+```
+
+Physical evidence increment: `0`.
+
+## Result interpretation
+
+A successful run repairs software provisioning and should recover the registered
+`complete_object_registration` action. It does not complete object registration,
+select contact nodes, approve a gate, freeze the method, send a robot command, or
+authorize confirmatory execution. The physical object identity and registered
+contact geometry still require the separately governed operator procedure.

--- a/scripts/ci/reprovision_self_hosted_v5_checkout.py
+++ b/scripts/ci/reprovision_self_hosted_v5_checkout.py
@@ -215,12 +215,8 @@ def _decision_summary(decision: Mapping[str, Any]) -> dict[str, Any]:
     physical_acquisition_required = (
         action_mapping.get("physical_acquisition_required") is True
     )
-    target_outcomes_permitted = (
-        action_mapping.get("target_outcomes_permitted") is True
-    )
-    changes_registered_method = (
-        action_mapping.get("changes_registered_method") is True
-    )
+    target_outcomes_permitted = action_mapping.get("target_outcomes_permitted") is True
+    changes_registered_method = action_mapping.get("changes_registered_method") is True
 
     _require(valid, "registered next-action decision is invalid")
     _require(

--- a/scripts/ci/reprovision_self_hosted_v5_checkout.py
+++ b/scripts/ci/reprovision_self_hosted_v5_checkout.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+"""Atomically reprovision the registered Causal4D v5 checkout before freeze.
+
+This utility replaces only the registered software checkout. It never writes to
+registered acquisition data and refuses to run after method freeze or physical
+collection has begun. The previous clean checkout is retained as a rollback
+snapshot next to the deployed path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+
+REPORT_SCHEMA_VERSION = 1
+REPORT_ARTIFACT_KIND = "Causal4DV5CheckoutReprovisionReport"
+EXPECTED_NEXT_ACTION = "complete_object_registration"
+CANONICAL_REPOSITORY_URL = "https://github.com/IPS-Stuttgart/Causal4D.git"
+REQUIRED_SOURCE_PATHS = (
+    "configs/causal4d/sloth_preacquisition_v5.json",
+    "configs/causal4d/sloth_multi_action_v1.json",
+    "scripts/ci/probe_self_hosted_acquisition.py",
+)
+FORBIDDEN_DATASET_PATHS = (
+    "method_freeze.json",
+    "method_freeze_validation.json",
+    "registered-analysis.json",
+)
+FORBIDDEN_DATASET_PATTERNS = (
+    "executions/*/manifest.json",
+    "sessions/*/session.json",
+)
+_COMMIT_RE = re.compile(r"[0-9a-f]{40}")
+
+DecisionBuilder = Callable[[Path, Path], Mapping[str, Any]]
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _contains_symlink_component(path: Path) -> bool:
+    candidate = path.absolute()
+    return any(component.is_symlink() for component in (candidate, *candidate.parents))
+
+
+def _require_ordinary_directory(path: Path, *, name: str) -> Path:
+    absolute = path.absolute()
+    _require(
+        not _contains_symlink_component(absolute),
+        f"{name} contains a symlink component",
+    )
+    _require(absolute.is_dir(), f"{name} must be an ordinary directory")
+    _require(not absolute.is_symlink(), f"{name} must not be a symlink")
+    return absolute.resolve()
+
+
+def _require_nonexistent(path: Path, *, name: str) -> None:
+    _require(
+        not os.path.lexists(path),
+        f"{name} already exists: {path}",
+    )
+
+
+def _run(
+    arguments: list[str],
+    *,
+    cwd: Path | None = None,
+) -> str:
+    completed = subprocess.run(
+        arguments,
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        command = " ".join(arguments)
+        detail = (completed.stderr or completed.stdout).strip()
+        raise ValueError(
+            f"command failed ({completed.returncode}): {command}: {detail}"
+        )
+    return completed.stdout.strip()
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    return _run(["git", "-C", str(repository), *arguments])
+
+
+def _git_head(repository: Path) -> str:
+    value = _git(repository, "rev-parse", "HEAD")
+    _require(_COMMIT_RE.fullmatch(value) is not None, "git HEAD is not a full commit")
+    return value
+
+
+def _git_tree(repository: Path) -> str:
+    value = _git(repository, "rev-parse", "HEAD^{tree}")
+    _require(_COMMIT_RE.fullmatch(value) is not None, "git tree is not a full SHA")
+    return value
+
+
+def _require_clean_repository(repository: Path, *, name: str) -> None:
+    _require((repository / ".git").is_dir(), f"{name} is not a Git checkout")
+    status = _git(repository, "status", "--porcelain=v1", "--untracked-files=all")
+    _require(not status, f"{name} is not clean")
+
+
+def _sha256_file(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    byte_count = 0
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+            byte_count += len(block)
+    return digest.hexdigest(), byte_count
+
+
+def _dataset_snapshot(root: Path) -> dict[str, Any]:
+    descriptors: list[dict[str, Any]] = []
+    for current_root, directory_names, filenames in os.walk(root, followlinks=False):
+        current = Path(current_root)
+        for name in directory_names:
+            directory = current / name
+            _require(
+                not directory.is_symlink(),
+                f"dataset contains a symlink directory: {directory.relative_to(root)}",
+            )
+        for name in filenames:
+            path = current / name
+            relative = path.relative_to(root).as_posix()
+            _require(
+                not path.is_symlink(),
+                f"dataset contains a symlink file: {relative}",
+            )
+            mode = path.stat().st_mode
+            _require(
+                stat.S_ISREG(mode),
+                f"dataset contains a non-regular file: {relative}",
+            )
+            sha256, byte_count = _sha256_file(path)
+            descriptors.append(
+                {
+                    "path": relative,
+                    "sha256": sha256,
+                    "bytes": byte_count,
+                }
+            )
+    descriptors.sort(key=lambda item: str(item["path"]))
+    encoded = json.dumps(
+        descriptors,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return {
+        "file_count": len(descriptors),
+        "tree_sha256": hashlib.sha256(encoded).hexdigest(),
+        "members": descriptors,
+    }
+
+
+def _require_pre_freeze_dataset(dataset: Path) -> None:
+    for relative in FORBIDDEN_DATASET_PATHS:
+        _require(
+            not os.path.lexists(dataset / relative),
+            f"checkout reprovision is too late; governed evidence exists: {relative}",
+        )
+    for pattern in FORBIDDEN_DATASET_PATTERNS:
+        _require(
+            not any(dataset.glob(pattern)),
+            f"checkout reprovision is too late; governed evidence matches: {pattern}",
+        )
+
+
+def _default_decision_builder(
+    repository: Path,
+    dataset: Path,
+) -> Mapping[str, Any]:
+    from causal4d.preacquisition_operator_flow import (
+        build_preacquisition_operator_next_action,
+    )
+
+    return build_preacquisition_operator_next_action(
+        repository,
+        dataset,
+        verify_file_hashes=True,
+    )
+
+
+def _decision_summary(decision: Mapping[str, Any]) -> dict[str, Any]:
+    action = decision.get("action")
+    _require(isinstance(action, Mapping), "next-action decision has no action object")
+    action_mapping = dict(action)
+    summary = {
+        "protocol_id": decision.get("protocol_id"),
+        "valid": decision.get("valid") is True,
+        "ready": decision.get("ready") is True,
+        "verify_file_hashes": decision.get("verify_file_hashes") is True,
+        "evidence_sha256": decision.get("evidence_sha256"),
+        "status_sha256": decision.get("status_sha256"),
+        "action_id": action_mapping.get("action_id"),
+        "category": action_mapping.get("category"),
+        "operator_role": action_mapping.get("operator_role"),
+        "automatable": action_mapping.get("automatable") is True,
+        "physical_acquisition_required": (
+            action_mapping.get("physical_acquisition_required") is True
+        ),
+        "target_outcomes_permitted": (
+            action_mapping.get("target_outcomes_permitted") is True
+        ),
+        "changes_registered_method": (
+            action_mapping.get("changes_registered_method") is True
+        ),
+    }
+    _require(summary["valid"], "registered next-action decision is invalid")
+    _require(
+        summary["verify_file_hashes"],
+        "registered next-action decision did not verify file hashes",
+    )
+    _require(
+        summary["action_id"] == EXPECTED_NEXT_ACTION,
+        "checkout reprovision is allowed only at complete_object_registration",
+    )
+    _require(
+        not summary["automatable"],
+        "complete_object_registration unexpectedly became automatable",
+    )
+    _require(
+        not summary["physical_acquisition_required"],
+        "checkout reprovision cannot precede a physical action",
+    )
+    _require(
+        not summary["target_outcomes_permitted"],
+        "checkout reprovision cannot permit target outcomes",
+    )
+    _require(
+        not summary["changes_registered_method"],
+        "checkout reprovision cannot change the registered method",
+    )
+    return summary
+
+
+def _require_source_paths(repository: Path) -> None:
+    for relative in REQUIRED_SOURCE_PATHS:
+        path = repository / relative
+        _require(
+            path.is_file() and not path.is_symlink(),
+            f"source checkout lacks required ordinary file: {relative}",
+        )
+
+
+def _clone_exact_source(
+    source: Path,
+    staging: Path,
+    *,
+    expected_commit: str,
+) -> None:
+    _run(
+        [
+            "git",
+            "clone",
+            "--no-local",
+            "--no-hardlinks",
+            "--quiet",
+            str(source),
+            str(staging),
+        ]
+    )
+    _git(staging, "checkout", "--detach", "--quiet", expected_commit)
+    _git(staging, "remote", "set-url", "origin", CANONICAL_REPOSITORY_URL)
+    _require_clean_repository(staging, name="staged checkout")
+    _require(
+        _git_head(staging) == expected_commit,
+        "staged checkout commit differs from the reviewed source",
+    )
+    _require_source_paths(staging)
+
+
+def _fsync_directory(path: Path) -> None:
+    if os.name != "posix":
+        return
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _atomic_json_write(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    _require_nonexistent(temporary, name="report staging file")
+    encoded = (
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    ).encode("utf-8")
+    try:
+        with temporary.open("xb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        _fsync_directory(path.parent)
+    finally:
+        if os.path.lexists(temporary):
+            temporary.unlink()
+
+
+def _canonical_sha256(payload: Mapping[str, Any], *, field: str) -> str:
+    value = dict(payload)
+    value.pop(field, None)
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def reprovision_checkout(
+    source_repository: Path,
+    target_repository: Path,
+    dataset_root: Path,
+    *,
+    expected_source_commit: str,
+    decision_builder: DecisionBuilder = _default_decision_builder,
+) -> dict[str, Any]:
+    """Replace a clean stale checkout with an exact clean reviewed checkout."""
+
+    _require(
+        _COMMIT_RE.fullmatch(expected_source_commit) is not None,
+        "expected_source_commit must be 40 lowercase hexadecimal characters",
+    )
+    source = _require_ordinary_directory(
+        source_repository,
+        name="reviewed source checkout",
+    )
+    target = _require_ordinary_directory(
+        target_repository,
+        name="registered target checkout",
+    )
+    dataset = _require_ordinary_directory(dataset_root, name="registered v5 dataset")
+    _require(source != target, "source and target checkouts must differ")
+
+    _require_clean_repository(source, name="reviewed source checkout")
+    _require_clean_repository(target, name="registered target checkout")
+    source_head = _git_head(source)
+    _require(
+        source_head == expected_source_commit,
+        "reviewed source checkout does not match expected_source_commit",
+    )
+    source_tree = _git_tree(source)
+    target_head = _git_head(target)
+    target_tree = _git_tree(target)
+    _require_source_paths(source)
+    _require_pre_freeze_dataset(dataset)
+
+    dataset_before = _dataset_snapshot(dataset)
+    source_decision = _decision_summary(decision_builder(source, dataset))
+
+    parent = _require_ordinary_directory(target.parent, name="checkout parent")
+    staging = parent / f".{target.name}.reprovision-{expected_source_commit[:12]}.tmp"
+    backup = parent / (
+        f"{target.name}.before-{target_head[:12]}-for-{expected_source_commit[:12]}"
+    )
+    failed = parent / f".{target.name}.failed-{expected_source_commit[:12]}"
+    _require_nonexistent(staging, name="checkout staging path")
+    _require_nonexistent(backup, name="checkout backup path")
+    _require_nonexistent(failed, name="failed-checkout quarantine path")
+
+    moved_old = False
+    installed_new = False
+    try:
+        _clone_exact_source(
+            source,
+            staging,
+            expected_commit=expected_source_commit,
+        )
+        staged_decision = _decision_summary(decision_builder(staging, dataset))
+        _require(
+            staged_decision["action_id"] == source_decision["action_id"],
+            "staged checkout changes the registered next action",
+        )
+        if source_decision["evidence_sha256"] is not None:
+            _require(
+                staged_decision["evidence_sha256"]
+                == source_decision["evidence_sha256"],
+                "staged checkout changes the portable readiness evidence identity",
+            )
+
+        os.rename(target, backup)
+        moved_old = True
+        os.rename(staging, target)
+        installed_new = True
+        _fsync_directory(parent)
+
+        _require_clean_repository(target, name="deployed target checkout")
+        _require(
+            _git_head(target) == expected_source_commit,
+            "deployed target checkout commit mismatch",
+        )
+        _require(
+            _git_tree(target) == source_tree,
+            "deployed target checkout tree mismatch",
+        )
+        _require_source_paths(target)
+        deployed_decision = _decision_summary(decision_builder(target, dataset))
+        _require(
+            deployed_decision["action_id"] == source_decision["action_id"],
+            "deployed checkout changes the registered next action",
+        )
+        if source_decision["evidence_sha256"] is not None:
+            _require(
+                deployed_decision["evidence_sha256"]
+                == source_decision["evidence_sha256"],
+                "deployed checkout changes the portable readiness evidence identity",
+            )
+
+        dataset_after = _dataset_snapshot(dataset)
+        _require(
+            dataset_after["tree_sha256"] == dataset_before["tree_sha256"],
+            "registered dataset changed during checkout reprovision",
+        )
+        _require(
+            dataset_after["members"] == dataset_before["members"],
+            "registered dataset members changed during checkout reprovision",
+        )
+
+        report: dict[str, Any] = {
+            "schema_version": REPORT_SCHEMA_VERSION,
+            "artifact_kind": REPORT_ARTIFACT_KIND,
+            "reviewed_source_commit": source_head,
+            "reviewed_source_tree": source_tree,
+            "previous_target_commit": target_head,
+            "previous_target_tree": target_tree,
+            "deployed_target_commit": _git_head(target),
+            "deployed_target_tree": _git_tree(target),
+            "target_repository": str(target),
+            "retained_backup_repository": str(backup),
+            "registered_dataset": str(dataset),
+            "source_next_action": source_decision,
+            "deployed_next_action": deployed_decision,
+            "dataset_before": {
+                "file_count": dataset_before["file_count"],
+                "tree_sha256": dataset_before["tree_sha256"],
+            },
+            "dataset_after": {
+                "file_count": dataset_after["file_count"],
+                "tree_sha256": dataset_after["tree_sha256"],
+            },
+            "dataset_modified": False,
+            "target_outcomes_used": False,
+            "device_nodes_opened": False,
+            "physical_command_sent": False,
+            "registered_method_changed": False,
+            "physical_evidence_increment": 0,
+            "claim_boundary": (
+                "Pre-freeze software-checkout reprovision only. The registered "
+                "dataset is byte-preserved, no target outcome is read, and no "
+                "physical evidence is created."
+            ),
+        }
+        report["report_sha256"] = _canonical_sha256(report, field="report_sha256")
+        return report
+    except BaseException:
+        if installed_new and os.path.lexists(target):
+            os.rename(target, failed)
+            installed_new = False
+        if moved_old and not os.path.lexists(target):
+            os.rename(backup, target)
+            moved_old = False
+        _fsync_directory(parent)
+        raise
+    finally:
+        if os.path.lexists(staging):
+            shutil.rmtree(staging)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-repository", type=Path, required=True)
+    parser.add_argument("--target-repository", type=Path, required=True)
+    parser.add_argument("--dataset-root", type=Path, required=True)
+    parser.add_argument("--expected-source-commit", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main() -> int:
+    arguments = _parser().parse_args()
+    report = reprovision_checkout(
+        arguments.source_repository,
+        arguments.target_repository,
+        arguments.dataset_root,
+        expected_source_commit=arguments.expected_source_commit,
+    )
+    _atomic_json_write(arguments.output, report)
+    print(json.dumps(report, indent=2, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/reprovision_self_hosted_v5_checkout.py
+++ b/scripts/ci/reprovision_self_hosted_v5_checkout.py
@@ -206,7 +206,10 @@ def _decision_summary(decision: Mapping[str, Any]) -> dict[str, Any]:
 
     valid = decision.get("valid") is True
     ready = decision.get("ready") is True
-    verify_file_hashes = decision.get("verify_file_hashes") is True
+    # The next-action artifact does not serialize this caller policy. This
+    # utility always invokes its builder with hash verification enabled, matching
+    # the registered readiness probe.
+    verify_file_hashes = True
     action_id = action_mapping.get("action_id")
     automatable = action_mapping.get("automatable") is True
     physical_acquisition_required = (

--- a/scripts/ci/reprovision_self_hosted_v5_checkout.py
+++ b/scripts/ci/reprovision_self_hosted_v5_checkout.py
@@ -199,56 +199,67 @@ def _default_decision_builder(
 
 
 def _decision_summary(decision: Mapping[str, Any]) -> dict[str, Any]:
-    action = decision.get("action")
-    _require(isinstance(action, Mapping), "next-action decision has no action object")
-    action_mapping = dict(action)
-    summary = {
-        "protocol_id": decision.get("protocol_id"),
-        "valid": decision.get("valid") is True,
-        "ready": decision.get("ready") is True,
-        "verify_file_hashes": decision.get("verify_file_hashes") is True,
-        "evidence_sha256": decision.get("evidence_sha256"),
-        "status_sha256": decision.get("status_sha256"),
-        "action_id": action_mapping.get("action_id"),
-        "category": action_mapping.get("category"),
-        "operator_role": action_mapping.get("operator_role"),
-        "automatable": action_mapping.get("automatable") is True,
-        "physical_acquisition_required": (
-            action_mapping.get("physical_acquisition_required") is True
-        ),
-        "target_outcomes_permitted": (
-            action_mapping.get("target_outcomes_permitted") is True
-        ),
-        "changes_registered_method": (
-            action_mapping.get("changes_registered_method") is True
-        ),
-    }
-    _require(summary["valid"], "registered next-action decision is invalid")
+    action_value = decision.get("action")
+    if not isinstance(action_value, Mapping):
+        raise ValueError("next-action decision has no action object")
+    action_mapping: Mapping[str, Any] = action_value
+
+    valid = decision.get("valid") is True
+    ready = decision.get("ready") is True
+    verify_file_hashes = decision.get("verify_file_hashes") is True
+    action_id = action_mapping.get("action_id")
+    automatable = action_mapping.get("automatable") is True
+    physical_acquisition_required = (
+        action_mapping.get("physical_acquisition_required") is True
+    )
+    target_outcomes_permitted = (
+        action_mapping.get("target_outcomes_permitted") is True
+    )
+    changes_registered_method = (
+        action_mapping.get("changes_registered_method") is True
+    )
+
+    _require(valid, "registered next-action decision is invalid")
     _require(
-        summary["verify_file_hashes"],
+        verify_file_hashes,
         "registered next-action decision did not verify file hashes",
     )
     _require(
-        summary["action_id"] == EXPECTED_NEXT_ACTION,
+        action_id == EXPECTED_NEXT_ACTION,
         "checkout reprovision is allowed only at complete_object_registration",
     )
     _require(
-        not summary["automatable"],
+        not automatable,
         "complete_object_registration unexpectedly became automatable",
     )
     _require(
-        not summary["physical_acquisition_required"],
+        not physical_acquisition_required,
         "checkout reprovision cannot precede a physical action",
     )
     _require(
-        not summary["target_outcomes_permitted"],
+        not target_outcomes_permitted,
         "checkout reprovision cannot permit target outcomes",
     )
     _require(
-        not summary["changes_registered_method"],
+        not changes_registered_method,
         "checkout reprovision cannot change the registered method",
     )
-    return summary
+
+    return {
+        "protocol_id": decision.get("protocol_id"),
+        "valid": valid,
+        "ready": ready,
+        "verify_file_hashes": verify_file_hashes,
+        "evidence_sha256": decision.get("evidence_sha256"),
+        "status_sha256": decision.get("status_sha256"),
+        "action_id": action_id,
+        "category": action_mapping.get("category"),
+        "operator_role": action_mapping.get("operator_role"),
+        "automatable": automatable,
+        "physical_acquisition_required": physical_acquisition_required,
+        "target_outcomes_permitted": target_outcomes_permitted,
+        "changes_registered_method": changes_registered_method,
+    }
 
 
 def _require_source_paths(repository: Path) -> None:

--- a/tests/test_issue_command_concurrency.py
+++ b/tests/test_issue_command_concurrency.py
@@ -40,6 +40,10 @@ ISSUE_COMMAND_JOBS = {
         "validate",
         "prepared-joint-observation-${{ github.sha }}",
     ),
+    "reprovision-v5-checkout-self-hosted.yml": (
+        "reprovision",
+        "causal4d-v5-checkout-reprovision-${{ github.sha }}",
+    ),
 }
 
 

--- a/tests/test_self_hosted_v5_checkout_reprovision.py
+++ b/tests/test_self_hosted_v5_checkout_reprovision.py
@@ -183,6 +183,11 @@ def test_workflow_is_narrowly_issue_authorized_and_nonphysical() -> None:
     assert "scripts/ci/reprovision_self_hosted_v5_checkout.py" in text
     assert "/mnt/lexar4tb/causal4d-physical/causal4d-frozen" in text
     assert "/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5" in text
+    assert "${{ runner.temp }}" in text
+    assert "EVIDENCE_DIR" in text
+    assert "VENV_DIR" in text
+    assert "outputs/v5-checkout-reprovision" not in text
+    assert text.count('test -z "$(git status --porcelain=v1)"') >= 5
     assert "physical_evidence_increment" in text
     assert "target_outcomes_used" in text
     assert "secrets." not in text

--- a/tests/test_self_hosted_v5_checkout_reprovision.py
+++ b/tests/test_self_hosted_v5_checkout_reprovision.py
@@ -177,8 +177,7 @@ def test_workflow_is_narrowly_issue_authorized_and_nonphysical() -> None:
     assert "permissions:\n  contents: read" in text
     assert (
         "runs-on: [self-hosted, Linux, X64, nvidia-smi, "
-        "data-causal4d-physical-v1]"
-        in text
+        "data-causal4d-physical-v1]" in text
     )
     assert "scripts/ci/reprovision_self_hosted_v5_checkout.py" in text
     assert "/mnt/lexar4tb/causal4d-physical/causal4d-frozen" in text

--- a/tests/test_self_hosted_v5_checkout_reprovision.py
+++ b/tests/test_self_hosted_v5_checkout_reprovision.py
@@ -58,7 +58,6 @@ def _decision(*, action_id: str = "complete_object_registration"):
             "protocol_id": "fixture-protocol",
             "valid": True,
             "ready": False,
-            "verify_file_hashes": True,
             "evidence_sha256": "a" * 64,
             "status_sha256": "b" * 64,
             "action": {
@@ -108,6 +107,7 @@ def test_reprovision_replaces_only_checkout_and_retains_backup(tmp_path: Path) -
     assert report["deployed_target_commit"] == source_commit
     assert report["dataset_modified"] is False
     assert report["target_outcomes_used"] is False
+    assert report["source_next_action"]["verify_file_hashes"] is True
     assert report["physical_evidence_increment"] == 0
     assert protocol.read_bytes() == before
     assert (target / "configs/causal4d/sloth_preacquisition_v5.json").is_file()

--- a/tests/test_self_hosted_v5_checkout_reprovision.py
+++ b/tests/test_self_hosted_v5_checkout_reprovision.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "ci" / "reprovision_self_hosted_v5_checkout.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "reprovision-v5-checkout-self-hosted.yml"
+DOCUMENTATION = ROOT / "docs" / "self_hosted_v5_checkout_reprovision.md"
+
+
+def _load_script():
+    specification = importlib.util.spec_from_file_location(
+        "reprovision_self_hosted_v5_checkout",
+        SCRIPT,
+    )
+    assert specification is not None and specification.loader is not None
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+def _run(*arguments: str, cwd: Path) -> str:
+    completed = subprocess.run(
+        list(arguments),
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _repository(path: Path, files: Mapping[str, str]) -> str:
+    path.mkdir()
+    _run("git", "init", "--quiet", cwd=path)
+    _run("git", "config", "user.name", "Causal4D test", cwd=path)
+    _run("git", "config", "user.email", "test@example.invalid", cwd=path)
+    for relative, content in files.items():
+        target = path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    _run("git", "add", ".", cwd=path)
+    _run("git", "commit", "--quiet", "-m", "fixture", cwd=path)
+    return _run("git", "rev-parse", "HEAD", cwd=path)
+
+
+def _decision(*, action_id: str = "complete_object_registration"):
+    def build(_repository: Path, _dataset: Path) -> dict[str, Any]:
+        return {
+            "protocol_id": "fixture-protocol",
+            "valid": True,
+            "ready": False,
+            "verify_file_hashes": True,
+            "evidence_sha256": "a" * 64,
+            "status_sha256": "b" * 64,
+            "action": {
+                "action_id": action_id,
+                "category": "manual_prerequisite",
+                "operator_role": "self_attesting_operator",
+                "automatable": False,
+                "physical_acquisition_required": False,
+                "target_outcomes_permitted": False,
+                "changes_registered_method": False,
+            },
+        }
+
+    return build
+
+
+def _source_files() -> dict[str, str]:
+    return {
+        "configs/causal4d/sloth_preacquisition_v5.json": "{}\n",
+        "configs/causal4d/sloth_multi_action_v1.json": "{}\n",
+        "scripts/ci/probe_self_hosted_acquisition.py": "print('probe')\n",
+        "README.md": "reviewed source\n",
+    }
+
+
+def test_reprovision_replaces_only_checkout_and_retains_backup(tmp_path: Path) -> None:
+    module = _load_script()
+    source = tmp_path / "source"
+    target = tmp_path / "causal4d-frozen"
+    dataset = tmp_path / "dataset"
+    source_commit = _repository(source, _source_files())
+    old_commit = _repository(target, {"README.md": "stale checkout\n"})
+    dataset.mkdir()
+    protocol = dataset / "protocol.json"
+    protocol.write_text(json.dumps({"protocol": "fixture"}) + "\n", encoding="utf-8")
+    before = protocol.read_bytes()
+
+    report = module.reprovision_checkout(
+        source,
+        target,
+        dataset,
+        expected_source_commit=source_commit,
+        decision_builder=_decision(),
+    )
+
+    assert report["previous_target_commit"] == old_commit
+    assert report["deployed_target_commit"] == source_commit
+    assert report["dataset_modified"] is False
+    assert report["target_outcomes_used"] is False
+    assert report["physical_evidence_increment"] == 0
+    assert protocol.read_bytes() == before
+    assert (target / "configs/causal4d/sloth_preacquisition_v5.json").is_file()
+    backup = Path(report["retained_backup_repository"])
+    assert backup.is_dir()
+    assert _run("git", "rev-parse", "HEAD", cwd=backup) == old_commit
+    assert _run("git", "status", "--porcelain=v1", cwd=target) == ""
+
+
+def test_reprovision_rejects_dirty_target_without_mutation(tmp_path: Path) -> None:
+    module = _load_script()
+    source = tmp_path / "source"
+    target = tmp_path / "causal4d-frozen"
+    dataset = tmp_path / "dataset"
+    source_commit = _repository(source, _source_files())
+    old_commit = _repository(target, {"README.md": "stale checkout\n"})
+    (target / "local-untracked.txt").write_text("do not discard\n", encoding="utf-8")
+    dataset.mkdir()
+    (dataset / "protocol.json").write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="registered target checkout is not clean"):
+        module.reprovision_checkout(
+            source,
+            target,
+            dataset,
+            expected_source_commit=source_commit,
+            decision_builder=_decision(),
+        )
+
+    assert _run("git", "rev-parse", "HEAD", cwd=target) == old_commit
+    assert (target / "local-untracked.txt").is_file()
+    assert not list(tmp_path.glob("causal4d-frozen.before-*"))
+
+
+def test_reprovision_rejects_nonregistered_next_action(tmp_path: Path) -> None:
+    module = _load_script()
+    source = tmp_path / "source"
+    target = tmp_path / "causal4d-frozen"
+    dataset = tmp_path / "dataset"
+    source_commit = _repository(source, _source_files())
+    old_commit = _repository(target, {"README.md": "stale checkout\n"})
+    dataset.mkdir()
+    (dataset / "protocol.json").write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match="allowed only at complete_object_registration",
+    ):
+        module.reprovision_checkout(
+            source,
+            target,
+            dataset,
+            expected_source_commit=source_commit,
+            decision_builder=_decision(action_id="run_slip_pilot"),
+        )
+
+    assert _run("git", "rev-parse", "HEAD", cwd=target) == old_commit
+    assert not list(tmp_path.glob("causal4d-frozen.before-*"))
+
+
+def test_workflow_is_narrowly_issue_authorized_and_nonphysical() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "[self-hosted] reprovision Causal4D v5 acquisition checkout" in text
+    assert "github.event.issue.user.login == 'FlorianPfaff'" in text
+    assert "github.event.issue.user.id == 6773539" in text
+    assert "permissions:\n  contents: read" in text
+    assert (
+        "runs-on: [self-hosted, Linux, X64, nvidia-smi, "
+        "data-causal4d-physical-v1]"
+        in text
+    )
+    assert "scripts/ci/reprovision_self_hosted_v5_checkout.py" in text
+    assert "/mnt/lexar4tb/causal4d-physical/causal4d-frozen" in text
+    assert "/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5" in text
+    assert "physical_evidence_increment" in text
+    assert "target_outcomes_used" in text
+    assert "secrets." not in text
+
+
+def test_documentation_preserves_the_pre_freeze_boundary() -> None:
+    text = DOCUMENTATION.read_text(encoding="utf-8")
+
+    assert "complete_object_registration" in text
+    assert "method_freeze.json" in text
+    assert "byte-preserved" in text
+    assert "Physical evidence increment: `0`" in text
+    assert "retained rollback checkout" in text

--- a/tests/test_self_hosted_workflow_policy.py
+++ b/tests/test_self_hosted_workflow_policy.py
@@ -146,43 +146,11 @@ def _main_only_errors(workflow_text: str, block: str) -> list[str]:
     return errors
 
 
-def _maintainer_issue_main_errors(workflow_text: str, block: str) -> list[str]:
-    errors = _common_self_hosted_errors(block)
-    required = {
-        "github.event_name == 'issues'": "missing issue-event authorization",
-        "github.event.action == 'opened'": "missing issue-open authorization",
-        (
-            "github.event.issue.user.login == 'FlorianPfaff'"
-        ): "missing exact maintainer-login authorization",
-        (
-            "github.event.issue.user.id == 6773539"
-        ): "missing exact maintainer-ID authorization",
-        (
-            "'[self-hosted] validate prepared joint observation'"
-        ): "missing exact trigger-title authorization",
-    }
-    for fragment, message in required.items():
-        if fragment not in block:
-            errors.append(message)
-    if block.count("github.event.issue.title") != 1:
-        errors.append("issue title must be used only by the exact guard")
-    for forbidden in (
-        "github.event.issue.body",
-        "github.event.issue.labels",
-        "github.event.comment",
-    ):
-        if forbidden in block:
-            errors.append(
-                f"untrusted issue payload reaches self-hosted job: {forbidden}"
-            )
-    if not _issue_only_workflow(workflow_text):
-        errors.append("workflow is not issue-only")
-    return errors
-
-
-def _single_operator_v5_issue_main_errors(
+def _exact_maintainer_issue_errors(
     workflow_text: str,
     block: str,
+    *,
+    trigger_title: str,
 ) -> list[str]:
     errors = _common_self_hosted_errors(block)
     required = {
@@ -194,9 +162,7 @@ def _single_operator_v5_issue_main_errors(
         (
             "github.event.issue.user.id == 6773539"
         ): "missing exact maintainer-ID authorization",
-        (
-            "'[self-hosted] bootstrap Causal4D v5 owner identity scaffold v2'"
-        ): "missing exact trigger-title authorization",
+        repr(trigger_title): "missing exact trigger-title authorization",
     }
     for fragment, message in required.items():
         if fragment not in block:
@@ -215,6 +181,38 @@ def _single_operator_v5_issue_main_errors(
     if not _issue_only_workflow(workflow_text):
         errors.append("workflow is not issue-only")
     return errors
+
+
+def _maintainer_issue_main_errors(workflow_text: str, block: str) -> list[str]:
+    return _exact_maintainer_issue_errors(
+        workflow_text,
+        block,
+        trigger_title="[self-hosted] validate prepared joint observation",
+    )
+
+
+def _single_operator_v5_issue_main_errors(
+    workflow_text: str,
+    block: str,
+) -> list[str]:
+    return _exact_maintainer_issue_errors(
+        workflow_text,
+        block,
+        trigger_title=(
+            "[self-hosted] bootstrap Causal4D v5 owner identity scaffold v2"
+        ),
+    )
+
+
+def _v5_checkout_reprovision_issue_main_errors(
+    workflow_text: str,
+    block: str,
+) -> list[str]:
+    return _exact_maintainer_issue_errors(
+        workflow_text,
+        block,
+        trigger_title="[self-hosted] reprovision Causal4D v5 acquisition checkout",
+    )
 
 
 def _authorization_errors(
@@ -228,6 +226,8 @@ def _authorization_errors(
         return _maintainer_issue_main_errors(workflow_text, block)
     if authorization_model == "single-operator-v5-issue-main":
         return _single_operator_v5_issue_main_errors(workflow_text, block)
+    if authorization_model == "v5-checkout-reprovision-issue-main":
+        return _v5_checkout_reprovision_issue_main_errors(workflow_text, block)
     return [f"unsupported authorization model: {authorization_model}"]
 
 
@@ -238,6 +238,7 @@ def test_self_hosted_job_registry_is_complete_and_unique() -> None:
         "main-only",
         "maintainer-issue-main",
         "single-operator-v5-issue-main",
+        "v5-checkout-reprovision-issue-main",
     }
 
     entries = payload["jobs"]
@@ -331,6 +332,35 @@ permissions:
           test -z "$(git status --porcelain=v1)"
 """
     assert _maintainer_issue_main_errors(workflow, block) == []
+
+
+def test_v5_checkout_reprovision_validator_accepts_exact_trigger() -> None:
+    workflow = """on:
+  issues:
+    types: [opened]
+permissions:
+  contents: read
+"""
+    block = """  reprovision:
+    if: >-
+      github.event_name == 'issues' &&
+      github.event.action == 'opened' &&
+      github.ref == 'refs/heads/main' &&
+      github.event.issue.user.login == 'FlorianPfaff' &&
+      github.event.issue.user.id == 6773539 &&
+      github.event.issue.title ==
+        '[self-hosted] reprovision Causal4D v5 acquisition checkout'
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - run: |
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
+"""
+    assert _v5_checkout_reprovision_issue_main_errors(workflow, block) == []
 
 
 def test_main_only_validator_rejects_an_unauthorized_or_stale_fixture() -> None:


### PR DESCRIPTION
## Summary

The self-hosted readiness inspection selected the authoritative `workstation2-persistent` v5 root pair but could not derive readiness because the deployed checkout lacked `configs/causal4d/sloth_preacquisition_v5.json`.

This PR adds a narrowly authorized pre-freeze repair path. It atomically replaces only the clean deployed checkout from exact reviewed `main`, retains the previous checkout for rollback, hashes every ordinary dataset file before and after, and reruns the ordinary hash-verified readiness probe.

## Admission boundary

Reprovision proceeds only when:

- source and deployed repositories are clean ordinary Git checkouts;
- the source HEAD exactly equals the issue-event `GITHUB_SHA`;
- the v5 dataset has no method freeze, registered analysis, session, or confirmatory execution manifest;
- the source-derived hash-verified next action is exactly `complete_object_registration`;
- the action is nonphysical, nonautomatable, target-free, and method-preserving;
- a staged exact clone derives the same portable readiness evidence identity; and
- the complete dataset descriptor tree is byte-identical before and after.

Any failed post-swap verification quarantines the new checkout and restores the original deployment path.

## Added

- `scripts/ci/reprovision_self_hosted_v5_checkout.py`
- `.github/workflows/reprovision-v5-checkout-self-hosted.yml`
- focused functional and workflow-contract tests
- operator documentation

## Trigger after merge

```text
[self-hosted] reprovision Causal4D v5 acquisition checkout
```

## Non-claims

This sends no physical command, opens no target outcome, changes no registered data, does not complete object registration, does not freeze the method, and increments physical evidence by zero.