### PR TITLE
Fix standalone PokeFlex replica discovery and retry on gpuserver4090

### DIFF
--- a/ops/public-realworld-probe-gpuserver4090-request.json
+++ b/ops/public-realworld-probe-gpuserver4090-request.json
@@ -3,7 +3,7 @@
   "enabled": true,
   "runner": "gpuserver4090",
   "public_data_only": true,
-  "request_id": "2026-09-01-public-realworld-probe-v3-pokeflex-development-replica",
+  "request_id": "2026-09-02-public-realworld-probe-v4-pokeflex-standalone-import",
   "pokeflex_replica_discovery": {
     "cache_root": "/home/github-runner/.cache/datasets/pokeflex-causal4d-realized-load-v1",
     "calibration_take_data_allowed": false,

--- a/scripts/remote/discover_pokeflex_development_replica_gpuserver4090.py
+++ b/scripts/remote/discover_pokeflex_development_replica_gpuserver4090.py
@@ -33,9 +33,7 @@ def _load_discovery_module() -> ModuleType:
 
 
 _DISCOVERY = _load_discovery_module()
-discover_pokeflex_development_replica = (
-    _DISCOVERY.discover_pokeflex_development_replica
-)
+discover_pokeflex_development_replica = _DISCOVERY.discover_pokeflex_development_replica
 validate_pokeflex_replica_discovery = _DISCOVERY.validate_pokeflex_replica_discovery
 
 

--- a/scripts/remote/discover_pokeflex_development_replica_gpuserver4090.py
+++ b/scripts/remote/discover_pokeflex_development_replica_gpuserver4090.py
@@ -4,19 +4,39 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 import sys
 from pathlib import Path
+from types import ModuleType
 
 
 ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(ROOT / "src"))
+DISCOVERY_MODULE_PATH = ROOT / "src/causal4d_public/pokeflex_replica_discovery.py"
 
-from causal4d_public.pokeflex_replica_discovery import (  # noqa: E402
-    discover_pokeflex_development_replica,
-    validate_pokeflex_replica_discovery,
+
+def _load_discovery_module() -> ModuleType:
+    """Load the pure-standard-library module without importing package __init__."""
+
+    module_name = "_causal4d_pokeflex_replica_discovery_standalone"
+    specification = importlib.util.spec_from_file_location(
+        module_name,
+        DISCOVERY_MODULE_PATH,
+    )
+    if specification is None or specification.loader is None:
+        raise RuntimeError("failed to create standalone PokeFlex discovery module")
+    module = importlib.util.module_from_spec(specification)
+    sys.modules[module_name] = module
+    specification.loader.exec_module(module)
+    return module
+
+
+_DISCOVERY = _load_discovery_module()
+discover_pokeflex_development_replica = (
+    _DISCOVERY.discover_pokeflex_development_replica
 )
+validate_pokeflex_replica_discovery = _DISCOVERY.validate_pokeflex_replica_discovery
 
 
 DEFAULT_SEARCH_ROOTS = (
@@ -73,7 +93,7 @@ def main() -> int:
         )
         validation = validate_pokeflex_replica_discovery(result)
         _write_json(args.output, result)
-    except (OSError, KeyError, TypeError, ValueError) as error:
+    except (OSError, KeyError, RuntimeError, TypeError, ValueError) as error:
         failure = {
             "passed": False,
             "technical_status": "replica-discovery-failed-closed",

--- a/tests/test_pokeflex_replica_discovery_cli.py
+++ b/tests/test_pokeflex_replica_discovery_cli.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/remote/discover_pokeflex_development_replica_gpuserver4090.py"
+
+
+def test_standalone_cli_imports_without_site_packages() -> None:
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = ""
+    completed = subprocess.run(
+        [sys.executable, "-S", str(SCRIPT), "--help"],
+        cwd=ROOT,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "Discover a verified PokeFlex development replica" in completed.stdout


### PR DESCRIPTION
## Failure being repaired

Exact-main run `33515604912` did not inspect any PokeFlex candidate file. The discovery CLI imported `causal4d_public.pokeflex_replica_discovery` through the package initializer, which imported the NumPy-dependent Deform360 module. The selected system interpreter had no NumPy, so execution stopped with `ModuleNotFoundError` before the bounded scan.

## Repair

- load the pure-standard-library PokeFlex discovery module directly from its file path with `importlib.util`;
- avoid executing `causal4d_public.__init__` and unrelated optional provider imports;
- add a regression test that runs the CLI with `python -S --help`, an empty `PYTHONPATH`, and therefore no site packages;
- advance only the technical request identity so merge retriggers the existing exact-main `gpuserver4090` workflow.

## Unchanged information boundary

The authorized development takes remain exactly T1, T3, T4, T6, and T7. Calibration T5 and target T2 are not mapped to readable members and must remain unopened. Source-QA hashes, bounded search roots, traversal caps, cache location, and atomic complete-roster requirement are unchanged.

## Expected outcome

After merge, the existing workflow will finally perform the runner-local custody scan and report whether all five exact development robot logs can be verified and cached. This is a technical discovery retry, not a source-gate, calibration, target, or paper result.