### PR TITLE
Admit complete DOT, Tracking Cloth, and DEFORM sources on gpuserver4090

### DIFF
--- a/.github/self-hosted-jobs.json
+++ b/.github/self-hosted-jobs.json
@@ -22,13 +22,7 @@
       "workflow": "acquisition-readiness-self-hosted.yml",
       "job": "inspect",
       "authorization_model": "main-only",
-      "runner_labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "nvidia-smi",
-        "data-causal4d-physical-v1"
-      ],
+      "runner_labels": ["self-hosted", "Linux", "X64", "nvidia-smi", "data-causal4d-physical-v1"],
       "purpose": "Read-only registered acquisition readiness and interface qualification",
       "dataset_access": "registered-local-preacquisition-read-only",
       "secrets_allowed": false
@@ -37,13 +31,7 @@
       "workflow": "automatable-preacquisition-self-hosted.yml",
       "job": "execute",
       "authorization_model": "main-only",
-      "runner_labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "nvidia-smi",
-        "data-causal4d-physical-v1"
-      ],
+      "runner_labels": ["self-hosted", "Linux", "X64", "nvidia-smi", "data-causal4d-physical-v1"],
       "purpose": "Execute one exact allowlisted nonphysical registered next action",
       "dataset_access": "registered-local-preacquisition-single-template-write",
       "secrets_allowed": false
@@ -52,27 +40,25 @@
       "workflow": "bootstrap-single-operator-v5-self-hosted.yml",
       "job": "bootstrap",
       "authorization_model": "single-operator-v5-issue-main",
-      "runner_labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "nvidia-smi",
-        "data-causal4d-physical-v1"
-      ],
+      "runner_labels": ["self-hosted", "Linux", "X64", "nvidia-smi", "data-causal4d-physical-v1"],
       "purpose": "Create or revalidate the fresh v5 single-operator acquisition scaffold",
       "dataset_access": "registered-local-preacquisition-v5-owner-identity-bootstrap",
+      "secrets_allowed": false
+    },
+    {
+      "workflow": "complete-deformable-dataset-admission.yml",
+      "job": "source-inventory",
+      "authorization_model": "main-only",
+      "runner_labels": ["self-hosted", "Linux", "X64", "nvidia-smi", "gpuserver4090"],
+      "purpose": "Read-only source admission for complete DOT, Tracking Cloth Deformation, and DEFORM DLO4/DLO5 layouts",
+      "dataset_access": "source-only-file-metadata-text-manifests-numpy-headers-and-zip-central-directories",
       "secrets_allowed": false
     },
     {
       "workflow": "contact-posterior-concentration.yml",
       "job": "evaluate",
       "authorization_model": "main-only",
-      "runner_labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "nvidia-smi"
-      ],
+      "runner_labels": ["self-hosted", "Linux", "X64", "nvidia-smi"],
       "purpose": "Fresh-seed source-only concentration diagnostic",
       "dataset_access": "none",
       "secrets_allowed": false
@@ -81,12 +67,7 @@
       "workflow": "contact-posterior-diagnostics.yml",
       "job": "diagnose",
       "authorization_model": "main-only",
-      "runner_labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "nvidia-smi"
-      ],
+      "runner_labels": ["self-hosted", "Linux", "X64", "nvidia-smi"],
       "purpose": "Independent-seed controlled contact-posterior diagnostics",
       "dataset_access": "none",
       "secrets_allowed": false
@@ -95,12 +76,7 @@
       "workflow": "contact-topology-covariance.yml",
       "job": "evaluate",
       "authorization_model": "main-only",
-      "runner_labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "nvidia-smi"
-      ],
+      "runner_labels": ["self-hosted", "Linux", "X64", "nvidia-smi"],
       "purpose": "Sealed dual-lane topology-covariance reproduction",
       "dataset_access": "none",
       "secrets_allowed": false
@@ -109,12 +85,7 @@
       "workflow": "controlled-demo-video.yml",
       "job": "render",
       "authorization_model": "main-only",
-      "runner_labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "collaborator-demo"
-      ],
+      "runner_labels": ["self-hosted", "Linux", "X64", "collaborator-demo"],
       "purpose": "Controlled collaborator presentation bundle",
       "dataset_access": "none",
       "secrets_allowed": false
@@ -123,13 +94,7 @@
       "workflow": "correct-operator-registry-self-hosted.yml",
       "job": "correct",
       "authorization_model": "main-only",
-      "runner_labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "nvidia-smi",
-        "data-causal4d-physical-v1"
-      ],
+      "runner_labels": ["self-hosted", "Linux", "X64", "nvidia-smi", "data-causal4d-physical-v1"],
       "purpose": "Replace the unsupported roster with the single real participant",
       "dataset_access": "registered-local-preacquisition-operator-registry-correction",
       "secrets_allowed": false
@@ -138,13 +103,7 @@
       "workflow": "deform360-contact-support.yml",
       "job": "source-diagnostic",
       "authorization_model": "main-only",
-      "runner_labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "nvidia-smi",
-        "data-deform360-v1"
-      ],
+      "runner_labels": ["self-hosted", "Linux", "X64", "nvidia-smi", "data-deform360-v1"],
       "purpose": "Locked Deform360 source contact/support diagnostic",
       "dataset_access": "approved-source-only-deform360",
       "secrets_allowed": false
@@ -153,13 +112,7 @@
       "workflow": "deform360-filament-support.yml",
       "job": "source-diagnostic",
       "authorization_model": "main-only",
-      "runner_labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "nvidia-smi",
-        "data-deform360-v1"
-      ],
+      "runner_labels": ["self-hosted", "Linux", "X64", "nvidia-smi", "data-deform360-v1"],
       "purpose": "Locked Deform360 source filament-support diagnostic",
       "dataset_access": "approved-source-only-deform360",
       "secrets_allowed": false
@@ -168,13 +121,7 @@
       "workflow": "deform360-prefix-kinematics.yml",
       "job": "source-diagnostic",
       "authorization_model": "main-only",
-      "runner_labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "nvidia-smi",
-        "data-deform360-v1"
-      ],
+      "runner_labels": ["self-hosted", "Linux", "X64", "nvidia-smi", "data-deform360-v1"],
       "purpose": "Locked Deform360 source prefix-kinematics diagnostic",
       "dataset_acess": "approved-source-only-deform360",
       "secrets_allowed": false
@@ -183,13 +130,7 @@
       "workflow": "deform360-reset-mechanics.yml",
       "job": "source-diagnostic",
       "authorization_model": "main-only",
-      "runner_labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "nvidia-smi",
-        "gpuserver4090"
-      ],
+      "runner_labels": ["self-hosted", "Linux", "X64", "nvidia-smi", "gpuserver4090"],
       "purpose": "Locked Deform360 source reset-mechanics diagnostic on gpuserver4090",
       "dataset_acess": "approved-source-only-deform360-read-only-inventory-and-derived-evaluation",
       "secrets_allowed": false
@@ -198,12 +139,7 @@
       "workflow": "optional-integrations.yml",
       "job": "gpu",
       "authorization_model": "main-only",
-      "runner_labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "nvidia-smi"
-      ],
+      "runner_labels": ["self-hosted", "Linux", "X64", "nvidia-smi"],
       "purpose": "Optional CUDA/Warp integration smoke",
       "dataset_access": "none",
       "secrets_allowed": false
@@ -212,12 +148,7 @@
       "workflow": "prepared-joint-observation-self-hosted.yml",
       "job": "validate",
       "authorization_model": "maintainer-issue-main",
-      "runner_labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "nvidia-smi"
-      ],
+      "runner_labels": ["self-hosted", "Linux", "X64", "nvidia-smi"],
       "purpose": "Installed-wheel prepared joint-observation parity and scale validation",
       "dataset_access": "none",
       "secrets_allowed": false
@@ -226,13 +157,7 @@
       "workflow": "reprovision-v5-checkout-self-hosted.yml",
       "job": "reprovision",
       "authorization_model": "v5-checkout-reprovision-issue-main",
-      "runner_labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "nvidia-smi",
-        "data-causal4d-physical-v1"
-      ],
+      "runner_labels": ["self-hosted", "Linux", "X64", "nvidia-smi", "data-causal4d-physical-v1"],
       "purpose": "Atomically replace a stale clean pre-freeze v5 acquisition checkout",
       "dataset_access": "registered-local-preacquisition-v5-checkout-replacement-with-byte-verification",
       "secrets_allowed": false
@@ -241,12 +166,7 @@
       "workflow": "self-hosted-evaluation.yml",
       "job": "evaluate",
       "authorization_model": "main-only",
-      "runner_labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "nvidia-smi"
-      ],
+      "runner_labels": ["self-hosted", "Linux", "X64", "nvidia-smi"],
       "purpose": "Higher-powered controlled and GPU diagnostics",
       "dataset_access": "none",
       "secrets_allowed": false
@@ -255,13 +175,7 @@
       "workflow": "stage-object-registration-inputs-self-hosted.yml",
       "job": "stage",
       "authorization_model": "object-registration-input-stage-issue-main",
-      "runner_labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "nvidia-smi",
-        "data-causal4d-physical-v1"
-      ],
+      "runner_labels": ["self-hosted", "Linux", "X64", "nvidia-smi", "data-causal4d-physical-v1"],
       "purpose": "Stage exact approved source-only node sets before manual object registration",
       "dataset_access": "registered-local-preacquisition-object-registration-node-set-stage",
       "secrets_allowed": false
@@ -270,13 +184,7 @@
       "workflow": "workstation2-evaluation.yml",
       "job": "evaluate",
       "authorization_model": "main-only",
-      "runner_labels": [
-        "self-hosted",
-        "Linux",
-        "X64",
-        "nvidia-smi",
-        "host-workstation2"
-      ],
+      "runner_labels": ["self-hosted", "Linux", "X64", "nvidia-smi", "host-workstation2"],
       "purpose": "CUDA qualification and controlled replication",
       "dataset_access": "none",
       "secrets_allowed": false

--- a/.github/workflows/complete-deformable-dataset-admission.yml
+++ b/.github/workflows/complete-deformable-dataset-admission.yml
@@ -1,0 +1,186 @@
+name: Complete deformable-dataset admission
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/complete-deformable-dataset-admission.yml"
+      - ".github/self-hosted-jobs.json"
+      - "scripts/remote/inventory_complete_deformable_datasets.py"
+      - "tests/test_complete_deformable_dataset_admission.py"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/complete-deformable-dataset-admission.yml"
+      - ".github/self-hosted-jobs.json"
+      - "scripts/remote/inventory_complete_deformable_datasets.py"
+      - "tests/test_complete_deformable_dataset_admission.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: complete-deformable-dataset-admission-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: Source-only scanner contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install development checks
+        run: python -m pip install -e ".[dev]"
+
+      - name: Validate scanner and focused tests
+        run: |
+          python -m ruff check \
+            scripts/remote/inventory_complete_deformable_datasets.py \
+            tests/test_complete_deformable_dataset_admission.py
+          python -m ruff format --check \
+            scripts/remote/inventory_complete_deformable_datasets.py \
+            tests/test_complete_deformable_dataset_admission.py
+          python -m mypy \
+            scripts/remote/inventory_complete_deformable_datasets.py
+          python -m pytest -q \
+            tests/test_complete_deformable_dataset_admission.py
+
+  source-inventory:
+    name: Read-only DOT, cloth, and DEFORM admission
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    needs: contract
+    runs-on: [self-hosted, Linux, X64, nvidia-smi, gpuserver4090]
+    timeout-minutes: 120
+    env:
+      DOT_ROOT: /mnt/seagate10tb/florianpfaff/datasets/dot
+      TRACKING_CLOTH_ROOT: /home/github-runner/.cache/datasets/tracking-cloth-deformation-v1-zenodo-14644526
+      DEFORM_ROOT: /mnt/seagate10tb/florianpfaff/datasets/deform/data_set
+      OUTPUT_ROOT: complete-deformable-dataset-admission
+    steps:
+      - name: Check out exact reviewed revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          clean: true
+
+      - name: Verify immutable checkout and mounted roots
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
+          test -d "${DOT_ROOT}"
+          test -d "${TRACKING_CLOTH_ROOT}"
+          test -d "${DEFORM_ROOT}/DLO4"
+          test -d "${DEFORM_ROOT}/DLO5"
+          mkdir -p "${OUTPUT_ROOT}"
+          {
+            echo "repository=${GITHUB_REPOSITORY}"
+            echo "revision=${GITHUB_SHA}"
+            echo "run_id=${GITHUB_RUN_ID}"
+            echo "runner_name=${RUNNER_NAME}"
+            echo "runner_os=${RUNNER_OS}"
+            echo "runner_arch=${RUNNER_ARCH}"
+            /usr/bin/python3 --version
+            uname -a
+            nvidia-smi -L
+            df -h "${DOT_ROOT}" "${TRACKING_CLOTH_ROOT}" "${DEFORM_ROOT}"
+          } > "${OUTPUT_ROOT}/runner.txt"
+
+      - name: Inventory source layouts without loading outcomes
+        shell: bash
+        run: |
+          set -euo pipefail
+          /usr/bin/python3 \
+            scripts/remote/inventory_complete_deformable_datasets.py \
+            --dot-root "${DOT_ROOT}" \
+            --tracking-root "${TRACKING_CLOTH_ROOT}" \
+            --deform-root "${DEFORM_ROOT}" \
+            --output-dir "${OUTPUT_ROOT}" \
+            --expected-dot-archives 21 \
+            --expected-tracking-recordings 120 \
+            --expected-deform-units DLO4 DLO5 \
+            --expected-deform-files-per-unit 70 \
+            --strict
+
+      - name: Record artifact hashes and source boundary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          /usr/bin/python3 - <<'PY'
+          from __future__ import annotations
+
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ["OUTPUT_ROOT"])
+          files = sorted(path for path in root.glob("*") if path.is_file())
+          manifest = {
+              "schema": "causal4d.complete-deformable-dataset-admission-manifest-v1",
+              "repository": os.environ["GITHUB_REPOSITORY"],
+              "revision": os.environ["GITHUB_SHA"],
+              "workflow_run_id": os.environ["GITHUB_RUN_ID"],
+              "runner": os.environ["RUNNER_NAME"],
+              "source_only": True,
+              "future_or_target_outcomes_read": False,
+              "dataset_modified": False,
+              "files": {
+                  path.name: {
+                      "bytes": path.stat().st_size,
+                      "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+                  }
+                  for path in files
+              },
+          }
+          (root / "manifest.json").write_text(
+              json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Publish admission summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### Complete deformable-dataset admission"
+            echo
+            echo "- Revision: \`${GITHUB_SHA}\`"
+            echo "- Runner: \`${RUNNER_NAME}\`"
+            echo "- Source-only metadata/layout scan: \`true\`"
+            echo "- Numeric trajectory/image/tactile/force payloads loaded: \`false\`"
+            echo
+            if [[ -f "${OUTPUT_ROOT}/admission.md" ]]; then
+              cat "${OUTPUT_ROOT}/admission.md"
+            else
+              echo "Admission report was not produced; inspect the retained artifact."
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload immutable admission evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v6.0.0
+        with:
+          name: complete-deformable-dataset-admission-${{ github.run_id }}-${{ github.run_attempt }}
+          path: complete-deformable-dataset-admission
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/remote/inventory_complete_deformable_datasets.py
+++ b/scripts/remote/inventory_complete_deformable_datasets.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""Inventory complete deformable-object datasets without reading outcomes.
+
+The scanner opens directory metadata, small text manifests, NumPy headers, and
+ZIP central directories only. It never loads image, tactile, trajectory, point,
+or force payloads, and it never extracts an archive. The resulting report is a
+source-admission artifact, not an empirical result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import os
+import re
+import struct
+import sys
+import zipfile
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable
+
+MAX_TEXT_BYTES = 1_000_000
+TEXT_TOKENS = (
+    "readme",
+    "metadata",
+    "manifest",
+    "license",
+    "checksum",
+    "sha256",
+    "md5",
+)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _extension(path: Path) -> str:
+    suffix = path.suffix.lower()
+    return suffix if suffix else "<none>"
+
+
+def _regular_files(root: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in root.rglob("*")
+        if path.is_file() and not path.is_symlink()
+    )
+
+
+def _small_text_metadata(root: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for path in _regular_files(root):
+        lowered = path.name.lower()
+        if not any(token in lowered for token in TEXT_TOKENS):
+            continue
+        size = path.stat().st_size
+        record: dict[str, Any] = {
+            "path": path.relative_to(root).as_posix(),
+            "bytes": size,
+            "sha256": _sha256(path),
+        }
+        if size <= MAX_TEXT_BYTES:
+            try:
+                text = path.read_text(encoding="utf-8", errors="replace")
+            except OSError as exc:
+                record["read_error"] = str(exc)
+            else:
+                record["first_nonempty_lines"] = [
+                    line.strip()
+                    for line in text.splitlines()
+                    if line.strip()
+                ][:20]
+                if path.suffix.lower() == ".json":
+                    try:
+                        payload = json.loads(text)
+                    except json.JSONDecodeError:
+                        pass
+                    else:
+                        if isinstance(payload, dict):
+                            record["top_level_keys"] = sorted(map(str, payload))
+        records.append(record)
+    return records
+
+
+def _npy_header(path: Path) -> dict[str, Any] | None:
+    """Read only a .npy header; return None for unsupported/corrupt headers."""
+    try:
+        with path.open("rb") as stream:
+            if stream.read(6) != b"\x93NUMPY":
+                return None
+            major, minor = struct.unpack("BB", stream.read(2))
+            if major == 1:
+                header_size = struct.unpack("<H", stream.read(2))[0]
+            elif major in {2, 3}:
+                header_size = struct.unpack("<I", stream.read(4))[0]
+            else:
+                return None
+            if header_size > MAX_TEXT_BYTES:
+                return None
+            encoding = "utf-8" if major == 3 else "latin1"
+            header = ast.literal_eval(stream.read(header_size).decode(encoding))
+    except (OSError, SyntaxError, ValueError, struct.error, UnicodeDecodeError):
+        return None
+    if not isinstance(header, dict):
+        return None
+    shape = header.get("shape")
+    if not isinstance(shape, tuple):
+        return None
+    return {
+        "version": [major, minor],
+        "shape": list(shape),
+        "dtype": str(header.get("descr")),
+        "fortran_order": bool(header.get("fortran_order")),
+    }
+
+
+def _directory_summary(root: Path) -> dict[str, Any]:
+    files = _regular_files(root)
+    directories = sorted(
+        path for path in root.rglob("*") if path.is_dir() and not path.is_symlink()
+    )
+    extension_counts = Counter(_extension(path) for path in files)
+    return {
+        "root": str(root),
+        "exists": root.is_dir(),
+        "file_count": len(files),
+        "directory_count": len(directories),
+        "total_bytes": sum(path.stat().st_size for path in files),
+        "extensions": dict(sorted(extension_counts.items())),
+        "top_level_directories": sorted(
+            path.name for path in root.iterdir() if path.is_dir()
+        )
+        if root.is_dir()
+        else [],
+        "top_level_files": sorted(
+            path.name for path in root.iterdir() if path.is_file()
+        )
+        if root.is_dir()
+        else [],
+    }
+
+
+def inspect_deform(root: Path, expected_units: Iterable[str]) -> dict[str, Any]:
+    summary = _directory_summary(root)
+    units: dict[str, Any] = {}
+    for name in expected_units:
+        unit = root / name
+        files = _regular_files(unit) if unit.is_dir() else []
+        headers: list[dict[str, Any]] = []
+        for path in files:
+            if path.suffix.lower() != ".npy":
+                continue
+            header = _npy_header(path)
+            if header is not None:
+                headers.append(
+                    {"path": path.relative_to(unit).as_posix(), **header}
+                )
+        units[name] = {
+            "exists": unit.is_dir(),
+            "file_count": len(files),
+            "total_bytes": sum(path.stat().st_size for path in files),
+            "extensions": dict(
+                sorted(Counter(_extension(path) for path in files).items())
+            ),
+            "sha256_by_file": {
+                path.relative_to(unit).as_posix(): _sha256(path) for path in files
+            },
+            "npy_headers": headers,
+            "sample_names": [
+                path.relative_to(unit).as_posix() for path in files[:30]
+            ],
+        }
+    summary.update(
+        {
+            "dataset": "DEFORM",
+            "expected_units": list(expected_units),
+            "units": units,
+            "metadata_files": _small_text_metadata(root),
+            "outcome_payloads_read": False,
+        }
+    )
+    return summary
+
+
+def _leaf_data_directories(root: Path) -> list[Path]:
+    leaves: list[Path] = []
+    for directory, child_directories, child_files in os.walk(root):
+        if child_files and not child_directories:
+            leaves.append(Path(directory))
+    return sorted(leaves)
+
+
+def inspect_tracking_cloth(root: Path) -> dict[str, Any]:
+    summary = _directory_summary(root)
+    immediate = sorted(path for path in root.iterdir() if path.is_dir())
+    leaves = _leaf_data_directories(root)
+    recording_pattern = re.compile(r"(?:record|sequence|trial|take|run)[-_]?\d+", re.I)
+    named = sorted(
+        path
+        for path in root.rglob("*")
+        if path.is_dir() and recording_pattern.search(path.name)
+    )
+    candidates = {
+        "immediate_directory_count": len(immediate),
+        "leaf_data_directory_count": len(leaves),
+        "named_recording_directory_count": len(named),
+    }
+    summary.update(
+        {
+            "dataset": "Tracking Cloth Deformation",
+            "recording_count_candidates": candidates,
+            "recording_count_estimate": max(candidates.values(), default=0),
+            "immediate_directory_names": [path.name for path in immediate],
+            "leaf_directory_samples": [
+                path.relative_to(root).as_posix() for path in leaves[:60]
+            ],
+            "named_recording_samples": [
+                path.relative_to(root).as_posix() for path in named[:60]
+            ],
+            "metadata_files": _small_text_metadata(root),
+            "npy_header_samples": _sample_npy_headers(root, limit=40),
+            "outcome_payloads_read": False,
+        }
+    )
+    return summary
+
+
+def _sample_npy_headers(root: Path, *, limit: int) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for path in _regular_files(root):
+        if path.suffix.lower() != ".npy":
+            continue
+        header = _npy_header(path)
+        if header is not None:
+            records.append({"path": path.relative_to(root).as_posix(), **header})
+        if len(records) >= limit:
+            break
+    return records
+
+
+def _zip_summary(path: Path) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "name": path.name,
+        "bytes": path.stat().st_size,
+    }
+    try:
+        with zipfile.ZipFile(path) as archive:
+            members = archive.infolist()
+    except (OSError, zipfile.BadZipFile) as exc:
+        record["central_directory_ok"] = False
+        record["error"] = str(exc)
+        return record
+    extensions = Counter(_extension(Path(member.filename)) for member in members)
+    prefixes = Counter(
+        Path(member.filename).parts[0]
+        for member in members
+        if Path(member.filename).parts
+    )
+    record.update(
+        {
+            "central_directory_ok": True,
+            "member_count": len(members),
+            "uncompressed_bytes": sum(member.file_size for member in members),
+            "compressed_bytes": sum(member.compress_size for member in members),
+            "extensions": dict(sorted(extensions.items())),
+            "top_level_prefixes": dict(prefixes.most_common(30)),
+            "member_samples": [member.filename for member in members[:40]],
+        }
+    )
+    return record
+
+
+def inspect_dot(root: Path) -> dict[str, Any]:
+    summary = _directory_summary(root)
+    archives = sorted(path for path in root.iterdir() if path.suffix.lower() == ".zip")
+    zip_summaries = [_zip_summary(path) for path in archives]
+    summary.update(
+        {
+            "dataset": "DOT",
+            "zip_count": len(archives),
+            "all_central_directories_ok": all(
+                item.get("central_directory_ok") is True for item in zip_summaries
+            ),
+            "archives": zip_summaries,
+            "metadata_files": _small_text_metadata(root),
+            "archive_members_extracted": False,
+            "outcome_payloads_read": False,
+        }
+    )
+    return summary
+
+
+def _canonical_sha256(value: object) -> str:
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), allow_nan=False
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def build_report(
+    *,
+    dot_root: Path,
+    tracking_root: Path,
+    deform_root: Path,
+    expected_dot_archives: int,
+    expected_tracking_recordings: int,
+    expected_deform_units: tuple[str, ...],
+    expected_deform_files_per_unit: int,
+) -> dict[str, Any]:
+    roots = {
+        "dot": dot_root.resolve(),
+        "tracking_cloth": tracking_root.resolve(),
+        "deform": deform_root.resolve(),
+    }
+    datasets = {
+        "dot": inspect_dot(roots["dot"]),
+        "tracking_cloth": inspect_tracking_cloth(roots["tracking_cloth"]),
+        "deform": inspect_deform(roots["deform"], expected_deform_units),
+    }
+    dot_ok = (
+        datasets["dot"]["zip_count"] == expected_dot_archives
+        and datasets["dot"]["all_central_directories_ok"]
+    )
+    tracking_counts = datasets["tracking_cloth"]["recording_count_candidates"]
+    tracking_ok = expected_tracking_recordings in tracking_counts.values()
+    deform_ok = all(
+        datasets["deform"]["units"][name]["file_count"]
+        == expected_deform_files_per_unit
+        for name in expected_deform_units
+    )
+    decisions = {
+        "dot_archive_admission": dot_ok,
+        "tracking_cloth_recording_admission": tracking_ok,
+        "deform_dlo4_dlo5_admission": deform_ok,
+        "all_expected_source_layouts_admitted": dot_ok and tracking_ok and deform_ok,
+        "deform_immediate_transfer_pilot": deform_ok,
+        "tracking_cloth_broad_prediction_candidate": tracking_ok,
+        "task_conditioned_intervention_claim_authorized": False,
+    }
+    report: dict[str, Any] = {
+        "schema": "causal4d.complete-deformable-dataset-admission-v1",
+        "source_only": True,
+        "future_or_target_outcomes_read": False,
+        "numeric_payloads_read": False,
+        "archives_extracted": False,
+        "roots": {name: str(path) for name, path in roots.items()},
+        "expectations": {
+            "dot_archives": expected_dot_archives,
+            "tracking_recordings": expected_tracking_recordings,
+            "deform_units": list(expected_deform_units),
+            "deform_files_per_unit": expected_deform_files_per_unit,
+        },
+        "datasets": datasets,
+        "decisions": decisions,
+        "interpretation": {
+            "deform": (
+                "Enough for an immediate real measured-system transfer pilot, "
+                "but only two DLO identities do not establish broad object generalization."
+            ),
+            "tracking_cloth": (
+                "Potentially the strongest complete statistical benchmark; action, "
+                "cloth-identity, and reset structure must be registered from metadata "
+                "before calling recordings independent interventions."
+            ),
+            "dot": (
+                "Complete archive source; the central-directory and README inventory "
+                "determines whether it supports prediction, tracking, or intervention value."
+            ),
+        },
+        "claim_boundary": (
+            "Admission and layout evidence only. No trajectory, image, tactile, point, "
+            "force, or target payload was loaded, and no real-world benefit claim is authorized."
+        ),
+    }
+    report["report_sha256_without_self_hash"] = _canonical_sha256(report)
+    return report
+
+
+def _markdown(report: dict[str, Any]) -> str:
+    decisions = report["decisions"]
+    datasets = report["datasets"]
+    lines = [
+        "# Complete deformable-dataset admission",
+        "",
+        "**Source-only:** no numeric outcome payloads were loaded.",
+        "",
+        "| Dataset | Admission | Observed structure | Immediate use |",
+        "|---|---:|---|---|",
+        (
+            "| DEFORM DLO4/DLO5 | "
+            f"{decisions['deform_dlo4_dlo5_admission']} | "
+            + ", ".join(
+                f"{name}: {unit['file_count']} files"
+                for name, unit in datasets["deform"]["units"].items()
+            )
+            + " | Real transfer pilot |"
+        ),
+        (
+            "| Tracking Cloth Deformation | "
+            f"{decisions['tracking_cloth_recording_admission']} | "
+            f"candidate counts {datasets['tracking_cloth']['recording_count_candidates']} | "
+            "Broad prediction/uncertainty candidate |"
+        ),
+        (
+            "| DOT | "
+            f"{decisions['dot_archive_admission']} | "
+            f"{datasets['dot']['zip_count']} ZIPs; central directories "
+            f"OK={datasets['dot']['all_central_directories_ok']} | "
+            "Determine task from README/member layout |"
+        ),
+        "",
+        "## Boundary",
+        "",
+        report["claim_boundary"],
+        "",
+        "The task-conditioned real-world experiment remains locked until independent "
+        "units, actions, challenge queries, risk/cost definitions, and source/target "
+        "splits are frozen from this metadata-only report.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dot-root", type=Path, required=True)
+    parser.add_argument("--tracking-root", type=Path, required=True)
+    parser.add_argument("--deform-root", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--expected-dot-archives", type=int, default=21)
+    parser.add_argument("--expected-tracking-recordings", type=int, default=120)
+    parser.add_argument(
+        "--expected-deform-units", nargs="+", default=["DLO4", "DLO5"]
+    )
+    parser.add_argument("--expected-deform-files-per-unit", type=int, default=70)
+    parser.add_argument("--strict", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    report = build_report(
+        dot_root=args.dot_root,
+        tracking_root=args.tracking_root,
+        deform_root=args.deform_root,
+        expected_dot_archives=args.expected_dot_archives,
+        expected_tracking_recordings=args.expected_tracking_recordings,
+        expected_deform_units=tuple(args.expected_deform_units),
+        expected_deform_files_per_unit=args.expected_deform_files_per_unit,
+    )
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    result_path = args.output_dir / "admission.json"
+    result_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    (args.output_dir / "admission.md").write_text(
+        _markdown(report), encoding="utf-8"
+    )
+    print(json.dumps(report["decisions"], sort_keys=True))
+    if args.strict and not report["decisions"][
+        "all_expected_source_layouts_admitted"
+    ]:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_complete_deformable_dataset_admission.py
+++ b/tests/test_complete_deformable_dataset_admission.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import zipfile
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_script() -> ModuleType:
+    root = Path(__file__).resolve().parents[1]
+    path = root / "scripts" / "remote" / "inventory_complete_deformable_datasets.py"
+    spec = importlib.util.spec_from_file_location("dataset_admission", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_zip(path: Path, members: dict[str, bytes]) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, payload in members.items():
+            archive.writestr(name, payload)
+
+
+def test_build_report_admits_complete_fixture_without_loading_payloads(
+    tmp_path: Path,
+) -> None:
+    module = _load_script()
+    dot = tmp_path / "dot"
+    tracking = tmp_path / "tracking"
+    deform = tmp_path / "deform"
+    dot.mkdir()
+    tracking.mkdir()
+    deform.mkdir()
+
+    _write_zip(dot / "part-01.zip", {"recording/a.bin": b"payload"})
+    _write_zip(dot / "part-02.zip", {"recording/b.bin": b"payload"})
+    (dot / "README.txt").write_text("DOT fixture\n", encoding="utf-8")
+
+    for index in range(3):
+        recording = tracking / f"recording_{index:03d}"
+        recording.mkdir()
+        (recording / "trajectory.bin").write_bytes(b"not opened")
+    (tracking / "metadata.json").write_text(
+        json.dumps({"recordings": 3}), encoding="utf-8"
+    )
+
+    for name in ("DLO4", "DLO5"):
+        unit = deform / name
+        unit.mkdir()
+        (unit / "a.bin").write_bytes(b"a")
+        (unit / "b.bin").write_bytes(b"b")
+
+    report = module.build_report(
+        dot_root=dot,
+        tracking_root=tracking,
+        deform_root=deform,
+        expected_dot_archives=2,
+        expected_tracking_recordings=3,
+        expected_deform_units=("DLO4", "DLO5"),
+        expected_deform_files_per_unit=2,
+    )
+
+    assert report["decisions"]["all_expected_source_layouts_admitted"] is True
+    assert report["future_or_target_outcomes_read"] is False
+    assert report["numeric_payloads_read"] is False
+    assert report["archives_extracted"] is False
+    assert report["datasets"]["dot"]["archives"][0][
+        "central_directory_ok"
+    ] is True
+    assert report["datasets"]["tracking_cloth"][
+        "recording_count_estimate"
+    ] == 3
+    assert set(report["datasets"]["deform"]["units"]) == {"DLO4", "DLO5"}
+
+
+def test_missing_layout_is_retained_as_negative_admission(tmp_path: Path) -> None:
+    module = _load_script()
+    dot = tmp_path / "dot"
+    tracking = tmp_path / "tracking"
+    deform = tmp_path / "deform"
+    dot.mkdir()
+    tracking.mkdir()
+    deform.mkdir()
+
+    report = module.build_report(
+        dot_root=dot,
+        tracking_root=tracking,
+        deform_root=deform,
+        expected_dot_archives=21,
+        expected_tracking_recordings=120,
+        expected_deform_units=("DLO4", "DLO5"),
+        expected_deform_files_per_unit=70,
+    )
+
+    assert report["decisions"]["all_expected_source_layouts_admitted"] is False
+    assert report["decisions"]["task_conditioned_intervention_claim_authorized"] is False


### PR DESCRIPTION
## Purpose

Replace the incomplete Deform360/PokeFlex path with a source-only admission run over the complete or verified public datasets currently mounted on `gpuserver4090`:

- DOT: `/mnt/seagate10tb/florianpfaff/datasets/dot`
- Tracking Cloth Deformation: `/home/github-runner/.cache/datasets/tracking-cloth-deformation-v1-zenodo-14644526`
- DEFORM DLO4/DLO5: `/mnt/seagate10tb/florianpfaff/datasets/deform/data_set`

## Scientific boundary

This PR does **not** run a trajectory benchmark or inspect target outcomes. It establishes the content and action/session structure needed to choose the first defensible real-data experiment. The scanner opens only:

- file and directory metadata;
- small README/metadata/manifest/checksum text files;
- NumPy array headers, never array payloads;
- ZIP central directories, never extracted archive members.

No image, tactile, trajectory, point, force, or challenge payload is loaded, and no real-world benefit claim is authorized.

## Workflow

`complete-deformable-dataset-admission.yml` has a hosted contract job and a reviewed-main self-hosted job on:

```text
[self-hosted, Linux, X64, nvidia-smi, gpuserver4090]
```

A merge to `main` triggers the self-hosted run by file change. The job verifies the exact checkout and mounted roots, then produces:

- `admission.json`: complete deterministic inventory and source-admission decisions;
- `admission.md`: compact scientific eligibility table;
- `manifest.json`: revision, run, runner, hashes, and source-only boundary;
- `runner.txt`: runtime, GPU, filesystem, and exact roots.

## Frozen expectations

- 21 DOT ZIP archives with readable central directories;
- one Tracking Cloth directory-layout interpretation yielding the expected 120 recordings;
- DLO4 and DLO5, each with exactly 70 files;
- all three source layouts must pass for the aggregate admission gate.

A mismatch is retained as a negative technical admission rather than silently relaxing expectations.

## Immediate decision after the artifact

- **DEFORM DLO4/DLO5** is the fastest real measured-system transfer pilot, but two DLO identities cannot establish broad object generalization.
- **Tracking Cloth Deformation** is the strongest candidate for a statistically broader prediction/uncertainty experiment, subject to the metadata revealing defensible independent units and action/reset structure.
- **DOT** is complete and may be preferable if its README/member layout exposes repeated intervention/challenge structure; the workflow will identify that without opening outcomes.

The task-conditioned experiment from issue #442 remains locked until the metadata-only artifact freezes independent units, candidate observations/interventions, challenge query, costs/risks, and source/calibration/target split.