### PR TITLE
Record the Tracking Cloth negative transfer result

### DIFF
--- a/evidence/negative/README.md
+++ b/evidence/negative/README.md
@@ -1,0 +1,18 @@
+# Negative evidence registry
+
+This directory preserves completed public-data evaluations whose registered
+decision was negative, inconclusive, or claim-ineligible. These records are
+scientific evidence, not cleanup targets or implicit requests for new
+experiments.
+
+## Records
+
+### Tracking Cloth shake-to-twist transfer
+
+[`tracking-cloth-shake-to-twist-20260830/`](tracking-cloth-shake-to-twist-20260830/)
+
+The reduced spring-mesh shake-to-twist transfer and the logged active-probe
+replay did not beat persistence.
+
+A later protocol may add a separate record, but must not silently rewrite the
+decision or provenance of an earlier registered evaluation.

--- a/evidence/negative/tracking-cloth-shake-to-twist-20260830/README.md
+++ b/evidence/negative/tracking-cloth-shake-to-twist-20260830/README.md
@@ -1,0 +1,134 @@
+# Negative evidence: Tracking Cloth shake-to-twist transfer
+
+**Record:** `tracking-cloth-shake-to-twist-20260830`  
+**Status:** completed negative result  
+**Paper claim authorized:** no  
+**New experiment required by this record:** no
+
+## Bottom line
+
+On the public **Tracking Cloth Deformation** dataset, the registered reduced
+spring-mesh transfer from shaking recordings to held-out twisting forecasts
+did **not** beat state persistence.
+
+The best physics arm was `map_physics`:
+
+| Arm | Specimen-balanced RMSE [mm] | Coordinate NLL | 90% coverage |
+| --- | ---: | ---: | ---: |
+| persistence | **75.1451** | **-1.7340** | **92.72%** |
+| map physics | 119.1681 | -0.7879 | 76.13% |
+| Bayesian physics | 132.2905 | -0.5454 | 70.41% |
+| last residual | 141.0674 | -0.5661 | 80.03% |
+| guarded Bayesian physics | 156.4626 | -0.4849 | 70.82% |
+| nominal physics | 208.7978 | -0.6192 | 75.75% |
+
+The best physics RMSE was **44.0230 mm higher than persistence**, or
+**58.58% worse relative to persistence**.
+
+This is a completed result. It is not a TODO, does not require new data
+collection, and must not be omitted merely because the outcome is negative.
+
+## Registered information boundary
+
+Study: `tracking-cloth-shake-to-twist-pilot-v1`
+
+- 120 verified public recordings.
+- 32 shaking recordings used as source data.
+- 32 twisting recordings used as target data.
+- 56 collision recordings reserved and not numerically read.
+- One-second all-marker initialization prefix.
+- Five-second forecast interval.
+- Known future measured corner positions supplied as boundary inputs.
+- Predictions for all 32 targets sealed before target scoring.
+- Primary inference unit: eight material-size specimens, with recordings
+  aggregated within specimens.
+- Raw recordings were not uploaded to GitHub.
+
+The experiment is a reduced spring-mesh pilot. It is not a PhysTwin/FEM
+reproduction, command-conditioned rollout, or fully online robot forecast.
+
+## Guard result
+
+The source-only guard accepted six of eight specimen candidates, corresponding
+to 24 of 32 target recordings; eight recordings used exact fallback.
+
+There were no harmful accepted records relative to **nominal physics** and no
+exact-fallback violations. This does not imply safety relative to the stronger
+persistence comparator: guarded Bayesian physics remained substantially worse
+than persistence.
+
+## Retrospective active-probe replay
+
+Study: `tracking-cloth-task-directed-active-probe-v1`
+
+A later logged-probe replay also remained negative:
+
+- primary one-probe task-directed RMSE: **119.8653 mm**;
+- persistence RMSE: **75.1451 mm**;
+- regret: **44.7202 mm**;
+- specimen-bootstrap 95% interval for regret:
+  **[39.6057, 49.7935] mm**;
+- losses versus persistence: **8/8 specimens**;
+- best exploratory budget among 0, 1, 2, and 4 probes:
+  **119.6666 mm**, still **59.25% worse** than persistence;
+- task-directed and parameter-information policies selected the same one-probe
+  condition for all eight specimens, so the mechanism-discrimination gate
+  failed.
+
+This replay had prior target-outcome exposure and is therefore a retrospective
+diagnostic, not fresh confirmation.
+
+## Scientific interpretation
+
+This record supports the following statement:
+
+> Under the registered public-data shake-to-twist protocol, the reduced
+> spring-mesh physics backend did not transfer well enough to beat persistence,
+> and the logged active-probe replay did not rescue it.
+
+It does **not** support any of the following broader claims:
+
+- Causal4D fails generally.
+- Physics-informed deformable-object prediction is universally inferior.
+- The covariance model is jointly calibrated.
+- The result establishes online-control, safety, material-identification,
+  unseen-object, or state-of-the-art performance.
+- Later, differently specified protocols may overwrite this result.
+
+The appropriate paper use is as a negative real-world transfer result,
+limitation, or failure-mode study.
+
+## Provenance
+
+Primary evaluation:
+
+- GitHub Actions run:
+  [`33302686759`](https://github.com/IPS-Stuttgart/Causal4D/actions/runs/33302686759)
+- evaluated commit: `0cd567b7b640f5e0b73eba8c1eeb1acb1f09f4c1`
+- protocol ID:
+  `4dfcabe6cca23b07244676441e61cc13d113ea7631a2af32707f69af55e00515`
+- prediction-seal SHA-256:
+  `db6156a5bbf6fdf536e8b37cef00e80b5b68b20833fa19001ea97ea6dba97e77`
+- metrics SHA-256:
+  `496cd70ab4221985897b8a768510ff5ccf3691aae2099895cadc034867af38c1`
+
+Active-probe replay:
+
+- GitHub Actions run:
+  [`33319276977`](https://github.com/IPS-Stuttgart/Causal4D/actions/runs/33319276977)
+- evaluated commit: `f8d5f16aa1b104108e6876db40bf2ed9c2e526fa`
+- protocol ID:
+  `ad01b8abc081999b7e042fb2563aaad84197ecbb48f1d9f5e09d322206c4af1c`
+- prediction-seal SHA-256:
+  `8dc08bd35dc434b98d103db94454bfad19957273a1a34131948cb4bf6310e8f2`
+- metrics SHA-256:
+  `2692d907558b520ed38f65807aece60f4827656057d449326cd65d7e83ec5898`
+
+Downloaded evidence-package hashes:
+
+```text
+44156a6adcef956c88508cb53b013add462bab248ad79905bf73a19ec7151ec8  tracking-cloth-evaluate.zip
+51ea6d6b39cd2a41f75c0ba4d734535c2e2c043f0bc1d83a38033f074f22d1ce  tracking-cloth-active-evaluate.zip
+```
+
+See [`result.json`](result.json) for the machine-readable record.

--- a/evidence/negative/tracking-cloth-shake-to-twist-20260830/result.json
+++ b/evidence/negative/tracking-cloth-shake-to-twist-20260830/result.json
@@ -118,7 +118,7 @@
     "primary_probe_budget": 1,
     "primary_task_directed_rmse_mm": 119.86533281968697,
     "primary_task_directed_minus_persistence_rmse_mm": 44.72019889063222,
-    "primary_task_directed_relative_regret_percent": 59.51181711059778,
+    "primary_task_directed_relative_regret_percent": 59.51176949508532,
     "primary_task_directed_specimen_bootstrap_95_interval_for_regret_mm": [
       39.60574216793094,
       49.79349911894488

--- a/evidence/negative/tracking-cloth-shake-to-twist-20260830/result.json
+++ b/evidence/negative/tracking-cloth-shake-to-twist-20260830/result.json
@@ -1,0 +1,166 @@
+{
+  "artifact_kind": "Causal4DNegativeEvidenceRecordV1",
+  "record_id": "tracking-cloth-shake-to-twist-20260830",
+  "recorded_at": "2026-09-01",
+  "status": "completed_negative_result",
+  "terminal_for_registered_protocol": true,
+  "creates_new_experiment_requirement": false,
+  "paper_claim_authorized": false,
+  "dataset": {
+    "name": "Tracking Cloth Deformation",
+    "public_record_id": "14644526",
+    "archive_md5": "b4868b702f8a42b2ea1069d0f1a3b8f6",
+    "recordings_total": 120,
+    "source_shake_recordings": 32,
+    "target_twist_recordings": 32,
+    "reserved_collision_recordings": 56,
+    "materials": [
+      "cotton",
+      "denim",
+      "polyester",
+      "wool"
+    ],
+    "sizes": [
+      "A2",
+      "A3"
+    ],
+    "license_policy": "CC-BY-NC-SA-4.0 pending author clarification of conflicting CC-BY-SA-4.0 metadata",
+    "raw_data_uploaded": false
+  },
+  "primary_evaluation": {
+    "study_id": "tracking-cloth-shake-to-twist-pilot-v1",
+    "evidence_class": "public-real-data-pilot; prior exposure not assumed absent",
+    "information_regime": "measured-corner-boundary-conditioned; all-marker initialization prefix only",
+    "source_motion": "shake",
+    "target_motion": "twist",
+    "prefix_seconds": 1.0,
+    "forecast_seconds": 5.0,
+    "inferential_unit": "8 material-size specimens; equal recordings within specimen, then equal specimens",
+    "github_repository": "IPS-Stuttgart/Causal4D",
+    "github_run_id": 33302686759,
+    "github_commit_sha": "0cd567b7b640f5e0b73eba8c1eeb1acb1f09f4c1",
+    "protocol_id": "4dfcabe6cca23b07244676441e61cc13d113ea7631a2af32707f69af55e00515",
+    "prediction_seal_sha256": "db6156a5bbf6fdf536e8b37cef00e80b5b68b20833fa19001ea97ea6dba97e77",
+    "metrics_sha256": "496cd70ab4221985897b8a768510ff5ccf3691aae2099895cadc034867af38c1",
+    "target_recordings": 32,
+    "arms": {
+      "persistence": {
+        "rmse_mm": 75.14513392905475,
+        "coordinate_nll": -1.7339515574197684,
+        "coordinate_90_coverage": 0.9272461846611654,
+        "mean_full_90_width_mm": 171.1983601064278
+      },
+      "map_physics": {
+        "rmse_mm": 119.16811826823869,
+        "coordinate_nll": -0.7878542652071743,
+        "coordinate_90_coverage": 0.7612916503733536,
+        "mean_full_90_width_mm": 134.1261836730478
+      },
+      "bayesian_physics": {
+        "rmse_mm": 132.29049200912868,
+        "coordinate_nll": -0.5454162990675424,
+        "coordinate_90_coverage": 0.7041387074693761,
+        "mean_full_90_width_mm": 123.31240567384623
+      },
+      "last_residual": {
+        "rmse_mm": 141.06742610829883,
+        "coordinate_nll": -0.5660645958248509,
+        "coordinate_90_coverage": 0.8003425559731366,
+        "mean_full_90_width_mm": 148.90046498604272
+      },
+      "guarded_bayesian_physics": {
+        "rmse_mm": 156.46258254135427,
+        "coordinate_nll": -0.4849315083896348,
+        "coordinate_90_coverage": 0.7082499371064404,
+        "mean_full_90_width_mm": 178.19184672134622
+      },
+      "nominal_physics": {
+        "rmse_mm": 208.7977533551574,
+        "coordinate_nll": -0.6191863948449721,
+        "coordinate_90_coverage": 0.7575408611705596,
+        "mean_full_90_width_mm": 299.3240752179182
+      },
+      "nominal_state_injection": {
+        "rmse_mm": 210.05271630590065,
+        "coordinate_nll": -0.6143129103346336,
+        "coordinate_90_coverage": 0.7635925339083205,
+        "mean_full_90_width_mm": 301.906883000486
+      }
+    },
+    "decision": {
+      "comparator": "persistence",
+      "best_physics_arm": "map_physics",
+      "persistence_rmse_mm": 75.14513392905475,
+      "best_physics_rmse_mm": 119.16811826823869,
+      "best_physics_minus_persistence_rmse_mm": 44.022984339183935,
+      "best_physics_relative_regret_percent": 58.583945542962844,
+      "physics_transfer_beats_persistence": false,
+      "source_guard_accepted_specimens": 6,
+      "source_guard_total_specimens": 8,
+      "accepted_recordings": 24,
+      "fallback_recordings": 8,
+      "harmful_accepted_recordings_vs_nominal_physics": 0,
+      "exact_fallback_violations": 0,
+      "interpretation": "The reduced spring-mesh shake-to-twist transfer failed against persistence. The guard protected accepted cases relative to nominal physics, but not relative to persistence."
+    }
+  },
+  "active_probe_replay": {
+    "study_id": "tracking-cloth-task-directed-active-probe-v1",
+    "evidence_class": "cross-validated public-real-data active-probe pilot; prior exposure not assumed absent",
+    "status": "completed_retrospective_diagnostic_not_fresh_confirmation",
+    "github_repository": "IPS-Stuttgart/Causal4D",
+    "github_run_id": 33319276977,
+    "github_commit_sha": "f8d5f16aa1b104108e6876db40bf2ed9c2e526fa",
+    "protocol_id": "ad01b8abc081999b7e042fb2563aaad84197ecbb48f1d9f5e09d322206c4af1c",
+    "prediction_seal_sha256": "8dc08bd35dc434b98d103db94454bfad19957273a1a34131948cb4bf6310e8f2",
+    "metrics_sha256": "2692d907558b520ed38f65807aece60f4827656057d449326cd65d7e83ec5898",
+    "prior_target_run_id": 33302686759,
+    "primary_probe_budget": 1,
+    "primary_task_directed_rmse_mm": 119.86533281968697,
+    "primary_task_directed_minus_persistence_rmse_mm": 44.72019889063222,
+    "primary_task_directed_relative_regret_percent": 59.51181711059778,
+    "primary_task_directed_specimen_bootstrap_95_interval_for_regret_mm": [
+      39.60574216793094,
+      49.79349911894488
+    ],
+    "primary_task_directed_specimen_wins_vs_persistence": 0,
+    "primary_task_directed_specimen_losses_vs_persistence": 8,
+    "best_exploratory_probe_budget": 2,
+    "best_exploratory_probe_rmse_mm": 119.66661341830303,
+    "best_exploratory_probe_relative_regret_percent": 59.24732203056746,
+    "task_vs_parameter_policy_disagreement_count": 0,
+    "task_vs_parameter_policy_disagreement_total": 8,
+    "mechanism_gate": {
+      "policies_make_different_k1_choices": false,
+      "task_directed_beats_parameter_information_overall": false,
+      "task_directed_beats_parameter_on_disagreements": false,
+      "task_directed_beats_persistence": false
+    },
+    "decision": "The retrospective logged active-probe replay did not rescue the negative transfer result and did not differentiate task-directed from parameter-information probe selection."
+  },
+  "claim_boundary": {
+    "supported": [
+      "For this completed public-data protocol, the registered reduced spring-mesh physics transfer from shaking to twisting did not beat persistence.",
+      "The registered source guard prevented accepted updates from worsening nominal physics, but did not make them competitive with persistence.",
+      "A retrospective logged active-probe replay did not rescue performance and selected the same one-probe condition as the parameter-information policy for all eight specimens."
+    ],
+    "not_supported": [
+      "Causal4D fails in general.",
+      "Physics-informed deformable-object prediction is universally inferior to persistence.",
+      "The experiment is command-conditioned, fully online, or a full PhysTwin/FEM reproduction.",
+      "The diagonal Gaussian scores validate joint trajectory covariance.",
+      "The result supports online control, safety, material identification, unseen-object generalization, or state-of-the-art claims."
+    ],
+    "paper_use": "Retain as a negative real-world transfer result, limitation, or failure-mode study. Do not silently promote it to positive evidence or erase it when later protocols differ."
+  },
+  "downloaded_evidence_archives": [
+    {
+      "filename": "tracking-cloth-evaluate.zip",
+      "sha256": "44156a6adcef956c88508cb53b013add462bab248ad79905bf73a19ec7151ec8"
+    },
+    {
+      "filename": "tracking-cloth-active-evaluate.zip",
+      "sha256": "51ea6d6b39cd2a41f75c0ba4d734535c2e2c043f0bc1d83a38033f074f22d1ce"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Preserve the completed Tracking Cloth public-data result as explicit negative evidence rather than leaving it only in transient workflow artifacts.

This adds:

- a negative-evidence registry;
- a human-readable record of the shake-to-twist transfer result;
- a machine-readable result with exact metrics, run IDs, commit IDs, prediction seals, and evidence-package hashes;
- the retrospective active-probe replay and its failed mechanism gate;
- explicit supported and unsupported claim boundaries.

## Registered decision

The best physics arm (`map_physics`, 119.1681 mm RMSE) was 44.0230 mm / 58.58% worse than persistence (75.1451 mm). The one-probe active replay also lost to persistence on all 8 specimens, and the task-directed and parameter-information policies selected the same probe for all specimens.

The record is marked completed, paper-claim-ineligible, and non-generative of any new experiment requirement. It does not make a general claim that Causal4D or physics-informed prediction fails.

## Evidence provenance

- primary run: `33302686759`
- active-probe replay: `33319276977`
- both prediction-seal and metrics hashes are retained
- raw public data are not added to the repository
