### PR TITLE
Stage source-QA-bound PokeFlex robot logs from readable ZIPs

### DIFF
--- a/ops/pokeflex-realized-load-source-gpuserver6000-request.json
+++ b/ops/pokeflex-realized-load-source-gpuserver6000-request.json
@@ -28,3 +28,4 @@
   "source_qa_artifact_path": "milestones/pokeflex-001-source-warp-gate-v1/artifacts/3dPrintedBunny_source_qa_v1.json",
   "stage": "development-source-gate"
 }
+

--- a/src/causal4d_public/cli/pokeflex_realized_load_source.py
+++ b/src/causal4d_public/cli/pokeflex_realized_load_source.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import tempfile
 from pathlib import Path
 
 import numpy as np
@@ -12,6 +13,10 @@ from causal4d_public.pokeflex_realized_load import (
     load_realized_load_policy,
     run_pokeflex_realized_load_source_gate,
     validate_realized_load_artifact,
+)
+from causal4d_public.pokeflex_robot_stage import (
+    stage_pokeflex_development_robot_records,
+    validate_pokeflex_robot_stage,
 )
 
 
@@ -25,13 +30,33 @@ def main() -> int:
     try:
         source_qa = json.loads(Path(args.source_qa_json).read_text(encoding="utf-8"))
         config = load_realized_load_policy(args.policy)
-        result = run_pokeflex_realized_load_source_gate(
-            args.dataset_root,
-            source_qa,
-            args.output_dir,
-            config,
-        )
+        output = Path(args.output_dir).resolve()
+        output.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix="causal4d-pokeflex-robot-stage-"
+        ) as temporary:
+            stage_root = Path(temporary) / "dataset"
+            stage = stage_pokeflex_development_robot_records(
+                args.dataset_root,
+                source_qa,
+                stage_root,
+                config,
+            )
+            stage_validation = validate_pokeflex_robot_stage(stage)
+            (output / "input_stage_manifest.json").write_text(
+                json.dumps(stage, indent=2, sort_keys=True, allow_nan=False) + "\n",
+                encoding="utf-8",
+            )
+            result = run_pokeflex_realized_load_source_gate(
+                stage_root,
+                source_qa,
+                output,
+                config,
+            )
         validation = validate_realized_load_artifact(result)
+        validation["input_stage_manifest_sha256"] = stage_validation[
+            "stage_manifest_sha256"
+        ]
     except (OSError, KeyError, TypeError, ValueError, np.linalg.LinAlgError) as error:
         print(json.dumps({"passed": False, "error": str(error)}, indent=2))
         return 2

--- a/src/causal4d_public/cli/pokeflex_robot_stage.py
+++ b/src/causal4d_public/cli/pokeflex_robot_stage.py
@@ -21,9 +21,7 @@ def main() -> int:
     parser.add_argument("--policy", required=True)
     args = parser.parse_args()
     try:
-        source_qa = json.loads(
-            Path(args.source_qa_json).read_text(encoding="utf-8")
-        )
+        source_qa = json.loads(Path(args.source_qa_json).read_text(encoding="utf-8"))
         config = load_realized_load_policy(args.policy)
         result = stage_pokeflex_development_robot_records(
             args.dataset_root,

--- a/src/causal4d_public/cli/pokeflex_robot_stage.py
+++ b/src/causal4d_public/cli/pokeflex_robot_stage.py
@@ -1,0 +1,43 @@
+"""Stage verified PokeFlex development robot records read-only."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from causal4d_public.pokeflex_realized_load import load_realized_load_policy
+from causal4d_public.pokeflex_robot_stage import (
+    stage_pokeflex_development_robot_records,
+    validate_pokeflex_robot_stage,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dataset_root")
+    parser.add_argument("source_qa_json")
+    parser.add_argument("destination_root")
+    parser.add_argument("--policy", required=True)
+    args = parser.parse_args()
+    try:
+        source_qa = json.loads(
+            Path(args.source_qa_json).read_text(encoding="utf-8")
+        )
+        config = load_realized_load_policy(args.policy)
+        result = stage_pokeflex_development_robot_records(
+            args.dataset_root,
+            source_qa,
+            args.destination_root,
+            config,
+        )
+        validation = validate_pokeflex_robot_stage(result)
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        print(json.dumps({"passed": False, "error": str(error)}, indent=2))
+        return 2
+    print(json.dumps(validation, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/causal4d_public/pokeflex_robot_stage.py
+++ b/src/causal4d_public/pokeflex_robot_stage.py
@@ -1,0 +1,300 @@
+"""Read-only staging of authorized PokeFlex development robot records."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import zipfile
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, Sequence
+
+from causal4d_public._pokeflex_realized_load_common import (
+    PokeFlexRealizedLoadSourceConfig,
+    _canonical_bytes,
+    _require,
+    validate_source_qa_binding,
+)
+
+
+POKEFLEX_ROBOT_STAGE_SCHEMA_VERSION = 1
+POKEFLEX_ROBOT_STAGE_KIND = "PublicPokeFlexRobotRecordStage"
+
+
+def _bytes_sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def robot_stage_manifest_sha256(payload: Mapping[str, Any]) -> str:
+    canonical = dict(payload)
+    canonical.pop("stage_manifest_sha256", None)
+    return hashlib.sha256(_canonical_bytes(canonical)).hexdigest()
+
+
+def _source_qa_robot_hashes(
+    source_qa: Mapping[str, Any],
+    config: PokeFlexRealizedLoadSourceConfig,
+) -> dict[str, str]:
+    validate_source_qa_binding(source_qa, config)
+    rows = source_qa.get("takes")
+    _require(isinstance(rows, list), "source QA take inventory is missing")
+    expected = set(config.expected_development_take_ids)
+    hashes: dict[str, str] = {}
+    for raw in rows:
+        _require(isinstance(raw, Mapping), "source QA take row is invalid")
+        take_id = str(raw.get("take_id", ""))
+        if take_id not in expected:
+            continue
+        digest = str(raw.get("robot_sha256", ""))
+        _require(
+            len(digest) == 64 and all(value in "0123456789abcdef" for value in digest),
+            f"source QA robot digest is invalid for {take_id}",
+        )
+        _require(take_id not in hashes, f"source QA take repeats: {take_id}")
+        hashes[take_id] = digest
+    _require(set(hashes) == expected, "source QA robot digest roster changed")
+    return hashes
+
+
+def _inside_root(path: Path, root: Path) -> Path:
+    resolved = path.resolve()
+    _require(
+        resolved == root or root in resolved.parents,
+        f"source path escapes the dataset root: {path}",
+    )
+    return resolved
+
+
+def _direct_robot_candidates(
+    root: Path,
+    object_id: str,
+    take_id: str,
+) -> tuple[Path, ...]:
+    candidates = (
+        root / take_id / "robot_data.json",
+        root / object_id / take_id / "robot_data.json",
+    )
+    unique: dict[str, Path] = {}
+    for candidate in candidates:
+        resolved = _inside_root(candidate, root)
+        if resolved.is_file() and not candidate.is_symlink():
+            unique[str(resolved)] = resolved
+    return tuple(unique[key] for key in sorted(unique))
+
+
+def _archive_candidates(root: Path, take_id: str) -> tuple[Path, ...]:
+    unique: dict[str, Path] = {}
+    patterns = (f"*{take_id}*.zip", f"*{take_id}*.ZIP")
+    for pattern in patterns:
+        for candidate in root.rglob(pattern):
+            if candidate.is_symlink() or not candidate.is_file():
+                continue
+            resolved = _inside_root(candidate, root)
+            unique[str(resolved)] = resolved
+    return tuple(unique[key] for key in sorted(unique))
+
+
+def _safe_member_path(name: str) -> PurePosixPath:
+    path = PurePosixPath(name)
+    _require(not path.is_absolute(), "archive member is absolute")
+    _require(".." not in path.parts, "archive member escapes its root")
+    return path
+
+
+def _robot_member_candidates(
+    archive: zipfile.ZipFile,
+    take_id: str,
+) -> tuple[zipfile.ZipInfo, ...]:
+    infos = archive.infolist()
+    names = [info.filename for info in infos]
+    _require(len(names) == len(set(names)), "archive contains duplicate members")
+    selected = []
+    for info in infos:
+        path = _safe_member_path(info.filename)
+        if info.is_dir() or path.name != "robot_data.json":
+            continue
+        if take_id in path.parts or len(path.parts) == 1:
+            selected.append(info)
+    return tuple(selected)
+
+
+def _read_verified_direct(
+    candidates: Sequence[Path],
+    expected_sha256: str,
+) -> tuple[bytes, dict[str, Any]] | None:
+    failures = []
+    for candidate in candidates:
+        try:
+            content = candidate.read_bytes()
+        except OSError as error:
+            failures.append({"path": str(candidate), "error": type(error).__name__})
+            continue
+        observed = _bytes_sha256(content)
+        _require(
+            observed == expected_sha256,
+            f"readable robot record differs from source QA: {candidate}",
+        )
+        return content, {
+            "source_kind": "verified-extracted-file",
+            "source_path": str(candidate),
+            "archive_member": None,
+            "candidate_failures": failures,
+        }
+    return None
+
+
+def _read_verified_archive(
+    candidates: Sequence[Path],
+    take_id: str,
+    expected_sha256: str,
+) -> tuple[bytes, dict[str, Any]]:
+    matches: list[tuple[bytes, Path, str]] = []
+    failures = []
+    for candidate in candidates:
+        try:
+            with zipfile.ZipFile(candidate) as archive:
+                members = _robot_member_candidates(archive, take_id)
+                if len(members) != 1:
+                    failures.append(
+                        {
+                            "path": str(candidate),
+                            "error": "robot-member-count",
+                            "observed": len(members),
+                        }
+                    )
+                    continue
+                member = members[0]
+                content = archive.read(member)
+        except (OSError, zipfile.BadZipFile, zipfile.LargeZipFile) as error:
+            failures.append({"path": str(candidate), "error": type(error).__name__})
+            continue
+        observed = _bytes_sha256(content)
+        if observed == expected_sha256:
+            matches.append((content, candidate, member.filename))
+        else:
+            failures.append(
+                {
+                    "path": str(candidate),
+                    "error": "source-qa-digest-mismatch",
+                    "observed_sha256": observed,
+                }
+            )
+    _require(matches, f"no verified readable robot record found for {take_id}")
+    matches.sort(key=lambda value: (str(value[1]), value[2]))
+    content, archive_path, member_name = matches[0]
+    return content, {
+        "source_kind": "verified-zip-member",
+        "source_path": str(archive_path),
+        "archive_member": member_name,
+        "verified_match_count": len(matches),
+        "candidate_failures": failures,
+    }
+
+
+def stage_pokeflex_development_robot_records(
+    dataset_root: str | Path,
+    source_qa: Mapping[str, Any],
+    destination_root: str | Path,
+    config: PokeFlexRealizedLoadSourceConfig,
+) -> dict[str, Any]:
+    """Stage only source-QA-authorized robot logs into an isolated directory."""
+
+    root = Path(dataset_root).resolve()
+    _require(root.is_dir(), f"missing PokeFlex dataset root: {root}")
+    destination = Path(destination_root).resolve()
+    _require(not destination.exists(), "robot-record stage destination exists")
+    destination.mkdir(parents=True)
+    expected_hashes = _source_qa_robot_hashes(source_qa, config)
+
+    records = []
+    for take_id in config.expected_development_take_ids:
+        expected_sha256 = expected_hashes[take_id]
+        direct = _read_verified_direct(
+            _direct_robot_candidates(root, config.expected_object_id, take_id),
+            expected_sha256,
+        )
+        if direct is None:
+            content, provenance = _read_verified_archive(
+                _archive_candidates(root, take_id),
+                take_id,
+                expected_sha256,
+            )
+        else:
+            content, provenance = direct
+        target = destination / config.expected_object_id / take_id / "robot_data.json"
+        target.parent.mkdir(parents=True, exist_ok=False)
+        target.write_bytes(content)
+        os.chmod(target, 0o600)
+        records.append(
+            {
+                "take_id": take_id,
+                "robot_sha256": expected_sha256,
+                "byte_count": len(content),
+                "staged_path": target.relative_to(destination).as_posix(),
+                **provenance,
+            }
+        )
+
+    manifest: dict[str, Any] = {
+        "artifact_kind": POKEFLEX_ROBOT_STAGE_KIND,
+        "schema_version": POKEFLEX_ROBOT_STAGE_SCHEMA_VERSION,
+        "source_qa_result_sha256": source_qa["result_sha256"],
+        "object_id": config.expected_object_id,
+        "development_take_ids": list(config.expected_development_take_ids),
+        "forbidden_take_ids": list(config.forbidden_take_ids),
+        "dataset_root": str(root),
+        "staging_root": str(destination),
+        "records": records,
+        "information_boundary": {
+            "development_robot_records_only": True,
+            "development_meshes_read": False,
+            "calibration_take_data_read": False,
+            "target_take_data_read": False,
+            "dataset_modified": False,
+        },
+    }
+    manifest["stage_manifest_sha256"] = robot_stage_manifest_sha256(manifest)
+    manifest_path = destination / "stage_manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def validate_pokeflex_robot_stage(payload: Mapping[str, Any]) -> dict[str, Any]:
+    _require(
+        payload.get("artifact_kind") == POKEFLEX_ROBOT_STAGE_KIND,
+        "unexpected robot-stage kind",
+    )
+    _require(
+        payload.get("schema_version") == POKEFLEX_ROBOT_STAGE_SCHEMA_VERSION,
+        "unsupported robot-stage schema",
+    )
+    _require(
+        payload.get("stage_manifest_sha256") == robot_stage_manifest_sha256(payload),
+        "robot-stage checksum mismatch",
+    )
+    boundary = payload.get("information_boundary", {})
+    _require(boundary.get("development_robot_records_only") is True, "stage widened")
+    _require(boundary.get("development_meshes_read") is False, "stage read meshes")
+    _require(
+        boundary.get("calibration_take_data_read") is False,
+        "stage opened calibration",
+    )
+    _require(boundary.get("target_take_data_read") is False, "stage opened target")
+    _require(boundary.get("dataset_modified") is False, "stage modified source")
+    return {
+        "passed": True,
+        "stage_manifest_sha256": payload["stage_manifest_sha256"],
+        "record_count": len(payload["records"]),
+    }
+
+
+__all__ = [
+    "POKEFLEX_ROBOT_STAGE_KIND",
+    "POKEFLEX_ROBOT_STAGE_SCHEMA_VERSION",
+    "robot_stage_manifest_sha256",
+    "stage_pokeflex_development_robot_records",
+    "validate_pokeflex_robot_stage",
+]

--- a/tests/test_pokeflex_robot_stage.py
+++ b/tests/test_pokeflex_robot_stage.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from causal4d_public.pokeflex_realized_load import (
+    PokeFlexRealizedLoadSourceConfig,
+)
+from causal4d_public.pokeflex_robot_stage import (
+    stage_pokeflex_development_robot_records,
+    validate_pokeflex_robot_stage,
+)
+
+
+def _robot_bytes(take_id: str) -> bytes:
+    payload = [
+        {
+            "frame": "00001",
+            "forces": [0.0, 4.0, 0.0],
+            "T_WT": [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+            "take_id": take_id,
+        }
+    ]
+    return json.dumps(payload, sort_keys=True).encode("utf-8")
+
+
+def _source_qa(
+    config: PokeFlexRealizedLoadSourceConfig,
+    content_by_take: dict[str, bytes],
+) -> dict[str, object]:
+    return {
+        "artifact_kind": "PublicPokeFlexSourceQa",
+        "schema_version": 1,
+        "result_sha256": config.expected_source_qa_result_sha256,
+        "source_qa_passed": True,
+        "object_id": config.expected_object_id,
+        "information_boundary": {
+            "opened_take_ids": list(config.expected_development_take_ids),
+            "unopened_take_ids": list(config.forbidden_take_ids),
+            "calibration_take_data_read": False,
+            "target_take_data_read": False,
+        },
+        "capability_gates": {"pose_wrench_contact_candidate_ready": True},
+        "takes": [
+            {
+                "take_id": take_id,
+                "robot_sha256": hashlib.sha256(content_by_take[take_id]).hexdigest(),
+            }
+            for take_id in config.expected_development_take_ids
+        ],
+    }
+
+
+def _write_archives(
+    root: Path,
+    config: PokeFlexRealizedLoadSourceConfig,
+    content_by_take: dict[str, bytes],
+) -> dict[str, bytes]:
+    archive_bytes = {}
+    archive_root = root / "poking" / config.expected_object_id
+    archive_root.mkdir(parents=True)
+    for take_id in config.expected_development_take_ids:
+        archive_path = archive_root / f"{take_id}.zip"
+        with zipfile.ZipFile(archive_path, mode="w") as archive:
+            archive.writestr(
+                f"release/{take_id}/robot_data.json",
+                content_by_take[take_id],
+            )
+            archive.writestr(
+                f"release/{take_id}/meshes/mesh-f00001.obj",
+                b"v 0 0 0\n",
+            )
+        archive_bytes[take_id] = archive_path.read_bytes()
+    return archive_bytes
+
+
+def test_stages_only_verified_development_robot_members(tmp_path: Path) -> None:
+    config = PokeFlexRealizedLoadSourceConfig()
+    content = {
+        take_id: _robot_bytes(take_id)
+        for take_id in config.expected_development_take_ids
+    }
+    archive_bytes = _write_archives(tmp_path, config, content)
+    for take_id in config.forbidden_take_ids:
+        (tmp_path / f"{take_id}.zip").write_bytes(b"forbidden invalid archive")
+
+    destination = tmp_path / "stage"
+    result = stage_pokeflex_development_robot_records(
+        tmp_path,
+        _source_qa(config, content),
+        destination,
+        config,
+    )
+
+    assert validate_pokeflex_robot_stage(result)["passed"] is True
+    assert [row["take_id"] for row in result["records"]] == list(
+        config.expected_development_take_ids
+    )
+    assert all(
+        row["source_kind"] == "verified-zip-member"
+        for row in result["records"]
+    )
+    assert result["information_boundary"]["calibration_take_data_read"] is False
+    assert result["information_boundary"]["target_take_data_read"] is False
+    assert result["information_boundary"]["dataset_modified"] is False
+    for take_id in config.expected_development_take_ids:
+        staged = (
+            destination
+            / config.expected_object_id
+            / take_id
+            / "robot_data.json"
+        )
+        assert staged.read_bytes() == content[take_id]
+        archive = (
+            tmp_path
+            / "poking"
+            / config.expected_object_id
+            / f"{take_id}.zip"
+        )
+        assert archive.read_bytes() == archive_bytes[take_id]
+
+
+def test_prefers_a_readable_source_qa_bound_extracted_file(tmp_path: Path) -> None:
+    config = PokeFlexRealizedLoadSourceConfig()
+    content = {
+        take_id: _robot_bytes(take_id)
+        for take_id in config.expected_development_take_ids
+    }
+    for take_id, payload in content.items():
+        path = tmp_path / take_id / "robot_data.json"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(payload)
+
+    result = stage_pokeflex_development_robot_records(
+        tmp_path,
+        _source_qa(config, content),
+        tmp_path / "stage",
+        config,
+    )
+
+    assert all(
+        row["source_kind"] == "verified-extracted-file"
+        for row in result["records"]
+    )
+
+
+def test_rejects_a_robot_member_that_differs_from_source_qa(tmp_path: Path) -> None:
+    config = PokeFlexRealizedLoadSourceConfig()
+    content = {
+        take_id: _robot_bytes(take_id)
+        for take_id in config.expected_development_take_ids
+    }
+    _write_archives(tmp_path, config, content)
+    first = config.expected_development_take_ids[0]
+    archive_path = (
+        tmp_path / "poking" / config.expected_object_id / f"{first}.zip"
+    )
+    with zipfile.ZipFile(archive_path, mode="w") as archive:
+        archive.writestr(f"{first}/robot_data.json", b"changed")
+
+    with pytest.raises(ValueError, match="no verified readable robot record"):
+        stage_pokeflex_development_robot_records(
+            tmp_path,
+            _source_qa(config, content),
+            tmp_path / "stage",
+            config,
+        )

--- a/tests/test_pokeflex_robot_stage.py
+++ b/tests/test_pokeflex_robot_stage.py
@@ -105,27 +105,14 @@ def test_stages_only_verified_development_robot_members(tmp_path: Path) -> None:
     assert [row["take_id"] for row in result["records"]] == list(
         config.expected_development_take_ids
     )
-    assert all(
-        row["source_kind"] == "verified-zip-member"
-        for row in result["records"]
-    )
+    assert all(row["source_kind"] == "verified-zip-member" for row in result["records"])
     assert result["information_boundary"]["calibration_take_data_read"] is False
     assert result["information_boundary"]["target_take_data_read"] is False
     assert result["information_boundary"]["dataset_modified"] is False
     for take_id in config.expected_development_take_ids:
-        staged = (
-            destination
-            / config.expected_object_id
-            / take_id
-            / "robot_data.json"
-        )
+        staged = destination / config.expected_object_id / take_id / "robot_data.json"
         assert staged.read_bytes() == content[take_id]
-        archive = (
-            tmp_path
-            / "poking"
-            / config.expected_object_id
-            / f"{take_id}.zip"
-        )
+        archive = tmp_path / "poking" / config.expected_object_id / f"{take_id}.zip"
         assert archive.read_bytes() == archive_bytes[take_id]
 
 
@@ -148,8 +135,7 @@ def test_prefers_a_readable_source_qa_bound_extracted_file(tmp_path: Path) -> No
     )
 
     assert all(
-        row["source_kind"] == "verified-extracted-file"
-        for row in result["records"]
+        row["source_kind"] == "verified-extracted-file" for row in result["records"]
     )
 
 
@@ -161,9 +147,7 @@ def test_rejects_a_robot_member_that_differs_from_source_qa(tmp_path: Path) -> N
     }
     _write_archives(tmp_path, config, content)
     first = config.expected_development_take_ids[0]
-    archive_path = (
-        tmp_path / "poking" / config.expected_object_id / f"{first}.zip"
-    )
+    archive_path = tmp_path / "poking" / config.expected_object_id / f"{first}.zip"
     with zipfile.ZipFile(archive_path, mode="w") as archive:
         archive.writestr(f"{first}/robot_data.json", b"changed")
 


### PR DESCRIPTION
## Failure retained

Exact-main source run `33498436053` reached the self-hosted runner, validated the frozen request and mounted root, then failed on the first extracted development log:

`Permission denied: /mnt/lexar4tb/pokeflex/3dPrintedBunny_T1/robot_data.json`

The failure occurred before a force trajectory was parsed or any metric was computed. T5 and T2 remained unopened.

## Repair

Add a read-only, checksum-bound carrier adapter for the five already authorized development robot records.

For each of T1, T3, T4, T6 and T7 it:

1. tries the extracted robot log;
2. if that copy is unreadable, searches only ZIP filenames associated with that exact development take;
3. rejects unsafe paths, duplicate members and ambiguous robot-member inventories;
4. reads only the matching `robot_data.json` member;
5. requires its SHA-256 to equal the robot hash already frozen in source-QA result `e09d36db4e1ba8a38c70e112c3af9ab95516ee245302f71a853f36cd2dd0e0e7`; and
6. writes the verified bytes into runner-temporary storage for the existing evaluator.

The source tree is never modified. The temporary raw bytes are deleted after evaluation and are not uploaded. A compact stage manifest records hashes, member identities and access provenance.

## Tests

Synthetic tests cover:

- ZIP-member staging with nested public-style paths;
- byte-for-byte source noninterference;
- exact development-only access while invalid T2/T5 archives remain untouched;
- preference for a readable source-QA-bound extracted copy; and
- failure on a robot member that differs from the frozen source-QA hash.

## Scientific boundary

The estimator, factual prefix, 48-frame query, candidate grid, thresholds, comparators, bootstrap seed and independent units are unchanged. Calibration T5 and target T2 remain forbidden, and no automatic follow-on is authorized. The request-file change is terminal whitespace only and preserves request ID `df02f0e81c3111177b43b9e346d4aafa107a658a66db1bc16b6acf573ec47b74`.