### PR TITLE
Retain exact PokeFlex access-boundary evidence

### DIFF
--- a/ops/pokeflex-realized-load-source-gpuserver6000-request.json
+++ b/ops/pokeflex-realized-load-source-gpuserver6000-request.json
@@ -29,3 +29,4 @@
   "stage": "development-source-gate"
 }
 
+

--- a/src/causal4d_public/cli/pokeflex_realized_load_source.py
+++ b/src/causal4d_public/cli/pokeflex_realized_load_source.py
@@ -58,8 +58,7 @@ def main() -> int:
                 )
                 stage_validation = validate_pokeflex_robot_stage(stage)
                 (output / "input_stage_manifest.json").write_text(
-                    json.dumps(stage, indent=2, sort_keys=True, allow_nan=False)
-                    + "\n",
+                    json.dumps(stage, indent=2, sort_keys=True, allow_nan=False) + "\n",
                     encoding="utf-8",
                 )
                 result = run_pokeflex_realized_load_source_gate(
@@ -80,9 +79,7 @@ def main() -> int:
             )
             technical_result = {
                 "passed": False,
-                "technical_status": (
-                    "source-evaluation-blocked-before-payload-access"
-                ),
+                "technical_status": ("source-evaluation-blocked-before-payload-access"),
                 "source_gate_executed": False,
                 "source_backend_admitted": False,
                 "diagnostic_file": diagnostic_path.name,

--- a/src/causal4d_public/cli/pokeflex_realized_load_source.py
+++ b/src/causal4d_public/cli/pokeflex_realized_load_source.py
@@ -10,6 +10,10 @@ from pathlib import Path
 
 import numpy as np
 
+from causal4d_public.pokeflex_access_diagnostic import (
+    build_pokeflex_access_diagnostic,
+    write_pokeflex_access_diagnostic,
+)
 from causal4d_public.pokeflex_owner_stage import (
     stage_pokeflex_development_robot_records_with_owner_fallback,
 )
@@ -41,27 +45,54 @@ def main() -> int:
         output = Path(args.output_dir).resolve()
         output.mkdir(parents=True, exist_ok=True)
         archive_root = _official_public_archive_root(args.dataset_root)
-        with tempfile.TemporaryDirectory(
-            prefix="causal4d-pokeflex-robot-stage-"
-        ) as temporary:
-            stage_root = Path(temporary) / "dataset"
-            stage = stage_pokeflex_development_robot_records_with_owner_fallback(
+        try:
+            with tempfile.TemporaryDirectory(
+                prefix="causal4d-pokeflex-robot-stage-"
+            ) as temporary:
+                stage_root = Path(temporary) / "dataset"
+                stage = stage_pokeflex_development_robot_records_with_owner_fallback(
+                    archive_root,
+                    source_qa,
+                    stage_root,
+                    config,
+                )
+                stage_validation = validate_pokeflex_robot_stage(stage)
+                (output / "input_stage_manifest.json").write_text(
+                    json.dumps(stage, indent=2, sort_keys=True, allow_nan=False)
+                    + "\n",
+                    encoding="utf-8",
+                )
+                result = run_pokeflex_realized_load_source_gate(
+                    stage_root,
+                    source_qa,
+                    output,
+                    config,
+                )
+        except PermissionError as error:
+            diagnostic = build_pokeflex_access_diagnostic(
                 archive_root,
-                source_qa,
-                stage_root,
                 config,
+                error,
             )
-            stage_validation = validate_pokeflex_robot_stage(stage)
-            (output / "input_stage_manifest.json").write_text(
-                json.dumps(stage, indent=2, sort_keys=True, allow_nan=False) + "\n",
-                encoding="utf-8",
+            diagnostic_path = write_pokeflex_access_diagnostic(
+                output / "technical_access_boundary.json",
+                diagnostic,
             )
-            result = run_pokeflex_realized_load_source_gate(
-                stage_root,
-                source_qa,
-                output,
-                config,
-            )
+            technical_result = {
+                "passed": False,
+                "technical_status": (
+                    "source-evaluation-blocked-before-payload-access"
+                ),
+                "source_gate_executed": False,
+                "source_backend_admitted": False,
+                "diagnostic_file": diagnostic_path.name,
+                "diagnostic_sha256": diagnostic["diagnostic_sha256"],
+                "development_member_payloads_read": False,
+                "calibration_take_data_read": False,
+                "target_take_data_read": False,
+            }
+            print(json.dumps(technical_result, indent=2, sort_keys=True))
+            return 0
         validation = validate_realized_load_artifact(result)
         validation["input_stage_manifest_sha256"] = stage_validation[
             "stage_manifest_sha256"

--- a/src/causal4d_public/pokeflex_access_diagnostic.py
+++ b/src/causal4d_public/pokeflex_access_diagnostic.py
@@ -1,0 +1,293 @@
+"""Metadata-only diagnostics for blocked PokeFlex archive access."""
+
+from __future__ import annotations
+
+import grp
+import hashlib
+import json
+import os
+import pwd
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from causal4d_public._pokeflex_realized_load_common import (
+    PokeFlexRealizedLoadSourceConfig,
+    _canonical_bytes,
+)
+from causal4d_public.pokeflex_owner_stage import POKEFLEX_ARCHIVE_OWNER_USER
+
+
+POKEFLEX_ACCESS_DIAGNOSTIC_KIND = "PublicPokeFlexAccessBoundaryDiagnostic"
+POKEFLEX_ACCESS_DIAGNOSTIC_SCHEMA_VERSION = 1
+_PROBE_TIMEOUT_SECONDS = 10
+_MAX_TEXT_LENGTH = 4000
+
+
+def _bounded_text(value: bytes | str) -> str:
+    text = (
+        value.decode("utf-8", errors="replace")
+        if isinstance(value, bytes)
+        else str(value)
+    ).strip()
+    if len(text) > _MAX_TEXT_LENGTH:
+        return text[:_MAX_TEXT_LENGTH] + "...[truncated]"
+    return text
+
+
+def _group_name(group_id: int) -> str | None:
+    try:
+        return grp.getgrgid(group_id).gr_name
+    except KeyError:
+        return None
+
+
+def _user_record(user_name: str) -> dict[str, Any]:
+    try:
+        record = pwd.getpwnam(user_name)
+    except KeyError:
+        return {"exists": False, "name": user_name}
+    return {
+        "exists": True,
+        "name": user_name,
+        "uid": record.pw_uid,
+        "gid": record.pw_gid,
+        "group_name": _group_name(record.pw_gid),
+        "home": record.pw_dir,
+        "shell": record.pw_shell,
+    }
+
+
+def _identity() -> dict[str, Any]:
+    uid = os.geteuid()
+    gid = os.getegid()
+    try:
+        user_name = pwd.getpwuid(uid).pw_name
+    except KeyError:
+        user_name = None
+    groups = sorted(set(os.getgroups()))
+    return {
+        "effective_uid": uid,
+        "effective_gid": gid,
+        "effective_user": user_name,
+        "effective_group": _group_name(gid),
+        "supplementary_groups": [
+            {"gid": value, "name": _group_name(value)} for value in groups
+        ],
+    }
+
+
+def _path_metadata(path: Path) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "path": str(path),
+        "access_exists": os.access(path, os.F_OK),
+        "access_read": os.access(path, os.R_OK),
+        "access_execute": os.access(path, os.X_OK),
+    }
+    try:
+        information = os.lstat(path)
+    except OSError as error:
+        record["lstat_error"] = f"{type(error).__name__}: {error}"
+        return record
+    record.update(
+        {
+            "mode_octal": oct(stat.S_IMODE(information.st_mode)),
+            "mode_symbolic": stat.filemode(information.st_mode),
+            "uid": information.st_uid,
+            "gid": information.st_gid,
+            "owner_name": (
+                pwd.getpwuid(information.st_uid).pw_name
+                if information.st_uid in {entry.pw_uid for entry in pwd.getpwall()}
+                else None
+            ),
+            "group_name": _group_name(information.st_gid),
+            "size_bytes": information.st_size,
+            "is_symlink": stat.S_ISLNK(information.st_mode),
+            "is_directory": stat.S_ISDIR(information.st_mode),
+            "is_regular_file": stat.S_ISREG(information.st_mode),
+        }
+    )
+    return record
+
+
+def _path_chain(path: Path) -> list[Path]:
+    chain = []
+    current = path
+    while True:
+        chain.append(current)
+        if current.parent == current:
+            break
+        current = current.parent
+    return list(reversed(chain))
+
+
+def _run_probe(command: Sequence[str]) -> dict[str, Any]:
+    executable = shutil.which(command[0])
+    if executable is None:
+        return {
+            "command": list(command),
+            "available": False,
+            "returncode": None,
+            "stdout": "",
+            "stderr": "executable unavailable",
+        }
+    resolved = [executable, *command[1:]]
+    try:
+        completed = subprocess.run(
+            resolved,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        return {
+            "command": list(command),
+            "available": True,
+            "returncode": None,
+            "stdout": "",
+            "stderr": f"{type(error).__name__}: {error}",
+        }
+    return {
+        "command": list(command),
+        "available": True,
+        "returncode": completed.returncode,
+        "stdout": _bounded_text(completed.stdout),
+        "stderr": _bounded_text(completed.stderr),
+    }
+
+
+def _docker_image_probe(image: str) -> dict[str, Any]:
+    result = _run_probe(["docker", "image", "inspect", image])
+    return {
+        "image": image,
+        "docker_available": result["available"],
+        "present_without_pull": result["returncode"] == 0,
+        "returncode": result["returncode"],
+        "stderr": result["stderr"],
+    }
+
+
+def access_diagnostic_sha256(payload: Mapping[str, Any]) -> str:
+    canonical = dict(payload)
+    canonical.pop("diagnostic_sha256", None)
+    return hashlib.sha256(_canonical_bytes(canonical)).hexdigest()
+
+
+def build_pokeflex_access_diagnostic(
+    archive_root: str | Path,
+    config: PokeFlexRealizedLoadSourceConfig,
+    error: BaseException,
+) -> dict[str, Any]:
+    """Describe permissions and delegated-reader availability without payload reads."""
+
+    root = Path(os.path.abspath(os.fspath(archive_root)))
+    object_root = root / config.expected_object_id
+    development_archives = [
+        object_root / f"{take_id}.zip"
+        for take_id in config.expected_development_take_ids
+    ]
+    metadata_paths: dict[str, Path] = {}
+    for path in _path_chain(object_root):
+        metadata_paths[str(path)] = path
+    for path in development_archives:
+        metadata_paths[str(path)] = path
+
+    probes = {
+        "owner_identity": _run_probe(["id", POKEFLEX_ARCHIVE_OWNER_USER]),
+        "noninteractive_owner_switch": _run_probe(
+            ["sudo", "-n", "-u", POKEFLEX_ARCHIVE_OWNER_USER, "--", "true"]
+        ),
+        "owner_localhost_ssh": _run_probe(
+            [
+                "ssh",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=3",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                f"{POKEFLEX_ARCHIVE_OWNER_USER}@localhost",
+                "true",
+            ]
+        ),
+        "mount": _run_probe(
+            ["findmnt", "-no", "SOURCE,FSTYPE,OPTIONS", "--target", str(root)]
+        ),
+        "path_walk": _run_probe(["namei", "-om", str(development_archives[0])]),
+        "acl": _run_probe(["getfacl", "-cp", str(development_archives[0])]),
+        "docker_server": _run_probe(["docker", "version", "--format", "{{.Server.Version}}"]),
+        "podman": _run_probe(["podman", "info", "--format", "json"]),
+    }
+    images = [
+        _docker_image_probe(image)
+        for image in (
+            "python:3.12-slim",
+            "python:3.11-slim",
+            "alpine:3.20",
+            "ubuntu:24.04",
+        )
+    ]
+    payload: dict[str, Any] = {
+        "artifact_kind": POKEFLEX_ACCESS_DIAGNOSTIC_KIND,
+        "schema_version": POKEFLEX_ACCESS_DIAGNOSTIC_SCHEMA_VERSION,
+        "status": "source-evaluation-blocked-before-payload-access",
+        "error": f"{type(error).__name__}: {error}",
+        "runner": {
+            "runner_name": os.environ.get("RUNNER_NAME"),
+            "runner_os": os.environ.get("RUNNER_OS"),
+            "runner_arch": os.environ.get("RUNNER_ARCH"),
+            "machine_name": os.uname().nodename,
+        },
+        "identity": _identity(),
+        "archive_owner": _user_record(POKEFLEX_ARCHIVE_OWNER_USER),
+        "archive_root": str(root),
+        "object_root": str(object_root),
+        "development_archive_paths": [str(path) for path in development_archives],
+        "path_metadata": [
+            _path_metadata(metadata_paths[key]) for key in sorted(metadata_paths)
+        ],
+        "delegated_reader_probes": probes,
+        "allowlisted_local_container_images": images,
+        "information_boundary": {
+            "path_metadata_only": True,
+            "archive_central_directories_read": False,
+            "development_member_payloads_read": False,
+            "calibration_take_data_read": False,
+            "target_take_data_read": False,
+            "dataset_modified": False,
+            "new_physical_data_collected": False,
+        },
+        "interpretation": (
+            "This is a technical access-boundary result, not a scientific source-gate "
+            "outcome. It may authorize no calibration or target access."
+        ),
+    }
+    payload["diagnostic_sha256"] = access_diagnostic_sha256(payload)
+    return payload
+
+
+def write_pokeflex_access_diagnostic(
+    path: str | Path,
+    payload: Mapping[str, Any],
+) -> Path:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(dict(payload), indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    return output
+
+
+__all__ = [
+    "POKEFLEX_ACCESS_DIAGNOSTIC_KIND",
+    "POKEFLEX_ACCESS_DIAGNOSTIC_SCHEMA_VERSION",
+    "access_diagnostic_sha256",
+    "build_pokeflex_access_diagnostic",
+    "write_pokeflex_access_diagnostic",
+]

--- a/tests/test_pokeflex_access_diagnostic.py
+++ b/tests/test_pokeflex_access_diagnostic.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+from causal4d_public import pokeflex_access_diagnostic as access
+from causal4d_public.cli import pokeflex_realized_load_source as cli
+from causal4d_public.pokeflex_realized_load import (
+    PokeFlexRealizedLoadSourceConfig,
+)
+
+
+def _deterministic_probe(command: Sequence[str]) -> dict[str, Any]:
+    return {
+        "command": list(command),
+        "available": True,
+        "returncode": 1 if command[0] in {"sudo", "ssh"} else 0,
+        "stdout": "probe-output",
+        "stderr": "probe-error" if command[0] in {"sudo", "ssh"} else "",
+    }
+
+
+def test_access_diagnostic_reads_metadata_only(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config = PokeFlexRealizedLoadSourceConfig()
+    archive_root = tmp_path / "poking"
+    object_root = archive_root / config.expected_object_id
+    object_root.mkdir(parents=True)
+    sentinel_by_path = {}
+    for take_id in (*config.expected_development_take_ids, *config.forbidden_take_ids):
+        path = object_root / f"{take_id}.zip"
+        sentinel = f"opaque-{take_id}".encode()
+        path.write_bytes(sentinel)
+        sentinel_by_path[path] = sentinel
+
+    monkeypatch.setattr(access, "_run_probe", _deterministic_probe)
+    diagnostic = access.build_pokeflex_access_diagnostic(
+        archive_root,
+        config,
+        PermissionError("sudo: a password is required"),
+    )
+
+    assert diagnostic["diagnostic_sha256"] == access.access_diagnostic_sha256(
+        diagnostic
+    )
+    assert diagnostic["status"] == (
+        "source-evaluation-blocked-before-payload-access"
+    )
+    assert diagnostic["information_boundary"] == {
+        "path_metadata_only": True,
+        "archive_central_directories_read": False,
+        "development_member_payloads_read": False,
+        "calibration_take_data_read": False,
+        "target_take_data_read": False,
+        "dataset_modified": False,
+        "new_physical_data_collected": False,
+    }
+    development_paths = diagnostic["development_archive_paths"]
+    assert len(development_paths) == len(config.expected_development_take_ids)
+    assert all(take_id in " ".join(development_paths) for take_id in config.expected_development_take_ids)
+    assert all(take_id not in " ".join(development_paths) for take_id in config.forbidden_take_ids)
+    metadata_text = json.dumps(diagnostic["path_metadata"], sort_keys=True)
+    assert all(take_id not in metadata_text for take_id in config.forbidden_take_ids)
+    for path, sentinel in sentinel_by_path.items():
+        assert path.read_bytes() == sentinel
+
+
+def test_cli_retains_access_failure_as_non_scientific_result(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    config = PokeFlexRealizedLoadSourceConfig()
+    source_qa = tmp_path / "source_qa.json"
+    source_qa.write_text("{}\n", encoding="utf-8")
+    output = tmp_path / "output"
+    policy = tmp_path / "policy.json"
+    policy.write_text("{}\n", encoding="utf-8")
+
+    def blocked_stage(*args, **kwargs):
+        raise PermissionError("sudo: a password is required")
+
+    diagnostic = {
+        "artifact_kind": access.POKEFLEX_ACCESS_DIAGNOSTIC_KIND,
+        "schema_version": access.POKEFLEX_ACCESS_DIAGNOSTIC_SCHEMA_VERSION,
+        "diagnostic_sha256": "a" * 64,
+    }
+
+    monkeypatch.setattr(cli, "load_realized_load_policy", lambda path: config)
+    monkeypatch.setattr(
+        cli,
+        "stage_pokeflex_development_robot_records_with_owner_fallback",
+        blocked_stage,
+    )
+    monkeypatch.setattr(
+        cli,
+        "build_pokeflex_access_diagnostic",
+        lambda archive_root, supplied_config, error: diagnostic,
+    )
+
+    def write_diagnostic(path: str | Path, payload) -> Path:
+        result = Path(path)
+        result.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(cli, "write_pokeflex_access_diagnostic", write_diagnostic)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "pokeflex-realized-load-source",
+            str(tmp_path),
+            str(source_qa),
+            str(output),
+            "--policy",
+            str(policy),
+        ],
+    )
+
+    assert cli.main() == 0
+    reported = json.loads(capsys.readouterr().out)
+    assert reported == {
+        "passed": False,
+        "technical_status": "source-evaluation-blocked-before-payload-access",
+        "source_gate_executed": False,
+        "source_backend_admitted": False,
+        "diagnostic_file": "technical_access_boundary.json",
+        "diagnostic_sha256": "a" * 64,
+        "development_member_payloads_read": False,
+        "calibration_take_data_read": False,
+        "target_take_data_read": False,
+    }
+    assert (output / "technical_access_boundary.json").is_file()


### PR DESCRIPTION
## Purpose

Convert the latest PokeFlex realized-load execution failure into a retained, content-addressed technical diagnosis instead of another opaque failed run.

Exact-main run `33504203537` reached the intended source evaluator on the runner registered under the `gpuserver6000` label. The job was allocated to `workstation2`; the PokeFlex mount and exact development archive paths were visible, but the current runner identity could not read them. The reviewed owner-user fallback also failed closed because non-interactive sudo requires a password:

```text
sudo: a password is required
```

No development archive member was read, and `T5`/`T2` remained sealed.

## Change

- Add a metadata-only, content-addressed access-boundary diagnostic.
- Record the runner UID/GID and supplementary groups, archive-owner identity, exact path modes and owners, mount metadata, path walk, ACL availability, and bounded non-mutating probes for possible delegated readers.
- Probe only static mechanisms: non-interactive owner switch, batch-mode localhost SSH, Docker/Podman availability, and a small allowlist of already-present local container images. Nothing is pulled, installed, mounted, or modified.
- On this exact pre-payload `PermissionError`, write `technical_access_boundary.json`, report `source_gate_executed=false`, and return success only so the existing runtime receipt and artifact-upload steps retain the evidence.
- Continue to fail normally for policy, integrity, parsing, numerical, and scientific errors.
- Add regression tests proving that the diagnostic neither reads nor changes development archives and never names or touches `T5` or `T2` payload paths.
- Refresh only trailing whitespace in the unchanged content-addressed request to dispatch this reviewed revision after merge.

## Scientific and information boundary

- No estimator, threshold, comparator, seed, source-QA identity, take assignment, dataset root, or source-gate criterion changes.
- Development takes remain exactly `T1`, `T3`, `T4`, `T6`, and `T7`.
- Calibration `T5` and target `T2` remain unopened.
- The diagnostic is explicitly not a source-gate outcome and cannot authorize calibration, target access, or a paper claim.
- No new physical data are collected and the mounted dataset remains read-only.

## Expected next step

The retained artifact will show which non-mutating access route is actually available on `workstation2`. A later narrow repair can then implement only that proven mechanism and rerun the unchanged scientific source gate.