### PR TITLE
Index PokeFlex development robot members independently of ZIP filenames

### DIFF
--- a/ops/pokeflex-realized-load-source-gpuserver6000-request.json
+++ b/ops/pokeflex-realized-load-source-gpuserver6000-request.json
@@ -28,3 +28,4 @@
   "source_qa_artifact_path": "milestones/pokeflex-001-source-warp-gate-v1/artifacts/3dPrintedBunny_source_qa_v1.json",
   "stage": "development-source-gate"
 }
+

--- a/src/causal4d_public/pokeflex_robot_stage.py
+++ b/src/causal4d_public/pokeflex_robot_stage.py
@@ -7,7 +7,7 @@ import json
 import os
 import zipfile
 from pathlib import Path, PurePosixPath
-from typing import Any, Mapping, Sequence
+from typing import Any, BinaryIO, Mapping, Sequence
 
 from causal4d_public._pokeflex_realized_load_common import (
     PokeFlexRealizedLoadSourceConfig,
@@ -19,6 +19,19 @@ from causal4d_public._pokeflex_realized_load_common import (
 
 POKEFLEX_ROBOT_STAGE_SCHEMA_VERSION = 1
 POKEFLEX_ROBOT_STAGE_KIND = "PublicPokeFlexRobotRecordStage"
+_MAX_ARCHIVE_DEPTH = 4
+_MAX_ARCHIVE_COUNT = 512
+_MAX_DIRECTORY_COUNT = 4096
+_PRUNED_DIRECTORY_NAMES = frozenset(
+    {
+        "images",
+        "kinect",
+        "meshes",
+        "realsense",
+        "triangle_meshes",
+        "volucam",
+    }
+)
 
 
 def _bytes_sha256(content: bytes) -> str:
@@ -89,65 +102,128 @@ def _direct_robot_candidates(
     )
 
 
-def _bounded_archive_paths(root: Path) -> tuple[Path, ...]:
-    paths = []
-    for pattern in ("*.zip", "*.ZIP", "*/*.zip", "*/*.ZIP", "*/*/*.zip", "*/*/*.ZIP"):
-        paths.extend(root.glob(pattern))
-    return tuple(paths)
+def _relative_display(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return str(path)
 
 
-def _archive_candidates(root: Path, take_id: str) -> tuple[Path, ...]:
-    take_component = _safe_component(take_id, "take id")
-    unique: dict[str, Path] = {}
-    for candidate in _bounded_archive_paths(root):
-        if take_component not in candidate.name:
-            continue
+def _bounded_archive_paths(
+    root: Path,
+) -> tuple[tuple[Path, ...], tuple[dict[str, str], ...]]:
+    """Enumerate ZIP carriers without descending into high-volume modality trees."""
+
+    archives: dict[str, Path] = {}
+    failures: list[dict[str, str]] = []
+    stack: list[tuple[Path, int]] = [(root, 0)]
+    directory_count = 0
+    while stack:
+        directory, depth = stack.pop()
+        directory_count += 1
+        _require(
+            directory_count <= _MAX_DIRECTORY_COUNT,
+            "PokeFlex archive directory scan exceeded its bound",
+        )
         try:
-            if candidate.is_symlink() or not candidate.is_file():
-                continue
-        except OSError:
+            with os.scandir(directory) as iterator:
+                entries = sorted(iterator, key=lambda value: value.name)
+        except OSError as error:
+            failures.append(
+                {
+                    "path": _relative_display(directory, root),
+                    "error": type(error).__name__,
+                }
+            )
             continue
-        resolved = _inside_root(candidate, root)
-        unique[str(resolved)] = resolved
-    return tuple(unique[key] for key in sorted(unique))
+        for entry in entries:
+            try:
+                if entry.is_symlink():
+                    continue
+                if entry.is_file(follow_symlinks=False):
+                    if entry.name.lower().endswith(".zip"):
+                        candidate = _inside_root(Path(entry.path), root)
+                        archives[str(candidate)] = candidate
+                        _require(
+                            len(archives) <= _MAX_ARCHIVE_COUNT,
+                            "PokeFlex archive count exceeded its bound",
+                        )
+                    continue
+                if (
+                    depth < _MAX_ARCHIVE_DEPTH
+                    and entry.is_dir(follow_symlinks=False)
+                    and entry.name.lower() not in _PRUNED_DIRECTORY_NAMES
+                ):
+                    stack.append((Path(entry.path), depth + 1))
+            except OSError as error:
+                failures.append(
+                    {
+                        "path": _relative_display(Path(entry.path), root),
+                        "error": type(error).__name__,
+                    }
+                )
+    ordered = tuple(archives[key] for key in sorted(archives))
+    return ordered, tuple(failures)
 
 
 def _safe_member_path(name: str) -> PurePosixPath:
-    path = PurePosixPath(name)
+    path = PurePosixPath(name.replace("\\", "/"))
     _require(not path.is_absolute(), "archive member is absolute")
     _require(".." not in path.parts, "archive member escapes its root")
     return path
 
 
-def _robot_member_candidates(
-    archive: zipfile.ZipFile,
-    take_id: str,
-) -> tuple[zipfile.ZipInfo, ...]:
-    infos = archive.infolist()
-    names = [info.filename for info in infos]
-    _require(len(names) == len(set(names)), "archive contains duplicate members")
-    selected = []
-    for info in infos:
-        path = _safe_member_path(info.filename)
-        if info.is_dir() or path.name != "robot_data.json":
-            continue
-        if take_id in path.parts or len(path.parts) == 1:
-            selected.append(info)
-    return tuple(selected)
+def _normalized_identifier(value: str) -> str:
+    return "".join(character.lower() for character in value if character.isalnum())
 
 
-def _read_bytes_no_follow(path: Path) -> bytes:
+def _member_take_id(
+    member_path: PurePosixPath,
+    archive_path: Path,
+    expected_take_ids: Sequence[str],
+) -> str | None:
+    expected = {
+        take_id: _normalized_identifier(take_id) for take_id in expected_take_ids
+    }
+    matches = set()
+    for part in member_path.parts[:-1]:
+        normalized = _normalized_identifier(part)
+        for take_id, expected_normalized in expected.items():
+            if normalized == expected_normalized or normalized.endswith(
+                expected_normalized
+            ):
+                matches.add(take_id)
+    if len(matches) == 1:
+        return next(iter(matches))
+    if matches:
+        return None
+    if len(member_path.parts) != 1:
+        return None
+    archive_normalized = _normalized_identifier(archive_path.stem)
+    filename_matches = [
+        take_id
+        for take_id, expected_normalized in expected.items()
+        if archive_normalized.endswith(expected_normalized)
+    ]
+    return filename_matches[0] if len(filename_matches) == 1 else None
+
+
+def _open_binary_no_follow(path: Path) -> BinaryIO:
     flags = os.O_RDONLY
     flags |= getattr(os, "O_NOFOLLOW", 0)
     descriptor = os.open(path, flags)
-    with os.fdopen(descriptor, "rb") as handle:
+    return os.fdopen(descriptor, "rb")
+
+
+def _read_bytes_no_follow(path: Path) -> bytes:
+    with _open_binary_no_follow(path) as handle:
         return handle.read()
 
 
 def _read_verified_direct(
     candidates: Sequence[Path],
     expected_sha256: str,
-) -> tuple[bytes, dict[str, Any]] | None:
+) -> tuple[tuple[bytes, dict[str, Any]] | None, tuple[dict[str, str], ...]]:
     failures = []
     for candidate in candidates:
         try:
@@ -160,61 +236,169 @@ def _read_verified_direct(
             observed == expected_sha256,
             f"readable robot record differs from source QA: {candidate}",
         )
-        return content, {
-            "source_kind": "verified-extracted-file",
-            "source_path": str(candidate),
-            "archive_member": None,
-            "candidate_failures": failures,
-        }
-    return None
+        return (
+            content,
+            {
+                "source_kind": "verified-extracted-file",
+                "source_path": str(candidate),
+                "archive_member": None,
+                "verified_match_count": 1,
+                "direct_candidate_failures": failures,
+            },
+        ), tuple(failures)
+    return None, tuple(failures)
 
 
-def _read_verified_archive(
-    candidates: Sequence[Path],
-    take_id: str,
-    expected_sha256: str,
-) -> tuple[bytes, dict[str, Any]]:
-    matches: list[tuple[bytes, Path, str]] = []
-    failures = []
-    for candidate in candidates:
+def _archive_failure_summary(
+    *,
+    root: Path,
+    archive_paths: Sequence[Path],
+    traversal_failures: Sequence[Mapping[str, str]],
+    archive_failures: Sequence[Mapping[str, Any]],
+    member_counts: Mapping[str, int],
+    payload_read_counts: Mapping[str, int],
+) -> dict[str, Any]:
+    return {
+        "archive_count": len(archive_paths),
+        "archive_path_sample": [
+            _relative_display(path, root) for path in archive_paths[:20]
+        ],
+        "traversal_failure_count": len(traversal_failures),
+        "traversal_failure_sample": list(traversal_failures[:10]),
+        "archive_failure_count": len(archive_failures),
+        "archive_failure_sample": list(archive_failures[:20]),
+        "development_robot_member_metadata_counts": dict(member_counts),
+        "development_robot_member_payload_read_counts": dict(payload_read_counts),
+    }
+
+
+def _read_verified_archive_index(
+    root: Path,
+    expected_hashes: Mapping[str, str],
+) -> tuple[dict[str, tuple[bytes, dict[str, Any]]], dict[str, Any]]:
+    """Index ZIP metadata once and read only exact development robot members."""
+
+    expected_take_ids = tuple(expected_hashes)
+    archive_paths, traversal_failures = _bounded_archive_paths(root)
+    matches: dict[str, list[tuple[bytes, Path, str]]] = {
+        take_id: [] for take_id in expected_take_ids
+    }
+    member_counts = {take_id: 0 for take_id in expected_take_ids}
+    payload_read_counts = {take_id: 0 for take_id in expected_take_ids}
+    archive_failures: list[dict[str, Any]] = []
+    readable_archive_count = 0
+
+    for candidate in archive_paths:
+        display_path = _relative_display(candidate, root)
         try:
-            with zipfile.ZipFile(candidate) as archive:
-                members = _robot_member_candidates(archive, take_id)
-                if len(members) != 1:
-                    failures.append(
-                        {
-                            "path": str(candidate),
-                            "error": "robot-member-count",
-                            "observed": len(members),
-                        }
-                    )
-                    continue
-                member = members[0]
-                content = archive.read(member)
+            with _open_binary_no_follow(candidate) as handle:
+                with zipfile.ZipFile(handle) as archive:
+                    infos = archive.infolist()
+                    names = [info.filename for info in infos]
+                    if len(names) != len(set(names)):
+                        archive_failures.append(
+                            {
+                                "path": display_path,
+                                "error": "duplicate-members",
+                            }
+                        )
+                        continue
+                    indexed: list[tuple[zipfile.ZipInfo, PurePosixPath, str]] = []
+                    invalid_member = None
+                    for info in infos:
+                        try:
+                            member_path = _safe_member_path(info.filename)
+                        except ValueError as error:
+                            invalid_member = str(error)
+                            break
+                        if info.is_dir() or member_path.name != "robot_data.json":
+                            continue
+                        take_id = _member_take_id(
+                            member_path,
+                            candidate,
+                            expected_take_ids,
+                        )
+                        if take_id is not None:
+                            indexed.append((info, member_path, take_id))
+                    if invalid_member is not None:
+                        archive_failures.append(
+                            {
+                                "path": display_path,
+                                "error": "unsafe-member",
+                                "detail": invalid_member,
+                            }
+                        )
+                        continue
+                    readable_archive_count += 1
+                    for info, member_path, take_id in indexed:
+                        member_counts[take_id] += 1
+                        try:
+                            content = archive.read(info)
+                        except (OSError, RuntimeError, zipfile.BadZipFile) as error:
+                            archive_failures.append(
+                                {
+                                    "path": display_path,
+                                    "error": type(error).__name__,
+                                    "take_id": take_id,
+                                }
+                            )
+                            continue
+                        payload_read_counts[take_id] += 1
+                        observed = _bytes_sha256(content)
+                        if observed == expected_hashes[take_id]:
+                            matches[take_id].append(
+                                (content, candidate, member_path.as_posix())
+                            )
+                        else:
+                            archive_failures.append(
+                                {
+                                    "path": display_path,
+                                    "error": "source-qa-digest-mismatch",
+                                    "take_id": take_id,
+                                    "observed_sha256": observed,
+                                }
+                            )
         except (OSError, zipfile.BadZipFile, zipfile.LargeZipFile) as error:
-            failures.append({"path": str(candidate), "error": type(error).__name__})
-            continue
-        observed = _bytes_sha256(content)
-        if observed == expected_sha256:
-            matches.append((content, candidate, member.filename))
-        else:
-            failures.append(
+            archive_failures.append(
                 {
-                    "path": str(candidate),
-                    "error": "source-qa-digest-mismatch",
-                    "observed_sha256": observed,
+                    "path": display_path,
+                    "error": type(error).__name__,
                 }
             )
-    _require(matches, f"no verified readable robot record found for {take_id}")
-    matches.sort(key=lambda value: (str(value[1]), value[2]))
-    content, archive_path, member_name = matches[0]
-    return content, {
-        "source_kind": "verified-zip-member",
-        "source_path": str(archive_path),
-        "archive_member": member_name,
-        "verified_match_count": len(matches),
-        "candidate_failures": failures,
-    }
+
+    summary = _archive_failure_summary(
+        root=root,
+        archive_paths=archive_paths,
+        traversal_failures=traversal_failures,
+        archive_failures=archive_failures,
+        member_counts=member_counts,
+        payload_read_counts=payload_read_counts,
+    )
+    summary["readable_archive_count"] = readable_archive_count
+    summary["archive_central_directories_read"] = True
+    summary["nondevelopment_member_payloads_read"] = False
+
+    missing = [take_id for take_id, values in matches.items() if not values]
+    _require(
+        not missing,
+        "no source-QA-verified archive member for "
+        f"{missing}; carrier diagnostic={json.dumps(summary, sort_keys=True)}",
+    )
+
+    selected: dict[str, tuple[bytes, dict[str, Any]]] = {}
+    for take_id, values in matches.items():
+        values.sort(key=lambda value: (str(value[1]), value[2]))
+        content, archive_path, member_name = values[0]
+        selected[take_id] = (
+            content,
+            {
+                "source_kind": "verified-zip-member",
+                "source_path": str(archive_path),
+                "archive_member": member_name,
+                "verified_match_count": len(values),
+            },
+        )
+    return selected, summary
 
 
 def stage_pokeflex_development_robot_records(
@@ -232,21 +416,44 @@ def stage_pokeflex_development_robot_records(
     destination.mkdir(parents=True)
     expected_hashes = _source_qa_robot_hashes(source_qa, config)
 
+    resolved: dict[str, tuple[bytes, dict[str, Any]]] = {}
+    direct_failures: dict[str, list[dict[str, str]]] = {}
+    for take_id in config.expected_development_take_ids:
+        direct, failures = _read_verified_direct(
+            _direct_robot_candidates(root, config.expected_object_id, take_id),
+            expected_hashes[take_id],
+        )
+        direct_failures[take_id] = list(failures)
+        if direct is not None:
+            resolved[take_id] = direct
+
+    unresolved_hashes = {
+        take_id: expected_hashes[take_id]
+        for take_id in config.expected_development_take_ids
+        if take_id not in resolved
+    }
+    archive_summary: dict[str, Any] = {
+        "archive_scan_required": bool(unresolved_hashes),
+        "archive_central_directories_read": False,
+        "nondevelopment_member_payloads_read": False,
+    }
+    if unresolved_hashes:
+        archive_records, archive_summary = _read_verified_archive_index(
+            root,
+            unresolved_hashes,
+        )
+        for take_id, value in archive_records.items():
+            content, provenance = value
+            provenance["direct_candidate_failures"] = direct_failures[take_id]
+            resolved[take_id] = content, provenance
+
+    _require(
+        set(resolved) == set(config.expected_development_take_ids),
+        "development robot-record staging roster is incomplete",
+    )
     records = []
     for take_id in config.expected_development_take_ids:
-        expected_sha256 = expected_hashes[take_id]
-        direct = _read_verified_direct(
-            _direct_robot_candidates(root, config.expected_object_id, take_id),
-            expected_sha256,
-        )
-        if direct is None:
-            content, provenance = _read_verified_archive(
-                _archive_candidates(root, take_id),
-                take_id,
-                expected_sha256,
-            )
-        else:
-            content, provenance = direct
+        content, provenance = resolved[take_id]
         target = destination / config.expected_object_id / take_id / "robot_data.json"
         target.parent.mkdir(parents=True, exist_ok=False)
         target.write_bytes(content)
@@ -254,7 +461,7 @@ def stage_pokeflex_development_robot_records(
         records.append(
             {
                 "take_id": take_id,
-                "robot_sha256": expected_sha256,
+                "robot_sha256": expected_hashes[take_id],
                 "byte_count": len(content),
                 "staged_path": target.relative_to(destination).as_posix(),
                 **provenance,
@@ -271,9 +478,14 @@ def stage_pokeflex_development_robot_records(
         "dataset_root": str(root),
         "staging_root": str(destination),
         "records": records,
+        "carrier_index": archive_summary,
         "information_boundary": {
             "development_robot_records_only": True,
             "development_meshes_read": False,
+            "archive_central_directory_metadata_read": bool(
+                archive_summary["archive_central_directories_read"]
+            ),
+            "nondevelopment_member_payloads_read": False,
             "calibration_take_data_read": False,
             "target_take_data_read": False,
             "dataset_modified": False,
@@ -304,6 +516,10 @@ def validate_pokeflex_robot_stage(payload: Mapping[str, Any]) -> dict[str, Any]:
     boundary = payload.get("information_boundary", {})
     _require(boundary.get("development_robot_records_only") is True, "stage widened")
     _require(boundary.get("development_meshes_read") is False, "stage read meshes")
+    _require(
+        boundary.get("nondevelopment_member_payloads_read") is False,
+        "stage read nondevelopment payloads",
+    )
     _require(
         boundary.get("calibration_take_data_read") is False,
         "stage opened calibration",

--- a/tests/test_pokeflex_robot_stage.py
+++ b/tests/test_pokeflex_robot_stage.py
@@ -106,14 +106,66 @@ def test_stages_only_verified_development_robot_members(tmp_path: Path) -> None:
         config.expected_development_take_ids
     )
     assert all(row["source_kind"] == "verified-zip-member" for row in result["records"])
-    assert result["information_boundary"]["calibration_take_data_read"] is False
-    assert result["information_boundary"]["target_take_data_read"] is False
-    assert result["information_boundary"]["dataset_modified"] is False
+    assert result["carrier_index"]["archive_count"] == 7
+    boundary = result["information_boundary"]
+    assert boundary["archive_central_directory_metadata_read"] is True
+    assert boundary["nondevelopment_member_payloads_read"] is False
+    assert boundary["calibration_take_data_read"] is False
+    assert boundary["target_take_data_read"] is False
+    assert boundary["dataset_modified"] is False
     for take_id in config.expected_development_take_ids:
         staged = destination / config.expected_object_id / take_id / "robot_data.json"
         assert staged.read_bytes() == content[take_id]
         archive = tmp_path / "poking" / config.expected_object_id / f"{take_id}.zip"
         assert archive.read_bytes() == archive_bytes[take_id]
+
+
+def test_archive_index_does_not_depend_on_archive_filename(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config = PokeFlexRealizedLoadSourceConfig()
+    content = {
+        take_id: _robot_bytes(take_id)
+        for take_id in config.expected_development_take_ids
+    }
+    archive_path = tmp_path / "downloads" / "release-part-042.zip"
+    archive_path.parent.mkdir()
+    with zipfile.ZipFile(archive_path, mode="w") as archive:
+        for take_id, payload in content.items():
+            archive.writestr(f"poking/{take_id}/robot_data.json", payload)
+        for take_id in config.forbidden_take_ids:
+            archive.writestr(
+                f"poking/{take_id}/robot_data.json",
+                b"FORBIDDEN PAYLOAD MUST NOT BE READ",
+            )
+
+    original_read = zipfile.ZipFile.read
+    read_names: list[str] = []
+
+    def tracked_read(archive, name, *args, **kwargs):
+        filename = name.filename if isinstance(name, zipfile.ZipInfo) else str(name)
+        read_names.append(filename)
+        assert not any(take_id in filename for take_id in config.forbidden_take_ids)
+        return original_read(archive, name, *args, **kwargs)
+
+    monkeypatch.setattr(zipfile.ZipFile, "read", tracked_read)
+    result = stage_pokeflex_development_robot_records(
+        tmp_path,
+        _source_qa(config, content),
+        tmp_path / "stage",
+        config,
+    )
+
+    assert set(read_names) == {
+        f"poking/{take_id}/robot_data.json"
+        for take_id in config.expected_development_take_ids
+    }
+    assert all(
+        Path(record["source_path"]).name == "release-part-042.zip"
+        for record in result["records"]
+    )
+    assert result["carrier_index"]["nondevelopment_member_payloads_read"] is False
 
 
 def test_prefers_a_readable_source_qa_bound_extracted_file(tmp_path: Path) -> None:
@@ -137,6 +189,7 @@ def test_prefers_a_readable_source_qa_bound_extracted_file(tmp_path: Path) -> No
     assert all(
         row["source_kind"] == "verified-extracted-file" for row in result["records"]
     )
+    assert result["carrier_index"]["archive_scan_required"] is False
 
 
 def test_rejects_a_robot_member_that_differs_from_source_qa(tmp_path: Path) -> None:
@@ -151,7 +204,7 @@ def test_rejects_a_robot_member_that_differs_from_source_qa(tmp_path: Path) -> N
     with zipfile.ZipFile(archive_path, mode="w") as archive:
         archive.writestr(f"{first}/robot_data.json", b"changed")
 
-    with pytest.raises(ValueError, match="no verified readable robot record"):
+    with pytest.raises(ValueError, match="no source-QA-verified archive member"):
         stage_pokeflex_development_robot_records(
             tmp_path,
             _source_qa(config, content),

--- a/tests/test_pokeflex_robot_stage_permission_fallback.py
+++ b/tests/test_pokeflex_robot_stage_permission_fallback.py
@@ -93,6 +93,8 @@ def test_permission_denied_direct_files_fall_back_to_verified_archives(
     assert result["information_boundary"] == {
         "development_robot_records_only": True,
         "development_meshes_read": False,
+        "archive_central_directory_metadata_read": True,
+        "nondevelopment_member_payloads_read": False,
         "calibration_take_data_read": False,
         "target_take_data_read": False,
         "dataset_modified": False,


### PR DESCRIPTION
## Failure retained

Exact-main source run `33500539435` reached `gpuserver6000`, passed every hosted and self-hosted preflight guard, and then reported:

`no verified readable robot record found for 3dPrintedBunny_T1`

The direct extracted copy remained unreadable. The fallback was still restricted to ZIP filenames containing the literal take ID, so it could not resolve a carrier whose archive name differs from its internal take-member path. No force trajectory was admitted, no metric was computed, and T5/T2 payloads remained unopened.

## Repair

Replace per-take filename guessing with one bounded carrier index:

- enumerate at most 512 ZIP files through at most four directory levels;
- prune high-volume mesh and camera modality trees;
- open ZIP central directories once each and reject unsafe or duplicate member names;
- identify only `robot_data.json` members belonging to T1, T3, T4, T6 or T7;
- read no other member payloads, including T5 and T2;
- require every admitted development member to match the robot SHA-256 already frozen in source-QA result `e09d36db4e1ba8a38c70e112c3af9ab95516ee245302f71a853f36cd2dd0e0e7`;
- select deterministic verified matches and stage them in runner-temporary storage; and
- emit bounded archive/member/failure diagnostics if a source member still cannot be resolved.

The index supports generic chunk/archive names and normalized per-take archive names. Central-directory metadata may be inspected to locate authorized members, but only development robot payload bytes can be read.

## Tests

The focused tests verify:

- generic archive filenames containing all five development members;
- no read of synthetic T2/T5 robot members in the same ZIP;
- exact source-QA hash admission;
- source archive byte noninterference;
- direct-file preference when readable;
- permission-denied direct fallback; and
- failure on a hash-mismatched development member.

## Scientific boundary

The estimator, six-frame factual prefix, 48-frame query, candidate grid, comparators, source thresholds, bootstrap seed and complete-take analysis units are unchanged. The request-file edit is terminal whitespace only and preserves request ID `df02f0e81c3111177b43b9e346d4aafa107a658a66db1bc16b6acf573ec47b74`. Calibration T5, target T2 and automatic follow-on remain disabled.