### PR TITLE
Use the frozen PokeFlex public poking-archive root

### DIFF
--- a/ops/pokeflex-realized-load-source-gpuserver6000-request.json
+++ b/ops/pokeflex-realized-load-source-gpuserver6000-request.json
@@ -28,4 +28,3 @@
   "source_qa_artifact_path": "milestones/pokeflex-001-source-warp-gate-v1/artifacts/3dPrintedBunny_source_qa_v1.json",
   "stage": "development-source-gate"
 }
-

--- a/src/causal4d_public/cli/pokeflex_realized_load_source.py
+++ b/src/causal4d_public/cli/pokeflex_realized_load_source.py
@@ -20,6 +20,12 @@ from causal4d_public.pokeflex_robot_stage import (
 )
 
 
+def _official_public_archive_root(dataset_root: str | Path) -> Path:
+    """Return the frozen public poking-archive root below the mounted dataset."""
+
+    return Path(dataset_root).resolve() / "poking"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("dataset_root")
@@ -32,12 +38,13 @@ def main() -> int:
         config = load_realized_load_policy(args.policy)
         output = Path(args.output_dir).resolve()
         output.mkdir(parents=True, exist_ok=True)
+        archive_root = _official_public_archive_root(args.dataset_root)
         with tempfile.TemporaryDirectory(
             prefix="causal4d-pokeflex-robot-stage-"
         ) as temporary:
             stage_root = Path(temporary) / "dataset"
             stage = stage_pokeflex_development_robot_records(
-                args.dataset_root,
+                archive_root,
                 source_qa,
                 stage_root,
                 config,

--- a/tests/test_pokeflex_official_archive_root.py
+++ b/tests/test_pokeflex_official_archive_root.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+from causal4d_public.cli.pokeflex_realized_load_source import (
+    _official_public_archive_root,
+)
+
+
+def test_pokeflex_realized_load_uses_the_frozen_poking_archive_root() -> None:
+    mounted = Path("/mnt/lexar4tb/pokeflex")
+    assert _official_public_archive_root(mounted) == mounted / "poking"


### PR DESCRIPTION
## Failure retained

Exact-main source run `33501757534` produced the first bounded carrier diagnostic from the real mount. It showed:

- `archive_count: 0`;
- root traversal failed with `PermissionError` at `/mnt/lexar4tb/pokeflex`;
- no development robot member payload was read;
- no scientific metric was computed; and
- T5/T2 remained unopened.

The failure was caused by passing the non-listable dataset parent to the staging adapter.

## Frozen carrier provenance

The existing BayesianPhysTwin PokeFlex inventories register the official public poking archives under:

`/mnt/lexar4tb/pokeflex/poking`

with the object/take convention `<Object>/<Take>.zip`. This is the carrier root used by prior source-only PokeFlex work on `gpuserver6000`.

## Fix

The realized-load CLI now derives exactly `dataset_root / "poking"` and passes that public archive root to the already merged bounded, checksum-bound staging adapter. The mounted request root itself remains `/mnt/lexar4tb/pokeflex`; runtime provenance continues to record it.

A focused unit test locks the derivation. The request file changes only terminal whitespace and retains canonical request ID:

`df02f0e81c3111177b43b9e346d4aafa107a658a66db1bc16b6acf573ec47b74`

## Scientific and access boundary

The estimator, six-frame factual prefix, 48-frame query, candidate grid, thresholds, comparators, seed and complete-take units are unchanged. Only T1, T3, T4, T6 and T7 robot payloads may be admitted after exact source-QA SHA-256 verification. Calibration T5, target T2 and automatic follow-on remain disabled.