### PR TITLE
Install the full base runtime for the PokeFlex Bayesian workflow

### DIFF
--- a/.github/workflows/pokeflex-bma-vs-map-gpuserver4090.yml
+++ b/.github/workflows/pokeflex-bma-vs-map-gpuserver4090.yml
@@ -19,6 +19,8 @@ env:
   PYTHONUNBUFFERED: "1"
   REQUEST_PATH: ops/pokeflex-bma-vs-map-gpuserver4090-request.json
   NUMPY_VERSION: "2.2.6"
+  SCIPY_VERSION: "1.13.1"
+  PACKAGING_VERSION: "23.0"
 
 jobs:
   evaluate:
@@ -49,7 +51,7 @@ jobs:
           test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
           test -z "$(git status --porcelain=v1)"
 
-      - name: Bootstrap isolated pinned NumPy runtime
+      - name: Bootstrap isolated pinned Causal4D base runtime
         shell: bash
         run: |
           set -euo pipefail
@@ -76,7 +78,7 @@ jobs:
             exit 1
           fi
 
-          runtime="$RUNNER_TEMP/pokeflex-bma-numpy-runtime"
+          runtime="$RUNNER_TEMP/pokeflex-bma-base-runtime"
           rm -rf "$runtime"
           mkdir -p "$runtime"
           "$selected" -m pip install \
@@ -84,22 +86,35 @@ jobs:
             --no-input \
             --only-binary=:all: \
             --target "$runtime" \
-            "numpy==${NUMPY_VERSION}" 2>&1 | tee "$output/pip-install.log"
+            "numpy==${NUMPY_VERSION}" \
+            "scipy==${SCIPY_VERSION}" \
+            "packaging==${PACKAGING_VERSION}" \
+            2>&1 | tee "$output/pip-install.log"
 
           PYTHONPATH="$runtime" "$selected" - <<'PY' > "$output/runtime.txt"
-          import numpy
           import os
+          import packaging
+          import numpy
           import platform
+          import scipy
           import sys
 
-          expected = os.environ["NUMPY_VERSION"]
-          if numpy.__version__ != expected:
-              raise SystemExit(
-                  f"unexpected isolated NumPy version: {numpy.__version__} != {expected}"
-              )
+          expected = {
+              "numpy": os.environ["NUMPY_VERSION"],
+              "scipy": os.environ["SCIPY_VERSION"],
+              "packaging": os.environ["PACKAGING_VERSION"],
+          }
+          observed = {
+              "numpy": numpy.__version__,
+              "scipy": scipy.__version__,
+              "packaging": packaging.__version__,
+          }
+          if observed != expected:
+              raise SystemExit(f"unexpected isolated runtime: {observed} != {expected}")
           print("python_executable", sys.executable)
           print("python", platform.python_version())
-          print("numpy", numpy.__version__)
+          for name, version in observed.items():
+              print(name, version)
           PY
           printf 'PYTHON_BIN=%s\n' "$selected" >> "$GITHUB_ENV"
           printf 'EVAL_PYTHONPATH=%s\n' "$runtime" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Second pre-science failure

Actions run `33750591069` passed the exact reviewed SHA, installed the isolated NumPy runtime, and validated the world-readable PokeFlex root. The PokeFlex CLI then failed during package initialization because `causal4d_public.__init__` imports a Deform360 base module that requires SciPy. The failure occurred before any PokeFlex record was opened.

## Fix

Install the complete pinned Causal4D base dependency set needed by package initialization into the isolated runner target:

- `numpy==2.2.6`
- `scipy==1.13.1`
- `packaging==23.0`

SciPy 1.13.1 is already recorded in the repository's established Python 3.10 GPU environment and is compatible with the selected system Python and NumPy pin. The workflow verifies all three versions before dataset access.

No scientific code, data roster, posterior, comparator, metric, prefix/suffix boundary, or target authorization changes. The existing workflow-path dispatcher will start the repaired exact-SHA run after merge.