### PR TITLE
Fix same-step PokeFlex request environment loading

### DIFF
--- a/.github/workflows/pokeflex-realized-load-source-gpuserver6000.yml
+++ b/.github/workflows/pokeflex-realized-load-source-gpuserver6000.yml
@@ -220,7 +220,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          "$PYTHON_BIN" - <<'PY' >> "$GITHUB_ENV"
+          request_env="$RUNNER_TEMP/pokeflex-realized-load-request.env"
+          "$PYTHON_BIN" - <<'PY' > "$request_env"
           import hashlib
           import json
           from pathlib import Path
@@ -254,6 +255,10 @@ jobs:
           print(f"POLICY_PATH={request['policy_path']}")
           print(f"SOURCE_QA_PATH={request['source_qa_artifact_path']}")
           PY
+          cat "$request_env" >> "$GITHUB_ENV"
+          set -a
+          source "$request_env"
+          set +a
           test "$DATASET_ROOT" = "/mnt/lexar4tb/pokeflex"
           test -d "$DATASET_ROOT"
       - name: Run development-only realized-load source gate

--- a/ops/pokeflex-realized-load-source-gpuserver6000-request.json
+++ b/ops/pokeflex-realized-load-source-gpuserver6000-request.json
@@ -28,4 +28,3 @@
   "source_qa_artifact_path": "milestones/pokeflex-001-source-warp-gate-v1/artifacts/3dPrintedBunny_source_qa_v1.json",
   "stage": "development-source-gate"
 }
-


### PR DESCRIPTION
## Failure retained

Reviewed source run `33498105157` reached the self-hosted runner and verified the exact main SHA, clean checkout and compatible Python. It then stopped before touching the dataset because `DATASET_ROOT` was appended to `$GITHUB_ENV` and read later in the same shell step. GitHub exposes `$GITHUB_ENV` values only to subsequent steps, so `set -u` raised:

`DATASET_ROOT: unbound variable`

No PokeFlex payload was opened and no scientific result was computed.

## Fix

- write the validated request variables to a runner-temporary environment file;
- append the same values to `$GITHUB_ENV` for subsequent steps;
- source the temporary file in the current shell before checking the mounted root;
- retain the exact-SHA, clean-tree, read-only and no-secrets guards.

The request file changes only terminal whitespace to retrigger the existing exact-file dispatcher. Its parsed value and request identity remain unchanged:

`df02f0e81c3111177b43b9e346d4aafa107a658a66db1bc16b6acf573ec47b74`

## Boundary

The estimator, thresholds, comparators, development roster and source-QA binding are unchanged. T5 and T2 remain forbidden and no automatic follow-on is enabled.