### PR TITLE
Guard unreadable PokeFlex direct files before ZIP fallback

### DIFF
--- a/ops/pokeflex-realized-load-source-gpuserver6000-request.json
+++ b/ops/pokeflex-realized-load-source-gpuserver6000-request.json
@@ -28,4 +28,3 @@
   "source_qa_artifact_path": "milestones/pokeflex-001-source-warp-gate-v1/artifacts/3dPrintedBunny_source_qa_v1.json",
   "stage": "development-source-gate"
 }
-

--- a/src/causal4d_public/pokeflex_robot_stage.py
+++ b/src/causal4d_public/pokeflex_robot_stage.py
@@ -56,6 +56,15 @@ def _source_qa_robot_hashes(
     return hashes
 
 
+def _safe_component(value: str, name: str) -> str:
+    path = PurePosixPath(value)
+    _require(
+        len(path.parts) == 1 and path.parts[0] not in {"", ".", ".."},
+        f"{name} is not one path component",
+    )
+    return value
+
+
 def _inside_root(path: Path, root: Path) -> Path:
     resolved = path.resolve()
     _require(
@@ -70,27 +79,36 @@ def _direct_robot_candidates(
     object_id: str,
     take_id: str,
 ) -> tuple[Path, ...]:
-    candidates = (
-        root / take_id / "robot_data.json",
-        root / object_id / take_id / "robot_data.json",
+    """Return trusted lexical paths without touching an unreadable source file."""
+
+    object_component = _safe_component(object_id, "object id")
+    take_component = _safe_component(take_id, "take id")
+    return (
+        root / take_component / "robot_data.json",
+        root / object_component / take_component / "robot_data.json",
     )
-    unique: dict[str, Path] = {}
-    for candidate in candidates:
-        resolved = _inside_root(candidate, root)
-        if resolved.is_file() and not candidate.is_symlink():
-            unique[str(resolved)] = resolved
-    return tuple(unique[key] for key in sorted(unique))
+
+
+def _bounded_archive_paths(root: Path) -> tuple[Path, ...]:
+    paths = []
+    for pattern in ("*.zip", "*.ZIP", "*/*.zip", "*/*.ZIP", "*/*/*.zip", "*/*/*.ZIP"):
+        paths.extend(root.glob(pattern))
+    return tuple(paths)
 
 
 def _archive_candidates(root: Path, take_id: str) -> tuple[Path, ...]:
+    take_component = _safe_component(take_id, "take id")
     unique: dict[str, Path] = {}
-    patterns = (f"*{take_id}*.zip", f"*{take_id}*.ZIP")
-    for pattern in patterns:
-        for candidate in root.rglob(pattern):
+    for candidate in _bounded_archive_paths(root):
+        if take_component not in candidate.name:
+            continue
+        try:
             if candidate.is_symlink() or not candidate.is_file():
                 continue
-            resolved = _inside_root(candidate, root)
-            unique[str(resolved)] = resolved
+        except OSError:
+            continue
+        resolved = _inside_root(candidate, root)
+        unique[str(resolved)] = resolved
     return tuple(unique[key] for key in sorted(unique))
 
 
@@ -118,6 +136,14 @@ def _robot_member_candidates(
     return tuple(selected)
 
 
+def _read_bytes_no_follow(path: Path) -> bytes:
+    flags = os.O_RDONLY
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    with os.fdopen(descriptor, "rb") as handle:
+        return handle.read()
+
+
 def _read_verified_direct(
     candidates: Sequence[Path],
     expected_sha256: str,
@@ -125,7 +151,7 @@ def _read_verified_direct(
     failures = []
     for candidate in candidates:
         try:
-            content = candidate.read_bytes()
+            content = _read_bytes_no_follow(candidate)
         except OSError as error:
             failures.append({"path": str(candidate), "error": type(error).__name__})
             continue

--- a/tests/test_pokeflex_robot_stage_permission_fallback.py
+++ b/tests/test_pokeflex_robot_stage_permission_fallback.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from pathlib import Path
+
+import causal4d_public.pokeflex_robot_stage as robot_stage
+from causal4d_public.pokeflex_realized_load import (
+    PokeFlexRealizedLoadSourceConfig,
+)
+
+
+def _robot_bytes(take_id: str) -> bytes:
+    return json.dumps(
+        [
+            {
+                "frame": "00001",
+                "forces": [0.0, 4.0, 0.0],
+                "T_WT": [
+                    [1.0, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                    [0.0, 0.0, 1.0, 0.0],
+                    [0.0, 0.0, 0.0, 1.0],
+                ],
+                "take_id": take_id,
+            }
+        ],
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _source_qa(
+    config: PokeFlexRealizedLoadSourceConfig,
+    content: dict[str, bytes],
+) -> dict[str, object]:
+    return {
+        "artifact_kind": "PublicPokeFlexSourceQa",
+        "schema_version": 1,
+        "result_sha256": config.expected_source_qa_result_sha256,
+        "source_qa_passed": True,
+        "object_id": config.expected_object_id,
+        "information_boundary": {
+            "opened_take_ids": list(config.expected_development_take_ids),
+            "unopened_take_ids": list(config.forbidden_take_ids),
+            "calibration_take_data_read": False,
+            "target_take_data_read": False,
+        },
+        "capability_gates": {"pose_wrench_contact_candidate_ready": True},
+        "takes": [
+            {
+                "take_id": take_id,
+                "robot_sha256": hashlib.sha256(content[take_id]).hexdigest(),
+            }
+            for take_id in config.expected_development_take_ids
+        ],
+    }
+
+
+def test_permission_denied_direct_files_fall_back_to_verified_archives(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config = PokeFlexRealizedLoadSourceConfig()
+    content = {
+        take_id: _robot_bytes(take_id)
+        for take_id in config.expected_development_take_ids
+    }
+    for take_id, payload in content.items():
+        with zipfile.ZipFile(tmp_path / f"{take_id}.zip", "w") as archive:
+            archive.writestr(f"{take_id}/robot_data.json", payload)
+
+    def deny_direct_read(path: Path) -> bytes:
+        raise PermissionError(13, "Permission denied", str(path))
+
+    monkeypatch.setattr(robot_stage, "_read_bytes_no_follow", deny_direct_read)
+    result = robot_stage.stage_pokeflex_development_robot_records(
+        tmp_path,
+        _source_qa(config, content),
+        tmp_path / "stage",
+        config,
+    )
+
+    assert [record["source_kind"] for record in result["records"]] == [
+        "verified-zip-member"
+    ] * len(config.expected_development_take_ids)
+    assert all(
+        record["candidate_failures"][0]["error"] == "PermissionError"
+        for record in result["records"]
+    )
+    assert result["information_boundary"] == {
+        "development_robot_records_only": True,
+        "development_meshes_read": False,
+        "calibration_take_data_read": False,
+        "target_take_data_read": False,
+        "dataset_modified": False,
+    }

--- a/tests/test_pokeflex_robot_stage_permission_fallback.py
+++ b/tests/test_pokeflex_robot_stage_permission_fallback.py
@@ -74,20 +74,22 @@ def test_permission_denied_direct_files_fall_back_to_verified_archives(
         raise PermissionError(13, "Permission denied", str(path))
 
     monkeypatch.setattr(robot_stage, "_read_bytes_no_follow", deny_direct_read)
+    destination = tmp_path / "stage"
     result = robot_stage.stage_pokeflex_development_robot_records(
         tmp_path,
         _source_qa(config, content),
-        tmp_path / "stage",
+        destination,
         config,
     )
 
     assert [record["source_kind"] for record in result["records"]] == [
         "verified-zip-member"
     ] * len(config.expected_development_take_ids)
-    assert all(
-        record["candidate_failures"][0]["error"] == "PermissionError"
-        for record in result["records"]
-    )
+    for record in result["records"]:
+        take_id = record["take_id"]
+        assert record["archive_member"] == f"{take_id}/robot_data.json"
+        staged = destination / record["staged_path"]
+        assert staged.read_bytes() == content[take_id]
     assert result["information_boundary"] == {
         "development_robot_records_only": True,
         "development_meshes_read": False,


### PR DESCRIPTION
## Failure retained

Exact-main run `33499740476` used the merged ZIP staging adapter but still stopped before parsing a force trajectory. The adapter called `Path.is_file()` while discovering the extracted T1 log, and that metadata operation raised the same permission error before control reached the guarded reader:

`Permission denied: /mnt/lexar4tb/pokeflex/3dPrintedBunny_T1/robot_data.json`

T5 and T2 remained unopened and no scientific metric was computed.

## Fix

- Construct the two authorized direct paths lexically without touching either file.
- Put the actual direct read behind `os.open(..., O_NOFOLLOW)` and the existing `OSError` fallback.
- When the extracted copy is unreadable, continue to the source-QA-bound ZIP member.
- Bound archive discovery to at most two directory levels rather than recursively traversing the 548-GiB tree.
- Keep exact source-QA SHA-256 verification before a byte is admitted to temporary staging.

A focused regression forces `PermissionError` for every direct read and verifies that all five development takes are recovered from exact ZIP members while T5/T2 remain outside the accessed roster.

## Boundary

The estimator, prefix, query, candidate grid, thresholds, comparators, seed and independent units are unchanged. The request-file change is terminal whitespace only and preserves request ID `df02f0e81c3111177b43b9e346d4aafa107a658a66db1bc16b6acf573ec47b74`. No calibration, target or automatic follow-on access is authorized.