### PR TITLE
Register the v5 reprovision workflow with valid contexts

### DIFF
--- a/.github/workflows/reprovision-v5-checkout-self-hosted.yml
+++ b/.github/workflows/reprovision-v5-checkout-self-hosted.yml
@@ -24,11 +24,6 @@ jobs:
       queue: max
     runs-on: [self-hosted, Linux, X64, nvidia-smi, data-causal4d-physical-v1]
     timeout-minutes: 45
-    env:
-      EVIDENCE_DIR: >-
-        ${{ runner.temp }}/causal4d-v5-checkout-reprovision-${{ github.run_id }}
-      VENV_DIR: >-
-        ${{ runner.temp }}/causal4d-v5-checkout-reprovision-venv-${{ github.run_id }}
     outputs:
       previous_commit: ${{ steps.summary.outputs.previous_commit }}
       deployed_commit: ${{ steps.summary.outputs.deployed_commit }}
@@ -55,6 +50,19 @@ jobs:
           test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
           test -z "$(git status --porcelain=v1)"
 
+      - name: Prepare isolated runtime paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence_dir="${RUNNER_TEMP}/causal4d-v5-checkout-reprovision-${GITHUB_RUN_ID}"
+          venv_dir="${RUNNER_TEMP}/causal4d-v5-checkout-reprovision-venv-${GITHUB_RUN_ID}"
+          test ! -e "${evidence_dir}"
+          test ! -e "${venv_dir}"
+          {
+            echo "EVIDENCE_DIR=${evidence_dir}"
+            echo "VENV_DIR=${venv_dir}"
+          } >> "${GITHUB_ENV}"
+
       - name: Set up Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -64,8 +72,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          test ! -e "${EVIDENCE_DIR}"
-          test ! -e "${VENV_DIR}"
           mkdir -p "${EVIDENCE_DIR}/wheels"
           python -m venv "${VENV_DIR}"
           "${VENV_DIR}/bin/python" -m pip install \
@@ -197,13 +203,13 @@ jobs:
         with:
           name: causal4d-v5-checkout-reprovision-self-hosted
           path: |
-            ${{ env.EVIDENCE_DIR }}/report.json
-            ${{ env.EVIDENCE_DIR }}/report.txt
-            ${{ env.EVIDENCE_DIR }}/readiness.json
-            ${{ env.EVIDENCE_DIR }}/readiness.txt
-            ${{ env.EVIDENCE_DIR }}/runner.txt
-            ${{ env.EVIDENCE_DIR }}/nvidia-smi-L.txt
-            ${{ env.EVIDENCE_DIR }}/wheel-sha256.txt
+            ${{ runner.temp }}/causal4d-v5-checkout-reprovision-${{ github.run_id }}/report.json
+            ${{ runner.temp }}/causal4d-v5-checkout-reprovision-${{ github.run_id }}/report.txt
+            ${{ runner.temp }}/causal4d-v5-checkout-reprovision-${{ github.run_id }}/readiness.json
+            ${{ runner.temp }}/causal4d-v5-checkout-reprovision-${{ github.run_id }}/readiness.txt
+            ${{ runner.temp }}/causal4d-v5-checkout-reprovision-${{ github.run_id }}/runner.txt
+            ${{ runner.temp }}/causal4d-v5-checkout-reprovision-${{ github.run_id }}/nvidia-smi-L.txt
+            ${{ runner.temp }}/causal4d-v5-checkout-reprovision-${{ github.run_id }}/wheel-sha256.txt
           if-no-files-found: error
           retention-days: 30
 

--- a/tests/test_self_hosted_v5_checkout_reprovision.py
+++ b/tests/test_self_hosted_v5_checkout_reprovision.py
@@ -183,6 +183,9 @@ def test_workflow_is_narrowly_issue_authorized_and_nonphysical() -> None:
     assert "/mnt/lexar4tb/causal4d-physical/causal4d-frozen" in text
     assert "/mnt/lexar4tb/causal4d-physical/causal4d-sloth-multi-action-v1-v5" in text
     assert "${{ runner.temp }}" in text
+    assert "- name: Prepare isolated runtime paths" in text
+    assert '>> "${GITHUB_ENV}"' in text
+    assert "    env:\n      EVIDENCE_DIR: >-\n        ${{ runner.temp }}" not in text
     assert "EVIDENCE_DIR" in text
     assert "VENV_DIR" in text
     assert "outputs/v5-checkout-reprovision" not in text


### PR DESCRIPTION
## Summary

Issue #428 and retry #429 each produced only the eight pre-existing issue workflows. The new checkout-reprovision workflow was present on `main` but absent from the Actions event catalog.

The cause is the job-level use of `${{ runner.temp }}`. The `runner` context is available after runner allocation, not in `jobs.<job>.env`, so GitHub rejected the workflow definition before event registration.

This patch:

- removes job-level `runner.temp` expressions;
- initializes isolated evidence and venv paths at runtime from `$RUNNER_TEMP`;
- persists those paths through `$GITHUB_ENV` for later shell steps;
- uses `runner.temp` only in the upload-artifact step, where the context is valid;
- retains all exact-title, clean-checkout, dataset-byte-identity, rollback, no-target, and zero-physical-evidence guards; and
- adds a regression assertion that forbids the invalid job-level context pattern.

## Boundary

No self-hosted mutation is performed by this PR. After hosted checks pass and the patch is merged, the exact issue trigger will be retried.