### PR TITLE
Preprocess three exploratory Deform360 objects for source development

### DIFF
--- a/ops/deform360-gpuserver6000-request.json
+++ b/ops/deform360-gpuserver6000-request.json
@@ -5,7 +5,7 @@
   "workflow": "deform360-public-holdings-gpuserver6000.yml",
   "ref": "main",
   "process_candidates": true,
-  "max_objects": "1",
+  "max_objects": "4",
   "hash_001_media": false,
-  "request_id": "2026-08-30-gpuserver6000-public-holdings-v1"
+  "request_id": "2026-08-31-gpuserver6000-public-holdings-expansion-v1"
 }

--- a/tests/test_deform360_gpuserver6000_workflow_policy.py
+++ b/tests/test_deform360_gpuserver6000_workflow_policy.py
@@ -56,7 +56,7 @@ def test_file_change_dispatcher_is_hosted_and_fixed() -> None:
     assert "workflow_dispatch" in text
 
 
-def test_request_is_bounded_to_one_exact_reproduction_object() -> None:
+def test_request_is_bounded_to_fixed_registered_public_objects() -> None:
     request = json.loads(REQUEST.read_text(encoding="utf-8"))
     assert request == {
         "schema_version": 1,
@@ -65,9 +65,9 @@ def test_request_is_bounded_to_one_exact_reproduction_object() -> None:
         "workflow": "deform360-public-holdings-gpuserver6000.yml",
         "ref": "main",
         "process_candidates": True,
-        "max_objects": "1",
+        "max_objects": "4",
         "hash_001_media": False,
-        "request_id": "2026-08-30-gpuserver6000-public-holdings-v1",
+        "request_id": "2026-08-31-gpuserver6000-public-holdings-expansion-v1",
     }
 
 


### PR DESCRIPTION
## Purpose

Extend the successful exact `001-rope` public-holdings reproduction to the three fixed exploratory ten-episode objects:

- `003-cable`
- `086-cotton-scarf-cloth`
- `171-penguin`

The completed `001-rope` output is retained under `--no-overwrite` semantics. This replacement is based on current `main` after the superseded workflow cleanup in #452; it supersedes conflicted PR #451 without changing the scientific request.

## Information boundary

- public Deform360 data only;
- the terminal six-object shared-physics cohort remains metadata-only and excluded from preprocessing;
- no protected target episode is opened;
- preprocessing is source-development infrastructure, not predictive validation;
- raw sources remain read-only and are fingerprinted before and after processing;
- no paper claim is authorized.

The aligned exploratory objects will be used only to evaluate a genuinely different state–discrepancy/intervention backend against persistence and `last_residual`. Any held-out evaluation requires a separately frozen protocol on untouched public objects or sessions.