### PR TITLE
Cluster Tracking Cloth horizons within complete recordings

### DIFF
--- a/.github/workflows/tracking-cloth-query-observation.yml
+++ b/.github/workflows/tracking-cloth-query-observation.yml
@@ -10,7 +10,9 @@ on:
       - "configs/causal4d_public/tracking_cloth_query_observation_v1.json"
       - "ops/tracking-cloth-query-observation-gpuserver4090-request.json"
       - "src/causal4d_public/tracking_cloth_query_observation.py"
+      - "src/causal4d_public/tracking_cloth_query_observation_recording_cluster.py"
       - "tests/test_tracking_cloth_query_observation.py"
+      - "tests/test_tracking_cloth_query_observation_recording_cluster.py"
   workflow_dispatch:
     inputs:
       request_id:
@@ -23,12 +25,12 @@ permissions:
 
 concurrency:
   group: tracking-cloth-query-observation-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   DATASET_ROOT: /home/github-runner/.cache/datasets/tracking-cloth-deformation-v1-zenodo-14644526
   REQUEST: configs/causal4d_public/tracking_cloth_query_observation_v1.json
-  MODULE_PATH: src/causal4d_public/tracking_cloth_query_observation.py
+  MODULE_PATH: src/causal4d_public/tracking_cloth_query_observation_recording_cluster.py
   EVIDENCE_DIR: tracking-cloth-query-observation-v1
   NUMPY_VERSION: 2.2.6
 
@@ -58,13 +60,18 @@ jobs:
           python -m pip check
           files=(
             src/causal4d_public/tracking_cloth_query_observation.py
+            src/causal4d_public/tracking_cloth_query_observation_recording_cluster.py
             tests/test_tracking_cloth_query_observation.py
+            tests/test_tracking_cloth_query_observation_recording_cluster.py
           )
           python -m ruff check "${files[@]}"
           python -m ruff format --check "${files[@]}"
           python -m mypy --no-site-packages \
-            src/causal4d_public/tracking_cloth_query_observation.py
-          python -m pytest -q tests/test_tracking_cloth_query_observation.py
+            src/causal4d_public/tracking_cloth_query_observation.py \
+            src/causal4d_public/tracking_cloth_query_observation_recording_cluster.py
+          python -m pytest -q \
+            tests/test_tracking_cloth_query_observation.py \
+            tests/test_tracking_cloth_query_observation_recording_cluster.py
           python - <<'PY'
           import hashlib
           import importlib.util
@@ -72,7 +79,8 @@ jobs:
           import sys
 
           module_path = Path(
-              "src/causal4d_public/tracking_cloth_query_observation.py"
+              "src/causal4d_public/"
+              "tracking_cloth_query_observation_recording_cluster.py"
           ).resolve()
           module_name = "tracking_cloth_query_observation_contract"
           spec = importlib.util.spec_from_file_location(module_name, module_path)

--- a/ops/tracking-cloth-query-observation-gpuserver4090-request.json
+++ b/ops/tracking-cloth-query-observation-gpuserver4090-request.json
@@ -1,8 +1,8 @@
 {
-  "schema_version": 1,
-  "enabled": true,
+  "request": "run-tracking-cloth-query-observation-gpuserver4090",
   "workflow": "tracking-cloth-query-observation.yml",
   "ref": "main",
-  "request": "run-tracking-cloth-query-observation-gpuserver4090",
-  "request_id": "3e9f77bd804f91545dbdac1098c324b3b155167c938c186a2e9238c712cdeca0"
+  "enabled": true,
+  "request_id": "3e9f77bd804f91545dbdac1098c324b3b155167c938c186a2e9238c712cdeca0",
+  "schema_version": 1
 }

--- a/src/causal4d_public/tracking_cloth_query_observation_recording_cluster.py
+++ b/src/causal4d_public/tracking_cloth_query_observation_recording_cluster.py
@@ -1,0 +1,264 @@
+"""Recording-cluster correction for the frozen Tracking Cloth experiment.
+
+The original evaluator declared complete recordings as the analysis units but
+aggregated and bootstrapped recording--horizon rows. This module changes only
+that bookkeeping: registered horizons are averaged inside each recording before
+source-win counting, aggregate metrics, and material-stratified bootstrapping.
+All data splits, marker choices, fitted models, thresholds, and target-access
+rules remain those of ``tracking_cloth_query_observation``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+from typing import Any
+
+import numpy as np
+
+_BASE_PATH = Path(__file__).with_name("tracking_cloth_query_observation.py")
+_BASE_NAME = "causal4d_tracking_cloth_query_observation_frozen_v1"
+_SPEC = importlib.util.spec_from_file_location(_BASE_NAME, _BASE_PATH)
+if _SPEC is None or _SPEC.loader is None:
+    raise ImportError(f"cannot load frozen evaluator from {_BASE_PATH}")
+_BASE: Any = importlib.util.module_from_spec(_SPEC)
+sys.modules[_BASE_NAME] = _BASE
+_SPEC.loader.exec_module(_BASE)
+_ORIGINAL_RUN_EVALUATION = _BASE.run_evaluation
+
+PILOT_KIND = _BASE.PILOT_KIND
+EXPECTED_ROOT = _BASE.EXPECTED_ROOT
+load_request = _BASE.load_request
+canonical_sha256 = _BASE.canonical_sha256
+
+
+def _group_recordings(rows: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        recording = str(row["recording"])
+        grouped.setdefault(recording, []).append(row)
+    if not grouped:
+        raise ValueError("no scored recording rows")
+    for recording, group in grouped.items():
+        materials = {str(row["material"]) for row in group}
+        scenarios = {str(row["scenario"]) for row in group}
+        horizons = [float(row["horizon_seconds"]) for row in group]
+        if len(materials) != 1 or len(scenarios) != 1:
+            raise ValueError(f"recording metadata changed within {recording}")
+        if len(horizons) != len(set(horizons)):
+            raise ValueError(f"duplicate horizon row for {recording}")
+    return grouped
+
+
+def _cluster_metric(
+    rows: list[dict[str, Any]],
+    arm: str,
+    metric: str,
+) -> float:
+    return float(np.mean([float(row["arms"][arm][metric]) for row in rows]))
+
+
+def aggregate_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    grouped = _group_recordings(rows)
+    arms = sorted(rows[0]["arms"])
+    for row in rows:
+        if sorted(row["arms"]) != arms:
+            raise ValueError("arm roster differs across scored rows")
+    aggregate: dict[str, Any] = {
+        "recordings": len(grouped),
+        "recording_horizon_rows": len(rows),
+        "horizon_clustering": "mean-within-complete-recording-v1",
+        "arms": {},
+    }
+    for arm in arms:
+        mse = np.asarray(
+            [_cluster_metric(group, arm, "mse_m2") for group in grouped.values()],
+            dtype=np.float64,
+        )
+        nll = np.asarray(
+            [
+                _cluster_metric(group, arm, "gaussian_nll")
+                for group in grouped.values()
+            ],
+            dtype=np.float64,
+        )
+        coverage = np.asarray(
+            [
+                _cluster_metric(group, arm, "marginal_90_coverage")
+                for group in grouped.values()
+            ],
+            dtype=np.float64,
+        )
+        aggregate["arms"][arm] = {
+            "equal_recording_mse_m2": float(np.mean(mse)),
+            "equal_recording_rmse_mm": 1000.0 * float(np.sqrt(np.mean(mse))),
+            "equal_recording_gaussian_nll": float(np.mean(nll)),
+            "equal_recording_marginal_90_coverage": float(np.mean(coverage)),
+        }
+    baseline = aggregate["arms"]["constant_velocity"]["equal_recording_mse_m2"]
+    for arm in arms:
+        value = aggregate["arms"][arm]["equal_recording_mse_m2"]
+        aggregate["arms"][arm]["relative_mse_improvement_vs_constant_velocity"] = (
+            float((baseline - value) / baseline) if baseline > 0.0 else 0.0
+        )
+    return aggregate
+
+
+def source_gate(rows: list[dict[str, Any]], request: dict[str, Any]) -> dict[str, Any]:
+    grouped = _group_recordings(rows)
+    aggregate = aggregate_rows(rows)
+    task = aggregate["arms"]["task_conditioned"]["equal_recording_mse_m2"]
+    generic = aggregate["arms"]["generic_information"]["equal_recording_mse_m2"]
+    baseline = aggregate["arms"]["constant_velocity"]["equal_recording_mse_m2"]
+    task_vs_generic = (generic - task) / generic
+    task_vs_baseline = (baseline - task) / baseline
+    recording_differences = np.asarray(
+        [
+            float(
+                np.mean(
+                    [
+                        row["arms"]["generic_information"]["mse_m2"]
+                        - row["arms"]["task_conditioned"]["mse_m2"]
+                        for row in group
+                    ]
+                )
+            )
+            for group in grouped.values()
+        ],
+        dtype=np.float64,
+    )
+    win_fraction = float(np.mean(recording_differences > 0.0))
+
+    ratios: dict[str, float] = {}
+    for scenario in _BASE.PRIMARY_SCENARIOS:
+        scenario_groups = [
+            group for group in grouped.values() if str(group[0]["scenario"]) == scenario
+        ]
+        if not scenario_groups:
+            continue
+        task_s = float(
+            np.mean(
+                [
+                    _cluster_metric(group, "task_conditioned", "mse_m2")
+                    for group in scenario_groups
+                ]
+            )
+        )
+        generic_s = float(
+            np.mean(
+                [
+                    _cluster_metric(group, "generic_information", "mse_m2")
+                    for group in scenario_groups
+                ]
+            )
+        )
+        ratios[scenario] = task_s / generic_s if generic_s > 0.0 else float("inf")
+
+    selections: dict[tuple[str, float], tuple[str, str]] = {}
+    for row in rows:
+        key = (str(row["scenario"]), float(row["horizon_seconds"]))
+        pair = (str(row["task_selected"]), str(row["generic_selected"]))
+        previous = selections.setdefault(key, pair)
+        if previous != pair:
+            raise ValueError(f"selection changed across recordings for {key}")
+    distinct = sum(task_group != generic_group for task_group, generic_group in selections.values())
+
+    thresholds = request["source_gate"]
+    checks = {
+        "minimum_improvement_vs_generic": task_vs_generic
+        >= float(thresholds["minimum_improvement_vs_generic"]),
+        "minimum_improvement_vs_constant_velocity": task_vs_baseline
+        >= float(thresholds["minimum_improvement_vs_constant_velocity"]),
+        "minimum_recording_win_fraction": win_fraction
+        >= float(thresholds["minimum_recording_win_fraction"]),
+        "maximum_worst_scenario_ratio": max(ratios.values(), default=float("inf"))
+        <= float(thresholds["maximum_worst_scenario_ratio"]),
+        "minimum_distinct_selection_rows": distinct
+        >= int(thresholds["minimum_distinct_selection_rows"]),
+    }
+    return {
+        "passed": all(checks.values()),
+        "checks": checks,
+        "task_vs_generic_relative_mse_improvement": float(task_vs_generic),
+        "task_vs_constant_velocity_relative_mse_improvement": float(task_vs_baseline),
+        "task_vs_generic_recording_win_fraction": win_fraction,
+        "task_to_generic_scenario_mse_ratios": ratios,
+        "distinct_task_vs_generic_selection_rows": int(distinct),
+        "distinct_registered_task_selections": int(distinct),
+        "win_fraction_unit": "complete recording averaged across horizons",
+        "aggregate": aggregate,
+    }
+
+
+def _bootstrap_difference(
+    rows: list[dict[str, Any]],
+    arm_a: str,
+    arm_b: str,
+    *,
+    seed: int,
+    draws: int,
+) -> dict[str, float]:
+    grouped = _group_recordings(rows)
+    by_material: dict[str, list[float]] = {}
+    for group in grouped.values():
+        material = str(group[0]["material"])
+        difference = float(
+            np.mean(
+                [
+                    row["arms"][arm_a]["mse_m2"]
+                    - row["arms"][arm_b]["mse_m2"]
+                    for row in group
+                ]
+            )
+        )
+        by_material.setdefault(material, []).append(difference)
+    rng = np.random.default_rng(seed)
+    simulated = np.empty(draws, dtype=np.float64)
+    materials = sorted(by_material)
+    for index in range(draws):
+        material_means: list[float] = []
+        for material in materials:
+            values = np.asarray(by_material[material], dtype=np.float64)
+            sample = rng.choice(values, size=values.size, replace=True)
+            material_means.append(float(np.mean(sample)))
+        simulated[index] = float(np.mean(material_means))
+    point = float(np.mean([np.mean(by_material[name]) for name in materials]))
+    lower, upper = np.quantile(simulated, [0.025, 0.975])
+    return {
+        "mean_m2": point,
+        "lower_m2": float(lower),
+        "upper_m2": float(upper),
+    }
+
+
+def run_evaluation(root: Path, request: dict[str, Any]) -> dict[str, Any]:
+    result = _ORIGINAL_RUN_EVALUATION(root, request)
+    result["analysis_unit_contract"] = {
+        "schema_version": 1,
+        "unit": "complete recording",
+        "registered_horizons": "nested and averaged within recording",
+        "source_win_fraction": "one indicator per complete recording",
+        "target_bootstrap": "material-stratified resampling of complete recordings",
+        "correction_stage": "before first source-payload evaluation",
+    }
+    unhashed = dict(result)
+    unhashed.pop("result_id", None)
+    result["result_id"] = canonical_sha256(unhashed)
+    return result
+
+
+_BASE.aggregate_rows = aggregate_rows
+_BASE.source_gate = source_gate
+_BASE._bootstrap_difference = _bootstrap_difference
+_BASE.run_evaluation = run_evaluation
+validate_result = _BASE.validate_result
+write_summary = _BASE.write_summary
+
+
+def main() -> int:
+    return int(_BASE.main())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d_public/tracking_cloth_query_observation_recording_cluster.py
+++ b/src/causal4d_public/tracking_cloth_query_observation_recording_cluster.py
@@ -77,10 +77,7 @@ def aggregate_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
             dtype=np.float64,
         )
         nll = np.asarray(
-            [
-                _cluster_metric(group, arm, "gaussian_nll")
-                for group in grouped.values()
-            ],
+            [_cluster_metric(group, arm, "gaussian_nll") for group in grouped.values()],
             dtype=np.float64,
         )
         coverage = np.asarray(
@@ -162,7 +159,9 @@ def source_gate(rows: list[dict[str, Any]], request: dict[str, Any]) -> dict[str
         previous = selections.setdefault(key, pair)
         if previous != pair:
             raise ValueError(f"selection changed across recordings for {key}")
-    distinct = sum(task_group != generic_group for task_group, generic_group in selections.values())
+    distinct = sum(
+        task_group != generic_group for task_group, generic_group in selections.values()
+    )
 
     thresholds = request["source_gate"]
     checks = {
@@ -206,8 +205,7 @@ def _bootstrap_difference(
         difference = float(
             np.mean(
                 [
-                    row["arms"][arm_a]["mse_m2"]
-                    - row["arms"][arm_b]["mse_m2"]
+                    row["arms"][arm_a]["mse_m2"] - row["arms"][arm_b]["mse_m2"]
                     for row in group
                 ]
             )

--- a/tests/test_tracking_cloth_query_observation_recording_cluster.py
+++ b/tests/test_tracking_cloth_query_observation_recording_cluster.py
@@ -7,7 +7,9 @@ from typing import Any
 
 import pytest
 
-from causal4d_public import tracking_cloth_query_observation_recording_cluster as cluster
+from causal4d_public import (
+    tracking_cloth_query_observation_recording_cluster as cluster,
+)
 
 
 def _row(
@@ -124,7 +126,9 @@ def test_duplicate_horizon_and_inconsistent_selection_fail_closed() -> None:
         cluster.source_gate(inconsistent, request)
 
 
-def test_run_evaluation_refreshes_result_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_evaluation_refreshes_result_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(
         cluster,
         "_ORIGINAL_RUN_EVALUATION",

--- a/tests/test_tracking_cloth_query_observation_recording_cluster.py
+++ b/tests/test_tracking_cloth_query_observation_recording_cluster.py
@@ -1,0 +1,144 @@
+"""Tests for complete-recording clustering in the Tracking Cloth evaluation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from causal4d_public import tracking_cloth_query_observation_recording_cluster as cluster
+
+
+def _row(
+    recording: str,
+    horizon: float,
+    *,
+    task: float,
+    generic: float,
+    baseline: float,
+    material: str = "denim",
+    scenario: str = "shake",
+) -> dict[str, Any]:
+    def metrics(mse: float) -> dict[str, float]:
+        return {
+            "mse_m2": mse,
+            "rmse_mm": 1000.0 * mse**0.5,
+            "gaussian_nll": mse + 1.0,
+            "marginal_90_coverage": 0.8,
+        }
+
+    return {
+        "recording": recording,
+        "material": material,
+        "scenario": scenario,
+        "size": "A3",
+        "horizon_seconds": horizon,
+        "windows": 20,
+        "task_selected": "lower",
+        "generic_selected": "upper",
+        "random_selected": "central",
+        "arms": {
+            "task_conditioned": metrics(task),
+            "generic_information": metrics(generic),
+            "constant_velocity": metrics(baseline),
+        },
+    }
+
+
+def test_aggregate_weights_recordings_not_recording_horizon_rows() -> None:
+    rows = [
+        _row("a.csv", 0.1, task=1.0, generic=2.0, baseline=3.0),
+        _row("b.csv", 0.1, task=9.0, generic=10.0, baseline=11.0),
+        _row("b.csv", 0.25, task=9.0, generic=10.0, baseline=11.0),
+        _row("b.csv", 0.5, task=9.0, generic=10.0, baseline=11.0),
+    ]
+    aggregate = cluster.aggregate_rows(rows)
+    assert aggregate["recordings"] == 2
+    assert aggregate["recording_horizon_rows"] == 4
+    assert aggregate["arms"]["task_conditioned"]["equal_recording_mse_m2"] == 5.0
+
+
+def test_source_win_fraction_has_one_vote_per_complete_recording() -> None:
+    rows = [
+        _row("winner.csv", 0.1, task=0.0, generic=10.0, baseline=10.0),
+        _row("loser.csv", 0.1, task=2.0, generic=1.0, baseline=3.0),
+        _row("loser.csv", 0.25, task=2.0, generic=1.0, baseline=3.0),
+        _row("loser.csv", 0.5, task=2.0, generic=1.0, baseline=3.0),
+    ]
+    request = {
+        "source_gate": {
+            "minimum_improvement_vs_generic": 0.0,
+            "minimum_improvement_vs_constant_velocity": 0.0,
+            "minimum_recording_win_fraction": 0.4,
+            "maximum_worst_scenario_ratio": 1.15,
+            "minimum_distinct_selection_rows": 1,
+        }
+    }
+    gate = cluster.source_gate(rows, request)
+    assert gate["passed"] is True
+    assert gate["task_vs_generic_recording_win_fraction"] == 0.5
+    assert gate["distinct_registered_task_selections"] == 3
+
+
+def test_bootstrap_clusters_horizons_before_resampling() -> None:
+    rows = [
+        _row("a.csv", 0.1, task=10.0, generic=0.0, baseline=11.0),
+        _row("b.csv", 0.1, task=-1.0, generic=0.0, baseline=11.0),
+        _row("b.csv", 0.25, task=-1.0, generic=0.0, baseline=11.0),
+        _row("b.csv", 0.5, task=-1.0, generic=0.0, baseline=11.0),
+    ]
+    result = cluster._bootstrap_difference(
+        rows,
+        "task_conditioned",
+        "generic_information",
+        seed=7,
+        draws=1000,
+    )
+    assert result["mean_m2"] == 4.5
+
+
+def test_duplicate_horizon_and_inconsistent_selection_fail_closed() -> None:
+    duplicate = [
+        _row("a.csv", 0.1, task=1.0, generic=2.0, baseline=3.0),
+        _row("a.csv", 0.1, task=1.0, generic=2.0, baseline=3.0),
+    ]
+    with pytest.raises(ValueError, match="duplicate horizon"):
+        cluster.aggregate_rows(duplicate)
+
+    inconsistent = [
+        _row("a.csv", 0.1, task=1.0, generic=2.0, baseline=3.0),
+        _row("b.csv", 0.1, task=1.0, generic=2.0, baseline=3.0),
+    ]
+    inconsistent[1]["task_selected"] = "central"
+    request = {
+        "source_gate": {
+            "minimum_improvement_vs_generic": 0.0,
+            "minimum_improvement_vs_constant_velocity": 0.0,
+            "minimum_recording_win_fraction": 0.0,
+            "maximum_worst_scenario_ratio": 2.0,
+            "minimum_distinct_selection_rows": 0,
+        }
+    }
+    with pytest.raises(ValueError, match="selection changed"):
+        cluster.source_gate(inconsistent, request)
+
+
+def test_run_evaluation_refreshes_result_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        cluster,
+        "_ORIGINAL_RUN_EVALUATION",
+        lambda _root, _request: {"result_id": "old", "decision": "synthetic"},
+    )
+    result = cluster.run_evaluation(Path("."), {})
+    assert result["analysis_unit_contract"]["unit"] == "complete recording"
+    unhashed = dict(result)
+    supplied = unhashed.pop("result_id")
+    assert supplied == cluster.canonical_sha256(unhashed)
+
+
+def test_frozen_base_is_patched_before_main_execution() -> None:
+    assert cluster._BASE.aggregate_rows is cluster.aggregate_rows
+    assert cluster._BASE.source_gate is cluster.source_gate
+    assert cluster._BASE._bootstrap_difference is cluster._bootstrap_difference
+    assert cluster._BASE.run_evaluation is cluster.run_evaluation


### PR DESCRIPTION
## Pre-execution audit finding

The frozen experiment states that a complete recording is the analysis unit and that forecast windows are nested. The implementation correctly averaged windows inside each recording–horizon row, but then treated the three registered horizons as separate units in two places:

1. the denim `minimum_recording_win_fraction`; and
2. the material-stratified target bootstrap.

No scientific payload was opened before this audit correction. Run `33361396768` failed before importing NumPy or reading a CSV payload, and repaired run `33361727803` is still pending on the shared self-hosted runner.

## Correction

Add a narrow execution wrapper that preserves the frozen evaluator and changes only inferential bookkeeping:

- average registered horizons within each complete recording before aggregate MSE/NLL/coverage;
- give each complete denim recording one win/loss vote;
- compute scenario ratios from equal-weighted complete recordings;
- count distinct task-vs-generic selections once per registered scenario/horizon rather than once per repeated scoring row;
- material-stratify the target bootstrap while resampling complete recordings, with all horizons retained inside a sampled recording; and
- add an explicit `analysis_unit_contract` to the result before refreshing its content identity.

All cotton/denim/wool-polyester splits, candidate marker groups, fitted models, ridge, horizons, query, source thresholds, comparators, and the target-open-only-after-every-gate-passes rule remain unchanged.

## Execution control

The workflow points to the correction wrapper and validates both the frozen evaluator and wrapper. `cancel-in-progress: true` prevents the pending uncorrected main run from consuming the runner once this reviewed version is dispatched. The operation request is reformatted without changing its parsed value or request identity, so merging retriggers the existing main-only file dispatcher.

## Tests

Focused tests cover unequal horizon counts, one-vote-per-recording source gating, clustered bootstrap point estimates, duplicate horizons, inconsistent selections across recordings, refreshed result identity, and the runtime patch binding.

This is a pre-outcome analysis-unit correction, not outcome-dependent tuning. No target result, paper claim, or empirical sign is known.