### PR TITLE
Apply the exact PokeFlex canonical-format artifact and rerun

### DIFF
--- a/ops/pokeflex-realized-load-source-gpuserver6000-request.json
+++ b/ops/pokeflex-realized-load-source-gpuserver6000-request.json
@@ -28,3 +28,4 @@
   "source_qa_artifact_path": "milestones/pokeflex-001-source-warp-gate-v1/artifacts/3dPrintedBunny_source_qa_v1.json",
   "stage": "development-source-gate"
 }
+

--- a/tests/test_pokeflex_realized_load.py
+++ b/tests/test_pokeflex_realized_load.py
@@ -163,8 +163,12 @@ def test_source_gate_is_deterministic_and_does_not_open_forbidden_takes(
         path = tmp_path / "3dPrintedBunny" / take_id / "robot_data.json"
         assert path.read_bytes() == expected
 
-    proposed = first["aggregate_equal_take_results"]["posterior_mean"]["force_rmse_n"]["mean"]
-    persistence = first["aggregate_equal_take_results"]["persistence"]["force_rmse_n"]["mean"]
+    proposed = first["aggregate_equal_take_results"]["posterior_mean"]["force_rmse_n"][
+        "mean"
+    ]
+    persistence = first["aggregate_equal_take_results"]["persistence"]["force_rmse_n"][
+        "mean"
+    ]
     assert proposed < persistence
     for take_id in config.expected_development_take_ids:
         seal_path = tmp_path / "first" / f"prediction_seal_{take_id}.json"
@@ -177,9 +181,7 @@ def test_source_gate_is_deterministic_and_does_not_open_forbidden_takes(
         )
         assert (
             metadata["posterior"]["component_prediction_multiset_sha256"]
-            == metadata["dependence_destroyed"][
-                "component_prediction_multiset_sha256"
-            ]
+            == metadata["dependence_destroyed"]["component_prediction_multiset_sha256"]
         )
 
 


### PR DESCRIPTION
## Purpose

Repair the remaining pre-dataset formatting failure in PokeFlex source-gate run `33497698508` and retrigger the unchanged reviewed source request.

## Exact correction

The hosted validation job uploaded `pokeflex-realized-load-canonical-format-33497698508`. This PR applies that artifact's exact Ruff layout to `tests/test_pokeflex_realized_load.py`. The failed run stopped at `git diff --exit-code`; the self-hosted evaluation was skipped, so no PokeFlex payload was opened.

The request file changes only from one terminal newline to two. Its parsed JSON and request identity remain unchanged:

`df02f0e81c3111177b43b9e346d4aafa107a658a66db1bc16b6acf573ec47b74`

## Scientific and access boundary

- no estimator, threshold, comparator, seed or source-QA change;
- development roster remains T1, T3, T4, T6 and T7;
- calibration T5 and target T2 remain forbidden;
- no automatic follow-on;
- no dataset payload access in this repair.

After merge, the exact-file dispatcher launches the same source-only workflow on `gpuserver6000`.