### PR TITLE
Retrigger the reviewed PokeFlex realized-load source gate

### DIFF
--- a/ops/pokeflex-realized-load-source-gpuserver6000-request.json
+++ b/ops/pokeflex-realized-load-source-gpuserver6000-request.json
@@ -28,4 +28,3 @@
   "source_qa_artifact_path": "milestones/pokeflex-001-source-warp-gate-v1/artifacts/3dPrintedBunny_source_qa_v1.json",
   "stage": "development-source-gate"
 }
-


### PR DESCRIPTION
## Purpose

Trigger the already reviewed, exact-SHA PokeFlex realized-load source workflow after the formatting repair in #476.

The previous repair changed only the focused test file, so the request-file dispatcher correctly did not run. This PR changes only the trailing newline count of the existing request file. Its parsed JSON value and content-addressed request identity remain unchanged:

`df02f0e81c3111177b43b9e346d4aafa107a658a66db1bc16b6acf573ec47b74`

## Scientific and access boundary

- same frozen estimator, thresholds, comparators, seeds and source-QA binding;
- same dataset root `/mnt/lexar4tb/pokeflex`;
- development takes remain exactly T1, T3, T4, T6 and T7;
- calibration take T5 remains forbidden;
- target take T2 remains forbidden;
- no automatic follow-on is authorized;
- no dataset payload is accessed by this PR.

After merge, the hosted dispatcher binds the merge SHA and launches the fixed source-only workflow on `gpuserver6000`.