### PR TITLE
Add counterexample-guided continuous decision certification

### DIFF
--- a/.github/workflows/continuous-decision-certification.yml
+++ b/.github/workflows/continuous-decision-certification.yml
@@ -1,0 +1,91 @@
+name: Continuous decision certification
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/continuous-decision-certification.yml"
+      - "src/causal4d/continuous_decision_certification.py"
+      - "tests/test_continuous_decision_certification.py"
+      - "scripts/experiments/continuous_decision_certification.py"
+      - "docs/continuous_decision_certification.md"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/continuous-decision-certification.yml"
+      - "src/causal4d/continuous_decision_certification.py"
+      - "tests/test_continuous_decision_certification.py"
+      - "scripts/experiments/continuous_decision_certification.py"
+      - "docs/continuous_decision_certification.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: continuous-decision-certification-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install focused dependencies
+        run: |
+          python -m pip install --disable-pip-version-check \
+            numpy==2.2.6 \
+            pytest==8.4.2 \
+            ruff==0.16.5
+
+      - name: Lint and verify formatting
+        run: |
+          python -m ruff check \
+            src/causal4d/continuous_decision_certification.py \
+            tests/test_continuous_decision_certification.py \
+            scripts/experiments/continuous_decision_certification.py
+          python -m ruff format --check \
+            src/causal4d/continuous_decision_certification.py \
+            tests/test_continuous_decision_certification.py \
+            scripts/experiments/continuous_decision_certification.py
+
+      - name: Run focused tests and controlled regression
+        env:
+          PYTHONPATH: src
+        run: |
+          pytest -q \
+            tests/test_continuous_decision_certification.py \
+            tests/test_controlled_decision_identification.py
+
+      - name: Execute deterministic study twice
+        env:
+          PYTHONPATH: src
+        run: |
+          mkdir -p build/continuous-decision-certification
+          python scripts/experiments/continuous_decision_certification.py \
+            --output build/continuous-decision-certification/result-a.json
+          python scripts/experiments/continuous_decision_certification.py \
+            --output build/continuous-decision-certification/result-b.json
+          cmp \
+            build/continuous-decision-certification/result-a.json \
+            build/continuous-decision-certification/result-b.json
+          python -m json.tool \
+            build/continuous-decision-certification/result-a.json >/dev/null
+
+      - name: Upload content-addressed result
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: continuous-decision-certification-${{ github.sha }}
+          path: build/continuous-decision-certification/result-a.json
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/continuous_decision_certification.md
+++ b/docs/continuous_decision_certification.md
@@ -1,0 +1,110 @@
+# Counterexample-guided continuous decision certification
+
+The finite decision-identification layers are exact only for a supplied finite
+hypothesis roster. A grid of material, contact, or alignment parameters is not a
+certificate: a decision-breaking physical world may lie between sampled nodes.
+This module replaces the finite roster by a compact continuous parameter box and
+verified loss-gap envelopes.
+
+## Registered interface
+
+Let `theta` lie in one axis-aligned box `Theta`, let `loss(theta, a)` be the
+registered terminal loss of action `a`, and let `K[a]` be a valid global
+Lipschitz constant in the parameter `L-infinity` metric:
+
+```text
+|loss(theta, a) - loss(theta', a)| <= K[a] ||theta - theta'||_infinity.
+```
+
+For a box with center `c` and radius `r`, every pairwise action-loss gap obeys
+
+```text
+loss(theta, a) - loss(theta, b)
+<= loss(c, a) - loss(c, b) + (K[a] + K[b]) r.
+```
+
+Taking the maximum over competitors gives a sound upper bound on the worst-case
+regret of action `a` throughout that box. Evaluating the center gives a concrete
+lower-bound witness. The implementation never promotes a finite grid into
+continuous support.
+
+## Counterexample-guided branch and bound
+
+`certify_continuous_decision` starts from the complete registered parameter box
+and repeatedly splits the region carrying the largest unresolved regret excess.
+For every action it maintains:
+
+- a witnessed lower bound from evaluated physical parameter points; and
+- a verified upper bound covering every still-active parameter box.
+
+The routine terminates in one of four states:
+
+1. `certified`: exactly one action has a verified upper regret below tolerance
+   and every other action has a concrete violating parameter;
+2. `no-admissible-action`: every action has a concrete counterexample;
+3. `multiple-admissible-actions`: at least two actions are uniformly within the
+   registered tolerance; or
+4. `inconclusive`: the evaluation, depth, or resolution budget is exhausted.
+
+Only the first state emits an action. Every other state routes to the caller's
+exact fallback. Search failure is therefore not confused with physical
+admissibility.
+
+## Controlled strict-separation study
+
+The deterministic mechanism uses a continuous physical coordinate `x` in
+`[-1, 1]`. Action 0 is preferable almost everywhere but has a narrow
+high-regret pocket centered at `x = 0.375`; action 1 has a small constant loss.
+A three-node grid at `{-1, 0, 1}` misses the pocket, reports zero empirical
+worst-case regret for action 0, and selects it.
+
+The continuous certificate instead:
+
+- finds the decision-breaking world at `x = 0.375`;
+- witnesses regret `0.9` for action 0;
+- verifies that action 1 has worst-case regret below the registered `0.15`
+  tolerance; and
+- certifies action 1.
+
+A source-qualified observation then restricts the relevant coordinate to
+`[-1, 0.2]` while leaving a full nuisance coordinate in `[-1, 1]` unresolved.
+Using a source-qualified local Lipschitz envelope on that restricted support, the
+certificate selects action 0 at tolerance `0.05`. Thus additional evidence
+changes the justified decision without identifying the complete physical state.
+
+A one-evaluation control returns `inconclusive` and exact fallback rather than a
+partial certificate.
+
+This establishes:
+
+```text
+finite-grid success != continuous-support certification
+counterexample elimination != complete-state identification
+optimizer exhaustion != action admissibility
+```
+
+## Relation to controlled interventions
+
+The state-changing intervention planner currently operates on finite physical
+support. The continuous certificate is the terminal support oracle required for
+a counterexample-guided dual-control extension:
+
+1. search the continuous physical model class for a world that breaks the
+   current terminal action;
+2. if none exists under verified envelopes, act;
+3. otherwise choose an intervention whose possible outcomes eliminate or
+   separate the surviving counterexamples;
+4. recompute the support certificate; and
+5. fall back whenever verification remains inconclusive.
+
+The present module implements steps 1, 2, 4, and 5. Coupling verified continuous
+support refinement to the merged controlled transition-observation planner is
+the next algorithmic layer.
+
+## Scientific boundary
+
+Soundness is conditional on the supplied parameter domain, deterministic loss
+oracle, and valid global or source-qualified local Lipschitz constants. The
+module does not validate those physical ingredients, establish that a learned
+simulator bounds reality, prove target-domain transport, authorize deployment,
+or provide a safety guarantee.

--- a/scripts/experiments/continuous_decision_certification.py
+++ b/scripts/experiments/continuous_decision_certification.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Run the counterexample-guided continuous-support mechanism study."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from causal4d.continuous_decision_certification import (
+    ParameterBox,
+    certify_continuous_decision,
+)
+
+
+def _content_id(value: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _losses(parameter: np.ndarray) -> tuple[float, float]:
+    x = float(parameter[0])
+    center = 0.375
+    half_width = 0.125
+    decision_breaking_bump = max(0.0, 1.0 - abs(x - center) / half_width)
+    return decision_breaking_bump, 0.1
+
+
+def _coarse_grid() -> dict[str, object]:
+    points = (-1.0, 0.0, 1.0)
+    losses = np.asarray([_losses(np.asarray([point])) for point in points])
+    oracle = np.min(losses, axis=1)
+    empirical_regret = np.max(losses - oracle[:, None], axis=0)
+    selected = int(np.argmin(empirical_regret))
+    return {
+        "points": list(points),
+        "empirical_worst_case_regret": [float(value) for value in empirical_regret],
+        "selected_action": selected,
+        "selected_action_appears_admissible_at_tolerance_0_15": bool(
+            empirical_regret[selected] <= 0.15
+        ),
+    }
+
+
+def run() -> dict[str, Any]:
+    full = certify_continuous_decision(
+        _losses,
+        ParameterBox((-1.0,), (1.0,)),
+        (8.0, 0.0),
+        regret_tolerance=0.15,
+        maximum_evaluations=1025,
+    )
+    restricted = certify_continuous_decision(
+        _losses,
+        ParameterBox((-1.0, -1.0), (0.20, 1.0)),
+        (0.0, 0.0),
+        regret_tolerance=0.05,
+        maximum_evaluations=9,
+    )
+    budget_limited = certify_continuous_decision(
+        lambda parameter: (float(parameter[0] ** 2), 0.2),
+        ParameterBox((-1.0,), (1.0,)),
+        (2.0, 0.0),
+        regret_tolerance=0.05,
+        maximum_evaluations=1,
+    )
+    coarse = _coarse_grid()
+    action_zero = full.action_bounds[0]
+    action_one = full.action_bounds[1]
+    result: dict[str, Any] = {
+        "schema": "causal4d.continuous-decision-certification-mechanism.v1",
+        "coarse_grid": coarse,
+        "continuous_full_support": full.as_dict(),
+        "source_qualified_restriction": restricted.as_dict(),
+        "search_budget_control": budget_limited.as_dict(),
+        "strict_separation": {
+            "coarse_grid_selects_wrong_action": (
+                coarse["selected_action"] == 0 and full.selected_action_index == 1
+            ),
+            "continuous_search_finds_decision_breaking_world": (
+                action_zero.witnessed_inadmissible
+                and 0.30 <= action_zero.witness_parameter[0] <= 0.45
+                and action_zero.witnessed_lower_bound >= 0.89
+            ),
+            "continuous_support_certifies_other_action": (
+                full.status == "certified"
+                and full.selected_action_index == 1
+                and action_one.certified_admissible
+            ),
+            "support_restriction_changes_certified_action": (
+                restricted.status == "certified"
+                and restricted.selected_action_index == 0
+            ),
+            "restriction_does_not_identify_full_state": (
+                restricted.maximum_remaining_radius > 0.0
+            ),
+            "budget_exhaustion_fails_closed": (
+                budget_limited.status == "inconclusive"
+                and budget_limited.used_exact_fallback
+            ),
+        },
+        "claim_boundary": (
+            "Controlled continuous-support mechanism only. Soundness is conditional "
+            "on the registered compact parameter domain, deterministic loss oracle, "
+            "and valid global or source-qualified local Lipschitz constants. No real "
+            "physical support, learned model, target transport, deployment, or safety "
+            "claim is established."
+        ),
+    }
+    if not all(result["strict_separation"].values()):
+        raise RuntimeError("continuous decision-certification mechanism check failed")
+    result["result_id"] = _content_id(result)
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    result = run()
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/causal4d/continuous_decision_certification.py
+++ b/src/causal4d/continuous_decision_certification.py
@@ -1,0 +1,453 @@
+"""Counterexample-guided certification over continuous physical support.
+
+The finite decision-identification layers are exact only for a supplied finite
+hypothesis roster. This module replaces that roster by one compact axis-aligned
+parameter domain and a deterministic loss oracle with registered Lipschitz
+constants. It uses sound branch-and-bound envelopes to certify or refute
+uniform action regret without treating a parameter grid as complete support.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from numbers import Integral, Real
+from typing import Literal
+
+import numpy as np
+
+ContinuousDecisionStatus = Literal[
+    "certified",
+    "no-admissible-action",
+    "multiple-admissible-actions",
+    "inconclusive",
+]
+
+CONTINUOUS_DECISION_CERTIFICATION_VERSION = 1
+CONTINUOUS_DECISION_CERTIFICATION_CLAIM_BOUNDARY = (
+    "Sound only for the supplied compact axis-aligned parameter domain, "
+    "deterministic finite loss oracle, valid global action-loss Lipschitz "
+    "constants in the L-infinity parameter metric, regret tolerance, and "
+    "numerical arithmetic. It does not validate the physical parameter set, "
+    "loss oracle, Lipschitz constants, target transport, deployment, or safety."
+)
+
+_ATOL = 1e-12
+
+
+def _finite_real(value: object, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise TypeError(f"{name} must be a finite real")
+    result = float(value)
+    if not np.isfinite(result):
+        raise ValueError(f"{name} must be a finite real")
+    return result
+
+
+def _finite_nonnegative(value: object, *, name: str) -> float:
+    result = _finite_real(value, name=name)
+    if result < 0.0:
+        raise ValueError(f"{name} must be nonnegative")
+    return result
+
+
+def _positive_integer(value: object, *, name: str) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
+        raise TypeError(f"{name} must be an integer")
+    result = int(value)
+    if result < 1:
+        raise ValueError(f"{name} must be positive")
+    return result
+
+
+def _canonical(value: float) -> float:
+    result = float(value)
+    return 0.0 if result == 0.0 else result
+
+
+@dataclass(frozen=True)
+class ParameterBox:
+    """One compact axis-aligned region of continuous physical parameters."""
+
+    lower: tuple[float, ...]
+    upper: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        lower = np.asarray(self.lower, dtype=np.float64)
+        upper = np.asarray(self.upper, dtype=np.float64)
+        if lower.ndim != 1 or upper.ndim != 1 or lower.size == 0:
+            raise ValueError("box bounds must be nonempty vectors")
+        if lower.shape != upper.shape:
+            raise ValueError("box lower and upper bounds must have equal shape")
+        if not np.isfinite(lower).all() or not np.isfinite(upper).all():
+            raise ValueError("box bounds must be finite")
+        if np.any(lower > upper):
+            raise ValueError("box lower bounds must not exceed upper bounds")
+        object.__setattr__(
+            self, "lower", tuple(_canonical(value) for value in lower)
+        )
+        object.__setattr__(
+            self, "upper", tuple(_canonical(value) for value in upper)
+        )
+
+    @property
+    def dimension(self) -> int:
+        return len(self.lower)
+
+    @property
+    def center(self) -> tuple[float, ...]:
+        return tuple((low + high) / 2.0 for low, high in zip(self.lower, self.upper))
+
+    @property
+    def widths(self) -> tuple[float, ...]:
+        return tuple(high - low for low, high in zip(self.lower, self.upper))
+
+    @property
+    def linf_radius(self) -> float:
+        return max(self.widths) / 2.0
+
+    @property
+    def maximum_width(self) -> float:
+        return max(self.widths)
+
+    def split(self) -> tuple[ParameterBox, ParameterBox] | None:
+        widths = self.widths
+        dimension = int(np.argmax(np.asarray(widths, dtype=np.float64)))
+        if widths[dimension] <= 0.0:
+            return None
+        midpoint = (self.lower[dimension] + self.upper[dimension]) / 2.0
+        first_upper = list(self.upper)
+        first_upper[dimension] = midpoint
+        second_lower = list(self.lower)
+        second_lower[dimension] = midpoint
+        return (
+            ParameterBox(self.lower, tuple(first_upper)),
+            ParameterBox(tuple(second_lower), self.upper),
+        )
+
+    def contains(self, point: Sequence[float]) -> bool:
+        values = np.asarray(point, dtype=np.float64)
+        if values.shape != (self.dimension,):
+            return False
+        lower = np.asarray(self.lower, dtype=np.float64)
+        upper = np.asarray(self.upper, dtype=np.float64)
+        return bool(
+            np.all(values >= lower - _ATOL) and np.all(values <= upper + _ATOL)
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "lower": list(self.lower),
+            "upper": list(self.upper),
+            "center": list(self.center),
+            "linf_radius": self.linf_radius,
+        }
+
+
+@dataclass(frozen=True)
+class ContinuousActionBound:
+    """Verified and witnessed bounds on one action's worst-case regret."""
+
+    action_index: int
+    witnessed_lower_bound: float
+    verified_upper_bound: float
+    certified_admissible: bool
+    witnessed_inadmissible: bool
+    witness_parameter: tuple[float, ...]
+    witness_losses: tuple[float, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "action_index": self.action_index,
+            "witnessed_lower_bound": self.witnessed_lower_bound,
+            "verified_upper_bound": self.verified_upper_bound,
+            "certified_admissible": self.certified_admissible,
+            "witnessed_inadmissible": self.witnessed_inadmissible,
+            "witness_parameter": list(self.witness_parameter),
+            "witness_losses": list(self.witness_losses),
+        }
+
+
+@dataclass(frozen=True)
+class ContinuousDecisionCertificate:
+    """Fail-closed continuous-support decision certificate."""
+
+    status: ContinuousDecisionStatus
+    selected_action_index: int | None
+    action_bounds: tuple[ContinuousActionBound, ...]
+    regret_tolerance: float
+    evaluated_points: int
+    active_boxes: int
+    maximum_remaining_radius: float
+    reason_code: str
+
+    @property
+    def certified(self) -> bool:
+        return self.status == "certified"
+
+    @property
+    def used_exact_fallback(self) -> bool:
+        return not self.certified
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "version": CONTINUOUS_DECISION_CERTIFICATION_VERSION,
+            "status": self.status,
+            "selected_action_index": self.selected_action_index,
+            "action_bounds": [bound.as_dict() for bound in self.action_bounds],
+            "regret_tolerance": self.regret_tolerance,
+            "evaluated_points": self.evaluated_points,
+            "active_boxes": self.active_boxes,
+            "maximum_remaining_radius": self.maximum_remaining_radius,
+            "reason_code": self.reason_code,
+            "used_exact_fallback": self.used_exact_fallback,
+            "claim_boundary": CONTINUOUS_DECISION_CERTIFICATION_CLAIM_BOUNDARY,
+        }
+
+
+@dataclass(frozen=True)
+class _EvaluatedBox:
+    box: ParameterBox
+    depth: int
+    losses: tuple[float, ...]
+    regret: tuple[float, ...]
+    regret_upper: tuple[float, ...]
+
+
+def _losses_at(
+    loss_oracle: Callable[[np.ndarray], Sequence[float]],
+    point: tuple[float, ...],
+    *,
+    expected_actions: int | None,
+) -> np.ndarray:
+    losses = np.asarray(
+        loss_oracle(np.asarray(point, dtype=np.float64)),
+        dtype=np.float64,
+    )
+    if losses.ndim != 1 or losses.size < 2:
+        raise ValueError("loss oracle must return at least two action losses")
+    if expected_actions is not None and losses.size != expected_actions:
+        raise ValueError("loss oracle changed the action count")
+    if not np.isfinite(losses).all():
+        raise ValueError("loss oracle returned a nonfinite value")
+    return losses
+
+
+def _evaluate_box(
+    box: ParameterBox,
+    depth: int,
+    loss_oracle: Callable[[np.ndarray], Sequence[float]],
+    lipschitz: np.ndarray,
+) -> _EvaluatedBox:
+    losses = _losses_at(loss_oracle, box.center, expected_actions=lipschitz.size)
+    regret = losses - float(np.min(losses))
+    radius = box.linf_radius
+    upper = np.empty(losses.size, dtype=np.float64)
+    for action in range(losses.size):
+        gaps = []
+        for competitor in range(losses.size):
+            if competitor == action:
+                gaps.append(0.0)
+            else:
+                gaps.append(
+                    float(losses[action] - losses[competitor])
+                    + float(lipschitz[action] + lipschitz[competitor]) * radius
+                )
+        upper[action] = max(0.0, max(gaps))
+    return _EvaluatedBox(
+        box=box,
+        depth=depth,
+        losses=tuple(float(value) for value in losses),
+        regret=tuple(max(0.0, float(value)) for value in regret),
+        regret_upper=tuple(max(0.0, float(value)) for value in upper),
+    )
+
+
+def _summarize(
+    active: Sequence[_EvaluatedBox],
+    samples: Sequence[_EvaluatedBox],
+    *,
+    regret_tolerance: float,
+) -> tuple[ContinuousActionBound, ...]:
+    action_count = len(active[0].losses)
+    upper = np.max(
+        np.asarray([box.regret_upper for box in active], dtype=np.float64),
+        axis=0,
+    )
+    sample_regret = np.asarray([box.regret for box in samples], dtype=np.float64)
+    lower = np.max(sample_regret, axis=0)
+    bounds: list[ContinuousActionBound] = []
+    for action in range(action_count):
+        witness_index = int(np.argmax(sample_regret[:, action]))
+        witness = samples[witness_index]
+        certified = bool(upper[action] <= regret_tolerance + _ATOL)
+        rejected = bool(lower[action] > regret_tolerance + _ATOL)
+        if certified and rejected:
+            raise RuntimeError("inconsistent continuous regret bounds")
+        bounds.append(
+            ContinuousActionBound(
+                action_index=action,
+                witnessed_lower_bound=float(lower[action]),
+                verified_upper_bound=float(upper[action]),
+                certified_admissible=certified,
+                witnessed_inadmissible=rejected,
+                witness_parameter=witness.box.center,
+                witness_losses=witness.losses,
+            )
+        )
+    return tuple(bounds)
+
+
+def _terminal_status(
+    bounds: Sequence[ContinuousActionBound],
+) -> tuple[ContinuousDecisionStatus | None, int | None, str | None]:
+    certified = [bound.action_index for bound in bounds if bound.certified_admissible]
+    rejected = [bound.action_index for bound in bounds if bound.witnessed_inadmissible]
+    if len(certified) >= 2:
+        return (
+            "multiple-admissible-actions",
+            None,
+            "multiple-actions-uniformly-within-regret-tolerance",
+        )
+    if len(rejected) == len(bounds):
+        return "no-admissible-action", None, "every-action-has-counterexample"
+    if len(certified) == 1 and len(rejected) == len(bounds) - 1:
+        return "certified", certified[0], "unique-continuous-support-admissible-action"
+    return None, None, None
+
+
+def certify_continuous_decision(
+    loss_oracle: Callable[[np.ndarray], Sequence[float]],
+    domain: ParameterBox,
+    action_loss_lipschitz: Sequence[float],
+    *,
+    regret_tolerance: float = 0.0,
+    maximum_evaluations: int = 4097,
+    maximum_depth: int = 40,
+    minimum_box_width: float = 0.0,
+) -> ContinuousDecisionCertificate:
+    """Certify a unique action or fail closed over a continuous parameter box.
+
+    The registered loss of action ``a`` must be globally ``K[a]``-Lipschitz in
+    the L-infinity parameter metric on ``domain``. For every box center ``c``
+    and competitor ``b``,
+
+    ``loss_a(theta) - loss_b(theta)``
+
+    is then at most its value at ``c`` plus ``(K[a] + K[b]) * radius``. The
+    branch-and-bound loop refines the box that carries the largest unresolved
+    regret excess. A sampled violating point is a concrete counterexample; a
+    verified upper bound below tolerance is a certificate. Exhausting the
+    registered search budget returns ``inconclusive`` and exact fallback.
+    """
+
+    if not isinstance(domain, ParameterBox):
+        raise TypeError("domain must be a ParameterBox")
+    lipschitz = np.asarray(action_loss_lipschitz, dtype=np.float64)
+    if lipschitz.ndim != 1 or lipschitz.size < 2:
+        raise ValueError("action_loss_lipschitz must contain at least two values")
+    if not np.isfinite(lipschitz).all() or np.any(lipschitz < 0.0):
+        raise ValueError("action_loss_lipschitz must be finite and nonnegative")
+    tolerance = _finite_nonnegative(regret_tolerance, name="regret_tolerance")
+    evaluation_limit = _positive_integer(
+        maximum_evaluations, name="maximum_evaluations"
+    )
+    depth_limit = _positive_integer(maximum_depth, name="maximum_depth")
+    minimum_width = _finite_nonnegative(
+        minimum_box_width, name="minimum_box_width"
+    )
+
+    initial = _evaluate_box(domain, 0, loss_oracle, lipschitz)
+    active: list[_EvaluatedBox] = [initial]
+    samples: list[_EvaluatedBox] = [initial]
+
+    while True:
+        bounds = _summarize(active, samples, regret_tolerance=tolerance)
+        status, selected, reason = _terminal_status(bounds)
+        if status is not None and reason is not None:
+            return ContinuousDecisionCertificate(
+                status=status,
+                selected_action_index=selected,
+                action_bounds=bounds,
+                regret_tolerance=tolerance,
+                evaluated_points=len(samples),
+                active_boxes=len(active),
+                maximum_remaining_radius=max(item.box.linf_radius for item in active),
+                reason_code=reason,
+            )
+
+        unresolved = {
+            bound.action_index
+            for bound in bounds
+            if not bound.certified_admissible and not bound.witnessed_inadmissible
+        }
+        if not unresolved:
+            return ContinuousDecisionCertificate(
+                status="inconclusive",
+                selected_action_index=None,
+                action_bounds=bounds,
+                regret_tolerance=tolerance,
+                evaluated_points=len(samples),
+                active_boxes=len(active),
+                maximum_remaining_radius=max(item.box.linf_radius for item in active),
+                reason_code="continuous-bounds-do-not-identify-unique-action",
+            )
+
+        splittable = [
+            (index, item)
+            for index, item in enumerate(active)
+            if item.depth < depth_limit
+            and item.box.maximum_width > minimum_width + _ATOL
+            and item.box.split() is not None
+        ]
+        if not splittable or len(samples) + 2 > evaluation_limit:
+            return ContinuousDecisionCertificate(
+                status="inconclusive",
+                selected_action_index=None,
+                action_bounds=bounds,
+                regret_tolerance=tolerance,
+                evaluated_points=len(samples),
+                active_boxes=len(active),
+                maximum_remaining_radius=max(item.box.linf_radius for item in active),
+                reason_code="continuous-search-budget-exhausted",
+            )
+
+        def priority(entry: tuple[int, _EvaluatedBox]) -> tuple[object, ...]:
+            index, item = entry
+            unresolved_upper = max(item.regret_upper[action] for action in unresolved)
+            unresolved_gap = max(
+                item.regret_upper[action] - item.regret[action]
+                for action in unresolved
+            )
+            return (
+                unresolved_upper - tolerance,
+                unresolved_gap,
+                item.box.linf_radius,
+                -item.depth,
+                tuple(-value for value in item.box.lower),
+                tuple(-value for value in item.box.upper),
+                -index,
+            )
+
+        split_index, parent = max(splittable, key=priority)
+        children = parent.box.split()
+        if children is None:
+            raise RuntimeError("selected box is not splittable")
+        active.pop(split_index)
+        evaluated_children = [
+            _evaluate_box(child, parent.depth + 1, loss_oracle, lipschitz)
+            for child in children
+        ]
+        active.extend(evaluated_children)
+        samples.extend(evaluated_children)
+
+
+__all__ = [
+    "CONTINUOUS_DECISION_CERTIFICATION_CLAIM_BOUNDARY",
+    "CONTINUOUS_DECISION_CERTIFICATION_VERSION",
+    "ContinuousActionBound",
+    "ContinuousDecisionCertificate",
+    "ContinuousDecisionStatus",
+    "ParameterBox",
+    "certify_continuous_decision",
+]

--- a/src/causal4d/continuous_decision_certification.py
+++ b/src/causal4d/continuous_decision_certification.py
@@ -83,12 +83,8 @@ class ParameterBox:
             raise ValueError("box bounds must be finite")
         if np.any(lower > upper):
             raise ValueError("box lower bounds must not exceed upper bounds")
-        object.__setattr__(
-            self, "lower", tuple(_canonical(value) for value in lower)
-        )
-        object.__setattr__(
-            self, "upper", tuple(_canonical(value) for value in upper)
-        )
+        object.__setattr__(self, "lower", tuple(_canonical(value) for value in lower))
+        object.__setattr__(self, "upper", tuple(_canonical(value) for value in upper))
 
     @property
     def dimension(self) -> int:
@@ -131,9 +127,7 @@ class ParameterBox:
             return False
         lower = np.asarray(self.lower, dtype=np.float64)
         upper = np.asarray(self.upper, dtype=np.float64)
-        return bool(
-            np.all(values >= lower - _ATOL) and np.all(values <= upper + _ATOL)
-        )
+        return bool(np.all(values >= lower - _ATOL) and np.all(values <= upper + _ATOL))
 
     def as_dict(self) -> dict[str, object]:
         return {
@@ -353,9 +347,7 @@ def certify_continuous_decision(
         maximum_evaluations, name="maximum_evaluations"
     )
     depth_limit = _positive_integer(maximum_depth, name="maximum_depth")
-    minimum_width = _finite_nonnegative(
-        minimum_box_width, name="minimum_box_width"
-    )
+    minimum_width = _finite_nonnegative(minimum_box_width, name="minimum_box_width")
 
     initial = _evaluate_box(domain, 0, loss_oracle, lipschitz)
     active: list[_EvaluatedBox] = [initial]
@@ -416,8 +408,7 @@ def certify_continuous_decision(
             index, item = entry
             unresolved_upper = max(item.regret_upper[action] for action in unresolved)
             unresolved_gap = max(
-                item.regret_upper[action] - item.regret[action]
-                for action in unresolved
+                item.regret_upper[action] - item.regret[action] for action in unresolved
             )
             return (
                 unresolved_upper - tolerance,

--- a/tests/test_continuous_decision_certification.py
+++ b/tests/test_continuous_decision_certification.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from causal4d.continuous_decision_certification import (
+    ParameterBox,
+    certify_continuous_decision,
+)
+
+
+def _triangular_losses(parameter: np.ndarray) -> tuple[float, float]:
+    x = float(parameter[0])
+    center = 0.375
+    half_width = 0.125
+    bump = max(0.0, 1.0 - abs(x - center) / half_width)
+    return bump, 0.1
+
+
+def test_continuous_certificate_finds_grid_missed_counterexample() -> None:
+    result = certify_continuous_decision(
+        _triangular_losses,
+        ParameterBox((-1.0,), (1.0,)),
+        (8.0, 0.0),
+        regret_tolerance=0.15,
+        maximum_evaluations=1025,
+    )
+    assert result.status == "certified"
+    assert result.selected_action_index == 1
+    action_zero = result.action_bounds[0]
+    action_one = result.action_bounds[1]
+    assert action_zero.witnessed_inadmissible
+    assert action_zero.witnessed_lower_bound >= 0.89
+    assert 0.30 <= action_zero.witness_parameter[0] <= 0.45
+    assert action_one.certified_admissible
+    assert action_one.verified_upper_bound <= 0.15 + 1e-12
+
+
+def test_restricted_domain_certifies_action_without_identifying_nuisance() -> None:
+    result = certify_continuous_decision(
+        _triangular_losses,
+        ParameterBox((-1.0, -1.0), (0.20, 1.0)),
+        (0.0, 0.0),
+        regret_tolerance=0.05,
+        maximum_evaluations=9,
+    )
+    assert result.status == "certified"
+    assert result.selected_action_index == 0
+    assert result.action_bounds[0].verified_upper_bound <= 0.05 + 1e-12
+    assert result.action_bounds[1].witnessed_inadmissible
+    assert result.maximum_remaining_radius > 0.0
+
+
+def test_claim_boundary_exposes_unvalidated_lipschitz_assumption() -> None:
+    result = certify_continuous_decision(
+        _triangular_losses,
+        ParameterBox((-1.0,), (1.0,)),
+        (0.0, 0.0),
+        regret_tolerance=0.01,
+        maximum_evaluations=9,
+    )
+    assert result.status == "certified"
+    assert result.selected_action_index == 0
+    assert "valid global action-loss Lipschitz constants" in result.as_dict()[
+        "claim_boundary"
+    ]
+
+
+def test_budget_exhaustion_fails_closed() -> None:
+    def losses(parameter: np.ndarray) -> tuple[float, float]:
+        return float(parameter[0] ** 2), 0.2
+
+    result = certify_continuous_decision(
+        losses,
+        ParameterBox((-1.0,), (1.0,)),
+        (2.0, 0.0),
+        regret_tolerance=0.05,
+        maximum_evaluations=1,
+    )
+    assert result.status == "inconclusive"
+    assert result.used_exact_fallback
+    assert result.reason_code == "continuous-search-budget-exhausted"
+
+
+def test_multiple_uniformly_admissible_actions_fail_closed() -> None:
+    result = certify_continuous_decision(
+        lambda _: (0.0, 0.0),
+        ParameterBox((-1.0,), (1.0,)),
+        (0.0, 0.0),
+        regret_tolerance=0.0,
+    )
+    assert result.status == "multiple-admissible-actions"
+    assert result.selected_action_index is None
+
+
+def test_no_uniformly_admissible_action_returns_counterexamples() -> None:
+    result = certify_continuous_decision(
+        lambda value: (
+            float((value[0] - 0.5) ** 2),
+            float((value[0] + 0.5) ** 2),
+        ),
+        ParameterBox((-1.0,), (1.0,)),
+        (3.0, 3.0),
+        regret_tolerance=0.1,
+        maximum_evaluations=1025,
+    )
+    assert result.status == "no-admissible-action"
+    assert all(bound.witnessed_inadmissible for bound in result.action_bounds)
+
+
+def test_parameter_box_validation_and_containment() -> None:
+    box = ParameterBox((-1.0, 0.0), (1.0, 2.0))
+    assert box.center == (0.0, 1.0)
+    assert box.contains((0.5, 1.5))
+    assert not box.contains((2.0, 1.5))
+    with pytest.raises(ValueError):
+        ParameterBox((1.0,), (-1.0,))
+
+
+def test_verified_regret_envelopes_cover_dense_affine_reference() -> None:
+    coefficients = np.asarray(
+        (
+            (1.0, -2.0),
+            (-0.5, 0.75),
+            (0.25, 0.10),
+        ),
+        dtype=np.float64,
+    )
+    offsets = np.asarray((0.1, -0.2, 0.05), dtype=np.float64)
+
+    def losses(parameter: np.ndarray) -> np.ndarray:
+        return coefficients @ parameter + offsets
+
+    lipschitz = np.sum(np.abs(coefficients), axis=1)
+    result = certify_continuous_decision(
+        losses,
+        ParameterBox((-1.0, -1.0), (1.0, 1.0)),
+        lipschitz,
+        regret_tolerance=0.01,
+        maximum_evaluations=65,
+    )
+    grid = np.linspace(-1.0, 1.0, 101)
+    reference = []
+    for first in grid:
+        for second in grid:
+            point_losses = losses(np.asarray((first, second)))
+            reference.append(point_losses - np.min(point_losses))
+    reference_worst = np.max(np.asarray(reference), axis=0)
+    for bound, actual in zip(result.action_bounds, reference_worst):
+        assert bound.witnessed_lower_bound <= actual + 1e-12
+        assert bound.verified_upper_bound >= actual - 1e-12
+
+
+def test_continuous_certificate_is_deterministic() -> None:
+    arguments = (
+        _triangular_losses,
+        ParameterBox((-1.0,), (1.0,)),
+        (8.0, 0.0),
+    )
+    first = certify_continuous_decision(
+        *arguments,
+        regret_tolerance=0.15,
+        maximum_evaluations=1025,
+    )
+    second = certify_continuous_decision(
+        *arguments,
+        regret_tolerance=0.15,
+        maximum_evaluations=1025,
+    )
+    assert first.as_dict() == second.as_dict()

--- a/tests/test_continuous_decision_certification.py
+++ b/tests/test_continuous_decision_certification.py
@@ -61,9 +61,10 @@ def test_claim_boundary_exposes_unvalidated_lipschitz_assumption() -> None:
     )
     assert result.status == "certified"
     assert result.selected_action_index == 0
-    assert "valid global action-loss Lipschitz constants" in result.as_dict()[
-        "claim_boundary"
-    ]
+    assert (
+        "valid global action-loss Lipschitz constants"
+        in result.as_dict()["claim_boundary"]
+    )
 
 
 def test_budget_exhaustion_fails_closed() -> None:


### PR DESCRIPTION
## Purpose

Remove the largest remaining formal weakness in the decision-identification stack: exactness only on a hand-supplied finite physical hypothesis roster.

This stacked PR adds a fail-closed continuous-support certificate over a registered compact physical parameter box. It searches for decision-breaking physical worlds with sound Lipschitz regret envelopes rather than treating a parameter grid as complete support.

## Method

For terminal losses `L(theta,a)` with registered global action-wise Lipschitz constants in the parameter `L-infinity` metric, every box center `c` and radius `r` gives the sound pairwise bound

```text
L(theta,a)-L(theta,b)
<= L(c,a)-L(c,b) + (K[a]+K[b]) r.
```

The branch-and-bound solver maintains, for every action:

- a concrete witnessed lower bound on worst-case regret; and
- a verified upper bound covering every active parameter cell.

It terminates as:

- `certified` only when exactly one action is uniformly within tolerance and every competitor has a concrete counterexample;
- `no-admissible-action` when every action has a counterexample;
- `multiple-admissible-actions` when at least two actions are uniformly within tolerance; or
- `inconclusive` when the registered evaluation/depth/resolution budget is exhausted.

Only `certified` emits an action. All other outcomes route to exact fallback.

## Controlled strict separation

A narrow decision-breaking physical pocket is placed between the three grid nodes `{-1,0,1}`.

- The finite grid reports zero worst-case regret for action 0 and selects it.
- Continuous branch and bound finds the missed world at `x=0.375`, witnessing regret `0.9` for action 0.
- It verifies action 1 below the registered `0.15` tolerance and certifies action 1.
- A source-qualified restriction to `x in [-1,0.2]` changes the certified action back to action 0 at tolerance `0.05`, while a full nuisance coordinate remains unresolved.
- A one-evaluation control returns `inconclusive` and exact fallback.

Thus the result establishes:

```text
finite-grid success != continuous-support certification
counterexample elimination != complete-state identification
optimizer exhaustion != action admissibility
```

## Validation

The dedicated workflow is read-only and requires:

- Ruff lint and exact formatting;
- nine focused continuous-support tests;
- regression against the state-changing controlled-decision suite;
- a dense affine-reference envelope audit;
- deterministic double execution with byte-identical JSON output; and
- content-addressed artifact retention.

## Stack and scientific boundary

This PR is intentionally stacked on `feature/controlled-decision-identification-v1` / PR #507. The controlled intervention planner remains finite-state; this PR supplies the continuous terminal-support oracle needed for the next counterexample-guided dual-control layer.

Soundness is conditional on the supplied compact parameter domain, deterministic loss oracle, and valid global or source-qualified local Lipschitz constants. This PR does not validate a real physical support, learned simulator, Lipschitz envelope, target-domain transport, deployment authorization, or safety.