### PR TITLE
Fix Tracking Cloth preflight before isolated NumPy bootstrap

### DIFF
--- a/.github/workflows/tracking-cloth-query-observation.yml
+++ b/.github/workflows/tracking-cloth-query-observation.yml
@@ -125,29 +125,51 @@ jobs:
           test -f "${REQUEST}"
           test -f "${MODULE_PATH}"
           /usr/bin/python3 - <<'PY'
-          import importlib.util
+          import hashlib
           import json
           import os
           from pathlib import Path
-          import sys
 
-          module_path = Path(os.environ["MODULE_PATH"]).resolve()
-          module_name = "tracking_cloth_query_observation_request_check"
-          spec = importlib.util.spec_from_file_location(module_name, module_path)
-          if spec is None or spec.loader is None:
-              raise SystemExit("failed to create standalone module specification")
-          module = importlib.util.module_from_spec(spec)
-          sys.modules[module_name] = module
-          spec.loader.exec_module(module)
-          request = module.load_request(Path(os.environ["REQUEST"]))
-          if os.environ["DISPATCH_REQUEST_ID"] != request["request_id"]:
+          request_path = Path(os.environ["REQUEST"])
+          request = json.loads(request_path.read_text(encoding="utf-8"))
+          if not isinstance(request, dict):
+              raise SystemExit("frozen request must be a JSON object")
+          supplied = request.get("request_id")
+          unhashed = dict(request)
+          unhashed.pop("request_id", None)
+          canonical = json.dumps(
+              unhashed,
+              sort_keys=True,
+              separators=(",", ":"),
+              ensure_ascii=False,
+              allow_nan=False,
+          ).encode("utf-8")
+          if supplied != hashlib.sha256(canonical).hexdigest():
+              raise SystemExit("frozen request identity is invalid")
+          expected = {
+              "schema": "causal4d.tracking-cloth-query-observation-request",
+              "schema_version": 1,
+              "stage": "source-gated-evaluation",
+              "dataset_root": os.environ["DATASET_ROOT"],
+              "source_fit_materials": ["cotton"],
+              "source_gate_materials": ["denim"],
+              "target_materials": ["wool", "polyester"],
+          }
+          for key, value in expected.items():
+              if request.get(key) != value:
+                  raise SystemExit(f"frozen request field changed: {key}")
+          if os.environ["DISPATCH_REQUEST_ID"] != supplied:
               raise SystemExit("dispatch request identity differs from frozen protocol")
           root = Path(os.environ["DATASET_ROOT"]).resolve()
-          if root != module.EXPECTED_ROOT.resolve():
+          expected_root = Path(
+              "/home/github-runner/.cache/datasets/"
+              "tracking-cloth-deformation-v1-zenodo-14644526"
+          ).resolve()
+          if root != expected_root:
               raise SystemExit("mounted root differs from the frozen protocol root")
           csv_count = sum(1 for _ in root.rglob("*.csv"))
           print(json.dumps({
-              "request_id": request["request_id"],
+              "request_id": supplied,
               "dataset_root": str(root),
               "csv_name_count_before_payload_access": csv_count,
               "target_file_contents_opened": False,

--- a/ops/tracking-cloth-query-observation-gpuserver4090-request.json
+++ b/ops/tracking-cloth-query-observation-gpuserver4090-request.json
@@ -1,8 +1,8 @@
 {
+  "schema_version": 1,
   "enabled": true,
+  "workflow": "tracking-cloth-query-observation.yml",
   "ref": "main",
   "request": "run-tracking-cloth-query-observation-gpuserver4090",
-  "request_id": "3e9f77bd804f91545dbdac1098c324b3b155167c938c186a2e9238c712cdeca0",
-  "schema_version": 1,
-  "workflow": "tracking-cloth-query-observation.yml"
+  "request_id": "3e9f77bd804f91545dbdac1098c324b3b155167c938c186a2e9238c712cdeca0"
 }


### PR DESCRIPTION
## Retained technical failure

The first exact-main Tracking Cloth execution reached `workstation1` under the required `gpuserver4090` label and verified the reviewed commit, clean checkout, request path, module path, and dataset-directory existence. It then imported the NumPy-dependent evaluator with `/usr/bin/python3` before the workflow's isolated NumPy bootstrap. The system interpreter has no NumPy, so the job stopped with `ModuleNotFoundError: No module named 'numpy'`.

Run: `33361396768`, self-hosted job: `99393393311`.

No dataset CSV payload was read by the evaluator, no source decision was computed, and no wool/polyester target content was opened. This is a pre-evaluation environment-ordering failure, not a scientific negative.

## Repair

- Keep exact revision, clean-tree, mounted-root, request-file, and module-file checks in the first self-hosted step.
- Replace the premature module import with a standard-library-only validation of the frozen request schema, canonical request identity, cotton/denim/wool-polyester split, exact mounted path, dispatch identity, and CSV-name census.
- Leave the pinned isolated `numpy==2.2.6` bootstrap unchanged before any evaluator import or execution.
- Reformat—but do not change the parsed value of—the reviewed operation request so merging this repair retriggers the existing file-change dispatcher exactly once.

No estimator, marker group, horizon, source threshold, source/target material roster, comparator, metric, or target-access rule changes. The request ID remains `3e9f77bd804f91545dbdac1098c324b3b155167c938c186a2e9238c712cdeca0`.

## Expected behavior after merge

The hosted dispatcher must validate the same frozen protocol and launch `tracking-cloth-query-observation.yml` on exact `main`. The self-hosted job then installs the pinned NumPy runtime, evaluates cotton and denim, and opens wool/polyester only if every frozen denim gate passes.