### PR TITLE
Register target-blind PokeFlex drop-query protocol

### DIFF
--- a/configs/causal4d_public/pokeflex_task_conditioned_drop_protocol_v1.json
+++ b/configs/causal4d_public/pokeflex_task_conditioned_drop_protocol_v1.json
@@ -1,0 +1,224 @@
+{
+  "claim_boundary": [
+    "A positive result supports offline task-conditioned selection of one logged physical poke for held cross-intervention drop queries.",
+    "It does not establish online probe execution, same-state counterfactual outcomes, unique material identification, calibrated full-state uncertainty, deployment safety, or closed-loop manipulation success.",
+    "If exact drop-outcome freshness cannot be established, the evidence class is retrospective real-data mechanism evidence."
+  ],
+  "dataset": {
+    "expected_archive_count": 170,
+    "expected_dropping_count": 54,
+    "expected_object_count": 18,
+    "expected_poking_count": 116,
+    "metadata_audit_request_id": "pokeflex-probe-challenge-fold-audit-gpuserver4090-v1",
+    "name": "PokeFlex"
+  },
+  "evidence_class": {
+    "online_execution": false,
+    "primary_challenge": "prospective-only-if-exact-drop-exposure-scan-passes",
+    "probe_panel": "retrospective-logged-physical-pokes",
+    "same-microscopic-state-counterfactual": false
+  },
+  "object_split": {
+    "calibration_objects_per_family": 1,
+    "calibration_selection_rule": "within each family remove target object_ids, sort by SHA256(salt,NUL,calibration,NUL,object_id); take first one",
+    "expected_if_all_18_objects_are_eligible": {
+      "calibration": {
+        "foam": [
+          "FoamCylinder"
+        ],
+        "printed": [
+          "3dPrintedPizza"
+        ],
+        "soft": [
+          "PlushOctopus"
+        ]
+      },
+      "source": [
+        "3dPrintedHeart",
+        "3dPrintedPyramid",
+        "FoamDice",
+        "FoamHalfSphere",
+        "PlushDice",
+        "PlushMoon",
+        "PlushTurtle",
+        "PlushVolleyball",
+        "ToiletPaperRoll"
+      ],
+      "target": {
+        "foam": [
+          "Sponge",
+          "MemoryFoam"
+        ],
+        "printed": [
+          "3dPrintedBunny",
+          "3dPrintedCylinder"
+        ],
+        "soft": [
+          "Beanbag",
+          "Pillow"
+        ]
+      }
+    },
+    "family_rules": [
+      {
+        "family": "printed",
+        "rule": "object_id starts with 3dPrinted"
+      },
+      {
+        "family": "foam",
+        "rule": "object_id contains Foam or equals Sponge or ToiletPaperRoll"
+      },
+      {
+        "family": "soft",
+        "rule": "all remaining registered object_ids"
+      }
+    ],
+    "minimum_primary_target_objects": 6,
+    "replacement_after_outcome_access": false,
+    "selection_salt": "PokeFlex-active-drop-target-v1-2026-09-02",
+    "source_objects": "all remaining eligible objects",
+    "target_objects_per_family": 2,
+    "target_selection_rule": "within each family sort eligible object_ids by SHA256(salt,NUL,target,NUL,object_id); take first two"
+  },
+  "policies": [
+    "no-probe",
+    "deterministic-random-safe",
+    "source-fixed-safe",
+    "generic-latent-information",
+    "task-conditioned-query-value",
+    "dependence-destroyed-task-value",
+    "target-outcome-oracle-diagnostic"
+  ],
+  "primary_analysis": {
+    "dependence_attribution_endpoint": "loss of task-conditioned advantage under object-matched probe-query dependence destruction",
+    "nested_units": [
+      "drop repetitions",
+      "frames",
+      "mesh vertices",
+      "query coordinates"
+    ],
+    "paired_object_bootstrap": {
+      "confidence_level": 0.95,
+      "resamples": 100000,
+      "seed": 20260902
+    },
+    "pool_frames_as_independent": false,
+    "pool_vertices_as_independent": false,
+    "primary_comparisons": [
+      "task-conditioned-query-value versus no-probe",
+      "task-conditioned-query-value versus source-fixed-safe",
+      "task-conditioned-query-value versus generic-latent-information"
+    ],
+    "statistical_unit": "physical object",
+    "task_dependence_endpoint": "fraction of target objects receiving different selected probes for the two registered queries"
+  },
+  "protocol_id": "pokeflex-task-conditioned-drop-protocol-v1",
+  "protocol_sha256": "4788fcc012c7809266d041adda50ac5333f5f21f0b828a9d088cca6253df49b9",
+  "registered_queries": [
+    {
+      "components": [
+        "maximum template-diagonal-normalized bounding-box compression",
+        "time to maximum compression",
+        "rebound ratio"
+      ],
+      "primary_loss": "source-standardized squared error",
+      "query_id": "drop-impact-geometry"
+    },
+    {
+      "components": [
+        "final template-diagonal-normalized symmetric Chamfer distance to initial mesh",
+        "final bounding-box compression",
+        "final centroid drift"
+      ],
+      "primary_loss": "source-standardized squared error",
+      "query_id": "drop-settled-geometry"
+    }
+  ],
+  "risk_and_cost": {
+    "no_safe_positive_value_behavior": "exact no-probe fallback",
+    "probe_cost_features": [
+      "path length",
+      "duration",
+      "predicted force impulse"
+    ],
+    "risk_features": [
+      "source-predicted peak force",
+      "source-predicted force impulse"
+    ],
+    "risk_thresholds": "frozen on source and calibration objects"
+  },
+  "schema": "causal4d/pokeflex-task-conditioned-drop-protocol",
+  "schema_version": 1,
+  "secondary_analysis": {
+    "all_object_cross_fitting": true,
+    "cannot_upgrade_primary_freshness": true,
+    "status": "retrospective-secondary-only"
+  },
+  "semantic_carriers": {
+    "action_descriptor": {
+      "allowed_fields": [
+        "frame",
+        "T_WT"
+      ],
+      "boundary": "isolated semantic slicer; byte-level carrier co-location is acknowledged",
+      "carrier": "robot_data.json",
+      "descriptor": [
+        "tool-path displacement and length",
+        "approach direction",
+        "pose-derived speed profile",
+        "tool location relative to the initial mesh"
+      ],
+      "forbidden_fields": [
+        "forces",
+        "torques",
+        "contact_response",
+        "future_mesh"
+      ]
+    },
+    "drop_outcome": {
+      "allowed_only_after_joint_prediction_seal": true,
+      "material_vertex_identity_required": false
+    },
+    "selected_probe_response": {
+      "allowed_after_selection": [
+        "force trajectory",
+        "pose trajectory",
+        "geometry-invariant mesh-response summaries"
+      ],
+      "material_vertex_identity_required": false
+    }
+  },
+  "source_gate": {
+    "failed_gate_behavior": "stop before target probe selection or target drop access",
+    "required": [
+      "both registered queries have positive task-conditioned calibration value",
+      "task-conditioned mean calibration loss is lower than no-probe",
+      "task-conditioned mean calibration loss is no worse than source-fixed-safe",
+      "task-conditioned mean calibration loss is no worse than generic-latent-information",
+      "dependence destruction removes at least half of the task-conditioned advantage over no-probe",
+      "at least two distinct probes are selected across calibration objects for at least one registered query",
+      "all unsafe probes are rejected and all zero-value cases return exact no-probe fallback"
+    ],
+    "target_drop_outcomes_opened": false
+  },
+  "stages": [
+    "metadata-only fold audit",
+    "exact historical exposure scan for every target drop take",
+    "source-object model fitting",
+    "calibration-object model and threshold selection",
+    "target action-descriptor slicing and probe selection",
+    "selected-probe response reveal",
+    "joint sealing of all target drop-query predictions",
+    "single target drop-outcome opening and scoring"
+  ],
+  "status": "registered-pending-metadata-and-exposure-gates",
+  "take_roles": {
+    "minimum_target_drops_per_object": 2,
+    "target_candidate_probe_count": 4,
+    "target_candidate_probe_rule": "sort complete target-object poking take_ids by SHA256(salt,NUL,probe,NUL,object_id,NUL,take_id); take first four",
+    "target_drop_outcome_available_before_prediction_seal": false,
+    "target_drop_rule": "all complete dropping takes of each primary target object are held challenges",
+    "target_probe_response_available_before_selection": false,
+    "unselected_target_probe_response_available": false
+  }
+}

--- a/docs/pokeflex_task_conditioned_drop_protocol_v1.md
+++ b/docs/pokeflex_task_conditioned_drop_protocol_v1.md
@@ -1,0 +1,150 @@
+# PokeFlex task-conditioned drop-query protocol v1
+
+**Status:** registered before any new drop-outcome access; activation is
+conditional on the metadata and exact historical-exposure gates.
+
+## Scientific question
+
+Can one logged physical poke be selected for the information it carries about a
+specific, different physical query—rather than for generic latent information—and
+then improve a sealed dropping-response prediction?
+
+This is the public-real-data precursor to active decision-identifiable physical
+twins. It evaluates an offline `act / probe / fallback` composition; it does not
+claim that the selected poke was executed online.
+
+## Evidence class
+
+The broader project has already exposed almost all historical poking outcomes.
+The diagnostic-poke panel is therefore explicitly retrospective. The primary
+drop challenge is called prospective only if a separate exact-take exposure scan
+finds no prior drop-outcome access in the relevant repositories, workflow
+artifacts, or retained runtime paths. Otherwise the complete study is labeled
+retrospective mechanism evidence.
+
+This distinction is immutable in the registered protocol. A secondary
+all-object cross-fit cannot upgrade the freshness of the six-object primary
+panel.
+
+## Object split
+
+Eligible objects are grouped without outcome access:
+
+- `printed`: object ID starts with `3dPrinted`;
+- `foam`: object ID contains `Foam`, or equals `Sponge` or
+  `ToiletPaperRoll`;
+- `soft`: every remaining registered object.
+
+Within each family, object IDs are ordered by SHA-256 under the frozen salt
+`PokeFlex-active-drop-target-v1-2026-09-02`. The first two are primary targets,
+the next independently hashed object is calibration, and all remaining objects
+are source objects. If all 18 expected objects pass metadata eligibility, the
+split is:
+
+| Role | Printed | Foam | Soft |
+|---|---|---|---|
+| Target | `3dPrintedBunny`, `3dPrintedCylinder` | `Sponge`, `MemoryFoam` | `Beanbag`, `Pillow` |
+| Calibration | `3dPrintedPizza` | `FoamCylinder` | `PlushOctopus` |
+| Source | `3dPrintedHeart`, `3dPrintedPyramid` | `FoamDice`, `FoamHalfSphere`, `ToiletPaperRoll` | `PlushDice`, `PlushMoon`, `PlushTurtle`, `PlushVolleyball` |
+
+No target may be replaced after outcome access. Insufficient metadata support
+stops the primary protocol instead of selecting a more favorable object.
+
+## Target roles and reveal order
+
+Each target object receives exactly four candidate diagnostic pokes, selected by
+a second salted hash from complete poking takes. All complete drop takes of that
+object are held challenges, with at least two required.
+
+The custody order is:
+
+1. metadata-only fold audit;
+2. exact historical exposure scan for every target drop take;
+3. source model fitting;
+4. calibration-only model and threshold selection;
+5. target action-descriptor slicing and probe selection;
+6. reveal of only the selected probe response;
+7. one joint seal over every target drop-query prediction; and
+8. a single target drop-outcome opening and scoring stage.
+
+Unselected target probe responses remain unavailable to the experiment.
+
+## Co-located action and response carrier
+
+PokeFlex stores measured tool pose and force in the same `robot_data.json`
+carrier. The selector may use only `frame` and `T_WT`. An isolated semantic
+slicer exports the registered path displacement, direction, speed profile, and
+tool location relative to the initial mesh. Force, torque, contact response, and
+future geometry are not exported.
+
+This is intentionally described as semantic slicing, not byte-level
+non-access: the isolation process must parse a co-located carrier to remove
+forbidden fields. The selected probe response becomes available only after the
+probe identity has been sealed.
+
+## Registered queries
+
+Two geometry-invariant drop queries avoid relying on persistent material vertex
+identity:
+
+1. **Drop impact geometry:** maximum template-diagonal-normalized bounding-box
+   compression, time to maximum compression, and rebound ratio.
+2. **Drop settled geometry:** final normalized symmetric Chamfer distance to the
+   initial mesh, final bounding-box compression, and final centroid drift.
+
+The primary loss is source-standardized squared error. Frames, vertices, drop
+repetitions, and query coordinates are nested observations; the physical object
+is the statistical unit.
+
+## Policies
+
+The frozen comparison set is:
+
+1. no probe;
+2. deterministic random-safe probe;
+3. one source-fixed safe rule;
+4. generic latent-information probe;
+5. task-conditioned query-value probe;
+6. a dependence-destroyed task-value control; and
+7. a target-outcome oracle used only as a diagnostic ceiling.
+
+Risk uses source-predicted peak force and force impulse. Cost uses path length,
+duration, and predicted impulse. If no safe probe has positive task value, the
+system returns the exact no-probe fallback.
+
+## Source gate
+
+Target probe selection and drop access are forbidden unless calibration shows,
+for both queries, positive task-conditioned value and lower mean loss than no
+probe. The task-conditioned policy must be no worse than the source-fixed and
+generic-information policies. Destroying the object-matched probe--query
+dependence must remove at least half of the task-conditioned advantage, and the
+selector must exhibit nontrivial probe diversity. Unsafe probes and zero-value
+cases must fail closed.
+
+A failed gate terminates this method version before target access.
+
+## Primary analysis
+
+The target comparison uses paired physical-object losses. The frozen bootstrap
+uses 100,000 object resamples at seed 20260902. Primary contrasts are
+ task-conditioned probing versus no probe, source-fixed probing, and generic
+information. The analysis also reports whether the two registered queries choose
+different probes and whether the benefit collapses under dependence destruction.
+
+## Claim boundary
+
+A positive result supports:
+
+> Offline task-conditioned selection of one logged real poke improves a sealed
+> cross-intervention drop query relative to passive, fixed, and generic-
+> information baselines.
+
+It does not establish online execution, same-state counterfactual outcomes,
+unique material identification, calibrated full-state uncertainty, deployment
+safety, or closed-loop manipulation success.
+
+The machine-readable owner is
+`configs/causal4d_public/pokeflex_task_conditioned_drop_protocol_v1.json`, whose
+canonical SHA-256 is
+`4788fcc012c7809266d041adda50ac5333f5f21f0b828a9d088cca6253df49b9`.

--- a/scripts/ci/verify_pokeflex_task_conditioned_drop_protocol_v1.py
+++ b/scripts/ci/verify_pokeflex_task_conditioned_drop_protocol_v1.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Verify the frozen PokeFlex task-conditioned drop-query protocol."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "causal4d/pokeflex-task-conditioned-drop-protocol"
+PROTOCOL_ID = "pokeflex-task-conditioned-drop-protocol-v1"
+EXPECTED_OBJECTS = (
+    "3dPrintedBunny",
+    "3dPrintedCylinder",
+    "3dPrintedHeart",
+    "3dPrintedPizza",
+    "3dPrintedPyramid",
+    "Beanbag",
+    "FoamCylinder",
+    "FoamDice",
+    "FoamHalfSphere",
+    "MemoryFoam",
+    "Pillow",
+    "PlushDice",
+    "PlushMoon",
+    "PlushOctopus",
+    "PlushTurtle",
+    "PlushVolleyball",
+    "Sponge",
+    "ToiletPaperRoll",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "protocol",
+        type=Path,
+        nargs="?",
+        default=Path(
+            "configs/causal4d_public/"
+            "pokeflex_task_conditioned_drop_protocol_v1.json"
+        ),
+    )
+    parser.add_argument("--output-json", type=Path)
+    return parser.parse_args()
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def family(object_id: str) -> str:
+    if object_id.startswith("3dPrinted"):
+        return "printed"
+    if "Foam" in object_id or object_id in {"Sponge", "ToiletPaperRoll"}:
+        return "foam"
+    return "soft"
+
+
+def digest_order(values: list[str], *, salt: str, role: str) -> list[str]:
+    return sorted(
+        values,
+        key=lambda value: (
+            hashlib.sha256(
+                f"{salt}\0{role}\0{value}".encode("utf-8")
+            ).hexdigest(),
+            value,
+        ),
+    )
+
+
+def verify_protocol(payload: dict[str, Any]) -> dict[str, Any]:
+    require(payload.get("schema") == SCHEMA, "unexpected protocol schema")
+    require(payload.get("schema_version") == 1, "unexpected protocol version")
+    require(payload.get("protocol_id") == PROTOCOL_ID, "unexpected protocol id")
+    require(
+        payload.get("status") == "registered-pending-metadata-and-exposure-gates",
+        "protocol status changed",
+    )
+
+    stored_digest = payload.get("protocol_sha256")
+    require(isinstance(stored_digest, str) and len(stored_digest) == 64, "bad protocol digest")
+    canonical = dict(payload)
+    canonical.pop("protocol_sha256", None)
+    actual_digest = hashlib.sha256(canonical_bytes(canonical)).hexdigest()
+    require(actual_digest == stored_digest, "protocol digest mismatch")
+
+    dataset = payload["dataset"]
+    require(dataset["name"] == "PokeFlex", "dataset changed")
+    require(dataset["expected_archive_count"] == 170, "archive count changed")
+    require(dataset["expected_poking_count"] == 116, "poking count changed")
+    require(dataset["expected_dropping_count"] == 54, "dropping count changed")
+    require(dataset["expected_object_count"] == 18, "object count changed")
+    require(
+        dataset["metadata_audit_request_id"]
+        == "pokeflex-probe-challenge-fold-audit-gpuserver4090-v1",
+        "metadata audit binding changed",
+    )
+
+    split = payload["object_split"]
+    require(split["target_objects_per_family"] == 2, "target allocation changed")
+    require(split["calibration_objects_per_family"] == 1, "calibration allocation changed")
+    require(split["minimum_primary_target_objects"] == 6, "target minimum changed")
+    require(split["replacement_after_outcome_access"] is False, "replacement enabled")
+    salt = split["selection_salt"]
+    require(salt == "PokeFlex-active-drop-target-v1-2026-09-02", "split salt changed")
+
+    groups: dict[str, list[str]] = {"printed": [], "foam": [], "soft": []}
+    for object_id in EXPECTED_OBJECTS:
+        groups[family(object_id)].append(object_id)
+    expected_target = {
+        name: digest_order(values, salt=salt, role="target")[:2]
+        for name, values in groups.items()
+    }
+    expected_calibration: dict[str, list[str]] = {}
+    for name, values in groups.items():
+        remaining = [value for value in values if value not in expected_target[name]]
+        expected_calibration[name] = digest_order(
+            remaining, salt=salt, role="calibration"
+        )[:1]
+    reserved = {
+        value
+        for values in (*expected_target.values(), *expected_calibration.values())
+        for value in values
+    }
+    expected_source = sorted(set(EXPECTED_OBJECTS) - reserved)
+    registered = split["expected_if_all_18_objects_are_eligible"]
+    require(registered["target"] == expected_target, "registered target split changed")
+    require(
+        registered["calibration"] == expected_calibration,
+        "registered calibration split changed",
+    )
+    require(registered["source"] == expected_source, "registered source split changed")
+    require(len(reserved) == 9 and len(expected_source) == 9, "object roles do not partition 18 objects")
+
+    roles = payload["take_roles"]
+    require(roles["target_candidate_probe_count"] == 4, "candidate probe count changed")
+    require(roles["minimum_target_drops_per_object"] == 2, "drop minimum changed")
+    require(roles["target_probe_response_available_before_selection"] is False, "probe response exposed")
+    require(roles["unselected_target_probe_response_available"] is False, "unselected responses exposed")
+    require(roles["target_drop_outcome_available_before_prediction_seal"] is False, "drop outcome exposed")
+
+    carrier = payload["semantic_carriers"]["action_descriptor"]
+    require(carrier["carrier"] == "robot_data.json", "action carrier changed")
+    require(carrier["allowed_fields"] == ["frame", "T_WT"], "action fields changed")
+    require("forces" in carrier["forbidden_fields"], "force exclusion missing")
+    require("byte-level carrier co-location is acknowledged" in carrier["boundary"], "co-location boundary missing")
+    require(
+        payload["semantic_carriers"]["drop_outcome"]["allowed_only_after_joint_prediction_seal"] is True,
+        "drop scoring custody changed",
+    )
+
+    query_ids = [item["query_id"] for item in payload["registered_queries"]]
+    require(query_ids == ["drop-impact-geometry", "drop-settled-geometry"], "query roster changed")
+    require(
+        all(item["primary_loss"] == "source-standardized squared error" for item in payload["registered_queries"]),
+        "query loss changed",
+    )
+
+    policies = payload["policies"]
+    require(
+        policies
+        == [
+            "no-probe",
+            "deterministic-random-safe",
+            "source-fixed-safe",
+            "generic-latent-information",
+            "task-conditioned-query-value",
+            "dependence-destroyed-task-value",
+            "target-outcome-oracle-diagnostic",
+        ],
+        "policy roster changed",
+    )
+    require(
+        payload["risk_and_cost"]["no_safe_positive_value_behavior"]
+        == "exact no-probe fallback",
+        "fallback changed",
+    )
+
+    stages = payload["stages"]
+    require(
+        stages.index("target action-descriptor slicing and probe selection")
+        < stages.index("selected-probe response reveal")
+        < stages.index("joint sealing of all target drop-query predictions")
+        < stages.index("single target drop-outcome opening and scoring"),
+        "target reveal order changed",
+    )
+    require(payload["source_gate"]["target_drop_outcomes_opened"] is False, "source gate opens targets")
+    require(
+        payload["source_gate"]["failed_gate_behavior"]
+        == "stop before target probe selection or target drop access",
+        "source failure behavior changed",
+    )
+
+    analysis = payload["primary_analysis"]
+    require(analysis["statistical_unit"] == "physical object", "statistical unit changed")
+    require(analysis["pool_frames_as_independent"] is False, "frame pseudoreplication enabled")
+    require(analysis["pool_vertices_as_independent"] is False, "vertex pseudoreplication enabled")
+    require(analysis["paired_object_bootstrap"] == {
+        "confidence_level": 0.95,
+        "resamples": 100000,
+        "seed": 20260902,
+    }, "bootstrap contract changed")
+    require(payload["secondary_analysis"]["cannot_upgrade_primary_freshness"] is True, "secondary analysis can alter freshness")
+
+    evidence = payload["evidence_class"]
+    require(evidence["probe_panel"] == "retrospective-logged-physical-pokes", "probe evidence class changed")
+    require(
+        evidence["primary_challenge"]
+        == "prospective-only-if-exact-drop-exposure-scan-passes",
+        "challenge evidence class changed",
+    )
+    require(evidence["online_execution"] is False, "online execution claimed")
+    require(evidence["same-microscopic-state-counterfactual"] is False, "same-state counterfactual claimed")
+
+    return {
+        "schema": "causal4d/pokeflex-task-conditioned-drop-protocol-verification",
+        "schema_version": 1,
+        "status": "verified-registered-before-drop-outcome-access",
+        "protocol_id": PROTOCOL_ID,
+        "protocol_sha256": stored_digest,
+        "expected_primary_target_objects": registered["target"],
+        "expected_calibration_objects": registered["calibration"],
+        "expected_source_objects": registered["source"],
+        "target_drop_outcomes_opened": False,
+        "claim_boundary_verified": True,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    payload = json.loads(args.protocol.read_text(encoding="utf-8"))
+    verification = verify_protocol(payload)
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(
+            json.dumps(verification, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    print(json.dumps(verification, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pokeflex_task_conditioned_drop_protocol_v1.py
+++ b/tests/test_pokeflex_task_conditioned_drop_protocol_v1.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.verify_pokeflex_task_conditioned_drop_protocol_v1 import (
+    verify_protocol,
+)
+
+
+PROTOCOL = Path(
+    "configs/causal4d_public/pokeflex_task_conditioned_drop_protocol_v1.json"
+)
+
+
+def load_protocol() -> dict[str, object]:
+    return json.loads(PROTOCOL.read_text(encoding="utf-8"))
+
+
+def test_registered_protocol_verifies_and_freezes_six_targets() -> None:
+    verification = verify_protocol(load_protocol())
+    assert verification["status"] == "verified-registered-before-drop-outcome-access"
+    targets = verification["expected_primary_target_objects"]
+    assert targets == {
+        "foam": ["Sponge", "MemoryFoam"],
+        "printed": ["3dPrintedBunny", "3dPrintedCylinder"],
+        "soft": ["Beanbag", "Pillow"],
+    }
+    assert verification["target_drop_outcomes_opened"] is False
+
+
+def test_protocol_digest_detects_any_post_registration_change() -> None:
+    payload = load_protocol()
+    altered = copy.deepcopy(payload)
+    altered["take_roles"]["target_candidate_probe_count"] = 5
+    with pytest.raises(ValueError, match="protocol digest mismatch"):
+        verify_protocol(altered)
+
+
+def test_protocol_rejects_target_outcome_access_even_with_rehashed_payload() -> None:
+    payload = load_protocol()
+    altered = copy.deepcopy(payload)
+    altered["take_roles"]["target_drop_outcome_available_before_prediction_seal"] = True
+    altered.pop("protocol_sha256")
+    import hashlib
+
+    canonical = json.dumps(
+        altered,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    altered["protocol_sha256"] = hashlib.sha256(canonical).hexdigest()
+    with pytest.raises(ValueError, match="drop outcome exposed"):
+        verify_protocol(altered)


### PR DESCRIPTION
## Purpose

Freeze the scientific and information-boundary choices for the public-real-data active-probing precursor before any new PokeFlex drop outcome is opened.

## Registered design

- diagnostic-poke panel explicitly labeled retrospective;
- primary drop challenge prospective only after an exact historical-exposure scan;
- family-stratified 9 source / 3 calibration / 6 target object split selected by a frozen hash;
- four candidate pokes per target object;
- impact-geometry and settled-geometry drop queries;
- passive, random-safe, source-fixed, generic-information, task-conditioned, dependence-destroyed, and oracle policies;
- source/calibration gate before target selection;
- selected-probe-only reveal;
- one joint prediction seal before target drop scoring;
- physical object as the statistical unit;
- exact no-probe fallback when no safe probe has positive value.

## Boundaries

The protocol does not claim online execution, same-state counterfactuals, deployment safety, unique material identification, or calibrated full-state uncertainty. A secondary all-object analysis cannot upgrade primary freshness.

This PR is stacked on the metadata-audit PR and contains no target data or outcomes.