### PR TITLE
Run the frozen PokeFlex source gate from a verified gpuserver4090 cache

### DIFF
--- a/.github/workflows/public-realworld-probe-gpuserver4090.yml
+++ b/.github/workflows/public-realworld-probe-gpuserver4090.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: public-realworld-probe-gpuserver4090
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   probe:
@@ -46,6 +46,10 @@ jobs:
           assert request["enabled"] is True
           assert request["runner"] == "gpuserver4090"
           assert request["public_data_only"] is True
+          assert request["request_id"] == (
+              "2026-09-01-public-realworld-probe-v4-"
+              "pokeflex-cache-source-gate"
+          )
           discovery = request["pokeflex_replica_discovery"]
           assert discovery == {
               "cache_root": (
@@ -63,6 +67,22 @@ jobs:
               "enabled": True,
               "source_qa_result_sha256": (
                   "e09d36db4e1ba8a38c70e112c3af9ab95516ee245302f71a853f36cd2dd0e0e7"
+              ),
+              "target_take_data_allowed": False,
+          }
+          cached_gate = request["pokeflex_cached_source_gate"]
+          assert cached_gate == {
+              "automatic_follow_on_allowed": False,
+              "calibration_take_data_allowed": False,
+              "enabled": True,
+              "policy_path": (
+                  "configs/causal4d_public/"
+                  "pokeflex_realized_load_source_v1.json"
+              ),
+              "run_only_when_cache_verified": True,
+              "source_qa_artifact_path": (
+                  "milestones/pokeflex-001-source-warp-gate-v1/artifacts/"
+                  "3dPrintedBunny_source_qa_v1.json"
               ),
               "target_take_data_allowed": False,
           }
@@ -130,6 +150,74 @@ jobs:
             2>&1 | tee \
               public-realworld-probe/pokeflex-development-replica.log
 
+      - name: Select numerical runtime only for a verified complete cache
+        shell: bash
+        run: |
+          set -euo pipefail
+          readarray -t fields < <("${PROBE_PYTHON}" - <<'PY'
+          import json
+          from pathlib import Path
+
+          result = json.loads(
+              Path(
+                  "public-realworld-probe/pokeflex-development-replica.json"
+              ).read_text()
+          )
+          ready = result.get("complete") is True and result.get("cache_verified") is True
+          print("1" if ready else "0")
+          print(result.get("cache_root", ""))
+          PY
+          )
+          ready="${fields[0]}"
+          cache_root="${fields[1]}"
+          echo "POKEFLEX_CACHE_READY=${ready}" >> "${GITHUB_ENV}"
+          echo "POKEFLEX_CACHE_ROOT=${cache_root}" >> "${GITHUB_ENV}"
+          if [[ "${ready}" != "1" ]]; then
+            echo "Exact five-log cache is incomplete; source gate remains closed."
+            exit 0
+          fi
+          selected=""
+          for candidate in \
+            /opt/pyvenv/bin/python python3.12 python3.11 python3.10 \
+            /usr/bin/python3 python3; do
+            command -v "${candidate}" >/dev/null 2>&1 || continue
+            if "${candidate}" - <<'PY'
+          import sys
+          if sys.version_info < (3, 10):
+              raise SystemExit(1)
+          import numpy
+          major, minor = map(int, numpy.__version__.split(".")[:2])
+          if (major, minor) < (1, 24):
+              raise SystemExit(1)
+          PY
+            then
+              selected="$(command -v "${candidate}")"
+              break
+            fi
+          done
+          test -n "${selected}"
+          echo "POKEFLEX_EVAL_PYTHON=${selected}" >> "${GITHUB_ENV}"
+          "${selected}" --version
+          "${selected}" -c 'import numpy; print("numpy", numpy.__version__)'
+
+      - name: Run frozen realized-load source gate from verified cache
+        if: env.POKEFLEX_CACHE_READY == '1'
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="public-realworld-probe/pokeflex-realized-load-source-v1"
+          mkdir -p "${output}"
+          PYTHONPATH=src "${POKEFLEX_EVAL_PYTHON}" \
+            scripts/remote/evaluate_pokeflex_cached_source_gpuserver4090.py \
+            --discovery \
+              public-realworld-probe/pokeflex-development-replica.json \
+            --source-qa \
+              milestones/pokeflex-001-source-warp-gate-v1/artifacts/3dPrintedBunny_source_qa_v1.json \
+            --policy \
+              configs/causal4d_public/pokeflex_realized_load_source_v1.json \
+            --output-dir "${output}" \
+            2>&1 | tee "${output}/run.log"
+
       - name: Record runner provenance
         if: always()
         shell: bash
@@ -143,6 +231,9 @@ jobs:
             echo "repository=${GITHUB_REPOSITORY}"
             echo "commit=${GITHUB_SHA}"
             echo "workflow_run_id=${GITHUB_RUN_ID}"
+            echo "pokeflex_cache_ready=${POKEFLEX_CACHE_READY:-unknown}"
+            echo "pokeflex_cache_root=${POKEFLEX_CACHE_ROOT:-unknown}"
+            echo "pokeflex_eval_python=${POKEFLEX_EVAL_PYTHON:-not-selected}"
             uname -a
             nvidia-smi -L || true
             df -h /mnt/seagate10tb || true
@@ -174,6 +265,24 @@ jobs:
           print(f"- Missing: `{', '.join(result.get('missing_take_ids', [])) or 'none'}`")
           print(f"- Cache verified: `{result.get('cache_verified')}`")
           print("- Calibration T5 and target T2 payloads were not read.")
+          PY
+          fi
+          decision="public-realworld-probe/pokeflex-realized-load-source-v1/cached_source_gate_decision.json"
+          if [[ -f "${decision}" ]]; then
+            DECISION_PATH="${decision}" \
+              "${POKEFLEX_EVAL_PYTHON:-${PROBE_PYTHON:-python3}}" \
+              - <<'PY' >> "${GITHUB_STEP_SUMMARY}"
+          import json
+          import os
+          from pathlib import Path
+
+          result = json.loads(Path(os.environ["DECISION_PATH"]).read_text())
+          print("\n### PokeFlex realized-load source gate")
+          print()
+          print(f"- Executed: `{result['source_gate_executed']}`")
+          print(f"- Decision: `{result['status']}`")
+          print(f"- Backend admitted: `{result['source_backend_admitted']}`")
+          print("- Automatic calibration and target follow-on remain disabled.")
           PY
           fi
 

--- a/.github/workflows/temporary-format-pokeflex-cached-source-gate.yml
+++ b/.github/workflows/temporary-format-pokeflex-cached-source-gate.yml
@@ -1,0 +1,58 @@
+name: Materialize cached PokeFlex source-gate formatting
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/temporary-format-pokeflex-cached-source-gate.yml"
+      - "scripts/remote/evaluate_pokeflex_cached_source_gpuserver4090.py"
+      - "src/causal4d_public/pokeflex_cached_source_gate.py"
+      - "tests/test_pokeflex_cached_source_gate.py"
+
+permissions:
+  contents: write
+
+jobs:
+  format:
+    name: Materialize and commit canonical Ruff output
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out pull-request branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 1
+          persist-credentials: true
+          clean: true
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Install exact formatter
+        run: python -m pip install "ruff==0.16.5"
+      - name: Materialize canonical formatting
+        run: |
+          python -m ruff format \
+            scripts/remote/evaluate_pokeflex_cached_source_gpuserver4090.py \
+            src/causal4d_public/pokeflex_cached_source_gate.py \
+            tests/test_pokeflex_cached_source_gate.py
+      - name: Commit canonical bytes when needed
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git add -- \
+            scripts/remote/evaluate_pokeflex_cached_source_gpuserver4090.py \
+            src/causal4d_public/pokeflex_cached_source_gate.py \
+            tests/test_pokeflex_cached_source_gate.py
+          if git diff --cached --quiet; then
+            echo "Canonical formatting is already committed."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Apply canonical cached PokeFlex source-gate formatting"
+          git push origin "HEAD:${HEAD_REF}"

--- a/ops/public-realworld-probe-gpuserver4090-request.json
+++ b/ops/public-realworld-probe-gpuserver4090-request.json
@@ -3,7 +3,7 @@
   "enabled": true,
   "runner": "gpuserver4090",
   "public_data_only": true,
-  "request_id": "2026-09-01-public-realworld-probe-v3-pokeflex-development-replica",
+  "request_id": "2026-09-01-public-realworld-probe-v4-pokeflex-cache-source-gate",
   "pokeflex_replica_discovery": {
     "cache_root": "/home/github-runner/.cache/datasets/pokeflex-causal4d-realized-load-v1",
     "calibration_take_data_allowed": false,
@@ -16,6 +16,15 @@
     ],
     "enabled": true,
     "source_qa_result_sha256": "e09d36db4e1ba8a38c70e112c3af9ab95516ee245302f71a853f36cd2dd0e0e7",
+    "target_take_data_allowed": false
+  },
+  "pokeflex_cached_source_gate": {
+    "automatic_follow_on_allowed": false,
+    "calibration_take_data_allowed": false,
+    "enabled": true,
+    "policy_path": "configs/causal4d_public/pokeflex_realized_load_source_v1.json",
+    "run_only_when_cache_verified": true,
+    "source_qa_artifact_path": "milestones/pokeflex-001-source-warp-gate-v1/artifacts/3dPrintedBunny_source_qa_v1.json",
     "target_take_data_allowed": false
   }
 }

--- a/scripts/remote/evaluate_pokeflex_cached_source_gpuserver4090.py
+++ b/scripts/remote/evaluate_pokeflex_cached_source_gpuserver4090.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Run the frozen PokeFlex source gate from an exact verified cache."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))
+
+from causal4d_public.pokeflex_cached_source_gate import (  # noqa: E402
+    run_cached_pokeflex_source_gate,
+    validate_cached_source_gate_decision,
+)
+from causal4d_public.pokeflex_realized_load import (  # noqa: E402
+    load_realized_load_policy,
+)
+
+
+DEFAULT_DISCOVERY = ROOT / (
+    "public-realworld-probe/pokeflex-development-replica.json"
+)
+DEFAULT_SOURCE_QA = ROOT / (
+    "milestones/pokeflex-001-source-warp-gate-v1/artifacts/"
+    "3dPrintedBunny_source_qa_v1.json"
+)
+DEFAULT_POLICY = ROOT / (
+    "configs/causal4d_public/pokeflex_realized_load_source_v1.json"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--discovery", type=Path, default=DEFAULT_DISCOVERY)
+    parser.add_argument("--source-qa", type=Path, default=DEFAULT_SOURCE_QA)
+    parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        discovery = json.loads(args.discovery.read_text(encoding="utf-8"))
+        source_qa = json.loads(args.source_qa.read_text(encoding="utf-8"))
+        config = load_realized_load_policy(args.policy)
+        decision = run_cached_pokeflex_source_gate(
+            discovery=discovery,
+            source_qa=source_qa,
+            output_dir=args.output_dir,
+            config=config,
+        )
+        validation = validate_cached_source_gate_decision(decision)
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        failure = {
+            "passed": False,
+            "technical_status": "cached-source-gate-failed-closed",
+            "error": f"{type(error).__name__}: {error}",
+            "calibration_take_data_read": False,
+            "target_take_data_read": False,
+        }
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        (args.output_dir / "cached_source_gate_failure.json").write_text(
+            json.dumps(failure, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        print(json.dumps(failure, indent=2, sort_keys=True))
+        return 2
+    print(json.dumps(validation, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/remote/evaluate_pokeflex_cached_source_gpuserver4090.py
+++ b/scripts/remote/evaluate_pokeflex_cached_source_gpuserver4090.py
@@ -21,9 +21,7 @@ from causal4d_public.pokeflex_realized_load import (  # noqa: E402
 )
 
 
-DEFAULT_DISCOVERY = ROOT / (
-    "public-realworld-probe/pokeflex-development-replica.json"
-)
+DEFAULT_DISCOVERY = ROOT / ("public-realworld-probe/pokeflex-development-replica.json")
 DEFAULT_SOURCE_QA = ROOT / (
     "milestones/pokeflex-001-source-warp-gate-v1/artifacts/"
     "3dPrintedBunny_source_qa_v1.json"

--- a/src/causal4d_public/pokeflex_cached_source_gate.py
+++ b/src/causal4d_public/pokeflex_cached_source_gate.py
@@ -1,0 +1,302 @@
+"""Consume a verified PokeFlex development cache for the frozen source gate."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+from causal4d_public._pokeflex_realized_load_common import (
+    PokeFlexRealizedLoadSourceConfig,
+    _canonical_bytes,
+    _require,
+    _sha256_file,
+    validate_source_qa_binding,
+)
+from causal4d_public.pokeflex_realized_load import (
+    run_pokeflex_realized_load_source_gate,
+    validate_realized_load_artifact,
+)
+from causal4d_public.pokeflex_replica_discovery import (
+    validate_pokeflex_replica_discovery,
+)
+
+
+POKEFLEX_DEVELOPMENT_CACHE_KIND = "PublicPokeFlexDevelopmentRobotCache"
+POKEFLEX_DEVELOPMENT_CACHE_SCHEMA_VERSION = 1
+POKEFLEX_CACHED_SOURCE_DECISION_KIND = "PublicPokeFlexCachedSourceGateDecision"
+POKEFLEX_CACHED_SOURCE_DECISION_SCHEMA_VERSION = 1
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(dict(payload), indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, path)
+
+
+def _source_robot_hashes(
+    source_qa: Mapping[str, Any],
+    config: PokeFlexRealizedLoadSourceConfig,
+) -> dict[str, str]:
+    validate_source_qa_binding(source_qa, config)
+    rows = source_qa.get("takes")
+    _require(isinstance(rows, list), "source QA take inventory is missing")
+    expected = set(config.expected_development_take_ids)
+    hashes: dict[str, str] = {}
+    for raw in rows:
+        _require(isinstance(raw, Mapping), "source QA take row is invalid")
+        take_id = str(raw.get("take_id", ""))
+        if take_id not in expected:
+            continue
+        digest = str(raw.get("robot_sha256", ""))
+        _require(
+            len(digest) == 64 and all(value in "0123456789abcdef" for value in digest),
+            f"source QA robot digest is invalid for {take_id}",
+        )
+        _require(take_id not in hashes, f"source QA take repeats: {take_id}")
+        hashes[take_id] = digest
+    _require(set(hashes) == expected, "source QA robot digest roster changed")
+    return hashes
+
+
+def _read_manifest(path: Path) -> dict[str, Any]:
+    _require(path.is_file(), "PokeFlex development cache manifest is missing")
+    _require(not path.is_symlink(), "PokeFlex development cache manifest is a symlink")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    _require(isinstance(payload, dict), "PokeFlex cache manifest is not an object")
+    return payload
+
+
+def _cache_binding_sha256(payload: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_bytes(payload)).hexdigest()
+
+
+def validate_pokeflex_development_cache(
+    cache_root: str | Path,
+    source_qa: Mapping[str, Any],
+    config: PokeFlexRealizedLoadSourceConfig,
+) -> dict[str, Any]:
+    """Validate an exact five-log cache without opening T2 or T5."""
+
+    supplied = Path(cache_root)
+    _require(not supplied.is_symlink(), "PokeFlex cache root is a symlink")
+    root = supplied.resolve()
+    _require(root.is_dir(), f"PokeFlex development cache is missing: {root}")
+    expected_hashes = _source_robot_hashes(source_qa, config)
+    manifest_path = root / "manifest.json"
+    manifest = _read_manifest(manifest_path)
+    _require(
+        manifest.get("artifact_kind") == POKEFLEX_DEVELOPMENT_CACHE_KIND,
+        "unexpected PokeFlex cache kind",
+    )
+    _require(
+        manifest.get("schema_version") == POKEFLEX_DEVELOPMENT_CACHE_SCHEMA_VERSION,
+        "unsupported PokeFlex cache schema",
+    )
+    _require(
+        manifest.get("source_qa_result_sha256")
+        == config.expected_source_qa_result_sha256,
+        "PokeFlex cache source-QA identity changed",
+    )
+    _require(
+        manifest.get("object_id") == config.expected_object_id,
+        "PokeFlex cache object changed",
+    )
+    _require(
+        tuple(map(str, manifest.get("development_take_ids", ())))
+        == config.expected_development_take_ids,
+        "PokeFlex cache development roster changed",
+    )
+    _require(
+        manifest.get("robot_sha256") == expected_hashes,
+        "PokeFlex cache robot digests changed",
+    )
+    _require(
+        manifest.get("calibration_take_data_read") is False,
+        "PokeFlex cache manifest reports calibration access",
+    )
+    _require(
+        manifest.get("target_take_data_read") is False,
+        "PokeFlex cache manifest reports target access",
+    )
+
+    expected_root_entries = {"manifest.json", config.expected_object_id}
+    actual_root_entries = {path.name for path in root.iterdir()}
+    _require(
+        actual_root_entries == expected_root_entries,
+        "PokeFlex cache root contains unexpected entries",
+    )
+    object_root = root / config.expected_object_id
+    _require(object_root.is_dir(), "PokeFlex cache object directory is missing")
+    _require(not object_root.is_symlink(), "PokeFlex cache object root is a symlink")
+    actual_take_ids = {path.name for path in object_root.iterdir()}
+    _require(
+        actual_take_ids == set(config.expected_development_take_ids),
+        "PokeFlex cache contains an unexpected take roster",
+    )
+    _require(
+        actual_take_ids.isdisjoint(config.forbidden_take_ids),
+        "PokeFlex cache contains T2 or T5",
+    )
+
+    observed_hashes: dict[str, str] = {}
+    byte_counts: dict[str, int] = {}
+    for take_id in config.expected_development_take_ids:
+        take_root = object_root / take_id
+        _require(take_root.is_dir(), f"PokeFlex cache take is missing: {take_id}")
+        _require(not take_root.is_symlink(), f"PokeFlex cache take is a symlink: {take_id}")
+        take_entries = {path.name for path in take_root.iterdir()}
+        _require(
+            take_entries == {"robot_data.json"},
+            f"PokeFlex cache take has unexpected entries: {take_id}",
+        )
+        robot_path = take_root / "robot_data.json"
+        _require(not robot_path.is_symlink(), f"PokeFlex robot log is a symlink: {take_id}")
+        observed = _sha256_file(robot_path)
+        _require(
+            observed == expected_hashes[take_id],
+            f"PokeFlex cached robot digest changed: {take_id}",
+        )
+        observed_hashes[take_id] = observed
+        byte_counts[take_id] = robot_path.stat().st_size
+
+    binding = {
+        "artifact_kind": "PublicPokeFlexDevelopmentCacheBinding",
+        "schema_version": 1,
+        "cache_root": str(root),
+        "source_qa_result_sha256": config.expected_source_qa_result_sha256,
+        "manifest_sha256": _sha256_file(manifest_path),
+        "object_id": config.expected_object_id,
+        "development_take_ids": list(config.expected_development_take_ids),
+        "robot_sha256": observed_hashes,
+        "robot_bytes": byte_counts,
+        "calibration_take_data_read": False,
+        "target_take_data_read": False,
+    }
+    binding["cache_binding_sha256"] = _cache_binding_sha256(binding)
+    return binding
+
+
+def cached_source_decision_sha256(payload: Mapping[str, Any]) -> str:
+    canonical = dict(payload)
+    canonical.pop("decision_sha256", None)
+    return hashlib.sha256(_canonical_bytes(canonical)).hexdigest()
+
+
+def run_cached_pokeflex_source_gate(
+    *,
+    discovery: Mapping[str, Any],
+    source_qa: Mapping[str, Any],
+    output_dir: str | Path,
+    config: PokeFlexRealizedLoadSourceConfig,
+) -> dict[str, Any]:
+    """Run the source gate only after complete exact cache verification."""
+
+    discovery_validation = validate_pokeflex_replica_discovery(discovery)
+    output = Path(output_dir).resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    ready = bool(discovery_validation["complete"] and discovery_validation["cache_verified"])
+    decision: dict[str, Any] = {
+        "artifact_kind": POKEFLEX_CACHED_SOURCE_DECISION_KIND,
+        "schema_version": POKEFLEX_CACHED_SOURCE_DECISION_SCHEMA_VERSION,
+        "discovery_result_sha256": discovery_validation["result_sha256"],
+        "source_qa_result_sha256": config.expected_source_qa_result_sha256,
+        "cache_ready": ready,
+        "source_gate_executed": False,
+        "source_backend_admitted": False,
+        "source_gate_result_sha256": None,
+        "cache_binding": None,
+        "status": "replica-incomplete-source-gate-not-run",
+        "calibration_take_data_read": False,
+        "target_take_data_read": False,
+        "automatic_follow_on_allowed": False,
+    }
+    if ready:
+        cache_root = str(discovery.get("cache_root", ""))
+        binding = validate_pokeflex_development_cache(
+            cache_root,
+            source_qa,
+            config,
+        )
+        result = run_pokeflex_realized_load_source_gate(
+            cache_root,
+            source_qa,
+            output,
+            config,
+        )
+        validation = validate_realized_load_artifact(result)
+        _require(validation["passed"] is True, "PokeFlex source result did not validate")
+        decision.update(
+            {
+                "source_gate_executed": True,
+                "source_backend_admitted": bool(result["source_backend_admitted"]),
+                "source_gate_result_sha256": result["result_sha256"],
+                "cache_binding": binding,
+                "status": str(result["decision"]),
+            }
+        )
+    decision["decision_sha256"] = cached_source_decision_sha256(decision)
+    _write_json(output / "cached_source_gate_decision.json", decision)
+    return decision
+
+
+def validate_cached_source_gate_decision(payload: Mapping[str, Any]) -> dict[str, Any]:
+    _require(
+        payload.get("artifact_kind") == POKEFLEX_CACHED_SOURCE_DECISION_KIND,
+        "unexpected cached-source decision kind",
+    )
+    _require(
+        payload.get("schema_version")
+        == POKEFLEX_CACHED_SOURCE_DECISION_SCHEMA_VERSION,
+        "unsupported cached-source decision schema",
+    )
+    _require(
+        payload.get("decision_sha256") == cached_source_decision_sha256(payload),
+        "cached-source decision checksum mismatch",
+    )
+    _require(payload.get("calibration_take_data_read") is False, "T5 was opened")
+    _require(payload.get("target_take_data_read") is False, "T2 was opened")
+    _require(
+        payload.get("automatic_follow_on_allowed") is False,
+        "automatic follow-on was enabled",
+    )
+    if payload.get("source_gate_executed") is True:
+        _require(payload.get("cache_ready") is True, "source gate ran without cache")
+        _require(bool(payload.get("cache_binding")), "cache binding is missing")
+        _require(
+            bool(payload.get("source_gate_result_sha256")),
+            "source result identity is missing",
+        )
+    else:
+        _require(
+            payload.get("source_backend_admitted") is False,
+            "unexecuted source gate was admitted",
+        )
+        _require(
+            payload.get("source_gate_result_sha256") is None,
+            "unexecuted source gate has a result identity",
+        )
+    return {
+        "passed": True,
+        "source_gate_executed": bool(payload["source_gate_executed"]),
+        "source_backend_admitted": bool(payload["source_backend_admitted"]),
+        "decision_sha256": payload["decision_sha256"],
+    }
+
+
+__all__ = [
+    "POKEFLEX_CACHED_SOURCE_DECISION_KIND",
+    "POKEFLEX_CACHED_SOURCE_DECISION_SCHEMA_VERSION",
+    "POKEFLEX_DEVELOPMENT_CACHE_KIND",
+    "POKEFLEX_DEVELOPMENT_CACHE_SCHEMA_VERSION",
+    "cached_source_decision_sha256",
+    "run_cached_pokeflex_source_gate",
+    "validate_cached_source_gate_decision",
+    "validate_pokeflex_development_cache",
+]

--- a/src/causal4d_public/pokeflex_cached_source_gate.py
+++ b/src/causal4d_public/pokeflex_cached_source_gate.py
@@ -150,14 +150,18 @@ def validate_pokeflex_development_cache(
     for take_id in config.expected_development_take_ids:
         take_root = object_root / take_id
         _require(take_root.is_dir(), f"PokeFlex cache take is missing: {take_id}")
-        _require(not take_root.is_symlink(), f"PokeFlex cache take is a symlink: {take_id}")
+        _require(
+            not take_root.is_symlink(), f"PokeFlex cache take is a symlink: {take_id}"
+        )
         take_entries = {path.name for path in take_root.iterdir()}
         _require(
             take_entries == {"robot_data.json"},
             f"PokeFlex cache take has unexpected entries: {take_id}",
         )
         robot_path = take_root / "robot_data.json"
-        _require(not robot_path.is_symlink(), f"PokeFlex robot log is a symlink: {take_id}")
+        _require(
+            not robot_path.is_symlink(), f"PokeFlex robot log is a symlink: {take_id}"
+        )
         observed = _sha256_file(robot_path)
         _require(
             observed == expected_hashes[take_id],
@@ -201,7 +205,9 @@ def run_cached_pokeflex_source_gate(
     discovery_validation = validate_pokeflex_replica_discovery(discovery)
     output = Path(output_dir).resolve()
     output.mkdir(parents=True, exist_ok=True)
-    ready = bool(discovery_validation["complete"] and discovery_validation["cache_verified"])
+    ready = bool(
+        discovery_validation["complete"] and discovery_validation["cache_verified"]
+    )
     decision: dict[str, Any] = {
         "artifact_kind": POKEFLEX_CACHED_SOURCE_DECISION_KIND,
         "schema_version": POKEFLEX_CACHED_SOURCE_DECISION_SCHEMA_VERSION,
@@ -231,7 +237,9 @@ def run_cached_pokeflex_source_gate(
             config,
         )
         validation = validate_realized_load_artifact(result)
-        _require(validation["passed"] is True, "PokeFlex source result did not validate")
+        _require(
+            validation["passed"] is True, "PokeFlex source result did not validate"
+        )
         decision.update(
             {
                 "source_gate_executed": True,
@@ -252,8 +260,7 @@ def validate_cached_source_gate_decision(payload: Mapping[str, Any]) -> dict[str
         "unexpected cached-source decision kind",
     )
     _require(
-        payload.get("schema_version")
-        == POKEFLEX_CACHED_SOURCE_DECISION_SCHEMA_VERSION,
+        payload.get("schema_version") == POKEFLEX_CACHED_SOURCE_DECISION_SCHEMA_VERSION,
         "unsupported cached-source decision schema",
     )
     _require(

--- a/tests/test_pokeflex_cached_source_gate.py
+++ b/tests/test_pokeflex_cached_source_gate.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from causal4d_public import pokeflex_cached_source_gate as cached
+from causal4d_public.pokeflex_realized_load import (
+    PokeFlexRealizedLoadSourceConfig,
+)
+from causal4d_public.pokeflex_replica_discovery import (
+    POKEFLEX_REPLICA_DISCOVERY_KIND,
+    POKEFLEX_REPLICA_DISCOVERY_SCHEMA_VERSION,
+    replica_discovery_sha256,
+)
+
+
+def _robot_bytes(take_id: str) -> bytes:
+    return json.dumps(
+        {
+            "take_id": take_id,
+            "frames": [0, 1, 2],
+            "forces": [4.0, 4.5, 5.0],
+        },
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _source_qa(
+    config: PokeFlexRealizedLoadSourceConfig,
+    content_by_take: dict[str, bytes],
+) -> dict[str, object]:
+    return {
+        "artifact_kind": "PublicPokeFlexSourceQa",
+        "schema_version": 1,
+        "result_sha256": config.expected_source_qa_result_sha256,
+        "source_qa_passed": True,
+        "object_id": config.expected_object_id,
+        "information_boundary": {
+            "opened_take_ids": list(config.expected_development_take_ids),
+            "unopened_take_ids": list(config.forbidden_take_ids),
+            "calibration_take_data_read": False,
+            "target_take_data_read": False,
+        },
+        "capability_gates": {"pose_wrench_contact_candidate_ready": True},
+        "takes": [
+            {
+                "take_id": take_id,
+                "robot_sha256": hashlib.sha256(content_by_take[take_id]).hexdigest(),
+            }
+            for take_id in config.expected_development_take_ids
+        ],
+    }
+
+
+def _write_cache(
+    root: Path,
+    config: PokeFlexRealizedLoadSourceConfig,
+    content_by_take: dict[str, bytes],
+) -> dict[str, str]:
+    hashes = {
+        take_id: hashlib.sha256(content_by_take[take_id]).hexdigest()
+        for take_id in config.expected_development_take_ids
+    }
+    for take_id in config.expected_development_take_ids:
+        path = root / config.expected_object_id / take_id / "robot_data.json"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(content_by_take[take_id])
+    manifest = {
+        "artifact_kind": cached.POKEFLEX_DEVELOPMENT_CACHE_KIND,
+        "schema_version": cached.POKEFLEX_DEVELOPMENT_CACHE_SCHEMA_VERSION,
+        "source_qa_result_sha256": config.expected_source_qa_result_sha256,
+        "object_id": config.expected_object_id,
+        "development_take_ids": list(config.expected_development_take_ids),
+        "robot_sha256": hashes,
+        "calibration_take_data_read": False,
+        "target_take_data_read": False,
+    }
+    (root / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return hashes
+
+
+def _discovery(
+    cache_root: Path,
+    *,
+    complete: bool,
+    cache_verified: bool,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "artifact_kind": POKEFLEX_REPLICA_DISCOVERY_KIND,
+        "schema_version": POKEFLEX_REPLICA_DISCOVERY_SCHEMA_VERSION,
+        "complete": complete,
+        "cache_verified": cache_verified,
+        "cache_root": str(cache_root),
+        "information_boundary": {
+            "nondevelopment_payloads_read": 0,
+            "calibration_take_data_read": False,
+            "target_take_data_read": False,
+        },
+    }
+    payload["result_sha256"] = replica_discovery_sha256(payload)
+    return payload
+
+
+def test_validates_exact_five_log_cache(tmp_path: Path) -> None:
+    config = PokeFlexRealizedLoadSourceConfig()
+    content = {
+        take_id: _robot_bytes(take_id)
+        for take_id in config.expected_development_take_ids
+    }
+    cache_root = tmp_path / "cache"
+    hashes = _write_cache(cache_root, config, content)
+
+    binding = cached.validate_pokeflex_development_cache(
+        cache_root,
+        _source_qa(config, content),
+        config,
+    )
+
+    assert binding["source_qa_result_sha256"] == (
+        config.expected_source_qa_result_sha256
+    )
+    assert binding["robot_sha256"] == hashes
+    assert binding["development_take_ids"] == list(
+        config.expected_development_take_ids
+    )
+    assert binding["calibration_take_data_read"] is False
+    assert binding["target_take_data_read"] is False
+    assert len(binding["cache_binding_sha256"]) == 64
+
+
+def test_rejects_forbidden_or_tampered_cache_entries(tmp_path: Path) -> None:
+    config = PokeFlexRealizedLoadSourceConfig()
+    content = {
+        take_id: _robot_bytes(take_id)
+        for take_id in config.expected_development_take_ids
+    }
+    cache_root = tmp_path / "cache"
+    _write_cache(cache_root, config, content)
+    forbidden = cache_root / config.expected_object_id / config.forbidden_take_ids[0]
+    forbidden.mkdir()
+
+    with pytest.raises(ValueError, match="unexpected take roster"):
+        cached.validate_pokeflex_development_cache(
+            cache_root,
+            _source_qa(config, content),
+            config,
+        )
+
+    forbidden.rmdir()
+    first = config.expected_development_take_ids[0]
+    robot_path = cache_root / config.expected_object_id / first / "robot_data.json"
+    robot_path.write_bytes(b"tampered")
+    with pytest.raises(ValueError, match="cached robot digest changed"):
+        cached.validate_pokeflex_development_cache(
+            cache_root,
+            _source_qa(config, content),
+            config,
+        )
+
+
+def test_incomplete_discovery_skips_source_gate_without_touching_cache(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config = PokeFlexRealizedLoadSourceConfig()
+    content = {
+        take_id: _robot_bytes(take_id)
+        for take_id in config.expected_development_take_ids
+    }
+    cache_root = tmp_path / "missing-cache"
+
+    def unexpected_gate(*args, **kwargs):
+        raise AssertionError("source gate must not run")
+
+    monkeypatch.setattr(
+        cached,
+        "run_pokeflex_realized_load_source_gate",
+        unexpected_gate,
+    )
+    decision = cached.run_cached_pokeflex_source_gate(
+        discovery=_discovery(
+            cache_root,
+            complete=False,
+            cache_verified=False,
+        ),
+        source_qa=_source_qa(config, content),
+        output_dir=tmp_path / "output",
+        config=config,
+    )
+
+    assert cached.validate_cached_source_gate_decision(decision) == {
+        "passed": True,
+        "source_gate_executed": False,
+        "source_backend_admitted": False,
+        "decision_sha256": decision["decision_sha256"],
+    }
+    assert decision["status"] == "replica-incomplete-source-gate-not-run"
+    assert decision["cache_binding"] is None
+    assert not cache_root.exists()
+
+
+def test_complete_cache_executes_frozen_source_gate(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config = PokeFlexRealizedLoadSourceConfig()
+    content = {
+        take_id: _robot_bytes(take_id)
+        for take_id in config.expected_development_take_ids
+    }
+    cache_root = tmp_path / "cache"
+    _write_cache(cache_root, config, content)
+    calls: list[Path] = []
+
+    def fake_gate(dataset_root, source_qa, output_dir, supplied_config):
+        calls.append(Path(dataset_root).resolve())
+        assert supplied_config is config
+        assert source_qa["result_sha256"] == config.expected_source_qa_result_sha256
+        return {
+            "result_sha256": "b" * 64,
+            "source_backend_admitted": True,
+            "decision": "source-positive",
+        }
+
+    monkeypatch.setattr(
+        cached,
+        "run_pokeflex_realized_load_source_gate",
+        fake_gate,
+    )
+    monkeypatch.setattr(
+        cached,
+        "validate_realized_load_artifact",
+        lambda result: {"passed": True, "result_sha256": result["result_sha256"]},
+    )
+
+    output = tmp_path / "output"
+    decision = cached.run_cached_pokeflex_source_gate(
+        discovery=_discovery(
+            cache_root,
+            complete=True,
+            cache_verified=True,
+        ),
+        source_qa=_source_qa(config, content),
+        output_dir=output,
+        config=config,
+    )
+
+    assert calls == [cache_root.resolve()]
+    assert decision["source_gate_executed"] is True
+    assert decision["source_backend_admitted"] is True
+    assert decision["source_gate_result_sha256"] == "b" * 64
+    assert decision["status"] == "source-positive"
+    assert decision["cache_binding"]["robot_sha256"] == {
+        take_id: hashlib.sha256(content[take_id]).hexdigest()
+        for take_id in config.expected_development_take_ids
+    }
+    assert cached.validate_cached_source_gate_decision(decision)["passed"] is True
+    committed = json.loads(
+        (output / "cached_source_gate_decision.json").read_text(encoding="utf-8")
+    )
+    assert committed == decision

--- a/tests/test_pokeflex_cached_source_gate.py
+++ b/tests/test_pokeflex_cached_source_gate.py
@@ -126,9 +126,7 @@ def test_validates_exact_five_log_cache(tmp_path: Path) -> None:
         config.expected_source_qa_result_sha256
     )
     assert binding["robot_sha256"] == hashes
-    assert binding["development_take_ids"] == list(
-        config.expected_development_take_ids
-    )
+    assert binding["development_take_ids"] == list(config.expected_development_take_ids)
     assert binding["calibration_take_data_read"] is False
     assert binding["target_take_data_read"] is False
     assert len(binding["cache_binding_sha256"]) == 64


### PR DESCRIPTION
## Purpose

Close the remaining execution gap after the bounded `gpuserver4090` replica discovery: when—and only when—the complete five-log cache is independently verified, execute the already frozen PokeFlex realized-load development source gate in the same exact-main job.

The currently queued custody-only run has not allocated a runner or opened a payload. This PR changes the shared concurrency group to `cancel-in-progress: true`, so after merge the reviewed combined run supersedes that stale pending run rather than creating two scans.

## Independent cache admission

The new cache consumer does not trust the discovery boolean alone. Before evaluation it independently requires:

- exact cache kind and schema;
- exact source-QA result SHA-256;
- exact `3dPrintedBunny` object identity;
- exact ordered development roster `T1`, `T3`, `T4`, `T6`, `T7`;
- exact robot SHA-256 mapping from the committed source-QA artifact;
- cache-root entries restricted to the manifest and one object directory;
- object-directory entries restricted to the five development take directories;
- each take directory restricted to one non-symlink `robot_data.json`;
- byte-level rehash of all five logs; and
- explicit absence of `T2` and `T5`.

The cache binding is itself content-addressed and records manifest SHA-256, per-take hashes, and byte counts.

## Execution semantics

- An incomplete or unverified discovery produces `replica-incomplete-source-gate-not-run`; it does not touch a cache or run the evaluator.
- A complete cache selects an existing Python with NumPy >=1.24 and invokes the unchanged frozen realized-load source policy.
- A valid positive, bounded, or negative source result is retained exactly as produced by the existing evaluator.
- The decision receipt binds discovery, cache, source QA, and source result identities.
- Cache, policy, integrity, parsing, and numerical inconsistencies fail closed rather than becoming scientific outcomes.

## Information boundary

This remains a development-only source experiment. Allowed takes are exactly `T1`, `T3`, `T4`, `T6`, and `T7`. Calibration `T5` and target `T2` remain unopened. Automatic calibration and target follow-on are disabled regardless of the source-gate sign. No model, threshold, comparator, seed, source-QA identity, or registered metric changes.

## Workflow

The reviewed `public-realworld-probe-gpuserver4090.yml` job now:

1. inventories public holdings;
2. performs bounded exact-hash replica discovery;
3. selects a numerical runtime only for a verified complete cache;
4. runs the frozen source gate conditionally; and
5. uploads the custody result, source result when present, decision receipt, and runner provenance.

No raw robot record is uploaded.

## Tests

Focused tests cover exact cache acceptance, T2/T5 rejection, tamper rejection, incomplete-discovery no-op behavior, complete-cache source-gate invocation, content-addressed decision validation, and committed receipt output.