### PR TITLE
Make physical specimens the primary Tracking Cloth inference units

### DIFF
--- a/ops/tracking-cloth-query-observation-gpuserver4090-request.json
+++ b/ops/tracking-cloth-query-observation-gpuserver4090-request.json
@@ -1,8 +1,8 @@
 {
-  "request": "run-tracking-cloth-query-observation-gpuserver4090",
-  "workflow": "tracking-cloth-query-observation.yml",
-  "ref": "main",
   "enabled": true,
+  "ref": "main",
   "request_id": "3e9f77bd804f91545dbdac1098c324b3b155167c938c186a2e9238c712cdeca0",
-  "schema_version": 1
+  "request": "run-tracking-cloth-query-observation-gpuserver4090",
+  "schema_version": 1,
+  "workflow": "tracking-cloth-query-observation.yml"
 }

--- a/src/causal4d_public/tracking_cloth_query_observation_recording_cluster.py
+++ b/src/causal4d_public/tracking_cloth_query_observation_recording_cluster.py
@@ -1,11 +1,11 @@
-"""Recording-cluster correction for the frozen Tracking Cloth experiment.
+"""Cluster the frozen Tracking Cloth evaluation at its valid analysis units.
 
-The original evaluator declared complete recordings as the analysis units but
-aggregated and bootstrapped recording--horizon rows. This module changes only
-that bookkeeping: registered horizons are averaged inside each recording before
-source-win counting, aggregate metrics, and material-stratified bootstrapping.
-All data splits, marker choices, fitted models, thresholds, and target-access
-rules remain those of ``tracking_cloth_query_observation``.
+Registered forecast horizons are nested within complete recordings. Repeated
+recordings are in turn nested within the physical material--size specimen. The
+frozen denim gate remains an operational repeated-recording rule, while target
+uncertainty and the primary held-out summary use material--size specimens. All
+data splits, marker choices, models, thresholds, and target-access rules remain
+those of ``tracking_cloth_query_observation``.
 """
 
 from __future__ import annotations
@@ -26,6 +26,7 @@ _BASE: Any = importlib.util.module_from_spec(_SPEC)
 sys.modules[_BASE_NAME] = _BASE
 _SPEC.loader.exec_module(_BASE)
 _ORIGINAL_RUN_EVALUATION = _BASE.run_evaluation
+_ORIGINAL_WRITE_SUMMARY = _BASE.write_summary
 
 PILOT_KIND = _BASE.PILOT_KIND
 EXPECTED_ROOT = _BASE.EXPECTED_ROOT
@@ -43,11 +44,25 @@ def _group_recordings(rows: list[dict[str, Any]]) -> dict[str, list[dict[str, An
     for recording, group in grouped.items():
         materials = {str(row["material"]) for row in group}
         scenarios = {str(row["scenario"]) for row in group}
+        sizes = {str(row["size"]) for row in group}
         horizons = [float(row["horizon_seconds"]) for row in group]
-        if len(materials) != 1 or len(scenarios) != 1:
+        if len(materials) != 1 or len(scenarios) != 1 or len(sizes) != 1:
             raise ValueError(f"recording metadata changed within {recording}")
         if len(horizons) != len(set(horizons)):
             raise ValueError(f"duplicate horizon row for {recording}")
+    return grouped
+
+
+def _group_specimens(rows: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        material = str(row["material"])
+        size = str(row["size"])
+        if size not in {"A2", "A3"}:
+            raise ValueError(f"unknown physical specimen size: {size}")
+        grouped.setdefault(f"{material}/{size}", []).append(row)
+    if not grouped:
+        raise ValueError("no physical specimen rows")
     return grouped
 
 
@@ -59,7 +74,21 @@ def _cluster_metric(
     return float(np.mean([float(row["arms"][arm][metric]) for row in rows]))
 
 
+def _specimen_metric(
+    rows: list[dict[str, Any]],
+    arm: str,
+    metric: str,
+) -> float:
+    recordings = _group_recordings(rows)
+    return float(
+        np.mean(
+            [_cluster_metric(group, arm, metric) for group in recordings.values()]
+        )
+    )
+
+
 def aggregate_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Equal-weight complete recordings after averaging registered horizons."""
     grouped = _group_recordings(rows)
     arms = sorted(rows[0]["arms"])
     for row in rows:
@@ -102,7 +131,78 @@ def aggregate_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
     return aggregate
 
 
+def aggregate_specimens(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Primary target summary over material--size physical specimens."""
+    specimens = _group_specimens(rows)
+    arms = sorted(rows[0]["arms"])
+    by_specimen: dict[str, Any] = {}
+    for specimen, group in sorted(specimens.items()):
+        recordings = _group_recordings(group)
+        arm_rows: dict[str, Any] = {}
+        for arm in arms:
+            mse = _specimen_metric(group, arm, "mse_m2")
+            arm_rows[arm] = {
+                "mse_m2": mse,
+                "rmse_mm": 1000.0 * float(np.sqrt(mse)),
+                "gaussian_nll": _specimen_metric(group, arm, "gaussian_nll"),
+                "marginal_90_coverage": _specimen_metric(
+                    group,
+                    arm,
+                    "marginal_90_coverage",
+                ),
+            }
+        by_specimen[specimen] = {
+            "material": str(group[0]["material"]),
+            "size": str(group[0]["size"]),
+            "recordings": len(recordings),
+            "recording_horizon_rows": len(group),
+            "arms": arm_rows,
+        }
+
+    aggregate: dict[str, Any] = {
+        "unit": "material-size physical specimen",
+        "specimens": len(specimens),
+        "recordings": len(_group_recordings(rows)),
+        "recording_horizon_rows": len(rows),
+        "by_specimen": by_specimen,
+        "arms": {},
+    }
+    for arm in arms:
+        mse = np.asarray(
+            [row["arms"][arm]["mse_m2"] for row in by_specimen.values()],
+            dtype=np.float64,
+        )
+        aggregate["arms"][arm] = {
+            "equal_specimen_mse_m2": float(np.mean(mse)),
+            "equal_specimen_rmse_mm": 1000.0 * float(np.sqrt(np.mean(mse))),
+            "equal_specimen_gaussian_nll": float(
+                np.mean(
+                    [
+                        row["arms"][arm]["gaussian_nll"]
+                        for row in by_specimen.values()
+                    ]
+                )
+            ),
+            "equal_specimen_marginal_90_coverage": float(
+                np.mean(
+                    [
+                        row["arms"][arm]["marginal_90_coverage"]
+                        for row in by_specimen.values()
+                    ]
+                )
+            ),
+        }
+    baseline = aggregate["arms"]["constant_velocity"]["equal_specimen_mse_m2"]
+    for arm in arms:
+        value = aggregate["arms"][arm]["equal_specimen_mse_m2"]
+        aggregate["arms"][arm]["relative_mse_improvement_vs_constant_velocity"] = (
+            float((baseline - value) / baseline) if baseline > 0.0 else 0.0
+        )
+    return aggregate
+
+
 def source_gate(rows: list[dict[str, Any]], request: dict[str, Any]) -> dict[str, Any]:
+    """Apply the frozen operational denim gate with one vote per recording."""
     grouped = _group_recordings(rows)
     aggregate = aggregate_rows(rows)
     task = aggregate["arms"]["task_conditioned"]["equal_recording_mse_m2"]
@@ -186,6 +286,10 @@ def source_gate(rows: list[dict[str, Any]], request: dict[str, Any]) -> dict[str
         "distinct_task_vs_generic_selection_rows": int(distinct),
         "distinct_registered_task_selections": int(distinct),
         "win_fraction_unit": "complete recording averaged across horizons",
+        "inferential_boundary": (
+            "Operational repeated-recording gate only; it is not a population "
+            "confidence statement over physical cloth specimens."
+        ),
         "aggregate": aggregate,
     }
 
@@ -198,18 +302,28 @@ def _bootstrap_difference(
     seed: int,
     draws: int,
 ) -> dict[str, float]:
-    grouped = _group_recordings(rows)
+    """Material-stratified bootstrap of material--size specimen contrasts."""
+    specimens = _group_specimens(rows)
     by_material: dict[str, list[float]] = {}
-    for group in grouped.values():
-        material = str(group[0]["material"])
+    for group in specimens.values():
+        recordings = _group_recordings(group)
         difference = float(
             np.mean(
                 [
-                    row["arms"][arm_a]["mse_m2"] - row["arms"][arm_b]["mse_m2"]
-                    for row in group
+                    float(
+                        np.mean(
+                            [
+                                row["arms"][arm_a]["mse_m2"]
+                                - row["arms"][arm_b]["mse_m2"]
+                                for row in recording_rows
+                            ]
+                        )
+                    )
+                    for recording_rows in recordings.values()
                 ]
             )
         )
+        material = str(group[0]["material"])
         by_material.setdefault(material, []).append(difference)
     rng = np.random.default_rng(seed)
     simulated = np.empty(draws, dtype=np.float64)
@@ -233,25 +347,75 @@ def _bootstrap_difference(
 def run_evaluation(root: Path, request: dict[str, Any]) -> dict[str, Any]:
     result = _ORIGINAL_RUN_EVALUATION(root, request)
     result["analysis_unit_contract"] = {
-        "schema_version": 1,
-        "unit": "complete recording",
-        "registered_horizons": "nested and averaged within recording",
-        "source_win_fraction": "one indicator per complete recording",
-        "target_bootstrap": "material-stratified resampling of complete recordings",
+        "schema_version": 2,
+        "source_selection": "cotton recordings; leave-one-recording-out",
+        "source_gate": "denim complete recordings; registered horizons nested",
+        "primary_target_unit": "material-size physical specimen",
+        "target_nesting": "horizons within recordings within specimens",
+        "target_bootstrap": "material-stratified resampling of specimens",
+        "target_specimen_count_if_opened": 4,
+        "population_generalization_claim_authorized": False,
         "correction_stage": "before first source-payload evaluation",
     }
+    if result["target"] is not None:
+        result["target"]["primary_statistical_unit"] = "material-size physical specimen"
+        result["target"]["primary_specimen_aggregate"] = aggregate_specimens(
+            result["target"]["rows"]
+        )
+    result["claim_boundary"].append(
+        "Recordings and horizons are nested within material-size specimens; the "
+        "held-out target contains four such specimens and supports no broad "
+        "cloth-population inference."
+    )
     unhashed = dict(result)
     unhashed.pop("result_id", None)
     result["result_id"] = canonical_sha256(unhashed)
     return result
 
 
+def write_summary(result: dict[str, Any], path: Path) -> None:
+    _ORIGINAL_WRITE_SUMMARY(result, path)
+    if result["target"] is None:
+        return
+    primary = result["target"]["primary_specimen_aggregate"]
+    lines = [
+        "",
+        "## Primary specimen-clustered target analysis",
+        "",
+        f"- Physical material-size specimens: `{primary['specimens']}`",
+        "- Registered horizons are nested within recordings and specimens.",
+    ]
+    for arm in (
+        "task_conditioned",
+        "generic_information",
+        "constant_velocity",
+        "fixed_upper",
+        "random_cost_matched",
+        "dependence_destroyed",
+    ):
+        row = primary["arms"][arm]
+        lines.append(
+            f"- **{arm}:** equal-specimen RMSE="
+            f"{row['equal_specimen_rmse_mm']:.6f} mm, "
+            f"NLL={row['equal_specimen_gaussian_nll']:.6f}, "
+            f"coverage={row['equal_specimen_marginal_90_coverage']:.3%}"
+        )
+    lines.extend(
+        [
+            "- The four-specimen target is a bounded diagnostic, not a cloth-population CI.",
+            "",
+        ]
+    )
+    with path.open("a", encoding="utf-8") as stream:
+        stream.write("\n".join(lines))
+
+
 _BASE.aggregate_rows = aggregate_rows
 _BASE.source_gate = source_gate
 _BASE._bootstrap_difference = _bootstrap_difference
 _BASE.run_evaluation = run_evaluation
+_BASE.write_summary = write_summary
 validate_result = _BASE.validate_result
-write_summary = _BASE.write_summary
 
 
 def main() -> int:

--- a/src/causal4d_public/tracking_cloth_query_observation_recording_cluster.py
+++ b/src/causal4d_public/tracking_cloth_query_observation_recording_cluster.py
@@ -81,9 +81,7 @@ def _specimen_metric(
 ) -> float:
     recordings = _group_recordings(rows)
     return float(
-        np.mean(
-            [_cluster_metric(group, arm, metric) for group in recordings.values()]
-        )
+        np.mean([_cluster_metric(group, arm, metric) for group in recordings.values()])
     )
 
 
@@ -177,10 +175,7 @@ def aggregate_specimens(rows: list[dict[str, Any]]) -> dict[str, Any]:
             "equal_specimen_rmse_mm": 1000.0 * float(np.sqrt(np.mean(mse))),
             "equal_specimen_gaussian_nll": float(
                 np.mean(
-                    [
-                        row["arms"][arm]["gaussian_nll"]
-                        for row in by_specimen.values()
-                    ]
+                    [row["arms"][arm]["gaussian_nll"] for row in by_specimen.values()]
                 )
             ),
             "equal_specimen_marginal_90_coverage": float(

--- a/tests/test_tracking_cloth_query_observation_recording_cluster.py
+++ b/tests/test_tracking_cloth_query_observation_recording_cluster.py
@@ -1,4 +1,4 @@
-"""Tests for complete-recording clustering in the Tracking Cloth evaluation."""
+"""Tests for nested analysis units in the Tracking Cloth evaluation."""
 
 from __future__ import annotations
 
@@ -20,6 +20,7 @@ def _row(
     generic: float,
     baseline: float,
     material: str = "denim",
+    size: str = "A3",
     scenario: str = "shake",
 ) -> dict[str, Any]:
     def metrics(mse: float) -> dict[str, float]:
@@ -34,7 +35,7 @@ def _row(
         "recording": recording,
         "material": material,
         "scenario": scenario,
-        "size": "A3",
+        "size": size,
         "horizon_seconds": horizon,
         "windows": 20,
         "task_selected": "lower",
@@ -61,7 +62,52 @@ def test_aggregate_weights_recordings_not_recording_horizon_rows() -> None:
     assert aggregate["arms"]["task_conditioned"]["equal_recording_mse_m2"] == 5.0
 
 
-def test_source_win_fraction_has_one_vote_per_complete_recording() -> None:
+def test_specimen_aggregate_nests_recordings_and_horizons() -> None:
+    rows = [
+        _row(
+            "wool_a2.csv",
+            0.1,
+            task=1.0,
+            generic=2.0,
+            baseline=3.0,
+            material="wool",
+            size="A2",
+        ),
+        _row(
+            "wool_a3.csv",
+            0.1,
+            task=9.0,
+            generic=10.0,
+            baseline=11.0,
+            material="wool",
+            size="A3",
+        ),
+        _row(
+            "wool_a3.csv",
+            0.25,
+            task=9.0,
+            generic=10.0,
+            baseline=11.0,
+            material="wool",
+            size="A3",
+        ),
+        _row(
+            "wool_a3.csv",
+            0.5,
+            task=9.0,
+            generic=10.0,
+            baseline=11.0,
+            material="wool",
+            size="A3",
+        ),
+    ]
+    aggregate = cluster.aggregate_specimens(rows)
+    assert aggregate["specimens"] == 2
+    assert aggregate["recordings"] == 2
+    assert aggregate["arms"]["task_conditioned"]["equal_specimen_mse_m2"] == 5.0
+
+
+def test_source_win_fraction_has_one_operational_vote_per_recording() -> None:
     rows = [
         _row("winner.csv", 0.1, task=0.0, generic=10.0, baseline=10.0),
         _row("loser.csv", 0.1, task=2.0, generic=1.0, baseline=3.0),
@@ -81,14 +127,47 @@ def test_source_win_fraction_has_one_vote_per_complete_recording() -> None:
     assert gate["passed"] is True
     assert gate["task_vs_generic_recording_win_fraction"] == 0.5
     assert gate["distinct_registered_task_selections"] == 3
+    assert "not a population" in gate["inferential_boundary"]
 
 
-def test_bootstrap_clusters_horizons_before_resampling() -> None:
+def test_bootstrap_clusters_recordings_inside_physical_specimens() -> None:
     rows = [
-        _row("a.csv", 0.1, task=10.0, generic=0.0, baseline=11.0),
-        _row("b.csv", 0.1, task=-1.0, generic=0.0, baseline=11.0),
-        _row("b.csv", 0.25, task=-1.0, generic=0.0, baseline=11.0),
-        _row("b.csv", 0.5, task=-1.0, generic=0.0, baseline=11.0),
+        _row(
+            "wool_a2.csv",
+            0.1,
+            task=10.0,
+            generic=0.0,
+            baseline=11.0,
+            material="wool",
+            size="A2",
+        ),
+        _row(
+            "wool_a3.csv",
+            0.1,
+            task=0.0,
+            generic=1.0,
+            baseline=11.0,
+            material="wool",
+            size="A3",
+        ),
+        _row(
+            "wool_a3.csv",
+            0.25,
+            task=0.0,
+            generic=1.0,
+            baseline=11.0,
+            material="wool",
+            size="A3",
+        ),
+        _row(
+            "wool_a3.csv",
+            0.5,
+            task=0.0,
+            generic=1.0,
+            baseline=11.0,
+            material="wool",
+            size="A3",
+        ),
     ]
     result = cluster._bootstrap_difference(
         rows,
@@ -126,16 +205,38 @@ def test_duplicate_horizon_and_inconsistent_selection_fail_closed() -> None:
         cluster.source_gate(inconsistent, request)
 
 
+def test_unknown_specimen_size_fails_closed() -> None:
+    rows = [
+        _row(
+            "unknown.csv",
+            0.1,
+            task=1.0,
+            generic=2.0,
+            baseline=3.0,
+            size="unknown",
+        )
+    ]
+    with pytest.raises(ValueError, match="unknown physical specimen size"):
+        cluster.aggregate_specimens(rows)
+
+
 def test_run_evaluation_refreshes_result_identity(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         cluster,
         "_ORIGINAL_RUN_EVALUATION",
-        lambda _root, _request: {"result_id": "old", "decision": "synthetic"},
+        lambda _root, _request: {
+            "result_id": "old",
+            "decision": "synthetic",
+            "target": None,
+            "claim_boundary": [],
+        },
     )
     result = cluster.run_evaluation(Path("."), {})
-    assert result["analysis_unit_contract"]["unit"] == "complete recording"
+    assert result["analysis_unit_contract"]["primary_target_unit"] == (
+        "material-size physical specimen"
+    )
     unhashed = dict(result)
     supplied = unhashed.pop("result_id")
     assert supplied == cluster.canonical_sha256(unhashed)
@@ -146,3 +247,4 @@ def test_frozen_base_is_patched_before_main_execution() -> None:
     assert cluster._BASE.source_gate is cluster.source_gate
     assert cluster._BASE._bootstrap_difference is cluster._bootstrap_difference
     assert cluster._BASE.run_evaluation is cluster.run_evaluation
+    assert cluster._BASE.write_summary is cluster.write_summary


### PR DESCRIPTION
## Final pre-outcome unit audit

The official free-hanging factorial identifies a physical specimen by `material_size`; four materials and A2/A3 therefore give eight physical specimens. The held-out wool/polyester target contains four specimens, with repeated recordings and horizons nested inside them.

The already merged correction made horizons nested within recordings. This PR completes the hierarchy before any scientific CSV payload has been evaluated:

```text
registered horizons
  within complete recordings
    within material-size physical specimens
```

The current exact-main run `33362679780` is still queued. Its predecessor was cancelled before runner allocation. The first technical attempt failed before importing NumPy or reading a CSV payload. No source sign, gate decision, target payload, or target result is known.

## What changes

- Preserve the frozen denim gate as an explicitly **operational repeated-recording gate**, with one vote per recording after averaging horizons. It is not presented as a population confidence statement.
- Make `material-size physical specimen` the primary held-out target unit.
- Add equal-specimen RMSE, NLL, marginal coverage, relative improvements, and per-specimen rows.
- Change both paired target bootstraps to material-stratified resampling of specimens, keeping all recordings and horizons inside a sampled specimen.
- Add a schema-v2 analysis-unit contract and an explicit four-specimen/no-population-generalization boundary to the content-addressed result.
- Append the specimen-clustered primary summary to `summary.md`.

No cotton/denim/wool-polyester assignment, marker candidate, model, ridge, query, horizon, operational gate threshold, comparator, random seed, or target-open condition changes. This is not outcome-dependent tuning.

The operation request is reformatted without changing its parsed value or request ID. After merge, the existing dispatcher launches this revision and the workflow concurrency policy cancels the pending recording-only run before it can consume the self-hosted runner.