### PR TITLE
Add public PokeFlex realized-load prefix source gate

### DIFF
--- a/.github/self-hosted-jobs.json
+++ b/.github/self-hosted-jobs.json
@@ -299,6 +299,21 @@
       "workflow": "optional-integrations.yml"
     },
     {
+      "authorization_model": "main-only",
+      "dataset_access": "verified-public-pokeflex-development-robot-records-only",
+      "job": "evaluate",
+      "purpose": "Development-only PokeFlex realized-load and contact-state source gate",
+      "runner_labels": [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "nvidia-smi",
+        "gpuserver6000"
+      ],
+      "secrets_allowed": false,
+      "workflow": "pokeflex-realized-load-source-gpuserver6000.yml"
+    },
+    {
       "authorization_model": "maintainer-issue-main",
       "dataset_access": "none",
       "job": "validate",

--- a/.github/workflows/pokeflex-realized-load-source-gpuserver6000.yml
+++ b/.github/workflows/pokeflex-realized-load-source-gpuserver6000.yml
@@ -1,0 +1,282 @@
+name: PokeFlex realized-load source gate on gpuserver6000
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/self-hosted-jobs.json"
+      - ".github/workflows/pokeflex-realized-load-source-gpuserver6000.yml"
+      - "configs/causal4d_public/pokeflex_realized_load_source_v1.json"
+      - "docs/causal4d_pokeflex_realized_load.md"
+      - "ops/pokeflex-realized-load-source-gpuserver6000-request.json"
+      - "src/causal4d_public/pokeflex_realized_load.py"
+      - "src/causal4d_public/cli/pokeflex_realized_load_source.py"
+      - "tests/test_pokeflex_realized_load.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pokeflex-realized-load-source-gpuserver6000-v1
+  cancel-in-progress: false
+
+env:
+  PYTHONUNBUFFERED: "1"
+  REQUEST_PATH: ops/pokeflex-realized-load-source-gpuserver6000-request.json
+
+jobs:
+  validate:
+    name: Validate frozen source-gate contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install focused test dependencies
+        run: |
+          python -m pip install -e ".[dev]"
+          python -m pip check
+      - name: Validate request and policy identities
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          from pathlib import Path
+
+          request_path = Path("ops/pokeflex-realized-load-source-gpuserver6000-request.json")
+          request = json.loads(request_path.read_text(encoding="utf-8"))
+          supplied = request.pop("request_id")
+          observed = hashlib.sha256(
+              json.dumps(
+                  request,
+                  sort_keys=True,
+                  separators=(",", ":"),
+                  allow_nan=False,
+              ).encode("utf-8")
+          ).hexdigest()
+          assert supplied == observed
+          assert request == {
+              "artifact_kind": "PublicPokeFlexRealizedLoadSourceRequest",
+              "dataset_root": "/mnt/lexar4tb/pokeflex",
+              "enabled": True,
+              "information_boundary": {
+                  "automatic_follow_on_allowed": False,
+                  "calibration_take_data_allowed": False,
+                  "development_take_ids": [
+                      "3dPrintedBunny_T1",
+                      "3dPrintedBunny_T3",
+                      "3dPrintedBunny_T4",
+                      "3dPrintedBunny_T6",
+                      "3dPrintedBunny_T7",
+                  ],
+                  "public_data_only": True,
+                  "target_take_data_allowed": False,
+              },
+              "policy_path": "configs/causal4d_public/pokeflex_realized_load_source_v1.json",
+              "runner_labels": [
+                  "self-hosted",
+                  "Linux",
+                  "X64",
+                  "nvidia-smi",
+                  "gpuserver6000",
+              ],
+              "schema_version": 1,
+              "source_qa_artifact_path": "milestones/pokeflex-001-source-warp-gate-v1/artifacts/3dPrintedBunny_source_qa_v1.json",
+              "stage": "development-source-gate",
+          }
+          PY
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          from causal4d_public.pokeflex_realized_load import (
+              validate_realized_load_policy,
+              validate_source_qa_binding,
+          )
+
+          policy = json.loads(
+              Path("configs/causal4d_public/pokeflex_realized_load_source_v1.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          validated = validate_realized_load_policy(policy)
+          source_qa = json.loads(
+              Path(
+                  "milestones/pokeflex-001-source-warp-gate-v1/artifacts/3dPrintedBunny_source_qa_v1.json"
+              ).read_text(encoding="utf-8")
+          )
+          validate_source_qa_binding(source_qa, validated["config"])
+          PY
+      - name: Materialize canonical formatting
+        run: |
+          python -m ruff format \
+            src/causal4d_public/pokeflex_realized_load.py \
+            src/causal4d_public/cli/pokeflex_realized_load_source.py \
+            tests/test_pokeflex_realized_load.py
+      - name: Upload canonical formatting candidate
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: pokeflex-realized-load-canonical-format-${{ github.run_id }}
+          path: |
+            src/causal4d_public/pokeflex_realized_load.py
+            src/causal4d_public/cli/pokeflex_realized_load_source.py
+            tests/test_pokeflex_realized_load.py
+          if-no-files-found: error
+          retention-days: 7
+      - name: Require committed canonical formatting
+        run: |
+          git diff --exit-code -- \
+            src/causal4d_public/pokeflex_realized_load.py \
+            src/causal4d_public/cli/pokeflex_realized_load_source.py \
+            tests/test_pokeflex_realized_load.py
+      - name: Run focused tests
+        run: |
+          python -m ruff check \
+            src/causal4d_public/pokeflex_realized_load.py \
+            src/causal4d_public/cli/pokeflex_realized_load_source.py \
+            tests/test_pokeflex_realized_load.py
+          python -m pytest -q \
+            tests/test_pokeflex_realized_load.py \
+            tests/test_self_hosted_workflow_policy.py
+
+  evaluate:
+    name: Evaluate development takes read-only
+    needs: validate
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      needs.validate.result == 'success'
+    runs-on: [self-hosted, Linux, X64, nvidia-smi, gpuserver6000]
+    timeout-minutes: 90
+    steps:
+      - name: Check out exact reviewed revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          clean: true
+      - name: Verify exact clean main revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "${GITHUB_REF}" = "refs/heads/main"
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
+      - name: Select an isolated compatible Python
+        shell: bash
+        run: |
+          set -euo pipefail
+          for candidate in /opt/pyvenv/bin/python python3 python; do
+            if command -v "$candidate" >/dev/null 2>&1 && \
+               "$candidate" - <<'PY' >/dev/null 2>&1
+          import numpy
+          assert tuple(map(int, numpy.__version__.split(".")[:2])) >= (1, 24)
+          PY
+            then
+              resolved="$(command -v "$candidate")"
+              printf 'PYTHON_BIN=%s\n' "$resolved" >> "$GITHUB_ENV"
+              exit 0
+            fi
+          done
+          echo "No Python with NumPy >=1.24 is available" >&2
+          exit 1
+      - name: Validate reviewed execution request
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$PYTHON_BIN" - <<'PY' >> "$GITHUB_ENV"
+          import hashlib
+          import json
+          from pathlib import Path
+
+          path = Path("ops/pokeflex-realized-load-source-gpuserver6000-request.json")
+          request = json.loads(path.read_text(encoding="utf-8"))
+          request_id = request.pop("request_id")
+          observed = hashlib.sha256(
+              json.dumps(
+                  request,
+                  sort_keys=True,
+                  separators=(",", ":"),
+                  allow_nan=False,
+              ).encode("utf-8")
+          ).hexdigest()
+          if request_id != observed:
+              raise SystemExit("request identity mismatch")
+          if request.get("enabled") is not True:
+              raise SystemExit("request is disabled")
+          if request.get("stage") != "development-source-gate":
+              raise SystemExit("unexpected request stage")
+          boundary = request.get("information_boundary", {})
+          if boundary.get("calibration_take_data_allowed") is not False:
+              raise SystemExit("calibration access was enabled")
+          if boundary.get("target_take_data_allowed") is not False:
+              raise SystemExit("target access was enabled")
+          if boundary.get("automatic_follow_on_allowed") is not False:
+              raise SystemExit("automatic follow-on was enabled")
+          print(f"REQUEST_ID={request_id}")
+          print(f"DATASET_ROOT={request['dataset_root']}")
+          print(f"POLICY_PATH={request['policy_path']}")
+          print(f"SOURCE_QA_PATH={request['source_qa_artifact_path']}")
+          PY
+          test "$DATASET_ROOT" = "/mnt/lexar4tb/pokeflex"
+          test -d "$DATASET_ROOT"
+      - name: Run development-only realized-load source gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/pokeflex-realized-load-source-v1"
+          rm -rf "$output"
+          mkdir -p "$output"
+          PYTHONPATH=src "$PYTHON_BIN" -m \
+            causal4d_public.cli.pokeflex_realized_load_source \
+            "$DATASET_ROOT" \
+            "$SOURCE_QA_PATH" \
+            "$output" \
+            --policy "$POLICY_PATH" | tee "$output/console.json"
+          OUTPUT_DIR="$output" "$PYTHON_BIN" - <<'PY'
+          import json
+          import os
+          import platform
+          from pathlib import Path
+
+          import numpy
+
+          output = Path(os.environ["OUTPUT_DIR"])
+          receipt = {
+              "artifact_kind": "PublicPokeFlexRealizedLoadRuntimeReceipt",
+              "schema_version": 1,
+              "github_repository": os.environ["GITHUB_REPOSITORY"],
+              "github_run_id": os.environ["GITHUB_RUN_ID"],
+              "github_run_attempt": os.environ["GITHUB_RUN_ATTEMPT"],
+              "github_sha": os.environ["GITHUB_SHA"],
+              "request_id": os.environ["REQUEST_ID"],
+              "runner_name": os.environ.get("RUNNER_NAME"),
+              "python": platform.python_version(),
+              "numpy": numpy.__version__,
+              "dataset_root": os.environ["DATASET_ROOT"],
+              "dataset_root_read_only_by_contract": True,
+              "new_physical_data_collected": False,
+              "calibration_take_data_read": False,
+              "target_take_data_read": False,
+          }
+          (output / "runtime_receipt.json").write_text(
+              json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+      - name: Upload compact source-gate evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: pokeflex-realized-load-source-v1-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/pokeflex-realized-load-source-v1
+          if-no-files-found: error
+          retention-days: 90

--- a/configs/causal4d_public/pokeflex_realized_load_source_v1.json
+++ b/configs/causal4d_public/pokeflex_realized_load_source_v1.json
@@ -1,0 +1,69 @@
+{
+  "artifact_kind": "PublicPokeFlexRealizedLoadSourcePolicy",
+  "config": {
+    "bootstrap_replicates": 20000,
+    "bootstrap_seed": 20260901,
+    "contact_threshold_n": 3.0,
+    "delay_grid_frames": [
+      -3,
+      -2,
+      -1,
+      0,
+      1,
+      2,
+      3
+    ],
+    "delay_prior_std_frames": 1.5,
+    "expected_development_take_ids": [
+      "3dPrintedBunny_T1",
+      "3dPrintedBunny_T3",
+      "3dPrintedBunny_T4",
+      "3dPrintedBunny_T6",
+      "3dPrintedBunny_T7"
+    ],
+    "expected_object_id": "3dPrintedBunny",
+    "expected_source_qa_result_sha256": "e09d36db4e1ba8a38c70e112c3af9ab95516ee245302f71a853f36cd2dd0e0e7",
+    "forbidden_take_ids": [
+      "3dPrintedBunny_T2",
+      "3dPrintedBunny_T5"
+    ],
+    "force_axis_index": 1,
+    "forecast_horizon_frames": 48,
+    "gain_grid": [
+      0.6,
+      0.7,
+      0.8,
+      0.9,
+      1.0,
+      1.1,
+      1.2,
+      1.3,
+      1.4
+    ],
+    "gain_prior_std": 0.25,
+    "likelihood_scale_floor_n": 0.25,
+    "maximum_mean_rmse_ratio_vs_kinematic_ridge": 1.05,
+    "maximum_worst_take_rmse_ratio_vs_persistence": 1.1,
+    "minimum_mean_rmse_improvement_fraction_vs_dependence_control": 0.02,
+    "minimum_mean_rmse_improvement_fraction_vs_persistence": 0.05,
+    "minimum_take_win_fraction_vs_persistence": 0.6,
+    "onset_consecutive_frames": 3,
+    "path_phase_weight": 0.5,
+    "policy_id": "causal4d-pokeflex-realized-load-source-v1",
+    "predictive_variance_floor_n2": 0.25,
+    "prefix_frame_count": 6,
+    "ridge_penalty": 0.01,
+    "student_t_degrees_of_freedom": 4.0
+  },
+  "config_sha256": "b785dfa1c7e02b265033781bf5b6d5f88e5e234979c56f9ccc8b370f8b630089",
+  "information_boundary": {
+    "automatic_calibration_or_target_dispatch_allowed": false,
+    "calibration_take_data_allowed": false,
+    "development_force_outcomes_allowed_for_source_gate": true,
+    "development_meshes_allowed": false,
+    "development_robot_records_only": true,
+    "new_physical_data_collected": false,
+    "target_take_data_allowed": false
+  },
+  "schema_version": 1
+}

--- a/docs/causal4d_pokeflex_realized_load.md
+++ b/docs/causal4d_pokeflex_realized_load.md
@@ -1,0 +1,136 @@
+# PokeFlex realized-load prefix forecasting
+
+## Purpose
+
+This study tests one public-data-only consequence of the Causal4D causal model:
+a recorded tool trajectory does not by itself identify the load and contact state
+realized by a deformable object.  The estimator observes a short factual wrench
+response, abducts a posterior over a finite source-take/gain/delay intervention
+bank, and forecasts the remaining measured load and contact state.
+
+No robot, new acquisition, or simulated target outcome is used.  The study reads
+only PokeFlex records already released by the dataset authors.
+
+## Frozen source stage
+
+The first stage is restricted to the five metadata-selected development takes of
+`3dPrintedBunny`:
+
+```text
+3dPrintedBunny_T1
+3dPrintedBunny_T3
+3dPrintedBunny_T4
+3dPrintedBunny_T6
+3dPrintedBunny_T7
+```
+
+The prior source QA identity is
+`e09d36db4e1ba8a38c70e112c3af9ab95516ee245302f71a853f36cd2dd0e0e7`.
+It established aligned robot/wrench records and pose--surface contact support.
+The calibration take `T5` and target take `T2` remain unopened.  The source
+workflow never names or parses their payloads; any fallback layout discovery
+examines path names only.
+
+Each development take is evaluated once as a complete held-out unit.  The other
+four takes form the source bank.  Frames, force coordinates, posterior
+candidates, and time samples are nested observations and are not treated as
+independent replicates.
+
+## Factual prefix and future query
+
+Contact onset is the first three consecutive frames whose released force-axis
+value exceeds 3 N.  The factual response consists of the first six frames from
+that onset.  The registered target is the following 48-frame force-axis and
+binary contact trajectory.
+
+The complete released tool trajectory over the registered window is supplied as
+conditioning evidence.  It is a measured kinematic record, not an independently
+logged command and not counterfactual ground truth.
+
+The forecast constructor receives only:
+
+- the six observed force values;
+- the target tool-trajectory phase and speed; and
+- the four complete source takes.
+
+Its target-conditioning type contains no future-force field.  Predictions and
+content hashes are written for all five folds before suffix scoring begins.
+
+## Estimator
+
+Source load profiles are expressed on a phase coordinate combining normalized
+time and cumulative tool-path length.  For each source take, gain in
+`[0.60, 1.40]` and response delay in `[-3, 3]` frames define one realized-load
+hypothesis.  A Student-t prefix likelihood with source-derived scale produces a
+posterior over the finite bank.  The posterior mean and total mixture variance
+are the principal forecast.
+
+The comparison set is:
+
+1. last-prefix-value persistence;
+2. linear prefix extrapolation;
+3. source-mean profile with prefix offset;
+4. a ridge predictor conditioned on the released tool kinematics;
+5. the posterior MAP intervention;
+6. the posterior mixture; and
+7. a dependence-destroyed control.
+
+The dependence control cyclically reassigns source prefixes to source suffixes.
+It preserves the empirical prefix and suffix profile marginals while removing
+their matched relation.  Its posterior weights are still computed from the
+original source prefixes.  A gain over this arm therefore cannot be attributed
+only to the marginal set of possible prefixes or futures.
+
+## Metrics and source gate
+
+For each complete held-out take, the study reports force RMSE and MAE, Gaussian
+NLL, nominal 90% coverage and width, peak/mean force error, and contact Brier and
+log scores.
+
+The backend passes the development source gate only when every frozen criterion
+holds:
+
+- all five complete development takes contribute;
+- every fold has a prediction seal before scoring;
+- mean force RMSE is at least 5% below persistence;
+- the posterior wins on at least 60% of takes;
+- mean force RMSE is at least 2% below the dependence-destroyed control;
+- no take is worse than 1.10 times persistence RMSE; and
+- mean RMSE is no more than 1.05 times the kinematics-conditioned ridge arm.
+
+A negative or bounded result is terminal for this method version.  A positive
+source gate still does not open `T5` or `T2`: calibration and target access would
+require a separate reviewed and content-addressed protocol.
+
+## Reproduction
+
+The source gate requires a manual dispatch from `main` and consumes the exact
+reviewed request file:
+
+```text
+ops/pokeflex-realized-load-source-gpuserver6000-request.json
+```
+
+The self-hosted workflow runs read-only on `gpuserver6000` against
+`/mnt/lexar4tb/pokeflex` and uploads only compact predictions, seals, metrics,
+and provenance:
+
+```text
+.github/workflows/pokeflex-realized-load-source-gpuserver6000.yml
+```
+
+The implementation and synthetic boundary tests are:
+
+```text
+src/causal4d_public/pokeflex_realized_load.py
+src/causal4d_public/cli/pokeflex_realized_load_source.py
+tests/test_pokeflex_realized_load.py
+```
+
+## Claim boundary
+
+A positive development result would justify testing this exact backend under a
+separate public calibration/target protocol.  It would not itself establish a
+held-out target effect, persistent material identity, mesh forecasting,
+population-level calibration, commanded-versus-measured actuation recovery,
+individual counterfactual ground truth, robot control, or safety.

--- a/ops/pokeflex-realized-load-source-gpuserver6000-request.json
+++ b/ops/pokeflex-realized-load-source-gpuserver6000-request.json
@@ -1,0 +1,30 @@
+{
+  "artifact_kind": "PublicPokeFlexRealizedLoadSourceRequest",
+  "dataset_root": "/mnt/lexar4tb/pokeflex",
+  "enabled": true,
+  "information_boundary": {
+    "automatic_follow_on_allowed": false,
+    "calibration_take_data_allowed": false,
+    "development_take_ids": [
+      "3dPrintedBunny_T1",
+      "3dPrintedBunny_T3",
+      "3dPrintedBunny_T4",
+      "3dPrintedBunny_T6",
+      "3dPrintedBunny_T7"
+    ],
+    "public_data_only": true,
+    "target_take_data_allowed": false
+  },
+  "policy_path": "configs/causal4d_public/pokeflex_realized_load_source_v1.json",
+  "request_id": "df02f0e81c3111177b43b9e346d4aafa107a658a66db1bc16b6acf573ec47b74",
+  "runner_labels": [
+    "self-hosted",
+    "Linux",
+    "X64",
+    "nvidia-smi",
+    "gpuserver6000"
+  ],
+  "schema_version": 1,
+  "source_qa_artifact_path": "milestones/pokeflex-001-source-warp-gate-v1/artifacts/3dPrintedBunny_source_qa_v1.json",
+  "stage": "development-source-gate"
+}

--- a/src/causal4d_public/_pokeflex_realized_load_common.py
+++ b/src/causal4d_public/_pokeflex_realized_load_common.py
@@ -1,0 +1,249 @@
+"""Shared contracts for the PokeFlex realized-load source study."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+FloatArray = NDArray[np.float64]
+BoolArray = NDArray[np.bool_]
+
+POKEFLEX_REALIZED_LOAD_POLICY_SCHEMA_VERSION = 1
+POKEFLEX_REALIZED_LOAD_ARTIFACT_SCHEMA_VERSION = 1
+POKEFLEX_REALIZED_LOAD_POLICY_ID = "causal4d-pokeflex-realized-load-source-v1"
+CANONICAL_POKEFLEX_REALIZED_LOAD_POLICY_SHA256 = (
+    "b785dfa1c7e02b265033781bf5b6d5f88e5e234979c56f9ccc8b370f8b630089"
+)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _array_digest(arrays: Mapping[str, FloatArray]) -> str:
+    digest = hashlib.sha256()
+    for name in sorted(arrays):
+        value = np.ascontiguousarray(arrays[name], dtype=np.float64)
+        digest.update(name.encode("utf-8"))
+        digest.update(str(value.shape).encode("ascii"))
+        digest.update(value.tobytes())
+    return digest.hexdigest()
+
+
+@dataclass(frozen=True)
+class PokeFlexRealizedLoadSourceConfig:
+    """Frozen development-only source-gate configuration."""
+
+    policy_id: str = POKEFLEX_REALIZED_LOAD_POLICY_ID
+    expected_source_qa_result_sha256: str = (
+        "e09d36db4e1ba8a38c70e112c3af9ab95516ee245302f71a853f36cd2dd0e0e7"
+    )
+    expected_object_id: str = "3dPrintedBunny"
+    expected_development_take_ids: tuple[str, ...] = (
+        "3dPrintedBunny_T1",
+        "3dPrintedBunny_T3",
+        "3dPrintedBunny_T4",
+        "3dPrintedBunny_T6",
+        "3dPrintedBunny_T7",
+    )
+    forbidden_take_ids: tuple[str, ...] = (
+        "3dPrintedBunny_T2",
+        "3dPrintedBunny_T5",
+    )
+    force_axis_index: int = 1
+    contact_threshold_n: float = 3.0
+    onset_consecutive_frames: int = 3
+    prefix_frame_count: int = 6
+    forecast_horizon_frames: int = 48
+    path_phase_weight: float = 0.5
+    gain_grid: tuple[float, ...] = (
+        0.60,
+        0.70,
+        0.80,
+        0.90,
+        1.00,
+        1.10,
+        1.20,
+        1.30,
+        1.40,
+    )
+    delay_grid_frames: tuple[int, ...] = (-3, -2, -1, 0, 1, 2, 3)
+    gain_prior_std: float = 0.25
+    delay_prior_std_frames: float = 1.5
+    student_t_degrees_of_freedom: float = 4.0
+    likelihood_scale_floor_n: float = 0.25
+    predictive_variance_floor_n2: float = 0.25
+    ridge_penalty: float = 0.01
+    minimum_mean_rmse_improvement_fraction_vs_persistence: float = 0.05
+    minimum_take_win_fraction_vs_persistence: float = 0.60
+    minimum_mean_rmse_improvement_fraction_vs_dependence_control: float = 0.02
+    maximum_worst_take_rmse_ratio_vs_persistence: float = 1.10
+    maximum_mean_rmse_ratio_vs_kinematic_ridge: float = 1.05
+    bootstrap_replicates: int = 20000
+    bootstrap_seed: int = 20260901
+
+    def __post_init__(self) -> None:
+        _require(self.policy_id == POKEFLEX_REALIZED_LOAD_POLICY_ID, "policy id changed")
+        _require(bool(self.expected_source_qa_result_sha256), "source QA identity is empty")
+        _require(bool(self.expected_object_id), "object id is empty")
+        _require(len(self.expected_development_take_ids) == 5, "expected five development takes")
+        _require(
+            len(set(self.expected_development_take_ids))
+            == len(self.expected_development_take_ids),
+            "development take ids repeat",
+        )
+        _require(
+            set(self.expected_development_take_ids).isdisjoint(self.forbidden_take_ids),
+            "development and forbidden takes overlap",
+        )
+        _require(self.force_axis_index in {0, 1, 2}, "force axis is invalid")
+        _require(self.contact_threshold_n > 0.0, "contact threshold must be positive")
+        _require(self.onset_consecutive_frames >= 2, "onset persistence is too short")
+        _require(self.prefix_frame_count >= 3, "prefix is too short")
+        _require(self.forecast_horizon_frames >= 6, "forecast horizon is too short")
+        _require(0.0 <= self.path_phase_weight <= 1.0, "phase weight is invalid")
+        gains = np.asarray(self.gain_grid, dtype=np.float64)
+        delays = np.asarray(self.delay_grid_frames, dtype=np.int64)
+        _require(gains.ndim == 1 and gains.size >= 3, "gain grid is too small")
+        _require(np.all(np.isfinite(gains)) and np.all(gains > 0.0), "gain grid is invalid")
+        _require(delays.ndim == 1 and delays.size >= 1, "delay grid is empty")
+        _require(len(set(map(int, delays))) == len(delays), "delay grid repeats")
+        _require(self.gain_prior_std > 0.0, "gain prior scale is invalid")
+        _require(self.delay_prior_std_frames > 0.0, "delay prior scale is invalid")
+        _require(self.student_t_degrees_of_freedom > 2.0, "Student-t df is invalid")
+        _require(self.likelihood_scale_floor_n > 0.0, "likelihood floor is invalid")
+        _require(self.predictive_variance_floor_n2 > 0.0, "variance floor is invalid")
+        _require(self.ridge_penalty > 0.0, "ridge penalty is invalid")
+        for value in (
+            self.minimum_mean_rmse_improvement_fraction_vs_persistence,
+            self.minimum_take_win_fraction_vs_persistence,
+            self.minimum_mean_rmse_improvement_fraction_vs_dependence_control,
+        ):
+            _require(0.0 <= value <= 1.0, "source gate fraction is invalid")
+        _require(
+            self.maximum_worst_take_rmse_ratio_vs_persistence >= 1.0,
+            "worst-take ratio must permit equality",
+        )
+        _require(
+            self.maximum_mean_rmse_ratio_vs_kinematic_ridge >= 1.0,
+            "ridge ratio must permit equality",
+        )
+        _require(self.bootstrap_replicates >= 1000, "too few bootstrap replicates")
+        _require(self.bootstrap_seed >= 0, "bootstrap seed is invalid")
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> PokeFlexRealizedLoadSourceConfig:
+        unknown = set(value) - set(cls.__dataclass_fields__)
+        _require(not unknown, f"unknown realized-load fields: {sorted(unknown)}")
+        payload = dict(value)
+        for name in (
+            "expected_development_take_ids",
+            "forbidden_take_ids",
+            "gain_grid",
+            "delay_grid_frames",
+        ):
+            if name in payload:
+                payload[name] = tuple(payload[name])
+        return cls(**payload)
+
+
+def realized_load_policy_sha256(payload: Mapping[str, Any]) -> str:
+    canonical = dict(payload)
+    canonical.pop("config_sha256", None)
+    return hashlib.sha256(_canonical_bytes(canonical)).hexdigest()
+
+
+def validate_realized_load_policy(payload: Mapping[str, Any]) -> dict[str, Any]:
+    _require(
+        payload.get("schema_version") == POKEFLEX_REALIZED_LOAD_POLICY_SCHEMA_VERSION,
+        "unsupported realized-load policy schema",
+    )
+    _require(
+        payload.get("artifact_kind") == "PublicPokeFlexRealizedLoadSourcePolicy",
+        "unexpected realized-load policy kind",
+    )
+    observed = realized_load_policy_sha256(payload)
+    _require(payload.get("config_sha256") == observed, "realized-load policy checksum mismatch")
+    if CANONICAL_POKEFLEX_REALIZED_LOAD_POLICY_SHA256:
+        _require(
+            observed == CANONICAL_POKEFLEX_REALIZED_LOAD_POLICY_SHA256,
+            "realized-load policy differs from the canonical lock",
+        )
+    boundary = payload.get("information_boundary")
+    _require(
+        boundary
+        == {
+            "development_robot_records_only": True,
+            "development_force_outcomes_allowed_for_source_gate": True,
+            "development_meshes_allowed": False,
+            "calibration_take_data_allowed": False,
+            "target_take_data_allowed": False,
+            "automatic_calibration_or_target_dispatch_allowed": False,
+            "new_physical_data_collected": False,
+        },
+        "realized-load information boundary changed",
+    )
+    config = PokeFlexRealizedLoadSourceConfig.from_mapping(payload["config"])
+    return {"passed": True, "config_sha256": observed, "config": config}
+
+
+def load_realized_load_policy(path: str | Path) -> PokeFlexRealizedLoadSourceConfig:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    return validate_realized_load_policy(payload)["config"]
+
+
+def validate_source_qa_binding(
+    payload: Mapping[str, Any],
+    config: PokeFlexRealizedLoadSourceConfig,
+) -> dict[str, Any]:
+    _require(payload.get("artifact_kind") == "PublicPokeFlexSourceQa", "unexpected source QA kind")
+    _require(payload.get("schema_version") == 1, "unsupported source QA schema")
+    _require(
+        payload.get("result_sha256") == config.expected_source_qa_result_sha256,
+        "source QA identity changed",
+    )
+    _require(payload.get("source_qa_passed") is True, "source QA did not pass")
+    _require(payload.get("object_id") == config.expected_object_id, "source QA object changed")
+    boundary = payload.get("information_boundary", {})
+    opened = tuple(sorted(map(str, boundary.get("opened_take_ids", ()))))
+    expected = tuple(sorted(config.expected_development_take_ids))
+    _require(opened == expected, "source QA development roster changed")
+    _require(boundary.get("calibration_take_data_read") is False, "source QA opened calibration")
+    _require(boundary.get("target_take_data_read") is False, "source QA opened target")
+    unopened = set(map(str, boundary.get("unopened_take_ids", ())))
+    _require(set(config.forbidden_take_ids).issubset(unopened), "source QA forbidden roster changed")
+    gates = payload.get("capability_gates", {})
+    _require(gates.get("pose_wrench_contact_candidate_ready") is True, "pose/wrench gate failed")
+    return {
+        "passed": True,
+        "result_sha256": payload["result_sha256"],
+        "development_take_ids": list(expected),
+    }

--- a/src/causal4d_public/_pokeflex_realized_load_common.py
+++ b/src/causal4d_public/_pokeflex_realized_load_common.py
@@ -108,10 +108,17 @@ class PokeFlexRealizedLoadSourceConfig:
     bootstrap_seed: int = 20260901
 
     def __post_init__(self) -> None:
-        _require(self.policy_id == POKEFLEX_REALIZED_LOAD_POLICY_ID, "policy id changed")
-        _require(bool(self.expected_source_qa_result_sha256), "source QA identity is empty")
+        _require(
+            self.policy_id == POKEFLEX_REALIZED_LOAD_POLICY_ID, "policy id changed"
+        )
+        _require(
+            bool(self.expected_source_qa_result_sha256), "source QA identity is empty"
+        )
         _require(bool(self.expected_object_id), "object id is empty")
-        _require(len(self.expected_development_take_ids) == 5, "expected five development takes")
+        _require(
+            len(self.expected_development_take_ids) == 5,
+            "expected five development takes",
+        )
         _require(
             len(set(self.expected_development_take_ids))
             == len(self.expected_development_take_ids),
@@ -130,7 +137,9 @@ class PokeFlexRealizedLoadSourceConfig:
         gains = np.asarray(self.gain_grid, dtype=np.float64)
         delays = np.asarray(self.delay_grid_frames, dtype=np.int64)
         _require(gains.ndim == 1 and gains.size >= 3, "gain grid is too small")
-        _require(np.all(np.isfinite(gains)) and np.all(gains > 0.0), "gain grid is invalid")
+        _require(
+            np.all(np.isfinite(gains)) and np.all(gains > 0.0), "gain grid is invalid"
+        )
         _require(delays.ndim == 1 and delays.size >= 1, "delay grid is empty")
         _require(len(set(map(int, delays))) == len(delays), "delay grid repeats")
         _require(self.gain_prior_std > 0.0, "gain prior scale is invalid")
@@ -191,7 +200,10 @@ def validate_realized_load_policy(payload: Mapping[str, Any]) -> dict[str, Any]:
         "unexpected realized-load policy kind",
     )
     observed = realized_load_policy_sha256(payload)
-    _require(payload.get("config_sha256") == observed, "realized-load policy checksum mismatch")
+    _require(
+        payload.get("config_sha256") == observed,
+        "realized-load policy checksum mismatch",
+    )
     if CANONICAL_POKEFLEX_REALIZED_LOAD_POLICY_SHA256:
         _require(
             observed == CANONICAL_POKEFLEX_REALIZED_LOAD_POLICY_SHA256,
@@ -224,24 +236,39 @@ def validate_source_qa_binding(
     payload: Mapping[str, Any],
     config: PokeFlexRealizedLoadSourceConfig,
 ) -> dict[str, Any]:
-    _require(payload.get("artifact_kind") == "PublicPokeFlexSourceQa", "unexpected source QA kind")
+    _require(
+        payload.get("artifact_kind") == "PublicPokeFlexSourceQa",
+        "unexpected source QA kind",
+    )
     _require(payload.get("schema_version") == 1, "unsupported source QA schema")
     _require(
         payload.get("result_sha256") == config.expected_source_qa_result_sha256,
         "source QA identity changed",
     )
     _require(payload.get("source_qa_passed") is True, "source QA did not pass")
-    _require(payload.get("object_id") == config.expected_object_id, "source QA object changed")
+    _require(
+        payload.get("object_id") == config.expected_object_id,
+        "source QA object changed",
+    )
     boundary = payload.get("information_boundary", {})
     opened = tuple(sorted(map(str, boundary.get("opened_take_ids", ()))))
     expected = tuple(sorted(config.expected_development_take_ids))
     _require(opened == expected, "source QA development roster changed")
-    _require(boundary.get("calibration_take_data_read") is False, "source QA opened calibration")
+    _require(
+        boundary.get("calibration_take_data_read") is False,
+        "source QA opened calibration",
+    )
     _require(boundary.get("target_take_data_read") is False, "source QA opened target")
     unopened = set(map(str, boundary.get("unopened_take_ids", ())))
-    _require(set(config.forbidden_take_ids).issubset(unopened), "source QA forbidden roster changed")
+    _require(
+        set(config.forbidden_take_ids).issubset(unopened),
+        "source QA forbidden roster changed",
+    )
     gates = payload.get("capability_gates", {})
-    _require(gates.get("pose_wrench_contact_candidate_ready") is True, "pose/wrench gate failed")
+    _require(
+        gates.get("pose_wrench_contact_candidate_ready") is True,
+        "pose/wrench gate failed",
+    )
     return {
         "passed": True,
         "result_sha256": payload["result_sha256"],

--- a/src/causal4d_public/_pokeflex_realized_load_model.py
+++ b/src/causal4d_public/_pokeflex_realized_load_model.py
@@ -93,7 +93,10 @@ def _discover_take_root(dataset_root: Path, take_id: str) -> Path:
         )
         _require(not candidate.is_symlink(), f"take root is a symlink: {take_id}")
         unique[str(resolved)] = resolved
-    _require(len(unique) == 1, f"expected exactly one root for {take_id}, found {len(unique)}")
+    _require(
+        len(unique) == 1,
+        f"expected exactly one root for {take_id}, found {len(unique)}",
+    )
     return next(iter(unique.values()))
 
 
@@ -104,7 +107,9 @@ def _first_persistent_true(values: BoolArray, count: int) -> int:
     raise ValueError("no persistent contact onset found")
 
 
-def _phase_and_speed(positions: FloatArray, path_phase_weight: float) -> tuple[FloatArray, FloatArray]:
+def _phase_and_speed(
+    positions: FloatArray, path_phase_weight: float
+) -> tuple[FloatArray, FloatArray]:
     steps = np.linalg.norm(np.diff(positions, axis=0), axis=1)
     speed = np.concatenate(([0.0], steps))
     cumulative = np.concatenate(([0.0], np.cumsum(steps)))
@@ -207,7 +212,9 @@ def _robust_scale(profiles: FloatArray, floor: float) -> FloatArray:
     return np.maximum(scale, floor).astype(np.float64)
 
 
-def _student_log_likelihood(residual: FloatArray, scale: FloatArray, degrees: float) -> float:
+def _student_log_likelihood(
+    residual: FloatArray, scale: FloatArray, degrees: float
+) -> float:
     standardized = residual / scale
     terms = -0.5 * (degrees + 1.0) * np.log1p((standardized**2) / degrees)
     terms -= np.log(scale)
@@ -219,7 +226,9 @@ def _normal_cdf(values: FloatArray) -> FloatArray:
     return 0.5 * (1.0 + erf(values / math.sqrt(2.0)))
 
 
-def _contact_probability(mean: FloatArray, variance: FloatArray, threshold: float) -> FloatArray:
+def _contact_probability(
+    mean: FloatArray, variance: FloatArray, threshold: float
+) -> FloatArray:
     standard_deviation = np.sqrt(np.maximum(variance, 1e-12))
     probability = 1.0 - _normal_cdf((threshold - mean) / standard_deviation)
     return np.clip(probability, 1e-6, 1.0 - 1e-6)
@@ -230,7 +239,9 @@ def _kinematic_features(
     speed_m_per_frame: FloatArray,
 ) -> FloatArray:
     length = len(phase)
-    _require(speed_m_per_frame.shape == (length,), "kinematic speed has the wrong shape")
+    _require(
+        speed_m_per_frame.shape == (length,), "kinematic speed has the wrong shape"
+    )
     time = np.linspace(0.0, 1.0, length)
     speed_scale = max(float(np.median(speed_m_per_frame)), 1e-8)
     speed = speed_m_per_frame / speed_scale
@@ -265,10 +276,13 @@ def _ridge_prediction(
     penalty = config.ridge_penalty * np.eye(design.shape[1])
     penalty[0, 0] = 0.0
     beta = np.linalg.solve(design.T @ design + penalty, design.T @ response)
-    prediction = _kinematic_features(
-        target.window_phase,
-        target.window_speed_m_per_frame,
-    ) @ beta
+    prediction = (
+        _kinematic_features(
+            target.window_phase,
+            target.window_speed_m_per_frame,
+        )
+        @ beta
+    )
     prefix = config.prefix_frame_count
     prediction += float(np.median(target_prefix - prediction[:prefix]))
     return prediction.astype(np.float64)
@@ -290,7 +304,9 @@ def _posterior_from_profiles(
     config: PokeFlexRealizedLoadSourceConfig,
 ) -> tuple[FloatArray, FloatArray, FloatArray, dict[str, Any]]:
     prefix = config.prefix_frame_count
-    scale = _robust_scale(evidence_profiles[:, :prefix], config.likelihood_scale_floor_n)
+    scale = _robust_scale(
+        evidence_profiles[:, :prefix], config.likelihood_scale_floor_n
+    )
     predictions: list[FloatArray] = []
     probabilities: list[FloatArray] = []
     metadata: list[dict[str, Any]] = []
@@ -300,7 +316,9 @@ def _posterior_from_profiles(
             evidence = _shift(evidence_profiles[template_index], int(delay))
             outcome = _shift(outcome_profiles[template_index], int(delay))
             for gain in config.gain_grid:
-                offset = float(np.median(target_prefix - float(gain) * evidence[:prefix]))
+                offset = float(
+                    np.median(target_prefix - float(gain) * evidence[:prefix])
+                )
                 evidence_prediction = float(gain) * evidence + offset
                 outcome_prediction = float(gain) * outcome + offset
                 residual = target_prefix - evidence_prediction[:prefix]
@@ -383,18 +401,22 @@ def build_forecast_bundle(
     _require(target.take_id not in source_ids, "target appears in source roster")
     _require(len(set(source_ids)) == len(source_ids), "source take ids repeat")
 
-    profiles = np.stack([_warp_profile(source, target.window_phase) for source in sources])
+    profiles = np.stack(
+        [_warp_profile(source, target.window_phase) for source in sources]
+    )
     template_variance = np.var(profiles, axis=0, ddof=1)
     template_variance = np.maximum(
         template_variance,
         config.predictive_variance_floor_n2,
     )
-    proposed_mean, proposed_variance, proposed_contact, posterior = _posterior_from_profiles(
-        target_prefix,
-        profiles,
-        profiles,
-        template_variance,
-        config,
+    proposed_mean, proposed_variance, proposed_contact, posterior = (
+        _posterior_from_profiles(
+            target_prefix,
+            profiles,
+            profiles,
+            template_variance,
+            config,
+        )
     )
     permutation = np.roll(np.arange(len(profiles)), -1)
     destroyed_profiles = profiles[permutation]

--- a/src/causal4d_public/_pokeflex_realized_load_model.py
+++ b/src/causal4d_public/_pokeflex_realized_load_model.py
@@ -1,0 +1,477 @@
+"""Forecast construction for PokeFlex realized-load prefix abduction."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+from numpy.typing import NDArray
+
+from causal4d_public._pokeflex_realized_load_common import (
+    BoolArray,
+    FloatArray,
+    PokeFlexRealizedLoadSourceConfig,
+    _require,
+    _sha256_file,
+)
+
+
+@dataclass(frozen=True)
+class RealizedLoadTake:
+    take_id: str
+    root: Path
+    robot_sha256: str
+    frame_ids: NDArray[np.int64]
+    force_axis_n: FloatArray
+    tool_positions_m: FloatArray
+    onset_index: int
+    window_force_n: FloatArray
+    window_tool_positions_m: FloatArray
+    window_phase: FloatArray
+    window_speed_m_per_frame: FloatArray
+
+
+@dataclass(frozen=True)
+class TargetKinematicConditioning:
+    """Target-side information exposed to the forecast constructor."""
+
+    take_id: str
+    window_phase: FloatArray
+    window_speed_m_per_frame: FloatArray
+
+
+@dataclass(frozen=True)
+class ForecastBundle:
+    means: Mapping[str, FloatArray]
+    variances: Mapping[str, FloatArray]
+    contact_probabilities: Mapping[str, FloatArray]
+    metadata: Mapping[str, Any]
+
+
+def _valid_transform(value: Any) -> FloatArray:
+    matrix = np.asarray(value, dtype=np.float64)
+    _require(matrix.shape == (4, 4), "tool transform must be 4 x 4")
+    _require(np.all(np.isfinite(matrix)), "tool transform is non-finite")
+    _require(
+        np.allclose(matrix[3], [0.0, 0.0, 0.0, 1.0], atol=1e-6, rtol=0.0),
+        "tool transform has an invalid homogeneous row",
+    )
+    rotation = matrix[:3, :3]
+    _require(
+        np.allclose(rotation.T @ rotation, np.eye(3), atol=1e-4, rtol=1e-4)
+        and np.linalg.det(rotation) > 0.0,
+        "tool transform has an invalid rotation",
+    )
+    return matrix
+
+
+def _discover_take_root(dataset_root: Path, take_id: str) -> Path:
+    direct = dataset_root / take_id
+    candidates: list[Path] = []
+    if (direct / "robot_data.json").is_file():
+        candidates.append(direct)
+    object_direct = dataset_root / "3dPrintedBunny" / take_id
+    if (object_direct / "robot_data.json").is_file():
+        candidates.append(object_direct)
+    if not candidates:
+        candidates = [
+            path.parent
+            for path in dataset_root.rglob("robot_data.json")
+            if path.parent.name == take_id
+        ]
+    unique: dict[str, Path] = {}
+    root_resolved = dataset_root.resolve()
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        _require(
+            resolved == root_resolved or root_resolved in resolved.parents,
+            f"take escapes dataset root: {take_id}",
+        )
+        _require(not candidate.is_symlink(), f"take root is a symlink: {take_id}")
+        unique[str(resolved)] = resolved
+    _require(len(unique) == 1, f"expected exactly one root for {take_id}, found {len(unique)}")
+    return next(iter(unique.values()))
+
+
+def _first_persistent_true(values: BoolArray, count: int) -> int:
+    for start in range(0, len(values) - count + 1):
+        if bool(np.all(values[start : start + count])):
+            return start
+    raise ValueError("no persistent contact onset found")
+
+
+def _phase_and_speed(positions: FloatArray, path_phase_weight: float) -> tuple[FloatArray, FloatArray]:
+    steps = np.linalg.norm(np.diff(positions, axis=0), axis=1)
+    speed = np.concatenate(([0.0], steps))
+    cumulative = np.concatenate(([0.0], np.cumsum(steps)))
+    if cumulative[-1] <= np.finfo(np.float64).eps:
+        path_phase = np.linspace(0.0, 1.0, len(positions))
+    else:
+        path_phase = cumulative / cumulative[-1]
+    time_phase = np.linspace(0.0, 1.0, len(positions))
+    phase = path_phase_weight * path_phase + (1.0 - path_phase_weight) * time_phase
+    return phase.astype(np.float64), speed.astype(np.float64)
+
+
+def load_realized_load_take(
+    dataset_root: str | Path,
+    take_id: str,
+    config: PokeFlexRealizedLoadSourceConfig,
+) -> RealizedLoadTake:
+    root = _discover_take_root(Path(dataset_root).resolve(), take_id)
+    robot_path = root / "robot_data.json"
+    payload = json.loads(robot_path.read_text(encoding="utf-8"))
+    _require(isinstance(payload, list) and payload, "robot log is empty")
+    records: dict[int, Mapping[str, Any]] = {}
+    for item in payload:
+        _require(isinstance(item, Mapping), "robot record is not an object")
+        frame_raw = item.get("frame")
+        _require(
+            isinstance(frame_raw, (int, str)) and not isinstance(frame_raw, bool),
+            "robot frame id is invalid",
+        )
+        frame = int(frame_raw)
+        _require(frame >= 0 and frame not in records, "robot frame ids repeat")
+        records[frame] = item
+    frame_ids = np.asarray(sorted(records), dtype=np.int64)
+    forces = []
+    positions = []
+    for frame in frame_ids:
+        item = records[int(frame)]
+        force = np.asarray(item.get("forces"), dtype=np.float64).reshape(-1)
+        _require(
+            len(force) > config.force_axis_index and np.all(np.isfinite(force)),
+            "force vector is invalid",
+        )
+        forces.append(float(force[config.force_axis_index]))
+        transform = _valid_transform(item.get("T_WT"))
+        positions.append(transform[:3, 3].copy())
+    force_axis = np.asarray(forces, dtype=np.float64)
+    tool_positions = np.asarray(positions, dtype=np.float64)
+    active = force_axis > config.contact_threshold_n
+    onset = _first_persistent_true(active, config.onset_consecutive_frames)
+    window_length = config.prefix_frame_count + config.forecast_horizon_frames
+    stop = onset + window_length
+    _require(stop <= len(force_axis), f"{take_id} has insufficient post-onset horizon")
+    window_force = force_axis[onset:stop].copy()
+    window_tool = tool_positions[onset:stop].copy()
+    phase, speed = _phase_and_speed(window_tool, config.path_phase_weight)
+    return RealizedLoadTake(
+        take_id=take_id,
+        root=root,
+        robot_sha256=_sha256_file(robot_path),
+        frame_ids=frame_ids,
+        force_axis_n=force_axis,
+        tool_positions_m=tool_positions,
+        onset_index=onset,
+        window_force_n=window_force,
+        window_tool_positions_m=window_tool,
+        window_phase=phase,
+        window_speed_m_per_frame=speed,
+    )
+
+
+def _warp_profile(source: RealizedLoadTake, target_phase: FloatArray) -> FloatArray:
+    phase = source.window_phase
+    force = source.window_force_n
+    keep = np.concatenate(([True], np.diff(phase) > 1e-12))
+    phase_unique = phase[keep]
+    force_unique = force[keep]
+    if len(phase_unique) < 2:
+        phase_unique = np.linspace(0.0, 1.0, len(force))
+        force_unique = force
+    return np.interp(target_phase, phase_unique, force_unique).astype(np.float64)
+
+
+def _shift(values: FloatArray, delay_frames: int) -> FloatArray:
+    indices = np.arange(len(values), dtype=np.int64) - int(delay_frames)
+    indices = np.clip(indices, 0, len(values) - 1)
+    return values[indices]
+
+
+def _softmax(log_weights: FloatArray) -> FloatArray:
+    shifted = log_weights - np.max(log_weights)
+    weights = np.exp(shifted)
+    total = float(np.sum(weights))
+    _require(np.isfinite(total) and total > 0.0, "posterior weights are invalid")
+    return weights / total
+
+
+def _robust_scale(profiles: FloatArray, floor: float) -> FloatArray:
+    center = np.median(profiles, axis=0)
+    scale = 1.4826 * np.median(np.abs(profiles - center[None, :]), axis=0)
+    return np.maximum(scale, floor).astype(np.float64)
+
+
+def _student_log_likelihood(residual: FloatArray, scale: FloatArray, degrees: float) -> float:
+    standardized = residual / scale
+    terms = -0.5 * (degrees + 1.0) * np.log1p((standardized**2) / degrees)
+    terms -= np.log(scale)
+    return float(np.sum(terms))
+
+
+def _normal_cdf(values: FloatArray) -> FloatArray:
+    erf = np.vectorize(math.erf, otypes=[np.float64])
+    return 0.5 * (1.0 + erf(values / math.sqrt(2.0)))
+
+
+def _contact_probability(mean: FloatArray, variance: FloatArray, threshold: float) -> FloatArray:
+    standard_deviation = np.sqrt(np.maximum(variance, 1e-12))
+    probability = 1.0 - _normal_cdf((threshold - mean) / standard_deviation)
+    return np.clip(probability, 1e-6, 1.0 - 1e-6)
+
+
+def _kinematic_features(
+    phase: FloatArray,
+    speed_m_per_frame: FloatArray,
+) -> FloatArray:
+    length = len(phase)
+    _require(speed_m_per_frame.shape == (length,), "kinematic speed has the wrong shape")
+    time = np.linspace(0.0, 1.0, length)
+    speed_scale = max(float(np.median(speed_m_per_frame)), 1e-8)
+    speed = speed_m_per_frame / speed_scale
+    return np.column_stack(
+        (
+            np.ones(length),
+            time,
+            time**2,
+            phase,
+            phase**2,
+            speed,
+        )
+    ).astype(np.float64)
+
+
+def _ridge_prediction(
+    target: TargetKinematicConditioning,
+    sources: Sequence[RealizedLoadTake],
+    target_prefix: FloatArray,
+    config: PokeFlexRealizedLoadSourceConfig,
+) -> FloatArray:
+    matrices = [
+        _kinematic_features(
+            source.window_phase,
+            source.window_speed_m_per_frame,
+        )
+        for source in sources
+    ]
+    observations = [source.window_force_n for source in sources]
+    design = np.concatenate(matrices, axis=0)
+    response = np.concatenate(observations, axis=0)
+    penalty = config.ridge_penalty * np.eye(design.shape[1])
+    penalty[0, 0] = 0.0
+    beta = np.linalg.solve(design.T @ design + penalty, design.T @ response)
+    prediction = _kinematic_features(
+        target.window_phase,
+        target.window_speed_m_per_frame,
+    ) @ beta
+    prefix = config.prefix_frame_count
+    prediction += float(np.median(target_prefix - prediction[:prefix]))
+    return prediction.astype(np.float64)
+
+
+def _linear_prediction(target_prefix: FloatArray, total_length: int) -> FloatArray:
+    x_prefix = np.arange(len(target_prefix), dtype=np.float64)
+    design = np.column_stack((np.ones(len(target_prefix)), x_prefix))
+    beta = np.linalg.lstsq(design, target_prefix, rcond=None)[0]
+    x = np.arange(total_length, dtype=np.float64)
+    return (beta[0] + beta[1] * x).astype(np.float64)
+
+
+def _posterior_from_profiles(
+    target_prefix: FloatArray,
+    evidence_profiles: FloatArray,
+    outcome_profiles: FloatArray,
+    template_variance: FloatArray,
+    config: PokeFlexRealizedLoadSourceConfig,
+) -> tuple[FloatArray, FloatArray, FloatArray, dict[str, Any]]:
+    prefix = config.prefix_frame_count
+    scale = _robust_scale(evidence_profiles[:, :prefix], config.likelihood_scale_floor_n)
+    predictions: list[FloatArray] = []
+    probabilities: list[FloatArray] = []
+    metadata: list[dict[str, Any]] = []
+    log_weights = []
+    for template_index in range(len(evidence_profiles)):
+        for delay in config.delay_grid_frames:
+            evidence = _shift(evidence_profiles[template_index], int(delay))
+            outcome = _shift(outcome_profiles[template_index], int(delay))
+            for gain in config.gain_grid:
+                offset = float(np.median(target_prefix - float(gain) * evidence[:prefix]))
+                evidence_prediction = float(gain) * evidence + offset
+                outcome_prediction = float(gain) * outcome + offset
+                residual = target_prefix - evidence_prediction[:prefix]
+                log_likelihood = _student_log_likelihood(
+                    residual,
+                    scale,
+                    config.student_t_degrees_of_freedom,
+                )
+                log_prior = -0.5 * ((float(gain) - 1.0) / config.gain_prior_std) ** 2
+                log_prior -= 0.5 * (float(delay) / config.delay_prior_std_frames) ** 2
+                predictions.append(outcome_prediction)
+                component_variance = (float(gain) ** 2) * template_variance
+                probabilities.append(
+                    _contact_probability(
+                        outcome_prediction,
+                        component_variance,
+                        config.contact_threshold_n,
+                    )
+                )
+                metadata.append(
+                    {
+                        "template_index": template_index,
+                        "delay_frames": int(delay),
+                        "gain": float(gain),
+                        "offset_n": offset,
+                    }
+                )
+                log_weights.append(log_likelihood + log_prior)
+    weights = _softmax(np.asarray(log_weights, dtype=np.float64))
+    prediction_array = np.stack(predictions)
+    mean = np.einsum("c,ct->t", weights, prediction_array)
+    component_variance = np.asarray(
+        [(item["gain"] ** 2) * template_variance for item in metadata],
+        dtype=np.float64,
+    )
+    variance = np.einsum(
+        "c,ct->t",
+        weights,
+        component_variance + (prediction_array - mean[None, :]) ** 2,
+    )
+    variance = np.maximum(variance, config.predictive_variance_floor_n2)
+    contact_probability = np.einsum("c,ct->t", weights, np.stack(probabilities))
+    map_index = int(np.argmax(weights))
+    summary = {
+        "candidate_count": len(metadata),
+        "posterior_entropy": float(-np.sum(weights * np.log(weights + 1e-300))),
+        "effective_candidate_count": float(1.0 / np.sum(weights**2)),
+        "map_candidate": metadata[map_index],
+        "map_prediction": prediction_array[map_index],
+        "map_variance": np.maximum(
+            component_variance[map_index],
+            config.predictive_variance_floor_n2,
+        ),
+        "map_contact_probability": probabilities[map_index],
+    }
+    return mean, variance, np.clip(contact_probability, 1e-6, 1.0 - 1e-6), summary
+
+
+def build_forecast_bundle(
+    target_prefix: FloatArray,
+    target: TargetKinematicConditioning,
+    sources: Sequence[RealizedLoadTake],
+    config: PokeFlexRealizedLoadSourceConfig,
+) -> ForecastBundle:
+    """Construct predictions without receiving the target force suffix."""
+
+    prefix = config.prefix_frame_count
+    total_length = prefix + config.forecast_horizon_frames
+    _require(target_prefix.shape == (prefix,), "target prefix has the wrong shape")
+    _require(
+        len(target.window_phase) == total_length,
+        "target window has the wrong length",
+    )
+    _require(
+        target.window_speed_m_per_frame.shape == (total_length,),
+        "target kinematic speed has the wrong length",
+    )
+    _require(len(sources) >= 3, "at least three source takes are required")
+    source_ids = tuple(source.take_id for source in sources)
+    _require(target.take_id not in source_ids, "target appears in source roster")
+    _require(len(set(source_ids)) == len(source_ids), "source take ids repeat")
+
+    profiles = np.stack([_warp_profile(source, target.window_phase) for source in sources])
+    template_variance = np.var(profiles, axis=0, ddof=1)
+    template_variance = np.maximum(
+        template_variance,
+        config.predictive_variance_floor_n2,
+    )
+    proposed_mean, proposed_variance, proposed_contact, posterior = _posterior_from_profiles(
+        target_prefix,
+        profiles,
+        profiles,
+        template_variance,
+        config,
+    )
+    permutation = np.roll(np.arange(len(profiles)), -1)
+    destroyed_profiles = profiles[permutation]
+    destroyed_mean, destroyed_variance, destroyed_contact, destroyed = (
+        _posterior_from_profiles(
+            target_prefix,
+            profiles,
+            destroyed_profiles,
+            template_variance,
+            config,
+        )
+    )
+    mean_profile = np.mean(profiles, axis=0)
+    mean_profile += float(np.median(target_prefix - mean_profile[:prefix]))
+    persistence = np.repeat(float(target_prefix[-1]), total_length)
+    linear = _linear_prediction(target_prefix, total_length)
+    ridge = _ridge_prediction(target, sources, target_prefix, config)
+    map_prediction = np.asarray(posterior.pop("map_prediction"), dtype=np.float64)
+    map_variance = np.asarray(posterior.pop("map_variance"), dtype=np.float64)
+    map_contact = np.asarray(posterior.pop("map_contact_probability"), dtype=np.float64)
+    destroyed.pop("map_prediction")
+    destroyed.pop("map_variance")
+    destroyed.pop("map_contact_probability")
+
+    means = {
+        "persistence": persistence,
+        "linear_extrapolation": linear,
+        "mean_prefix_offset": mean_profile,
+        "kinematic_ridge": ridge,
+        "posterior_map": map_prediction,
+        "posterior_mean": proposed_mean,
+        "dependence_destroyed": destroyed_mean,
+    }
+    variances = {
+        name: template_variance.copy()
+        for name in (
+            "persistence",
+            "linear_extrapolation",
+            "mean_prefix_offset",
+            "kinematic_ridge",
+        )
+    }
+    variances.update(
+        {
+            "posterior_map": map_variance,
+            "posterior_mean": proposed_variance,
+            "dependence_destroyed": destroyed_variance,
+        }
+    )
+    contact_probabilities = {
+        name: _contact_probability(
+            mean,
+            variances[name],
+            config.contact_threshold_n,
+        )
+        for name, mean in means.items()
+        if name not in {"posterior_map", "posterior_mean", "dependence_destroyed"}
+    }
+    contact_probabilities.update(
+        {
+            "posterior_map": map_contact,
+            "posterior_mean": proposed_contact,
+            "dependence_destroyed": destroyed_contact,
+        }
+    )
+    return ForecastBundle(
+        means=means,
+        variances=variances,
+        contact_probabilities=contact_probabilities,
+        metadata={
+            "source_take_ids": list(source_ids),
+            "known_future_tool_kinematics_used": True,
+            "target_force_suffix_used": False,
+            "posterior": posterior,
+            "dependence_destroyed": destroyed,
+            "dependence_control_permutation": permutation.tolist(),
+            "dependence_control_prefix_marginal_preserved": True,
+            "dependence_control_suffix_marginal_preserved": True,
+        },
+    )

--- a/src/causal4d_public/_pokeflex_realized_load_scoring.py
+++ b/src/causal4d_public/_pokeflex_realized_load_scoring.py
@@ -1,0 +1,484 @@
+"""Scoring and source-gate execution for PokeFlex realized-load forecasts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+from causal4d_public._pokeflex_realized_load_common import (
+    BoolArray,
+    FloatArray,
+    POKEFLEX_REALIZED_LOAD_ARTIFACT_SCHEMA_VERSION,
+    PokeFlexRealizedLoadSourceConfig,
+    _array_digest,
+    _canonical_bytes,
+    _require,
+    validate_source_qa_binding,
+)
+from causal4d_public._pokeflex_realized_load_model import (
+    ForecastBundle,
+    RealizedLoadTake,
+    TargetKinematicConditioning,
+    build_forecast_bundle,
+    load_realized_load_take,
+)
+
+
+def _method_metrics(
+    truth: FloatArray,
+    contact_truth: BoolArray,
+    mean: FloatArray,
+    variance: FloatArray,
+    contact_probability: FloatArray,
+) -> dict[str, float]:
+    safe_variance = np.maximum(variance, 1e-12)
+    error = truth - mean
+    half_width = 1.6448536269514722 * np.sqrt(safe_variance)
+    probability = np.clip(contact_probability, 1e-6, 1.0 - 1e-6)
+    contact_float = contact_truth.astype(np.float64)
+    log_score = -np.mean(
+        contact_float * np.log(probability)
+        + (1.0 - contact_float) * np.log(1.0 - probability)
+    )
+    return {
+        "force_rmse_n": float(np.sqrt(np.mean(error**2))),
+        "force_mae_n": float(np.mean(np.abs(error))),
+        "force_gaussian_nll": float(
+            np.mean(
+                0.5
+                * (
+                    np.log(2.0 * math.pi * safe_variance)
+                    + error**2 / safe_variance
+                )
+            )
+        ),
+        "force_90pct_coverage": float(np.mean(np.abs(error) <= half_width)),
+        "mean_90pct_interval_width_n": float(np.mean(2.0 * half_width)),
+        "contact_brier": float(np.mean((probability - contact_float) ** 2)),
+        "contact_log_score": float(log_score),
+        "peak_force_error_n": float(abs(np.max(mean) - np.max(truth))),
+        "mean_force_error_n": float(abs(np.mean(mean) - np.mean(truth))),
+    }
+
+
+def _bootstrap_mean_ci(
+    values: Sequence[float],
+    config: PokeFlexRealizedLoadSourceConfig,
+    key: str,
+) -> dict[str, float]:
+    array = np.asarray(values, dtype=np.float64)
+    _require(array.ndim == 1 and array.size >= 2, "bootstrap input is invalid")
+    digest = hashlib.sha256(key.encode("utf-8")).digest()
+    seed = (config.bootstrap_seed + int.from_bytes(digest[:8], "big")) % (2**63 - 1)
+    generator = np.random.default_rng(seed)
+    indices = generator.integers(
+        0,
+        len(array),
+        size=(config.bootstrap_replicates, len(array)),
+    )
+    means = np.mean(array[indices], axis=1)
+    return {
+        "mean": float(np.mean(array)),
+        "lower95": float(np.quantile(means, 0.025)),
+        "upper95": float(np.quantile(means, 0.975)),
+    }
+
+
+def _one_sided_sign_pvalue(wins: int, non_ties: int) -> float:
+    if non_ties == 0:
+        return 1.0
+    numerator = sum(
+        math.comb(non_ties, value) for value in range(wins, non_ties + 1)
+    )
+    return float(numerator / (2**non_ties))
+
+
+def _write_json(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, path)
+
+
+def _write_prediction_bundle(
+    output_dir: Path,
+    target: RealizedLoadTake,
+    bundle: ForecastBundle,
+    config: PokeFlexRealizedLoadSourceConfig,
+) -> dict[str, Any]:
+    arrays: dict[str, FloatArray] = {}
+    for method in sorted(bundle.means):
+        arrays[f"{method}__mean"] = np.asarray(
+            bundle.means[method], dtype=np.float64
+        )
+        arrays[f"{method}__variance"] = np.asarray(
+            bundle.variances[method], dtype=np.float64
+        )
+        arrays[f"{method}__contact_probability"] = np.asarray(
+            bundle.contact_probabilities[method],
+            dtype=np.float64,
+        )
+    prediction_sha256 = _array_digest(arrays)
+    npz_path = output_dir / f"predictions_{target.take_id}.npz"
+    np.savez_compressed(npz_path, **arrays)
+    prefix = config.prefix_frame_count
+    receipt = {
+        "artifact_kind": "PublicPokeFlexRealizedLoadPredictionSeal",
+        "schema_version": 1,
+        "target_take_id": target.take_id,
+        "source_take_ids": list(bundle.metadata["source_take_ids"]),
+        "target_robot_sha256": target.robot_sha256,
+        "contact_onset_frame_id": int(target.frame_ids[target.onset_index]),
+        "prefix_frame_ids": target.frame_ids[
+            target.onset_index : target.onset_index + prefix
+        ]
+        .astype(int)
+        .tolist(),
+        "forecast_frame_ids": target.frame_ids[
+            target.onset_index
+            + prefix : target.onset_index
+            + prefix
+            + config.forecast_horizon_frames
+        ]
+        .astype(int)
+        .tolist(),
+        "prediction_sha256": prediction_sha256,
+        "prediction_file": npz_path.name,
+        "target_force_suffix_used": False,
+        "known_future_tool_kinematics_used": True,
+        "metadata": bundle.metadata,
+    }
+    receipt["seal_sha256"] = hashlib.sha256(_canonical_bytes(receipt)).hexdigest()
+    _write_json(output_dir / f"prediction_seal_{target.take_id}.json", receipt)
+    return receipt
+
+
+def realized_load_artifact_sha256(payload: Mapping[str, Any]) -> str:
+    canonical = dict(payload)
+    canonical.pop("result_sha256", None)
+    return hashlib.sha256(_canonical_bytes(canonical)).hexdigest()
+
+
+def run_pokeflex_realized_load_source_gate(
+    dataset_root: str | Path,
+    source_qa: Mapping[str, Any],
+    output_dir: str | Path,
+    config: PokeFlexRealizedLoadSourceConfig,
+) -> dict[str, Any]:
+    """Run the frozen leave-one-development-take-out source gate."""
+
+    binding = validate_source_qa_binding(source_qa, config)
+    root = Path(dataset_root).resolve()
+    _require(root.is_dir(), f"missing PokeFlex root: {root}")
+    output = Path(output_dir).resolve()
+    output.mkdir(parents=True, exist_ok=True)
+
+    takes = {
+        take_id: load_realized_load_take(root, take_id, config)
+        for take_id in config.expected_development_take_ids
+    }
+    _require(
+        set(takes).isdisjoint(config.forbidden_take_ids),
+        "forbidden take entered the loaded roster",
+    )
+
+    bundles: dict[str, ForecastBundle] = {}
+    seals: dict[str, dict[str, Any]] = {}
+    for target_id in config.expected_development_take_ids:
+        target = takes[target_id]
+        sources = [
+            takes[source_id]
+            for source_id in config.expected_development_take_ids
+            if source_id != target_id
+        ]
+        target_prefix = target.window_force_n[: config.prefix_frame_count].copy()
+        conditioning = TargetKinematicConditioning(
+            take_id=target.take_id,
+            window_phase=target.window_phase.copy(),
+            window_speed_m_per_frame=target.window_speed_m_per_frame.copy(),
+        )
+        bundle = build_forecast_bundle(
+            target_prefix,
+            conditioning,
+            sources,
+            config,
+        )
+        bundles[target_id] = bundle
+        seals[target_id] = _write_prediction_bundle(output, target, bundle, config)
+
+    rows: list[dict[str, Any]] = []
+    prefix = config.prefix_frame_count
+    suffix = slice(prefix, prefix + config.forecast_horizon_frames)
+    for target_id in config.expected_development_take_ids:
+        target = takes[target_id]
+        bundle = bundles[target_id]
+        truth = target.window_force_n[suffix]
+        contact_truth = truth > config.contact_threshold_n
+        metrics = {
+            method: _method_metrics(
+                truth,
+                contact_truth,
+                np.asarray(bundle.means[method])[suffix],
+                np.asarray(bundle.variances[method])[suffix],
+                np.asarray(bundle.contact_probabilities[method])[suffix],
+            )
+            for method in sorted(bundle.means)
+        }
+        rows.append(
+            {
+                "take_id": target_id,
+                "robot_sha256": target.robot_sha256,
+                "contact_onset_index": target.onset_index,
+                "contact_onset_frame_id": int(
+                    target.frame_ids[target.onset_index]
+                ),
+                "prediction_seal_sha256": seals[target_id]["seal_sha256"],
+                "metrics": metrics,
+            }
+        )
+
+    methods = sorted(rows[0]["metrics"])
+    aggregate = {
+        method: {
+            metric: {
+                "mean": float(
+                    np.mean([row["metrics"][method][metric] for row in rows])
+                ),
+                "median": float(
+                    np.median([row["metrics"][method][metric] for row in rows])
+                ),
+            }
+            for metric in rows[0]["metrics"][method]
+        }
+        for method in methods
+    }
+
+    comparisons: dict[str, Any] = {}
+    for comparator in (
+        "persistence",
+        "linear_extrapolation",
+        "mean_prefix_offset",
+        "kinematic_ridge",
+        "posterior_map",
+        "dependence_destroyed",
+    ):
+        differences = [
+            row["metrics"][comparator]["force_rmse_n"]
+            - row["metrics"]["posterior_mean"]["force_rmse_n"]
+            for row in rows
+        ]
+        wins = sum(value > 1e-12 for value in differences)
+        losses = sum(value < -1e-12 for value in differences)
+        comparisons[f"posterior_mean_vs_{comparator}"] = {
+            "positive_difference_means_posterior_is_better": True,
+            "take_differences_n": {
+                row["take_id"]: float(value)
+                for row, value in zip(rows, differences, strict=True)
+            },
+            "wins": wins,
+            "ties": len(rows) - wins - losses,
+            "losses": losses,
+            "win_fraction": wins / len(rows),
+            "one_sided_sign_pvalue": _one_sided_sign_pvalue(
+                wins, wins + losses
+            ),
+            "mean_difference_bootstrap": _bootstrap_mean_ci(
+                differences,
+                config,
+                f"posterior_mean_vs_{comparator}",
+            ),
+        }
+
+    proposed_rmse = aggregate["posterior_mean"]["force_rmse_n"]["mean"]
+    persistence_rmse = aggregate["persistence"]["force_rmse_n"]["mean"]
+    destroyed_rmse = aggregate["dependence_destroyed"]["force_rmse_n"]["mean"]
+    ridge_rmse = aggregate["kinematic_ridge"]["force_rmse_n"]["mean"]
+    persistence_win_fraction = comparisons["posterior_mean_vs_persistence"][
+        "win_fraction"
+    ]
+    worst_ratio = max(
+        row["metrics"]["posterior_mean"]["force_rmse_n"]
+        / max(row["metrics"]["persistence"]["force_rmse_n"], 1e-12)
+        for row in rows
+    )
+    criteria = {
+        "five_locked_development_takes_evaluated": len(rows) == 5,
+        "all_predictions_sealed_before_scoring": all(
+            bool(row["prediction_seal_sha256"]) for row in rows
+        ),
+        "mean_rmse_improvement_vs_persistence": (
+            proposed_rmse
+            <= (
+                1.0
+                - config.minimum_mean_rmse_improvement_fraction_vs_persistence
+            )
+            * persistence_rmse
+        ),
+        "take_win_fraction_vs_persistence": (
+            persistence_win_fraction
+            >= config.minimum_take_win_fraction_vs_persistence
+        ),
+        "mean_rmse_improvement_vs_dependence_destroyed": (
+            proposed_rmse
+            <= (
+                1.0
+                - config.minimum_mean_rmse_improvement_fraction_vs_dependence_control
+            )
+            * destroyed_rmse
+        ),
+        "worst_take_ratio_vs_persistence": (
+            worst_ratio <= config.maximum_worst_take_rmse_ratio_vs_persistence
+        ),
+        "mean_rmse_noninferior_to_kinematic_ridge": (
+            proposed_rmse
+            <= config.maximum_mean_rmse_ratio_vs_kinematic_ridge * ridge_rmse
+        ),
+        "forbidden_takes_remained_outside_loaded_roster": set(takes).isdisjoint(
+            config.forbidden_take_ids
+        ),
+    }
+    admitted = all(criteria.values())
+    result: dict[str, Any] = {
+        "artifact_kind": "PublicPokeFlexRealizedLoadSourceGate",
+        "schema_version": POKEFLEX_REALIZED_LOAD_ARTIFACT_SCHEMA_VERSION,
+        "policy_id": config.policy_id,
+        "policy_config": config.as_dict(),
+        "source_qa_binding": binding,
+        "dataset": {
+            "name": "PokeFlex",
+            "object_id": config.expected_object_id,
+            "opened_take_ids": list(config.expected_development_take_ids),
+            "forbidden_unopened_take_ids": list(config.forbidden_take_ids),
+            "independent_unit": "complete development take",
+            "robot_records_only": True,
+            "mesh_payloads_opened": False,
+        },
+        "design": {
+            "factual_prefix": (
+                f"first {config.prefix_frame_count} frames from the source-locked "
+                "persistent force-threshold contact onset"
+            ),
+            "forecast_horizon_frames": config.forecast_horizon_frames,
+            "future_conditioning": "released measured tool trajectory only",
+            "latent_intervention_bank": "source take, gain, and response delay",
+            "dependence_control": (
+                "cyclic source-prefix/source-suffix reassignment preserving both "
+                "marginals"
+            ),
+            "target_force_suffix_passed_to_inference": False,
+        },
+        "per_take_results": rows,
+        "aggregate_equal_take_results": aggregate,
+        "comparisons": comparisons,
+        "source_gate_criteria": criteria,
+        "source_backend_admitted": admitted,
+        "decision": "source-positive"
+        if admitted
+        else "source-negative-or-bounded",
+        "next_stage_authorization": {
+            "automatic_calibration_open": False,
+            "automatic_target_open": False,
+            "separate_reviewed_protocol_required": True,
+        },
+        "information_boundary": {
+            "public_data_only": True,
+            "new_physical_data_collected": False,
+            "development_robot_records_read": True,
+            "development_meshes_read": False,
+            "calibration_take_data_read": False,
+            "target_take_data_read": False,
+            "forbidden_take_discovery_required": False,
+            "predictions_sealed_before_suffix_scoring": True,
+        },
+        "claim_boundary": [
+            "This is a development-only source gate, not a held-out target result.",
+            "It tests realized-load and contact-state forecasting from public measured wrench records.",
+            "The released future measured tool trajectory is conditioning evidence, not a commanded control stream.",
+            "No material-point identity, mesh forecast, calibrated population uncertainty, individual counterfactual, control, or safety claim is authorized.",
+            "A positive source gate cannot open calibration or target data without a separate reviewed protocol.",
+        ],
+    }
+    result["result_sha256"] = realized_load_artifact_sha256(result)
+    _write_json(output / "result.json", result)
+    (output / "summary.md").write_text(render_summary(result), encoding="utf-8")
+    return result
+
+
+def validate_realized_load_artifact(payload: Mapping[str, Any]) -> dict[str, Any]:
+    _require(
+        payload.get("artifact_kind") == "PublicPokeFlexRealizedLoadSourceGate",
+        "unexpected realized-load artifact kind",
+    )
+    _require(
+        payload.get("schema_version")
+        == POKEFLEX_REALIZED_LOAD_ARTIFACT_SCHEMA_VERSION,
+        "unsupported realized-load artifact schema",
+    )
+    _require(
+        payload.get("result_sha256") == realized_load_artifact_sha256(payload),
+        "realized-load artifact checksum mismatch",
+    )
+    boundary = payload.get("information_boundary", {})
+    _require(boundary.get("public_data_only") is True, "public-data boundary changed")
+    _require(
+        boundary.get("calibration_take_data_read") is False,
+        "calibration was opened",
+    )
+    _require(boundary.get("target_take_data_read") is False, "target was opened")
+    _require(
+        boundary.get("development_meshes_read") is False,
+        "mesh payload was opened",
+    )
+    _require(
+        payload.get("next_stage_authorization", {}).get("automatic_target_open")
+        is False,
+        "artifact automatically authorizes target access",
+    )
+    return {
+        "passed": True,
+        "result_sha256": payload["result_sha256"],
+        "source_backend_admitted": bool(payload["source_backend_admitted"]),
+        "decision": payload["decision"],
+    }
+
+
+def render_summary(result: Mapping[str, Any]) -> str:
+    lines = [
+        "# PokeFlex realized-load source gate",
+        "",
+        f"Decision: **{result['decision']}**",
+        "",
+        "This source-only study uses the five metadata-locked development takes. "
+        "The calibration take T5 and target take T2 remain unopened.",
+        "",
+        "## Equal-take force forecast",
+        "",
+        "| Method | RMSE [N] | Gaussian NLL | 90% coverage | Contact Brier |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    aggregate = result["aggregate_equal_take_results"]
+    for method in sorted(aggregate):
+        row = aggregate[method]
+        lines.append(
+            f"| `{method}` | {row['force_rmse_n']['mean']:.4f} | "
+            f"{row['force_gaussian_nll']['mean']:.4f} | "
+            f"{row['force_90pct_coverage']['mean']:.3f} | "
+            f"{row['contact_brier']['mean']:.4f} |"
+        )
+    lines.extend(["", "## Source-gate criteria", ""])
+    lines.extend(
+        f"- {'PASS' if passed else 'FAIL'} — `{name}`"
+        for name, passed in result["source_gate_criteria"].items()
+    )
+    lines.extend(["", "## Boundary", ""])
+    lines.extend(f"- {item}" for item in result["claim_boundary"])
+    return "\n".join(lines) + "\n"

--- a/src/causal4d_public/_pokeflex_realized_load_scoring.py
+++ b/src/causal4d_public/_pokeflex_realized_load_scoring.py
@@ -51,11 +51,7 @@ def _method_metrics(
         "force_mae_n": float(np.mean(np.abs(error))),
         "force_gaussian_nll": float(
             np.mean(
-                0.5
-                * (
-                    np.log(2.0 * math.pi * safe_variance)
-                    + error**2 / safe_variance
-                )
+                0.5 * (np.log(2.0 * math.pi * safe_variance) + error**2 / safe_variance)
             )
         ),
         "force_90pct_coverage": float(np.mean(np.abs(error) <= half_width)),
@@ -93,9 +89,7 @@ def _bootstrap_mean_ci(
 def _one_sided_sign_pvalue(wins: int, non_ties: int) -> float:
     if non_ties == 0:
         return 1.0
-    numerator = sum(
-        math.comb(non_ties, value) for value in range(wins, non_ties + 1)
-    )
+    numerator = sum(math.comb(non_ties, value) for value in range(wins, non_ties + 1))
     return float(numerator / (2**non_ties))
 
 
@@ -117,9 +111,7 @@ def _write_prediction_bundle(
 ) -> dict[str, Any]:
     arrays: dict[str, FloatArray] = {}
     for method in sorted(bundle.means):
-        arrays[f"{method}__mean"] = np.asarray(
-            bundle.means[method], dtype=np.float64
-        )
+        arrays[f"{method}__mean"] = np.asarray(bundle.means[method], dtype=np.float64)
         arrays[f"{method}__variance"] = np.asarray(
             bundle.variances[method], dtype=np.float64
         )
@@ -144,8 +136,7 @@ def _write_prediction_bundle(
         .astype(int)
         .tolist(),
         "forecast_frame_ids": target.frame_ids[
-            target.onset_index
-            + prefix : target.onset_index
+            target.onset_index + prefix : target.onset_index
             + prefix
             + config.forecast_horizon_frames
         ]
@@ -238,9 +229,7 @@ def run_pokeflex_realized_load_source_gate(
                 "take_id": target_id,
                 "robot_sha256": target.robot_sha256,
                 "contact_onset_index": target.onset_index,
-                "contact_onset_frame_id": int(
-                    target.frame_ids[target.onset_index]
-                ),
+                "contact_onset_frame_id": int(target.frame_ids[target.onset_index]),
                 "prediction_seal_sha256": seals[target_id]["seal_sha256"],
                 "metrics": metrics,
             }
@@ -288,9 +277,7 @@ def run_pokeflex_realized_load_source_gate(
             "ties": len(rows) - wins - losses,
             "losses": losses,
             "win_fraction": wins / len(rows),
-            "one_sided_sign_pvalue": _one_sided_sign_pvalue(
-                wins, wins + losses
-            ),
+            "one_sided_sign_pvalue": _one_sided_sign_pvalue(wins, wins + losses),
             "mean_difference_bootstrap": _bootstrap_mean_ci(
                 differences,
                 config,
@@ -317,15 +304,11 @@ def run_pokeflex_realized_load_source_gate(
         ),
         "mean_rmse_improvement_vs_persistence": (
             proposed_rmse
-            <= (
-                1.0
-                - config.minimum_mean_rmse_improvement_fraction_vs_persistence
-            )
+            <= (1.0 - config.minimum_mean_rmse_improvement_fraction_vs_persistence)
             * persistence_rmse
         ),
         "take_win_fraction_vs_persistence": (
-            persistence_win_fraction
-            >= config.minimum_take_win_fraction_vs_persistence
+            persistence_win_fraction >= config.minimum_take_win_fraction_vs_persistence
         ),
         "mean_rmse_improvement_vs_dependence_destroyed": (
             proposed_rmse
@@ -381,9 +364,7 @@ def run_pokeflex_realized_load_source_gate(
         "comparisons": comparisons,
         "source_gate_criteria": criteria,
         "source_backend_admitted": admitted,
-        "decision": "source-positive"
-        if admitted
-        else "source-negative-or-bounded",
+        "decision": "source-positive" if admitted else "source-negative-or-bounded",
         "next_stage_authorization": {
             "automatic_calibration_open": False,
             "automatic_target_open": False,
@@ -419,8 +400,7 @@ def validate_realized_load_artifact(payload: Mapping[str, Any]) -> dict[str, Any
         "unexpected realized-load artifact kind",
     )
     _require(
-        payload.get("schema_version")
-        == POKEFLEX_REALIZED_LOAD_ARTIFACT_SCHEMA_VERSION,
+        payload.get("schema_version") == POKEFLEX_REALIZED_LOAD_ARTIFACT_SCHEMA_VERSION,
         "unsupported realized-load artifact schema",
     )
     _require(

--- a/src/causal4d_public/cli/pokeflex_realized_load_source.py
+++ b/src/causal4d_public/cli/pokeflex_realized_load_source.py
@@ -1,0 +1,43 @@
+"""Run the frozen development-only PokeFlex realized-load source gate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+from causal4d_public.pokeflex_realized_load import (
+    load_realized_load_policy,
+    run_pokeflex_realized_load_source_gate,
+    validate_realized_load_artifact,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dataset_root")
+    parser.add_argument("source_qa_json")
+    parser.add_argument("output_dir")
+    parser.add_argument("--policy", required=True)
+    args = parser.parse_args()
+    try:
+        source_qa = json.loads(Path(args.source_qa_json).read_text(encoding="utf-8"))
+        config = load_realized_load_policy(args.policy)
+        result = run_pokeflex_realized_load_source_gate(
+            args.dataset_root,
+            source_qa,
+            args.output_dir,
+            config,
+        )
+        validation = validate_realized_load_artifact(result)
+    except (OSError, KeyError, TypeError, ValueError, np.linalg.LinAlgError) as error:
+        print(json.dumps({"passed": False, "error": str(error)}, indent=2))
+        return 2
+    print(json.dumps(validation, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d_public/pokeflex_realized_load.py
+++ b/src/causal4d_public/pokeflex_realized_load.py
@@ -1,0 +1,51 @@
+"""Development-only PokeFlex realized-load prefix forecasting.
+
+The public facade exposes frozen contracts, forecast construction, and source-gate
+execution while keeping the implementation split into reviewable modules.
+"""
+
+from causal4d_public._pokeflex_realized_load_common import (
+    CANONICAL_POKEFLEX_REALIZED_LOAD_POLICY_SHA256,
+    POKEFLEX_REALIZED_LOAD_ARTIFACT_SCHEMA_VERSION,
+    POKEFLEX_REALIZED_LOAD_POLICY_ID,
+    POKEFLEX_REALIZED_LOAD_POLICY_SCHEMA_VERSION,
+    PokeFlexRealizedLoadSourceConfig,
+    load_realized_load_policy,
+    realized_load_policy_sha256,
+    validate_realized_load_policy,
+    validate_source_qa_binding,
+)
+from causal4d_public._pokeflex_realized_load_model import (
+    ForecastBundle,
+    RealizedLoadTake,
+    TargetKinematicConditioning,
+    build_forecast_bundle,
+    load_realized_load_take,
+)
+from causal4d_public._pokeflex_realized_load_scoring import (
+    realized_load_artifact_sha256,
+    render_summary,
+    run_pokeflex_realized_load_source_gate,
+    validate_realized_load_artifact,
+)
+
+__all__ = [
+    "CANONICAL_POKEFLEX_REALIZED_LOAD_POLICY_SHA256",
+    "ForecastBundle",
+    "POKEFLEX_REALIZED_LOAD_ARTIFACT_SCHEMA_VERSION",
+    "POKEFLEX_REALIZED_LOAD_POLICY_ID",
+    "POKEFLEX_REALIZED_LOAD_POLICY_SCHEMA_VERSION",
+    "PokeFlexRealizedLoadSourceConfig",
+    "RealizedLoadTake",
+    "TargetKinematicConditioning",
+    "build_forecast_bundle",
+    "load_realized_load_policy",
+    "load_realized_load_take",
+    "realized_load_artifact_sha256",
+    "realized_load_policy_sha256",
+    "render_summary",
+    "run_pokeflex_realized_load_source_gate",
+    "validate_realized_load_artifact",
+    "validate_realized_load_policy",
+    "validate_source_qa_binding",
+]

--- a/tests/test_pokeflex_realized_load.py
+++ b/tests/test_pokeflex_realized_load.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+import numpy as np
+
+from causal4d_public.pokeflex_realized_load import (
+    CANONICAL_POKEFLEX_REALIZED_LOAD_POLICY_SHA256,
+    PokeFlexRealizedLoadSourceConfig,
+    TargetKinematicConditioning,
+    build_forecast_bundle,
+    realized_load_policy_sha256,
+    run_pokeflex_realized_load_source_gate,
+    validate_realized_load_artifact,
+    validate_realized_load_policy,
+)
+
+
+def _source_qa(config: PokeFlexRealizedLoadSourceConfig) -> dict[str, object]:
+    return {
+        "artifact_kind": "PublicPokeFlexSourceQa",
+        "schema_version": 1,
+        "result_sha256": config.expected_source_qa_result_sha256,
+        "source_qa_passed": True,
+        "object_id": config.expected_object_id,
+        "information_boundary": {
+            "opened_take_ids": list(config.expected_development_take_ids),
+            "unopened_take_ids": list(config.forbidden_take_ids),
+            "calibration_take_data_read": False,
+            "target_take_data_read": False,
+        },
+        "capability_gates": {"pose_wrench_contact_candidate_ready": True},
+    }
+
+
+def _write_take(
+    root: Path,
+    take_id: str,
+    *,
+    shape: float,
+    prefix: int,
+    horizon: int,
+) -> None:
+    take_root = root / "3dPrintedBunny" / take_id
+    take_root.mkdir(parents=True)
+    onset = 10
+    total = onset + prefix + horizon + 8
+    window_time = np.arange(prefix + horizon, dtype=float)
+    early = 4.0 + (0.20 + 0.35 * shape) * window_time
+    peak = 8.0 + 8.0 * shape
+    future_shape = peak + 2.5 * np.sin((window_time - prefix) / 5.0)
+    blend = 1.0 / (1.0 + np.exp(-(window_time - prefix + 1.0)))
+    window_force = (1.0 - blend) * early + blend * future_shape
+    window_force += 0.05 * np.sin(0.7 * window_time + shape)
+    force = np.zeros(total, dtype=float)
+    force[onset : onset + len(window_force)] = window_force
+    position = np.zeros((total, 3), dtype=float)
+    position[:, 0] = 0.0015 * np.arange(total)
+    position[:, 1] = 0.0002 * shape * np.arange(total)
+    records = []
+    for frame in range(total):
+        transform = np.eye(4)
+        transform[:3, 3] = position[frame]
+        records.append(
+            {
+                "frame": f"{frame:05d}",
+                "forces": [0.0, float(force[frame]), 0.0],
+                "T_WT": transform.tolist(),
+            }
+        )
+    (take_root / "robot_data.json").write_text(json.dumps(records), encoding="utf-8")
+
+
+def _synthetic_config() -> PokeFlexRealizedLoadSourceConfig:
+    return PokeFlexRealizedLoadSourceConfig(
+        forecast_horizon_frames=24,
+        gain_grid=(0.8, 0.9, 1.0, 1.1, 1.2),
+        delay_grid_frames=(-1, 0, 1),
+        minimum_mean_rmse_improvement_fraction_vs_persistence=0.02,
+        minimum_take_win_fraction_vs_persistence=0.60,
+        minimum_mean_rmse_improvement_fraction_vs_dependence_control=0.0,
+        maximum_worst_take_rmse_ratio_vs_persistence=1.10,
+        maximum_mean_rmse_ratio_vs_kinematic_ridge=1.20,
+        bootstrap_replicates=2000,
+    )
+
+
+def test_canonical_policy_validates() -> None:
+    config_path = (
+        Path(__file__).resolve().parents[1]
+        / "configs"
+        / "causal4d_public"
+        / "pokeflex_realized_load_source_v1.json"
+    )
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    validation = validate_realized_load_policy(payload)
+    assert validation["passed"] is True
+    assert payload["config_sha256"] == CANONICAL_POKEFLEX_REALIZED_LOAD_POLICY_SHA256
+    assert payload["config_sha256"] == realized_load_policy_sha256(payload)
+
+
+def test_forecast_constructor_has_no_target_suffix_argument() -> None:
+    parameters = inspect.signature(build_forecast_bundle).parameters
+    assert "target_suffix" not in parameters
+    assert tuple(parameters) == ("target_prefix", "target", "sources", "config")
+    conditioning_fields = set(TargetKinematicConditioning.__dataclass_fields__)
+    assert "window_force_n" not in conditioning_fields
+    assert conditioning_fields == {
+        "take_id",
+        "window_phase",
+        "window_speed_m_per_frame",
+    }
+
+
+def test_source_gate_is_deterministic_and_does_not_open_forbidden_takes(
+    tmp_path: Path,
+) -> None:
+    config = _synthetic_config()
+    shapes = (0.05, 0.20, 0.40, 0.65, 0.90)
+    for take_id, shape in zip(config.expected_development_take_ids, shapes, strict=True):
+        _write_take(
+            tmp_path,
+            take_id,
+            shape=shape,
+            prefix=config.prefix_frame_count,
+            horizon=config.forecast_horizon_frames,
+        )
+    forbidden_contents = {}
+    for take_id in config.forbidden_take_ids:
+        take_root = tmp_path / "3dPrintedBunny" / take_id
+        take_root.mkdir(parents=True)
+        path = take_root / "robot_data.json"
+        path.write_text("FORBIDDEN PAYLOAD MUST NOT BE PARSED", encoding="utf-8")
+        forbidden_contents[take_id] = path.read_bytes()
+
+    first = run_pokeflex_realized_load_source_gate(
+        tmp_path,
+        _source_qa(config),
+        tmp_path / "first",
+        config,
+    )
+    second = run_pokeflex_realized_load_source_gate(
+        tmp_path,
+        _source_qa(config),
+        tmp_path / "second",
+        config,
+    )
+
+    assert first["result_sha256"] == second["result_sha256"]
+    assert first["dataset"]["opened_take_ids"] == list(
+        config.expected_development_take_ids
+    )
+    assert first["information_boundary"]["calibration_take_data_read"] is False
+    assert first["information_boundary"]["target_take_data_read"] is False
+    assert first["information_boundary"]["development_meshes_read"] is False
+    assert len(first["per_take_results"]) == 5
+    assert validate_realized_load_artifact(first)["passed"] is True
+    for take_id, expected in forbidden_contents.items():
+        path = tmp_path / "3dPrintedBunny" / take_id / "robot_data.json"
+        assert path.read_bytes() == expected
+
+    proposed = first["aggregate_equal_take_results"]["posterior_mean"][
+        "force_rmse_n"
+    ]["mean"]
+    persistence = first["aggregate_equal_take_results"]["persistence"][
+        "force_rmse_n"
+    ]["mean"]
+    assert proposed < persistence
+    assert all(
+        (tmp_path / "first" / f"prediction_seal_{take_id}.json").is_file()
+        for take_id in config.expected_development_take_ids
+    )
+
+
+def test_policy_rejects_target_access() -> None:
+    config = PokeFlexRealizedLoadSourceConfig()
+    payload = {
+        "schema_version": 1,
+        "artifact_kind": "PublicPokeFlexRealizedLoadSourcePolicy",
+        "config": config.as_dict(),
+        "information_boundary": {
+            "development_robot_records_only": True,
+            "development_force_outcomes_allowed_for_source_gate": True,
+            "development_meshes_allowed": False,
+            "calibration_take_data_allowed": False,
+            "target_take_data_allowed": True,
+            "automatic_calibration_or_target_dispatch_allowed": False,
+            "new_physical_data_collected": False,
+        },
+    }
+    payload["config_sha256"] = realized_load_policy_sha256(payload)
+    try:
+        validate_realized_load_policy(payload)
+    except ValueError as error:
+        assert "canonical lock" in str(error) or "information boundary" in str(error)
+    else:
+        raise AssertionError("target-enabled policy was accepted")

--- a/tests/test_pokeflex_realized_load.py
+++ b/tests/test_pokeflex_realized_load.py
@@ -119,7 +119,9 @@ def test_source_gate_is_deterministic_and_does_not_open_forbidden_takes(
 ) -> None:
     config = _synthetic_config()
     shapes = (0.05, 0.20, 0.40, 0.65, 0.90)
-    for take_id, shape in zip(config.expected_development_take_ids, shapes, strict=True):
+    for take_id, shape in zip(
+        config.expected_development_take_ids, shapes, strict=True
+    ):
         _write_take(
             tmp_path,
             take_id,
@@ -161,12 +163,12 @@ def test_source_gate_is_deterministic_and_does_not_open_forbidden_takes(
         path = tmp_path / "3dPrintedBunny" / take_id / "robot_data.json"
         assert path.read_bytes() == expected
 
-    proposed = first["aggregate_equal_take_results"]["posterior_mean"][
-        "force_rmse_n"
-    ]["mean"]
-    persistence = first["aggregate_equal_take_results"]["persistence"][
-        "force_rmse_n"
-    ]["mean"]
+    proposed = first["aggregate_equal_take_results"]["posterior_mean"]["force_rmse_n"][
+        "mean"
+    ]
+    persistence = first["aggregate_equal_take_results"]["persistence"]["force_rmse_n"][
+        "mean"
+    ]
     assert proposed < persistence
     assert all(
         (tmp_path / "first" / f"prediction_seal_{take_id}.json").is_file()


### PR DESCRIPTION
## Purpose

Add a public-data-only Causal4D study that tests whether a six-frame factual wrench response can abduct a finite realized-load intervention and forecast the remaining measured load/contact trajectory.

This is the stronger source-gate successor to the rejected sparse Warp backend. It does not use a robot, collect new data, reopen that backend, or reinterpret its negative result.

## Frozen information boundary

Only the five already opened metadata-selected development takes are admissible:

- `3dPrintedBunny_T1`
- `3dPrintedBunny_T3`
- `3dPrintedBunny_T4`
- `3dPrintedBunny_T6`
- `3dPrintedBunny_T7`

`3dPrintedBunny_T5` remains calibration-only and `3dPrintedBunny_T2` remains the sealed target. The policy and workflow prohibit both payloads and forbid automatic continuation even after a positive source gate. Mesh payloads are not used.

The source-QA binding is fixed to result `e09d36db4e1ba8a38c70e112c3af9ab95516ee245302f71a853f36cd2dd0e0e7`.

## Method

For each development take, the other four takes form an empirical source bank. Contact onset is the first three consecutive frames above 3 N. The factual prefix is six frames; the registered suffix is 48 frames.

The estimator:

- aligns each source load trajectory using a frozen time/path phase;
- forms a finite source-take × gain × delay intervention bank;
- uses a Student-t prefix likelihood and source-derived scale;
- returns posterior mean, total mixture variance, contact probabilities, and MAP hypothesis;
- consumes the released future tool trajectory only as measured kinematic conditioning; and
- receives no target-force suffix in its forecast-construction interface.

Every fold prediction is content-sealed before any suffix is scored.

## Comparators and attribution

The frozen comparison set contains:

1. last-value persistence;
2. prefix linear extrapolation;
3. source mean with prefix offset;
4. kinematics-conditioned ridge regression;
5. posterior MAP;
6. posterior mixture; and
7. a dependence-destroyed control that cyclically reassigns source prefixes to source suffixes while preserving both empirical marginals.

The dependence control tests whether any gain comes from the matched prefix–future relation rather than merely the available profile marginals.

## Source gate

The backend is admitted only if all criteria pass on the five complete held-out development takes:

- at least 5% lower mean force RMSE than persistence;
- wins on at least 60% of takes;
- at least 2% lower mean RMSE than the dependence-destroyed control;
- no take above 1.10× persistence RMSE;
- mean RMSE no more than 1.05× the kinematic ridge comparator;
- all fold predictions sealed; and
- both forbidden takes remain outside the loaded roster.

A negative or bounded result is terminal for this method version.

## Execution and security

- hosted PR validation checks policy/request identities, focused tests, and the repository-wide self-hosted registry;
- the scientific job is manual `main` dispatch only;
- it runs read-only on `[self-hosted, Linux, X64, nvidia-smi, gpuserver6000]` against `/mnt/lexar4tb/pokeflex`;
- exact `GITHUB_SHA` checkout, clean-tree validation, read-only token, and no secrets are required; and
- only compact predictions, seals, metrics, and provenance are uploaded.

## Claim boundary

A positive source result would justify a separately reviewed calibration/target protocol. It would not itself establish a target effect, mesh forecasting, material-point identity, population calibration, individual counterfactual ground truth, control, or safety.