### PR TITLE
Fix Deform360 squash-merge file dispatch and retry gpuserver4090

### DIFF
--- a/.github/workflows/deform360-public-holdings-file-dispatch.yml
+++ b/.github/workflows/deform360-public-holdings-file-dispatch.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Select and validate one fixed request
         id: request
+        env:
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -37,6 +39,7 @@ jobs:
           /usr/bin/python3 - <<'PY' >> "${GITHUB_OUTPUT}"
           import json
           import os
+          import urllib.request
           from pathlib import Path
 
           holdings_path = "ops/deform360-gpuserver6000-request.json"
@@ -48,13 +51,47 @@ jobs:
           else:
               event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
               changed = set()
-              for commit in event.get("commits", []):
+              records = list(event.get("commits", []))
+              head_commit = event.get("head_commit")
+              if isinstance(head_commit, dict):
+                  records.append(head_commit)
+              for commit in records:
                   for field in ("added", "modified", "removed"):
                       changed.update(commit.get(field, []))
+
               changed_requests = sorted(changed & allowed_paths)
               if len(changed_requests) != 1:
+                  before = event.get("before")
+                  after = event.get("after", os.environ["GITHUB_SHA"])
+                  if not isinstance(before, str) or not isinstance(after, str):
+                      raise SystemExit("push payload lacks before/after revisions")
+                  if before == "0" * 40:
+                      raise SystemExit("initial-branch pushes are not dispatchable")
+                  compare_url = (
+                      f'{os.environ["GITHUB_API_URL"]}/repos/'
+                      f'{os.environ["GITHUB_REPOSITORY"]}/compare/{before}...{after}'
+                  )
+                  api_request = urllib.request.Request(
+                      compare_url,
+                      headers={
+                          "Accept": "application/vnd.github+json",
+                          "Authorization": f'Bearer {os.environ["GH_TOKEN"]}',
+                          "X-GitHub-Api-Version": "2022-11-28",
+                      },
+                  )
+                  with urllib.request.urlopen(api_request, timeout=30) as response:
+                      comparison = json.load(response)
+                  changed = {
+                      item["filename"]
+                      for item in comparison.get("files", [])
+                      if isinstance(item, dict) and isinstance(item.get("filename"), str)
+                  }
+                  changed_requests = sorted(changed & allowed_paths)
+
+              if len(changed_requests) != 1:
                   raise SystemExit(
-                      "push must change exactly one reviewed Deform360 request file"
+                      "push must change exactly one reviewed Deform360 request file; "
+                      f"found {changed_requests}"
                   )
               selected_path = changed_requests[0]
 

--- a/ops/deform360-reset-mechanics-gpuserver4090-request.json
+++ b/ops/deform360-reset-mechanics-gpuserver4090-request.json
@@ -6,5 +6,5 @@
   "ref": "main",
   "data_root": "",
   "run_source_diagnostic": true,
-  "request_id": "2026-08-30-gpuserver4090-reset-mechanics-source-v1"
+  "request_id": "2026-08-30-gpuserver4090-reset-mechanics-source-v2"
 }

--- a/tests/test_deform360_gpuserver6000_workflow_policy.py
+++ b/tests/test_deform360_gpuserver6000_workflow_policy.py
@@ -50,6 +50,8 @@ def test_file_change_dispatcher_is_hosted_and_fixed() -> None:
     assert "deform360-public-holdings-gpuserver6000.yml" in text
     assert "deform360-reset-mechanics.yml" in text
     assert "GITHUB_EVENT_PATH" in text
+    assert 'event.get("head_commit")' in text
+    assert "/compare/{before}...{after}" in text
     assert "changed_requests" in text
     assert "workflow_dispatch" in text
 
@@ -79,7 +81,7 @@ def test_reset_request_is_source_only_on_gpuserver4090() -> None:
         "ref": "main",
         "data_root": "",
         "run_source_diagnostic": True,
-        "request_id": "2026-08-30-gpuserver4090-reset-mechanics-source-v1",
+        "request_id": "2026-08-30-gpuserver4090-reset-mechanics-source-v2",
     }
 
     workflow = RESET_WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Purpose

The first merged request exposed a dispatcher bug: the squash-merge push payload did not populate the per-commit change lists used to identify the reviewed request, so the downstream workflow was not dispatched.

## Fix

- inspect both `commits` and `head_commit` change lists;
- fail over to the authenticated GitHub compare API for the exact push `before...after` revisions;
- continue to require exactly one of the two reviewed Deform360 request files;
- increment the source-only gpuserver4090 request identity to `v2` so this merge retriggers the request;
- test the fallback mechanism and exact request identity.

## Boundary

The requested downstream job remains the existing source-only Deform360 reset-and-roll mechanics diagnostic on `[self-hosted, Linux, X64, nvidia-smi, gpuserver4090]` using `/mnt/seagate10tb/florianpfaff/datasets/deform360`. Calibration and target outcomes remain closed.