### PR TITLE
Replicate the frozen Deform360 pilot from the public Hub

### DIFF
--- a/.github/workflows/deform360-official-pcd-hosted-replication.yml
+++ b/.github/workflows/deform360-official-pcd-hosted-replication.yml
@@ -1,0 +1,403 @@
+# workflow-lifecycle: one-shot
+# workflow-owner: IPS-Stuttgart maintainers
+name: Deform360 official point-cloud hosted replication
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/deform360-official-pcd-hosted-replication.yml"
+      - "configs/causal4d_public/deform360_official_pcd_hosted_replication_v1.json"
+      - "docs/causal4d_deform360_official_pcd_hosted_replication.md"
+      - "ops/deform360-official-pcd-hosted-replication-request.json"
+  push:
+    branches: [main]
+    paths:
+      - "ops/deform360-official-pcd-hosted-replication-request.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deform360-official-pcd-hosted-replication-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  contract:
+    name: Validate frozen hosted-replication contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out exact candidate revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install and test the frozen pilot
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]"
+          python -m pip check
+          python -m ruff check \
+            scripts/remote/run_deform360_official_pcd_pilot.py \
+            src/causal4d_public/deform360_official_pcd_pilot.py \
+            tests/test_deform360_official_pcd_pilot.py
+          python -m ruff format --check \
+            scripts/remote/run_deform360_official_pcd_pilot.py \
+            src/causal4d_public/deform360_official_pcd_pilot.py \
+            tests/test_deform360_official_pcd_pilot.py
+          python -m pytest -q tests/test_deform360_official_pcd_pilot.py
+
+      - name: Verify content-addressed replication request
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib
+          import json
+          from pathlib import Path
+
+          config_path = Path(
+              "configs/causal4d_public/"
+              "deform360_official_pcd_hosted_replication_v1.json"
+          )
+          request_path = Path(
+              "ops/deform360-official-pcd-hosted-replication-request.json"
+          )
+          config = json.loads(config_path.read_text(encoding="utf-8"))
+          request = json.loads(request_path.read_text(encoding="utf-8"))
+          canonical = dict(config)
+          observed = canonical.pop("config_sha256")
+          encoded = json.dumps(
+              canonical,
+              sort_keys=True,
+              separators=(",", ":"),
+              allow_nan=False,
+          ).encode("utf-8")
+          expected = hashlib.sha256(encoded).hexdigest()
+          if observed != expected:
+              raise SystemExit("hosted-replication config checksum mismatch")
+          if request != {
+              "schema_version": 1,
+              "request": "run-deform360-official-pcd-hosted-replication",
+              "enabled": True,
+              "workflow": "deform360-official-pcd-hosted-replication.yml",
+              "ref": "main",
+              "protocol_id": config["protocol_id"],
+              "method_protocol_id": config["method_protocol_id"],
+              "config_sha256": observed,
+              "request_id": (
+                  "2026-08-30-deform360-official-pcd-hosted-"
+                  "replication-v1"
+              ),
+          }:
+              raise SystemExit("hosted-replication request changed")
+          episodes = [row["episode_id"] for row in config["source_archives"]]
+          if episodes != [0, 2, 5, 6, 7, 9]:
+              raise SystemExit("source episode roster changed")
+          if config["forbidden_episode_ids"] != [1, 3, 4, 8]:
+              raise SystemExit("forbidden episode roster changed")
+          if sum(
+              row["expected_size_bytes"] for row in config["source_archives"]
+          ) != config["expected_total_source_bytes"]:
+              raise SystemExit("source archive size total changed")
+          boundary = config["information_boundary"]
+          if not (
+              boundary["source_only"] is True
+              and boundary["forbidden_episode_archives_downloaded"] is False
+              and boundary["forbidden_episode_payloads_read"] is False
+              and boundary["official_velocity_arrays_used"] is False
+              and boundary["dataset_modified"] is False
+              and boundary["paper_claim_authorized"] is False
+          ):
+              raise SystemExit("hosted replication opens a forbidden boundary")
+          PY
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
+  replicate:
+    name: Download and replicate six frozen source episodes
+    if: >-
+      github.event_name != 'pull_request' &&
+      github.ref == 'refs/heads/main'
+    needs: contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      CONFIG: configs/causal4d_public/deform360_official_pcd_hosted_replication_v1.json
+      METHOD_CONFIG: configs/causal4d_public/deform360_official_pcd_source_pilot_v1.json
+      EVIDENCE_DIR: deform360-official-pcd-hosted-replication
+      DOWNLOAD_ROOT: ${{ runner.temp }}/deform360-official-pcd-hosted-replication
+    steps:
+      - name: Check out exact reviewed main revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install pinned numerical runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install \
+            --disable-pip-version-check \
+            --no-input \
+            --no-cache-dir \
+            "numpy==1.26.4"
+          python - <<'PY'
+          import numpy
+          import sys
+          print(sys.version)
+          print("numpy", numpy.__version__)
+          PY
+
+      - name: Resolve one public repository revision before data access
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${EVIDENCE_DIR}" "${DOWNLOAD_ROOT}"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          import urllib.request
+
+          config = json.loads(Path(os.environ["CONFIG"]).read_text(encoding="utf-8"))
+          repository = config["source_repository"]
+          url = f"https://huggingface.co/api/datasets/{repository}"
+          request = urllib.request.Request(
+              url,
+              headers={"User-Agent": "Causal4D-Deform360-replication/1"},
+          )
+          with urllib.request.urlopen(request, timeout=60) as response:
+              info = json.load(response)
+          revision = info.get("sha")
+          if not isinstance(revision, str) or len(revision) != 40:
+              raise SystemExit("Hugging Face did not return a 40-hex revision")
+          if any(character not in "0123456789abcdef" for character in revision):
+              raise SystemExit("resolved revision is not lowercase hexadecimal")
+          record = {
+              "schema_version": 1,
+              "repository": repository,
+              "resolved_revision": revision,
+              "private": info.get("private"),
+              "gated": info.get("gated"),
+              "last_modified": info.get("lastModified"),
+              "resolved_before_source_archive_download": True,
+          }
+          output = Path(os.environ["EVIDENCE_DIR"], "repository-resolution.json")
+          output.write_text(
+              json.dumps(record, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          with Path(os.environ["GITHUB_ENV"]).open("a", encoding="utf-8") as stream:
+              stream.write(f"HF_REVISION={revision}\n")
+          print(json.dumps(record, indent=2, sort_keys=True))
+          PY
+
+      - name: Download only the six frozen source archives
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+          import shutil
+          import urllib.parse
+          import urllib.request
+
+          config = json.loads(Path(os.environ["CONFIG"]).read_text(encoding="utf-8"))
+          revision = os.environ["HF_REVISION"]
+          repository = config["source_repository"]
+          root = Path(os.environ["DOWNLOAD_ROOT"])
+          records = []
+          total = 0
+
+          for archive in config["source_archives"]:
+              relative = archive["path"]
+              destination = root / relative
+              destination.parent.mkdir(parents=True, exist_ok=True)
+              quoted = urllib.parse.quote(relative, safe="/")
+              url = (
+                  f"https://huggingface.co/datasets/{repository}/resolve/"
+                  f"{revision}/{quoted}?download=true"
+              )
+              request = urllib.request.Request(
+                  url,
+                  headers={"User-Agent": "Causal4D-Deform360-replication/1"},
+              )
+              digest = hashlib.sha256()
+              size = 0
+              with urllib.request.urlopen(request, timeout=180) as response:
+                  with destination.open("wb") as output:
+                      while True:
+                          block = response.read(1024 * 1024)
+                          if not block:
+                              break
+                          output.write(block)
+                          digest.update(block)
+                          size += len(block)
+              expected = archive["expected_size_bytes"]
+              if size != expected or destination.stat().st_size != expected:
+                  raise SystemExit(
+                      f"archive size mismatch for {relative}: "
+                      f"expected {expected}, observed {size}"
+                  )
+              total += size
+              records.append(
+                  {
+                      "episode_id": archive["episode_id"],
+                      "action": archive["action"],
+                      "repository_path": relative,
+                      "expected_size_bytes": expected,
+                      "observed_size_bytes": size,
+                      "sha256": digest.hexdigest(),
+                  }
+              )
+
+          if total != config["expected_total_source_bytes"]:
+              raise SystemExit("downloaded source byte total changed")
+          object_root = root / "processed" / config["object_id"]
+          forbidden = [
+              object_root / f"episode_{episode_id}" / "pcd_clean.tar"
+              for episode_id in config["forbidden_episode_ids"]
+          ]
+          if any(path.exists() for path in forbidden):
+              raise SystemExit("a forbidden episode archive was downloaded")
+          manifest = {
+              "schema_version": 1,
+              "artifact_kind": "Deform360OfficialPointCloudDownloadManifest",
+              "repository": repository,
+              "resolved_revision": revision,
+              "source_archive_count": len(records),
+              "source_total_bytes": total,
+              "archives": records,
+              "forbidden_episode_ids": config["forbidden_episode_ids"],
+              "forbidden_episode_archives_downloaded": False,
+              "forbidden_episode_payloads_read": False,
+              "dataset_modified": False,
+          }
+          Path(os.environ["EVIDENCE_DIR"], "download-manifest.json").write_text(
+              json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print(json.dumps(manifest, indent=2, sort_keys=True))
+          PY
+
+      - name: Run the unchanged frozen source pilot
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PYTHONPATH="$PWD/src"
+          python scripts/remote/run_deform360_official_pcd_pilot.py \
+            --processed-root "${DOWNLOAD_ROOT}/processed" \
+            --config "${METHOD_CONFIG}" \
+            --output "${EVIDENCE_DIR}/result.json" \
+            2>&1 | tee "${EVIDENCE_DIR}/run.log"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          import platform
+          import sys
+          import numpy
+
+          evidence = Path(os.environ["EVIDENCE_DIR"])
+          result = json.loads((evidence / "result.json").read_text(encoding="utf-8"))
+          runtime = {
+              "schema_version": 1,
+              "python": sys.version,
+              "platform": platform.platform(),
+              "numpy": numpy.__version__,
+              "repository": os.environ["GITHUB_REPOSITORY"],
+              "commit": os.environ["GITHUB_SHA"],
+              "workflow_run_id": os.environ["GITHUB_RUN_ID"],
+              "huggingface_revision": os.environ["HF_REVISION"],
+              "result_sha256": result["result_sha256"],
+          }
+          (evidence / "runtime.json").write_text(
+              json.dumps(runtime, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+          sha256sum "${EVIDENCE_DIR}"/*.json "${EVIDENCE_DIR}/run.log" \
+            > "${EVIDENCE_DIR}/SHA256SUMS"
+
+      - name: Publish metric-bearing replication summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### Deform360 official point-cloud hosted replication"
+            echo
+            echo "- Reviewed head: \`${GITHUB_SHA}\`"
+            if [[ -f "${EVIDENCE_DIR}/repository-resolution.json" ]]; then
+              revision="$(python -c 'import json; print(json.load(open("deform360-official-pcd-hosted-replication/repository-resolution.json"))["resolved_revision"])')"
+              echo "- Resolved public dataset revision: \`${revision}\`"
+            fi
+            if [[ -f "${EVIDENCE_DIR}/result.json" ]]; then
+              python - <<'PY'
+          import json
+          from pathlib import Path
+
+          result = json.loads(
+              Path(
+                  "deform360-official-pcd-hosted-replication/result.json"
+              ).read_text(encoding="utf-8")
+          )
+          decision = result["decision"]
+          primary = result["horizon_summaries"][
+              str(decision["primary_horizon_frames"])
+          ]
+          comparison = primary["comparisons"]["guarded"]
+          print(f"- Classification: `{decision['classification']}`")
+          print(f"- Decision passed: `{decision['passed']}`")
+          print(f"- Source episodes: `{len(result['episode_records'])}`")
+          print(
+              "- Guarded relative RMSE improvement vs persistence: "
+              f"`{comparison['relative_improvement_vs_persistence']:.6f}`"
+          )
+          print(
+              "- Episode win fraction: "
+              f"`{comparison['episode_win_fraction_vs_persistence']:.6f}`"
+          )
+          print(
+              "- Worst episode ratio: "
+              f"`{comparison['worst_episode_ratio_vs_persistence']:.6f}`"
+          )
+          print(f"- Exact fallback fraction: `{primary['exact_fallback_fraction']:.6f}`")
+          print(f"- Result SHA-256: `{result['result_sha256']}`")
+          print("- Paper claim authorized: `false`")
+          PY
+            else
+              echo "- No metric-bearing result was produced; inspect the evidence."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload hosted-replication evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: deform360-official-pcd-hosted-replication-${{ github.sha }}
+          path: deform360-official-pcd-hosted-replication/
+          if-no-files-found: warn
+          retention-days: 30

--- a/configs/causal4d_public/deform360_official_pcd_hosted_replication_v1.json
+++ b/configs/causal4d_public/deform360_official_pcd_hosted_replication_v1.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": 1,
+  "artifact_kind": "Deform360OfficialPointCloudHostedReplicationConfig",
+  "protocol_id": "causal4d-deform360-official-pcd-hosted-replication-v1",
+  "status": "source-only-public-hub-replication",
+  "method_protocol_id": "causal4d-deform360-official-pcd-source-pilot-v1",
+  "source_repository": "brownu/deform360_processed",
+  "source_revision_policy": "resolve-main-once-before-any-source-archive-download-and-pin-returned-sha",
+  "local_gpuserver4090_inventory": {
+    "github_run_id": 33322193007,
+    "artifact_id": 9735203992,
+    "artifact_digest": "sha256:eda811e372e460d437d2d4ceaf2b25c5c41d8af026b905f593d090c47cbe1ffe",
+    "inventory_file": "download-layout.json"
+  },
+  "object_id": "002-rope-silk",
+  "source_archives": [
+    {
+      "episode_id": 0,
+      "action": "lift side",
+      "path": "processed/002-rope-silk/episode_0/pcd_clean.tar",
+      "expected_size_bytes": 58900480
+    },
+    {
+      "episode_id": 2,
+      "action": "drag side",
+      "path": "processed/002-rope-silk/episode_2/pcd_clean.tar",
+      "expected_size_bytes": 70144000
+    },
+    {
+      "episode_id": 5,
+      "action": "lift sides",
+      "path": "processed/002-rope-silk/episode_5/pcd_clean.tar",
+      "expected_size_bytes": 61788160
+    },
+    {
+      "episode_id": 6,
+      "action": "lift middle and side",
+      "path": "processed/002-rope-silk/episode_6/pcd_clean.tar",
+      "expected_size_bytes": 52561920
+    },
+    {
+      "episode_id": 7,
+      "action": "drag sides",
+      "path": "processed/002-rope-silk/episode_7/pcd_clean.tar",
+      "expected_size_bytes": 55562240
+    },
+    {
+      "episode_id": 9,
+      "action": "fold",
+      "path": "processed/002-rope-silk/episode_9/pcd_clean.tar",
+      "expected_size_bytes": 70850560
+    }
+  ],
+  "forbidden_episode_ids": [
+    1,
+    3,
+    4,
+    8
+  ],
+  "expected_total_source_bytes": 369807360,
+  "information_boundary": {
+    "source_only": true,
+    "source_archives_downloaded": true,
+    "forbidden_episode_archives_downloaded": false,
+    "forbidden_episode_payloads_read": false,
+    "official_velocity_arrays_used": false,
+    "dataset_modified": false,
+    "new_physical_data_collected": false,
+    "paper_claim_authorized": false
+  },
+  "config_sha256": "801f856de3988161308b35b6fbf00aa617801d1928e7a7dc83b16bba89f32d92"
+}

--- a/docs/causal4d_deform360_official_pcd_hosted_replication.md
+++ b/docs/causal4d_deform360_official_pcd_hosted_replication.md
@@ -1,0 +1,34 @@
+# Deform360 official point-cloud hosted replication
+
+This one-shot workflow independently reproduces the frozen source-only
+Deform360 point-cloud pilot on a GitHub-hosted runner. It exists because the
+primary `gpuserver4090` evaluation can remain queued when the self-hosted runner
+is unavailable.
+
+The replication does not replace the primary self-hosted run. It downloads the
+same six registered `002-rope-silk` `pcd_clean.tar` archives from the public
+`brownu/deform360_processed` repository, verifies each byte size against the
+metadata-only `gpuserver4090` inventory from GitHub Actions run `33322193007`,
+and executes the unchanged method protocol
+`causal4d-deform360-official-pcd-source-pilot-v1`.
+
+## Frozen source boundary
+
+- Source episodes: `0, 2, 5, 6, 7, 9`.
+- Forbidden episodes: `1, 3, 4, 8`.
+- Expected source bytes: `369807360`.
+- The public repository `main` revision is resolved exactly once before any
+  source archive is downloaded; the returned 40-hex revision is then pinned for
+  all six downloads and recorded in the evidence bundle.
+- Forbidden archives are neither downloaded nor opened.
+- Only `pts` arrays are consumed by the unchanged pilot; released velocity
+  arrays remain ignored.
+
+## Interpretation
+
+Agreement between this hosted lane and the primary self-hosted lane would show
+that the metric-bearing pilot does not depend on a private runner environment.
+A positive pilot still supports only a same-object, cross-action, source-only
+short-horizon result on released reconstructed point trajectories. It does not
+authorize the broader task-conditioned probe-selection paper claim, unseen-object
+transfer, Prob4D provider validation, online robot probing, or deployment safety.

--- a/ops/deform360-official-pcd-hosted-replication-request.json
+++ b/ops/deform360-official-pcd-hosted-replication-request.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "request": "run-deform360-official-pcd-hosted-replication",
+  "enabled": true,
+  "workflow": "deform360-official-pcd-hosted-replication.yml",
+  "ref": "main",
+  "protocol_id": "causal4d-deform360-official-pcd-hosted-replication-v1",
+  "method_protocol_id": "causal4d-deform360-official-pcd-source-pilot-v1",
+  "config_sha256": "801f856de3988161308b35b6fbf00aa617801d1928e7a7dc83b16bba89f32d92",
+  "request_id": "2026-08-30-deform360-official-pcd-hosted-replication-v1"
+}


### PR DESCRIPTION
## Purpose

Run an independent metric-bearing replication of the unchanged Deform360 source pilot on a GitHub-hosted runner while the primary `gpuserver4090` job remains queued.

## Frozen correspondence to the primary lane

- method protocol: `causal4d-deform360-official-pcd-source-pilot-v1`;
- object: `002-rope-silk`;
- source episodes: `0, 2, 5, 6, 7, 9`;
- forbidden episodes: `1, 3, 4, 8`;
- expected source bytes: `369807360`;
- per-archive sizes copied from the metadata-only `gpuserver4090` inventory in run `33322193007`, artifact `9735203992`, digest `sha256:eda811e3...`.

The workflow resolves the current public `brownu/deform360_processed` repository revision exactly once before archive access, pins that returned 40-hex SHA for all six downloads, verifies every archive size, records content SHA-256 values, and runs the already merged pilot code unchanged.

## Information boundary

Only the six frozen source archives are downloaded. Forbidden archives are neither downloaded nor opened. The pilot consumes only `pts`; released velocity arrays are ignored. This lane modifies no dataset, collects no physical data, and authorizes no paper claim. The primary self-hosted job remains queued and will provide an environment-independent comparison when `gpuserver4090` reconnects.