### PR TITLE
Consume trajectory-calibrated support-robust decisions fail closed

### DIFF
--- a/docs/support_robust_intervention.md
+++ b/docs/support_robust_intervention.md
@@ -1,0 +1,68 @@
+# Trajectory-calibrated support-robust interventions
+
+`causal4d.support_robust_intervention` is the Causal4D consumer for the
+trajectory-level split-conformal regret envelope produced by BayesianPhysTwin.
+It is deliberately independent of BayesianPhysTwin at runtime: live records and
+serialized mappings are both accepted, but every numerical field that controls
+the action is reconstructed before use.
+
+## Operational rule
+
+For registered finite-support regret bounds `B[a]`, conformal radius `rho`,
+regret budget `epsilon`, and a registered nonfallback action roster, Causal4D
+reconstructs
+
+```text
+inflated[a] = B[a] + rho
+admissible[a] = candidate[a] and inflated[a] <= epsilon
+```
+
+It executes a nonfallback action only when exactly one admissible action has the
+smallest inflated regret. Otherwise it returns the caller-owned fallback. In
+particular:
+
+- an infinite conformal radius returns fallback;
+- two equally good admissible actions return fallback;
+- the fallback cannot appear in the candidate mask;
+- supplied selected indices, masks, and inflated bounds are never trusted;
+- malformed or tampered records are rejected before an action name is exposed.
+
+## Example
+
+```python
+from causal4d.support_robust_intervention import (
+    consume_support_robust_decision,
+)
+
+result = consume_support_robust_decision(
+    bayesian_phystwin_record,
+    ("physical_fallback", "half_update", "full_update"),
+    expected_fallback_action_index=0,
+)
+
+if result.used_fallback:
+    execute_registered_physical_fallback()
+else:
+    execute_registered_action(result.selected_action_name)
+```
+
+The action roster is caller-owned and must be registered independently of the
+record. Optional BayesianPhysTwin `version` and `semantics` metadata are checked
+when available.
+
+## Statistical boundary
+
+The underlying split-conformal statement uses one score per complete calibration
+trajectory. Under exchangeability, the inflated bounds cover every registered
+decision and candidate action within one future complete trajectory with the
+declared trajectory-marginal probability. The guarantee is not pointwise
+conditional, does not validate exchangeability, and does not establish
+unseen-object transport.
+
+With too few calibration trajectories for a requested finite-sample rank, the
+BayesianPhysTwin radius is positive infinity. Causal4D preserves that result as
+an exact fallback rather than treating correlated windows as extra samples.
+
+This consumer verifies arithmetic and action-selection semantics only. It does
+not validate the physical support, provider, loss, regret budget, intervention
+cost, deployment context, or safety.

--- a/src/causal4d/support_robust_intervention.py
+++ b/src/causal4d/support_robust_intervention.py
@@ -1,0 +1,334 @@
+"""Consume trajectory-calibrated finite-action regret envelopes fail closed.
+
+BayesianPhysTwin may augment a registered finite-support worst-case regret vector
+with a split-conformal trajectory-level inflation radius.  This module verifies
+that record independently before Causal4D selects a physical intervention.  It
+never trusts a supplied selected index, admissibility mask, or inflated bound.
+
+A nonfallback action is emitted only when it is the unique minimum among the
+candidate actions whose independently reconstructed inflated regret is below
+the declared tolerance.  Infinite radii, malformed records, and admissible ties
+all return or raise before an unsupported intervention can be selected.
+
+The conformal statement is marginal over an exchangeable complete trajectory
+and simultaneous only for the registered decisions and actions represented by
+the score.  It is not pointwise conditional validity, unseen-object transport,
+or a deployment-safety certificate.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from numbers import Real
+from typing import Any, Final, NamedTuple, TypeAlias
+
+import numpy as np
+import numpy.typing as npt
+
+FloatArray: TypeAlias = npt.NDArray[np.float64]
+BoolArray: TypeAlias = npt.NDArray[np.bool_]
+
+SUPPORT_ROBUST_INTERVENTION_VERSION: Final = 1
+SUPPORT_ROBUST_INTERVENTION_SEMANTICS: Final = (
+    "independently-verified-trajectory-conformal-regret-intervention-v1"
+)
+BAYESIAN_PHYSTWIN_ENVELOPE_VERSION: Final = 1
+BAYESIAN_PHYSTWIN_ENVELOPE_SEMANTICS: Final = (
+    "trajectory-split-conformal-simultaneous-action-regret-inflation-v1"
+)
+SUPPORT_ROBUST_INTERVENTION_CLAIM_BOUNDARY: Final = (
+    "The consumer verifies arithmetic and fail-closed action-selection semantics "
+    "for the supplied finite action record. The trajectory-level conformal claim "
+    "still requires exchangeable complete trajectories and remains marginal over "
+    "a future trajectory. This module does not validate exchangeability, the "
+    "physical support, provider, action set, loss, regret budget, unseen-object "
+    "transport, deployment, or safety."
+)
+
+_ATOL: Final = 1e-12
+
+
+def _immutable_float64(value: object) -> FloatArray:
+    array = np.ascontiguousarray(value, dtype=np.float64)
+    array.setflags(write=False)
+    return array
+
+
+def _immutable_bool(value: object) -> BoolArray:
+    array = np.ascontiguousarray(value, dtype=np.bool_)
+    array.setflags(write=False)
+    return array
+
+
+def _field(record: object, name: str) -> object:
+    if isinstance(record, Mapping):
+        if name not in record:
+            raise ValueError(f"support-robust record is missing {name!r}")
+        return record[name]
+    if not hasattr(record, name):
+        raise ValueError(f"support-robust record is missing {name!r}")
+    return getattr(record, name)
+
+
+def _optional_field(record: object, name: str) -> object | None:
+    if isinstance(record, Mapping):
+        return record.get(name)
+    return getattr(record, name, None)
+
+
+def _summary(record: object) -> Mapping[str, object] | None:
+    direct = _optional_field(record, "summary")
+    if isinstance(direct, Mapping):
+        return direct
+    if callable(direct):
+        value = direct()
+        if not isinstance(value, Mapping):
+            raise ValueError("support-robust summary() must return a mapping")
+        return value
+    return None
+
+
+def _finite_nonnegative_vector(value: object, *, name: str) -> FloatArray:
+    raw = np.asarray(value)
+    if raw.dtype.kind not in "iuf":
+        raise ValueError(f"{name} must contain real numeric values")
+    array = np.ascontiguousarray(raw, dtype=np.float64)
+    if array.ndim != 1 or array.size < 2:
+        raise ValueError(f"{name} must contain at least two actions")
+    if not np.all(np.isfinite(array)) or np.any(array < 0.0):
+        raise ValueError(f"{name} must be finite and nonnegative")
+    return _immutable_float64(array)
+
+
+def _boolean_vector(value: object, *, name: str, size: int) -> BoolArray:
+    raw = np.asarray(value)
+    if raw.dtype.kind != "b":
+        raise ValueError(f"{name} must contain boolean values")
+    array = np.ascontiguousarray(raw, dtype=np.bool_)
+    if array.shape != (size,):
+        raise ValueError(f"{name} must have shape ({size},)")
+    return _immutable_bool(array)
+
+
+def _nonnegative_real_or_infinity(value: object, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a nonnegative real or positive infinity")
+    result = float(value)
+    if np.isnan(result) or result < 0.0:
+        raise ValueError(f"{name} must be a nonnegative real or positive infinity")
+    return result
+
+
+def _finite_nonnegative_real(value: object, *, name: str) -> float:
+    result = _nonnegative_real_or_infinity(value, name=name)
+    if not np.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _integer(value: object, *, name: str, size: int) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(
+        value, (int, np.integer)
+    ):
+        raise ValueError(f"{name} must be an integer")
+    result = int(value)
+    if not 0 <= result < size:
+        raise ValueError(f"{name} is out of range")
+    return result
+
+
+def _action_names(value: Sequence[str], *, size: int) -> tuple[str, ...]:
+    names = tuple(value)
+    if len(names) != size:
+        raise ValueError(f"action_names must contain exactly {size} entries")
+    if any(not isinstance(name, str) or not name.strip() for name in names):
+        raise ValueError("action_names must contain nonempty strings")
+    if len(set(names)) != len(names):
+        raise ValueError("action_names must be unique")
+    return names
+
+
+def _validate_optional_metadata(record: object) -> None:
+    summary = _summary(record)
+    if summary is None:
+        return
+    version = summary.get("version")
+    semantics = summary.get("semantics")
+    if version != BAYESIAN_PHYSTWIN_ENVELOPE_VERSION:
+        raise ValueError("unsupported BayesianPhysTwin envelope version")
+    if semantics != BAYESIAN_PHYSTWIN_ENVELOPE_SEMANTICS:
+        raise ValueError("unsupported BayesianPhysTwin envelope semantics")
+
+
+class SupportRobustInterventionV1(NamedTuple):
+    """Independently reconstructed Causal4D physical-intervention decision."""
+
+    action_names: tuple[str, ...]
+    registered_worst_case_regret: FloatArray
+    conformal_radius: float
+    inflated_regret_upper_bound: FloatArray
+    regret_tolerance: float
+    candidate_action_mask: BoolArray
+    tolerance_admissible_action_mask: BoolArray
+    selected_action_index: int
+    selected_action_name: str
+    fallback_action_index: int
+    fallback_action_name: str
+    used_fallback: bool
+
+    def summary(self) -> dict[str, object]:
+        return {
+            "version": SUPPORT_ROBUST_INTERVENTION_VERSION,
+            "semantics": SUPPORT_ROBUST_INTERVENTION_SEMANTICS,
+            "selected_action_index": self.selected_action_index,
+            "selected_action_name": self.selected_action_name,
+            "fallback_action_index": self.fallback_action_index,
+            "fallback_action_name": self.fallback_action_name,
+            "used_fallback": self.used_fallback,
+            "conformal_radius": self.conformal_radius,
+            "regret_tolerance": self.regret_tolerance,
+            "admissible_action_count": int(
+                np.count_nonzero(self.tolerance_admissible_action_mask)
+            ),
+            "claim_boundary": SUPPORT_ROBUST_INTERVENTION_CLAIM_BOUNDARY,
+        }
+
+
+def consume_support_robust_decision(
+    record: object,
+    action_names: Sequence[str],
+    *,
+    expected_fallback_action_index: int | None = None,
+) -> SupportRobustInterventionV1:
+    """Verify a BayesianPhysTwin support-robust record and select fail closed.
+
+    ``record`` may be a live ``SupportRobustDecisionV1`` object or a mapping
+    retaining all of its fields.  Optional ``summary`` metadata is checked when
+    present.  The selected index, masks, and inflated regrets are reconstructed
+    from the registered regret vector, conformal radius, and tolerance before
+    any action name is returned.
+    """
+
+    _validate_optional_metadata(record)
+    registered = _finite_nonnegative_vector(
+        _field(record, "registered_worst_case_regret"),
+        name="registered_worst_case_regret",
+    )
+    size = int(registered.size)
+    names = _action_names(action_names, size=size)
+    radius = _nonnegative_real_or_infinity(
+        _field(record, "conformal_radius"),
+        name="conformal_radius",
+    )
+    tolerance = _finite_nonnegative_real(
+        _field(record, "regret_tolerance"),
+        name="regret_tolerance",
+    )
+    fallback = _integer(
+        _field(record, "fallback_action_index"),
+        name="fallback_action_index",
+        size=size,
+    )
+    if expected_fallback_action_index is not None:
+        expected = _integer(
+            expected_fallback_action_index,
+            name="expected_fallback_action_index",
+            size=size,
+        )
+        if fallback != expected:
+            raise ValueError("support-robust fallback action does not match caller")
+
+    supplied_candidates = _boolean_vector(
+        _field(record, "candidate_action_mask"),
+        name="candidate_action_mask",
+        size=size,
+    )
+    candidates = np.asarray(supplied_candidates, dtype=np.bool_).copy()
+    if candidates[fallback]:
+        raise ValueError("candidate_action_mask must exclude the fallback action")
+    if not np.any(candidates):
+        raise ValueError("candidate_action_mask must select a nonfallback action")
+
+    reconstructed_inflated = np.asarray(registered, dtype=np.float64) + radius
+    reconstructed_admissible = candidates & (
+        reconstructed_inflated <= tolerance + _ATOL
+    )
+    reconstructed_selected = fallback
+    reconstructed_used_fallback = True
+    if np.any(reconstructed_admissible):
+        minimum = float(np.min(reconstructed_inflated[reconstructed_admissible]))
+        minimizers = np.flatnonzero(
+            reconstructed_admissible
+            & np.isclose(
+                reconstructed_inflated,
+                minimum,
+                rtol=0.0,
+                atol=_ATOL,
+            )
+        )
+        if minimizers.size == 1:
+            reconstructed_selected = int(minimizers[0])
+            reconstructed_used_fallback = False
+
+    supplied_inflated = np.asarray(
+        _field(record, "inflated_regret_upper_bound"),
+        dtype=np.float64,
+    )
+    if supplied_inflated.shape != (size,) or np.any(np.isnan(supplied_inflated)):
+        raise ValueError("inflated_regret_upper_bound has invalid shape or NaN")
+    if not np.allclose(
+        supplied_inflated,
+        reconstructed_inflated,
+        rtol=0.0,
+        atol=_ATOL,
+    ):
+        raise ValueError("supplied inflated regret bounds failed verification")
+
+    supplied_admissible = _boolean_vector(
+        _field(record, "tolerance_admissible_action_mask"),
+        name="tolerance_admissible_action_mask",
+        size=size,
+    )
+    if not np.array_equal(supplied_admissible, reconstructed_admissible):
+        raise ValueError("supplied admissibility mask failed verification")
+
+    supplied_selected = _integer(
+        _field(record, "selected_action_index"),
+        name="selected_action_index",
+        size=size,
+    )
+    if supplied_selected != reconstructed_selected:
+        raise ValueError("supplied selected action failed verification")
+    supplied_used_fallback = _field(record, "used_fallback")
+    if not isinstance(supplied_used_fallback, (bool, np.bool_)):
+        raise ValueError("used_fallback must be boolean")
+    if bool(supplied_used_fallback) != reconstructed_used_fallback:
+        raise ValueError("supplied fallback flag failed verification")
+
+    return SupportRobustInterventionV1(
+        action_names=names,
+        registered_worst_case_regret=registered,
+        conformal_radius=radius,
+        inflated_regret_upper_bound=_immutable_float64(reconstructed_inflated),
+        regret_tolerance=tolerance,
+        candidate_action_mask=_immutable_bool(candidates),
+        tolerance_admissible_action_mask=_immutable_bool(
+            reconstructed_admissible
+        ),
+        selected_action_index=reconstructed_selected,
+        selected_action_name=names[reconstructed_selected],
+        fallback_action_index=fallback,
+        fallback_action_name=names[fallback],
+        used_fallback=reconstructed_used_fallback,
+    )
+
+
+__all__ = [
+    "BAYESIAN_PHYSTWIN_ENVELOPE_SEMANTICS",
+    "BAYESIAN_PHYSTWIN_ENVELOPE_VERSION",
+    "SUPPORT_ROBUST_INTERVENTION_CLAIM_BOUNDARY",
+    "SUPPORT_ROBUST_INTERVENTION_SEMANTICS",
+    "SUPPORT_ROBUST_INTERVENTION_VERSION",
+    "SupportRobustInterventionV1",
+    "consume_support_robust_decision",
+]

--- a/tests/test_support_robust_intervention.py
+++ b/tests/test_support_robust_intervention.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from causal4d.support_robust_intervention import (
+    BAYESIAN_PHYSTWIN_ENVELOPE_SEMANTICS,
+    SUPPORT_ROBUST_INTERVENTION_CLAIM_BOUNDARY,
+    consume_support_robust_decision,
+)
+
+
+def make_record(
+    *,
+    registered: tuple[float, ...] = (0.0, 0.10, 0.40),
+    radius: float = 0.05,
+    tolerance: float = 0.20,
+    candidates: tuple[bool, ...] = (False, True, True),
+    fallback: int = 0,
+) -> dict[str, object]:
+    registered_array = np.asarray(registered, dtype=np.float64)
+    candidate_array = np.asarray(candidates, dtype=np.bool_)
+    inflated = registered_array + radius
+    admissible = candidate_array & (inflated <= tolerance + 1e-12)
+    selected = fallback
+    used_fallback = True
+    if np.any(admissible):
+        minimum = float(np.min(inflated[admissible]))
+        minimizers = np.flatnonzero(
+            admissible & np.isclose(inflated, minimum, rtol=0.0, atol=1e-12)
+        )
+        if minimizers.size == 1:
+            selected = int(minimizers[0])
+            used_fallback = False
+    return {
+        "registered_worst_case_regret": registered_array,
+        "conformal_radius": radius,
+        "inflated_regret_upper_bound": inflated,
+        "regret_tolerance": tolerance,
+        "candidate_action_mask": candidate_array,
+        "tolerance_admissible_action_mask": admissible,
+        "selected_action_index": selected,
+        "fallback_action_index": fallback,
+        "used_fallback": used_fallback,
+        "summary": {
+            "version": 1,
+            "semantics": BAYESIAN_PHYSTWIN_ENVELOPE_SEMANTICS,
+        },
+    }
+
+
+def test_executes_unique_verified_nonfallback_action() -> None:
+    result = consume_support_robust_decision(
+        make_record(),
+        ("fallback", "half_update", "full_update"),
+        expected_fallback_action_index=0,
+    )
+
+    assert result.selected_action_index == 1
+    assert result.selected_action_name == "half_update"
+    assert result.used_fallback is False
+    np.testing.assert_array_equal(
+        result.tolerance_admissible_action_mask,
+        [False, True, False],
+    )
+
+
+def test_infinite_radius_returns_exact_fallback() -> None:
+    result = consume_support_robust_decision(
+        make_record(radius=float("inf"), tolerance=100.0),
+        ("physical_fallback", "half_update", "full_update"),
+    )
+
+    assert result.selected_action_name == "physical_fallback"
+    assert result.used_fallback is True
+    assert np.all(np.isinf(result.inflated_regret_upper_bound))
+    assert not np.any(result.tolerance_admissible_action_mask)
+
+
+def test_admissible_tie_returns_fallback_instead_of_arbitrary_action() -> None:
+    result = consume_support_robust_decision(
+        make_record(registered=(0.0, 0.10, 0.10)),
+        ("fallback", "left", "right"),
+    )
+
+    assert result.selected_action_index == 0
+    assert result.used_fallback is True
+    np.testing.assert_array_equal(
+        result.tolerance_admissible_action_mask,
+        [False, True, True],
+    )
+
+
+def test_live_object_summary_and_serialized_mapping_have_parity() -> None:
+    mapping = make_record()
+    live = SimpleNamespace(
+        **{key: value for key, value in mapping.items() if key != "summary"}
+    )
+    live.summary = lambda: mapping["summary"]
+
+    mapping_result = consume_support_robust_decision(
+        mapping,
+        ("fallback", "half", "full"),
+    )
+    live_result = consume_support_robust_decision(
+        live,
+        ("fallback", "half", "full"),
+    )
+
+    assert live_result.summary() == mapping_result.summary()
+    np.testing.assert_array_equal(
+        live_result.inflated_regret_upper_bound,
+        mapping_result.inflated_regret_upper_bound,
+    )
+
+
+def test_rejects_tampered_inflated_regret() -> None:
+    record = make_record()
+    record["inflated_regret_upper_bound"] = np.asarray([0.05, 0.06, 0.45])
+
+    with pytest.raises(ValueError, match="inflated regret bounds"):
+        consume_support_robust_decision(
+            record,
+            ("fallback", "half", "full"),
+        )
+
+
+def test_rejects_tampered_admissibility_mask() -> None:
+    record = make_record()
+    record["tolerance_admissible_action_mask"] = np.asarray(
+        [False, False, True]
+    )
+
+    with pytest.raises(ValueError, match="admissibility mask"):
+        consume_support_robust_decision(
+            record,
+            ("fallback", "half", "full"),
+        )
+
+
+def test_rejects_tampered_selected_action_and_fallback_flag() -> None:
+    selected = make_record()
+    selected["selected_action_index"] = 2
+    with pytest.raises(ValueError, match="selected action"):
+        consume_support_robust_decision(
+            selected,
+            ("fallback", "half", "full"),
+        )
+
+    flag = make_record()
+    flag["used_fallback"] = True
+    with pytest.raises(ValueError, match="fallback flag"):
+        consume_support_robust_decision(
+            flag,
+            ("fallback", "half", "full"),
+        )
+
+
+def test_rejects_candidate_mask_that_contains_or_only_leaves_fallback() -> None:
+    contains = make_record(candidates=(True, True, False))
+    with pytest.raises(ValueError, match="exclude the fallback"):
+        consume_support_robust_decision(
+            contains,
+            ("fallback", "half", "full"),
+        )
+
+    only_fallback = make_record(candidates=(True, False, False))
+    with pytest.raises(ValueError, match="exclude the fallback"):
+        consume_support_robust_decision(
+            only_fallback,
+            ("fallback", "half", "full"),
+        )
+
+
+def test_rejects_wrong_version_semantics_or_fallback_contract() -> None:
+    wrong_version = make_record()
+    wrong_version["summary"] = {
+        "version": 2,
+        "semantics": BAYESIAN_PHYSTWIN_ENVELOPE_SEMANTICS,
+    }
+    with pytest.raises(ValueError, match="version"):
+        consume_support_robust_decision(
+            wrong_version,
+            ("fallback", "half", "full"),
+        )
+
+    wrong_semantics = make_record()
+    wrong_semantics["summary"] = {"version": 1, "semantics": "wrong"}
+    with pytest.raises(ValueError, match="semantics"):
+        consume_support_robust_decision(
+            wrong_semantics,
+            ("fallback", "half", "full"),
+        )
+
+    with pytest.raises(ValueError, match="does not match caller"):
+        consume_support_robust_decision(
+            make_record(),
+            ("fallback", "half", "full"),
+            expected_fallback_action_index=2,
+        )
+
+
+def test_rejects_bad_action_roster_and_malformed_numerics() -> None:
+    with pytest.raises(ValueError, match="exactly 3"):
+        consume_support_robust_decision(
+            make_record(),
+            ("fallback", "half"),
+        )
+    with pytest.raises(ValueError, match="unique"):
+        consume_support_robust_decision(
+            make_record(),
+            ("fallback", "same", "same"),
+        )
+
+    nan_radius = make_record()
+    nan_radius["conformal_radius"] = float("nan")
+    with pytest.raises(ValueError, match="conformal_radius"):
+        consume_support_robust_decision(
+            nan_radius,
+            ("fallback", "half", "full"),
+        )
+
+    negative = make_record()
+    negative["registered_worst_case_regret"] = np.asarray([0.0, -0.1, 0.2])
+    with pytest.raises(ValueError, match="nonnegative"):
+        consume_support_robust_decision(
+            negative,
+            ("fallback", "half", "full"),
+        )
+
+
+def test_returned_arrays_are_read_only_and_claim_is_bounded() -> None:
+    result = consume_support_robust_decision(
+        make_record(),
+        ("fallback", "half", "full"),
+    )
+
+    assert result.registered_worst_case_regret.flags.writeable is False
+    assert result.inflated_regret_upper_bound.flags.writeable is False
+    assert result.candidate_action_mask.flags.writeable is False
+    assert result.tolerance_admissible_action_mask.flags.writeable is False
+    with pytest.raises(ValueError):
+        result.inflated_regret_upper_bound[1] = 99.0
+    boundary = SUPPORT_ROBUST_INTERVENTION_CLAIM_BOUNDARY.lower()
+    assert "exchangeable complete trajectories" in boundary
+    assert "unseen-object" in boundary
+    assert "safety" in boundary


### PR DESCRIPTION
## Purpose

Complete the operational chain for BayesianPhysTwin's merged trajectory-level conformal regret envelope (BayesianPhysTwin PR #884, merge `0ee1443bc35b8da9765e04810bb44ba0fe70ebc4`). Causal4D now independently reconstructs every action-controlling quantity before exposing a physical intervention.

## Behavior

For registered finite-support regret bounds `B[a]`, conformal radius `rho`, regret budget `epsilon`, and a caller-owned finite action roster, the consumer recomputes

```text
inflated[a] = B[a] + rho
admissible[a] = candidate[a] and inflated[a] <= epsilon
```

It emits a nonfallback action only when one admissible action is the unique minimum up to the frozen numerical tolerance. Otherwise it returns the exact caller-owned fallback.

The consumer independently verifies:

- optional BayesianPhysTwin envelope version and semantics;
- action roster length, uniqueness, and fallback identity;
- finite registered regret values;
- the conformal inflation radius, including positive infinity;
- candidate and tolerance-admissible masks;
- inflated regret bounds;
- selected action index and fallback flag.

It rejects tampered or malformed records before an action name is returned. The fallback cannot be smuggled into the candidate mask, and admissible ties are never broken arbitrarily.

## Validation

Focused local validation covers:

- unique support-robust action execution;
- infinite-radius exact fallback;
- exact fallback under admissible ties;
- parity between live and serialized records;
- tampered bound, mask, selected-index, and fallback-flag rejection;
- wrong version/semantics and caller-fallback rejection;
- malformed numerics and action rosters;
- immutable returned arrays and bounded claim language.

## Claim boundary

This module verifies finite-action arithmetic and fail-closed consumption. The underlying conformal statement remains marginal over an exchangeable complete future trajectory and simultaneous only for the registered decisions/actions represented by the score. It does not validate exchangeability, the physical support, provider, action set, loss, regret budget, unseen-object transport, deployment, or safety.