### PR TITLE
Support Python 3.10 in the Deform360 layout probe

### DIFF
--- a/scripts/remote/inventory_deform360_download.py
+++ b/scripts/remote/inventory_deform360_download.py
@@ -70,9 +70,7 @@ def _relative(path: Path, root: Path) -> str:
 def _iso_utc(mtime_ns: int | None) -> str | None:
     if mtime_ns is None:
         return None
-    return datetime.fromtimestamp(
-        mtime_ns / 1_000_000_000, tz=timezone.utc
-    ).isoformat()
+    return datetime.fromtimestamp(mtime_ns / 1_000_000_000, tz=timezone.utc).isoformat()
 
 
 def _is_archive(name: str) -> bool:

--- a/scripts/remote/inventory_deform360_download.py
+++ b/scripts/remote/inventory_deform360_download.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import argparse
 from collections import Counter, deque
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 import json
 import os
 from pathlib import Path
@@ -70,7 +70,9 @@ def _relative(path: Path, root: Path) -> str:
 def _iso_utc(mtime_ns: int | None) -> str | None:
     if mtime_ns is None:
         return None
-    return datetime.fromtimestamp(mtime_ns / 1_000_000_000, tz=UTC).isoformat()
+    return datetime.fromtimestamp(
+        mtime_ns / 1_000_000_000, tz=timezone.utc
+    ).isoformat()
 
 
 def _is_archive(name: str) -> bool:


### PR DESCRIPTION
The `gpuserver4090` workflow uses `/usr/bin/python3`, which is Python 3.10 on the runner. The first reviewed layout run therefore stopped before metadata traversal because `datetime.UTC` is available only from Python 3.11.

This patch replaces it with `timezone.utc`, preserving identical UTC timestamps and the metadata-only information boundary. No workflow permissions, dataset access, split, or execution policy changes.