### PR TITLE
Apply canonical PokeFlex source-gate formatting

### DIFF
--- a/tests/test_pokeflex_realized_load.py
+++ b/tests/test_pokeflex_realized_load.py
@@ -163,12 +163,8 @@ def test_source_gate_is_deterministic_and_does_not_open_forbidden_takes(
         path = tmp_path / "3dPrintedBunny" / take_id / "robot_data.json"
         assert path.read_bytes() == expected
 
-    proposed = first["aggregate_equal_take_results"]["posterior_mean"]["force_rmse_n"][
-        "mean"
-    ]
-    persistence = first["aggregate_equal_take_results"]["persistence"]["force_rmse_n"][
-        "mean"
-    ]
+    proposed = first["aggregate_equal_take_results"]["posterior_mean"]["force_rmse_n"]["mean"]
+    persistence = first["aggregate_equal_take_results"]["persistence"]["force_rmse_n"]["mean"]
     assert proposed < persistence
     for take_id in config.expected_development_take_ids:
         seal_path = tmp_path / "first" / f"prediction_seal_{take_id}.json"


### PR DESCRIPTION
## Purpose

Repair the pre-dataset formatting gate that blocked the first reviewed PokeFlex realized-load source execution.

The merge-time run validated the canonical request identity and sealed-take boundary, then stopped at `git diff --exit-code` after Ruff reformatted the focused test. The self-hosted evaluation job was skipped, so no PokeFlex dataset payload was read.

## Change

- Apply the exact test-file layout emitted by the failed workflow's retained canonical-format artifact.
- Change only trailing whitespace in the existing reviewed request file so that, after merge, the hosted exact-SHA dispatcher launches the same frozen source request again.

The request parses to the same object and retains request ID:

`df02f0e81c3111177b43b9e346d4aafa107a658a66db1bc16b6acf573ec47b74`

## Scientific and access boundary

- No model, query, threshold, comparator, seed, source-QA identity, dataset root, or development roster changes.
- Development takes remain exactly `T1`, `T3`, `T4`, `T6`, and `T7`.
- Calibration take `T5` remains forbidden.
- Target take `T2` remains forbidden.
- Automatic follow-on remains disabled.
- The failed run created no scientific result and opened no dataset payload.

After merge, the existing dispatcher will bind the new reviewed merge SHA and launch the development-only source gate on `gpuserver6000`.