### PR TITLE
Dispatch the reviewed PokeFlex realized-load source gate

### DIFF
--- a/.github/workflows/dispatch-pokeflex-realized-load-source.yml
+++ b/.github/workflows/dispatch-pokeflex-realized-load-source.yml
@@ -1,0 +1,149 @@
+name: Dispatch reviewed PokeFlex realized-load source gate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/dispatch-pokeflex-realized-load-source.yml"
+      - ".github/workflows/pokeflex-realized-load-source-gpuserver6000.yml"
+      - "ops/pokeflex-realized-load-source-gpuserver6000-request.json"
+  push:
+    branches: [main]
+    paths:
+      - "ops/pokeflex-realized-load-source-gpuserver6000-request.json"
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: dispatch-pokeflex-realized-load-source
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate reviewed request and exact-SHA target
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out exact reviewed revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          clean: true
+      - name: Verify clean immutable checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain=v1)"
+      - name: Verify source-only request and target-workflow contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import hashlib
+          import json
+          from pathlib import Path
+
+          request_path = Path(
+              "ops/pokeflex-realized-load-source-gpuserver6000-request.json"
+          )
+          request = json.loads(request_path.read_text(encoding="utf-8"))
+          supplied = request.pop("request_id")
+          observed = hashlib.sha256(
+              json.dumps(
+                  request,
+                  sort_keys=True,
+                  separators=(",", ":"),
+                  allow_nan=False,
+              ).encode("utf-8")
+          ).hexdigest()
+          if supplied != observed:
+              raise SystemExit("reviewed request identity mismatch")
+          if request.get("enabled") is not True:
+              raise SystemExit("reviewed request is disabled")
+          if request.get("stage") != "development-source-gate":
+              raise SystemExit("unexpected reviewed request stage")
+          if request.get("dataset_root") != "/mnt/lexar4tb/pokeflex":
+              raise SystemExit("unexpected PokeFlex dataset root")
+          boundary = request.get("information_boundary", {})
+          expected_development = [
+              "3dPrintedBunny_T1",
+              "3dPrintedBunny_T3",
+              "3dPrintedBunny_T4",
+              "3dPrintedBunny_T6",
+              "3dPrintedBunny_T7",
+          ]
+          if boundary.get("development_take_ids") != expected_development:
+              raise SystemExit("development-take roster changed")
+          if boundary.get("public_data_only") is not True:
+              raise SystemExit("public-data-only boundary changed")
+          if boundary.get("calibration_take_data_allowed") is not False:
+              raise SystemExit("calibration take was authorized")
+          if boundary.get("target_take_data_allowed") is not False:
+              raise SystemExit("target take was authorized")
+          if boundary.get("automatic_follow_on_allowed") is not False:
+              raise SystemExit("automatic follow-on was authorized")
+
+          workflow = Path(
+              ".github/workflows/pokeflex-realized-load-source-gpuserver6000.yml"
+          ).read_text(encoding="utf-8")
+          required = (
+              "workflow_dispatch:",
+              "expected_sha:",
+              "github.event_name == 'workflow_dispatch'",
+              "github.ref == 'refs/heads/main'",
+              "inputs.expected_sha == github.sha",
+              'test "${EXPECTED_SHA}" = "${GITHUB_SHA}"',
+          )
+          missing = [fragment for fragment in required if fragment not in workflow]
+          if missing:
+              raise SystemExit(f"target workflow lost exact-SHA guards: {missing}")
+          PY
+
+  dispatch:
+    name: Dispatch exact reviewed main revision
+    needs: validate
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      EXPECTED_SHA: ${{ github.sha }}
+      GH_TOKEN: ${{ github.token }}
+      TARGET_WORKFLOW: pokeflex-realized-load-source-gpuserver6000.yml
+    steps:
+      - name: Dispatch fixed workflow with exact expected SHA
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]
+          payload=$(printf '{"ref":"main","inputs":{"expected_sha":"%s"}}' "$EXPECTED_SHA")
+          response="$RUNNER_TEMP/dispatch-response.txt"
+          status=$(curl \
+            --fail-with-body \
+            --location \
+            --silent \
+            --show-error \
+            --output "$response" \
+            --write-out '%{http_code}' \
+            --request POST \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/workflows/$TARGET_WORKFLOW/dispatches" \
+            --data "$payload")
+          if [[ "$status" != "204" ]]; then
+            cat "$response" >&2
+            echo "workflow dispatch returned HTTP $status" >&2
+            exit 1
+          fi
+          {
+            echo "### PokeFlex source gate dispatched"
+            echo
+            echo "- Workflow: \`$TARGET_WORKFLOW\`"
+            echo "- Exact reviewed SHA: \`$EXPECTED_SHA\`"
+            echo "- Calibration and target access remain disabled by the reviewed request."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pokeflex-realized-load-source-gpuserver6000.yml
+++ b/.github/workflows/pokeflex-realized-load-source-gpuserver6000.yml
@@ -5,14 +5,24 @@ on:
     branches: [main]
     paths:
       - ".github/self-hosted-jobs.json"
+      - ".github/workflows/dispatch-pokeflex-realized-load-source.yml"
       - ".github/workflows/pokeflex-realized-load-source-gpuserver6000.yml"
       - "configs/causal4d_public/pokeflex_realized_load_source_v1.json"
       - "docs/causal4d_pokeflex_realized_load.md"
       - "ops/pokeflex-realized-load-source-gpuserver6000-request.json"
+      - "src/causal4d_public/_pokeflex_realized_load_common.py"
+      - "src/causal4d_public/_pokeflex_realized_load_model.py"
+      - "src/causal4d_public/_pokeflex_realized_load_scoring.py"
       - "src/causal4d_public/pokeflex_realized_load.py"
       - "src/causal4d_public/cli/pokeflex_realized_load_source.py"
       - "tests/test_pokeflex_realized_load.py"
+      - "tests/test_self_hosted_workflow_policy.py"
   workflow_dispatch:
+    inputs:
+      expected_sha:
+        description: Exact reviewed main commit authorized for execution
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -34,7 +44,20 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.sha }}
           persist-credentials: false
+          clean: true
+      - name: Validate exact dispatch revision
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$EXPECTED_SHA" = "$GITHUB_SHA"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test -z "$(git status --porcelain=v1)"
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -153,9 +176,12 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/main' &&
+      inputs.expected_sha == github.sha &&
       needs.validate.result == 'success'
     runs-on: [self-hosted, Linux, X64, nvidia-smi, gpuserver6000]
     timeout-minutes: 90
+    env:
+      EXPECTED_SHA: ${{ inputs.expected_sha }}
     steps:
       - name: Check out exact reviewed revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -169,6 +195,7 @@ jobs:
         run: |
           set -euo pipefail
           test "${GITHUB_REF}" = "refs/heads/main"
+          test "${EXPECTED_SHA}" = "${GITHUB_SHA}"
           test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
           test -z "$(git status --porcelain=v1)"
       - name: Select an isolated compatible Python

--- a/ops/pokeflex-realized-load-source-gpuserver6000-request.json
+++ b/ops/pokeflex-realized-load-source-gpuserver6000-request.json
@@ -28,3 +28,4 @@
   "source_qa_artifact_path": "milestones/pokeflex-001-source-warp-gate-v1/artifacts/3dPrintedBunny_source_qa_v1.json",
   "stage": "development-source-gate"
 }
+

--- a/src/causal4d_public/_pokeflex_realized_load_model.py
+++ b/src/causal4d_public/_pokeflex_realized_load_model.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 from dataclasses import dataclass
@@ -296,6 +297,21 @@ def _linear_prediction(target_prefix: FloatArray, total_length: int) -> FloatArr
     return (beta[0] + beta[1] * x).astype(np.float64)
 
 
+def _component_prediction_multiset_sha256(predictions: FloatArray) -> str:
+    """Hash a component set independently of its template ordering."""
+
+    array = np.asarray(predictions, dtype=np.float64)
+    _require(array.ndim == 2, "component predictions must form a matrix")
+    row_digests = sorted(
+        hashlib.sha256(np.ascontiguousarray(row).tobytes()).hexdigest()
+        for row in array
+    )
+    digest = hashlib.sha256()
+    for row_digest in row_digests:
+        digest.update(row_digest.encode("ascii"))
+    return digest.hexdigest()
+
+
 def _posterior_from_profiles(
     target_prefix: FloatArray,
     evidence_profiles: FloatArray,
@@ -316,11 +332,14 @@ def _posterior_from_profiles(
             evidence = _shift(evidence_profiles[template_index], int(delay))
             outcome = _shift(outcome_profiles[template_index], int(delay))
             for gain in config.gain_grid:
-                offset = float(
+                evidence_offset = float(
                     np.median(target_prefix - float(gain) * evidence[:prefix])
                 )
-                evidence_prediction = float(gain) * evidence + offset
-                outcome_prediction = float(gain) * outcome + offset
+                outcome_offset = float(
+                    np.median(target_prefix - float(gain) * outcome[:prefix])
+                )
+                evidence_prediction = float(gain) * evidence + evidence_offset
+                outcome_prediction = float(gain) * outcome + outcome_offset
                 residual = target_prefix - evidence_prediction[:prefix]
                 log_likelihood = _student_log_likelihood(
                     residual,
@@ -343,7 +362,8 @@ def _posterior_from_profiles(
                         "template_index": template_index,
                         "delay_frames": int(delay),
                         "gain": float(gain),
-                        "offset_n": offset,
+                        "offset_n": evidence_offset,
+                        "outcome_offset_n": outcome_offset,
                     }
                 )
                 log_weights.append(log_likelihood + log_prior)
@@ -364,6 +384,9 @@ def _posterior_from_profiles(
     map_index = int(np.argmax(weights))
     summary = {
         "candidate_count": len(metadata),
+        "component_prediction_multiset_sha256": (
+            _component_prediction_multiset_sha256(prediction_array)
+        ),
         "posterior_entropy": float(-np.sum(weights * np.log(weights + 1e-300))),
         "effective_candidate_count": float(1.0 / np.sum(weights**2)),
         "map_candidate": metadata[map_index],
@@ -428,6 +451,11 @@ def build_forecast_bundle(
             template_variance,
             config,
         )
+    )
+    _require(
+        posterior["component_prediction_multiset_sha256"]
+        == destroyed["component_prediction_multiset_sha256"],
+        "dependence control changed the component prediction marginal",
     )
     mean_profile = np.mean(profiles, axis=0)
     mean_profile += float(np.median(target_prefix - mean_profile[:prefix]))
@@ -495,5 +523,6 @@ def build_forecast_bundle(
             "dependence_control_permutation": permutation.tolist(),
             "dependence_control_prefix_marginal_preserved": True,
             "dependence_control_suffix_marginal_preserved": True,
+            "dependence_control_component_prediction_marginal_preserved": True,
         },
     )

--- a/tests/test_pokeflex_realized_load.py
+++ b/tests/test_pokeflex_realized_load.py
@@ -175,7 +175,10 @@ def test_source_gate_is_deterministic_and_does_not_open_forbidden_takes(
         assert seal_path.is_file()
         seal = json.loads(seal_path.read_text(encoding="utf-8"))
         metadata = seal["metadata"]
-        assert metadata["dependence_control_component_prediction_marginal_preserved"] is True
+        assert (
+            metadata["dependence_control_component_prediction_marginal_preserved"]
+            is True
+        )
         assert (
             metadata["posterior"]["component_prediction_multiset_sha256"]
             == metadata["dependence_destroyed"][

--- a/tests/test_pokeflex_realized_load.py
+++ b/tests/test_pokeflex_realized_load.py
@@ -170,10 +170,18 @@ def test_source_gate_is_deterministic_and_does_not_open_forbidden_takes(
         "mean"
     ]
     assert proposed < persistence
-    assert all(
-        (tmp_path / "first" / f"prediction_seal_{take_id}.json").is_file()
-        for take_id in config.expected_development_take_ids
-    )
+    for take_id in config.expected_development_take_ids:
+        seal_path = tmp_path / "first" / f"prediction_seal_{take_id}.json"
+        assert seal_path.is_file()
+        seal = json.loads(seal_path.read_text(encoding="utf-8"))
+        metadata = seal["metadata"]
+        assert metadata["dependence_control_component_prediction_marginal_preserved"] is True
+        assert (
+            metadata["posterior"]["component_prediction_multiset_sha256"]
+            == metadata["dependence_destroyed"][
+                "component_prediction_multiset_sha256"
+            ]
+        )
 
 
 def test_policy_rejects_target_access() -> None:


### PR DESCRIPTION
## Purpose

Make the newly merged public PokeFlex realized-load source gate executable through a reviewed request-file change, without broadening its scientific or data-access boundary.

The self-hosted workflow remains `workflow_dispatch`-only. A new GitHub-hosted dispatcher listens only for the exact reviewed request path on `main`, validates the canonical request and sealed-take boundary, and dispatches the fixed source-gate workflow with the exact reviewed commit SHA.

## Exact-SHA authorization

The target workflow now requires a 40-character `expected_sha` input. Both its hosted validation job and self-hosted evaluation job require that input to equal `github.sha`; a later default-branch revision therefore cannot be substituted after the dispatcher validates the reviewed commit.

The dispatcher passes the merge commit SHA and invokes only:

`pokeflex-realized-load-source-gpuserver6000.yml`

No request contents, commit messages, pull-request text, or other event payloads become execution inputs.

## Pre-outcome dependence-control correction

The audit found that the dependence-destroyed arm permuted source suffix profiles while retaining offsets fitted to the original prefix profiles. Although the raw source-profile marginals were permuted, the resulting target-conditioned component prediction multiset was not guaranteed to remain unchanged.

This PR fixes the control before any source-gate execution:

- prefix likelihoods remain associated with the original source profile;
- each permuted outcome profile receives the offset that the corresponding complete outcome component would receive from the permitted target prefix;
- the original and dependence-destroyed arms therefore contain exactly the same complete component predictions, only paired with different likelihood evidence;
- an order-invariant SHA-256 digest verifies component-prediction marginal identity at runtime; and
- the focused test checks that identity in every synthetic leave-one-take-out seal.

The proposed arm is numerically unchanged because its evidence and outcome profiles are identical. No source outcome informed this correction.

## Information boundary retained

- public PokeFlex data only;
- opened development takes remain exactly `T1`, `T3`, `T4`, `T6`, and `T7`;
- calibration take `T5` remains forbidden;
- target take `T2` remains forbidden;
- automatic follow-on remains disabled;
- no threshold, query, comparator, seed, source-QA identity, dataset root, or request identity changes.

The request file change is whitespace-only. Its canonical parsed contents and existing request SHA-256 remain unchanged; the path change exists solely to provide the reviewed main-branch dispatch signal.

## Additional contract coverage

The target workflow's pull-request path set now includes the three split realized-load implementation modules, the dispatcher, and the self-hosted policy test, so changes to any executable component rerun the focused hosted validation.

## Expected execution

After merge, the request-path push triggers the hosted dispatcher. It validates the exact merge revision and launches the development-only source gate on `gpuserver6000`. Whatever source result occurs is terminal for this exact model version; the dispatcher cannot open `T5` or `T2` and cannot launch a follow-on stage.